### PR TITLE
Fail closed release tuples to stable lanes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,17 @@ Harbor preview state, and promotion orchestration.
 
 ## Purpose
 
+- Act as the Odoo-first Harbor proving ground for durable deployment truth.
 - Own artifact, backup-gate, deployment, promotion, and inventory records
   outside the code and local-DX repos.
 - Own ship and promotion orchestration behind explicit control-plane
   contracts.
 - Keep code and local DX in `odoo-devkit`, tenant repos, and shared-addons,
   with only explicit artifact and operator handoffs into this repo.
+
+This repo's docs describe the implemented Odoo-first contracts that exist
+today. Broader Harbor product-direction guidance stays in saved plans until
+matching code and operator surfaces exist here.
 
 ## Bootstrap Scope
 
@@ -31,6 +36,9 @@ uv run python -m unittest
 
 The tracked Dokploy route catalog lives in `config/dokploy.toml`, with
 operator-local target IDs supplied through `config/dokploy-targets.toml`.
+The stable remote lane catalog is now `testing` plus `prod`; pull requests use
+Harbor-managed preview identities and ephemeral preview stacks instead of a
+durable shared `dev` lane.
 
 ## Docs
 

--- a/config/dokploy-targets.toml.example
+++ b/config/dokploy-targets.toml.example
@@ -1,9 +1,8 @@
 schema_version = 1
 
-[[targets]]
-context = "cm"
-instance = "dev"
-target_id = "cm-dev-compose-id"
+# Stable target ids map only the shared testing and prod lanes.
+# PR previews stay outside this catalog because Harbor manages them as
+# ephemeral per-PR stacks.
 
 [[targets]]
 context = "cm"
@@ -14,11 +13,6 @@ target_id = "cm-testing-compose-id"
 context = "cm"
 instance = "prod"
 target_id = "cm-prod-compose-id"
-
-[[targets]]
-context = "opw"
-instance = "dev"
-target_id = "opw-dev-compose-id"
 
 [[targets]]
 context = "opw"

--- a/config/dokploy.toml
+++ b/config/dokploy.toml
@@ -36,20 +36,9 @@ ODOO_ADDON_REPOSITORIES = "cbusillo/disable_odoo_online@411f6b8e85cac72dc7aa2e2d
 OPENUPGRADE_ADDON_REPOSITORY = "OCA/OpenUpgrade@89e649728027a8ab656b3aa4be18f4bd364db417"
 OPENUPGRADELIB_INSTALL_SPEC = "git+https://github.com/OCA/openupgradelib.git@46d66ff5ed6a99481f84d3c79fc6e50835da7286"
 
-[[targets]]
-profile = "cm"
-context = "cm"
-instance = "dev"
-git_branch = "cm-dev"
-require_test_gate = false
-require_prod_gate = false
-domains = ["cm-dev.shinycomputers.com"]
-
-[targets.env]
-ENV_OVERRIDE_CONFIG_PARAM__WEB__BASE__URL = "https://cm-dev.shinycomputers.com"
-ENV_OVERRIDE_AUTHENTIK__BASE_URL = "https://authentik.cellmechanic.com"
-ENV_OVERRIDE_AUTHENTIK__DISABLE_PROVIDERS = "Odoo.com"
-ENV_OVERRIDE_AUTHENTIK__GROUP_CLAIM = "groups"
+# Stable Dokploy routes cover only the shared testing and prod lanes.
+# Pull-request previews are Harbor-managed ephemeral stacks, not durable routes
+# in this catalog.
 
 [[targets]]
 profile = "cm"
@@ -80,18 +69,6 @@ ENV_OVERRIDE_CONFIG_PARAM__WEB__BASE__URL = "https://odoo.cellmechanic.com"
 ENV_OVERRIDE_AUTHENTIK__BASE_URL = "https://authentik.cellmechanic.com"
 ENV_OVERRIDE_AUTHENTIK__DISABLE_PROVIDERS = "Odoo.com"
 ENV_OVERRIDE_AUTHENTIK__GROUP_CLAIM = "groups"
-
-[[targets]]
-profile = "opw"
-context = "opw"
-instance = "dev"
-git_branch = "opw-dev"
-require_test_gate = false
-require_prod_gate = false
-domains = ["opw-dev.shinycomputers.com"]
-
-[targets.env]
-ENV_OVERRIDE_CONFIG_PARAM__WEB__BASE__URL = "https://opw-dev.shinycomputers.com"
 
 [[targets]]
 profile = "opw"

--- a/config/release-tuples.toml
+++ b/config/release-tuples.toml
@@ -2,14 +2,9 @@ schema_version = 1
 
 # Current runtime baseline captured from the legacy odoo-ai remote deploy
 # branches on 2026-04-16. These entries preserve the active cockpit's exact
-# deployed-source branch heads until split-repo artifact promotion replaces the
-# legacy monorepo baseline.
-
-[contexts.cm.channels.dev]
-tuple_id = "cm-dev-odoo-ai-671a0cff"
-
-[contexts.cm.channels.dev.repo_shas]
-odoo-ai = "671a0cffe57a7f84bf5f487fa03a433185c2da15"
+# shared testing and prod branch heads until split-repo artifact promotion
+# replaces the legacy monorepo baseline. Pull requests now use Harbor previews
+# instead of a long-lived shared dev lane.
 
 [contexts.cm.channels.testing]
 tuple_id = "cm-testing-odoo-ai-671a0cff"
@@ -22,12 +17,6 @@ tuple_id = "cm-prod-odoo-ai-671a0cff"
 
 [contexts.cm.channels.prod.repo_shas]
 odoo-ai = "671a0cffe57a7f84bf5f487fa03a433185c2da15"
-
-[contexts.opw.channels.dev]
-tuple_id = "opw-dev-odoo-ai-95425c07"
-
-[contexts.opw.channels.dev.repo_shas]
-odoo-ai = "95425c073765f1807c97648244ab9b28a2c03035"
 
 [contexts.opw.channels.testing]
 tuple_id = "opw-testing-odoo-ai-a250ab79"

--- a/config/runtime-environments.toml.example
+++ b/config/runtime-environments.toml.example
@@ -30,9 +30,6 @@ ENV_OVERRIDE_SHOPIFY__API_TOKEN = ""
 ENV_OVERRIDE_SHOPIFY__WEBHOOK_KEY = ""
 ENV_OVERRIDE_AUTHENTIK__CLIENT_ID = "cm-local-client-id"
 
-[contexts.cm.instances.dev.env]
-ENV_OVERRIDE_AUTHENTIK__CLIENT_ID = "cm-dev-client-id"
-
 [contexts.cm.instances.testing.env]
 ENV_OVERRIDE_AUTHENTIK__CLIENT_ID = "cm-testing-client-id"
 

--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -22,6 +22,7 @@ CONTROL_PLANE_DOKPLOY_SOURCE_FILE_ENV_VAR = "ODOO_CONTROL_PLANE_DOKPLOY_SOURCE_F
 CONTROL_PLANE_DOKPLOY_TARGET_IDS_FILE_ENV_VAR = "ODOO_CONTROL_PLANE_DOKPLOY_TARGET_IDS_FILE"
 DEFAULT_CONTROL_PLANE_DOKPLOY_SOURCE_FILE = Path("config/dokploy.toml")
 DEFAULT_CONTROL_PLANE_DOKPLOY_TARGET_IDS_FILE = Path("config/dokploy-targets.toml")
+DEFAULT_STABLE_REMOTE_INSTANCES = {"testing", "prod"}
 DOKPLOY_DATA_WORKFLOW_SCHEDULE_NAME = "platform-data-workflow"
 DOKPLOY_MANUAL_ONLY_CRON_EXPRESSION = "0 0 31 2 *"
 DOKPLOY_RUNNING_DEPLOYMENT_STATUSES = {"pending", "queued", "running", "in_progress", "starting"}
@@ -105,6 +106,13 @@ class DokploySourceOfTruth(BaseModel):
                     f"Duplicate Dokploy target definition for {context_name}/{instance_name} in source-of-truth"
                 )
             seen_targets.add(target_route)
+            if target_definition.instance not in DEFAULT_STABLE_REMOTE_INSTANCES:
+                supported_instances = ", ".join(sorted(DEFAULT_STABLE_REMOTE_INSTANCES))
+                raise ValueError(
+                    "Tracked Dokploy source-of-truth only supports stable remote instances "
+                    f"{supported_instances}; found {target_definition.context}/{target_definition.instance}. "
+                    "Use Harbor preview records for PR previews instead of adding another tracked Dokploy lane."
+                )
         return self
 
 

--- a/control_plane/release_tuples.py
+++ b/control_plane/release_tuples.py
@@ -15,7 +15,7 @@ from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
 RELEASE_TUPLES_FILE_ENV_VAR = "ODOO_CONTROL_PLANE_RELEASE_TUPLES_FILE"
 DEFAULT_RELEASE_TUPLES_FILE = "config/release-tuples.toml"
 GIT_SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{7,40}$")
-LONG_LIVED_RELEASE_TUPLE_CHANNELS = {"dev", "testing", "prod"}
+LONG_LIVED_RELEASE_TUPLE_CHANNELS = {"testing", "prod"}
 
 
 @dataclass(frozen=True)
@@ -39,14 +39,29 @@ def should_mint_release_tuple_for_channel(channel_name: str) -> bool:
     return channel_name.strip() in LONG_LIVED_RELEASE_TUPLE_CHANNELS
 
 
+def _require_stable_release_tuple_channel(channel_name: str, *, scope: str) -> str:
+    normalized_channel_name = channel_name.strip()
+    if normalized_channel_name not in LONG_LIVED_RELEASE_TUPLE_CHANNELS:
+        supported_channels = ", ".join(sorted(LONG_LIVED_RELEASE_TUPLE_CHANNELS))
+        raise click.ClickException(
+            f"{scope} only supports stable remote channels {supported_channels}; got {normalized_channel_name!r}. "
+            "Use Harbor preview records for preview/dev runtime instead of minting or tracking release tuples there."
+        )
+    return normalized_channel_name
+
+
 def render_release_tuple_catalog_toml(records: tuple[ReleaseTupleRecord, ...]) -> str:
     lines = ["schema_version = 1", ""]
     for record in sorted(records, key=lambda item: (item.context, item.channel)):
-        lines.append(f"[contexts.{_toml_bare_key(record.context)}.channels.{_toml_bare_key(record.channel)}]")
+        channel_name = _require_stable_release_tuple_channel(
+            record.channel,
+            scope=f"Release tuple record {record.tuple_id}",
+        )
+        lines.append(f"[contexts.{_toml_bare_key(record.context)}.channels.{_toml_bare_key(channel_name)}]")
         lines.append(f"tuple_id = {_toml_string(record.tuple_id)}")
         lines.append("")
         lines.append(
-            f"[contexts.{_toml_bare_key(record.context)}.channels.{_toml_bare_key(record.channel)}.repo_shas]"
+            f"[contexts.{_toml_bare_key(record.context)}.channels.{_toml_bare_key(channel_name)}.repo_shas]"
         )
         for repo_name, git_sha in sorted(record.repo_shas.items()):
             lines.append(f"{_toml_bare_key(repo_name)} = {_toml_string(git_sha)}")
@@ -62,6 +77,10 @@ def build_release_tuple_record_from_artifact_manifest(
     deployment_record_id: str,
     minted_at: str,
 ) -> ReleaseTupleRecord:
+    normalized_channel_name = _require_stable_release_tuple_channel(
+        channel_name,
+        scope="Release tuple minting",
+    )
     repo_shas = repo_shas_from_artifact_manifest(
         context_name=context_name,
         artifact_manifest=artifact_manifest,
@@ -69,11 +88,11 @@ def build_release_tuple_record_from_artifact_manifest(
     return ReleaseTupleRecord(
         tuple_id=_artifact_release_tuple_id(
             context_name=context_name,
-            channel_name=channel_name,
+            channel_name=normalized_channel_name,
             artifact_id=artifact_manifest.artifact_id,
         ),
         context=context_name,
-        channel=channel_name,
+        channel=normalized_channel_name,
         artifact_id=artifact_manifest.artifact_id,
         repo_shas=repo_shas,
         image_repository=artifact_manifest.image.repository,
@@ -92,14 +111,18 @@ def build_promoted_release_tuple_record(
     promotion_record_id: str,
     minted_at: str,
 ) -> ReleaseTupleRecord:
+    normalized_channel_name = _require_stable_release_tuple_channel(
+        to_channel_name,
+        scope="Release tuple promotion",
+    )
     return ReleaseTupleRecord(
         tuple_id=_artifact_release_tuple_id(
             context_name=source_tuple.context,
-            channel_name=to_channel_name,
+            channel_name=normalized_channel_name,
             artifact_id=source_tuple.artifact_id,
         ),
         context=source_tuple.context,
-        channel=to_channel_name,
+        channel=normalized_channel_name,
         artifact_id=source_tuple.artifact_id,
         repo_shas=dict(source_tuple.repo_shas),
         image_repository=source_tuple.image_repository,
@@ -266,14 +289,18 @@ def _parse_release_tuple_catalog(
                 raise click.ClickException(
                     f"Expected release_tuples.contexts.{context_name}.channels keys to be non-empty strings."
                 )
+            normalized_channel_name = _require_stable_release_tuple_channel(
+                channel_name,
+                scope=f"release_tuples.contexts.{context_name}.channels",
+            )
             channel_table = _ensure_table(
                 raw_channel,
-                scope=f"release_tuples.contexts.{context_name}.channels.{channel_name}",
+                scope=f"release_tuples.contexts.{context_name}.channels.{normalized_channel_name}",
             )
             tuple_id = _read_required_non_empty_string(
                 channel_table,
                 "tuple_id",
-                scope=f"release_tuples.contexts.{context_name}.channels.{channel_name}",
+                scope=f"release_tuples.contexts.{context_name}.channels.{normalized_channel_name}",
             )
             if tuple_id in seen_tuple_ids:
                 raise click.ClickException(
@@ -283,9 +310,9 @@ def _parse_release_tuple_catalog(
             repo_shas = _read_required_git_sha_map(
                 channel_table,
                 "repo_shas",
-                scope=f"release_tuples.contexts.{context_name}.channels.{channel_name}",
+                scope=f"release_tuples.contexts.{context_name}.channels.{normalized_channel_name}",
             )
-            channels[channel_name] = ReleaseTupleDefinition(tuple_id=tuple_id, repo_shas=repo_shas)
+            channels[normalized_channel_name] = ReleaseTupleDefinition(tuple_id=tuple_id, repo_shas=repo_shas)
         contexts[context_name] = ReleaseTupleContextDefinition(channels=channels)
     return ReleaseTupleCatalog(schema_version=schema_version, contexts=contexts)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,6 +8,11 @@ title: Architecture
 - Make artifact identity and promotion records first-class control-plane data.
 - Own promotion and deploy orchestration behind explicit contracts.
 
+This repo is the Odoo-first Harbor proving ground. The contracts documented
+here are the implemented Odoo control-plane boundaries that exist today.
+Reusable Harbor product direction lives in saved plans until the same concepts
+are expressed through code and operator surface here.
+
 ## Repo Boundary
 
 `odoo-control-plane` owns:
@@ -34,6 +39,18 @@ Code and local-DX repos own:
 GitHub owns the engineering workflow around this system: issues, branches,
 pull requests, labels, checks, PR comments, releases, and CI execution.
 
+## Harbor Shape Today
+
+- Stable remote environment lanes are `testing` and `prod` only.
+- PR previews are Harbor-managed preview identities backed by separate preview
+  generations and ephemeral preview runtime state, not extra long-lived Dokploy
+  lanes.
+- The tracked Dokploy route catalog is therefore limited to stable tenant lanes
+  rather than acting as a registry for every preview or ad hoc environment.
+- Durable control-plane records use generic deployment nouns when the concept
+  is reusable across products, but Odoo-specific runtime behavior remains
+  explicit in the Odoo workflow code and deploy evidence.
+
 ## Current Contract
 
 - `promote` accepts the native artifact-backed promotion contract and uses this
@@ -45,6 +62,9 @@ pull requests, labels, checks, PR comments, releases, and CI execution.
   `config/dokploy.toml` by default, with an explicit
   `ODOO_CONTROL_PLANE_DOKPLOY_SOURCE_FILE` override for alternate operator
   paths.
+- The tracked Dokploy route catalog is limited to stable remote lanes
+  (`testing`, `prod`). Pull-request previews flow through Harbor preview
+  records instead of tracked Dokploy lane entries.
 - Harbor baseline release tuples belong here as explicit control-plane data.
   Tuple entries carry exact repo SHAs for preview-manifest resolution, not
   floating branch names.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -7,6 +7,10 @@ title: Operations
 Use `uv run control-plane --help` for the complete CLI surface. The current
 top-level groups are:
 
+Today this CLI is the Odoo-first Harbor operator surface. It owns stable-lane
+deploy and promotion workflows for `testing` and `prod`, plus Harbor preview
+records and read models for PR review flows.
+
 - `artifacts`: write, ingest, and inspect artifact manifests.
 - `backup-gates`: write and inspect backup-gate records.
 - `deployments`: inspect deployment records.
@@ -42,19 +46,24 @@ top-level groups are:
 - Direct artifact-backed execution also fails closed when the Dokploy target
   still points at a legacy monorepo source or carries mutable addon repository
   refs instead of exact git SHAs.
-- Successful waited `ship` executions for `dev`, `testing`, and `prod` mint
-  current release tuple records from stored artifact manifests.
+- Successful waited `ship` executions for `testing` and `prod` mint current
+  release tuple records from stored artifact manifests.
 - `promote execute` requires the source lane's current release tuple to match
   the requested artifact, then promotes that exact tuple to the destination
   lane after the deploy passes.
 - Current environment inventory is refreshed from successful waited `ship` and
   `promote` executions.
+- The tracked Dokploy route catalog is only for stable remote lanes. If a pull
+  request needs runtime state, Harbor models that through preview records and
+  preview generations instead of adding another long-lived route.
 - Operator read models compose inventory, deployment, promotion, and
   backup-gate records instead of requiring operators to inspect raw JSON first.
 
 ## Dokploy Contracts
 
 - Tracked Dokploy route definitions live in `config/dokploy.toml` by default.
+- Tracked route definitions are expected to be stable remote lanes only:
+  `testing` and `prod`.
 - Live Dokploy `target_id` values come from untracked
   `config/dokploy-targets.toml` by default.
 - Set `ODOO_CONTROL_PLANE_DOKPLOY_SOURCE_FILE` to use an alternate route
@@ -115,11 +124,12 @@ The current command group supports:
 catalog without relying on process-wide environment setup.
 
 The tracked default catalog at `config/release-tuples.toml` records the current
-legacy `odoo-ai` deploy-branch heads for `dev`, `testing`, and `prod`. Treat it
-as active runtime baseline evidence until split-repo artifact tuple records are
-materialized into the baseline catalog. Runtime `ship` and `promote` flows write
-current tuple records under the selected state directory rather than silently
-rewriting this tracked file.
+legacy `odoo-ai` deploy-branch heads for `testing` and `prod`. Treat it as
+active runtime baseline evidence until split-repo artifact tuple records are
+materialized into the baseline catalog. Pull requests now flow through Harbor
+preview records instead of a tracked long-lived `dev` tuple lane. Runtime
+`ship` and `promote` flows write current tuple records under the selected state
+directory rather than silently rewriting this tracked file.
 
 Use `release-tuples export-catalog --state-dir <state>` to render those minted
 state records as catalog TOML when an operator is ready to review and
@@ -139,9 +149,12 @@ companion PR head SHA snapshots from ingest. Tenant renders use those stored
 snapshots for preview request recipes and keep unresolved companion requests
 blocked instead of guessing source inputs.
 
-## GitHub Boundary
+## Harbor Boundary
 
-GitHub is the engineering workflow surface: issues, branches, pull requests,
-labels, checks, PR comments, releases, and CI execution. `odoo-control-plane`
-owns the durable operational truth behind those workflows: release tuples,
-artifacts, previews, deployments, promotions, backup gates, and inventory.
+- GitHub remains the engineering workflow surface: issues, branches, pull
+  requests, labels, checks, PR comments, releases, and CI execution.
+- `odoo-control-plane` owns the durable operational truth behind those
+  workflows: artifacts, release tuples, previews, deployments, promotions,
+  backup gates, and inventory.
+- Broader reusable Harbor product direction is intentionally held in saved
+  plans until those boundaries become implemented repo contracts here.

--- a/docs/records.md
+++ b/docs/records.md
@@ -8,6 +8,10 @@ title: Records
 - Keep git history separate from operational history.
 - Favor append-style writes for promotion records.
 
+These records are the durable Odoo-first Harbor truth for this repo today.
+Stable lane records (`testing`, `prod`) and preview records are separate on
+purpose: previews are not another long-lived environment lane.
+
 ## Layout
 
 ```text
@@ -40,6 +44,8 @@ state/
 - Preserve build-affecting addon, OpenUpgrade, and flag inputs alongside the
   image identity so the control plane owns the full manifest instead of a thin
   image pointer.
+- Use generic artifact vocabulary at the record level, but keep Odoo-specific
+  source inputs explicit in the stored evidence.
 
 ## Promotion Record
 
@@ -97,15 +103,16 @@ state/
 ## Release Tuple Record
 
 - Release tuple records are keyed by long-lived environment channel.
-- Successful waited `ship` executions for `dev`, `testing`, and `prod` mint the
-  current channel tuple from the stored artifact manifest after deploy evidence
-  passes.
+- Successful waited `ship` executions for `testing` and `prod` mint the current
+  channel tuple from the stored artifact manifest after deploy evidence passes.
 - Tuple minting requires artifact manifest source refs to be exact git SHAs;
   branch names such as `main` or `origin/testing` are rejected instead of being
   written as release truth.
 - Promotion execution copies the source channel tuple to the destination
   channel after the destination deploy passes, retaining the promotion and
   deployment record ids that established the promoted state.
+- Harbor previews are not long-lived release-tuple channels; they derive their
+  baseline from stored tuple evidence plus preview generation records.
 - Runtime tuple records live under `state/` and do not rewrite the tracked
   default TOML catalog implicitly.
 
@@ -115,6 +122,8 @@ state/
 - Record the anchor PR identity, deterministic preview label, canonical preview
   URL, lifecycle timestamps, current preview state, and the active/serving/
   latest generation links.
+- Preview records model the durable Harbor identity for PR review, while the
+  underlying preview runtime remains ephemeral and replaceable.
 - Destroyed previews should remain readable durable evidence instead of being
   removed from state.
 - Preview records should preserve one stable identity per anchor PR even when

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -349,6 +349,38 @@ target_type = "compose"
 
         self.assertIn("Duplicate Dokploy target definition for opw/prod", str(raised_error.exception))
 
+    def test_read_control_plane_dokploy_source_of_truth_rejects_dev_lane_targets(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            explicit_source_file = control_plane_root / "tmp" / "dokploy.toml"
+            explicit_source_file.parent.mkdir(parents=True, exist_ok=True)
+            explicit_source_file.write_text(
+                """
+schema_version = 2
+
+[[targets]]
+context = "opw"
+instance = "dev"
+target_id = "compose-123"
+target_type = "compose"
+""".strip(),
+                encoding="utf-8",
+            )
+
+            with patch.dict(
+                os.environ,
+                {
+                    control_plane_dokploy.CONTROL_PLANE_DOKPLOY_SOURCE_FILE_ENV_VAR: str(explicit_source_file),
+                },
+                clear=True,
+            ):
+                with self.assertRaises(click.ClickException) as raised_error:
+                    control_plane_dokploy.read_control_plane_dokploy_source_of_truth(control_plane_root=control_plane_root)
+
+        self.assertIn("stable remote instances prod, testing", str(raised_error.exception))
+        self.assertIn("opw/dev", str(raised_error.exception))
+        self.assertIn("Harbor preview records", str(raised_error.exception))
+
     def test_read_control_plane_dokploy_source_of_truth_rejects_unknown_target_id_override_routes(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)

--- a/tests/test_release_tuples.py
+++ b/tests/test_release_tuples.py
@@ -12,6 +12,12 @@ from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
 
 
 class ReleaseTupleTests(unittest.TestCase):
+    def test_should_mint_release_tuple_only_for_stable_remote_channels(self) -> None:
+        self.assertTrue(control_plane_release_tuples.should_mint_release_tuple_for_channel("testing"))
+        self.assertTrue(control_plane_release_tuples.should_mint_release_tuple_for_channel("prod"))
+        self.assertFalse(control_plane_release_tuples.should_mint_release_tuple_for_channel("dev"))
+        self.assertFalse(control_plane_release_tuples.should_mint_release_tuple_for_channel("preview"))
+
     def test_resolve_release_tuple_reads_context_channel_repo_refs(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -164,6 +170,31 @@ shared-addons = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                     control_plane_root=control_plane_root,
                 )
 
+    def test_load_release_tuple_catalog_rejects_non_stable_remote_channels(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            tuples_file = control_plane_root / "config" / "release-tuples.toml"
+            tuples_file.parent.mkdir(parents=True, exist_ok=True)
+            tuples_file.write_text(
+                """
+schema_version = 1
+
+[contexts.opw.channels.dev]
+tuple_id = "opw-dev-2026-04-13"
+
+[contexts.opw.channels.dev.repo_shas]
+tenant-opw = "1111111111111111111111111111111111111111"
+shared-addons = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(Exception, "stable remote channels"):
+                control_plane_release_tuples.load_release_tuple_catalog(
+                    control_plane_root=control_plane_root,
+                )
+
     def test_build_release_tuple_record_from_artifact_manifest_uses_split_repo_shas(self) -> None:
         manifest = ArtifactIdentityManifest(
             artifact_id="artifact-sha256-image456",
@@ -212,6 +243,32 @@ shared-addons = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                 artifact_manifest=manifest,
             )
 
+    def test_build_release_tuple_record_rejects_dev_channel(self) -> None:
+        manifest = ArtifactIdentityManifest(
+            artifact_id="artifact-sha256-image456",
+            source_commit="abc1234",
+            enterprise_base_digest="sha256:enterprise123",
+            addon_sources=(
+                {
+                    "repository": "cbusillo/odoo-shared-addons",
+                    "ref": "def5678",
+                },
+            ),
+            image={
+                "repository": "ghcr.io/cbusillo/odoo-private",
+                "digest": "sha256:image456",
+            },
+        )
+
+        with self.assertRaisesRegex(Exception, "stable remote channels"):
+            control_plane_release_tuples.build_release_tuple_record_from_artifact_manifest(
+                context_name="opw",
+                channel_name="dev",
+                artifact_manifest=manifest,
+                deployment_record_id="deployment-1",
+                minted_at="2026-04-10T18:24:00Z",
+            )
+
     def test_render_release_tuple_catalog_toml_round_trips_to_catalog(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -241,6 +298,42 @@ shared-addons = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         release_tuple = catalog.contexts["opw"].channels["testing"]
         self.assertEqual(release_tuple.tuple_id, "opw-testing-artifact-sha256-image456")
         self.assertEqual(release_tuple.repo_shas["tenant-opw"], "abc1234")
+
+    def test_render_release_tuple_catalog_toml_rejects_preview_channel(self) -> None:
+        with self.assertRaisesRegex(Exception, "stable remote channels"):
+            control_plane_release_tuples.render_release_tuple_catalog_toml(
+                (
+                    ReleaseTupleRecord(
+                        tuple_id="opw-preview-artifact-sha256-image456",
+                        context="opw",
+                        channel="preview",
+                        artifact_id="artifact-sha256-image456",
+                        repo_shas={"tenant-opw": "abc1234", "shared-addons": "def5678"},
+                        provenance="ship",
+                        minted_at="2026-04-10T18:24:00Z",
+                    ),
+                )
+            )
+
+    def test_build_promoted_release_tuple_record_rejects_preview_channel(self) -> None:
+        source_tuple = ReleaseTupleRecord(
+            tuple_id="opw-testing-artifact-sha256-image456",
+            context="opw",
+            channel="testing",
+            artifact_id="artifact-sha256-image456",
+            repo_shas={"tenant-opw": "abc1234", "shared-addons": "def5678"},
+            provenance="ship",
+            minted_at="2026-04-10T18:24:00Z",
+        )
+
+        with self.assertRaisesRegex(Exception, "stable remote channels"):
+            control_plane_release_tuples.build_promoted_release_tuple_record(
+                source_tuple=source_tuple,
+                to_channel_name="preview",
+                deployment_record_id="deployment-2",
+                promotion_record_id="promotion-1",
+                minted_at="2026-04-10T18:25:00Z",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- tighten control-plane lane ownership around stable remote lanes only
- remove durable `dev` lane examples from release and Dokploy guidance
- reject non-stable tuple channels in `release_tuples.py`

## Verification
- `uv run python -m unittest tests.test_release_tuples`
- `uv run python -m unittest tests.test_release_tuples tests.test_dokploy`
- `uv run python -m unittest tests.test_dokploy`

## Related PRs
- devkit: https://github.com/cbusillo/odoo-devkit/pull/1
- tenant-opw: https://github.com/cbusillo/odoo-tenant-opw/pull/1
- tenant-cm: https://github.com/cbusillo/odoo-tenant-cm/pull/1