### PR TITLE
Clarify Harbor boundary in control-plane docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # odoo-control-plane
 
-Private control-plane repo for Odoo release records, environment operations,
+Private Odoo control-plane repo for release records, environment operations,
 Harbor preview state, and promotion orchestration.
 
 ## Purpose
 
-- Act as the Odoo-first Harbor proving ground for durable deployment truth.
+- Own the current Odoo Harbor operator surface for durable deployment truth.
 - Own artifact, backup-gate, deployment, promotion, and inventory records
   outside the code and local-DX repos.
 - Own ship and promotion orchestration behind explicit control-plane
@@ -13,9 +13,11 @@ Harbor preview state, and promotion orchestration.
 - Keep code and local DX in `odoo-devkit`, tenant repos, and shared-addons,
   with only explicit artifact and operator handoffs into this repo.
 
-This repo's docs describe the implemented Odoo-first contracts that exist
-today. Broader Harbor product-direction guidance stays in saved plans until
-matching code and operator surfaces exist here.
+This repo's docs describe the implemented Odoo control-plane contracts that
+exist today. Harbor is the operator surface name used inside this repo today;
+this repository is still the Odoo-specific implementation, not a standalone
+general Harbor repo. Broader Harbor product direction stays in saved plans
+until matching generic code and operator surfaces exist.
 
 ## Bootstrap Scope
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,10 +8,11 @@ title: Architecture
 - Make artifact identity and promotion records first-class control-plane data.
 - Own promotion and deploy orchestration behind explicit contracts.
 
-This repo is the Odoo-first Harbor proving ground. The contracts documented
-here are the implemented Odoo control-plane boundaries that exist today.
-Reusable Harbor product direction lives in saved plans until the same concepts
-are expressed through code and operator surface here.
+This repo is the current Odoo implementation of the Harbor operator surface.
+The contracts documented here are the implemented Odoo control-plane
+boundaries that exist today. Reusable Harbor product direction lives in saved
+plans until the same concepts are expressed through generic code and operator
+surfaces.
 
 ## Repo Boundary
 
@@ -39,9 +40,15 @@ Code and local-DX repos own:
 GitHub owns the engineering workflow around this system: issues, branches,
 pull requests, labels, checks, PR comments, releases, and CI execution.
 
+This repository is not the generic Harbor product boundary today. It is the
+Odoo-specific control plane that currently contains Harbor preview and
+promotion behavior.
+
 ## Harbor Shape Today
 
 - Stable remote environment lanes are `testing` and `prod` only.
+- Harbor currently lives inside `odoo-control-plane`; there is no separate
+  extracted Harbor repo or package contract yet.
 - PR previews are Harbor-managed preview identities backed by separate preview
   generations and ephemeral preview runtime state, not extra long-lived Dokploy
   lanes.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -7,9 +7,9 @@ title: Operations
 Use `uv run control-plane --help` for the complete CLI surface. The current
 top-level groups are:
 
-Today this CLI is the Odoo-first Harbor operator surface. It owns stable-lane
-deploy and promotion workflows for `testing` and `prod`, plus Harbor preview
-records and read models for PR review flows.
+Today this CLI is the Harbor operator surface for the Odoo system owned by
+this repo. It owns stable-lane deploy and promotion workflows for `testing`
+and `prod`, plus Harbor preview records and read models for PR review flows.
 
 - `artifacts`: write, ingest, and inspect artifact manifests.
 - `backup-gates`: write and inspect backup-gate records.
@@ -156,5 +156,7 @@ blocked instead of guessing source inputs.
 - `odoo-control-plane` owns the durable operational truth behind those
   workflows: artifacts, release tuples, previews, deployments, promotions,
   backup gates, and inventory.
-- Broader reusable Harbor product direction is intentionally held in saved
-  plans until those boundaries become implemented repo contracts here.
+- Harbor is the operator surface inside this repo today, not a separate
+  general-purpose repo boundary.
+- Broader reusable Harbor product direction stays in saved plans until a
+  generic contract exists in code and operator surface.


### PR DESCRIPTION
$'## Summary
- keep `odoo-control-plane` explicitly Odoo-specific in the repo docs
- describe Harbor as the operator surface that currently lives inside this repo
- keep broader general-product Harbor direction in saved plans until a generic contract exists

## Verification
- uv run python -m unittest'