### PR TITLE
Refresh Harbor inventory from accepted evidence

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+state
+tmp
+tests

--- a/.github/workflows/deploy-harbor.yml
+++ b/.github/workflows/deploy-harbor.yml
@@ -1,0 +1,158 @@
+name: Deploy Harbor
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: Git ref to build when deploying a new Harbor image.
+        required: false
+        type: string
+      image_reference:
+        description: Exact image reference to deploy instead of building a new one.
+        required: false
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+  packages: write
+
+concurrency:
+  group: harbor-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: >-
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'main') ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      DOKPLOY_HOST: ${{ secrets.DOKPLOY_HOST }}
+      DOKPLOY_TOKEN: ${{ secrets.DOKPLOY_TOKEN }}
+      HARBOR_DOKPLOY_TARGET_ID: ${{ vars.HARBOR_DOKPLOY_TARGET_ID }}
+      HARBOR_DOKPLOY_TARGET_TYPE: ${{ vars.HARBOR_DOKPLOY_TARGET_TYPE }}
+      HARBOR_DEPLOY_HEALTH_URLS: ${{ vars.HARBOR_DEPLOY_HEALTH_URLS }}
+      HARBOR_DOKPLOY_DEPLOY_TIMEOUT_SECONDS: ${{ vars.HARBOR_DOKPLOY_DEPLOY_TIMEOUT_SECONDS }}
+      HARBOR_DEPLOY_HEALTH_TIMEOUT_SECONDS: ${{ vars.HARBOR_DEPLOY_HEALTH_TIMEOUT_SECONDS }}
+      HARBOR_IMAGE_REPOSITORY: ${{ vars.HARBOR_IMAGE_REPOSITORY }}
+    steps:
+      - name: Resolve deploy inputs
+        id: prep
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            checkout_ref="${{ github.event.workflow_run.head_sha }}"
+          elif [ -n "${{ inputs.git_ref }}" ]; then
+            checkout_ref="${{ inputs.git_ref }}"
+          else
+            checkout_ref="${{ github.sha }}"
+          fi
+
+          image_repository="${HARBOR_IMAGE_REPOSITORY}"
+          if [ -z "$image_repository" ]; then
+            image_repository="ghcr.io/${GITHUB_REPOSITORY,,}"
+          fi
+
+          deploy_image_reference="${{ inputs.image_reference }}"
+          if [ -n "$deploy_image_reference" ]; then
+            should_build="false"
+          else
+            should_build="true"
+          fi
+
+          {
+            echo "checkout_ref=$checkout_ref"
+            echo "image_repository=$image_repository"
+            echo "should_build=$should_build"
+            echo "deploy_image_reference=$deploy_image_reference"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate deploy configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${DOKPLOY_HOST:?Missing DOKPLOY_HOST secret}"
+          : "${DOKPLOY_TOKEN:?Missing DOKPLOY_TOKEN secret}"
+          : "${HARBOR_DOKPLOY_TARGET_TYPE:?Missing HARBOR_DOKPLOY_TARGET_TYPE variable}"
+          : "${HARBOR_DOKPLOY_TARGET_ID:?Missing HARBOR_DOKPLOY_TARGET_ID variable}"
+          : "${HARBOR_DEPLOY_HEALTH_URLS:?Missing HARBOR_DEPLOY_HEALTH_URLS variable}"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.prep.outputs.checkout_ref }}
+
+      - name: Set up Docker Buildx
+        if: steps.prep.outputs.should_build == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: steps.prep.outputs.should_build == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Harbor image
+        if: steps.prep.outputs.should_build == 'true'
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ steps.prep.outputs.image_repository }}:main
+            ${{ steps.prep.outputs.image_repository }}:sha-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Resolve image reference
+        id: image
+        shell: bash
+        run: |
+          set -euo pipefail
+          image_reference="${{ steps.prep.outputs.deploy_image_reference }}"
+          if [ -z "$image_reference" ]; then
+            image_reference="${{ steps.prep.outputs.image_repository }}@${{ steps.build.outputs.digest }}"
+          fi
+          echo "image_reference=$image_reference" >> "$GITHUB_OUTPUT"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: pyproject.toml
+
+      - name: Deploy Harbor in Dokploy
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          health_args=()
+          while IFS= read -r raw_url; do
+            health_url="$(printf '%s' "$raw_url" | xargs)"
+            if [ -n "$health_url" ]; then
+              health_args+=(--health-url "$health_url")
+            fi
+          done < <(printf '%s\n' "$HARBOR_DEPLOY_HEALTH_URLS" | tr ',' '\n')
+
+          uv run harbor service deploy-dokploy-image \
+            --target-type "$HARBOR_DOKPLOY_TARGET_TYPE" \
+            --target-id "$HARBOR_DOKPLOY_TARGET_ID" \
+            --image-reference "${{ steps.image.outputs.image_reference }}" \
+            --deploy-timeout-seconds "${HARBOR_DOKPLOY_DEPLOY_TIMEOUT_SECONDS:-600}" \
+            --health-timeout-seconds "${HARBOR_DEPLOY_HEALTH_TIMEOUT_SECONDS:-180}" \
+            "${health_args[@]}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.13-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    UV_LINK_MODE=copy
+
+RUN pip install --no-cache-dir uv
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock README.md /app/
+COPY control_plane /app/control_plane
+COPY config /app/config
+COPY scripts /app/scripts
+
+RUN uv sync --frozen --no-dev
+
+ENV PATH="/app/.venv/bin:${PATH}"
+
+EXPOSE 8080
+
+CMD ["/app/scripts/start-harbor-service.sh"]

--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ similar long-running hosts:
 - `docker-compose.yml`
 - `scripts/start-harbor-service.sh`
 
+The compose service now expects the Harbor container image through
+`DOCKER_IMAGE_REFERENCE`. Dokploy should set that to an immutable GHCR digest
+for real Harbor deploys. For purely local compose usage, build a local image
+first, for example `docker build -t harbor:local .`, then run `docker compose up`.
+
 The entrypoint can bootstrap operator-local files from environment variables so
 the deployed service does not need checked-in secret or target-id files:
 
@@ -111,6 +116,38 @@ Regular runtime env such as `DOKPLOY_HOST`, `DOKPLOY_TOKEN`, and any
 `DOKPLOY_SHIP_MODE_*` overrides can still be passed directly as process
 environment variables. `HARBOR_MASTER_ENCRYPTION_KEY` must be present whenever
 Harbor needs to read or write DB-backed managed secrets.
+
+The intended first real Harbor bring-up path is GitHub-driven deploy, not a
+manual laptop-side image swap. The current operator posture is:
+
+- `CI` remains the separate test gate and must pass before Harbor deploy
+  automation replaces the live Dokploy app.
+- Harbor currently targets a single real Dokploy-hosted service instance,
+  without a separate Harbor testing lane yet.
+- Deploys should update Dokploy by immutable image digest and capture the
+  previously running digest before replacement.
+- Deploy automation should verify Harbor health after rollout and immediately
+  restore the previous digest when the new image fails health checks.
+- Until Harbor has a formal schema migration system, Postgres schema changes
+  must remain additive and backward-compatible so code rollback stays viable.
+
+The repo now includes `.github/workflows/deploy-harbor.yml` for that path.
+Configure these GitHub settings before enabling it:
+
+- repository secrets:
+  - `DOKPLOY_HOST`
+  - `DOKPLOY_TOKEN`
+- repository variables:
+  - `HARBOR_DOKPLOY_TARGET_TYPE`
+  - `HARBOR_DOKPLOY_TARGET_ID`
+  - `HARBOR_DEPLOY_HEALTH_URLS`
+  - optional `HARBOR_DOKPLOY_DEPLOY_TIMEOUT_SECONDS`
+  - optional `HARBOR_DEPLOY_HEALTH_TIMEOUT_SECONDS`
+  - optional `HARBOR_IMAGE_REPOSITORY`
+
+Manual `workflow_dispatch` may also deploy an explicit prior image reference,
+which acts as the first operator rollback path while Harbor still has only one
+real Dokploy-hosted service instance.
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ Shared-service core records can now be backed by Postgres with
 `HARBOR_DATABASE_URL` or `uv run harbor service serve --database-url ...`.
 The same service boundary now exposes authenticated operator read endpoints for
 deployment, promotion, inventory, preview, preview history, and recent
-context-scoped operations.
+context-scoped operations. Harbor-managed secrets now use the same Postgres
+backend, with encrypted secret values stored in DB and a bootstrap import path
+from the existing `dokploy.env` and runtime-environment file surfaces.
 
 ## Quick Start
 
@@ -61,6 +63,7 @@ cp config/dokploy-targets.toml.example config/dokploy-targets.toml
 uv run harbor --help
 uv run harbor service serve --help
 uv run harbor storage import-core-records --help
+uv run harbor secrets import-bootstrap --help
 uv run python -m unittest
 ```
 
@@ -69,6 +72,11 @@ external Harbor config files such as
 `${XDG_CONFIG_HOME:-$HOME/.config}/harbor/dokploy.env` and
 `${XDG_CONFIG_HOME:-$HOME/.config}/harbor/runtime-environments.toml`, not from
 repo-local secret files.
+
+Once Harbor-managed secret records exist in Postgres, Harbor reads those
+encrypted DB-backed values first for Dokploy credentials and runtime
+environment secret keys, then falls back to the older file/env surfaces only
+when no Harbor-managed secret has been written yet.
 
 For the first local Harbor service run, copy
 `config/harbor-authz.toml.example` to a local policy file and adjust the repo,
@@ -94,13 +102,15 @@ The entrypoint can bootstrap operator-local files from environment variables so
 the deployed service does not need checked-in secret or target-id files:
 
 - `HARBOR_DATABASE_URL`
+- `HARBOR_MASTER_ENCRYPTION_KEY`
 - `HARBOR_POLICY_TOML` or `HARBOR_POLICY_B64`
 - `HARBOR_DOKPLOY_TARGET_IDS_TOML` or `HARBOR_DOKPLOY_TARGET_IDS_B64`
 - `HARBOR_RUNTIME_ENVIRONMENTS_TOML` or `HARBOR_RUNTIME_ENVIRONMENTS_B64`
 
 Regular runtime env such as `DOKPLOY_HOST`, `DOKPLOY_TOKEN`, and any
 `DOKPLOY_SHIP_MODE_*` overrides can still be passed directly as process
-environment variables.
+environment variables. `HARBOR_MASTER_ENCRYPTION_KEY` must be present whenever
+Harbor needs to read or write DB-backed managed secrets.
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ shape. The intended direction is:
 The first implemented ingress slice now exists in this repo as a local Harbor
 service command with GitHub OIDC verification, a static workflow policy, and
 evidence ingress for deployments, promotions, and the full preview lifecycle.
+Shared-service core records can now be backed by Postgres with
+`HARBOR_DATABASE_URL` or `uv run harbor service serve --database-url ...`.
+The same service boundary now exposes authenticated operator read endpoints for
+deployment, promotion, inventory, preview, preview history, and recent
+context-scoped operations.
 
 ## Quick Start
 
@@ -55,6 +60,7 @@ mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/harbor"
 cp config/dokploy-targets.toml.example config/dokploy-targets.toml
 uv run harbor --help
 uv run harbor service serve --help
+uv run harbor storage import-core-records --help
 uv run python -m unittest
 ```
 
@@ -74,6 +80,27 @@ operator-local target IDs supplied through `config/dokploy-targets.toml`.
 The stable remote lane catalog is now `testing` plus `prod`; pull requests use
 Harbor-managed preview identities and ephemeral preview stacks instead of a
 durable shared `dev` lane.
+
+## Service Container Deploy
+
+The repo now includes a containerized Harbor service entrypoint for Dokploy or
+similar long-running hosts:
+
+- `Dockerfile`
+- `docker-compose.yml`
+- `scripts/start-harbor-service.sh`
+
+The entrypoint can bootstrap operator-local files from environment variables so
+the deployed service does not need checked-in secret or target-id files:
+
+- `HARBOR_DATABASE_URL`
+- `HARBOR_POLICY_TOML` or `HARBOR_POLICY_B64`
+- `HARBOR_DOKPLOY_TARGET_IDS_TOML` or `HARBOR_DOKPLOY_TARGET_IDS_B64`
+- `HARBOR_RUNTIME_ENVIRONMENTS_TOML` or `HARBOR_RUNTIME_ENVIRONMENTS_B64`
+
+Regular runtime env such as `DOKPLOY_HOST`, `DOKPLOY_TOKEN`, and any
+`DOKPLOY_SHIP_MODE_*` overrides can still be passed directly as process
+environment variables.
 
 ## Docs
 

--- a/config/dokploy-targets.toml.example
+++ b/config/dokploy-targets.toml.example
@@ -23,3 +23,8 @@ target_id = "opw-testing-compose-id"
 context = "opw"
 instance = "prod"
 target_id = "opw-prod-compose-id"
+
+[[targets]]
+context = "verireel"
+instance = "testing"
+target_id = "verireel-testing-application-id"

--- a/config/dokploy.toml
+++ b/config/dokploy.toml
@@ -93,3 +93,15 @@ domains = ["opw-prod.shinycomputers.com"]
 
 [targets.env]
 ENV_OVERRIDE_CONFIG_PARAM__WEB__BASE__URL = "https://opw-prod.shinycomputers.com"
+
+[[targets]]
+project_name = "verireel"
+target_type = "application"
+context = "verireel"
+instance = "testing"
+target_name = "ver-testing-app"
+require_test_gate = true
+require_prod_gate = false
+deploy_timeout_seconds = 600
+healthcheck_enabled = false
+domains = ["ver-testing.shinycomputers.com"]

--- a/config/harbor-authz.toml.example
+++ b/config/harbor-authz.toml.example
@@ -21,6 +21,26 @@ contexts = ["verireel-testing"]
 actions = ["preview_destroyed.write"]
 
 [[github_actions]]
+repository = "every/verireel"
+workflow_refs = [
+  "every/verireel/.github/workflows/publish-image.yml@refs/heads/main",
+]
+event_names = ["push", "workflow_dispatch"]
+products = ["verireel"]
+contexts = ["verireel"]
+actions = ["deployment.write"]
+
+[[github_actions]]
+repository = "every/verireel"
+workflow_refs = [
+  "every/verireel/.github/workflows/promote-image.yml@refs/heads/main",
+]
+event_names = ["workflow_dispatch"]
+products = ["verireel"]
+contexts = ["verireel"]
+actions = ["promotion.write"]
+
+[[github_actions]]
 repository = "every/tenant-opw"
 workflow_refs = [
   "every/tenant-opw/.github/workflows/harbor-preview.yml@refs/heads/main",

--- a/config/harbor-authz.toml.example
+++ b/config/harbor-authz.toml.example
@@ -33,6 +33,16 @@ actions = ["deployment.write"]
 [[github_actions]]
 repository = "every/verireel"
 workflow_refs = [
+  "every/verireel/.github/workflows/publish-image.yml@refs/heads/main",
+]
+event_names = ["push", "workflow_dispatch"]
+products = ["verireel"]
+contexts = ["verireel"]
+actions = ["verireel_testing_deploy.execute"]
+
+[[github_actions]]
+repository = "every/verireel"
+workflow_refs = [
   "every/verireel/.github/workflows/promote-image.yml@refs/heads/main",
 ]
 event_names = ["workflow_dispatch"]

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -16,6 +16,7 @@ from pydantic import ValidationError
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import release_tuples as control_plane_release_tuples
 from control_plane import runtime_environments as control_plane_runtime_environments
+from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
@@ -7024,6 +7025,11 @@ def storage() -> None:
     """Harbor storage commands."""
 
 
+@main.group()
+def secrets() -> None:
+    """Harbor managed secret commands."""
+
+
 @storage.command("import-core-records")
 @click.option(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
@@ -7040,6 +7046,124 @@ def storage_import_core_records(state_dir: Path, database_url: str) -> None:
     postgres_store.ensure_schema()
     counts = postgres_store.import_core_records_from_filesystem(filesystem_store)
     click.echo(json.dumps({"status": "ok", "counts": counts}, indent=2, sort_keys=True))
+
+
+@secrets.command("import-bootstrap")
+@click.option(
+    "--database-url",
+    envvar="HARBOR_DATABASE_URL",
+    required=True,
+    help="Postgres connection string for Harbor managed secrets.",
+)
+@click.option(
+    "--control-plane-root",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Optional Harbor repo root to scan for existing bootstrap secret sources.",
+)
+@click.option("--actor", default="bootstrap", show_default=True)
+def secrets_import_bootstrap(database_url: str, control_plane_root: Path | None, actor: str) -> None:
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    postgres_store.ensure_schema()
+    try:
+        summary = control_plane_secrets.import_bootstrap_secrets(
+            record_store=postgres_store,
+            control_plane_root=control_plane_root or _control_plane_root(),
+            actor=actor,
+        )
+    finally:
+        postgres_store.close()
+    click.echo(json.dumps({"status": "ok", "summary": summary}, indent=2, sort_keys=True))
+
+
+@secrets.command("put")
+@click.option(
+    "--database-url",
+    envvar="HARBOR_DATABASE_URL",
+    required=True,
+    help="Postgres connection string for Harbor managed secrets.",
+)
+@click.option("--scope", type=click.Choice(["global", "context", "context_instance"]), required=True)
+@click.option("--integration", required=True)
+@click.option("--name", required=True)
+@click.option("--binding-key", required=True)
+@click.option("--value", required=True)
+@click.option("--context", "context_name", default="")
+@click.option("--instance", "instance_name", default="")
+@click.option("--description", default="")
+@click.option("--actor", default="cli", show_default=True)
+def secrets_put(
+    database_url: str,
+    scope: str,
+    integration: str,
+    name: str,
+    binding_key: str,
+    value: str,
+    context_name: str,
+    instance_name: str,
+    description: str,
+    actor: str,
+) -> None:
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    postgres_store.ensure_schema()
+    try:
+        result = control_plane_secrets.write_secret_value(
+            record_store=postgres_store,
+            scope=scope,
+            integration=integration,
+            name=name,
+            plaintext_value=value,
+            binding_key=binding_key,
+            context_name=context_name,
+            instance_name=instance_name,
+            description=description,
+            actor=actor,
+        )
+        payload = control_plane_secrets.build_secret_status(postgres_store, secret_id=result["secret_id"])
+    finally:
+        postgres_store.close()
+    click.echo(json.dumps({"status": "ok", "result": result, "secret": payload}, indent=2, sort_keys=True))
+
+
+@secrets.command("list")
+@click.option(
+    "--database-url",
+    envvar="HARBOR_DATABASE_URL",
+    required=True,
+    help="Postgres connection string for Harbor managed secrets.",
+)
+@click.option("--integration", default="")
+@click.option("--context", "context_name", default="")
+@click.option("--instance", "instance_name", default="")
+def secrets_list(database_url: str, integration: str, context_name: str, instance_name: str) -> None:
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    try:
+        payload = control_plane_secrets.list_secret_statuses(
+            postgres_store,
+            integration=integration,
+            context_name=context_name,
+            instance_name=instance_name,
+        )
+    finally:
+        postgres_store.close()
+    click.echo(json.dumps(payload, indent=2, sort_keys=True))
+
+
+@secrets.command("show")
+@click.option(
+    "--database-url",
+    envvar="HARBOR_DATABASE_URL",
+    required=True,
+    help="Postgres connection string for Harbor managed secrets.",
+)
+@click.option("--secret-id", required=True)
+def secrets_show(database_url: str, secret_id: str) -> None:
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    try:
+        payload = control_plane_secrets.build_secret_status(postgres_store, secret_id=secret_id)
+    finally:
+        postgres_store.close()
+    click.echo(json.dumps(payload, indent=2, sort_keys=True))
 
 
 @service.command("serve")

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -58,6 +58,7 @@ from control_plane.harbor_mutations import (
 )
 from control_plane.service import serve_harbor_service
 from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.harbor import (
     adapt_github_webhook_pull_request_event,
     apply_generation_failed_transition,
@@ -701,6 +702,10 @@ def _build_harbor_preview_enablement_action_payload(
             "summary": "The current tenant snapshot is missing the exact anchor PR evidence needed for a typed request-generation recipe.",
             "recipe": "",
         }
+    if request_metadata_companions and not request_metadata_companion_summaries:
+        return unresolved_companion_payload(
+            detail="The saved PR metadata asks Harbor to include companion pull requests, but Harbor has no exact companion head SHA snapshot for this enablement record."
+        )
 
     synthetic_event = GitHubPullRequestEvent(
         action="opened",
@@ -7014,6 +7019,29 @@ def service() -> None:
     """Harbor service commands."""
 
 
+@main.group()
+def storage() -> None:
+    """Harbor storage commands."""
+
+
+@storage.command("import-core-records")
+@click.option(
+    "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
+)
+@click.option(
+    "--database-url",
+    envvar="HARBOR_DATABASE_URL",
+    required=True,
+    help="Postgres connection string for Harbor shared-service core records.",
+)
+def storage_import_core_records(state_dir: Path, database_url: str) -> None:
+    filesystem_store = FilesystemRecordStore(state_dir=state_dir)
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    postgres_store.ensure_schema()
+    counts = postgres_store.import_core_records_from_filesystem(filesystem_store)
+    click.echo(json.dumps({"status": "ok", "counts": counts}, indent=2, sort_keys=True))
+
+
 @service.command("serve")
 @click.option(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
@@ -7027,13 +7055,27 @@ def service() -> None:
     show_default=True,
     help="Expected GitHub OIDC audience for Harbor service tokens.",
 )
-def service_serve(state_dir: Path, policy_file: Path, host: str, port: int, audience: str) -> None:
+@click.option(
+    "--database-url",
+    envvar="HARBOR_DATABASE_URL",
+    default=None,
+    help="Postgres connection string for Harbor shared-service core records.",
+)
+def service_serve(
+    state_dir: Path,
+    policy_file: Path,
+    host: str,
+    port: int,
+    audience: str,
+    database_url: str | None,
+) -> None:
     serve_harbor_service(
         state_dir=state_dir,
         policy_file=policy_file,
         host=host,
         port=port,
         audience=audience,
+        database_url=database_url,
     )
 
 

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -5720,6 +5720,138 @@ def _verify_ship_healthchecks(*, request: ShipRequest) -> None:
         )
 
 
+def _verify_healthcheck_urls(*, health_urls: tuple[str, ...], timeout_seconds: int) -> None:
+    if not health_urls:
+        raise click.ClickException("At least one Harbor service health URL is required.")
+    if timeout_seconds <= 0:
+        raise click.ClickException("Harbor service health timeout must be greater than zero seconds.")
+    healthcheck_errors: list[str] = []
+    for healthcheck_url in health_urls:
+        try:
+            _wait_for_ship_healthcheck(url=healthcheck_url, timeout_seconds=timeout_seconds)
+            return
+        except click.ClickException as error:
+            healthcheck_errors.append(str(error))
+    raise click.ClickException(
+        "Harbor service health verification failed for all configured URLs:\n"
+        + "\n".join(healthcheck_errors)
+    )
+
+
+def _apply_dokploy_image_reference(
+    *,
+    host: str,
+    token: str,
+    target_type: str,
+    target_id: str,
+    image_reference: str,
+) -> dict[str, object]:
+    normalized_image_reference = image_reference.strip()
+    if not normalized_image_reference:
+        raise click.ClickException("Harbor service deploy requires a non-empty image reference.")
+    target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
+        host=host,
+        token=token,
+        target_type=target_type,
+        target_id=target_id,
+    )
+    raw_env_text = str(target_payload.get("env") or "")
+    env_map = control_plane_dokploy.parse_dokploy_env_text(raw_env_text)
+    previous_value_present = ARTIFACT_IMAGE_REFERENCE_ENV_KEY in env_map
+    previous_image_reference = env_map.get(ARTIFACT_IMAGE_REFERENCE_ENV_KEY, "")
+    updated_env_text = control_plane_dokploy.render_dokploy_env_text_with_overrides(
+        raw_env_text,
+        updates={ARTIFACT_IMAGE_REFERENCE_ENV_KEY: normalized_image_reference},
+    )
+    if updated_env_text != raw_env_text:
+        control_plane_dokploy.update_dokploy_target_env(
+            host=host,
+            token=token,
+            target_type=target_type,
+            target_id=target_id,
+            target_payload=target_payload,
+            env_text=updated_env_text,
+        )
+    return {
+        "previous_image_reference": previous_image_reference,
+        "previous_image_reference_present": previous_value_present,
+        "image_reference_changed": updated_env_text != raw_env_text,
+    }
+
+
+def _restore_dokploy_image_reference(
+    *,
+    host: str,
+    token: str,
+    target_type: str,
+    target_id: str,
+    image_reference: str,
+    value_present: bool,
+) -> dict[str, object]:
+    target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
+        host=host,
+        token=token,
+        target_type=target_type,
+        target_id=target_id,
+    )
+    raw_env_text = str(target_payload.get("env") or "")
+    if value_present:
+        restored_env_text = control_plane_dokploy.render_dokploy_env_text_with_overrides(
+            raw_env_text,
+            updates={ARTIFACT_IMAGE_REFERENCE_ENV_KEY: image_reference},
+        )
+    else:
+        restored_env_text = control_plane_dokploy.render_dokploy_env_text_with_overrides(
+            raw_env_text,
+            removals=(ARTIFACT_IMAGE_REFERENCE_ENV_KEY,),
+        )
+    if restored_env_text != raw_env_text:
+        control_plane_dokploy.update_dokploy_target_env(
+            host=host,
+            token=token,
+            target_type=target_type,
+            target_id=target_id,
+            target_payload=target_payload,
+            env_text=restored_env_text,
+        )
+    return {"image_reference_changed": restored_env_text != raw_env_text}
+
+
+def _trigger_and_wait_for_dokploy_target_deploy(
+    *,
+    host: str,
+    token: str,
+    target_type: str,
+    target_id: str,
+    deploy_timeout_seconds: int,
+    no_cache: bool,
+) -> dict[str, str]:
+    if deploy_timeout_seconds <= 0:
+        raise click.ClickException("Harbor service deploy timeout must be greater than zero seconds.")
+    latest_before = control_plane_dokploy.latest_deployment_for_target(
+        host=host,
+        token=token,
+        target_type=target_type,
+        target_id=target_id,
+    )
+    control_plane_dokploy.trigger_deployment(
+        host=host,
+        token=token,
+        target_type=target_type,
+        target_id=target_id,
+        no_cache=no_cache,
+    )
+    deployment_result = control_plane_dokploy.wait_for_target_deployment(
+        host=host,
+        token=token,
+        target_type=target_type,
+        target_id=target_id,
+        before_key=control_plane_dokploy.deployment_key(latest_before),
+        timeout_seconds=deploy_timeout_seconds,
+    )
+    return {"deployment_result": deployment_result}
+
+
 def _resolve_dokploy_target(
     *,
     request: ShipRequest,
@@ -7201,6 +7333,128 @@ def service_serve(
         audience=audience,
         database_url=database_url,
     )
+
+
+@service.command("deploy-dokploy-image")
+@click.option(
+    "--target-type",
+    type=click.Choice(["compose", "application"]),
+    envvar="HARBOR_DOKPLOY_TARGET_TYPE",
+    required=True,
+    help="Dokploy target type for the live Harbor service.",
+)
+@click.option(
+    "--target-id",
+    envvar="HARBOR_DOKPLOY_TARGET_ID",
+    required=True,
+    help="Dokploy target id for the live Harbor service.",
+)
+@click.option("--image-reference", required=True, help="Immutable image reference to deploy, usually repo@sha256:...")
+@click.option(
+    "--health-url",
+    "health_urls",
+    multiple=True,
+    required=True,
+    help="Public Harbor health URL to verify after Dokploy rollout. Repeat for alternate URLs.",
+)
+@click.option("--deploy-timeout-seconds", type=int, default=600, show_default=True)
+@click.option("--health-timeout-seconds", type=int, default=180, show_default=True)
+@click.option("--rollback-on-failure/--no-rollback-on-failure", default=True, show_default=True)
+@click.option("--no-cache", is_flag=True, default=False, help="Request Dokploy no-cache redeploy semantics when supported.")
+@click.option(
+    "--control-plane-root",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Optional Harbor repo root used to resolve Dokploy credentials.",
+)
+def service_deploy_dokploy_image(
+    target_type: str,
+    target_id: str,
+    image_reference: str,
+    health_urls: tuple[str, ...],
+    deploy_timeout_seconds: int,
+    health_timeout_seconds: int,
+    rollback_on_failure: bool,
+    no_cache: bool,
+    control_plane_root: Path | None,
+) -> None:
+    harbor_root = control_plane_root or _control_plane_root()
+    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=harbor_root)
+    normalized_health_urls = tuple(url.strip() for url in health_urls if url.strip())
+    apply_result = _apply_dokploy_image_reference(
+        host=host,
+        token=token,
+        target_type=target_type,
+        target_id=target_id,
+        image_reference=image_reference,
+    )
+    payload: dict[str, object] = {
+        "status": "pending",
+        "target_type": target_type,
+        "target_id": target_id,
+        "image_reference": image_reference,
+        "health_urls": list(normalized_health_urls),
+        "deploy_timeout_seconds": deploy_timeout_seconds,
+        "health_timeout_seconds": health_timeout_seconds,
+        "rollback_on_failure": rollback_on_failure,
+        **apply_result,
+    }
+    previous_image_reference = str(apply_result["previous_image_reference"])
+    previous_value_present = bool(apply_result["previous_image_reference_present"])
+    rollback_payload: dict[str, object] | None = None
+    try:
+        payload.update(
+            _trigger_and_wait_for_dokploy_target_deploy(
+                host=host,
+                token=token,
+                target_type=target_type,
+                target_id=target_id,
+                deploy_timeout_seconds=deploy_timeout_seconds,
+                no_cache=no_cache,
+            )
+        )
+        _verify_healthcheck_urls(health_urls=normalized_health_urls, timeout_seconds=health_timeout_seconds)
+        payload["status"] = "ok"
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    except click.ClickException as error:
+        payload["status"] = "failed"
+        payload["error"] = str(error)
+        if rollback_on_failure:
+            rollback_payload = {
+                "requested_image_reference": previous_image_reference,
+                "requested_image_reference_present": previous_value_present,
+                "status": "pending",
+            }
+            try:
+                rollback_payload.update(
+                    _restore_dokploy_image_reference(
+                        host=host,
+                        token=token,
+                        target_type=target_type,
+                        target_id=target_id,
+                        image_reference=previous_image_reference,
+                        value_present=previous_value_present,
+                    )
+                )
+                rollback_payload.update(
+                    _trigger_and_wait_for_dokploy_target_deploy(
+                        host=host,
+                        token=token,
+                        target_type=target_type,
+                        target_id=target_id,
+                        deploy_timeout_seconds=deploy_timeout_seconds,
+                        no_cache=no_cache,
+                    )
+                )
+                _verify_healthcheck_urls(health_urls=normalized_health_urls, timeout_seconds=health_timeout_seconds)
+                rollback_payload["status"] = "ok"
+            except click.ClickException as rollback_error:
+                rollback_payload["status"] = "failed"
+                rollback_payload["error"] = str(rollback_error)
+        payload["rollback"] = rollback_payload
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        raise click.ClickException(str(error)) from error
 
 
 @artifacts.command("write")

--- a/control_plane/contracts/secret_record.py
+++ b/control_plane/contracts/secret_record.py
@@ -1,0 +1,126 @@
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+SecretScope = Literal["global", "context", "context_instance"]
+SecretPolicy = Literal["write_only"]
+SecretStatus = Literal["configured", "disabled"]
+SecretEventType = Literal["created", "rotated", "imported", "validated", "disabled"]
+
+
+class SecretRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    secret_id: str
+    scope: SecretScope
+    integration: str
+    name: str
+    context: str = ""
+    instance: str = ""
+    description: str = ""
+    policy: SecretPolicy = "write_only"
+    status: SecretStatus = "configured"
+    current_version_id: str
+    created_at: str
+    updated_at: str
+    last_validated_at: str = ""
+    updated_by: str = ""
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "SecretRecord":
+        if not self.secret_id.strip():
+            raise ValueError("secret record requires secret_id")
+        if not self.integration.strip():
+            raise ValueError("secret record requires integration")
+        if not self.name.strip():
+            raise ValueError("secret record requires name")
+        if not self.current_version_id.strip():
+            raise ValueError("secret record requires current_version_id")
+        if not self.created_at.strip() or not self.updated_at.strip():
+            raise ValueError("secret record requires created_at and updated_at")
+        if self.scope in {"context", "context_instance"} and not self.context.strip():
+            raise ValueError("context-scoped secret record requires context")
+        if self.scope == "context_instance" and not self.instance.strip():
+            raise ValueError("instance-scoped secret record requires instance")
+        if self.scope != "context_instance" and self.instance.strip():
+            raise ValueError("only instance-scoped secret records may set instance")
+        return self
+
+
+class SecretVersion(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    version_id: str
+    secret_id: str
+    created_at: str
+    created_by: str = ""
+    cipher_alg: Literal["fernet-v1"] = "fernet-v1"
+    key_id: str = "harbor-master-key"
+    ciphertext: str
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "SecretVersion":
+        if not self.version_id.strip():
+            raise ValueError("secret version requires version_id")
+        if not self.secret_id.strip():
+            raise ValueError("secret version requires secret_id")
+        if not self.created_at.strip():
+            raise ValueError("secret version requires created_at")
+        if not self.ciphertext.strip():
+            raise ValueError("secret version requires ciphertext")
+        return self
+
+
+class SecretBinding(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    binding_id: str
+    secret_id: str
+    integration: str
+    binding_type: Literal["env"] = "env"
+    binding_key: str
+    context: str = ""
+    instance: str = ""
+    status: SecretStatus = "configured"
+    created_at: str
+    updated_at: str
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "SecretBinding":
+        if not self.binding_id.strip():
+            raise ValueError("secret binding requires binding_id")
+        if not self.secret_id.strip():
+            raise ValueError("secret binding requires secret_id")
+        if not self.integration.strip():
+            raise ValueError("secret binding requires integration")
+        if not self.binding_key.strip():
+            raise ValueError("secret binding requires binding_key")
+        if not self.created_at.strip() or not self.updated_at.strip():
+            raise ValueError("secret binding requires created_at and updated_at")
+        return self
+
+
+class SecretAuditEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    event_id: str
+    secret_id: str
+    event_type: SecretEventType
+    recorded_at: str
+    actor: str = ""
+    detail: str = ""
+    metadata: dict[str, str] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "SecretAuditEvent":
+        if not self.event_id.strip():
+            raise ValueError("secret audit event requires event_id")
+        if not self.secret_id.strip():
+            raise ValueError("secret audit event requires secret_id")
+        if not self.recorded_at.strip():
+            raise ValueError("secret audit event requires recorded_at")
+        return self

--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -523,6 +523,21 @@ def parse_dokploy_env_text(raw_env_text: str) -> dict[str, str]:
     return env_map
 
 
+def render_dokploy_env_text_with_overrides(
+    raw_env_text: str,
+    *,
+    updates: Mapping[str, str] | None = None,
+    removals: tuple[str, ...] = (),
+) -> str:
+    env_map = parse_dokploy_env_text(raw_env_text)
+    for env_key in removals:
+        env_map.pop(env_key, None)
+    if updates is not None:
+        for env_key, env_value in updates.items():
+            env_map[env_key] = env_value
+    return serialize_dokploy_env_text(env_map)
+
+
 def serialize_dokploy_env_text(env_map: dict[str, str]) -> str:
     if not env_map:
         return ""

--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -14,6 +14,8 @@ from urllib.request import Request, urlopen
 import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane import secrets as control_plane_secrets
+
 DEFAULT_DOKPLOY_DEPLOY_TIMEOUT_SECONDS = 600
 DEFAULT_DOKPLOY_HEALTH_TIMEOUT_SECONDS = 180
 DEFAULT_DOKPLOY_HEALTHCHECK_PATH = "/web/health"
@@ -305,7 +307,8 @@ def load_runtime_environment_values(
 
 def read_control_plane_environment_values(*, control_plane_root: Path) -> dict[str, str]:
     control_plane_env_file = resolve_control_plane_env_file(control_plane_root)
-    return load_runtime_environment_values(default_env_file=control_plane_env_file)
+    environment_values = load_runtime_environment_values(default_env_file=control_plane_env_file)
+    return control_plane_secrets.overlay_dokploy_environment_values(environment_values=environment_values)
 
 
 def resolve_harbor_config_dir() -> Path:

--- a/control_plane/runtime_environments.py
+++ b/control_plane/runtime_environments.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import click
 
 from control_plane import dokploy as control_plane_dokploy
+from control_plane import secrets as control_plane_secrets
 
 RUNTIME_ENVIRONMENTS_FILE_ENV_VAR = "ODOO_CONTROL_PLANE_RUNTIME_ENVIRONMENTS_FILE"
 DEFAULT_RUNTIME_ENVIRONMENTS_FILE = "config/runtime-environments.toml"
@@ -98,7 +99,11 @@ def resolve_runtime_environment_values(
             instance_name=instance_name,
         )
     )
-    return merged_values
+    return control_plane_secrets.overlay_runtime_environment_secret_values(
+        environment_values=merged_values,
+        context_name=context_name,
+        instance_name=instance_name,
+    )
 
 
 def resolve_runtime_context_values(
@@ -114,7 +119,10 @@ def resolve_runtime_context_values(
             f"Runtime environments file has no context definition for {context_name!r}."
         )
     merged_values.update(_normalize_scalar_map(context_definition.shared_env))
-    return merged_values
+    return control_plane_secrets.overlay_runtime_environment_secret_values(
+        environment_values=merged_values,
+        context_name=context_name,
+    )
 
 
 def resolve_tracked_target_environment_values(

--- a/control_plane/secrets.py
+++ b/control_plane/secrets.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import re
+import uuid
+from pathlib import Path
+from typing import Any, Literal
+
+import click
+from cryptography.fernet import Fernet, InvalidToken
+
+from control_plane.contracts.secret_record import SecretAuditEvent, SecretBinding, SecretRecord, SecretScope, SecretVersion
+from control_plane.storage.factory import resolve_database_url
+from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.workflows.ship import utc_now_timestamp
+
+HARBOR_SECRET_MASTER_KEY_ENV_VAR = "HARBOR_MASTER_ENCRYPTION_KEY"
+DOKPLOY_SECRET_INTEGRATION = "dokploy"
+RUNTIME_ENVIRONMENT_SECRET_INTEGRATION = "runtime_environment"
+SECRET_STATUS_CONFIGURED = "configured"
+SECRET_VALUE_PATTERN = re.compile(r"(^|_)(PASSWORD|TOKEN|SECRET|KEY)(_|$)")
+
+SecretWriteAction = Literal["created", "rotated", "unchanged"]
+
+
+def _secret_slug(value: str) -> str:
+    compact = "".join(character.lower() if character.isalnum() else "-" for character in value.strip())
+    normalized = "-".join(part for part in compact.split("-") if part)
+    return normalized or "secret"
+
+
+def _secret_id(*, integration: str, name: str, context: str, instance: str) -> str:
+    parts = ["secret", integration, name]
+    if context.strip():
+        parts.append(context)
+    if instance.strip():
+        parts.append(instance)
+    return "-".join(_secret_slug(part) for part in parts)
+
+
+def _binding_id(*, secret_id: str, binding_key: str) -> str:
+    return f"{secret_id}-binding-{_secret_slug(binding_key)}"
+
+
+def _version_id(*, secret_id: str) -> str:
+    return f"{secret_id}-version-{uuid.uuid4().hex[:12]}"
+
+
+def _audit_event_id(*, secret_id: str, event_type: str) -> str:
+    return f"{secret_id}-event-{_secret_slug(event_type)}-{uuid.uuid4().hex[:12]}"
+
+
+def _scope_rank(scope: str) -> int:
+    if scope == "global":
+        return 0
+    if scope == "context":
+        return 1
+    return 2
+
+
+def _runtime_environment_key_is_secret(key_name: str) -> bool:
+    return bool(SECRET_VALUE_PATTERN.search(key_name.strip().upper()))
+
+
+def _master_fernet_key(raw_key: str) -> bytes:
+    normalized = raw_key.strip()
+    if not normalized:
+        raise click.ClickException(
+            f"Harbor managed secrets require {HARBOR_SECRET_MASTER_KEY_ENV_VAR} to read or write encrypted values."
+        )
+    encoded = normalized.encode("utf-8")
+    try:
+        Fernet(encoded)
+        return encoded
+    except (ValueError, TypeError):
+        digest = hashlib.sha256(encoded).digest()
+        return base64.urlsafe_b64encode(digest)
+
+
+def _secret_cipher() -> Fernet:
+    return Fernet(_master_fernet_key(os.environ.get(HARBOR_SECRET_MASTER_KEY_ENV_VAR, "")))
+
+
+def _encrypt_secret_value(plaintext_value: str) -> str:
+    return _secret_cipher().encrypt(plaintext_value.encode("utf-8")).decode("utf-8")
+
+
+def _decrypt_secret_value(ciphertext: str) -> str:
+    try:
+        return _secret_cipher().decrypt(ciphertext.encode("utf-8")).decode("utf-8")
+    except InvalidToken as error:
+        raise click.ClickException(
+            "Harbor could not decrypt a managed secret with the configured master key."
+        ) from error
+
+
+def _open_secret_store(database_url: str | None = None) -> PostgresRecordStore | None:
+    resolved_database_url = resolve_database_url(database_url)
+    if resolved_database_url is None:
+        return None
+    return PostgresRecordStore(database_url=resolved_database_url)
+
+
+def _scope_matches_record(
+    record: SecretRecord,
+    *,
+    context_name: str,
+    instance_name: str,
+) -> bool:
+    if record.scope == "global":
+        return True
+    if record.scope == "context":
+        return record.context == context_name
+    return record.context == context_name and record.instance == instance_name
+
+
+def _binding_for_secret(record_store: PostgresRecordStore, *, secret_id: str) -> SecretBinding | None:
+    for binding in record_store.list_secret_bindings(limit=None):
+        if binding.secret_id == secret_id and binding.status == SECRET_STATUS_CONFIGURED:
+            return binding
+    return None
+
+
+def resolve_secret_values_for_integration(
+    *,
+    integration: str,
+    context_name: str = "",
+    instance_name: str = "",
+    database_url: str | None = None,
+) -> dict[str, str]:
+    store = _open_secret_store(database_url)
+    if store is None:
+        return {}
+    try:
+        candidate_records = [
+            record
+            for record in store.list_secret_records(integration=integration)
+            if record.status == SECRET_STATUS_CONFIGURED
+            and _scope_matches_record(record, context_name=context_name, instance_name=instance_name)
+        ]
+        candidate_records.sort(key=lambda record: (_scope_rank(record.scope), record.updated_at, record.secret_id))
+        resolved_values: dict[str, str] = {}
+        for record in candidate_records:
+            binding = _binding_for_secret(store, secret_id=record.secret_id)
+            if binding is None:
+                continue
+            version = store.read_secret_version(record.current_version_id)
+            resolved_values[binding.binding_key] = _decrypt_secret_value(version.ciphertext)
+        return resolved_values
+    finally:
+        store.close()
+
+
+def overlay_dokploy_environment_values(
+    *,
+    environment_values: dict[str, str],
+    database_url: str | None = None,
+) -> dict[str, str]:
+    managed_values = resolve_secret_values_for_integration(
+        integration=DOKPLOY_SECRET_INTEGRATION,
+        database_url=database_url,
+    )
+    if not managed_values:
+        return environment_values
+    merged_values = dict(environment_values)
+    merged_values.update(managed_values)
+    return merged_values
+
+
+def overlay_runtime_environment_secret_values(
+    *,
+    environment_values: dict[str, str],
+    context_name: str,
+    instance_name: str = "",
+    database_url: str | None = None,
+) -> dict[str, str]:
+    managed_values = resolve_secret_values_for_integration(
+        integration=RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+        context_name=context_name,
+        instance_name=instance_name,
+        database_url=database_url,
+    )
+    if not managed_values:
+        return environment_values
+    merged_values = dict(environment_values)
+    merged_values.update(managed_values)
+    return merged_values
+
+
+def write_secret_value(
+    *,
+    record_store: PostgresRecordStore,
+    scope: SecretScope,
+    integration: str,
+    name: str,
+    plaintext_value: str,
+    binding_key: str,
+    context_name: str = "",
+    instance_name: str = "",
+    description: str = "",
+    actor: str = "",
+    source_label: str = "manual",
+) -> dict[str, str]:
+    if not plaintext_value.strip():
+        raise click.ClickException("Harbor managed secrets require a non-empty plaintext value.")
+    now = utc_now_timestamp()
+    existing_record = record_store.find_secret_record(
+        scope=scope,
+        integration=integration,
+        name=name,
+        context=context_name,
+        instance=instance_name,
+    )
+    secret_id = existing_record.secret_id if existing_record is not None else _secret_id(
+        integration=integration,
+        name=name,
+        context=context_name,
+        instance=instance_name,
+    )
+    if existing_record is not None:
+        current_version = record_store.read_secret_version(existing_record.current_version_id)
+        if _decrypt_secret_value(current_version.ciphertext) == plaintext_value:
+            binding = SecretBinding(
+                binding_id=_binding_id(secret_id=secret_id, binding_key=binding_key),
+                secret_id=secret_id,
+                integration=integration,
+                binding_key=binding_key,
+                context=context_name,
+                instance=instance_name,
+                created_at=existing_record.created_at,
+                updated_at=now,
+            )
+            record_store.write_secret_binding(binding)
+            return {"status": "ok", "secret_id": secret_id, "action": "unchanged"}
+    action: SecretWriteAction = "created" if existing_record is None else "rotated"
+    version_id = _version_id(secret_id=secret_id)
+    record_store.write_secret_version(
+        SecretVersion(
+            version_id=version_id,
+            secret_id=secret_id,
+            created_at=now,
+            created_by=actor,
+            ciphertext=_encrypt_secret_value(plaintext_value),
+        )
+    )
+    created_at = existing_record.created_at if existing_record is not None else now
+    record_store.write_secret_record(
+        SecretRecord(
+            secret_id=secret_id,
+            scope=scope,
+            integration=integration,
+            name=name,
+            context=context_name,
+            instance=instance_name,
+            description=description,
+            current_version_id=version_id,
+            created_at=created_at,
+            updated_at=now,
+            updated_by=actor,
+            last_validated_at=existing_record.last_validated_at if existing_record is not None else "",
+        )
+    )
+    record_store.write_secret_binding(
+        SecretBinding(
+            binding_id=_binding_id(secret_id=secret_id, binding_key=binding_key),
+            secret_id=secret_id,
+            integration=integration,
+            binding_key=binding_key,
+            context=context_name,
+            instance=instance_name,
+            created_at=created_at,
+            updated_at=now,
+        )
+    )
+    record_store.write_secret_audit_event(
+        SecretAuditEvent(
+            event_id=_audit_event_id(secret_id=secret_id, event_type=action),
+            secret_id=secret_id,
+            event_type="created" if action == "created" else "rotated",
+            recorded_at=now,
+            actor=actor,
+            detail=f"Harbor {action} managed secret from {source_label}.",
+            metadata={"source": source_label, "binding_key": binding_key},
+        )
+    )
+    return {"status": "ok", "secret_id": secret_id, "action": action, "version_id": version_id}
+
+
+def _import_runtime_environment_scope(
+    *,
+    record_store: PostgresRecordStore,
+    values: dict[str, Any],
+    scope: SecretScope,
+    context_name: str = "",
+    instance_name: str = "",
+    actor: str,
+) -> dict[str, int]:
+    imported = 0
+    unchanged = 0
+    for key_name, raw_value in values.items():
+        if not _runtime_environment_key_is_secret(key_name):
+            continue
+        result = write_secret_value(
+            record_store=record_store,
+            scope=scope,
+            integration=RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+            name=key_name,
+            plaintext_value=str(raw_value),
+            binding_key=key_name,
+            context_name=context_name,
+            instance_name=instance_name,
+            description=f"Managed runtime environment value for {key_name}.",
+            actor=actor,
+            source_label="runtime-environments.toml",
+        )
+        if result["action"] == "unchanged":
+            unchanged += 1
+        else:
+            imported += 1
+    return {"imported": imported, "unchanged": unchanged}
+
+
+def import_bootstrap_secrets(
+    *,
+    record_store: PostgresRecordStore,
+    control_plane_root: Path,
+    actor: str = "bootstrap",
+) -> dict[str, object]:
+    from control_plane import dokploy as control_plane_dokploy
+    from control_plane import runtime_environments as control_plane_runtime_environments
+
+    summary: dict[str, object] = {
+        "dokploy": {"imported": 0, "unchanged": 0},
+        "runtime_environment": {"imported": 0, "unchanged": 0},
+    }
+    environment_values = control_plane_dokploy.read_control_plane_environment_values(control_plane_root=control_plane_root)
+    for secret_name, binding_key in (("host", "DOKPLOY_HOST"), ("token", "DOKPLOY_TOKEN")):
+        value = environment_values.get(binding_key, "").strip()
+        if not value:
+            continue
+        result = write_secret_value(
+            record_store=record_store,
+            scope="global",
+            integration=DOKPLOY_SECRET_INTEGRATION,
+            name=secret_name,
+            plaintext_value=value,
+            binding_key=binding_key,
+            description=f"Managed Dokploy {secret_name} value.",
+            actor=actor,
+            source_label="dokploy.env",
+        )
+        category = "unchanged" if result["action"] == "unchanged" else "imported"
+        dokploy_summary = summary["dokploy"]
+        assert isinstance(dokploy_summary, dict)
+        dokploy_summary[category] = int(dokploy_summary[category]) + 1
+
+    definition = control_plane_runtime_environments.load_runtime_environment_definition(
+        control_plane_root=control_plane_root
+    )
+    shared_summary = _import_runtime_environment_scope(
+        record_store=record_store,
+        values=definition.shared_env,
+        scope="global",
+        actor=actor,
+    )
+    runtime_summary = summary["runtime_environment"]
+    assert isinstance(runtime_summary, dict)
+    runtime_summary["imported"] = int(runtime_summary["imported"]) + shared_summary["imported"]
+    runtime_summary["unchanged"] = int(runtime_summary["unchanged"]) + shared_summary["unchanged"]
+    for context_name, context_definition in definition.contexts.items():
+        context_summary = _import_runtime_environment_scope(
+            record_store=record_store,
+            values=context_definition.shared_env,
+            scope="context",
+            context_name=context_name,
+            actor=actor,
+        )
+        runtime_summary["imported"] = int(runtime_summary["imported"]) + context_summary["imported"]
+        runtime_summary["unchanged"] = int(runtime_summary["unchanged"]) + context_summary["unchanged"]
+        for instance_name, instance_definition in context_definition.instances.items():
+            instance_summary = _import_runtime_environment_scope(
+                record_store=record_store,
+                values=instance_definition.env,
+                scope="context_instance",
+                context_name=context_name,
+                instance_name=instance_name,
+                actor=actor,
+            )
+            runtime_summary["imported"] = int(runtime_summary["imported"]) + instance_summary["imported"]
+            runtime_summary["unchanged"] = int(runtime_summary["unchanged"]) + instance_summary["unchanged"]
+    return summary
+
+
+def build_secret_status(record_store: PostgresRecordStore, *, secret_id: str) -> dict[str, object]:
+    record = record_store.read_secret_record(secret_id)
+    versions = record_store.list_secret_versions(secret_id=secret_id)
+    binding = _binding_for_secret(record_store, secret_id=secret_id)
+    audit_events = record_store.list_secret_audit_events(secret_id=secret_id)
+    return {
+        "secret_id": record.secret_id,
+        "scope": record.scope,
+        "integration": record.integration,
+        "name": record.name,
+        "context": record.context,
+        "instance": record.instance,
+        "policy": record.policy,
+        "status": record.status,
+        "description": record.description,
+        "created_at": record.created_at,
+        "updated_at": record.updated_at,
+        "updated_by": record.updated_by,
+        "last_validated_at": record.last_validated_at,
+        "current_version_id": record.current_version_id,
+        "version_count": len(versions),
+        "current_version_created_at": versions[0].created_at if versions else "",
+        "binding": (
+            {
+                "binding_id": binding.binding_id,
+                "binding_type": binding.binding_type,
+                "binding_key": binding.binding_key,
+                "status": binding.status,
+                "context": binding.context,
+                "instance": binding.instance,
+                "updated_at": binding.updated_at,
+            }
+            if binding is not None
+            else None
+        ),
+        "recent_audit_events": [
+            {
+                "event_id": event.event_id,
+                "event_type": event.event_type,
+                "recorded_at": event.recorded_at,
+                "actor": event.actor,
+                "detail": event.detail,
+                "metadata": event.metadata,
+            }
+            for event in audit_events[:5]
+        ],
+    }
+
+
+def list_secret_statuses(
+    record_store: PostgresRecordStore,
+    *,
+    integration: str = "",
+    context_name: str = "",
+    instance_name: str = "",
+) -> list[dict[str, object]]:
+    statuses: list[dict[str, object]] = []
+    for record in record_store.list_secret_records(integration=integration or ""):
+        if context_name and not _scope_matches_record(record, context_name=context_name, instance_name=instance_name):
+            continue
+        if not context_name and instance_name:
+            continue
+        statuses.append(build_secret_status(record_store, secret_id=record.secret_id))
+    statuses.sort(key=lambda item: (str(item["updated_at"]), str(item["secret_id"])), reverse=True)
+    return statuses

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -10,6 +10,7 @@ from wsgiref.simple_server import make_server
 import click
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
+from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.preview_mutation_request import (
     PreviewDestroyMutationRequest,
@@ -177,8 +178,20 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "preview.read", {"preview_id": segments[2]}
     if len(segments) == 4 and segments[:2] == ["v1", "previews"] and segments[3] == "history":
         return "preview.read", {"preview_id": segments[2], "include_history": "true"}
+    if len(segments) == 3 and segments[:2] == ["v1", "secrets"]:
+        return "secret.read", {"secret_id": segments[2]}
+    if len(segments) == 4 and segments[:2] == ["v1", "contexts"] and segments[3] == "secrets":
+        return "secret.list", {"context": segments[2]}
+    if len(segments) == 6 and segments[:2] == ["v1", "contexts"] and segments[3] == "instances" and segments[5] == "secrets":
+        return "secret.list", {"context": segments[2], "instance": segments[4]}
     if len(segments) == 5 and segments[:2] == ["v1", "contexts"] and segments[3:] == ["operations", "recent"]:
         return "operations.read", {"context": segments[2]}
+    return None
+
+
+def _secret_capable_store(record_store: object):
+    if hasattr(record_store, "read_secret_record") and hasattr(record_store, "list_secret_records"):
+        return record_store
     return None
 
 
@@ -425,6 +438,102 @@ def create_harbor_service_app(
                             "status": "ok",
                             "trace_id": request_trace_id,
                             "record": preview.model_dump(mode="json"),
+                        },
+                    )
+                if action == "secret.read":
+                    secret_store = _secret_capable_store(record_store)
+                    if secret_store is None:
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=404,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "not_found",
+                                    "message": "Harbor secret status routes require the Postgres storage backend.",
+                                },
+                            },
+                        )
+                    secret_status = control_plane_secrets.build_secret_status(
+                        secret_store,
+                        secret_id=params["secret_id"],
+                    )
+                    if not authz_policy.allows(
+                        identity=identity,
+                        action=action,
+                        product="harbor",
+                        context=str(secret_status["context"]),
+                    ):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=403,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "authorization_denied",
+                                    "message": "Workflow cannot read Harbor managed secret status for the requested context.",
+                                },
+                            },
+                        )
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=200,
+                        payload={
+                            "status": "ok",
+                            "trace_id": request_trace_id,
+                            "secret": secret_status,
+                        },
+                    )
+                if action == "secret.list":
+                    context_name = params["context"]
+                    if not authz_policy.allows(
+                        identity=identity,
+                        action=action,
+                        product="harbor",
+                        context=context_name,
+                    ):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=403,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "authorization_denied",
+                                    "message": "Workflow cannot list Harbor managed secret status for the requested context.",
+                                },
+                            },
+                        )
+                    secret_store = _secret_capable_store(record_store)
+                    if secret_store is None:
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=404,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "not_found",
+                                    "message": "Harbor secret status routes require the Postgres storage backend.",
+                                },
+                            },
+                        )
+                    statuses = control_plane_secrets.list_secret_statuses(
+                        secret_store,
+                        context_name=context_name,
+                        instance_name=params.get("instance", ""),
+                    )
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=200,
+                        payload={
+                            "status": "ok",
+                            "trace_id": request_trace_id,
+                            "context": context_name,
+                            "instance": params.get("instance", ""),
+                            "secrets": statuses,
                         },
                     )
                 context_name = params["context"]

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -28,6 +28,10 @@ from control_plane.workflows.evidence_ingestion import (
     apply_deployment_evidence,
     apply_promotion_evidence,
 )
+from control_plane.workflows.verireel_testing_deploy import (
+    VeriReelTestingDeployRequest,
+    execute_verireel_testing_deploy,
+)
 
 
 class PreviewGenerationEvidenceEnvelope(BaseModel):
@@ -92,6 +96,20 @@ class PromotionEvidenceEnvelope(BaseModel):
     def _validate_alignment(self) -> "PromotionEvidenceEnvelope":
         if not self.product.strip():
             raise ValueError("promotion evidence requires product")
+        return self
+
+
+class VeriReelTestingDeployEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    deploy: VeriReelTestingDeployRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "VeriReelTestingDeployEnvelope":
+        if self.product.strip() != "verireel":
+            raise ValueError("VeriReel testing deploy requires product 'verireel'.")
         return self
 
 
@@ -185,6 +203,7 @@ def create_harbor_service_app(
             "/v1/evidence/previews/generations",
             "/v1/evidence/previews/destroyed",
             "/v1/evidence/promotions",
+            "/v1/drivers/verireel/testing-deploy",
         }:
             return _json_response(
                 start_response=start_response,
@@ -204,7 +223,7 @@ def create_harbor_service_app(
                     "trace_id": request_trace_id,
                     "error": {
                         "code": "method_not_allowed",
-                        "message": "Only POST is allowed for this Harbor evidence route.",
+                        "message": "Only POST is allowed for this Harbor route.",
                     },
                 },
             )
@@ -213,6 +232,7 @@ def create_harbor_service_app(
             identity = verifier.verify(token)
             payload = _read_json_request(environ)
             record_store = FilesystemRecordStore(state_dir=state_dir)
+            driver_result = None
             if path == "/v1/evidence/deployments":
                 request = DeploymentEvidenceEnvelope.model_validate(payload)
                 if not authz_policy.allows(
@@ -240,6 +260,35 @@ def create_harbor_service_app(
                     record_store=record_store,
                     deployment_record=request.deployment,
                 )
+            elif path == "/v1/drivers/verireel/testing-deploy":
+                request = VeriReelTestingDeployEnvelope.model_validate(payload)
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="verireel_testing_deploy.execute",
+                    product=request.product,
+                    context=request.deploy.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot execute the VeriReel testing deploy driver"
+                                    " for the requested product/context."
+                                ),
+                            },
+                        },
+                    )
+                driver_result = execute_verireel_testing_deploy(
+                    control_plane_root=resolved_root,
+                    record_store=record_store,
+                    request=request.deploy,
+                )
+                result = {"deployment_record_id": driver_result.deployment_record_id}
             elif path == "/v1/evidence/promotions":
                 request = PromotionEvidenceEnvelope.model_validate(payload)
                 if not authz_policy.allows(
@@ -372,6 +421,7 @@ def create_harbor_service_app(
                         "transition",
                     }
                 },
+                **({"result": driver_result.model_dump(mode="json")} if driver_result else {}),
             },
         )
 

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -23,7 +23,7 @@ from control_plane.harbor_mutations import (
     control_plane_root,
 )
 from control_plane.service_auth import HarborAuthzPolicy, TokenVerifier, load_authz_policy
-from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.storage.factory import build_record_store, storage_backend_name
 from control_plane.workflows.evidence_ingestion import (
     apply_deployment_evidence,
     apply_promotion_evidence,
@@ -148,6 +148,40 @@ def _trace_id() -> str:
     return f"harbor_req_{uuid.uuid4().hex}"
 
 
+def _not_found_response(
+    *,
+    start_response: Callable[[str, list[tuple[str, str]]], None],
+    trace_id: str,
+    path: str,
+) -> list[bytes]:
+    return _json_response(
+        start_response=start_response,
+        status_code=404,
+        payload={
+            "status": "rejected",
+            "trace_id": trace_id,
+            "error": {"code": "not_found", "message": f"No Harbor route for {path}."},
+        },
+    )
+
+
+def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
+    segments = [segment for segment in path.split("/") if segment]
+    if len(segments) == 3 and segments[:2] == ["v1", "deployments"]:
+        return "deployment.read", {"record_id": segments[2]}
+    if len(segments) == 3 and segments[:2] == ["v1", "promotions"]:
+        return "promotion.read", {"record_id": segments[2]}
+    if len(segments) == 4 and segments[:2] == ["v1", "inventory"]:
+        return "inventory.read", {"context": segments[2], "instance": segments[3]}
+    if len(segments) == 3 and segments[:2] == ["v1", "previews"]:
+        return "preview.read", {"preview_id": segments[2]}
+    if len(segments) == 4 and segments[:2] == ["v1", "previews"] and segments[3] == "history":
+        return "preview.read", {"preview_id": segments[2], "include_history": "true"}
+    if len(segments) == 5 and segments[:2] == ["v1", "contexts"] and segments[3:] == ["operations", "recent"]:
+        return "operations.read", {"context": segments[2]}
+    return None
+
+
 def _read_json_request(environ: dict[str, object]) -> dict[str, object]:
     content_length = int(str(environ.get("CONTENT_LENGTH", "0") or "0"))
     body_stream = environ.get("wsgi.input")
@@ -182,8 +216,18 @@ def create_harbor_service_app(
     verifier: TokenVerifier,
     authz_policy: HarborAuthzPolicy,
     control_plane_root_path: Path | None = None,
+    database_url: str | None = None,
 ):
     resolved_root = control_plane_root_path or control_plane_root()
+    record_store = build_record_store(state_dir=state_dir, database_url=database_url)
+    storage_backend = storage_backend_name(record_store)
+    write_routes = {
+        "/v1/evidence/deployments",
+        "/v1/evidence/previews/generations",
+        "/v1/evidence/previews/destroyed",
+        "/v1/evidence/promotions",
+        "/v1/drivers/verireel/testing-deploy",
+    }
 
     def app(
         environ: dict[str, object],
@@ -196,25 +240,29 @@ def create_harbor_service_app(
             return _json_response(
                 start_response=start_response,
                 status_code=200,
-                payload={"status": "ok", "trace_id": request_trace_id},
+                payload={"status": "ok", "trace_id": request_trace_id, "storage_backend": storage_backend},
             )
-        if path not in {
-            "/v1/evidence/deployments",
-            "/v1/evidence/previews/generations",
-            "/v1/evidence/previews/destroyed",
-            "/v1/evidence/promotions",
-            "/v1/drivers/verireel/testing-deploy",
-        }:
+        read_route = _match_read_route(path)
+        if path not in write_routes and read_route is None:
+            return _not_found_response(
+                start_response=start_response,
+                trace_id=request_trace_id,
+                path=path,
+            )
+        if method not in {"GET", "POST"}:
             return _json_response(
                 start_response=start_response,
-                status_code=404,
+                status_code=405,
                 payload={
                     "status": "rejected",
                     "trace_id": request_trace_id,
-                    "error": {"code": "not_found", "message": f"No Harbor route for {path}."},
+                    "error": {
+                        "code": "method_not_allowed",
+                        "message": "Only GET and POST are allowed for Harbor routes.",
+                    },
                 },
             )
-        if method != "POST":
+        if method == "GET" and read_route is None:
             return _json_response(
                 start_response=start_response,
                 status_code=405,
@@ -227,11 +275,200 @@ def create_harbor_service_app(
                     },
                 },
             )
+        if method == "POST" and path not in write_routes:
+            return _json_response(
+                start_response=start_response,
+                status_code=405,
+                payload={
+                    "status": "rejected",
+                    "trace_id": request_trace_id,
+                    "error": {
+                        "code": "method_not_allowed",
+                        "message": "Only GET is allowed for this Harbor route.",
+                    },
+                },
+            )
         try:
             token = _bearer_token(environ)
             identity = verifier.verify(token)
+            if method == "GET":
+                assert read_route is not None
+                action, params = read_route
+                if action == "deployment.read":
+                    deployment = record_store.read_deployment_record(params["record_id"])
+                    if not authz_policy.allows(
+                        identity=identity,
+                        action=action,
+                        product="harbor",
+                        context=deployment.context,
+                    ):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=403,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "authorization_denied",
+                                    "message": "Workflow cannot read deployment records for the requested context.",
+                                },
+                            },
+                        )
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=200,
+                        payload={
+                            "status": "ok",
+                            "trace_id": request_trace_id,
+                            "record": deployment.model_dump(mode="json"),
+                        },
+                    )
+                if action == "promotion.read":
+                    promotion = record_store.read_promotion_record(params["record_id"])
+                    if not authz_policy.allows(
+                        identity=identity,
+                        action=action,
+                        product="harbor",
+                        context=promotion.context,
+                    ):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=403,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "authorization_denied",
+                                    "message": "Workflow cannot read promotion records for the requested context.",
+                                },
+                            },
+                        )
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=200,
+                        payload={
+                            "status": "ok",
+                            "trace_id": request_trace_id,
+                            "record": promotion.model_dump(mode="json"),
+                        },
+                    )
+                if action == "inventory.read":
+                    inventory = record_store.read_environment_inventory(
+                        context_name=params["context"],
+                        instance_name=params["instance"],
+                    )
+                    if not authz_policy.allows(
+                        identity=identity,
+                        action=action,
+                        product="harbor",
+                        context=inventory.context,
+                    ):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=403,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "authorization_denied",
+                                    "message": "Workflow cannot read inventory for the requested context.",
+                                },
+                            },
+                        )
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=200,
+                        payload={
+                            "status": "ok",
+                            "trace_id": request_trace_id,
+                            "record": inventory.model_dump(mode="json"),
+                        },
+                    )
+                if action == "preview.read":
+                    preview = record_store.read_preview_record(params["preview_id"])
+                    if not authz_policy.allows(
+                        identity=identity,
+                        action=action,
+                        product="harbor",
+                        context=preview.context,
+                    ):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=403,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "authorization_denied",
+                                    "message": "Workflow cannot read previews for the requested context.",
+                                },
+                            },
+                        )
+                    if params.get("include_history") == "true":
+                        generations = record_store.list_preview_generation_records(preview_id=preview.preview_id)
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=200,
+                            payload={
+                                "status": "ok",
+                                "trace_id": request_trace_id,
+                                "preview": preview.model_dump(mode="json"),
+                                "generations": [
+                                    generation.model_dump(mode="json") for generation in generations
+                                ],
+                            },
+                        )
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=200,
+                        payload={
+                            "status": "ok",
+                            "trace_id": request_trace_id,
+                            "record": preview.model_dump(mode="json"),
+                        },
+                    )
+                context_name = params["context"]
+                if not authz_policy.allows(
+                    identity=identity,
+                    action=action,
+                    product="harbor",
+                    context=context_name,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot read recent operations for the requested context.",
+                            },
+                        },
+                    )
+                deployments = record_store.list_deployment_records(context_name=context_name, limit=10)
+                promotions = record_store.list_promotion_records(context_name=context_name, limit=10)
+                previews = record_store.list_preview_records(context_name=context_name, limit=10)
+                inventory = [
+                    record
+                    for record in record_store.list_environment_inventory()
+                    if record.context == context_name
+                ]
+                return _json_response(
+                    start_response=start_response,
+                    status_code=200,
+                    payload={
+                        "status": "ok",
+                        "trace_id": request_trace_id,
+                        "context": context_name,
+                        "storage_backend": storage_backend,
+                        "inventory": [record.model_dump(mode="json") for record in inventory],
+                        "recent_deployments": [record.model_dump(mode="json") for record in deployments],
+                        "recent_promotions": [record.model_dump(mode="json") for record in promotions],
+                        "recent_previews": [record.model_dump(mode="json") for record in previews],
+                    },
+                )
             payload = _read_json_request(environ)
-            record_store = FilesystemRecordStore(state_dir=state_dir)
             driver_result = None
             if path == "/v1/evidence/deployments":
                 request = DeploymentEvidenceEnvelope.model_validate(payload)
@@ -382,6 +619,12 @@ def create_harbor_service_app(
                     "error": {"code": "authentication_required", "message": str(exc)},
                 },
             )
+        except FileNotFoundError:
+            return _not_found_response(
+                start_response=start_response,
+                trace_id=request_trace_id,
+                path=path,
+            )
         except ValidationError as exc:
             return _json_response(
                 start_response=start_response,
@@ -435,6 +678,7 @@ def serve_harbor_service(
     host: str,
     port: int,
     audience: str,
+    database_url: str | None = None,
 ) -> None:
     from control_plane.service_auth import GitHubOidcVerifier
 
@@ -444,6 +688,7 @@ def serve_harbor_service(
         state_dir=state_dir,
         verifier=verifier,
         authz_policy=authz_policy,
+        database_url=database_url,
     )
     with make_server(host, port, application) as server:
         click.echo(f"Harbor service listening on http://{host}:{port}")

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -24,6 +24,10 @@ from control_plane.harbor_mutations import (
 )
 from control_plane.service_auth import HarborAuthzPolicy, TokenVerifier, load_authz_policy
 from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.workflows.evidence_ingestion import (
+    apply_deployment_evidence,
+    apply_promotion_evidence,
+)
 
 
 class PreviewGenerationEvidenceEnvelope(BaseModel):
@@ -232,8 +236,10 @@ def create_harbor_service_app(
                             },
                         },
                     )
-                record_store.write_deployment_record(request.deployment)
-                result = {"deployment_record_id": request.deployment.record_id}
+                result = apply_deployment_evidence(
+                    record_store=record_store,
+                    deployment_record=request.deployment,
+                )
             elif path == "/v1/evidence/promotions":
                 request = PromotionEvidenceEnvelope.model_validate(payload)
                 if not authz_policy.allows(
@@ -257,8 +263,10 @@ def create_harbor_service_app(
                             },
                         },
                     )
-                record_store.write_promotion_record(request.promotion)
-                result = {"promotion_record_id": request.promotion.record_id}
+                result = apply_promotion_evidence(
+                    record_store=record_store,
+                    promotion_record=request.promotion,
+                )
             elif path == "/v1/evidence/previews/generations":
                 request = PreviewGenerationEvidenceEnvelope.model_validate(payload)
                 if not authz_policy.allows(
@@ -357,6 +365,7 @@ def create_harbor_service_app(
                     if key
                     in {
                         "deployment_record_id",
+                        "inventory_record_id",
                         "preview_id",
                         "generation_id",
                         "promotion_record_id",

--- a/control_plane/storage/factory.py
+++ b/control_plane/storage/factory.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.storage.postgres import PostgresRecordStore
+
+DATABASE_URL_ENV_VAR = "HARBOR_DATABASE_URL"
+
+
+def resolve_database_url(database_url: str | None = None) -> str | None:
+    if database_url is not None and database_url.strip():
+        return database_url.strip()
+    environment_value = os.environ.get(DATABASE_URL_ENV_VAR, "").strip()
+    return environment_value or None
+
+
+def build_record_store(*, state_dir: Path, database_url: str | None = None) -> FilesystemRecordStore | PostgresRecordStore:
+    resolved_database_url = resolve_database_url(database_url)
+    if resolved_database_url is None:
+        return FilesystemRecordStore(state_dir=state_dir)
+    store = PostgresRecordStore(database_url=resolved_database_url)
+    store.ensure_schema()
+    return store
+
+
+def storage_backend_name(record_store: object) -> str:
+    backend_name = getattr(record_store, "backend_name", "")
+    if isinstance(backend_name, str) and backend_name.strip():
+        return backend_name
+    return "filesystem"

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-import json
 from collections.abc import Callable, Sequence
 from typing import Any, TypeVar
 
 from pydantic import BaseModel
+from sqlalchemy import JSON, Index, Integer, String, create_engine, desc, select
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, sessionmaker
 
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
@@ -13,121 +15,222 @@ from control_plane.contracts.preview_generation_record import PreviewGenerationR
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+from control_plane.contracts.secret_record import SecretAuditEvent, SecretBinding, SecretRecord, SecretVersion
 from control_plane.storage.filesystem import FilesystemRecordStore
 
 RecordModel = TypeVar("RecordModel", bound=BaseModel)
 ConnectionFactory = Callable[[], Any]
+PayloadDict = dict[str, Any]
+PayloadJsonType = JSON().with_variant(JSONB(), "postgresql")
 
 
-SCHEMA_STATEMENTS: tuple[str, ...] = (
-    """
-    CREATE TABLE IF NOT EXISTS harbor_backup_gates (
-        record_id TEXT PRIMARY KEY,
-        context TEXT NOT NULL,
-        instance TEXT NOT NULL,
-        created_at TEXT NOT NULL,
-        status TEXT NOT NULL,
-        payload JSONB NOT NULL
+class Base(DeclarativeBase):
+    pass
+
+
+class HarborBackupGateRow(Base):
+    __tablename__ = "harbor_backup_gates"
+    __table_args__ = (
+        Index("harbor_backup_gates_context_instance_idx", "context", "instance", desc("created_at")),
     )
-    """,
-    "CREATE INDEX IF NOT EXISTS harbor_backup_gates_context_instance_idx ON harbor_backup_gates (context, instance, created_at DESC)",
-    """
-    CREATE TABLE IF NOT EXISTS harbor_deployments (
-        record_id TEXT PRIMARY KEY,
-        context TEXT NOT NULL,
-        instance TEXT NOT NULL,
-        artifact_id TEXT NOT NULL,
-        source_git_ref TEXT NOT NULL,
-        deploy_started_at TEXT NOT NULL,
-        deploy_finished_at TEXT NOT NULL,
-        payload JSONB NOT NULL
+
+    record_id: Mapped[str] = mapped_column(String, primary_key=True)
+    context: Mapped[str] = mapped_column(String, nullable=False)
+    instance: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class HarborDeploymentRow(Base):
+    __tablename__ = "harbor_deployments"
+    __table_args__ = (
+        Index(
+            "harbor_deployments_context_instance_idx",
+            "context",
+            "instance",
+            desc("deploy_finished_at"),
+            desc("deploy_started_at"),
+        ),
     )
-    """,
-    "CREATE INDEX IF NOT EXISTS harbor_deployments_context_instance_idx ON harbor_deployments (context, instance, deploy_finished_at DESC, deploy_started_at DESC)",
-    """
-    CREATE TABLE IF NOT EXISTS harbor_promotions (
-        record_id TEXT PRIMARY KEY,
-        context TEXT NOT NULL,
-        from_instance TEXT NOT NULL,
-        to_instance TEXT NOT NULL,
-        artifact_id TEXT NOT NULL,
-        deploy_started_at TEXT NOT NULL,
-        deploy_finished_at TEXT NOT NULL,
-        payload JSONB NOT NULL
+
+    record_id: Mapped[str] = mapped_column(String, primary_key=True)
+    context: Mapped[str] = mapped_column(String, nullable=False)
+    instance: Mapped[str] = mapped_column(String, nullable=False)
+    artifact_id: Mapped[str] = mapped_column(String, nullable=False)
+    source_git_ref: Mapped[str] = mapped_column(String, nullable=False)
+    deploy_started_at: Mapped[str] = mapped_column(String, nullable=False)
+    deploy_finished_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class HarborPromotionRow(Base):
+    __tablename__ = "harbor_promotions"
+    __table_args__ = (
+        Index(
+            "harbor_promotions_context_path_idx",
+            "context",
+            "from_instance",
+            "to_instance",
+            desc("deploy_finished_at"),
+            desc("deploy_started_at"),
+        ),
     )
-    """,
-    "CREATE INDEX IF NOT EXISTS harbor_promotions_context_path_idx ON harbor_promotions (context, from_instance, to_instance, deploy_finished_at DESC, deploy_started_at DESC)",
-    """
-    CREATE TABLE IF NOT EXISTS harbor_inventory (
-        context TEXT NOT NULL,
-        instance TEXT NOT NULL,
-        artifact_id TEXT NOT NULL,
-        source_git_ref TEXT NOT NULL,
-        updated_at TEXT NOT NULL,
-        deployment_record_id TEXT NOT NULL,
-        promotion_record_id TEXT NOT NULL,
-        promoted_from_instance TEXT NOT NULL,
-        payload JSONB NOT NULL,
-        PRIMARY KEY (context, instance)
+
+    record_id: Mapped[str] = mapped_column(String, primary_key=True)
+    context: Mapped[str] = mapped_column(String, nullable=False)
+    from_instance: Mapped[str] = mapped_column(String, nullable=False)
+    to_instance: Mapped[str] = mapped_column(String, nullable=False)
+    artifact_id: Mapped[str] = mapped_column(String, nullable=False)
+    deploy_started_at: Mapped[str] = mapped_column(String, nullable=False)
+    deploy_finished_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class HarborInventoryRow(Base):
+    __tablename__ = "harbor_inventory"
+    __table_args__ = (Index("harbor_inventory_updated_idx", desc("updated_at")),)
+
+    context: Mapped[str] = mapped_column(String, primary_key=True)
+    instance: Mapped[str] = mapped_column(String, primary_key=True)
+    artifact_id: Mapped[str] = mapped_column(String, nullable=False)
+    source_git_ref: Mapped[str] = mapped_column(String, nullable=False)
+    updated_at: Mapped[str] = mapped_column(String, nullable=False)
+    deployment_record_id: Mapped[str] = mapped_column(String, nullable=False)
+    promotion_record_id: Mapped[str] = mapped_column(String, nullable=False)
+    promoted_from_instance: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class HarborPreviewRow(Base):
+    __tablename__ = "harbor_preview_records"
+    __table_args__ = (
+        Index(
+            "harbor_preview_records_lookup_idx",
+            "context",
+            "anchor_repo",
+            "anchor_pr_number",
+            desc("updated_at"),
+        ),
     )
-    """,
-    "CREATE INDEX IF NOT EXISTS harbor_inventory_updated_idx ON harbor_inventory (updated_at DESC)",
-    """
-    CREATE TABLE IF NOT EXISTS harbor_preview_records (
-        preview_id TEXT PRIMARY KEY,
-        context TEXT NOT NULL,
-        anchor_repo TEXT NOT NULL,
-        anchor_pr_number INTEGER NOT NULL,
-        state TEXT NOT NULL,
-        updated_at TEXT NOT NULL,
-        payload JSONB NOT NULL
+
+    preview_id: Mapped[str] = mapped_column(String, primary_key=True)
+    context: Mapped[str] = mapped_column(String, nullable=False)
+    anchor_repo: Mapped[str] = mapped_column(String, nullable=False)
+    anchor_pr_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    state: Mapped[str] = mapped_column(String, nullable=False)
+    updated_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class HarborPreviewGenerationRow(Base):
+    __tablename__ = "harbor_preview_generations"
+    __table_args__ = (
+        Index(
+            "harbor_preview_generations_preview_idx",
+            "preview_id",
+            desc("sequence"),
+            desc("requested_at"),
+        ),
     )
-    """,
-    "CREATE INDEX IF NOT EXISTS harbor_preview_records_lookup_idx ON harbor_preview_records (context, anchor_repo, anchor_pr_number, updated_at DESC)",
-    """
-    CREATE TABLE IF NOT EXISTS harbor_preview_generations (
-        generation_id TEXT PRIMARY KEY,
-        preview_id TEXT NOT NULL,
-        sequence INTEGER NOT NULL,
-        state TEXT NOT NULL,
-        requested_at TEXT NOT NULL,
-        finished_at TEXT NOT NULL,
-        artifact_id TEXT NOT NULL,
-        payload JSONB NOT NULL
+
+    generation_id: Mapped[str] = mapped_column(String, primary_key=True)
+    preview_id: Mapped[str] = mapped_column(String, nullable=False)
+    sequence: Mapped[int] = mapped_column(Integer, nullable=False)
+    state: Mapped[str] = mapped_column(String, nullable=False)
+    requested_at: Mapped[str] = mapped_column(String, nullable=False)
+    finished_at: Mapped[str] = mapped_column(String, nullable=False)
+    artifact_id: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class HarborReleaseTupleRow(Base):
+    __tablename__ = "harbor_release_tuples"
+    __table_args__ = (Index("harbor_release_tuples_minted_idx", desc("minted_at")),)
+
+    context: Mapped[str] = mapped_column(String, primary_key=True)
+    channel: Mapped[str] = mapped_column(String, primary_key=True)
+    tuple_id: Mapped[str] = mapped_column(String, nullable=False)
+    artifact_id: Mapped[str] = mapped_column(String, nullable=False)
+    minted_at: Mapped[str] = mapped_column(String, nullable=False)
+    provenance: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class HarborSecretRow(Base):
+    __tablename__ = "harbor_secrets"
+    __table_args__ = (
+        Index(
+            "harbor_secrets_scope_name_idx",
+            "scope",
+            "integration",
+            "name",
+            "context",
+            "instance",
+            unique=True,
+        ),
+        Index("harbor_secrets_lookup_idx", "integration", "context", "instance", desc("updated_at")),
     )
-    """,
-    "CREATE INDEX IF NOT EXISTS harbor_preview_generations_preview_idx ON harbor_preview_generations (preview_id, sequence DESC, requested_at DESC)",
-    """
-    CREATE TABLE IF NOT EXISTS harbor_release_tuples (
-        context TEXT NOT NULL,
-        channel TEXT NOT NULL,
-        tuple_id TEXT NOT NULL,
-        artifact_id TEXT NOT NULL,
-        minted_at TEXT NOT NULL,
-        provenance TEXT NOT NULL,
-        payload JSONB NOT NULL,
-        PRIMARY KEY (context, channel)
+
+    secret_id: Mapped[str] = mapped_column(String, primary_key=True)
+    scope: Mapped[str] = mapped_column(String, nullable=False)
+    integration: Mapped[str] = mapped_column(String, nullable=False)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    context: Mapped[str] = mapped_column(String, nullable=False)
+    instance: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    current_version_id: Mapped[str] = mapped_column(String, nullable=False)
+    updated_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class HarborSecretVersionRow(Base):
+    __tablename__ = "harbor_secret_versions"
+    __table_args__ = (
+        Index("harbor_secret_versions_secret_idx", "secret_id", desc("created_at")),
     )
-    """,
-    "CREATE INDEX IF NOT EXISTS harbor_release_tuples_minted_idx ON harbor_release_tuples (minted_at DESC)",
-    """
-    CREATE TABLE IF NOT EXISTS harbor_idempotency_keys (
-        idempotency_key TEXT PRIMARY KEY,
-        route TEXT NOT NULL,
-        first_seen_at TEXT NOT NULL,
-        response_payload JSONB NOT NULL
+
+    version_id: Mapped[str] = mapped_column(String, primary_key=True)
+    secret_id: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class HarborSecretBindingRow(Base):
+    __tablename__ = "harbor_secret_bindings"
+    __table_args__ = (
+        Index(
+            "harbor_secret_bindings_lookup_idx",
+            "integration",
+            "context",
+            "instance",
+            "binding_key",
+            desc("updated_at"),
+        ),
     )
-    """,
-    """
-    CREATE TABLE IF NOT EXISTS harbor_audit_events (
-        event_id TEXT PRIMARY KEY,
-        event_type TEXT NOT NULL,
-        recorded_at TEXT NOT NULL,
-        payload JSONB NOT NULL
+
+    binding_id: Mapped[str] = mapped_column(String, primary_key=True)
+    secret_id: Mapped[str] = mapped_column(String, nullable=False)
+    integration: Mapped[str] = mapped_column(String, nullable=False)
+    binding_key: Mapped[str] = mapped_column(String, nullable=False)
+    context: Mapped[str] = mapped_column(String, nullable=False)
+    instance: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    updated_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class HarborSecretAuditEventRow(Base):
+    __tablename__ = "harbor_secret_audit_events"
+    __table_args__ = (
+        Index("harbor_secret_audit_events_secret_idx", "secret_id", desc("recorded_at")),
     )
-    """,
-    "CREATE INDEX IF NOT EXISTS harbor_audit_events_recorded_idx ON harbor_audit_events (recorded_at DESC)",
-)
+
+    event_id: Mapped[str] = mapped_column(String, primary_key=True)
+    secret_id: Mapped[str] = mapped_column(String, nullable=False)
+    event_type: Mapped[str] = mapped_column(String, nullable=False)
+    recorded_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
 def _artifact_id_from_model(model: BaseModel) -> str:
@@ -136,13 +239,13 @@ def _artifact_id_from_model(model: BaseModel) -> str:
     return artifact_id if isinstance(artifact_id, str) else ""
 
 
-def _default_connection_factory(database_url: str) -> ConnectionFactory:
-    def connect() -> Any:
-        import psycopg
-
-        return psycopg.connect(database_url)
-
-    return connect
+def _build_engine(database_url: str, *, connection_factory: ConnectionFactory | None = None):
+    engine_kwargs: dict[str, Any] = {}
+    if connection_factory is not None:
+        engine_kwargs["creator"] = connection_factory
+    if database_url.startswith("sqlite"):
+        engine_kwargs["connect_args"] = {"check_same_thread": False}
+    return create_engine(database_url, **engine_kwargs)
 
 
 class PostgresRecordStore:
@@ -153,113 +256,86 @@ class PostgresRecordStore:
         connection_factory: ConnectionFactory | None = None,
     ) -> None:
         self.database_url = database_url
-        self._connection_factory = connection_factory or _default_connection_factory(database_url)
+        self._engine = _build_engine(database_url, connection_factory=connection_factory)
+        self._session_factory = sessionmaker(self._engine, expire_on_commit=False)
 
     @property
     def backend_name(self) -> str:
         return "postgres"
 
     def ensure_schema(self) -> None:
-        with self._connection_factory() as connection:
-            with connection.cursor() as cursor:
-                for statement in SCHEMA_STATEMENTS:
-                    cursor.execute(statement)
-            connection.commit()
+        Base.metadata.create_all(self._engine)
 
-    def _payload_json(self, model: BaseModel) -> str:
-        return json.dumps(model.model_dump(mode="json", exclude_none=True), sort_keys=True)
+    def close(self) -> None:
+        self._engine.dispose()
 
-    def _fetch_payload_text(self, row: object) -> str:
-        if isinstance(row, dict):
-            payload = row.get("payload")
-        else:
-            payload = row[0] if row is not None else None
-        if not isinstance(payload, str):
-            raise RuntimeError("Postgres record store expected payload text from query row.")
-        return payload
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            return None
 
-    def _write_model(
-        self,
-        *,
-        table: str,
-        columns: Sequence[str],
-        values: Sequence[object],
-        conflict_columns: Sequence[str],
-        model: BaseModel,
-    ) -> None:
-        assignment_columns = [*columns, "payload"]
-        placeholders = ["%s" for _ in values] + ["%s::jsonb"]
-        update_clause = ", ".join(f"{column} = EXCLUDED.{column}" for column in assignment_columns)
-        query = (
-            f"INSERT INTO {table} ({', '.join(assignment_columns)}) "
-            f"VALUES ({', '.join(placeholders)}) "
-            f"ON CONFLICT ({', '.join(conflict_columns)}) DO UPDATE SET {update_clause}"
-        )
-        params = (*values, self._payload_json(model))
-        with self._connection_factory() as connection:
-            with connection.cursor() as cursor:
-                cursor.execute(query, params)
-            connection.commit()
+    def _payload_dict(self, model: BaseModel) -> PayloadDict:
+        return model.model_dump(mode="json", exclude_none=True)
+
+    def _read_payload(self, *, model_type: type[RecordModel], payload: PayloadDict) -> RecordModel:
+        return model_type.model_validate(payload)
+
+    def _write_row(self, row: Base) -> None:
+        with self._session_factory() as session:
+            session.merge(row)
+            session.commit()
 
     def _read_model(
         self,
         *,
         model_type: type[RecordModel],
-        table: str,
-        where_clause: str,
-        params: Sequence[object],
+        orm_model: type[Base],
+        filters: Sequence[object],
     ) -> RecordModel:
-        query = f"SELECT payload::text FROM {table} WHERE {where_clause}"
-        with self._connection_factory() as connection:
-            with connection.cursor() as cursor:
-                cursor.execute(query, params)
-                row = cursor.fetchone()
-        if row is None:
-            raise FileNotFoundError(f"No Harbor record found in {table} for {params!r}")
-        return model_type.model_validate(json.loads(self._fetch_payload_text(row)))
+        statement = select(orm_model).where(*filters).limit(1)
+        with self._session_factory() as session:
+            row = session.scalar(statement)
+            if row is None:
+                raise FileNotFoundError(f"No Harbor record found in {orm_model.__tablename__} for {tuple(filters)!r}")
+            return self._read_payload(model_type=model_type, payload=getattr(row, "payload"))
 
     def _list_models(
         self,
         *,
         model_type: type[RecordModel],
-        table: str,
-        filters: Sequence[tuple[str, object]] = (),
-        order_by: str,
+        orm_model: type[Base],
+        filters: Sequence[object] = (),
+        order_by: Sequence[object],
         limit: int | None = None,
     ) -> tuple[RecordModel, ...]:
-        clauses: list[str] = []
-        params: list[object] = []
-        for clause, value in filters:
-            clauses.append(clause)
-            params.append(value)
-        query = f"SELECT payload::text FROM {table}"
-        if clauses:
-            query += f" WHERE {' AND '.join(clauses)}"
-        query += f" ORDER BY {order_by}"
+        statement = select(orm_model)
+        if filters:
+            statement = statement.where(*filters)
+        statement = statement.order_by(*order_by)
         if limit is not None:
-            query += " LIMIT %s"
-            params.append(limit)
-        with self._connection_factory() as connection:
-            with connection.cursor() as cursor:
-                cursor.execute(query, params)
-                rows = cursor.fetchall()
-        return tuple(model_type.model_validate(json.loads(self._fetch_payload_text(row))) for row in rows)
+            statement = statement.limit(limit)
+        with self._session_factory() as session:
+            rows = session.scalars(statement).all()
+            return tuple(self._read_payload(model_type=model_type, payload=row.payload) for row in rows)
 
     def write_backup_gate_record(self, record: BackupGateRecord) -> None:
-        self._write_model(
-            table="harbor_backup_gates",
-            columns=("record_id", "context", "instance", "created_at", "status"),
-            values=(record.record_id, record.context, record.instance, record.created_at, record.status),
-            conflict_columns=("record_id",),
-            model=record,
+        self._write_row(
+            HarborBackupGateRow(
+                record_id=record.record_id,
+                context=record.context,
+                instance=record.instance,
+                created_at=record.created_at,
+                status=record.status,
+                payload=self._payload_dict(record),
+            )
         )
 
     def read_backup_gate_record(self, record_id: str) -> BackupGateRecord:
         return self._read_model(
             model_type=BackupGateRecord,
-            table="harbor_backup_gates",
-            where_clause="record_id = %s",
-            params=(record_id,),
+            orm_model=HarborBackupGateRow,
+            filters=(HarborBackupGateRow.record_id == record_id,),
         )
 
     def list_backup_gate_records(
@@ -269,50 +345,38 @@ class PostgresRecordStore:
         instance_name: str = "",
         limit: int | None = None,
     ) -> tuple[BackupGateRecord, ...]:
-        filters: list[tuple[str, object]] = []
+        filters: list[object] = []
         if context_name:
-            filters.append(("context = %s", context_name))
+            filters.append(HarborBackupGateRow.context == context_name)
         if instance_name:
-            filters.append(("instance = %s", instance_name))
+            filters.append(HarborBackupGateRow.instance == instance_name)
         return self._list_models(
             model_type=BackupGateRecord,
-            table="harbor_backup_gates",
+            orm_model=HarborBackupGateRow,
             filters=filters,
-            order_by="created_at DESC, record_id DESC",
+            order_by=(HarborBackupGateRow.created_at.desc(), HarborBackupGateRow.record_id.desc()),
             limit=limit,
         )
 
     def write_deployment_record(self, record: DeploymentRecord) -> None:
-        self._write_model(
-            table="harbor_deployments",
-            columns=(
-                "record_id",
-                "context",
-                "instance",
-                "artifact_id",
-                "source_git_ref",
-                "deploy_started_at",
-                "deploy_finished_at",
-            ),
-            values=(
-                record.record_id,
-                record.context,
-                record.instance,
-                _artifact_id_from_model(record),
-                record.source_git_ref,
-                record.deploy.started_at,
-                record.deploy.finished_at,
-            ),
-            conflict_columns=("record_id",),
-            model=record,
+        self._write_row(
+            HarborDeploymentRow(
+                record_id=record.record_id,
+                context=record.context,
+                instance=record.instance,
+                artifact_id=_artifact_id_from_model(record),
+                source_git_ref=record.source_git_ref,
+                deploy_started_at=record.deploy.started_at,
+                deploy_finished_at=record.deploy.finished_at,
+                payload=self._payload_dict(record),
+            )
         )
 
     def read_deployment_record(self, record_id: str) -> DeploymentRecord:
         return self._read_model(
             model_type=DeploymentRecord,
-            table="harbor_deployments",
-            where_clause="record_id = %s",
-            params=(record_id,),
+            orm_model=HarborDeploymentRow,
+            filters=(HarborDeploymentRow.record_id == record_id,),
         )
 
     def list_deployment_records(
@@ -322,50 +386,42 @@ class PostgresRecordStore:
         instance_name: str = "",
         limit: int | None = None,
     ) -> tuple[DeploymentRecord, ...]:
-        filters: list[tuple[str, object]] = []
+        filters: list[object] = []
         if context_name:
-            filters.append(("context = %s", context_name))
+            filters.append(HarborDeploymentRow.context == context_name)
         if instance_name:
-            filters.append(("instance = %s", instance_name))
+            filters.append(HarborDeploymentRow.instance == instance_name)
         return self._list_models(
             model_type=DeploymentRecord,
-            table="harbor_deployments",
+            orm_model=HarborDeploymentRow,
             filters=filters,
-            order_by="deploy_finished_at DESC, deploy_started_at DESC, record_id DESC",
+            order_by=(
+                HarborDeploymentRow.deploy_finished_at.desc(),
+                HarborDeploymentRow.deploy_started_at.desc(),
+                HarborDeploymentRow.record_id.desc(),
+            ),
             limit=limit,
         )
 
     def write_promotion_record(self, record: PromotionRecord) -> None:
-        self._write_model(
-            table="harbor_promotions",
-            columns=(
-                "record_id",
-                "context",
-                "from_instance",
-                "to_instance",
-                "artifact_id",
-                "deploy_started_at",
-                "deploy_finished_at",
-            ),
-            values=(
-                record.record_id,
-                record.context,
-                record.from_instance,
-                record.to_instance,
-                record.artifact_identity.artifact_id,
-                record.deploy.started_at,
-                record.deploy.finished_at,
-            ),
-            conflict_columns=("record_id",),
-            model=record,
+        self._write_row(
+            HarborPromotionRow(
+                record_id=record.record_id,
+                context=record.context,
+                from_instance=record.from_instance,
+                to_instance=record.to_instance,
+                artifact_id=record.artifact_identity.artifact_id,
+                deploy_started_at=record.deploy.started_at,
+                deploy_finished_at=record.deploy.finished_at,
+                payload=self._payload_dict(record),
+            )
         )
 
     def read_promotion_record(self, record_id: str) -> PromotionRecord:
         return self._read_model(
             model_type=PromotionRecord,
-            table="harbor_promotions",
-            where_clause="record_id = %s",
-            params=(record_id,),
+            orm_model=HarborPromotionRow,
+            filters=(HarborPromotionRow.record_id == record_id,),
         )
 
     def list_promotion_records(
@@ -376,85 +432,72 @@ class PostgresRecordStore:
         to_instance_name: str = "",
         limit: int | None = None,
     ) -> tuple[PromotionRecord, ...]:
-        filters: list[tuple[str, object]] = []
+        filters: list[object] = []
         if context_name:
-            filters.append(("context = %s", context_name))
+            filters.append(HarborPromotionRow.context == context_name)
         if from_instance_name:
-            filters.append(("from_instance = %s", from_instance_name))
+            filters.append(HarborPromotionRow.from_instance == from_instance_name)
         if to_instance_name:
-            filters.append(("to_instance = %s", to_instance_name))
+            filters.append(HarborPromotionRow.to_instance == to_instance_name)
         return self._list_models(
             model_type=PromotionRecord,
-            table="harbor_promotions",
+            orm_model=HarborPromotionRow,
             filters=filters,
-            order_by="deploy_finished_at DESC, deploy_started_at DESC, record_id DESC",
+            order_by=(
+                HarborPromotionRow.deploy_finished_at.desc(),
+                HarborPromotionRow.deploy_started_at.desc(),
+                HarborPromotionRow.record_id.desc(),
+            ),
             limit=limit,
         )
 
     def write_environment_inventory(self, record: EnvironmentInventory) -> None:
-        self._write_model(
-            table="harbor_inventory",
-            columns=(
-                "context",
-                "instance",
-                "artifact_id",
-                "source_git_ref",
-                "updated_at",
-                "deployment_record_id",
-                "promotion_record_id",
-                "promoted_from_instance",
-            ),
-            values=(
-                record.context,
-                record.instance,
-                _artifact_id_from_model(record),
-                record.source_git_ref,
-                record.updated_at,
-                record.deployment_record_id,
-                record.promotion_record_id,
-                record.promoted_from_instance,
-            ),
-            conflict_columns=("context", "instance"),
-            model=record,
+        self._write_row(
+            HarborInventoryRow(
+                context=record.context,
+                instance=record.instance,
+                artifact_id=_artifact_id_from_model(record),
+                source_git_ref=record.source_git_ref,
+                updated_at=record.updated_at,
+                deployment_record_id=record.deployment_record_id,
+                promotion_record_id=record.promotion_record_id,
+                promoted_from_instance=record.promoted_from_instance,
+                payload=self._payload_dict(record),
+            )
         )
 
     def read_environment_inventory(self, *, context_name: str, instance_name: str) -> EnvironmentInventory:
         return self._read_model(
             model_type=EnvironmentInventory,
-            table="harbor_inventory",
-            where_clause="context = %s AND instance = %s",
-            params=(context_name, instance_name),
+            orm_model=HarborInventoryRow,
+            filters=(HarborInventoryRow.context == context_name, HarborInventoryRow.instance == instance_name),
         )
 
     def list_environment_inventory(self) -> tuple[EnvironmentInventory, ...]:
         return self._list_models(
             model_type=EnvironmentInventory,
-            table="harbor_inventory",
-            order_by="context ASC, instance ASC",
+            orm_model=HarborInventoryRow,
+            order_by=(HarborInventoryRow.context.asc(), HarborInventoryRow.instance.asc()),
         )
 
     def write_preview_record(self, record: PreviewRecord) -> None:
-        self._write_model(
-            table="harbor_preview_records",
-            columns=("preview_id", "context", "anchor_repo", "anchor_pr_number", "state", "updated_at"),
-            values=(
-                record.preview_id,
-                record.context,
-                record.anchor_repo,
-                record.anchor_pr_number,
-                record.state,
-                record.updated_at,
-            ),
-            conflict_columns=("preview_id",),
-            model=record,
+        self._write_row(
+            HarborPreviewRow(
+                preview_id=record.preview_id,
+                context=record.context,
+                anchor_repo=record.anchor_repo,
+                anchor_pr_number=record.anchor_pr_number,
+                state=record.state,
+                updated_at=record.updated_at,
+                payload=self._payload_dict(record),
+            )
         )
 
     def read_preview_record(self, preview_id: str) -> PreviewRecord:
         return self._read_model(
             model_type=PreviewRecord,
-            table="harbor_preview_records",
-            where_clause="preview_id = %s",
-            params=(preview_id,),
+            orm_model=HarborPreviewRow,
+            filters=(HarborPreviewRow.preview_id == preview_id,),
         )
 
     def list_preview_records(
@@ -465,52 +508,40 @@ class PostgresRecordStore:
         anchor_pr_number: int | None = None,
         limit: int | None = None,
     ) -> tuple[PreviewRecord, ...]:
-        filters: list[tuple[str, object]] = []
+        filters: list[object] = []
         if context_name:
-            filters.append(("context = %s", context_name))
+            filters.append(HarborPreviewRow.context == context_name)
         if anchor_repo:
-            filters.append(("anchor_repo = %s", anchor_repo))
+            filters.append(HarborPreviewRow.anchor_repo == anchor_repo)
         if anchor_pr_number is not None:
-            filters.append(("anchor_pr_number = %s", anchor_pr_number))
+            filters.append(HarborPreviewRow.anchor_pr_number == anchor_pr_number)
         return self._list_models(
             model_type=PreviewRecord,
-            table="harbor_preview_records",
+            orm_model=HarborPreviewRow,
             filters=filters,
-            order_by="updated_at DESC, preview_id DESC",
+            order_by=(HarborPreviewRow.updated_at.desc(), HarborPreviewRow.preview_id.desc()),
             limit=limit,
         )
 
     def write_preview_generation_record(self, record: PreviewGenerationRecord) -> None:
-        self._write_model(
-            table="harbor_preview_generations",
-            columns=(
-                "generation_id",
-                "preview_id",
-                "sequence",
-                "state",
-                "requested_at",
-                "finished_at",
-                "artifact_id",
-            ),
-            values=(
-                record.generation_id,
-                record.preview_id,
-                record.sequence,
-                record.state,
-                record.requested_at,
-                record.finished_at,
-                record.artifact_id,
-            ),
-            conflict_columns=("generation_id",),
-            model=record,
+        self._write_row(
+            HarborPreviewGenerationRow(
+                generation_id=record.generation_id,
+                preview_id=record.preview_id,
+                sequence=record.sequence,
+                state=record.state,
+                requested_at=record.requested_at,
+                finished_at=record.finished_at,
+                artifact_id=record.artifact_id,
+                payload=self._payload_dict(record),
+            )
         )
 
     def read_preview_generation_record(self, generation_id: str) -> PreviewGenerationRecord:
         return self._read_model(
             model_type=PreviewGenerationRecord,
-            table="harbor_preview_generations",
-            where_clause="generation_id = %s",
-            params=(generation_id,),
+            orm_model=HarborPreviewGenerationRow,
+            filters=(HarborPreviewGenerationRow.generation_id == generation_id,),
         )
 
     def list_preview_generation_records(
@@ -519,46 +550,198 @@ class PostgresRecordStore:
         preview_id: str = "",
         limit: int | None = None,
     ) -> tuple[PreviewGenerationRecord, ...]:
-        filters: list[tuple[str, object]] = []
+        filters: list[object] = []
         if preview_id:
-            filters.append(("preview_id = %s", preview_id))
+            filters.append(HarborPreviewGenerationRow.preview_id == preview_id)
         return self._list_models(
             model_type=PreviewGenerationRecord,
-            table="harbor_preview_generations",
+            orm_model=HarborPreviewGenerationRow,
             filters=filters,
-            order_by="sequence DESC, requested_at DESC, generation_id DESC",
+            order_by=(
+                HarborPreviewGenerationRow.sequence.desc(),
+                HarborPreviewGenerationRow.requested_at.desc(),
+                HarborPreviewGenerationRow.generation_id.desc(),
+            ),
             limit=limit,
         )
 
     def write_release_tuple_record(self, record: ReleaseTupleRecord) -> None:
-        self._write_model(
-            table="harbor_release_tuples",
-            columns=("context", "channel", "tuple_id", "artifact_id", "minted_at", "provenance"),
-            values=(
-                record.context,
-                record.channel,
-                record.tuple_id,
-                record.artifact_id,
-                record.minted_at,
-                record.provenance,
-            ),
-            conflict_columns=("context", "channel"),
-            model=record,
+        self._write_row(
+            HarborReleaseTupleRow(
+                context=record.context,
+                channel=record.channel,
+                tuple_id=record.tuple_id,
+                artifact_id=record.artifact_id,
+                minted_at=record.minted_at,
+                provenance=record.provenance,
+                payload=self._payload_dict(record),
+            )
         )
 
     def read_release_tuple_record(self, *, context_name: str, channel_name: str) -> ReleaseTupleRecord:
         return self._read_model(
             model_type=ReleaseTupleRecord,
-            table="harbor_release_tuples",
-            where_clause="context = %s AND channel = %s",
-            params=(context_name, channel_name),
+            orm_model=HarborReleaseTupleRow,
+            filters=(HarborReleaseTupleRow.context == context_name, HarborReleaseTupleRow.channel == channel_name),
         )
 
     def list_release_tuple_records(self) -> tuple[ReleaseTupleRecord, ...]:
         return self._list_models(
             model_type=ReleaseTupleRecord,
-            table="harbor_release_tuples",
-            order_by="context ASC, channel ASC",
+            orm_model=HarborReleaseTupleRow,
+            order_by=(HarborReleaseTupleRow.context.asc(), HarborReleaseTupleRow.channel.asc()),
+        )
+
+    def write_secret_record(self, record: SecretRecord) -> None:
+        self._write_row(
+            HarborSecretRow(
+                secret_id=record.secret_id,
+                scope=record.scope,
+                integration=record.integration,
+                name=record.name,
+                context=record.context,
+                instance=record.instance,
+                status=record.status,
+                current_version_id=record.current_version_id,
+                updated_at=record.updated_at,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def read_secret_record(self, secret_id: str) -> SecretRecord:
+        return self._read_model(
+            model_type=SecretRecord,
+            orm_model=HarborSecretRow,
+            filters=(HarborSecretRow.secret_id == secret_id,),
+        )
+
+    def find_secret_record(
+        self,
+        *,
+        scope: str,
+        integration: str,
+        name: str,
+        context: str = "",
+        instance: str = "",
+    ) -> SecretRecord | None:
+        records = self._list_models(
+            model_type=SecretRecord,
+            orm_model=HarborSecretRow,
+            filters=(
+                HarborSecretRow.scope == scope,
+                HarborSecretRow.integration == integration,
+                HarborSecretRow.name == name,
+                HarborSecretRow.context == context,
+                HarborSecretRow.instance == instance,
+            ),
+            order_by=(HarborSecretRow.updated_at.desc(), HarborSecretRow.secret_id.desc()),
+            limit=1,
+        )
+        return records[0] if records else None
+
+    def list_secret_records(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[SecretRecord, ...]:
+        filters: list[object] = []
+        if integration:
+            filters.append(HarborSecretRow.integration == integration)
+        if context_name:
+            filters.append(HarborSecretRow.context == context_name)
+        if instance_name:
+            filters.append(HarborSecretRow.instance == instance_name)
+        return self._list_models(
+            model_type=SecretRecord,
+            orm_model=HarborSecretRow,
+            filters=filters,
+            order_by=(HarborSecretRow.updated_at.desc(), HarborSecretRow.secret_id.desc()),
+            limit=limit,
+        )
+
+    def write_secret_version(self, version: SecretVersion) -> None:
+        self._write_row(
+            HarborSecretVersionRow(
+                version_id=version.version_id,
+                secret_id=version.secret_id,
+                created_at=version.created_at,
+                payload=self._payload_dict(version),
+            )
+        )
+
+    def read_secret_version(self, version_id: str) -> SecretVersion:
+        return self._read_model(
+            model_type=SecretVersion,
+            orm_model=HarborSecretVersionRow,
+            filters=(HarborSecretVersionRow.version_id == version_id,),
+        )
+
+    def list_secret_versions(self, *, secret_id: str) -> tuple[SecretVersion, ...]:
+        return self._list_models(
+            model_type=SecretVersion,
+            orm_model=HarborSecretVersionRow,
+            filters=(HarborSecretVersionRow.secret_id == secret_id,),
+            order_by=(HarborSecretVersionRow.created_at.desc(), HarborSecretVersionRow.version_id.desc()),
+        )
+
+    def write_secret_binding(self, binding: SecretBinding) -> None:
+        self._write_row(
+            HarborSecretBindingRow(
+                binding_id=binding.binding_id,
+                secret_id=binding.secret_id,
+                integration=binding.integration,
+                binding_key=binding.binding_key,
+                context=binding.context,
+                instance=binding.instance,
+                status=binding.status,
+                updated_at=binding.updated_at,
+                payload=self._payload_dict(binding),
+            )
+        )
+
+    def list_secret_bindings(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[SecretBinding, ...]:
+        filters: list[object] = []
+        if integration:
+            filters.append(HarborSecretBindingRow.integration == integration)
+        if context_name:
+            filters.append(HarborSecretBindingRow.context == context_name)
+        if instance_name:
+            filters.append(HarborSecretBindingRow.instance == instance_name)
+        return self._list_models(
+            model_type=SecretBinding,
+            orm_model=HarborSecretBindingRow,
+            filters=filters,
+            order_by=(HarborSecretBindingRow.updated_at.desc(), HarborSecretBindingRow.binding_id.desc()),
+            limit=limit,
+        )
+
+    def write_secret_audit_event(self, event: SecretAuditEvent) -> None:
+        self._write_row(
+            HarborSecretAuditEventRow(
+                event_id=event.event_id,
+                secret_id=event.secret_id,
+                event_type=event.event_type,
+                recorded_at=event.recorded_at,
+                payload=self._payload_dict(event),
+            )
+        )
+
+    def list_secret_audit_events(self, *, secret_id: str) -> tuple[SecretAuditEvent, ...]:
+        return self._list_models(
+            model_type=SecretAuditEvent,
+            orm_model=HarborSecretAuditEventRow,
+            filters=(HarborSecretAuditEventRow.secret_id == secret_id,),
+            order_by=(HarborSecretAuditEventRow.recorded_at.desc(), HarborSecretAuditEventRow.event_id.desc()),
         )
 
     def import_core_records_from_filesystem(self, filesystem_store: FilesystemRecordStore) -> dict[str, int]:

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -1,0 +1,595 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Sequence
+from typing import Any, TypeVar
+
+from pydantic import BaseModel
+
+from control_plane.contracts.backup_gate_record import BackupGateRecord
+from control_plane.contracts.deployment_record import DeploymentRecord
+from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
+from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.contracts.promotion_record import PromotionRecord
+from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+from control_plane.storage.filesystem import FilesystemRecordStore
+
+RecordModel = TypeVar("RecordModel", bound=BaseModel)
+ConnectionFactory = Callable[[], Any]
+
+
+SCHEMA_STATEMENTS: tuple[str, ...] = (
+    """
+    CREATE TABLE IF NOT EXISTS harbor_backup_gates (
+        record_id TEXT PRIMARY KEY,
+        context TEXT NOT NULL,
+        instance TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        status TEXT NOT NULL,
+        payload JSONB NOT NULL
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS harbor_backup_gates_context_instance_idx ON harbor_backup_gates (context, instance, created_at DESC)",
+    """
+    CREATE TABLE IF NOT EXISTS harbor_deployments (
+        record_id TEXT PRIMARY KEY,
+        context TEXT NOT NULL,
+        instance TEXT NOT NULL,
+        artifact_id TEXT NOT NULL,
+        source_git_ref TEXT NOT NULL,
+        deploy_started_at TEXT NOT NULL,
+        deploy_finished_at TEXT NOT NULL,
+        payload JSONB NOT NULL
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS harbor_deployments_context_instance_idx ON harbor_deployments (context, instance, deploy_finished_at DESC, deploy_started_at DESC)",
+    """
+    CREATE TABLE IF NOT EXISTS harbor_promotions (
+        record_id TEXT PRIMARY KEY,
+        context TEXT NOT NULL,
+        from_instance TEXT NOT NULL,
+        to_instance TEXT NOT NULL,
+        artifact_id TEXT NOT NULL,
+        deploy_started_at TEXT NOT NULL,
+        deploy_finished_at TEXT NOT NULL,
+        payload JSONB NOT NULL
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS harbor_promotions_context_path_idx ON harbor_promotions (context, from_instance, to_instance, deploy_finished_at DESC, deploy_started_at DESC)",
+    """
+    CREATE TABLE IF NOT EXISTS harbor_inventory (
+        context TEXT NOT NULL,
+        instance TEXT NOT NULL,
+        artifact_id TEXT NOT NULL,
+        source_git_ref TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        deployment_record_id TEXT NOT NULL,
+        promotion_record_id TEXT NOT NULL,
+        promoted_from_instance TEXT NOT NULL,
+        payload JSONB NOT NULL,
+        PRIMARY KEY (context, instance)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS harbor_inventory_updated_idx ON harbor_inventory (updated_at DESC)",
+    """
+    CREATE TABLE IF NOT EXISTS harbor_preview_records (
+        preview_id TEXT PRIMARY KEY,
+        context TEXT NOT NULL,
+        anchor_repo TEXT NOT NULL,
+        anchor_pr_number INTEGER NOT NULL,
+        state TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        payload JSONB NOT NULL
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS harbor_preview_records_lookup_idx ON harbor_preview_records (context, anchor_repo, anchor_pr_number, updated_at DESC)",
+    """
+    CREATE TABLE IF NOT EXISTS harbor_preview_generations (
+        generation_id TEXT PRIMARY KEY,
+        preview_id TEXT NOT NULL,
+        sequence INTEGER NOT NULL,
+        state TEXT NOT NULL,
+        requested_at TEXT NOT NULL,
+        finished_at TEXT NOT NULL,
+        artifact_id TEXT NOT NULL,
+        payload JSONB NOT NULL
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS harbor_preview_generations_preview_idx ON harbor_preview_generations (preview_id, sequence DESC, requested_at DESC)",
+    """
+    CREATE TABLE IF NOT EXISTS harbor_release_tuples (
+        context TEXT NOT NULL,
+        channel TEXT NOT NULL,
+        tuple_id TEXT NOT NULL,
+        artifact_id TEXT NOT NULL,
+        minted_at TEXT NOT NULL,
+        provenance TEXT NOT NULL,
+        payload JSONB NOT NULL,
+        PRIMARY KEY (context, channel)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS harbor_release_tuples_minted_idx ON harbor_release_tuples (minted_at DESC)",
+    """
+    CREATE TABLE IF NOT EXISTS harbor_idempotency_keys (
+        idempotency_key TEXT PRIMARY KEY,
+        route TEXT NOT NULL,
+        first_seen_at TEXT NOT NULL,
+        response_payload JSONB NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS harbor_audit_events (
+        event_id TEXT PRIMARY KEY,
+        event_type TEXT NOT NULL,
+        recorded_at TEXT NOT NULL,
+        payload JSONB NOT NULL
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS harbor_audit_events_recorded_idx ON harbor_audit_events (recorded_at DESC)",
+)
+
+
+def _artifact_id_from_model(model: BaseModel) -> str:
+    artifact_identity = getattr(model, "artifact_identity", None)
+    artifact_id = getattr(artifact_identity, "artifact_id", "")
+    return artifact_id if isinstance(artifact_id, str) else ""
+
+
+def _default_connection_factory(database_url: str) -> ConnectionFactory:
+    def connect() -> Any:
+        import psycopg
+
+        return psycopg.connect(database_url)
+
+    return connect
+
+
+class PostgresRecordStore:
+    def __init__(
+        self,
+        *,
+        database_url: str,
+        connection_factory: ConnectionFactory | None = None,
+    ) -> None:
+        self.database_url = database_url
+        self._connection_factory = connection_factory or _default_connection_factory(database_url)
+
+    @property
+    def backend_name(self) -> str:
+        return "postgres"
+
+    def ensure_schema(self) -> None:
+        with self._connection_factory() as connection:
+            with connection.cursor() as cursor:
+                for statement in SCHEMA_STATEMENTS:
+                    cursor.execute(statement)
+            connection.commit()
+
+    def _payload_json(self, model: BaseModel) -> str:
+        return json.dumps(model.model_dump(mode="json", exclude_none=True), sort_keys=True)
+
+    def _fetch_payload_text(self, row: object) -> str:
+        if isinstance(row, dict):
+            payload = row.get("payload")
+        else:
+            payload = row[0] if row is not None else None
+        if not isinstance(payload, str):
+            raise RuntimeError("Postgres record store expected payload text from query row.")
+        return payload
+
+    def _write_model(
+        self,
+        *,
+        table: str,
+        columns: Sequence[str],
+        values: Sequence[object],
+        conflict_columns: Sequence[str],
+        model: BaseModel,
+    ) -> None:
+        assignment_columns = [*columns, "payload"]
+        placeholders = ["%s" for _ in values] + ["%s::jsonb"]
+        update_clause = ", ".join(f"{column} = EXCLUDED.{column}" for column in assignment_columns)
+        query = (
+            f"INSERT INTO {table} ({', '.join(assignment_columns)}) "
+            f"VALUES ({', '.join(placeholders)}) "
+            f"ON CONFLICT ({', '.join(conflict_columns)}) DO UPDATE SET {update_clause}"
+        )
+        params = (*values, self._payload_json(model))
+        with self._connection_factory() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(query, params)
+            connection.commit()
+
+    def _read_model(
+        self,
+        *,
+        model_type: type[RecordModel],
+        table: str,
+        where_clause: str,
+        params: Sequence[object],
+    ) -> RecordModel:
+        query = f"SELECT payload::text FROM {table} WHERE {where_clause}"
+        with self._connection_factory() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(query, params)
+                row = cursor.fetchone()
+        if row is None:
+            raise FileNotFoundError(f"No Harbor record found in {table} for {params!r}")
+        return model_type.model_validate(json.loads(self._fetch_payload_text(row)))
+
+    def _list_models(
+        self,
+        *,
+        model_type: type[RecordModel],
+        table: str,
+        filters: Sequence[tuple[str, object]] = (),
+        order_by: str,
+        limit: int | None = None,
+    ) -> tuple[RecordModel, ...]:
+        clauses: list[str] = []
+        params: list[object] = []
+        for clause, value in filters:
+            clauses.append(clause)
+            params.append(value)
+        query = f"SELECT payload::text FROM {table}"
+        if clauses:
+            query += f" WHERE {' AND '.join(clauses)}"
+        query += f" ORDER BY {order_by}"
+        if limit is not None:
+            query += " LIMIT %s"
+            params.append(limit)
+        with self._connection_factory() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(query, params)
+                rows = cursor.fetchall()
+        return tuple(model_type.model_validate(json.loads(self._fetch_payload_text(row))) for row in rows)
+
+    def write_backup_gate_record(self, record: BackupGateRecord) -> None:
+        self._write_model(
+            table="harbor_backup_gates",
+            columns=("record_id", "context", "instance", "created_at", "status"),
+            values=(record.record_id, record.context, record.instance, record.created_at, record.status),
+            conflict_columns=("record_id",),
+            model=record,
+        )
+
+    def read_backup_gate_record(self, record_id: str) -> BackupGateRecord:
+        return self._read_model(
+            model_type=BackupGateRecord,
+            table="harbor_backup_gates",
+            where_clause="record_id = %s",
+            params=(record_id,),
+        )
+
+    def list_backup_gate_records(
+        self,
+        *,
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[BackupGateRecord, ...]:
+        filters: list[tuple[str, object]] = []
+        if context_name:
+            filters.append(("context = %s", context_name))
+        if instance_name:
+            filters.append(("instance = %s", instance_name))
+        return self._list_models(
+            model_type=BackupGateRecord,
+            table="harbor_backup_gates",
+            filters=filters,
+            order_by="created_at DESC, record_id DESC",
+            limit=limit,
+        )
+
+    def write_deployment_record(self, record: DeploymentRecord) -> None:
+        self._write_model(
+            table="harbor_deployments",
+            columns=(
+                "record_id",
+                "context",
+                "instance",
+                "artifact_id",
+                "source_git_ref",
+                "deploy_started_at",
+                "deploy_finished_at",
+            ),
+            values=(
+                record.record_id,
+                record.context,
+                record.instance,
+                _artifact_id_from_model(record),
+                record.source_git_ref,
+                record.deploy.started_at,
+                record.deploy.finished_at,
+            ),
+            conflict_columns=("record_id",),
+            model=record,
+        )
+
+    def read_deployment_record(self, record_id: str) -> DeploymentRecord:
+        return self._read_model(
+            model_type=DeploymentRecord,
+            table="harbor_deployments",
+            where_clause="record_id = %s",
+            params=(record_id,),
+        )
+
+    def list_deployment_records(
+        self,
+        *,
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[DeploymentRecord, ...]:
+        filters: list[tuple[str, object]] = []
+        if context_name:
+            filters.append(("context = %s", context_name))
+        if instance_name:
+            filters.append(("instance = %s", instance_name))
+        return self._list_models(
+            model_type=DeploymentRecord,
+            table="harbor_deployments",
+            filters=filters,
+            order_by="deploy_finished_at DESC, deploy_started_at DESC, record_id DESC",
+            limit=limit,
+        )
+
+    def write_promotion_record(self, record: PromotionRecord) -> None:
+        self._write_model(
+            table="harbor_promotions",
+            columns=(
+                "record_id",
+                "context",
+                "from_instance",
+                "to_instance",
+                "artifact_id",
+                "deploy_started_at",
+                "deploy_finished_at",
+            ),
+            values=(
+                record.record_id,
+                record.context,
+                record.from_instance,
+                record.to_instance,
+                record.artifact_identity.artifact_id,
+                record.deploy.started_at,
+                record.deploy.finished_at,
+            ),
+            conflict_columns=("record_id",),
+            model=record,
+        )
+
+    def read_promotion_record(self, record_id: str) -> PromotionRecord:
+        return self._read_model(
+            model_type=PromotionRecord,
+            table="harbor_promotions",
+            where_clause="record_id = %s",
+            params=(record_id,),
+        )
+
+    def list_promotion_records(
+        self,
+        *,
+        context_name: str = "",
+        from_instance_name: str = "",
+        to_instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[PromotionRecord, ...]:
+        filters: list[tuple[str, object]] = []
+        if context_name:
+            filters.append(("context = %s", context_name))
+        if from_instance_name:
+            filters.append(("from_instance = %s", from_instance_name))
+        if to_instance_name:
+            filters.append(("to_instance = %s", to_instance_name))
+        return self._list_models(
+            model_type=PromotionRecord,
+            table="harbor_promotions",
+            filters=filters,
+            order_by="deploy_finished_at DESC, deploy_started_at DESC, record_id DESC",
+            limit=limit,
+        )
+
+    def write_environment_inventory(self, record: EnvironmentInventory) -> None:
+        self._write_model(
+            table="harbor_inventory",
+            columns=(
+                "context",
+                "instance",
+                "artifact_id",
+                "source_git_ref",
+                "updated_at",
+                "deployment_record_id",
+                "promotion_record_id",
+                "promoted_from_instance",
+            ),
+            values=(
+                record.context,
+                record.instance,
+                _artifact_id_from_model(record),
+                record.source_git_ref,
+                record.updated_at,
+                record.deployment_record_id,
+                record.promotion_record_id,
+                record.promoted_from_instance,
+            ),
+            conflict_columns=("context", "instance"),
+            model=record,
+        )
+
+    def read_environment_inventory(self, *, context_name: str, instance_name: str) -> EnvironmentInventory:
+        return self._read_model(
+            model_type=EnvironmentInventory,
+            table="harbor_inventory",
+            where_clause="context = %s AND instance = %s",
+            params=(context_name, instance_name),
+        )
+
+    def list_environment_inventory(self) -> tuple[EnvironmentInventory, ...]:
+        return self._list_models(
+            model_type=EnvironmentInventory,
+            table="harbor_inventory",
+            order_by="context ASC, instance ASC",
+        )
+
+    def write_preview_record(self, record: PreviewRecord) -> None:
+        self._write_model(
+            table="harbor_preview_records",
+            columns=("preview_id", "context", "anchor_repo", "anchor_pr_number", "state", "updated_at"),
+            values=(
+                record.preview_id,
+                record.context,
+                record.anchor_repo,
+                record.anchor_pr_number,
+                record.state,
+                record.updated_at,
+            ),
+            conflict_columns=("preview_id",),
+            model=record,
+        )
+
+    def read_preview_record(self, preview_id: str) -> PreviewRecord:
+        return self._read_model(
+            model_type=PreviewRecord,
+            table="harbor_preview_records",
+            where_clause="preview_id = %s",
+            params=(preview_id,),
+        )
+
+    def list_preview_records(
+        self,
+        *,
+        context_name: str = "",
+        anchor_repo: str = "",
+        anchor_pr_number: int | None = None,
+        limit: int | None = None,
+    ) -> tuple[PreviewRecord, ...]:
+        filters: list[tuple[str, object]] = []
+        if context_name:
+            filters.append(("context = %s", context_name))
+        if anchor_repo:
+            filters.append(("anchor_repo = %s", anchor_repo))
+        if anchor_pr_number is not None:
+            filters.append(("anchor_pr_number = %s", anchor_pr_number))
+        return self._list_models(
+            model_type=PreviewRecord,
+            table="harbor_preview_records",
+            filters=filters,
+            order_by="updated_at DESC, preview_id DESC",
+            limit=limit,
+        )
+
+    def write_preview_generation_record(self, record: PreviewGenerationRecord) -> None:
+        self._write_model(
+            table="harbor_preview_generations",
+            columns=(
+                "generation_id",
+                "preview_id",
+                "sequence",
+                "state",
+                "requested_at",
+                "finished_at",
+                "artifact_id",
+            ),
+            values=(
+                record.generation_id,
+                record.preview_id,
+                record.sequence,
+                record.state,
+                record.requested_at,
+                record.finished_at,
+                record.artifact_id,
+            ),
+            conflict_columns=("generation_id",),
+            model=record,
+        )
+
+    def read_preview_generation_record(self, generation_id: str) -> PreviewGenerationRecord:
+        return self._read_model(
+            model_type=PreviewGenerationRecord,
+            table="harbor_preview_generations",
+            where_clause="generation_id = %s",
+            params=(generation_id,),
+        )
+
+    def list_preview_generation_records(
+        self,
+        *,
+        preview_id: str = "",
+        limit: int | None = None,
+    ) -> tuple[PreviewGenerationRecord, ...]:
+        filters: list[tuple[str, object]] = []
+        if preview_id:
+            filters.append(("preview_id = %s", preview_id))
+        return self._list_models(
+            model_type=PreviewGenerationRecord,
+            table="harbor_preview_generations",
+            filters=filters,
+            order_by="sequence DESC, requested_at DESC, generation_id DESC",
+            limit=limit,
+        )
+
+    def write_release_tuple_record(self, record: ReleaseTupleRecord) -> None:
+        self._write_model(
+            table="harbor_release_tuples",
+            columns=("context", "channel", "tuple_id", "artifact_id", "minted_at", "provenance"),
+            values=(
+                record.context,
+                record.channel,
+                record.tuple_id,
+                record.artifact_id,
+                record.minted_at,
+                record.provenance,
+            ),
+            conflict_columns=("context", "channel"),
+            model=record,
+        )
+
+    def read_release_tuple_record(self, *, context_name: str, channel_name: str) -> ReleaseTupleRecord:
+        return self._read_model(
+            model_type=ReleaseTupleRecord,
+            table="harbor_release_tuples",
+            where_clause="context = %s AND channel = %s",
+            params=(context_name, channel_name),
+        )
+
+    def list_release_tuple_records(self) -> tuple[ReleaseTupleRecord, ...]:
+        return self._list_models(
+            model_type=ReleaseTupleRecord,
+            table="harbor_release_tuples",
+            order_by="context ASC, channel ASC",
+        )
+
+    def import_core_records_from_filesystem(self, filesystem_store: FilesystemRecordStore) -> dict[str, int]:
+        counts = {
+            "backup_gates": 0,
+            "deployments": 0,
+            "promotions": 0,
+            "inventory": 0,
+            "preview_records": 0,
+            "preview_generations": 0,
+            "release_tuples": 0,
+        }
+        for record in filesystem_store.list_backup_gate_records():
+            self.write_backup_gate_record(record)
+            counts["backup_gates"] += 1
+        for record in filesystem_store.list_deployment_records():
+            self.write_deployment_record(record)
+            counts["deployments"] += 1
+        for record in filesystem_store.list_promotion_records():
+            self.write_promotion_record(record)
+            counts["promotions"] += 1
+        for record in filesystem_store.list_environment_inventory():
+            self.write_environment_inventory(record)
+            counts["inventory"] += 1
+        for record in filesystem_store.list_preview_records():
+            self.write_preview_record(record)
+            counts["preview_records"] += 1
+        for record in filesystem_store.list_preview_generation_records():
+            self.write_preview_generation_record(record)
+            counts["preview_generations"] += 1
+        for record in filesystem_store.list_release_tuple_records():
+            self.write_release_tuple_record(record)
+            counts["release_tuples"] += 1
+        return counts

--- a/control_plane/workflows/evidence_ingestion.py
+++ b/control_plane/workflows/evidence_ingestion.py
@@ -1,0 +1,92 @@
+import click
+
+from control_plane.contracts.deployment_record import DeploymentRecord
+from control_plane.contracts.promotion_record import PromotionRecord
+from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.workflows.inventory import build_environment_inventory, inventory_record_id
+from control_plane.workflows.ship import utc_now_timestamp
+
+
+def _artifact_id_or_empty(artifact_identity: object) -> str:
+    if artifact_identity is None:
+        return ""
+    artifact_id = getattr(artifact_identity, "artifact_id", "")
+    if isinstance(artifact_id, str):
+        return artifact_id
+    return ""
+
+
+def _write_environment_inventory(
+    *,
+    record_store: FilesystemRecordStore,
+    deployment_record: DeploymentRecord,
+    promotion_record_id: str = "",
+    promoted_from_instance: str = "",
+) -> str:
+    inventory_record = build_environment_inventory(
+        deployment_record=deployment_record,
+        updated_at=utc_now_timestamp(),
+        promotion_record_id=promotion_record_id,
+        promoted_from_instance=promoted_from_instance,
+    )
+    record_store.write_environment_inventory(inventory_record)
+    return inventory_record_id(
+        context_name=inventory_record.context,
+        instance_name=inventory_record.instance,
+    )
+
+
+def apply_deployment_evidence(
+    *,
+    record_store: FilesystemRecordStore,
+    deployment_record: DeploymentRecord,
+) -> dict[str, str]:
+    record_store.write_deployment_record(deployment_record)
+    result = {"deployment_record_id": deployment_record.record_id}
+    result["inventory_record_id"] = _write_environment_inventory(
+        record_store=record_store,
+        deployment_record=deployment_record,
+    )
+    return result
+
+
+def apply_promotion_evidence(
+    *,
+    record_store: FilesystemRecordStore,
+    promotion_record: PromotionRecord,
+) -> dict[str, str]:
+    record_store.write_promotion_record(promotion_record)
+    result = {"promotion_record_id": promotion_record.record_id}
+
+    deployment_record_id = promotion_record.deployment_record_id.strip()
+    if not deployment_record_id:
+        return result
+
+    deployment_record = record_store.read_deployment_record(deployment_record_id)
+    if deployment_record.context != promotion_record.context:
+        raise click.ClickException(
+            "Promotion record context does not match linked deployment record context."
+        )
+    if deployment_record.instance != promotion_record.to_instance:
+        raise click.ClickException(
+            "Promotion destination instance does not match linked deployment record instance."
+        )
+
+    promotion_artifact_id = _artifact_id_or_empty(promotion_record.artifact_identity)
+    deployment_artifact_id = _artifact_id_or_empty(deployment_record.artifact_identity)
+    if (
+        promotion_artifact_id
+        and deployment_artifact_id
+        and promotion_artifact_id != deployment_artifact_id
+    ):
+        raise click.ClickException(
+            "Promotion artifact_id does not match linked deployment record artifact_id."
+        )
+
+    result["inventory_record_id"] = _write_environment_inventory(
+        record_store=record_store,
+        deployment_record=deployment_record,
+        promotion_record_id=promotion_record.record_id,
+        promoted_from_instance=promotion_record.from_instance,
+    )
+    return result

--- a/control_plane/workflows/verireel_testing_deploy.py
+++ b/control_plane/workflows/verireel_testing_deploy.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+import click
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane import dokploy as control_plane_dokploy
+from control_plane.contracts.deployment_record import ResolvedTargetEvidence
+from control_plane.contracts.promotion_record import HealthcheckEvidence
+from control_plane.contracts.ship_request import ShipRequest
+from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.workflows.ship import build_deployment_record, generate_deployment_record_id, utc_now_timestamp
+
+
+class VeriReelTestingDeployRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    context: str = "verireel"
+    instance: str = "testing"
+    artifact_id: str
+    source_git_ref: str
+    timeout_seconds: int | None = Field(default=None, ge=1)
+    no_cache: bool = False
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "VeriReelTestingDeployRequest":
+        if self.context != "verireel":
+            raise ValueError("VeriReel testing deploy requires context 'verireel'.")
+        if self.instance != "testing":
+            raise ValueError("VeriReel testing deploy requires instance 'testing'.")
+        if not self.artifact_id.strip():
+            raise ValueError("VeriReel testing deploy requires artifact_id.")
+        if not self.source_git_ref.strip():
+            raise ValueError("VeriReel testing deploy requires source_git_ref.")
+        return self
+
+
+class VeriReelTestingDeployResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    deployment_record_id: str
+    deploy_status: Literal["pass", "fail"]
+    deploy_started_at: str
+    deploy_finished_at: str
+    target_name: str
+    target_type: str
+    target_id: str
+    error_message: str = ""
+
+
+def _resolve_deploy_mode(*, configured_ship_mode: str, target_type: str) -> str:
+    if configured_ship_mode == "auto":
+        return f"dokploy-{target_type}-api"
+    return f"dokploy-{configured_ship_mode}-api"
+
+
+def _fallback_ship_request(request: VeriReelTestingDeployRequest) -> ShipRequest:
+    return ShipRequest(
+        artifact_id=request.artifact_id,
+        context=request.context,
+        instance=request.instance,
+        source_git_ref=request.source_git_ref,
+        target_name="ver-testing-app",
+        target_type="application",
+        deploy_mode="dokploy-application-api",
+        wait=True,
+        timeout_seconds=request.timeout_seconds,
+        verify_health=False,
+        no_cache=request.no_cache,
+        destination_health=HealthcheckEvidence(status="skipped"),
+    )
+
+
+def _resolve_ship_request(
+    *,
+    control_plane_root: Path,
+    request: VeriReelTestingDeployRequest,
+) -> tuple[ShipRequest, ResolvedTargetEvidence, int]:
+    source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
+        control_plane_root=control_plane_root,
+    )
+    target_definition = control_plane_dokploy.find_dokploy_target_definition(
+        source_of_truth,
+        context_name=request.context,
+        instance_name=request.instance,
+    )
+    if target_definition is None:
+        raise click.ClickException(
+            f"No Dokploy target definition found for {request.context}/{request.instance}."
+        )
+
+    environment_values = control_plane_dokploy.read_control_plane_environment_values(
+        control_plane_root=control_plane_root,
+    )
+    deploy_mode = _resolve_deploy_mode(
+        configured_ship_mode=control_plane_dokploy.resolve_dokploy_ship_mode(
+            request.context,
+            request.instance,
+            environment_values,
+        ),
+        target_type=target_definition.target_type,
+    )
+    ship_request = ShipRequest(
+        artifact_id=request.artifact_id,
+        context=request.context,
+        instance=request.instance,
+        source_git_ref=request.source_git_ref,
+        target_name=target_definition.target_name.strip() or f"{request.context}-{request.instance}",
+        target_type=target_definition.target_type,
+        deploy_mode=deploy_mode,
+        wait=True,
+        timeout_seconds=request.timeout_seconds,
+        verify_health=False,
+        no_cache=request.no_cache,
+        destination_health=HealthcheckEvidence(status="skipped"),
+    )
+    resolved_target = ResolvedTargetEvidence(
+        target_type=target_definition.target_type,
+        target_id=target_definition.target_id,
+        target_name=target_definition.target_name.strip() or ship_request.target_name,
+    )
+    deploy_timeout_seconds = control_plane_dokploy.resolve_ship_timeout_seconds(
+        timeout_override_seconds=request.timeout_seconds,
+        target_definition=target_definition,
+    )
+    return ship_request, resolved_target, deploy_timeout_seconds
+
+
+def _execute_dokploy_deploy(
+    *,
+    control_plane_root: Path,
+    ship_request: ShipRequest,
+    resolved_target: ResolvedTargetEvidence,
+    deploy_timeout_seconds: int,
+) -> None:
+    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
+    latest_before = control_plane_dokploy.latest_deployment_for_target(
+        host=host,
+        token=token,
+        target_type=resolved_target.target_type,
+        target_id=resolved_target.target_id,
+    )
+    control_plane_dokploy.trigger_deployment(
+        host=host,
+        token=token,
+        target_type=resolved_target.target_type,
+        target_id=resolved_target.target_id,
+        no_cache=ship_request.no_cache,
+    )
+    control_plane_dokploy.wait_for_target_deployment(
+        host=host,
+        token=token,
+        target_type=resolved_target.target_type,
+        target_id=resolved_target.target_id,
+        before_key=control_plane_dokploy.deployment_key(latest_before),
+        timeout_seconds=deploy_timeout_seconds,
+    )
+
+
+def execute_verireel_testing_deploy(
+    *,
+    control_plane_root: Path,
+    record_store: FilesystemRecordStore,
+    request: VeriReelTestingDeployRequest,
+) -> VeriReelTestingDeployResult:
+    record_id = generate_deployment_record_id(
+        context_name=request.context,
+        instance_name=request.instance,
+    )
+    started_at = utc_now_timestamp()
+    fallback_request = _fallback_ship_request(request)
+
+    try:
+        ship_request, resolved_target, deploy_timeout_seconds = _resolve_ship_request(
+            control_plane_root=control_plane_root,
+            request=request,
+        )
+    except click.ClickException as exc:
+        finished_at = utc_now_timestamp()
+        record_store.write_deployment_record(
+            build_deployment_record(
+                request=fallback_request,
+                record_id=record_id,
+                deployment_id="control-plane-dokploy",
+                deployment_status="fail",
+                started_at=started_at,
+                finished_at=finished_at,
+            )
+        )
+        return VeriReelTestingDeployResult(
+            deployment_record_id=record_id,
+            deploy_status="fail",
+            deploy_started_at=started_at,
+            deploy_finished_at=finished_at,
+            target_name=fallback_request.target_name,
+            target_type=fallback_request.target_type,
+            target_id="",
+            error_message=str(exc),
+        )
+
+    record_store.write_deployment_record(
+        build_deployment_record(
+            request=ship_request,
+            record_id=record_id,
+            deployment_id="control-plane-dokploy",
+            deployment_status="pending",
+            started_at=started_at,
+            finished_at="",
+            resolved_target=resolved_target,
+        )
+    )
+
+    try:
+        _execute_dokploy_deploy(
+            control_plane_root=control_plane_root,
+            ship_request=ship_request,
+            resolved_target=resolved_target,
+            deploy_timeout_seconds=deploy_timeout_seconds,
+        )
+    except click.ClickException as exc:
+        finished_at = utc_now_timestamp()
+        record_store.write_deployment_record(
+            build_deployment_record(
+                request=ship_request,
+                record_id=record_id,
+                deployment_id="control-plane-dokploy",
+                deployment_status="fail",
+                started_at=started_at,
+                finished_at=finished_at,
+                resolved_target=resolved_target,
+            )
+        )
+        return VeriReelTestingDeployResult(
+            deployment_record_id=record_id,
+            deploy_status="fail",
+            deploy_started_at=started_at,
+            deploy_finished_at=finished_at,
+            target_name=resolved_target.target_name,
+            target_type=resolved_target.target_type,
+            target_id=resolved_target.target_id,
+            error_message=str(exc),
+        )
+
+    finished_at = utc_now_timestamp()
+    record_store.write_deployment_record(
+        build_deployment_record(
+            request=ship_request,
+            record_id=record_id,
+            deployment_id="control-plane-dokploy",
+            deployment_status="pass",
+            started_at=started_at,
+            finished_at=finished_at,
+            resolved_target=resolved_target,
+        )
+    )
+    return VeriReelTestingDeployResult(
+        deployment_record_id=record_id,
+        deploy_status="pass",
+        deploy_started_at=started_at,
+        deploy_finished_at=finished_at,
+        target_name=resolved_target.target_name,
+        target_type=resolved_target.target_type,
+        target_id=resolved_target.target_id,
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  harbor:
+    build:
+      context: .
+    command:
+      - /app/scripts/start-harbor-service.sh
+    environment:
+      HARBOR_SERVICE_AUDIENCE: ${HARBOR_SERVICE_AUDIENCE:-harbor.shinycomputers.com}
+      HARBOR_SERVICE_HOST: 0.0.0.0
+      HARBOR_SERVICE_PORT: 8080
+      HARBOR_STATE_DIR: /app/state
+    volumes:
+      - harbor-state:/app/state
+
+volumes:
+  harbor-state: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   harbor:
-    build:
-      context: .
+    image: ${DOCKER_IMAGE_REFERENCE:-harbor:local}
+    pull_policy: always
     command:
       - /app/scripts/start-harbor-service.sh
     environment:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -216,3 +216,8 @@ The first concrete HTTP/OIDC/API shape for that boundary is defined in
 - New cross-product integrations should target the future Harbor service
   boundary in design, even if a temporary local adapter is still required
   during migration.
+- Harbor now also has Postgres-backed shared-service storage and managed
+  secrets, but it does not yet have a formal schema migration system.
+- Until that migration story exists, schema changes for DB-backed Harbor state
+  should remain additive and backward-compatible so deploy rollback can safely
+  return to the previous Harbor image.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -86,6 +86,13 @@ The service currently uses a static authz policy file and GitHub OIDC bearer
 tokens. Additional evidence routes should land against the same authn/authz
 boundary rather than creating separate ad hoc ingress patterns.
 
+Current derived-state behavior:
+
+- accepted deployment evidence also refreshes current environment inventory for
+  that `context/instance`
+- accepted promotion evidence refreshes destination inventory when the
+  promotion record includes valid `deployment_record_id` linkage
+
 ## Core Rules
 
 - Promotions and deploys reference explicit artifact identifiers.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -81,6 +81,7 @@ Current implementation scope:
 - `POST /v1/evidence/promotions`
 - `POST /v1/evidence/previews/generations`
 - `POST /v1/evidence/previews/destroyed`
+- `POST /v1/drivers/verireel/testing-deploy`
 
 The service currently uses a static authz policy file and GitHub OIDC bearer
 tokens. Additional evidence routes should land against the same authn/authz
@@ -92,6 +93,10 @@ Current derived-state behavior:
   that `context/instance`
 - accepted promotion evidence refreshes destination inventory when the
   promotion record includes valid `deployment_record_id` linkage
+- Harbor can also execute the first explicit driver action directly:
+  `POST /v1/drivers/verireel/testing-deploy` triggers the shared testing deploy,
+  writes an initial deployment record, and returns deploy timing/status for the
+  caller to thread into later evidence reporting.
 
 ## Core Rules
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -87,6 +87,49 @@ The service currently uses a static authz policy file and GitHub OIDC bearer
 tokens. Additional evidence routes should land against the same authn/authz
 boundary rather than creating separate ad hoc ingress patterns.
 
+## Harbor Service Deploy Posture
+
+The first real Harbor service deployment should be GitHub-driven and
+Dokploy-hosted.
+
+- Keep test and deploy automation separate.
+- `CI` is the gate for Harbor code changes and must pass before a deploy
+  workflow replaces the live Harbor app.
+- The first real Harbor bring-up should target a single Dokploy-hosted Harbor
+  instance rather than introducing a separate Harbor testing instance during
+  bootstrap.
+- Harbor deploy automation should publish an immutable image artifact, update
+  Dokploy by digest, and record the previously running digest before
+  replacement.
+- The current repo workflow for that posture is
+  `.github/workflows/deploy-harbor.yml`.
+- Deploy verification should probe Harbor's live health endpoint, currently
+  `GET /v1/health`, after the Dokploy update.
+- When rollout health fails, deploy automation should restore the previous
+  digest automatically instead of requiring a manual Dokploy click path.
+- Keep a manual rollback path too, so operators can redeploy a known-good
+  digest even after a technically successful rollout.
+
+This posture is the current safety net while Harbor still lacks a dedicated
+testing environment of its own.
+
+Required GitHub configuration for that workflow:
+
+- repository secrets:
+  - `DOKPLOY_HOST`
+  - `DOKPLOY_TOKEN`
+- repository variables:
+  - `HARBOR_DOKPLOY_TARGET_TYPE`
+  - `HARBOR_DOKPLOY_TARGET_ID`
+  - `HARBOR_DEPLOY_HEALTH_URLS`
+  - optional `HARBOR_DOKPLOY_DEPLOY_TIMEOUT_SECONDS`
+  - optional `HARBOR_DEPLOY_HEALTH_TIMEOUT_SECONDS`
+  - optional `HARBOR_IMAGE_REPOSITORY`
+
+The Dokploy-hosted Harbor target should consume `DOCKER_IMAGE_REFERENCE` from
+its env so deploy automation can switch the service by immutable digest and
+roll back to the prior digest when verification fails.
+
 Current derived-state behavior:
 
 - accepted deployment evidence also refreshes current environment inventory for
@@ -137,6 +180,9 @@ Current derived-state behavior:
   preview generations instead of adding another long-lived route.
 - Operator read models compose inventory, deployment, promotion, and
   backup-gate records instead of requiring operators to inspect raw JSON first.
+- Until Harbor has a formal schema migration system, DB-backed schema changes
+  must stay additive and backward-compatible so image rollback remains a valid
+  recovery path.
 
 ## Dokploy Contracts
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -8,6 +8,9 @@ title: Records
 - Use Postgres-backed Harbor core-record tables for shared-service ingress when
   Harbor is running with `HARBOR_DATABASE_URL` or `harbor service serve
   --database-url ...`.
+- Use Postgres-backed Harbor secret tables for managed secret records when
+  Harbor is running with `HARBOR_DATABASE_URL` and
+  `HARBOR_MASTER_ENCRYPTION_KEY`.
 - Keep git history separate from operational history.
 - Favor append-style writes for promotion records.
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -4,7 +4,10 @@ title: Records
 
 ## Storage Policy
 
-- Persist records as JSON files in a local state directory.
+- Persist local-dev records as JSON files in a local state directory.
+- Use Postgres-backed Harbor core-record tables for shared-service ingress when
+  Harbor is running with `HARBOR_DATABASE_URL` or `harbor service serve
+  --database-url ...`.
 - Keep git history separate from operational history.
 - Favor append-style writes for promotion records.
 
@@ -23,9 +26,9 @@ deployment, promotion, inventory, and preview evidence ingestion before this
 control plane takes over product-specific runtime actions.
 
 Under the target Harbor shape, product workflows and drivers should speak in
-typed evidence payloads. Harbor may store those facts in file-backed JSON while
-it still lives in this repo, but callers should treat the durable record model
-as canonical and the storage engine as replaceable.
+typed evidence payloads. Harbor may still store those facts in file-backed JSON
+for local development, but the shared-service path should write the same record
+nouns into Postgres-backed tables without inventing a second record model.
 
 ## Layout
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -231,6 +231,10 @@ state/
 - Successful waited `promote` executions refresh the same inventory record and
   add promotion linkage so the current state can still be tied back to the
   controlling promotion and deployment records.
+- Harbor service evidence ingress now applies the same pattern for external
+  evidence: accepted deployment evidence refreshes inventory immediately, and
+  accepted promotion evidence refreshes destination inventory when the
+  promotion record carries explicit deployment linkage.
 - For a second product such as VeriReel, inventory should first be derived from
   ingested deployment/promotion evidence before Harbor becomes the runtime
   executor for that product. The first explicit mutation surfaces for that are

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -10,15 +10,23 @@ title: Secrets
 ## Current Contract
 
 - Dokploy credentials belong to `harbor`.
-- Keep real Dokploy values in the current process environment or in an
+- Harbor can now persist managed secret values in the Postgres shared-service
+  backend when `HARBOR_DATABASE_URL` is configured.
+- Managed secret values are encrypted before Harbor stores them; the master key
+  stays outside the database in `HARBOR_MASTER_ENCRYPTION_KEY`.
+- Keep existing bootstrap values in the current process environment or in an
   external Harbor config file such as
-  `${XDG_CONFIG_HOME:-$HOME/.config}/harbor/dokploy.env`.
+  `${XDG_CONFIG_HOME:-$HOME/.config}/harbor/dokploy.env` until they have been
+  imported into Harbor-managed secret records.
 - Local runtime environment truth should live outside the repo checkout, such
   as `${XDG_CONFIG_HOME:-$HOME/.config}/harbor/runtime-environments.toml`.
 - Live Dokploy `target_id` values belong in the control-plane repo's untracked
   `config/dokploy-targets.toml`.
 - `DOKPLOY_HOST` and `DOKPLOY_TOKEN` may also be provided through the current
   process environment.
+- Harbor can import the current `DOKPLOY_HOST` / `DOKPLOY_TOKEN` values with
+  `uv run harbor secrets import-bootstrap --database-url ...` so the first
+  shared-service bring-up does not require manual secret re-entry.
 - Optional ship-mode overrides such as `DOKPLOY_SHIP_MODE` and
   `DOKPLOY_SHIP_MODE_<CONTEXT>_<INSTANCE>` are also read from the same
   control-plane env surface.
@@ -30,6 +38,19 @@ title: Secrets
 - If you need a non-default runtime environments file location, set
   `ODOO_CONTROL_PLANE_RUNTIME_ENVIRONMENTS_FILE`.
 
+## DB-Backed Secret Resolution
+
+- Harbor reads DB-backed managed secrets first when matching secret records
+  exist for:
+  - Dokploy `DOKPLOY_HOST`
+  - Dokploy `DOKPLOY_TOKEN`
+  - runtime-environment keys that look like secrets, such as `*_PASSWORD`,
+    `*_TOKEN`, `*_SECRET`, and `*_KEY`
+- Harbor falls back to the older file/env surfaces only when no managed secret
+  record exists for a requested binding.
+- Secret status surfaces return metadata only. Harbor does not expose routine
+  plaintext read commands or service endpoints.
+
 ## Rules
 
 - Do not keep real secret files in the repo checkout.
@@ -40,6 +61,8 @@ title: Secrets
   start from `config/dokploy-targets.toml.example`.
 - Do not rely on a repo-local `.env` for control-plane-owned secrets.
 - Missing Dokploy credentials are a hard error, not a silent fallback.
+- Missing `HARBOR_MASTER_ENCRYPTION_KEY` is a hard error when Harbor needs to
+  read or write DB-backed managed secrets.
 
 ## Local Runtime Contract
 
@@ -63,4 +86,6 @@ cp config/dokploy-targets.toml.example config/dokploy-targets.toml
 cp config/runtime-environments.toml.example \
   "${XDG_CONFIG_HOME:-$HOME/.config}/harbor/runtime-environments.toml"
 cp .env.example "${XDG_CONFIG_HOME:-$HOME/.config}/harbor/dokploy.env"
+export HARBOR_MASTER_ENCRYPTION_KEY="replace-me"
+uv run harbor secrets import-bootstrap --database-url "$HARBOR_DATABASE_URL"
 ```

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -139,6 +139,28 @@ allowed actions:
   - preview_destroyed.write
 ```
 
+Stable-lane examples:
+
+```text
+repository: every/verireel
+workflow_ref: every/verireel/.github/workflows/publish-image.yml@refs/heads/main
+event_name: push or workflow_dispatch
+allowed product: verireel
+allowed contexts: verireel
+allowed actions:
+  - deployment.write
+```
+
+```text
+repository: every/verireel
+workflow_ref: every/verireel/.github/workflows/promote-image.yml@refs/heads/main
+event_name: workflow_dispatch
+allowed product: verireel
+allowed contexts: verireel
+allowed actions:
+  - promotion.write
+```
+
 The initial policy engine can be config-backed and static. It does not need a
 full RBAC system yet.
 
@@ -276,6 +298,11 @@ CLI adapters and expose them over HTTP.
 
 The deployment and promotion endpoints should follow the same pattern: stable
 typed record payloads inside a Harbor-owned API envelope.
+
+For VeriReel's first stable-lane Harbor slice, use context `verireel` for the
+long-lived `testing` and `prod` instances. Preview evidence remains separate
+under `verireel-testing` because previews are not another durable promotion
+lane.
 
 ## CLI Relationship
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -188,6 +188,12 @@ writes, not on every possible operator action.
 - `GET /v1/inventory/{context}/{instance}`
 - `GET /v1/promotions/{record_id}`
 - `GET /v1/deployments/{record_id}`
+- `GET /v1/contexts/{context}/operations/recent`
+
+These operator reads use the same Harbor authn/authz boundary as evidence
+ingress. The intent is to give operators a minimal typed read surface for the
+current Harbor record nouns without forcing them to infer state from workflow
+logs or host-local files.
 
 ### Driver execution endpoints
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -30,10 +30,14 @@ The first service slice is now implemented locally in this repo:
   - `POST /v1/evidence/promotions`
   - `POST /v1/evidence/previews/generations`
   - `POST /v1/evidence/previews/destroyed`
+- first driver route:
+  - `POST /v1/drivers/verireel/testing-deploy`
 
-That slice now covers the first documented evidence surface end to end. Harbor
-can verify GitHub OIDC, authorize workflow identity claims, and accept the
-first deployment, promotion, and preview lifecycle evidence writes over HTTP.
+That slice now covers the first documented evidence surface end to end plus the
+first explicit Harbor-owned driver action. Harbor can verify GitHub OIDC,
+authorize workflow identity claims, accept deployment/promotion/preview
+lifecycle evidence over HTTP, and execute the VeriReel shared testing deploy as
+an authenticated Harbor route.
 
 ## First Host Assumption
 
@@ -148,6 +152,7 @@ event_name: push or workflow_dispatch
 allowed product: verireel
 allowed contexts: verireel
 allowed actions:
+  - verireel_testing_deploy.execute
   - deployment.write
 ```
 
@@ -186,12 +191,17 @@ writes, not on every possible operator action.
 
 ### Driver execution endpoints
 
-These can exist later, but should use the same authn/authz boundary:
+These use the same authn/authz boundary as evidence ingress:
 
 - `POST /v1/drivers/odoo/...`
 - `POST /v1/drivers/verireel/...`
 
-Do not block the first evidence-ingest service slice on driver execution.
+The first explicit driver route now in service is:
+
+- `POST /v1/drivers/verireel/testing-deploy`
+
+Do not generalize the full driver surface before a few product-specific routes
+have proven the shape.
 
 ## Request And Response Rules
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -188,12 +188,16 @@ writes, not on every possible operator action.
 - `GET /v1/inventory/{context}/{instance}`
 - `GET /v1/promotions/{record_id}`
 - `GET /v1/deployments/{record_id}`
+- `GET /v1/contexts/{context}/secrets`
+- `GET /v1/contexts/{context}/instances/{instance}/secrets`
+- `GET /v1/secrets/{secret_id}`
 - `GET /v1/contexts/{context}/operations/recent`
 
 These operator reads use the same Harbor authn/authz boundary as evidence
 ingress. The intent is to give operators a minimal typed read surface for the
 current Harbor record nouns without forcing them to infer state from workflow
-logs or host-local files.
+logs or host-local files. Secret status reads return metadata only: Harbor does
+not expose plaintext secret retrieval through the service boundary.
 
 ### Driver execution endpoints
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.13"
 dependencies = [
     "click>=8.1",
     "pydantic>=2.8",
+    "psycopg[binary]>=3.2",
     "pyjwt[crypto]>=2.10",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pydantic>=2.8",
     "psycopg[binary]>=3.2",
     "pyjwt[crypto]>=2.10",
+    "sqlalchemy>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/start-harbor-service.sh
+++ b/scripts/start-harbor-service.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+
+set -eu
+
+write_text_file() {
+  file_path="$1"
+  file_contents="$2"
+  mkdir -p "$(dirname "$file_path")"
+  printf '%s\n' "$file_contents" >"$file_path"
+}
+
+write_base64_file() {
+  file_path="$1"
+  env_name="$2"
+  mkdir -p "$(dirname "$file_path")"
+  python3 - "$file_path" "$env_name" <<'PY'
+import base64
+import os
+import sys
+
+path = sys.argv[1]
+env_name = sys.argv[2]
+value = os.environ.get(env_name, "")
+with open(path, "wb") as handle:
+    handle.write(base64.b64decode(value))
+PY
+}
+
+app_root="${HARBOR_APP_ROOT:-/app}"
+state_dir="${HARBOR_STATE_DIR:-$app_root/state}"
+policy_file="${HARBOR_POLICY_FILE:-$app_root/config/harbor-authz.toml.example}"
+
+mkdir -p "$state_dir"
+
+if [ -n "${HARBOR_POLICY_TOML:-}" ]; then
+  policy_file="/tmp/harbor-authz.toml"
+  write_text_file "$policy_file" "$HARBOR_POLICY_TOML"
+elif [ -n "${HARBOR_POLICY_B64:-}" ]; then
+  policy_file="/tmp/harbor-authz.toml"
+  write_base64_file "$policy_file" "HARBOR_POLICY_B64"
+fi
+
+if [ -n "${HARBOR_DOKPLOY_TARGET_IDS_TOML:-}" ]; then
+  target_ids_file="/tmp/dokploy-targets.toml"
+  write_text_file "$target_ids_file" "$HARBOR_DOKPLOY_TARGET_IDS_TOML"
+  export ODOO_CONTROL_PLANE_DOKPLOY_TARGET_IDS_FILE="$target_ids_file"
+elif [ -n "${HARBOR_DOKPLOY_TARGET_IDS_B64:-}" ]; then
+  target_ids_file="/tmp/dokploy-targets.toml"
+  write_base64_file "$target_ids_file" "HARBOR_DOKPLOY_TARGET_IDS_B64"
+  export ODOO_CONTROL_PLANE_DOKPLOY_TARGET_IDS_FILE="$target_ids_file"
+fi
+
+if [ -n "${HARBOR_RUNTIME_ENVIRONMENTS_TOML:-}" ]; then
+  runtime_env_file="/tmp/runtime-environments.toml"
+  write_text_file "$runtime_env_file" "$HARBOR_RUNTIME_ENVIRONMENTS_TOML"
+  export ODOO_CONTROL_PLANE_RUNTIME_ENVIRONMENTS_FILE="$runtime_env_file"
+elif [ -n "${HARBOR_RUNTIME_ENVIRONMENTS_B64:-}" ]; then
+  runtime_env_file="/tmp/runtime-environments.toml"
+  write_base64_file "$runtime_env_file" "HARBOR_RUNTIME_ENVIRONMENTS_B64"
+  export ODOO_CONTROL_PLANE_RUNTIME_ENVIRONMENTS_FILE="$runtime_env_file"
+fi
+
+exec uv run harbor service serve \
+  --host "${HARBOR_SERVICE_HOST:-0.0.0.0}" \
+  --port "${HARBOR_SERVICE_PORT:-8080}" \
+  --state-dir "$state_dir" \
+  --policy-file "$policy_file" \
+  --audience "${HARBOR_SERVICE_AUDIENCE:-harbor.shinycomputers.com}"

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -664,5 +664,134 @@ target_id = "compose-456"
         self.assertIn("UNRELATED_RUNTIME_KEY", str(raised_error.exception))
 
 
+class HarborServiceDeployTests(unittest.TestCase):
+    def test_render_dokploy_env_text_with_overrides_updates_and_removes_keys(self) -> None:
+        rendered = control_plane_dokploy.render_dokploy_env_text_with_overrides(
+            "KEEP=1\nREMOVE=old\n",
+            updates={"ADD": "2"},
+            removals=("REMOVE",),
+        )
+
+        self.assertEqual(rendered, "KEEP=1\nADD=2")
+
+    def test_service_deploy_dokploy_image_rolls_forward_and_verifies_health(self) -> None:
+        runner = CliRunner()
+        captured_env_updates: list[dict[str, object]] = []
+        captured_trigger_calls: list[dict[str, object]] = []
+
+        with patch(
+            "control_plane.dokploy.read_dokploy_config",
+            return_value=("https://dokploy.example.com", "token-123"),
+        ), patch(
+            "control_plane.dokploy.fetch_dokploy_target_payload",
+            return_value={"env": "DOCKER_IMAGE_REFERENCE=ghcr.io/every/harbor@sha256:old\n"},
+        ), patch(
+            "control_plane.dokploy.update_dokploy_target_env",
+            side_effect=lambda **kwargs: captured_env_updates.append(kwargs),
+        ), patch(
+            "control_plane.dokploy.latest_deployment_for_target",
+            return_value={"deploymentId": "deploy-old"},
+        ), patch(
+            "control_plane.dokploy.trigger_deployment",
+            side_effect=lambda **kwargs: captured_trigger_calls.append(kwargs),
+        ), patch(
+            "control_plane.dokploy.wait_for_target_deployment",
+            return_value="deployment=deploy-new status=done",
+        ), patch(
+            "control_plane.cli._wait_for_ship_healthcheck",
+            return_value=None,
+        ):
+            result = runner.invoke(
+                main,
+                [
+                    "service",
+                    "deploy-dokploy-image",
+                    "--target-type",
+                    "compose",
+                    "--target-id",
+                    "compose-123",
+                    "--image-reference",
+                    "ghcr.io/every/harbor@sha256:new",
+                    "--health-url",
+                    "https://harbor.example.com/v1/health",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertEqual(len(captured_env_updates), 1)
+        self.assertEqual(len(captured_trigger_calls), 1)
+        self.assertIn("sha256:new", str(captured_env_updates[0]["env_text"]))
+        payload = json.loads(result.output)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["previous_image_reference"], "ghcr.io/every/harbor@sha256:old")
+        self.assertEqual(payload["deployment_result"], "deployment=deploy-new status=done")
+
+    def test_service_deploy_dokploy_image_rolls_back_when_health_verification_fails(self) -> None:
+        runner = CliRunner()
+        captured_env_updates: list[dict[str, object]] = []
+        captured_trigger_calls: list[dict[str, object]] = []
+
+        with patch(
+            "control_plane.dokploy.read_dokploy_config",
+            return_value=("https://dokploy.example.com", "token-123"),
+        ), patch(
+            "control_plane.dokploy.fetch_dokploy_target_payload",
+            side_effect=[
+                {"env": "DOCKER_IMAGE_REFERENCE=ghcr.io/every/harbor@sha256:old\n"},
+                {"env": "DOCKER_IMAGE_REFERENCE=ghcr.io/every/harbor@sha256:new\n"},
+            ],
+        ), patch(
+            "control_plane.dokploy.update_dokploy_target_env",
+            side_effect=lambda **kwargs: captured_env_updates.append(kwargs),
+        ), patch(
+            "control_plane.dokploy.latest_deployment_for_target",
+            side_effect=[
+                {"deploymentId": "deploy-old"},
+                {"deploymentId": "deploy-new"},
+            ],
+        ), patch(
+            "control_plane.dokploy.trigger_deployment",
+            side_effect=lambda **kwargs: captured_trigger_calls.append(kwargs),
+        ), patch(
+            "control_plane.dokploy.wait_for_target_deployment",
+            side_effect=[
+                "deployment=deploy-new status=done",
+                "deployment=deploy-rollback status=done",
+            ],
+        ), patch(
+            "control_plane.cli._wait_for_ship_healthcheck",
+            side_effect=[
+                click.ClickException("Healthcheck failed for https://harbor.example.com/v1/health: http 503"),
+                None,
+            ],
+        ):
+            result = runner.invoke(
+                main,
+                [
+                    "service",
+                    "deploy-dokploy-image",
+                    "--target-type",
+                    "compose",
+                    "--target-id",
+                    "compose-123",
+                    "--image-reference",
+                    "ghcr.io/every/harbor@sha256:new",
+                    "--health-url",
+                    "https://harbor.example.com/v1/health",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0, msg=result.output)
+        self.assertEqual(len(captured_env_updates), 2)
+        self.assertEqual(len(captured_trigger_calls), 2)
+        self.assertIn("sha256:new", str(captured_env_updates[0]["env_text"]))
+        self.assertIn("sha256:old", str(captured_env_updates[1]["env_text"]))
+        self.assertIn("Harbor service health verification failed", result.output)
+        payload_text = result.output.split("Error:", 1)[0].strip()
+        payload = json.loads(payload_text) if payload_text else {}
+        self.assertEqual(payload.get("status"), "failed")
+        self.assertEqual(payload.get("rollback", {}).get("status"), "ok")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1,0 +1,412 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+from control_plane.cli import main
+from control_plane.contracts.backup_gate_record import BackupGateRecord
+from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
+from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.preview_generation_record import (
+    PreviewGenerationRecord,
+    PreviewPullRequestSummary,
+)
+from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.contracts.promotion_record import (
+    ArtifactIdentityReference,
+    DeploymentEvidence,
+    PromotionRecord,
+)
+from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.storage.postgres import PostgresRecordStore
+
+
+TABLE_PRIMARY_KEYS = {
+    "harbor_backup_gates": ("record_id",),
+    "harbor_deployments": ("record_id",),
+    "harbor_promotions": ("record_id",),
+    "harbor_inventory": ("context", "instance"),
+    "harbor_preview_records": ("preview_id",),
+    "harbor_preview_generations": ("generation_id",),
+    "harbor_release_tuples": ("context", "channel"),
+}
+
+
+class _FakeCursor:
+    def __init__(self, connection: "_FakeConnection") -> None:
+        self.connection = connection
+        self._rows: list[tuple[str]] = []
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def execute(self, query: str, params=None) -> "_FakeCursor":
+        normalized_query = " ".join(query.split())
+        bound_params = tuple(params or ())
+        if normalized_query.startswith("CREATE TABLE") or normalized_query.startswith("CREATE INDEX"):
+            self.connection.executed.append((normalized_query, bound_params))
+            self._rows = []
+            return self
+
+        if normalized_query.startswith("INSERT INTO "):
+            table_name = normalized_query.split()[2]
+            column_fragment = normalized_query.split("(", 1)[1].split(")", 1)[0]
+            columns = [column.strip() for column in column_fragment.split(",")]
+            row = dict(zip(columns, bound_params, strict=True))
+            primary_key_columns = TABLE_PRIMARY_KEYS[table_name]
+            primary_key = tuple(row[column] for column in primary_key_columns)
+            if len(primary_key) == 1:
+                primary_key = primary_key[0]
+            self.connection.tables.setdefault(table_name, {})[primary_key] = row
+            self.connection.executed.append((normalized_query, bound_params))
+            self._rows = []
+            return self
+
+        if normalized_query.startswith("SELECT payload::text FROM "):
+            table_name = normalized_query.split("FROM ", 1)[1].split(" ", 1)[0]
+            rows = list(self.connection.tables.get(table_name, {}).values())
+            limit = None
+            filter_params = list(bound_params)
+            if " LIMIT %s" in normalized_query:
+                limit = int(filter_params.pop())
+            if " WHERE " in normalized_query:
+                where_clause = normalized_query.split(" WHERE ", 1)[1].split(" ORDER BY ", 1)[0]
+                predicates = [predicate.strip() for predicate in where_clause.split(" AND ")]
+                for predicate, value in zip(predicates, filter_params, strict=True):
+                    column_name = predicate.split("=", 1)[0].strip()
+                    rows = [row for row in rows if row[column_name] == value]
+            if " ORDER BY " in normalized_query:
+                order_by_clause = normalized_query.split(" ORDER BY ", 1)[1].split(" LIMIT %s", 1)[0]
+                order_clauses = [clause.strip() for clause in order_by_clause.split(",")]
+                for clause in reversed(order_clauses):
+                    column_name, direction = clause.rsplit(" ", 1)
+                    rows.sort(key=lambda row: row[column_name.strip()], reverse=direction == "DESC")
+            if limit is not None:
+                rows = rows[:limit]
+            self.connection.executed.append((normalized_query, bound_params))
+            self._rows = [(str(row["payload"]),) for row in rows]
+            return self
+
+        raise AssertionError(f"Unexpected query in fake Postgres connection: {normalized_query}")
+
+    def fetchone(self):
+        if not self._rows:
+            return None
+        return self._rows[0]
+
+    def fetchall(self):
+        return list(self._rows)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.tables: dict[str, dict[object, dict[str, object]]] = {}
+        self.executed: list[tuple[str, tuple[object, ...]]] = []
+        self.commit_count = 0
+
+    def __enter__(self) -> "_FakeConnection":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def cursor(self) -> _FakeCursor:
+        return _FakeCursor(self)
+
+    def commit(self) -> None:
+        self.commit_count += 1
+
+
+def _deployment_record(*, record_id: str, started_at: str, finished_at: str) -> DeploymentRecord:
+    return DeploymentRecord(
+        record_id=record_id,
+        artifact_identity=ArtifactIdentityReference(artifact_id="artifact-20260420-a1b2c3d4"),
+        context="opw",
+        instance="testing",
+        source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
+        resolved_target=ResolvedTargetEvidence(
+            target_type="compose",
+            target_id="compose-123",
+            target_name="opw-testing",
+        ),
+        deploy=DeploymentEvidence(
+            target_name="opw-testing",
+            target_type="compose",
+            deploy_mode="dokploy-compose-api",
+            deployment_id="dokploy-1",
+            status="pass",
+            started_at=started_at,
+            finished_at=finished_at,
+        ),
+    )
+
+
+def _promotion_record(*, record_id: str) -> PromotionRecord:
+    return PromotionRecord(
+        record_id=record_id,
+        artifact_identity=ArtifactIdentityReference(artifact_id="artifact-20260420-a1b2c3d4"),
+        deployment_record_id="deployment-20260420T153000Z-opw-testing",
+        backup_record_id="backup-opw-prod-20260420T160000Z",
+        context="opw",
+        from_instance="testing",
+        to_instance="prod",
+        deploy=DeploymentEvidence(
+            target_name="opw-prod",
+            target_type="compose",
+            deploy_mode="dokploy-compose-api",
+            deployment_id="dokploy-2",
+            status="pass",
+            started_at="2026-04-20T16:05:00Z",
+            finished_at="2026-04-20T16:07:00Z",
+        ),
+    )
+
+
+def _inventory_record() -> EnvironmentInventory:
+    return EnvironmentInventory(
+        context="opw",
+        instance="testing",
+        artifact_identity=ArtifactIdentityReference(artifact_id="artifact-20260420-a1b2c3d4"),
+        source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
+        deploy=DeploymentEvidence(
+            target_name="opw-testing",
+            target_type="compose",
+            deploy_mode="dokploy-compose-api",
+            deployment_id="dokploy-1",
+            status="pass",
+            started_at="2026-04-20T15:30:00Z",
+            finished_at="2026-04-20T15:32:00Z",
+        ),
+        updated_at="2026-04-20T15:33:00Z",
+        deployment_record_id="deployment-20260420T153000Z-opw-testing",
+    )
+
+
+def _preview_record(*, preview_id: str, updated_at: str, pr_number: int) -> PreviewRecord:
+    return PreviewRecord(
+        preview_id=preview_id,
+        context="verireel-testing",
+        anchor_repo="verireel",
+        anchor_pr_number=pr_number,
+        anchor_pr_url=f"https://github.com/every/verireel/pull/{pr_number}",
+        preview_label=f"verireel/pr-{pr_number}",
+        canonical_url=f"https://pr-{pr_number}.ver-preview.shinycomputers.com",
+        state="active",
+        created_at="2026-04-20T10:00:00Z",
+        updated_at=updated_at,
+        eligible_at=updated_at,
+    )
+
+
+def _preview_generation_record(*, generation_id: str, preview_id: str) -> PreviewGenerationRecord:
+    return PreviewGenerationRecord(
+        generation_id=generation_id,
+        preview_id=preview_id,
+        sequence=1,
+        state="ready",
+        requested_reason="external_preview_refresh",
+        requested_at="2026-04-20T10:01:00Z",
+        ready_at="2026-04-20T10:05:00Z",
+        finished_at="2026-04-20T10:05:00Z",
+        resolved_manifest_fingerprint="preview-manifest-123",
+        artifact_id="ghcr.io/every/verireel-app:pr-123",
+        anchor_summary=PreviewPullRequestSummary(
+            repo="verireel",
+            pr_number=123,
+            head_sha="6b3c9d7e8f901234567890abcdef1234567890ab",
+            pr_url="https://github.com/every/verireel/pull/123",
+        ),
+        deploy_status="pass",
+        verify_status="pass",
+        overall_health_status="pass",
+    )
+
+
+def _backup_gate_record() -> BackupGateRecord:
+    return BackupGateRecord(
+        record_id="backup-opw-prod-20260420T160000Z",
+        context="opw",
+        instance="prod",
+        created_at="2026-04-20T16:00:00Z",
+        source="prod-gate",
+        status="pass",
+        evidence={"snapshot": "opw-predeploy-20260420-160000"},
+    )
+
+
+def _release_tuple_record() -> ReleaseTupleRecord:
+    return ReleaseTupleRecord(
+        tuple_id="opw-testing-artifact-20260420-a1b2c3d4",
+        context="opw",
+        channel="testing",
+        artifact_id="artifact-20260420-a1b2c3d4",
+        repo_shas={"tenant-opw": "a1b2c3d4", "shared-addons": "abcdef1"},
+        deployment_record_id="deployment-20260420T153000Z-opw-testing",
+        provenance="ship",
+        minted_at="2026-04-20T15:33:00Z",
+    )
+
+
+class PostgresRecordStoreTests(unittest.TestCase):
+    def test_storage_import_core_records_command_reports_counts(self) -> None:
+        runner = CliRunner()
+        postgres_store = Mock()
+        postgres_store.import_core_records_from_filesystem.return_value = {
+            "backup_gates": 0,
+            "deployments": 1,
+            "promotions": 0,
+            "inventory": 1,
+            "preview_records": 0,
+            "preview_generations": 0,
+            "release_tuples": 0,
+        }
+
+        with TemporaryDirectory() as temporary_directory_name:
+            with patch("control_plane.cli.PostgresRecordStore", return_value=postgres_store) as store_class:
+                result = runner.invoke(
+                    main,
+                    [
+                        "storage",
+                        "import-core-records",
+                        "--state-dir",
+                        temporary_directory_name,
+                        "--database-url",
+                        "postgresql://harbor:test@db/harbor",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        store_class.assert_called_once_with(database_url="postgresql://harbor:test@db/harbor")
+        postgres_store.ensure_schema.assert_called_once_with()
+        postgres_store.import_core_records_from_filesystem.assert_called_once()
+        self.assertIn('"deployments": 1', result.output)
+
+    def test_write_and_read_deployment_record(self) -> None:
+        connection = _FakeConnection()
+        store = PostgresRecordStore(
+            database_url="postgresql://harbor:test@db/harbor",
+            connection_factory=lambda: connection,
+        )
+
+        store.ensure_schema()
+        store.write_deployment_record(
+            _deployment_record(
+                record_id="deployment-20260420T153000Z-opw-testing",
+                started_at="2026-04-20T15:30:00Z",
+                finished_at="2026-04-20T15:32:00Z",
+            )
+        )
+        loaded_record = store.read_deployment_record("deployment-20260420T153000Z-opw-testing")
+
+        self.assertEqual(store.backend_name, "postgres")
+        self.assertEqual(loaded_record.context, "opw")
+        self.assertEqual(loaded_record.resolved_target.target_id, "compose-123")
+        self.assertGreaterEqual(connection.commit_count, 2)
+
+    def test_list_preview_records_filters_and_limits(self) -> None:
+        connection = _FakeConnection()
+        store = PostgresRecordStore(
+            database_url="postgresql://harbor:test@db/harbor",
+            connection_factory=lambda: connection,
+        )
+
+        store.write_preview_record(
+            _preview_record(
+                preview_id="preview-verireel-testing-verireel-pr-101",
+                updated_at="2026-04-20T10:01:00Z",
+                pr_number=101,
+            )
+        )
+        store.write_preview_record(
+            _preview_record(
+                preview_id="preview-verireel-testing-verireel-pr-102",
+                updated_at="2026-04-20T10:03:00Z",
+                pr_number=102,
+            )
+        )
+        store.write_preview_record(
+            _preview_record(
+                preview_id="preview-verireel-testing-verireel-pr-103",
+                updated_at="2026-04-20T10:02:00Z",
+                pr_number=103,
+            )
+        )
+
+        listed_records = store.list_preview_records(
+            context_name="verireel-testing",
+            anchor_repo="verireel",
+            limit=2,
+        )
+
+        self.assertEqual(
+            [record.preview_id for record in listed_records],
+            [
+                "preview-verireel-testing-verireel-pr-102",
+                "preview-verireel-testing-verireel-pr-103",
+            ],
+        )
+
+    def test_import_core_records_from_filesystem(self) -> None:
+        connection = _FakeConnection()
+        store = PostgresRecordStore(
+            database_url="postgresql://harbor:test@db/harbor",
+            connection_factory=lambda: connection,
+        )
+
+        with TemporaryDirectory() as temporary_directory_name:
+            filesystem_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name))
+            filesystem_store.write_backup_gate_record(_backup_gate_record())
+            filesystem_store.write_deployment_record(
+                _deployment_record(
+                    record_id="deployment-20260420T153000Z-opw-testing",
+                    started_at="2026-04-20T15:30:00Z",
+                    finished_at="2026-04-20T15:32:00Z",
+                )
+            )
+            filesystem_store.write_promotion_record(_promotion_record(record_id="promotion-20260420T160500Z-opw-testing-to-prod"))
+            filesystem_store.write_environment_inventory(_inventory_record())
+            filesystem_store.write_preview_record(
+                _preview_record(
+                    preview_id="preview-verireel-testing-verireel-pr-123",
+                    updated_at="2026-04-20T10:05:00Z",
+                    pr_number=123,
+                )
+            )
+            filesystem_store.write_preview_generation_record(
+                _preview_generation_record(
+                    generation_id="preview-verireel-testing-verireel-pr-123-generation-0001",
+                    preview_id="preview-verireel-testing-verireel-pr-123",
+                )
+            )
+            filesystem_store.write_release_tuple_record(_release_tuple_record())
+
+            counts = store.import_core_records_from_filesystem(filesystem_store)
+
+        self.assertEqual(
+            counts,
+            {
+                "backup_gates": 1,
+                "deployments": 1,
+                "promotions": 1,
+                "inventory": 1,
+                "preview_records": 1,
+                "preview_generations": 1,
+                "release_tuples": 1,
+            },
+        )
+        self.assertEqual(
+            store.read_promotion_record("promotion-20260420T160500Z-opw-testing-to-prod").to_instance,
+            "prod",
+        )
+        self.assertEqual(
+            store.read_preview_generation_record(
+                "preview-verireel-testing-verireel-pr-123-generation-0001"
+            ).state,
+            "ready",
+        )

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -20,107 +20,13 @@ from control_plane.contracts.promotion_record import (
     PromotionRecord,
 )
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+from control_plane.contracts.secret_record import SecretAuditEvent, SecretBinding, SecretRecord, SecretVersion
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
 
 
-TABLE_PRIMARY_KEYS = {
-    "harbor_backup_gates": ("record_id",),
-    "harbor_deployments": ("record_id",),
-    "harbor_promotions": ("record_id",),
-    "harbor_inventory": ("context", "instance"),
-    "harbor_preview_records": ("preview_id",),
-    "harbor_preview_generations": ("generation_id",),
-    "harbor_release_tuples": ("context", "channel"),
-}
-
-
-class _FakeCursor:
-    def __init__(self, connection: "_FakeConnection") -> None:
-        self.connection = connection
-        self._rows: list[tuple[str]] = []
-
-    def __enter__(self) -> "_FakeCursor":
-        return self
-
-    def __exit__(self, exc_type, exc, tb) -> None:
-        return None
-
-    def execute(self, query: str, params=None) -> "_FakeCursor":
-        normalized_query = " ".join(query.split())
-        bound_params = tuple(params or ())
-        if normalized_query.startswith("CREATE TABLE") or normalized_query.startswith("CREATE INDEX"):
-            self.connection.executed.append((normalized_query, bound_params))
-            self._rows = []
-            return self
-
-        if normalized_query.startswith("INSERT INTO "):
-            table_name = normalized_query.split()[2]
-            column_fragment = normalized_query.split("(", 1)[1].split(")", 1)[0]
-            columns = [column.strip() for column in column_fragment.split(",")]
-            row = dict(zip(columns, bound_params, strict=True))
-            primary_key_columns = TABLE_PRIMARY_KEYS[table_name]
-            primary_key = tuple(row[column] for column in primary_key_columns)
-            if len(primary_key) == 1:
-                primary_key = primary_key[0]
-            self.connection.tables.setdefault(table_name, {})[primary_key] = row
-            self.connection.executed.append((normalized_query, bound_params))
-            self._rows = []
-            return self
-
-        if normalized_query.startswith("SELECT payload::text FROM "):
-            table_name = normalized_query.split("FROM ", 1)[1].split(" ", 1)[0]
-            rows = list(self.connection.tables.get(table_name, {}).values())
-            limit = None
-            filter_params = list(bound_params)
-            if " LIMIT %s" in normalized_query:
-                limit = int(filter_params.pop())
-            if " WHERE " in normalized_query:
-                where_clause = normalized_query.split(" WHERE ", 1)[1].split(" ORDER BY ", 1)[0]
-                predicates = [predicate.strip() for predicate in where_clause.split(" AND ")]
-                for predicate, value in zip(predicates, filter_params, strict=True):
-                    column_name = predicate.split("=", 1)[0].strip()
-                    rows = [row for row in rows if row[column_name] == value]
-            if " ORDER BY " in normalized_query:
-                order_by_clause = normalized_query.split(" ORDER BY ", 1)[1].split(" LIMIT %s", 1)[0]
-                order_clauses = [clause.strip() for clause in order_by_clause.split(",")]
-                for clause in reversed(order_clauses):
-                    column_name, direction = clause.rsplit(" ", 1)
-                    rows.sort(key=lambda row: row[column_name.strip()], reverse=direction == "DESC")
-            if limit is not None:
-                rows = rows[:limit]
-            self.connection.executed.append((normalized_query, bound_params))
-            self._rows = [(str(row["payload"]),) for row in rows]
-            return self
-
-        raise AssertionError(f"Unexpected query in fake Postgres connection: {normalized_query}")
-
-    def fetchone(self):
-        if not self._rows:
-            return None
-        return self._rows[0]
-
-    def fetchall(self):
-        return list(self._rows)
-
-
-class _FakeConnection:
-    def __init__(self) -> None:
-        self.tables: dict[str, dict[object, dict[str, object]]] = {}
-        self.executed: list[tuple[str, tuple[object, ...]]] = []
-        self.commit_count = 0
-
-    def __enter__(self) -> "_FakeConnection":
-        return self
-
-    def __exit__(self, exc_type, exc, tb) -> None:
-        return None
-
-    def cursor(self) -> _FakeCursor:
-        return _FakeCursor(self)
-
-    def commit(self) -> None:
-        self.commit_count += 1
+def _sqlite_database_url(database_path: Path) -> str:
+    return f"sqlite+pysqlite:///{database_path}"
 
 
 def _deployment_record(*, record_id: str, started_at: str, finished_at: str) -> DeploymentRecord:
@@ -253,6 +159,57 @@ def _release_tuple_record() -> ReleaseTupleRecord:
     )
 
 
+def _secret_record(*, secret_id: str, updated_at: str, current_version_id: str) -> SecretRecord:
+    return SecretRecord(
+        secret_id=secret_id,
+        scope="context_instance",
+        integration="dokploy",
+        name="api_token",
+        context="opw",
+        instance="testing",
+        description="Dokploy API token",
+        current_version_id=current_version_id,
+        created_at="2026-04-20T18:00:00Z",
+        updated_at=updated_at,
+        updated_by="harbor-bootstrap",
+    )
+
+
+def _secret_version(*, version_id: str, secret_id: str, created_at: str) -> SecretVersion:
+    return SecretVersion(
+        version_id=version_id,
+        secret_id=secret_id,
+        created_at=created_at,
+        created_by="harbor-bootstrap",
+        ciphertext="gAAAAABo-bootstrap-ciphertext",
+    )
+
+
+def _secret_binding(*, binding_id: str, secret_id: str, updated_at: str) -> SecretBinding:
+    return SecretBinding(
+        binding_id=binding_id,
+        secret_id=secret_id,
+        integration="dokploy",
+        binding_key="DOKPLOY_TOKEN",
+        context="opw",
+        instance="testing",
+        created_at="2026-04-20T18:00:00Z",
+        updated_at=updated_at,
+    )
+
+
+def _secret_audit_event(*, event_id: str, secret_id: str, recorded_at: str) -> SecretAuditEvent:
+    return SecretAuditEvent(
+        event_id=event_id,
+        secret_id=secret_id,
+        event_type="imported",
+        recorded_at=recorded_at,
+        actor="harbor-bootstrap",
+        detail="Imported existing Dokploy secret",
+        metadata={"source": "dokploy.env"},
+    )
+
+
 class PostgresRecordStoreTests(unittest.TestCase):
     def test_storage_import_core_records_command_reports_counts(self) -> None:
         runner = CliRunner()
@@ -288,61 +245,61 @@ class PostgresRecordStoreTests(unittest.TestCase):
         self.assertIn('"deployments": 1', result.output)
 
     def test_write_and_read_deployment_record(self) -> None:
-        connection = _FakeConnection()
-        store = PostgresRecordStore(
-            database_url="postgresql://harbor:test@db/harbor",
-            connection_factory=lambda: connection,
-        )
-
-        store.ensure_schema()
-        store.write_deployment_record(
-            _deployment_record(
-                record_id="deployment-20260420T153000Z-opw-testing",
-                started_at="2026-04-20T15:30:00Z",
-                finished_at="2026-04-20T15:32:00Z",
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "harbor.sqlite3")
             )
-        )
-        loaded_record = store.read_deployment_record("deployment-20260420T153000Z-opw-testing")
+
+            store.ensure_schema()
+            store.write_deployment_record(
+                _deployment_record(
+                    record_id="deployment-20260420T153000Z-opw-testing",
+                    started_at="2026-04-20T15:30:00Z",
+                    finished_at="2026-04-20T15:32:00Z",
+                )
+            )
+            loaded_record = store.read_deployment_record("deployment-20260420T153000Z-opw-testing")
+            store.close()
 
         self.assertEqual(store.backend_name, "postgres")
         self.assertEqual(loaded_record.context, "opw")
         self.assertEqual(loaded_record.resolved_target.target_id, "compose-123")
-        self.assertGreaterEqual(connection.commit_count, 2)
 
     def test_list_preview_records_filters_and_limits(self) -> None:
-        connection = _FakeConnection()
-        store = PostgresRecordStore(
-            database_url="postgresql://harbor:test@db/harbor",
-            connection_factory=lambda: connection,
-        )
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "harbor.sqlite3")
+            )
+            store.ensure_schema()
 
-        store.write_preview_record(
-            _preview_record(
-                preview_id="preview-verireel-testing-verireel-pr-101",
-                updated_at="2026-04-20T10:01:00Z",
-                pr_number=101,
+            store.write_preview_record(
+                _preview_record(
+                    preview_id="preview-verireel-testing-verireel-pr-101",
+                    updated_at="2026-04-20T10:01:00Z",
+                    pr_number=101,
+                )
             )
-        )
-        store.write_preview_record(
-            _preview_record(
-                preview_id="preview-verireel-testing-verireel-pr-102",
-                updated_at="2026-04-20T10:03:00Z",
-                pr_number=102,
+            store.write_preview_record(
+                _preview_record(
+                    preview_id="preview-verireel-testing-verireel-pr-102",
+                    updated_at="2026-04-20T10:03:00Z",
+                    pr_number=102,
+                )
             )
-        )
-        store.write_preview_record(
-            _preview_record(
-                preview_id="preview-verireel-testing-verireel-pr-103",
-                updated_at="2026-04-20T10:02:00Z",
-                pr_number=103,
+            store.write_preview_record(
+                _preview_record(
+                    preview_id="preview-verireel-testing-verireel-pr-103",
+                    updated_at="2026-04-20T10:02:00Z",
+                    pr_number=103,
+                )
             )
-        )
 
-        listed_records = store.list_preview_records(
-            context_name="verireel-testing",
-            anchor_repo="verireel",
-            limit=2,
-        )
+            listed_records = store.list_preview_records(
+                context_name="verireel-testing",
+                anchor_repo="verireel",
+                limit=2,
+            )
+            store.close()
 
         self.assertEqual(
             [record.preview_id for record in listed_records],
@@ -352,15 +309,84 @@ class PostgresRecordStoreTests(unittest.TestCase):
             ],
         )
 
-    def test_import_core_records_from_filesystem(self) -> None:
-        connection = _FakeConnection()
-        store = PostgresRecordStore(
-            database_url="postgresql://harbor:test@db/harbor",
-            connection_factory=lambda: connection,
-        )
-
+    def test_secret_records_round_trip_and_find_latest(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
-            filesystem_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name))
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "harbor.sqlite3")
+            )
+            store.ensure_schema()
+
+            older_record = _secret_record(
+                secret_id="secret-dokploy-token",
+                updated_at="2026-04-20T18:05:00Z",
+                current_version_id="secret-version-0001",
+            )
+            newer_record = _secret_record(
+                secret_id="secret-dokploy-token",
+                updated_at="2026-04-20T18:07:00Z",
+                current_version_id="secret-version-0002",
+            )
+            older_version = _secret_version(
+                version_id="secret-version-0001",
+                secret_id=older_record.secret_id,
+                created_at="2026-04-20T18:05:00Z",
+            )
+            newer_version = _secret_version(
+                version_id="secret-version-0002",
+                secret_id=newer_record.secret_id,
+                created_at="2026-04-20T18:07:00Z",
+            )
+            binding = _secret_binding(
+                binding_id="binding-dokploy-token",
+                secret_id=newer_record.secret_id,
+                updated_at="2026-04-20T18:07:00Z",
+            )
+            audit_event = _secret_audit_event(
+                event_id="audit-secret-import-0001",
+                secret_id=newer_record.secret_id,
+                recorded_at="2026-04-20T18:07:30Z",
+            )
+
+            store.write_secret_record(older_record)
+            store.write_secret_version(older_version)
+            store.write_secret_record(newer_record)
+            store.write_secret_version(newer_version)
+            store.write_secret_binding(binding)
+            store.write_secret_audit_event(audit_event)
+
+            found_record = store.find_secret_record(
+                scope="context_instance",
+                integration="dokploy",
+                name="api_token",
+                context="opw",
+                instance="testing",
+            )
+            listed_records = store.list_secret_records(integration="dokploy", context_name="opw", instance_name="testing")
+            listed_versions = store.list_secret_versions(secret_id=newer_record.secret_id)
+            listed_bindings = store.list_secret_bindings(
+                integration="dokploy",
+                context_name="opw",
+                instance_name="testing",
+            )
+            listed_events = store.list_secret_audit_events(secret_id=newer_record.secret_id)
+            self.assertIsNotNone(found_record)
+            assert found_record is not None
+            self.assertEqual(found_record.secret_id, newer_record.secret_id)
+            self.assertEqual(store.read_secret_record(newer_record.secret_id).current_version_id, "secret-version-0002")
+            self.assertEqual(store.read_secret_version("secret-version-0002").secret_id, newer_record.secret_id)
+            self.assertEqual([record.secret_id for record in listed_records], [newer_record.secret_id])
+            self.assertEqual([version.version_id for version in listed_versions], ["secret-version-0002", "secret-version-0001"])
+            self.assertEqual([item.binding_id for item in listed_bindings], ["binding-dokploy-token"])
+            self.assertEqual([item.event_id for item in listed_events], ["audit-secret-import-0001"])
+            store.close()
+
+    def test_import_core_records_from_filesystem(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "harbor.sqlite3")
+            )
+            store.ensure_schema()
+            filesystem_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
             filesystem_store.write_backup_gate_record(_backup_gate_record())
             filesystem_store.write_deployment_record(
                 _deployment_record(
@@ -369,7 +395,9 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     finished_at="2026-04-20T15:32:00Z",
                 )
             )
-            filesystem_store.write_promotion_record(_promotion_record(record_id="promotion-20260420T160500Z-opw-testing-to-prod"))
+            filesystem_store.write_promotion_record(
+                _promotion_record(record_id="promotion-20260420T160500Z-opw-testing-to-prod")
+            )
             filesystem_store.write_environment_inventory(_inventory_record())
             filesystem_store.write_preview_record(
                 _preview_record(
@@ -387,26 +415,26 @@ class PostgresRecordStoreTests(unittest.TestCase):
             filesystem_store.write_release_tuple_record(_release_tuple_record())
 
             counts = store.import_core_records_from_filesystem(filesystem_store)
-
-        self.assertEqual(
-            counts,
-            {
-                "backup_gates": 1,
-                "deployments": 1,
-                "promotions": 1,
-                "inventory": 1,
-                "preview_records": 1,
-                "preview_generations": 1,
-                "release_tuples": 1,
-            },
-        )
-        self.assertEqual(
-            store.read_promotion_record("promotion-20260420T160500Z-opw-testing-to-prod").to_instance,
-            "prod",
-        )
-        self.assertEqual(
-            store.read_preview_generation_record(
-                "preview-verireel-testing-verireel-pr-123-generation-0001"
-            ).state,
-            "ready",
-        )
+            self.assertEqual(
+                counts,
+                {
+                    "backup_gates": 1,
+                    "deployments": 1,
+                    "promotions": 1,
+                    "inventory": 1,
+                    "preview_records": 1,
+                    "preview_generations": 1,
+                    "release_tuples": 1,
+                },
+            )
+            self.assertEqual(
+                store.read_promotion_record("promotion-20260420T160500Z-opw-testing-to-prod").to_instance,
+                "prod",
+            )
+            self.assertEqual(
+                store.read_preview_generation_record(
+                    "preview-verireel-testing-verireel-pr-123-generation-0001"
+                ).state,
+                "ready",
+            )
+            store.close()

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from control_plane import dokploy as control_plane_dokploy
+from control_plane import runtime_environments as control_plane_runtime_environments
+from control_plane import secrets as control_plane_secrets
+from control_plane.cli import main
+from control_plane.storage.postgres import PostgresRecordStore
+
+
+def _sqlite_database_url(database_path: Path) -> str:
+    return f"sqlite+pysqlite:///{database_path}"
+
+
+class HarborSecretsTests(unittest.TestCase):
+    def test_read_dokploy_config_prefers_managed_secret_overlay(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "harbor.sqlite3")
+            (control_plane_root / ".env").write_text(
+                "DOKPLOY_HOST=https://dokploy.file.example\nDOKPLOY_TOKEN=file-token\n",
+                encoding="utf-8",
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            with patch.dict(
+                os.environ,
+                {
+                    control_plane_secrets.HARBOR_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                    "HARBOR_DATABASE_URL": database_url,
+                },
+                clear=True,
+            ):
+                control_plane_secrets.write_secret_value(
+                    record_store=store,
+                    scope="global",
+                    integration=control_plane_secrets.DOKPLOY_SECRET_INTEGRATION,
+                    name="host",
+                    plaintext_value="https://dokploy.db.example",
+                    binding_key="DOKPLOY_HOST",
+                    actor="test",
+                )
+                control_plane_secrets.write_secret_value(
+                    record_store=store,
+                    scope="global",
+                    integration=control_plane_secrets.DOKPLOY_SECRET_INTEGRATION,
+                    name="token",
+                    plaintext_value="db-token",
+                    binding_key="DOKPLOY_TOKEN",
+                    actor="test",
+                )
+                host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
+                self.assertEqual(host, "https://dokploy.db.example")
+                self.assertEqual(token, "db-token")
+            store.close()
+
+    def test_resolve_runtime_environment_values_prefers_managed_secret_overlay(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "harbor.sqlite3")
+            environments_file = control_plane_root / "config" / "runtime-environments.toml"
+            environments_file.parent.mkdir(parents=True, exist_ok=True)
+            environments_file.write_text(
+                """
+schema_version = 1
+
+[shared_env]
+ODOO_MASTER_PASSWORD = "file-shared-master"
+
+[contexts.opw.shared_env]
+GITHUB_WEBHOOK_SECRET = "file-context-secret"
+
+[contexts.opw.instances.testing.env]
+ODOO_DB_PASSWORD = "file-instance-secret"
+HARBOR_PREVIEW_BASE_URL = "https://preview.example.com"
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            with patch.dict(
+                os.environ,
+                {
+                    control_plane_secrets.HARBOR_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                    "HARBOR_DATABASE_URL": database_url,
+                },
+                clear=True,
+            ):
+                control_plane_secrets.write_secret_value(
+                    record_store=store,
+                    scope="global",
+                    integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+                    name="ODOO_MASTER_PASSWORD",
+                    plaintext_value="db-shared-master",
+                    binding_key="ODOO_MASTER_PASSWORD",
+                    actor="test",
+                )
+                control_plane_secrets.write_secret_value(
+                    record_store=store,
+                    scope="context",
+                    integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+                    name="GITHUB_WEBHOOK_SECRET",
+                    plaintext_value="db-context-secret",
+                    binding_key="GITHUB_WEBHOOK_SECRET",
+                    context_name="opw",
+                    actor="test",
+                )
+                control_plane_secrets.write_secret_value(
+                    record_store=store,
+                    scope="context_instance",
+                    integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+                    name="ODOO_DB_PASSWORD",
+                    plaintext_value="db-instance-secret",
+                    binding_key="ODOO_DB_PASSWORD",
+                    context_name="opw",
+                    instance_name="testing",
+                    actor="test",
+                )
+                resolved_values = control_plane_runtime_environments.resolve_runtime_environment_values(
+                    control_plane_root=control_plane_root,
+                    context_name="opw",
+                    instance_name="testing",
+                )
+                self.assertEqual(resolved_values["ODOO_MASTER_PASSWORD"], "db-shared-master")
+                self.assertEqual(resolved_values["GITHUB_WEBHOOK_SECRET"], "db-context-secret")
+                self.assertEqual(resolved_values["ODOO_DB_PASSWORD"], "db-instance-secret")
+                self.assertEqual(resolved_values["HARBOR_PREVIEW_BASE_URL"], "https://preview.example.com")
+            store.close()
+
+    def test_import_bootstrap_secrets_pulls_existing_dokploy_and_runtime_values(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "harbor.sqlite3")
+            (control_plane_root / ".env").write_text(
+                "DOKPLOY_HOST=https://dokploy.bootstrap.example\nDOKPLOY_TOKEN=bootstrap-token\n",
+                encoding="utf-8",
+            )
+            runtime_environments_file = control_plane_root / "config" / "runtime-environments.toml"
+            runtime_environments_file.parent.mkdir(parents=True, exist_ok=True)
+            runtime_environments_file.write_text(
+                """
+schema_version = 1
+
+[shared_env]
+ODOO_MASTER_PASSWORD = "shared-master"
+
+[contexts.opw.shared_env]
+GITHUB_WEBHOOK_SECRET = "webhook-secret"
+HARBOR_PREVIEW_BASE_URL = "https://preview.example.com"
+
+[contexts.opw.instances.testing.env]
+ODOO_DB_PASSWORD = "instance-password"
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            with patch.dict(
+                os.environ,
+                {control_plane_secrets.HARBOR_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"},
+                clear=True,
+            ):
+                summary = control_plane_secrets.import_bootstrap_secrets(
+                    record_store=store,
+                    control_plane_root=control_plane_root,
+                    actor="bootstrap-test",
+                )
+                statuses = control_plane_secrets.list_secret_statuses(store, context_name="opw", instance_name="testing")
+                self.assertEqual(summary["dokploy"]["imported"], 2)
+                self.assertEqual(summary["runtime_environment"]["imported"], 3)
+                self.assertEqual(
+                    {status["binding"]["binding_key"] for status in statuses if status["binding"] is not None},
+                    {
+                        "DOKPLOY_HOST",
+                        "DOKPLOY_TOKEN",
+                        "ODOO_MASTER_PASSWORD",
+                        "GITHUB_WEBHOOK_SECRET",
+                        "ODOO_DB_PASSWORD",
+                    },
+                )
+            store.close()
+
+    def test_secrets_cli_import_bootstrap_reports_summary(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "harbor.sqlite3")
+            (control_plane_root / ".env").write_text(
+                "DOKPLOY_HOST=https://dokploy.bootstrap.example\nDOKPLOY_TOKEN=bootstrap-token\n",
+                encoding="utf-8",
+            )
+            runtime_environments_file = control_plane_root / "config" / "runtime-environments.toml"
+            runtime_environments_file.parent.mkdir(parents=True, exist_ok=True)
+            runtime_environments_file.write_text(
+                """
+schema_version = 1
+
+[contexts.opw.shared_env]
+GITHUB_WEBHOOK_SECRET = "webhook-secret"
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            with patch.dict(
+                os.environ,
+                {control_plane_secrets.HARBOR_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"},
+                clear=True,
+            ):
+                result = runner.invoke(
+                    main,
+                    [
+                        "secrets",
+                        "import-bootstrap",
+                        "--database-url",
+                        database_url,
+                        "--control-plane-root",
+                        str(control_plane_root),
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn('"dokploy": {', result.output)
+        self.assertIn('"runtime_environment": {', result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,11 +1,13 @@
 import io
 import json
+import os
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord, PreviewPullRequestSummary
@@ -14,6 +16,7 @@ from control_plane.contracts.promotion_record import ArtifactIdentityReference, 
 from control_plane.service import create_harbor_service_app
 from control_plane.service_auth import GitHubActionsIdentity, GitHubOidcVerifier, HarborAuthzPolicy
 from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.verireel_testing_deploy import VeriReelTestingDeployResult
 
 
@@ -837,6 +840,86 @@ class HarborServiceTests(unittest.TestCase):
             self.assertEqual(len(operations_payload["recent_deployments"]), 1)
             self.assertEqual(len(operations_payload["recent_promotions"]), 1)
             self.assertEqual(len(operations_payload["recent_previews"]), 1)
+
+    def test_secret_status_endpoints_return_operator_read_models(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = f"sqlite+pysqlite:///{root / 'harbor.sqlite3'}"
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            with patch.dict(
+                os.environ,
+                {control_plane_secrets.HARBOR_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"},
+                clear=True,
+            ):
+                control_plane_secrets.write_secret_value(
+                    record_store=store,
+                    scope="global",
+                    integration=control_plane_secrets.DOKPLOY_SECRET_INTEGRATION,
+                    name="token",
+                    plaintext_value="dokploy-token",
+                    binding_key="DOKPLOY_TOKEN",
+                    actor="test",
+                )
+                context_secret = control_plane_secrets.write_secret_value(
+                    record_store=store,
+                    scope="context",
+                    integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+                    name="GITHUB_WEBHOOK_SECRET",
+                    plaintext_value="webhook-secret",
+                    binding_key="GITHUB_WEBHOOK_SECRET",
+                    context_name="opw",
+                    actor="test",
+                )
+            store.close()
+            policy = HarborAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "contexts": ["opw"],
+                            "actions": ["secret.read", "secret.list"],
+                        }
+                    ]
+                }
+            )
+            app = create_harbor_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            with patch.dict(
+                os.environ,
+                {
+                    control_plane_secrets.HARBOR_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                    "HARBOR_DATABASE_URL": database_url,
+                },
+                clear=True,
+            ):
+                list_status_code, list_payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/contexts/opw/secrets",
+                )
+                show_status_code, show_payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path=f"/v1/secrets/{context_secret['secret_id']}",
+                )
+
+            self.assertEqual(list_status_code, 200)
+            self.assertEqual(list_payload["context"], "opw")
+            self.assertEqual(len(list_payload["secrets"]), 2)
+            self.assertEqual(show_status_code, 200)
+            self.assertEqual(show_payload["secret"]["secret_id"], context_secret["secret_id"])
+            self.assertEqual(show_payload["secret"]["binding"]["binding_key"], "GITHUB_WEBHOOK_SECRET")
 
     def test_preview_generation_endpoint_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -6,9 +6,11 @@ from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
+from control_plane.contracts.preview_generation_record import PreviewGenerationRecord, PreviewPullRequestSummary
 from control_plane.contracts.preview_record import PreviewRecord
-from control_plane.contracts.promotion_record import DeploymentEvidence
+from control_plane.contracts.promotion_record import ArtifactIdentityReference, DeploymentEvidence, PromotionRecord
 from control_plane.service import create_harbor_service_app
 from control_plane.service_auth import GitHubActionsIdentity, GitHubOidcVerifier, HarborAuthzPolicy
 from control_plane.storage.filesystem import FilesystemRecordStore
@@ -110,6 +112,21 @@ class GitHubOidcVerifierTests(unittest.TestCase):
 
 
 class HarborServiceTests(unittest.TestCase):
+    def test_health_endpoint_reports_storage_backend(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_harbor_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=HarborAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+
+            status_code, payload = _invoke_app(app, method="GET", path="/v1/health", authorization="")
+
+            self.assertEqual(status_code, 200)
+            self.assertEqual(payload["status"], "ok")
+            self.assertEqual(payload["storage_backend"], "filesystem")
+
     def test_preview_generation_endpoint_writes_records_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -608,6 +625,218 @@ class HarborServiceTests(unittest.TestCase):
 
             self.assertEqual(status_code, 403)
             self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_deployment_read_endpoint_returns_record_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_deployment_record(
+                DeploymentRecord(
+                    record_id="deployment-20260420T153000Z-opw-testing",
+                    artifact_identity=ArtifactIdentityReference(artifact_id="artifact-20260420-a1b2c3d4"),
+                    context="opw",
+                    instance="testing",
+                    source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
+                    resolved_target=ResolvedTargetEvidence(
+                        target_type="compose",
+                        target_id="compose-123",
+                        target_name="opw-testing",
+                    ),
+                    deploy=DeploymentEvidence(
+                        target_name="opw-testing",
+                        target_type="compose",
+                        deploy_mode="dokploy-compose-api",
+                        deployment_id="delegated-compose-ship",
+                        status="pass",
+                        started_at="2026-04-20T15:30:00Z",
+                        finished_at="2026-04-20T15:32:10Z",
+                    ),
+                )
+            )
+            policy = HarborAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "contexts": ["opw"],
+                            "actions": ["deployment.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_harbor_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/deployments/deployment-20260420T153000Z-opw-testing",
+            )
+
+            self.assertEqual(status_code, 200)
+            self.assertEqual(payload["status"], "ok")
+            self.assertEqual(payload["record"]["record_id"], "deployment-20260420T153000Z-opw-testing")
+            self.assertEqual(payload["record"]["resolved_target"]["target_id"], "compose-123")
+
+    def test_preview_history_and_recent_operations_endpoints_return_operator_read_models(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_preview_record(
+                PreviewRecord(
+                    preview_id="preview-verireel-testing-verireel-pr-123",
+                    context="verireel-testing",
+                    anchor_repo="verireel",
+                    anchor_pr_number=123,
+                    anchor_pr_url="https://github.com/every/verireel/pull/123",
+                    preview_label="verireel/pr-123",
+                    canonical_url="https://pr-123.ver-preview.shinycomputers.com",
+                    state="active",
+                    created_at="2026-04-20T10:00:00Z",
+                    updated_at="2026-04-20T10:05:00Z",
+                    eligible_at="2026-04-20T10:05:00Z",
+                )
+            )
+            store.write_preview_generation_record(
+                PreviewGenerationRecord(
+                    generation_id="preview-verireel-testing-verireel-pr-123-generation-0001",
+                    preview_id="preview-verireel-testing-verireel-pr-123",
+                    sequence=1,
+                    state="ready",
+                    requested_reason="external_preview_refresh",
+                    requested_at="2026-04-20T10:01:00Z",
+                    ready_at="2026-04-20T10:05:00Z",
+                    finished_at="2026-04-20T10:05:00Z",
+                    resolved_manifest_fingerprint="preview-manifest-123",
+                    artifact_id="ghcr.io/every/verireel-app:pr-123",
+                    anchor_summary=PreviewPullRequestSummary(
+                        repo="verireel",
+                        pr_number=123,
+                        head_sha="6b3c9d7e8f901234567890abcdef1234567890ab",
+                        pr_url="https://github.com/every/verireel/pull/123",
+                    ),
+                    deploy_status="pass",
+                    verify_status="pass",
+                    overall_health_status="pass",
+                )
+            )
+            store.write_deployment_record(
+                DeploymentRecord(
+                    record_id="deployment-20260420T153000Z-verireel-testing",
+                    artifact_identity=ArtifactIdentityReference(artifact_id="artifact-20260420-a1b2c3d4"),
+                    context="verireel-testing",
+                    instance="testing",
+                    source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
+                    resolved_target=ResolvedTargetEvidence(
+                        target_type="application",
+                        target_id="app-123",
+                        target_name="verireel-testing",
+                    ),
+                    deploy=DeploymentEvidence(
+                        target_name="verireel-testing",
+                        target_type="application",
+                        deploy_mode="dokploy-application-api",
+                        deployment_id="delegated-app-ship",
+                        status="pass",
+                        started_at="2026-04-20T15:30:00Z",
+                        finished_at="2026-04-20T15:32:10Z",
+                    ),
+                )
+            )
+            store.write_promotion_record(
+                PromotionRecord(
+                    record_id="promotion-20260420T160500Z-verireel-testing-to-prod",
+                    artifact_identity=ArtifactIdentityReference(artifact_id="artifact-20260420-a1b2c3d4"),
+                    deployment_record_id="deployment-20260420T153000Z-verireel-testing",
+                    backup_record_id="backup-verireel-prod-20260420T160000Z",
+                    context="verireel-testing",
+                    from_instance="testing",
+                    to_instance="prod",
+                    deploy=DeploymentEvidence(
+                        target_name="verireel-prod",
+                        target_type="application",
+                        deploy_mode="dokploy-application-api",
+                        deployment_id="delegated-app-promote",
+                        status="pass",
+                        started_at="2026-04-20T16:05:00Z",
+                        finished_at="2026-04-20T16:07:00Z",
+                    ),
+                )
+            )
+            store.write_environment_inventory(
+                EnvironmentInventory(
+                    context="verireel-testing",
+                    instance="testing",
+                    artifact_identity=ArtifactIdentityReference(artifact_id="artifact-20260420-a1b2c3d4"),
+                    source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
+                    deploy=DeploymentEvidence(
+                        target_name="verireel-testing",
+                        target_type="application",
+                        deploy_mode="dokploy-application-api",
+                        deployment_id="delegated-app-ship",
+                        status="pass",
+                        started_at="2026-04-20T15:30:00Z",
+                        finished_at="2026-04-20T15:32:10Z",
+                    ),
+                    updated_at="2026-04-20T15:33:00Z",
+                    deployment_record_id="deployment-20260420T153000Z-verireel-testing",
+                )
+            )
+            policy = HarborAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "contexts": ["verireel-testing"],
+                            "actions": ["preview.read", "operations.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_harbor_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            history_status_code, history_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/previews/preview-verireel-testing-verireel-pr-123/history",
+            )
+            operations_status_code, operations_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/contexts/verireel-testing/operations/recent",
+            )
+
+            self.assertEqual(history_status_code, 200)
+            self.assertEqual(history_payload["preview"]["preview_id"], "preview-verireel-testing-verireel-pr-123")
+            self.assertEqual(len(history_payload["generations"]), 1)
+            self.assertEqual(history_payload["generations"][0]["state"], "ready")
+
+            self.assertEqual(operations_status_code, 200)
+            self.assertEqual(operations_payload["context"], "verireel-testing")
+            self.assertEqual(operations_payload["storage_backend"], "filesystem")
+            self.assertEqual(len(operations_payload["inventory"]), 1)
+            self.assertEqual(len(operations_payload["recent_deployments"]), 1)
+            self.assertEqual(len(operations_payload["recent_promotions"]), 1)
+            self.assertEqual(len(operations_payload["recent_previews"]), 1)
 
     def test_preview_generation_endpoint_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -6,7 +6,9 @@ from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.contracts.promotion_record import DeploymentEvidence
 from control_plane.service import create_harbor_service_app
 from control_plane.service_auth import GitHubActionsIdentity, GitHubOidcVerifier, HarborAuthzPolicy
 from control_plane.storage.filesystem import FilesystemRecordStore
@@ -262,19 +264,51 @@ class HarborServiceTests(unittest.TestCase):
             self.assertEqual(payload["status"], "accepted")
             self.assertEqual(
                 payload["records"],
-                {"deployment_record_id": "deployment-20260420T153000Z-opw-testing"},
+                {
+                    "deployment_record_id": "deployment-20260420T153000Z-opw-testing",
+                    "inventory_record_id": "opw-testing",
+                },
             )
             store = FilesystemRecordStore(state_dir=state_dir)
             deployment = store.read_deployment_record("deployment-20260420T153000Z-opw-testing")
+            inventory = store.read_environment_inventory(
+                context_name="opw",
+                instance_name="testing",
+            )
             self.assertEqual(deployment.context, "opw")
             self.assertEqual(deployment.instance, "testing")
             self.assertEqual(deployment.deploy.status, "pass")
             self.assertEqual(deployment.resolved_target.target_id, "compose-123")
+            self.assertEqual(inventory.deployment_record_id, deployment.record_id)
+            self.assertEqual(inventory.promotion_record_id, "")
 
     def test_promotion_endpoint_writes_record_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_deployment_record(
+                DeploymentRecord(
+                    record_id="deployment-20260420T160500Z-opw-prod",
+                    artifact_identity={"artifact_id": "artifact-20260420-a1b2c3d4"},
+                    context="opw",
+                    instance="prod",
+                    source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
+                    resolved_target=ResolvedTargetEvidence(
+                        target_type="compose",
+                        target_id="compose-456",
+                        target_name="opw-prod",
+                    ),
+                    deploy=DeploymentEvidence(
+                        target_name="opw-prod",
+                        target_type="compose",
+                        deploy_mode="dokploy-compose-api",
+                        status="pass",
+                        started_at="2026-04-20T16:05:00Z",
+                        finished_at="2026-04-20T16:08:30Z",
+                    ),
+                )
+            )
             policy = HarborAuthzPolicy.model_validate(
                 {
                     "github_actions": [
@@ -315,6 +349,7 @@ class HarborServiceTests(unittest.TestCase):
                     "promotion": {
                         "record_id": "promotion-20260420T160500Z-opw-testing-to-prod",
                         "artifact_identity": {"artifact_id": "artifact-20260420-a1b2c3d4"},
+                        "deployment_record_id": "deployment-20260420T160500Z-opw-prod",
                         "backup_record_id": "backup-opw-prod-20260420T155000Z",
                         "context": "opw",
                         "from_instance": "testing",
@@ -346,17 +381,26 @@ class HarborServiceTests(unittest.TestCase):
             self.assertEqual(payload["status"], "accepted")
             self.assertEqual(
                 payload["records"],
-                {"promotion_record_id": "promotion-20260420T160500Z-opw-testing-to-prod"},
+                {
+                    "promotion_record_id": "promotion-20260420T160500Z-opw-testing-to-prod",
+                    "inventory_record_id": "opw-prod",
+                },
             )
-            store = FilesystemRecordStore(state_dir=state_dir)
             promotion = store.read_promotion_record(
                 "promotion-20260420T160500Z-opw-testing-to-prod"
+            )
+            inventory = store.read_environment_inventory(
+                context_name="opw",
+                instance_name="prod",
             )
             self.assertEqual(promotion.context, "opw")
             self.assertEqual(promotion.from_instance, "testing")
             self.assertEqual(promotion.to_instance, "prod")
             self.assertEqual(promotion.deploy.status, "pass")
             self.assertEqual(promotion.backup_gate.status, "pass")
+            self.assertEqual(inventory.deployment_record_id, "deployment-20260420T160500Z-opw-prod")
+            self.assertEqual(inventory.promotion_record_id, promotion.record_id)
+            self.assertEqual(inventory.promoted_from_instance, "testing")
 
     def test_preview_destroyed_endpoint_writes_records_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -12,6 +12,7 @@ from control_plane.contracts.promotion_record import DeploymentEvidence
 from control_plane.service import create_harbor_service_app
 from control_plane.service_auth import GitHubActionsIdentity, GitHubOidcVerifier, HarborAuthzPolicy
 from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.workflows.verireel_testing_deploy import VeriReelTestingDeployResult
 
 
 class _StubVerifier:
@@ -489,6 +490,124 @@ class HarborServiceTests(unittest.TestCase):
                 preview.latest_generation_id,
                 "preview-verireel-testing-verireel-pr-123-generation-0001",
             )
+
+    def test_verireel_testing_deploy_driver_executes_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            policy = HarborAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/publish-image.yml@refs/heads/main"
+                            ],
+                            "event_names": ["push", "workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel"],
+                            "actions": ["verireel_testing_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_harbor_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/publish-image.yml@refs/heads/main"
+                        ),
+                        event_name="push",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_verireel_testing_deploy",
+                return_value=VeriReelTestingDeployResult(
+                    deployment_record_id="deployment-verireel-testing-run-12345-attempt-1",
+                    deploy_status="pass",
+                    deploy_started_at="2026-04-20T18:20:00Z",
+                    deploy_finished_at="2026-04-20T18:21:15Z",
+                    target_name="ver-testing-app",
+                    target_type="application",
+                    target_id="testing-app-123",
+                ),
+            ) as execute_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/testing-deploy",
+                    payload={
+                        "product": "verireel",
+                        "deploy": {
+                            "artifact_id": "ghcr.io/every/verireel-app:sha-abcdef1234567890",
+                            "source_git_ref": "abcdef1234567890",
+                        },
+                    },
+                )
+
+            self.assertEqual(status_code, 202)
+            self.assertEqual(payload["status"], "accepted")
+            self.assertEqual(
+                payload["records"],
+                {"deployment_record_id": "deployment-verireel-testing-run-12345-attempt-1"},
+            )
+            self.assertEqual(payload["result"]["deploy_status"], "pass")
+            self.assertEqual(payload["result"]["target_id"], "testing-app-123")
+            execute_mock.assert_called_once()
+
+    def test_verireel_testing_deploy_driver_rejects_unauthorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = HarborAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/publish-image.yml@refs/heads/main"
+                            ],
+                            "event_names": ["push", "workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel"],
+                            "actions": ["deployment.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_harbor_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/publish-image.yml@refs/heads/main"
+                        ),
+                        event_name="push",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/verireel/testing-deploy",
+                payload={
+                    "product": "verireel",
+                    "deploy": {
+                        "artifact_id": "ghcr.io/every/verireel-app:sha-abcdef1234567890",
+                        "source_git_ref": "abcdef1234567890",
+                    },
+                },
+            )
+
+            self.assertEqual(status_code, 403)
+            self.assertEqual(payload["error"]["code"], "authorization_denied")
 
     def test_preview_generation_endpoint_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_verireel_testing_deploy.py
+++ b/tests/test_verireel_testing_deploy.py
@@ -1,0 +1,135 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import click
+
+from control_plane.contracts.deployment_record import ResolvedTargetEvidence
+from control_plane.contracts.promotion_record import HealthcheckEvidence
+from control_plane.contracts.ship_request import ShipRequest
+from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.workflows.verireel_testing_deploy import (
+    VeriReelTestingDeployRequest,
+    execute_verireel_testing_deploy,
+)
+
+
+class VeriReelTestingDeployWorkflowTests(unittest.TestCase):
+    def test_execute_writes_passed_deployment_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            request = VeriReelTestingDeployRequest(
+                artifact_id="ghcr.io/every/verireel-app:sha-abcdef1234567890",
+                source_git_ref="abcdef1234567890",
+            )
+            ship_request = ShipRequest(
+                artifact_id=request.artifact_id,
+                context="verireel",
+                instance="testing",
+                source_git_ref=request.source_git_ref,
+                target_name="ver-testing-app",
+                target_type="application",
+                deploy_mode="dokploy-application-api",
+                wait=True,
+                verify_health=False,
+                destination_health=HealthcheckEvidence(status="skipped"),
+            )
+
+            with patch(
+                "control_plane.workflows.verireel_testing_deploy.generate_deployment_record_id",
+                return_value="deployment-verireel-testing-run-12345-attempt-1",
+            ), patch(
+                "control_plane.workflows.verireel_testing_deploy.utc_now_timestamp",
+                side_effect=[
+                    "2026-04-20T18:20:00Z",
+                    "2026-04-20T18:21:15Z",
+                ],
+            ), patch(
+                "control_plane.workflows.verireel_testing_deploy._resolve_ship_request",
+                return_value=(
+                    ship_request,
+                    ResolvedTargetEvidence(
+                        target_type="application",
+                        target_id="testing-app-123",
+                        target_name="ver-testing-app",
+                    ),
+                    300,
+                ),
+            ), patch(
+                "control_plane.workflows.verireel_testing_deploy._execute_dokploy_deploy"
+            ):
+                result = execute_verireel_testing_deploy(
+                    control_plane_root=root,
+                    record_store=store,
+                    request=request,
+                )
+
+            self.assertEqual(result.deployment_record_id, "deployment-verireel-testing-run-12345-attempt-1")
+            self.assertEqual(result.deploy_status, "pass")
+            self.assertEqual(result.target_id, "testing-app-123")
+            deployment = store.read_deployment_record("deployment-verireel-testing-run-12345-attempt-1")
+            self.assertEqual(deployment.deploy.status, "pass")
+            self.assertEqual(deployment.deploy.started_at, "2026-04-20T18:20:00Z")
+            self.assertEqual(deployment.deploy.finished_at, "2026-04-20T18:21:15Z")
+            self.assertEqual(deployment.destination_health.status, "skipped")
+
+    def test_execute_writes_failed_deployment_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            request = VeriReelTestingDeployRequest(
+                artifact_id="ghcr.io/every/verireel-app:sha-abcdef1234567890",
+                source_git_ref="abcdef1234567890",
+            )
+            ship_request = ShipRequest(
+                artifact_id=request.artifact_id,
+                context="verireel",
+                instance="testing",
+                source_git_ref=request.source_git_ref,
+                target_name="ver-testing-app",
+                target_type="application",
+                deploy_mode="dokploy-application-api",
+                wait=True,
+                verify_health=False,
+                destination_health=HealthcheckEvidence(status="skipped"),
+            )
+
+            with patch(
+                "control_plane.workflows.verireel_testing_deploy.generate_deployment_record_id",
+                return_value="deployment-verireel-testing-run-12345-attempt-1",
+            ), patch(
+                "control_plane.workflows.verireel_testing_deploy.utc_now_timestamp",
+                side_effect=[
+                    "2026-04-20T18:20:00Z",
+                    "2026-04-20T18:21:15Z",
+                ],
+            ), patch(
+                "control_plane.workflows.verireel_testing_deploy._resolve_ship_request",
+                return_value=(
+                    ship_request,
+                    ResolvedTargetEvidence(
+                        target_type="application",
+                        target_id="testing-app-123",
+                        target_name="ver-testing-app",
+                    ),
+                    300,
+                ),
+            ), patch(
+                "control_plane.workflows.verireel_testing_deploy._execute_dokploy_deploy",
+                side_effect=click.ClickException("deploy failed"),
+            ):
+                result = execute_verireel_testing_deploy(
+                    control_plane_root=root,
+                    record_store=store,
+                    request=request,
+                )
+
+            self.assertEqual(result.deploy_status, "fail")
+            self.assertEqual(result.error_message, "deploy failed")
+            deployment = store.read_deployment_record("deployment-verireel-testing-run-12345-attempt-1")
+            self.assertEqual(deployment.deploy.status, "fail")
+            self.assertEqual(deployment.resolved_target.target_id, "testing-app-123")

--- a/uv.lock
+++ b/uv.lock
@@ -131,6 +131,43 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/94/a5935717b307d7c71fe877b52b884c6af707d2d2090db118a03fbd799369/greenlet-3.4.0.tar.gz", hash = "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff", size = 195913, upload-time = "2026-04-08T17:08:00.863Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1", size = 285856, upload-time = "2026-04-08T15:52:45.82Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1", size = 610208, upload-time = "2026-04-08T16:24:39.674Z" },
+    { url = "https://files.pythonhosted.org/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82", size = 621269, upload-time = "2026-04-08T16:30:59.767Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/93/c8c508d68ba93232784bbc1b5474d92371f2897dfc6bc281b419f2e0d492/greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f", size = 628455, upload-time = "2026-04-08T16:40:40.698Z" },
+    { url = "https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf", size = 617549, upload-time = "2026-04-08T15:56:34.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/46/cfaaa0ade435a60550fd83d07dfd5c41f873a01da17ede5c4cade0b9bab8/greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55", size = 426238, upload-time = "2026-04-08T16:43:06.865Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729", size = 1575310, upload-time = "2026-04-08T16:26:21.671Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c", size = 1640435, upload-time = "2026-04-08T15:57:32.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940", size = 238760, upload-time = "2026-04-08T17:04:03.878Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/96/795619651d39c7fbd809a522f881aa6f0ead504cc8201c3a5b789dfaef99/greenlet-3.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:9390ad88b652b1903814eaabd629ca184db15e0eeb6fe8a390bbf8b9106ae15a", size = 235498, upload-time = "2026-04-08T17:05:00.584Z" },
+    { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19", size = 673405, upload-time = "2026-04-08T16:40:42.527Z" },
+    { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd", size = 471670, upload-time = "2026-04-08T16:43:08.512Z" },
+    { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
+    { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c4/6f621023364d7e85a4769c014c8982f98053246d142420e0328980933ceb/greenlet-3.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:f8296d4e2b92af34ebde81085a01690f26a51eb9ac09a0fcadb331eb36dbc802", size = 236932, upload-time = "2026-04-08T17:04:33.551Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa", size = 665872, upload-time = "2026-04-08T16:40:43.912Z" },
+    { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72", size = 489237, upload-time = "2026-04-08T16:43:09.993Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
+    { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
+]
+
+[[package]]
 name = "harbor"
 version = "0.1.0"
 source = { editable = "." }
@@ -139,6 +176,7 @@ dependencies = [
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pyjwt", extra = ["crypto"] },
+    { name = "sqlalchemy" },
 ]
 
 [package.optional-dependencies]
@@ -155,6 +193,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.8" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12" },
+    { name = "sqlalchemy", specifier = ">=2.0" },
 ]
 provides-extras = ["dev"]
 
@@ -419,6 +458,45 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
     { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
     { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/81/81755f50eb2478eaf2049728491d4ea4f416c1eb013338682173259efa09/sqlalchemy-2.0.49-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df2d441bacf97022e81ad047e1597552eb3f83ca8a8f1a1fdd43cd7fe3898120", size = 2154547, upload-time = "2026-04-03T16:53:08.64Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bc/3494270da80811d08bcfa247404292428c4fe16294932bce5593f215cad9/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e20e511dc15265fb433571391ba313e10dd8ea7e509d51686a51313b4ac01a2", size = 3280782, upload-time = "2026-04-03T17:07:43.508Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f5/038741f5e747a5f6ea3e72487211579d8cbea5eb9827a9cbd61d0108c4bd/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3", size = 3297156, upload-time = "2026-04-03T17:12:27.697Z" },
+    { url = "https://files.pythonhosted.org/packages/88/50/a6af0ff9dc954b43a65ca9b5367334e45d99684c90a3d3413fc19a02d43c/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:22d8798819f86720bc646ab015baff5ea4c971d68121cb36e2ebc2ee43ead2b7", size = 3228832, upload-time = "2026-04-03T17:07:45.38Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d1/5f6bdad8de0bf546fc74370939621396515e0cdb9067402d6ba1b8afbe9a/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b1c058c171b739e7c330760044803099c7fff11511e3ab3573e5327116a9c33", size = 3267000, upload-time = "2026-04-03T17:12:29.657Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/30/ad62227b4a9819a5e1c6abff77c0f614fa7c9326e5a3bdbee90f7139382b/sqlalchemy-2.0.49-cp313-cp313-win32.whl", hash = "sha256:a143af2ea6672f2af3f44ed8f9cd020e9cc34c56f0e8db12019d5d9ecf41cb3b", size = 2115641, upload-time = "2026-04-03T17:05:43.989Z" },
+    { url = "https://files.pythonhosted.org/packages/17/3a/7215b1b7d6d49dc9a87211be44562077f5f04f9bb5a59552c1c8e2d98173/sqlalchemy-2.0.49-cp313-cp313-win_amd64.whl", hash = "sha256:12b04d1db2663b421fe072d638a138460a51d5a862403295671c4f3987fb9148", size = 2141498, upload-time = "2026-04-03T17:05:45.7Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4b/52a0cb2687a9cd1648252bb257be5a1ba2c2ded20ba695c65756a55a15a4/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24bd94bb301ec672d8f0623eba9226cc90d775d25a0c92b5f8e4965d7f3a1518", size = 3560807, upload-time = "2026-04-03T16:58:31.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d8/fda95459204877eed0458550d6c7c64c98cc50c2d8d618026737de9ed41a/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a51d3db74ba489266ef55c7a4534eb0b8db9a326553df481c11e5d7660c8364d", size = 3527481, upload-time = "2026-04-03T17:06:00.155Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0a/2aac8b78ac6487240cf7afef8f203ca783e8796002dc0cf65c4ee99ff8bb/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:55250fe61d6ebfd6934a272ee16ef1244e0f16b7af6cd18ab5b1fc9f08631db0", size = 3468565, upload-time = "2026-04-03T16:58:33.414Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/ce71cfa82c50a373fd2148b3c870be05027155ce791dc9a5dcf439790b8b/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:46796877b47034b559a593d7e4b549aba151dae73f9e78212a3478161c12ab08", size = 3477769, upload-time = "2026-04-03T17:06:02.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e8/0a9f5c1f7c6f9ca480319bf57c2d7423f08d31445974167a27d14483c948/sqlalchemy-2.0.49-cp313-cp313t-win32.whl", hash = "sha256:9c4969a86e41454f2858256c39bdfb966a20961e9b58bf8749b65abf447e9a8d", size = 2143319, upload-time = "2026-04-03T17:02:04.328Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/51/fb5240729fbec73006e137c4f7a7918ffd583ab08921e6ff81a999d6517a/sqlalchemy-2.0.49-cp313-cp313t-win_amd64.whl", hash = "sha256:b9870d15ef00e4d0559ae10ee5bc71b654d1f20076dbe8bc7ed19b4c0625ceba", size = 2175104, upload-time = "2026-04-03T17:02:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e", size = 2156356, upload-time = "2026-04-03T16:53:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a", size = 3276486, upload-time = "2026-04-03T17:07:46.9Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066", size = 3281479, upload-time = "2026-04-03T17:12:32.226Z" },
+    { url = "https://files.pythonhosted.org/packages/91/68/bb406fa4257099c67bd75f3f2261b129c63204b9155de0d450b37f004698/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187", size = 3226269, upload-time = "2026-04-03T17:07:48.678Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/acb56c00cca9f251f437cb49e718e14f7687505749ea9255d7bd8158a6df/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401", size = 3248260, upload-time = "2026-04-03T17:12:34.381Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/6a20ea25606d1efd7bd1862149bb2a22d1451c3f851d23d887969201633f/sqlalchemy-2.0.49-cp314-cp314-win32.whl", hash = "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5", size = 2118463, upload-time = "2026-04-03T17:05:47.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl", hash = "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5", size = 2144204, upload-time = "2026-04-03T17:05:48.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/33/95e7216df810c706e0cd3655a778604bbd319ed4f43333127d465a46862d/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977", size = 3565474, upload-time = "2026-04-03T16:58:35.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a4/ed7b18d8ccf7f954a83af6bb73866f5bc6f5636f44c7731fbb741f72cc4f/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01", size = 3530567, upload-time = "2026-04-03T17:06:04.587Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a3/20faa869c7e21a827c4a2a42b41353a54b0f9f5e96df5087629c306df71e/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61", size = 3474282, upload-time = "2026-04-03T16:58:37.131Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/50/276b9a007aa0764304ad467eceb70b04822dc32092492ee5f322d559a4dc/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a", size = 3480406, upload-time = "2026-04-03T17:06:07.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151, upload-time = "2026-04-03T17:02:07.281Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178, upload-time = "2026-04-03T17:02:08.623Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -131,6 +131,34 @@ wheels = [
 ]
 
 [[package]]
+name = "harbor"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "click" },
+    { name = "psycopg", extra = ["binary"] },
+    { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "click", specifier = ">=8.1" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
+    { name = "pydantic", specifier = ">=2.8" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12" },
+]
+provides-extras = ["dev"]
+
+[[package]]
 name = "librt"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -223,38 +251,58 @@ wheels = [
 ]
 
 [[package]]
-name = "harbor"
-version = "0.1.0"
-source = { editable = "." }
-dependencies = [
-    { name = "click" },
-    { name = "pydantic" },
-    { name = "pyjwt", extra = ["crypto"] },
-]
-
-[package.optional-dependencies]
-dev = [
-    { name = "mypy" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "click", specifier = ">=8.1" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
-    { name = "pydantic", specifier = ">=2.8" },
-    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12" },
-]
-provides-extras = ["dev"]
-
-[[package]]
 name = "pathspec"
 version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/b6/379d0a960f8f435ec78720462fd94c4863e7a31237cf81bf76d0af5883bf/psycopg-3.3.3.tar.gz", hash = "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9", size = 165624, upload-time = "2026-02-18T16:52:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/5b/181e2e3becb7672b502f0ed7f16ed7352aca7c109cfb94cf3878a9186db9/psycopg-3.3.3-py3-none-any.whl", hash = "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698", size = 212768, upload-time = "2026-02-18T16:46:27.365Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/0a/cac9fdf1df16a269ba0e5f0f06cac61f826c94cadb39df028cdfe19d3a33/psycopg_binary-3.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:05f32239aec25c5fb15f7948cffdc2dc0dac098e48b80a140e4ba32b572a2e7d", size = 4590414, upload-time = "2026-02-18T16:50:01.441Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c0/d8f8508fbf440edbc0099b1abff33003cd80c9e66eb3a1e78834e3fb4fb9/psycopg_binary-3.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c84f9d214f2d1de2fafebc17fa68ac3f6561a59e291553dfc45ad299f4898c1", size = 4669021, upload-time = "2026-02-18T16:50:08.803Z" },
+    { url = "https://files.pythonhosted.org/packages/04/05/097016b77e343b4568feddf12c72171fc513acef9a4214d21b9478569068/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e77957d2ba17cada11be09a5066d93026cdb61ada7c8893101d7fe1c6e1f3925", size = 5467453, upload-time = "2026-02-18T16:50:14.985Z" },
+    { url = "https://files.pythonhosted.org/packages/91/23/73244e5feb55b5ca109cede6e97f32ef45189f0fdac4c80d75c99862729d/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:42961609ac07c232a427da7c87a468d3c82fee6762c220f38e37cfdacb2b178d", size = 5151135, upload-time = "2026-02-18T16:50:24.82Z" },
+    { url = "https://files.pythonhosted.org/packages/11/49/5309473b9803b207682095201d8708bbc7842ddf3f192488a69204e36455/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae07a3114313dd91fce686cab2f4c44af094398519af0e0f854bc707e1aeedf1", size = 6737315, upload-time = "2026-02-18T16:50:35.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5d/03abe74ef34d460b33c4d9662bf6ec1dd38888324323c1a1752133c10377/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d257c58d7b36a621dcce1d01476ad8b60f12d80eb1406aee4cf796f88b2ae482", size = 4979783, upload-time = "2026-02-18T16:50:42.067Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/6c/3fbf8e604e15f2f3752900434046c00c90bb8764305a1b81112bff30ba24/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:07c7211f9327d522c9c47560cae00a4ecf6687f4e02d779d035dd3177b41cb12", size = 4509023, upload-time = "2026-02-18T16:50:50.116Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6b/1a06b43b7c7af756c80b67eac8bfaa51d77e68635a8a8d246e4f0bb7604a/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:8e7e9eca9b363dbedeceeadd8be97149d2499081f3c52d141d7cd1f395a91f83", size = 4185874, upload-time = "2026-02-18T16:50:55.97Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d3/bf49e3dcaadba510170c8d111e5e69e5ae3f981c1554c5bb71c75ce354bb/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cb85b1d5702877c16f28d7b92ba030c1f49ebcc9b87d03d8c10bf45a2f1c7508", size = 3925668, upload-time = "2026-02-18T16:51:03.299Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/92/0aac830ed6a944fe334404e1687a074e4215630725753f0e3e9a9a595b62/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4d4606c84d04b80f9138d72f1e28c6c02dc5ae0c7b8f3f8aaf89c681ce1cd1b1", size = 4234973, upload-time = "2026-02-18T16:51:09.097Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/96/102244653ee5a143ece5afe33f00f52fe64e389dfce8dbc87580c6d70d3d/psycopg_binary-3.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:74eae563166ebf74e8d950ff359be037b85723d99ca83f57d9b244a871d6c13b", size = 3551342, upload-time = "2026-02-18T16:51:13.892Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/71/7a57e5b12275fe7e7d84d54113f0226080423a869118419c9106c083a21c/psycopg_binary-3.3.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:497852c5eaf1f0c2d88ab74a64a8097c099deac0c71de1cbcf18659a8a04a4b2", size = 4607368, upload-time = "2026-02-18T16:51:19.295Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/04/cb834f120f2b2c10d4003515ef9ca9d688115b9431735e3936ae48549af8/psycopg_binary-3.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:258d1ea53464d29768bf25930f43291949f4c7becc706f6e220c515a63a24edd", size = 4687047, upload-time = "2026-02-18T16:51:23.84Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e9/47a69692d3da9704468041aa5ed3ad6fc7f6bb1a5ae788d261a26bbca6c7/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:111c59897a452196116db12e7f608da472fbff000693a21040e35fc978b23430", size = 5487096, upload-time = "2026-02-18T16:51:29.645Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b6/0e0dd6a2f802864a4ae3dbadf4ec620f05e3904c7842b326aafc43e5f464/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:17bb6600e2455993946385249a3c3d0af52cd70c1c1cdbf712e9d696d0b0bf1b", size = 5168720, upload-time = "2026-02-18T16:51:36.499Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/0d/977af38ac19a6b55d22dff508bd743fd7c1901e1b73657e7937c7cccb0a3/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:642050398583d61c9856210568eb09a8e4f2fe8224bf3be21b67a370e677eead", size = 6762076, upload-time = "2026-02-18T16:51:43.167Z" },
+    { url = "https://files.pythonhosted.org/packages/34/40/912a39d48322cf86895c0eaf2d5b95cb899402443faefd4b09abbba6b6e1/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:533efe6dc3a7cba5e2a84e38970786bb966306863e45f3db152007e9f48638a6", size = 4997623, upload-time = "2026-02-18T16:51:47.707Z" },
+    { url = "https://files.pythonhosted.org/packages/98/0c/c14d0e259c65dc7be854d926993f151077887391d5a081118907a9d89603/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5958dbf28b77ce2033482f6cb9ef04d43f5d8f4b7636e6963d5626f000efb23e", size = 4532096, upload-time = "2026-02-18T16:51:51.421Z" },
+    { url = "https://files.pythonhosted.org/packages/39/21/8b7c50a194cfca6ea0fd4d1f276158307785775426e90700ab2eba5cd623/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a6af77b6626ce92b5817bf294b4d45ec1a6161dba80fc2d82cdffdd6814fd023", size = 4208884, upload-time = "2026-02-18T16:51:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2c/a4981bf42cf30ebba0424971d7ce70a222ae9b82594c42fc3f2105d7b525/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:47f06fcbe8542b4d96d7392c476a74ada521c5aebdb41c3c0155f6595fc14c8d", size = 3944542, upload-time = "2026-02-18T16:52:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e9/b7c29b56aa0b85a4e0c4d89db691c1ceef08f46a356369144430c155a2f5/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7800e6c6b5dc4b0ca7cc7370f770f53ac83886b76afda0848065a674231e856", size = 4254339, upload-time = "2026-02-18T16:52:10.444Z" },
+    { url = "https://files.pythonhosted.org/packages/98/5a/291d89f44d3820fffb7a04ebc8f3ef5dda4f542f44a5daea0c55a84abf45/psycopg_binary-3.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:165f22ab5a9513a3d7425ffb7fcc7955ed8ccaeef6d37e369d6cc1dff1582383", size = 3652796, upload-time = "2026-02-18T16:52:14.02Z" },
 ]
 
 [[package]]
@@ -392,4 +440,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
 ]


### PR DESCRIPTION
## Summary
- refresh lane inventory immediately when Harbor accepts deployment evidence
- refresh destination inventory from promotion evidence when linked deployment records exist
- cover the new ingress behavior in service tests and docs

## Verification
- python3 -m unittest tests.test_service
- python3 -m py_compile control_plane/workflows/evidence_ingestion.py control_plane/service.py