### PR TITLE
Pass Dokploy env through Harbor compose service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ services:
   harbor:
     image: ${DOCKER_IMAGE_REFERENCE:-harbor:local}
     pull_policy: always
+    env_file:
+      - .env
     command:
       - /app/scripts/start-harbor-service.sh
     environment:


### PR DESCRIPTION
This follow-up fixes the first Harbor deploy failure in Dokploy.

Dokploy writes target env values to the stack `.env`, but the compose service was only passing a small subset of variables into the Harbor container. Adding `env_file: .env` ensures Harbor receives its database URL, encryption key, policy payload, and other runtime config during deploy.

## Verification
- Observed first `Deploy Harbor` run fail after image build, during Dokploy compose deployment
- Confirmed current Dokploy target env is attached at the compose stack level
- Updated `docker-compose.yml` to load `.env` into the Harbor service"