### PR TITLE
Harden Harbor Dokploy deploy preflight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: pyproject.toml
 

--- a/.github/workflows/deploy-harbor.yml
+++ b/.github/workflows/deploy-harbor.yml
@@ -89,9 +89,26 @@ jobs:
           : "${HARBOR_DEPLOY_HEALTH_URLS:?Missing HARBOR_DEPLOY_HEALTH_URLS variable}"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.prep.outputs.checkout_ref }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: pyproject.toml
+
+      - name: Preflight Dokploy Harbor target
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          uv run harbor service inspect-dokploy-target \
+            --target-type "$HARBOR_DOKPLOY_TARGET_TYPE" \
+            --target-id "$HARBOR_DOKPLOY_TARGET_ID"
 
       - name: Set up Docker Buildx
         if: steps.prep.outputs.should_build == 'true'
@@ -127,14 +144,6 @@ jobs:
             image_reference="${{ steps.prep.outputs.image_repository }}@${{ steps.build.outputs.digest }}"
           fi
           echo "image_reference=$image_reference" >> "$GITHUB_OUTPUT"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: pyproject.toml
 
       - name: Deploy Harbor in Dokploy
         shell: bash

--- a/.github/workflows/deploy-harbor.yml
+++ b/.github/workflows/deploy-harbor.yml
@@ -94,7 +94,7 @@ jobs:
           ref: ${{ steps.prep.outputs.checkout_ref }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # harbor
 
-Private Odoo control-plane repo for release records, environment operations,
+Odoo control-plane repo for release records, environment operations,
 Harbor preview state, and promotion orchestration.
 
 ## Purpose
@@ -145,9 +145,47 @@ Configure these GitHub settings before enabling it:
   - optional `HARBOR_DEPLOY_HEALTH_TIMEOUT_SECONDS`
   - optional `HARBOR_IMAGE_REPOSITORY`
 
+`HARBOR_DEPLOY_HEALTH_URLS` must point at Harbor URLs that GitHub-hosted
+runners can reach, typically the public `https://.../v1/health` endpoint.
+
+Before a real Dokploy deploy, Harbor now exposes a sanitized preflight check:
+
+```bash
+uv run harbor service inspect-dokploy-target \
+  --target-type compose \
+  --target-id "$HARBOR_DOKPLOY_TARGET_ID"
+```
+
+That preflight fails closed when the live Harbor target is missing critical
+runtime contract pieces such as:
+
+- `HARBOR_DATABASE_URL`
+- `HARBOR_MASTER_ENCRYPTION_KEY`
+- `DOKPLOY_HOST`
+- `DOKPLOY_TOKEN`
+- a Dokploy SSH key for private `git@github.com:...` compose sources
+
+It also reports warnings when the live target lacks a policy input, target-id
+catalog input, runtime-environment catalog input, or an existing
+`DOCKER_IMAGE_REFERENCE` rollback baseline.
+
+The deploy path still depends on two Dokploy-side prerequisites that Harbor can
+document but cannot fully validate through the current Dokploy API surface:
+
+- Dokploy must have a working saved registry credential for the Harbor GHCR
+  image repository.
+- The dedicated Postgres service referenced by `HARBOR_DATABASE_URL` must
+  already be deployed and reachable on the Dokploy network before Harbor is
+  redeployed.
+
 Manual `workflow_dispatch` may also deploy an explicit prior image reference,
 which acts as the first operator rollback path while Harbor still has only one
 real Dokploy-hosted service instance.
+
+## Public Readiness
+
+The repo is not ready to flip public blindly yet. The current gap list and the
+cleanup needed before that move live in [docs/public-readiness.md](docs/public-readiness.md).
 
 ## Docs
 
@@ -156,3 +194,4 @@ real Dokploy-hosted service instance.
 - [docs/service-boundary.md](docs/service-boundary.md)
 - [docs/operations.md](docs/operations.md)
 - [docs/records.md](docs/records.md)
+- [docs/public-readiness.md](docs/public-readiness.md)

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -8,6 +8,7 @@ import time
 from json import JSONDecodeError
 from pathlib import Path
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit
 from urllib.request import Request, urlopen
 
 import click
@@ -106,6 +107,28 @@ _RUNTIME_CONTRACT_ENV_KEYS = (
     "ODOO_ADDON_REPOSITORIES",
     "OPENUPGRADE_ADDON_REPOSITORY",
 )
+_HARBOR_SERVICE_REQUIRED_ENV_KEYS = (
+    "HARBOR_DATABASE_URL",
+    "HARBOR_MASTER_ENCRYPTION_KEY",
+    "DOKPLOY_HOST",
+    "DOKPLOY_TOKEN",
+)
+_HARBOR_SERVICE_POLICY_ENV_KEYS = (
+    "HARBOR_POLICY_TOML",
+    "HARBOR_POLICY_B64",
+    "HARBOR_POLICY_FILE",
+)
+_HARBOR_SERVICE_TARGET_IDS_ENV_KEYS = (
+    "HARBOR_DOKPLOY_TARGET_IDS_TOML",
+    "HARBOR_DOKPLOY_TARGET_IDS_B64",
+    "ODOO_CONTROL_PLANE_DOKPLOY_TARGET_IDS_FILE",
+)
+_HARBOR_SERVICE_RUNTIME_ENVIRONMENT_ENV_KEYS = (
+    "HARBOR_RUNTIME_ENVIRONMENTS_TOML",
+    "HARBOR_RUNTIME_ENVIRONMENTS_B64",
+    "ODOO_CONTROL_PLANE_RUNTIME_ENVIRONMENTS_FILE",
+)
+_SUCCESSFUL_DOKPLOY_STATUSES = {"success", "succeeded", "done", "completed", "healthy", "finished"}
 
 
 @contextmanager
@@ -5738,6 +5761,171 @@ def _verify_healthcheck_urls(*, health_urls: tuple[str, ...], timeout_seconds: i
     )
 
 
+def _harbor_service_env_key_present(*, env_map: dict[str, str], env_key: str) -> bool:
+    return bool(env_map.get(env_key, "").strip())
+
+
+def _harbor_service_any_env_keys_present(*, env_map: dict[str, str], env_keys: tuple[str, ...]) -> bool:
+    return any(_harbor_service_env_key_present(env_map=env_map, env_key=env_key) for env_key in env_keys)
+
+
+def _build_harbor_service_target_preflight(
+    *,
+    target_type: str,
+    target_id: str,
+    target_payload: dict[str, object],
+) -> dict[str, object]:
+    env_map = control_plane_dokploy.parse_dokploy_env_text(str(target_payload.get("env") or ""))
+    source_type = str(target_payload.get("sourceType") or "").strip()
+    custom_git_url = str(target_payload.get("customGitUrl") or "").strip()
+    custom_git_branch = str(target_payload.get("customGitBranch") or "").strip()
+    custom_git_ssh_key_id = str(target_payload.get("customGitSSHKeyId") or "").strip()
+    compose_path = str(target_payload.get("composePath") or "").strip()
+    compose_status = str(target_payload.get("composeStatus") or "").strip()
+    database_url = str(env_map.get("HARBOR_DATABASE_URL") or "").strip()
+    database_scheme = ""
+    database_host = ""
+    if database_url:
+        parsed_database_url = urlsplit(database_url)
+        database_scheme = parsed_database_url.scheme.strip().lower()
+        database_host = (parsed_database_url.hostname or "").strip()
+
+    git_access_mode = ""
+    if custom_git_url.startswith("git@"):
+        git_access_mode = "ssh"
+    elif custom_git_url.startswith("https://") or custom_git_url.startswith("http://"):
+        git_access_mode = "https"
+
+    runtime_contract = {
+        "database_url_present": bool(database_url),
+        "database_scheme": database_scheme,
+        "database_host": database_host,
+        "master_encryption_key_present": _harbor_service_env_key_present(
+            env_map=env_map,
+            env_key="HARBOR_MASTER_ENCRYPTION_KEY",
+        ),
+        "dokploy_host_present": _harbor_service_env_key_present(
+            env_map=env_map,
+            env_key="DOKPLOY_HOST",
+        ),
+        "dokploy_token_present": _harbor_service_env_key_present(
+            env_map=env_map,
+            env_key="DOKPLOY_TOKEN",
+        ),
+        "policy_configured": _harbor_service_any_env_keys_present(
+            env_map=env_map,
+            env_keys=_HARBOR_SERVICE_POLICY_ENV_KEYS,
+        ),
+        "target_ids_configured": _harbor_service_any_env_keys_present(
+            env_map=env_map,
+            env_keys=_HARBOR_SERVICE_TARGET_IDS_ENV_KEYS,
+        ),
+        "runtime_environments_configured": _harbor_service_any_env_keys_present(
+            env_map=env_map,
+            env_keys=_HARBOR_SERVICE_RUNTIME_ENVIRONMENT_ENV_KEYS,
+        ),
+        "docker_image_reference_present": _harbor_service_env_key_present(
+            env_map=env_map,
+            env_key=ARTIFACT_IMAGE_REFERENCE_ENV_KEY,
+        ),
+    }
+
+    blockers: list[str] = []
+    warnings: list[str] = []
+    if target_type == "compose" and not compose_path:
+        blockers.append("Dokploy compose target is missing composePath.")
+    if source_type == "git" and not custom_git_url:
+        blockers.append("Dokploy target uses sourceType=git but is missing customGitUrl.")
+    if source_type == "git" and not custom_git_branch:
+        blockers.append("Dokploy target uses sourceType=git but is missing customGitBranch.")
+    if git_access_mode == "ssh" and not custom_git_ssh_key_id:
+        blockers.append(
+            "Dokploy target uses an SSH git remote but has no customGitSSHKeyId configured."
+        )
+    if not runtime_contract["database_url_present"]:
+        blockers.append("Harbor service target is missing HARBOR_DATABASE_URL.")
+    elif not database_scheme.startswith("postgresql"):
+        blockers.append("Harbor service target HARBOR_DATABASE_URL is not a PostgreSQL URL.")
+    elif not database_host:
+        blockers.append("Harbor service target HARBOR_DATABASE_URL is missing a database host.")
+
+    for env_key in _HARBOR_SERVICE_REQUIRED_ENV_KEYS[1:]:
+        if not _harbor_service_env_key_present(env_map=env_map, env_key=env_key):
+            blockers.append(f"Harbor service target is missing {env_key}.")
+
+    if not runtime_contract["policy_configured"]:
+        warnings.append(
+            "Harbor service target does not declare HARBOR_POLICY_* or HARBOR_POLICY_FILE in target env. "
+            "Startup will fall back to the repo example policy unless Dokploy mounts a real policy file separately."
+        )
+    if not runtime_contract["target_ids_configured"]:
+        warnings.append(
+            "Harbor service target does not declare Dokploy target-id catalog env/file inputs. "
+            "Live route resolution depends on a separate mounted file or a future env update."
+        )
+    if not runtime_contract["runtime_environments_configured"]:
+        warnings.append(
+            "Harbor service target does not declare runtime-environment catalog env/file inputs. "
+            "Environment resolution depends on a separate mounted file or a future env update."
+        )
+    if not runtime_contract["docker_image_reference_present"]:
+        warnings.append(
+            "Harbor service target does not currently define DOCKER_IMAGE_REFERENCE. "
+            "The first deploy cannot capture a previous image reference for rollback."
+        )
+    normalized_compose_status = compose_status.lower()
+    if normalized_compose_status and normalized_compose_status not in _SUCCESSFUL_DOKPLOY_STATUSES:
+        warnings.append(
+            f"Dokploy target currently reports composeStatus={compose_status!r}; investigate the live target before replacing it."
+        )
+
+    return {
+        "target_id": target_id,
+        "target_type": target_type,
+        "target_name": str(target_payload.get("name") or "").strip(),
+        "app_name": str(target_payload.get("appName") or "").strip(),
+        "compose_status": compose_status,
+        "source_type": source_type,
+        "custom_git_url": custom_git_url,
+        "custom_git_branch": custom_git_branch,
+        "custom_git_ssh_key_configured": bool(custom_git_ssh_key_id),
+        "git_access_mode": git_access_mode,
+        "compose_path": compose_path,
+        "runtime_contract": runtime_contract,
+        "blockers": blockers,
+        "warnings": warnings,
+    }
+
+
+def _inspect_harbor_service_dokploy_target(
+    *,
+    host: str,
+    token: str,
+    target_type: str,
+    target_id: str,
+) -> tuple[dict[str, object], dict[str, object]]:
+    target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
+        host=host,
+        token=token,
+        target_type=target_type,
+        target_id=target_id,
+    )
+    preflight_payload = _build_harbor_service_target_preflight(
+        target_type=target_type,
+        target_id=target_id,
+        target_payload=target_payload,
+    )
+    return target_payload, preflight_payload
+
+
+def _harbor_service_target_preflight_error_message(*, preflight_payload: dict[str, object]) -> str:
+    blockers = preflight_payload.get("blockers")
+    if not isinstance(blockers, list) or not blockers:
+        return "Harbor service Dokploy target preflight failed."
+    rendered_blockers = "\n".join(f"- {str(blocker)}" for blocker in blockers)
+    return f"Harbor service Dokploy target preflight failed:\n{rendered_blockers}"
+
+
 def _apply_dokploy_image_reference(
     *,
     host: str,
@@ -5745,17 +5933,18 @@ def _apply_dokploy_image_reference(
     target_type: str,
     target_id: str,
     image_reference: str,
+    target_payload: dict[str, object] | None = None,
 ) -> dict[str, object]:
     normalized_image_reference = image_reference.strip()
     if not normalized_image_reference:
         raise click.ClickException("Harbor service deploy requires a non-empty image reference.")
-    target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
+    resolved_target_payload = target_payload or control_plane_dokploy.fetch_dokploy_target_payload(
         host=host,
         token=token,
         target_type=target_type,
         target_id=target_id,
     )
-    raw_env_text = str(target_payload.get("env") or "")
+    raw_env_text = str(resolved_target_payload.get("env") or "")
     env_map = control_plane_dokploy.parse_dokploy_env_text(raw_env_text)
     previous_value_present = ARTIFACT_IMAGE_REFERENCE_ENV_KEY in env_map
     previous_image_reference = env_map.get(ARTIFACT_IMAGE_REFERENCE_ENV_KEY, "")
@@ -5769,7 +5958,7 @@ def _apply_dokploy_image_reference(
             token=token,
             target_type=target_type,
             target_id=target_id,
-            target_payload=target_payload,
+            target_payload=resolved_target_payload,
             env_text=updated_env_text,
         )
     return {
@@ -7380,6 +7569,16 @@ def service_deploy_dokploy_image(
 ) -> None:
     harbor_root = control_plane_root or _control_plane_root()
     host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=harbor_root)
+    target_payload, preflight_payload = _inspect_harbor_service_dokploy_target(
+        host=host,
+        token=token,
+        target_type=target_type,
+        target_id=target_id,
+    )
+    if preflight_payload["blockers"]:
+        raise click.ClickException(
+            _harbor_service_target_preflight_error_message(preflight_payload=preflight_payload)
+        )
     normalized_health_urls = tuple(url.strip() for url in health_urls if url.strip())
     apply_result = _apply_dokploy_image_reference(
         host=host,
@@ -7387,12 +7586,14 @@ def service_deploy_dokploy_image(
         target_type=target_type,
         target_id=target_id,
         image_reference=image_reference,
+        target_payload=target_payload,
     )
     payload: dict[str, object] = {
         "status": "pending",
         "target_type": target_type,
         "target_id": target_id,
         "image_reference": image_reference,
+        "preflight": preflight_payload,
         "health_urls": list(normalized_health_urls),
         "deploy_timeout_seconds": deploy_timeout_seconds,
         "health_timeout_seconds": health_timeout_seconds,
@@ -7455,6 +7656,46 @@ def service_deploy_dokploy_image(
         payload["rollback"] = rollback_payload
         click.echo(json.dumps(payload, indent=2, sort_keys=True))
         raise click.ClickException(str(error)) from error
+
+
+@service.command("inspect-dokploy-target")
+@click.option(
+    "--target-type",
+    type=click.Choice(["compose", "application"]),
+    envvar="HARBOR_DOKPLOY_TARGET_TYPE",
+    required=True,
+    help="Dokploy target type for the live Harbor service.",
+)
+@click.option(
+    "--target-id",
+    envvar="HARBOR_DOKPLOY_TARGET_ID",
+    required=True,
+    help="Dokploy target id for the live Harbor service.",
+)
+@click.option(
+    "--control-plane-root",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Optional Harbor repo root used to resolve Dokploy credentials.",
+)
+def service_inspect_dokploy_target(
+    target_type: str,
+    target_id: str,
+    control_plane_root: Path | None,
+) -> None:
+    harbor_root = control_plane_root or _control_plane_root()
+    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=harbor_root)
+    _, preflight_payload = _inspect_harbor_service_dokploy_target(
+        host=host,
+        token=token,
+        target_type=target_type,
+        target_id=target_id,
+    )
+    click.echo(json.dumps(preflight_payload, indent=2, sort_keys=True))
+    if preflight_payload["blockers"]:
+        raise click.ClickException(
+            _harbor_service_target_preflight_error_message(preflight_payload=preflight_payload)
+        )
 
 
 @artifacts.command("write")

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,8 @@ Use these docs as the source of truth for `harbor`.
   OIDC trust, and first API contracts.
 - [operations.md](operations.md) — operator workflows and runtime boundary rules.
 - [records.md](records.md) — persisted record formats and storage policy.
+- [public-readiness.md](public-readiness.md) — current blockers and exit criteria
+  before making Harbor public.
 - [secrets.md](secrets.md) — control-plane secret ownership and local contract.
 - [style/python.md](style/python.md) — Python conventions.
 - [style/testing.md](style/testing.md) — testing conventions.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -126,9 +126,36 @@ Required GitHub configuration for that workflow:
   - optional `HARBOR_DEPLOY_HEALTH_TIMEOUT_SECONDS`
   - optional `HARBOR_IMAGE_REPOSITORY`
 
+`HARBOR_DEPLOY_HEALTH_URLS` must resolve from GitHub-hosted runners. Use the
+public Harbor `GET /v1/health` endpoint rather than an internal-only Dokploy
+network hostname.
+
 The Dokploy-hosted Harbor target should consume `DOCKER_IMAGE_REFERENCE` from
 its env so deploy automation can switch the service by immutable digest and
 roll back to the prior digest when verification fails.
+
+Before a real Harbor deploy, run the sanitized preflight check against the live
+Dokploy target:
+
+```bash
+uv run harbor service inspect-dokploy-target \
+  --target-type compose \
+  --target-id "$HARBOR_DOKPLOY_TARGET_ID"
+```
+
+That command reports only non-secret metadata and fails closed when the live
+Harbor target is missing critical runtime pieces such as `HARBOR_DATABASE_URL`,
+`HARBOR_MASTER_ENCRYPTION_KEY`, `DOKPLOY_HOST`, `DOKPLOY_TOKEN`, or a Dokploy
+SSH key for a private `git@github.com:...` compose source. The GitHub deploy
+workflow now runs that same preflight before it builds or deploys a new image.
+
+Two deployment prerequisites remain Dokploy-side operational contracts rather
+than Harbor CLI validations:
+
+- Dokploy must already have a working saved registry credential that can pull
+  Harbor's GHCR image.
+- The Postgres service referenced by `HARBOR_DATABASE_URL` must already be
+  deployed and reachable on the Dokploy network before Harbor is redeployed.
 
 Current derived-state behavior:
 

--- a/docs/public-readiness.md
+++ b/docs/public-readiness.md
@@ -1,0 +1,58 @@
+---
+title: Public Readiness
+---
+
+## Current Verdict
+
+Do not flip `cbusillo/harbor` public yet.
+
+The immediate deploy incident is fixed, but the repo and its runtime contract
+still carry private-operations assumptions that should be cleaned up first.
+
+## Current Blockers
+
+- The repo still documents Harbor as the Odoo-specific implementation rather
+  than a generic public Harbor surface. That is accurate today, but it means a
+  public move would expose product-specific internals before the public story is
+  coherent.
+- The live Dokploy target depends on a private git compose source plus a
+  Dokploy-managed SSH key. Public visibility for the repo does not remove that
+  contract automatically, and operators still need an intentional Dokploy key
+  story.
+- Harbor image pulls still depend on a Dokploy-side saved GHCR credential. A
+  public repo does not help if the image package remains private or if Dokploy
+  is configured with stale registry credentials.
+- Harbor runtime secrets and operator catalogs remain intentionally external to
+  git. That is the correct contract, but the repo must make it obvious that
+  public source visibility does not imply public runtime configuration.
+- Product and tenant-specific examples remain throughout the docs and config
+  examples. They are acceptable for a private Odoo control-plane repo today,
+  but they should be pruned or generalized before treating the repo as a public
+  Harbor reference implementation.
+
+## Ready-To-Public Checklist
+
+- Replace or generalize tenant-specific examples that do not need to be public
+  product documentation.
+- Decide whether the Harbor GHCR package should also become public, or keep the
+  repo public while documenting the private package contract explicitly.
+- Document the Dokploy SSH and registry prerequisites in one operator-facing
+  place, with a short failure-mode checklist.
+- Keep all runtime secrets, target-id catalogs, and runtime-environment files
+  outside git. Treat that as a hard invariant, not a best effort.
+- Confirm the repo README tells a public reader what Harbor is today, what is
+  Odoo-specific, and what is still intentionally private operational state.
+
+## Safe Public Posture
+
+If the repo needs to go public before Harbor is fully generalized, the safe
+interim posture is:
+
+- public source code
+- private runtime secrets and operator catalogs
+- explicit docs for private GHCR and Dokploy prerequisites
+- no checked-in live environment identifiers, credentials, or rendered secret
+  files
+
+That posture is workable, but only once the docs and examples stop implying
+that private operator knowledge is stored in the repo.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -63,6 +63,12 @@ title: Secrets
 - Missing Dokploy credentials are a hard error, not a silent fallback.
 - Missing `HARBOR_MASTER_ENCRYPTION_KEY` is a hard error when Harbor needs to
   read or write DB-backed managed secrets.
+- The live Harbor Dokploy target should expose `HARBOR_DATABASE_URL`,
+  `HARBOR_MASTER_ENCRYPTION_KEY`, `DOKPLOY_HOST`, and `DOKPLOY_TOKEN` through
+  target env or an equivalent mounted runtime contract.
+- Use `uv run harbor service inspect-dokploy-target ...` to verify that the
+  live Harbor target has the required secret-backed contract without printing
+  plaintext secret values.
 
 ## Local Runtime Contract
 
@@ -88,4 +94,9 @@ cp config/runtime-environments.toml.example \
 cp .env.example "${XDG_CONFIG_HOME:-$HOME/.config}/harbor/dokploy.env"
 export HARBOR_MASTER_ENCRYPTION_KEY="replace-me"
 uv run harbor secrets import-bootstrap --database-url "$HARBOR_DATABASE_URL"
+uv run harbor secrets list --database-url "$HARBOR_DATABASE_URL" --integration dokploy
 ```
+
+After bootstrap import succeeds, verify Harbor can resolve the managed secret
+status you expect before removing older operator-local bootstrap files such as
+`~/.config/harbor/dokploy.env`.

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -665,6 +665,20 @@ target_id = "compose-456"
 
 
 class HarborServiceDeployTests(unittest.TestCase):
+    @staticmethod
+    def _target_payload(*, env_text: str, custom_git_ssh_key_id: str = "ssh-key-123") -> dict[str, object]:
+        return {
+            "name": "harbor",
+            "appName": "compose-harbor",
+            "sourceType": "git",
+            "customGitUrl": "git@github.com:example/harbor.git",
+            "customGitBranch": "main",
+            "customGitSSHKeyId": custom_git_ssh_key_id,
+            "composePath": "./docker-compose.yml",
+            "composeStatus": "done",
+            "env": env_text,
+        }
+
     def test_render_dokploy_env_text_with_overrides_updates_and_removes_keys(self) -> None:
         rendered = control_plane_dokploy.render_dokploy_env_text_with_overrides(
             "KEEP=1\nREMOVE=old\n",
@@ -684,7 +698,18 @@ class HarborServiceDeployTests(unittest.TestCase):
             return_value=("https://dokploy.example.com", "token-123"),
         ), patch(
             "control_plane.dokploy.fetch_dokploy_target_payload",
-            return_value={"env": "DOCKER_IMAGE_REFERENCE=ghcr.io/every/harbor@sha256:old\n"},
+            return_value=self._target_payload(
+                env_text=(
+                    "DOCKER_IMAGE_REFERENCE=ghcr.io/every/harbor@sha256:old\n"
+                    "HARBOR_DATABASE_URL=postgresql+psycopg://harbor:test@db.internal:5432/harbor\n"
+                    "HARBOR_MASTER_ENCRYPTION_KEY=test-key\n"
+                    "DOKPLOY_HOST=https://dokploy.example.com\n"
+                    "DOKPLOY_TOKEN=token-123\n"
+                    "HARBOR_POLICY_B64=dGVzdA==\n"
+                    "HARBOR_DOKPLOY_TARGET_IDS_B64=dGVzdA==\n"
+                    "HARBOR_RUNTIME_ENVIRONMENTS_B64=dGVzdA==\n"
+                ),
+            ),
         ), patch(
             "control_plane.dokploy.update_dokploy_target_env",
             side_effect=lambda **kwargs: captured_env_updates.append(kwargs),
@@ -725,6 +750,8 @@ class HarborServiceDeployTests(unittest.TestCase):
         self.assertEqual(payload["status"], "ok")
         self.assertEqual(payload["previous_image_reference"], "ghcr.io/every/harbor@sha256:old")
         self.assertEqual(payload["deployment_result"], "deployment=deploy-new status=done")
+        self.assertEqual(payload["preflight"]["runtime_contract"]["database_host"], "db.internal")
+        self.assertTrue(payload["preflight"]["custom_git_ssh_key_configured"])
 
     def test_service_deploy_dokploy_image_rolls_back_when_health_verification_fails(self) -> None:
         runner = CliRunner()
@@ -737,8 +764,30 @@ class HarborServiceDeployTests(unittest.TestCase):
         ), patch(
             "control_plane.dokploy.fetch_dokploy_target_payload",
             side_effect=[
-                {"env": "DOCKER_IMAGE_REFERENCE=ghcr.io/every/harbor@sha256:old\n"},
-                {"env": "DOCKER_IMAGE_REFERENCE=ghcr.io/every/harbor@sha256:new\n"},
+                self._target_payload(
+                    env_text=(
+                        "DOCKER_IMAGE_REFERENCE=ghcr.io/every/harbor@sha256:old\n"
+                        "HARBOR_DATABASE_URL=postgresql+psycopg://harbor:test@db.internal:5432/harbor\n"
+                        "HARBOR_MASTER_ENCRYPTION_KEY=test-key\n"
+                        "DOKPLOY_HOST=https://dokploy.example.com\n"
+                        "DOKPLOY_TOKEN=token-123\n"
+                        "HARBOR_POLICY_B64=dGVzdA==\n"
+                        "HARBOR_DOKPLOY_TARGET_IDS_B64=dGVzdA==\n"
+                        "HARBOR_RUNTIME_ENVIRONMENTS_B64=dGVzdA==\n"
+                    ),
+                ),
+                self._target_payload(
+                    env_text=(
+                        "DOCKER_IMAGE_REFERENCE=ghcr.io/every/harbor@sha256:new\n"
+                        "HARBOR_DATABASE_URL=postgresql+psycopg://harbor:test@db.internal:5432/harbor\n"
+                        "HARBOR_MASTER_ENCRYPTION_KEY=test-key\n"
+                        "DOKPLOY_HOST=https://dokploy.example.com\n"
+                        "DOKPLOY_TOKEN=token-123\n"
+                        "HARBOR_POLICY_B64=dGVzdA==\n"
+                        "HARBOR_DOKPLOY_TARGET_IDS_B64=dGVzdA==\n"
+                        "HARBOR_RUNTIME_ENVIRONMENTS_B64=dGVzdA==\n"
+                    ),
+                ),
             ],
         ), patch(
             "control_plane.dokploy.update_dokploy_target_env",
@@ -791,6 +840,85 @@ class HarborServiceDeployTests(unittest.TestCase):
         payload = json.loads(payload_text) if payload_text else {}
         self.assertEqual(payload.get("status"), "failed")
         self.assertEqual(payload.get("rollback", {}).get("status"), "ok")
+
+    def test_service_inspect_dokploy_target_fails_closed_on_missing_runtime_contract(self) -> None:
+        runner = CliRunner()
+
+        with patch(
+            "control_plane.dokploy.read_dokploy_config",
+            return_value=("https://dokploy.example.com", "token-123"),
+        ), patch(
+            "control_plane.dokploy.fetch_dokploy_target_payload",
+            return_value=self._target_payload(
+                env_text="DOCKER_IMAGE_REFERENCE=ghcr.io/example/harbor@sha256:old\n",
+                custom_git_ssh_key_id="",
+            ),
+        ):
+            result = runner.invoke(
+                main,
+                [
+                    "service",
+                    "inspect-dokploy-target",
+                    "--target-type",
+                    "compose",
+                    "--target-id",
+                    "compose-123",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0, msg=result.output)
+        payload_text = result.output.split("Error:", 1)[0].strip()
+        payload = json.loads(payload_text) if payload_text else {}
+        self.assertIn(
+            "Dokploy target uses an SSH git remote but has no customGitSSHKeyId configured.",
+            payload.get("blockers", []),
+        )
+        self.assertIn(
+            "Harbor service target is missing HARBOR_DATABASE_URL.",
+            payload.get("blockers", []),
+        )
+        self.assertIn("Harbor service Dokploy target preflight failed", result.output)
+
+    def test_service_deploy_dokploy_image_stops_before_env_change_when_preflight_fails(self) -> None:
+        runner = CliRunner()
+
+        with patch(
+            "control_plane.dokploy.read_dokploy_config",
+            return_value=("https://dokploy.example.com", "token-123"),
+        ), patch(
+            "control_plane.dokploy.fetch_dokploy_target_payload",
+            return_value=self._target_payload(
+                env_text=(
+                    "HARBOR_MASTER_ENCRYPTION_KEY=test-key\n"
+                    "DOKPLOY_HOST=https://dokploy.example.com\n"
+                    "DOKPLOY_TOKEN=token-123\n"
+                ),
+            ),
+        ), patch(
+            "control_plane.dokploy.update_dokploy_target_env",
+        ) as update_target_env, patch(
+            "control_plane.dokploy.trigger_deployment",
+        ) as trigger_deployment:
+            result = runner.invoke(
+                main,
+                [
+                    "service",
+                    "deploy-dokploy-image",
+                    "--target-type",
+                    "compose",
+                    "--target-id",
+                    "compose-123",
+                    "--image-reference",
+                    "ghcr.io/example/harbor@sha256:new",
+                    "--health-url",
+                    "https://harbor.example.com/v1/health",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0, msg=result.output)
+        update_target_env.assert_not_called()
+        trigger_deployment.assert_not_called()
+        self.assertIn("Harbor service target is missing HARBOR_DATABASE_URL.", result.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a sanitized Harbor Dokploy target preflight and run it before deploys
- document the live Dokploy/GHCR/Postgres contract and current public-readiness blockers
- update CI/deploy workflow action versions and cover the new preflight in tests

## Verification
- uv run python -m unittest tests.test_dokploy
- uv run python -m unittest
- uv run harbor service inspect-dokploy-target --target-type compose --target-id BJlEs8KD9a-HDALEVX8C2
