### PR TITLE
Add idempotent Harbor evidence writes

### DIFF
--- a/config/harbor-authz.toml.example
+++ b/config/harbor-authz.toml.example
@@ -48,6 +48,16 @@ workflow_refs = [
 event_names = ["workflow_dispatch"]
 products = ["verireel"]
 contexts = ["verireel"]
+actions = ["deployment.write"]
+
+[[github_actions]]
+repository = "every/verireel"
+workflow_refs = [
+  "every/verireel/.github/workflows/promote-image.yml@refs/heads/main",
+]
+event_names = ["workflow_dispatch"]
+products = ["verireel"]
+contexts = ["verireel"]
 actions = ["promotion.write"]
 
 [[github_actions]]

--- a/control_plane/contracts/idempotency_record.py
+++ b/control_plane/contracts/idempotency_record.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class HarborIdempotencyRecord(BaseModel):
+    schema_version: int = 1
+    record_id: str
+    scope: str
+    route_path: str
+    idempotency_key: str
+    request_fingerprint: str
+    response_status_code: int = Field(ge=100, le=599)
+    response_trace_id: str
+    recorded_at: str
+    response_payload: dict[str, Any]
+
+
+def build_harbor_idempotency_record_id(*, scope: str, route_path: str, idempotency_key: str) -> str:
+    normalized = f"{scope.strip()}\n{route_path.strip()}\n{idempotency_key.strip()}"
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:24]
+    return f"idempotency-{digest}"

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+import hashlib
 import io
 import json
 import uuid
@@ -12,6 +14,8 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_valida
 
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.deployment_record import DeploymentRecord
+from control_plane.contracts.idempotency_record import HarborIdempotencyRecord
+from control_plane.contracts.idempotency_record import build_harbor_idempotency_record_id
 from control_plane.contracts.preview_mutation_request import (
     PreviewDestroyMutationRequest,
     PreviewGenerationMutationRequest,
@@ -141,12 +145,17 @@ def _http_status_text(status_code: int) -> str:
         403: "Forbidden",
         404: "Not Found",
         405: "Method Not Allowed",
+        409: "Conflict",
         500: "Internal Server Error",
     }.get(status_code, "OK")
 
 
 def _trace_id() -> str:
     return f"harbor_req_{uuid.uuid4().hex}"
+
+
+def _utc_now_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def _not_found_response(
@@ -193,6 +202,181 @@ def _secret_capable_store(record_store: object):
     if hasattr(record_store, "read_secret_record") and hasattr(record_store, "list_secret_records"):
         return record_store
     return None
+
+
+def _idempotency_capable_store(record_store: object):
+    if hasattr(record_store, "read_idempotency_record") and hasattr(record_store, "write_idempotency_record"):
+        return record_store
+    return None
+
+
+def _idempotency_key(environ: dict[str, object]) -> str:
+    return str(environ.get("HTTP_IDEMPOTENCY_KEY", "")).strip()
+
+
+def _idempotency_scope(identity) -> str:
+    workflow_ref = identity.workflow_ref or identity.job_workflow_ref or ""
+    return "|".join(
+        (
+            str(identity.repository).strip(),
+            str(workflow_ref).strip(),
+            str(identity.subject).strip(),
+        )
+    )
+
+
+def _request_fingerprint(payload: dict[str, object]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _accepted_payload(
+    *,
+    trace_id: str,
+    result: dict[str, object],
+    driver_result: BaseModel | dict[str, object] | None,
+    replayed: bool = False,
+    original_trace_id: str = "",
+) -> dict[str, object]:
+    serialized_driver_result: dict[str, object] | None = None
+    if isinstance(driver_result, BaseModel):
+        serialized_driver_result = driver_result.model_dump(mode="json")
+    elif isinstance(driver_result, dict):
+        serialized_driver_result = dict(driver_result)
+    payload: dict[str, object] = {
+        "status": "accepted",
+        "trace_id": trace_id,
+        "records": {
+            key: str(value)
+            for key, value in result.items()
+            if key
+            in {
+                "deployment_record_id",
+                "inventory_record_id",
+                "preview_id",
+                "generation_id",
+                "promotion_record_id",
+                "transition",
+            }
+        },
+        **({"result": serialized_driver_result} if serialized_driver_result else {}),
+    }
+    if replayed:
+        payload["replayed"] = True
+        payload["original_trace_id"] = original_trace_id
+    return payload
+
+
+def _replay_idempotent_response(
+    *,
+    start_response: Callable[[str, list[tuple[str, str]]], None],
+    trace_id: str,
+    stored_record: HarborIdempotencyRecord,
+) -> list[bytes]:
+    stored_payload = dict(stored_record.response_payload)
+    stored_driver_result = stored_payload.get("result")
+    result_payload = _accepted_payload(
+        trace_id=trace_id,
+        result=dict(stored_payload.get("records") or {}),
+        driver_result=stored_driver_result if isinstance(stored_driver_result, dict) else None,
+        replayed=True,
+        original_trace_id=stored_record.response_trace_id,
+    )
+    return _json_response(
+        start_response=start_response,
+        status_code=stored_record.response_status_code,
+        payload=result_payload,
+    )
+
+
+def _read_idempotency_record(
+    *,
+    record_store: object,
+    scope: str,
+    route_path: str,
+    idempotency_key: str,
+) -> HarborIdempotencyRecord | None:
+    idempotency_store = _idempotency_capable_store(record_store)
+    if idempotency_store is None or not idempotency_key:
+        return None
+    return idempotency_store.read_idempotency_record(
+        scope=scope,
+        route_path=route_path,
+        idempotency_key=idempotency_key,
+    )
+
+
+def _write_idempotency_record(
+    *,
+    record_store: object,
+    scope: str,
+    route_path: str,
+    idempotency_key: str,
+    request_fingerprint: str,
+    response_status_code: int,
+    response_trace_id: str,
+    response_payload: dict[str, object],
+) -> None:
+    idempotency_store = _idempotency_capable_store(record_store)
+    if idempotency_store is None or not idempotency_key:
+        return
+    idempotency_store.write_idempotency_record(
+        HarborIdempotencyRecord(
+            record_id=build_harbor_idempotency_record_id(
+                scope=scope,
+                route_path=route_path,
+                idempotency_key=idempotency_key,
+            ),
+            scope=scope,
+            route_path=route_path,
+            idempotency_key=idempotency_key,
+            request_fingerprint=request_fingerprint,
+            response_status_code=response_status_code,
+            response_trace_id=response_trace_id,
+            recorded_at=_utc_now_timestamp(),
+            response_payload=response_payload,
+        )
+    )
+
+
+def _check_idempotent_request(
+    *,
+    record_store: object,
+    scope: str,
+    route_path: str,
+    idempotency_key: str,
+    request_fingerprint: str,
+    start_response: Callable[[str, list[tuple[str, str]]], None],
+    trace_id: str,
+) -> list[bytes] | None:
+    stored_record = _read_idempotency_record(
+        record_store=record_store,
+        scope=scope,
+        route_path=route_path,
+        idempotency_key=idempotency_key,
+    )
+    if stored_record is None:
+        return None
+    if stored_record.request_fingerprint != request_fingerprint:
+        return _json_response(
+            start_response=start_response,
+            status_code=409,
+            payload={
+                "status": "rejected",
+                "trace_id": trace_id,
+                "error": {
+                    "code": "idempotency_key_reused",
+                    "message": (
+                        "Idempotency-Key was already used for a different Harbor request payload on this route."
+                    ),
+                },
+            },
+        )
+    return _replay_idempotent_response(
+        start_response=start_response,
+        trace_id=trace_id,
+        stored_record=stored_record,
+    )
 
 
 def _read_json_request(environ: dict[str, object]) -> dict[str, object]:
@@ -578,6 +762,9 @@ def create_harbor_service_app(
                     },
                 )
             payload = _read_json_request(environ)
+            request_idempotency_key = _idempotency_key(environ)
+            request_scope = _idempotency_scope(identity)
+            request_fingerprint = _request_fingerprint(payload)
             driver_result = None
             if path == "/v1/evidence/deployments":
                 request = DeploymentEvidenceEnvelope.model_validate(payload)
@@ -602,6 +789,17 @@ def create_harbor_service_app(
                             },
                         },
                     )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
                 result = apply_deployment_evidence(
                     record_store=record_store,
                     deployment_record=request.deployment,
@@ -629,6 +827,17 @@ def create_harbor_service_app(
                             },
                         },
                     )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
                 driver_result = execute_verireel_testing_deploy(
                     control_plane_root=resolved_root,
                     record_store=record_store,
@@ -658,6 +867,17 @@ def create_harbor_service_app(
                             },
                         },
                     )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
                 result = apply_promotion_evidence(
                     record_store=record_store,
                     promotion_record=request.promotion,
@@ -685,6 +905,17 @@ def create_harbor_service_app(
                             },
                         },
                     )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
                 result = apply_harbor_generation_evidence(
                     control_plane_root_path=resolved_root,
                     record_store=record_store,
@@ -714,6 +945,17 @@ def create_harbor_service_app(
                             },
                         },
                     )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
                 result = apply_harbor_destroy_preview(
                     record_store=record_store,
                     request=request.destroy,
@@ -754,27 +996,26 @@ def create_harbor_service_app(
                     "error": {"code": "invalid_request", "message": str(exc)},
                 },
             )
+        accepted_payload = _accepted_payload(
+            trace_id=request_trace_id,
+            result=result,
+            driver_result=driver_result,
+        )
+        if method == "POST" and request_idempotency_key:
+            _write_idempotency_record(
+                record_store=record_store,
+                scope=request_scope,
+                route_path=path,
+                idempotency_key=request_idempotency_key,
+                request_fingerprint=request_fingerprint,
+                response_status_code=202,
+                response_trace_id=request_trace_id,
+                response_payload=accepted_payload,
+            )
         return _json_response(
             start_response=start_response,
             status_code=202,
-            payload={
-                "status": "accepted",
-                "trace_id": request_trace_id,
-                "records": {
-                    key: str(value)
-                    for key, value in result.items()
-                    if key
-                    in {
-                        "deployment_record_id",
-                        "inventory_record_id",
-                        "preview_id",
-                        "generation_id",
-                        "promotion_record_id",
-                        "transition",
-                    }
-                },
-                **({"result": driver_result.model_dump(mode="json")} if driver_result else {}),
-            },
+            payload=accepted_payload,
         )
 
     return app

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -8,6 +8,8 @@ from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.idempotency_record import HarborIdempotencyRecord
+from control_plane.contracts.idempotency_record import build_harbor_idempotency_record_id
 from control_plane.contracts.preview_enablement_record import PreviewEnablementRecord
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
 from control_plane.contracts.preview_record import PreviewRecord
@@ -85,6 +87,28 @@ class FilesystemRecordStore:
         records = list(self._list_models(ReleaseTupleRecord, "release_tuples"))
         records.sort(key=lambda record: (record.context, record.channel))
         return tuple(records)
+
+    def write_idempotency_record(self, record: HarborIdempotencyRecord) -> Path:
+        return self._write_model("idempotency", record.record_id, record)
+
+    def read_idempotency_record(
+        self,
+        *,
+        scope: str,
+        route_path: str,
+        idempotency_key: str,
+    ) -> HarborIdempotencyRecord | None:
+        record_id = build_harbor_idempotency_record_id(
+            scope=scope,
+            route_path=route_path,
+            idempotency_key=idempotency_key,
+        )
+        record_path = self._record_path("idempotency", record_id)
+        if not record_path.exists():
+            return None
+        return HarborIdempotencyRecord.model_validate(
+            self._read_model(HarborIdempotencyRecord, "idempotency", record_id).model_dump(mode="json")
+        )
 
     def write_backup_gate_record(self, record: BackupGateRecord) -> Path:
         return self._write_model("backup_gates", record.record_id, record)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -11,6 +11,8 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, sess
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.idempotency_record import HarborIdempotencyRecord
+from control_plane.contracts.idempotency_record import build_harbor_idempotency_record_id
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.promotion_record import PromotionRecord
@@ -154,6 +156,29 @@ class HarborReleaseTupleRow(Base):
     artifact_id: Mapped[str] = mapped_column(String, nullable=False)
     minted_at: Mapped[str] = mapped_column(String, nullable=False)
     provenance: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class HarborIdempotencyRow(Base):
+    __tablename__ = "harbor_idempotency_records"
+    __table_args__ = (
+        Index(
+            "harbor_idempotency_scope_route_key_idx",
+            "scope",
+            "route_path",
+            "idempotency_key",
+            unique=True,
+        ),
+    )
+
+    record_id: Mapped[str] = mapped_column(String, primary_key=True)
+    scope: Mapped[str] = mapped_column(String, nullable=False)
+    route_path: Mapped[str] = mapped_column(String, nullable=False)
+    idempotency_key: Mapped[str] = mapped_column(String, nullable=False)
+    request_fingerprint: Mapped[str] = mapped_column(String, nullable=False)
+    response_status_code: Mapped[int] = mapped_column(Integer, nullable=False)
+    response_trace_id: Mapped[str] = mapped_column(String, nullable=False)
+    recorded_at: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -357,6 +382,40 @@ class PostgresRecordStore:
             order_by=(HarborBackupGateRow.created_at.desc(), HarborBackupGateRow.record_id.desc()),
             limit=limit,
         )
+
+    def write_idempotency_record(self, record: HarborIdempotencyRecord) -> None:
+        self._write_row(
+            HarborIdempotencyRow(
+                record_id=record.record_id,
+                scope=record.scope,
+                route_path=record.route_path,
+                idempotency_key=record.idempotency_key,
+                request_fingerprint=record.request_fingerprint,
+                response_status_code=record.response_status_code,
+                response_trace_id=record.response_trace_id,
+                recorded_at=record.recorded_at,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def read_idempotency_record(
+        self,
+        *,
+        scope: str,
+        route_path: str,
+        idempotency_key: str,
+    ) -> HarborIdempotencyRecord | None:
+        record_id = build_harbor_idempotency_record_id(
+            scope=scope,
+            route_path=route_path,
+            idempotency_key=idempotency_key,
+        )
+        statement = select(HarborIdempotencyRow).where(HarborIdempotencyRow.record_id == record_id).limit(1)
+        with self._session_factory() as session:
+            row = session.scalar(statement)
+            if row is None:
+                return None
+            return self._read_payload(model_type=HarborIdempotencyRecord, payload=row.payload)
 
     def write_deployment_record(self, record: DeploymentRecord) -> None:
         self._write_row(

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -163,6 +163,7 @@ event_name: workflow_dispatch
 allowed product: verireel
 allowed contexts: verireel
 allowed actions:
+  - deployment.write
   - promotion.write
 ```
 
@@ -227,6 +228,21 @@ Recommended first headers:
 - `Authorization: Bearer <github_oidc_token>`
 - `Content-Type: application/json`
 - `Idempotency-Key: <stable-retry-key>`
+
+The current Harbor service implementation now honors `Idempotency-Key` for all
+write routes. Harbor replays the first successful accepted response when the
+same authenticated workflow scope retries the same route with the same key and
+the same request fingerprint. Harbor rejects reuse of the same key for a
+different payload on the same route.
+
+Current VeriReel key shapes:
+
+- preview generation: `preview-generation:<product>:<context>:<anchor_repo>:<pr_number>:<sha>`
+- preview destroy: `preview-destroyed:<product>:<context>:<anchor_repo>:<pr_number>:<destroy_reason>`
+- testing deployment evidence: `testing-deployment:<product>:<context>:<instance>:<record_id>`
+- prod deployment evidence: `prod-deployment:<product>:<context>:<instance>:<record_id>`
+- prod promotion evidence: `prod-promotion:<product>:<context>:<from_instance>:<to_instance>:<record_id>`
+- VeriReel testing deploy driver: `verireel-testing-deploy:<product>:<context>:<instance>:<artifact_id>:<source_git_ref>`
 
 Recommended first success shape:
 

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -9,6 +9,8 @@ from control_plane.cli import main
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.idempotency_record import HarborIdempotencyRecord
+from control_plane.contracts.idempotency_record import build_harbor_idempotency_record_id
 from control_plane.contracts.preview_generation_record import (
     PreviewGenerationRecord,
     PreviewPullRequestSummary,
@@ -211,6 +213,40 @@ def _secret_audit_event(*, event_id: str, secret_id: str, recorded_at: str) -> S
 
 
 class PostgresRecordStoreTests(unittest.TestCase):
+    def test_idempotency_records_round_trip(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "harbor.sqlite3"
+            store = PostgresRecordStore(database_url=_sqlite_database_url(database_path))
+            store.ensure_schema()
+
+            record = HarborIdempotencyRecord(
+                record_id=build_harbor_idempotency_record_id(
+                    scope="every/verireel|workflow|repo:every/verireel:pull_request",
+                    route_path="/v1/evidence/previews/generations",
+                    idempotency_key="preview-generation:verireel:verireel-testing:verireel:35:abcdef",
+                ),
+                scope="every/verireel|workflow|repo:every/verireel:pull_request",
+                route_path="/v1/evidence/previews/generations",
+                idempotency_key="preview-generation:verireel:verireel-testing:verireel:35:abcdef",
+                request_fingerprint="fingerprint-123",
+                response_status_code=202,
+                response_trace_id="harbor_req_123",
+                recorded_at="2026-04-21T01:00:00Z",
+                response_payload={"status": "accepted", "records": {"preview_id": "preview-35"}},
+            )
+
+            store.write_idempotency_record(record)
+            loaded = store.read_idempotency_record(
+                scope=record.scope,
+                route_path=record.route_path,
+                idempotency_key=record.idempotency_key,
+            )
+
+            self.assertIsNotNone(loaded)
+            assert loaded is not None
+            self.assertEqual(loaded.request_fingerprint, "fingerprint-123")
+            self.assertEqual(loaded.response_payload["records"]["preview_id"], "preview-35")
+
     def test_storage_import_core_records_command_reports_counts(self) -> None:
         runner = CliRunner()
         postgres_store = Mock()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -60,6 +60,7 @@ def _invoke_app(
     path: str,
     payload: dict[str, object] | None = None,
     authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
 ):
     body_bytes = json.dumps(payload).encode("utf-8") if payload is not None else b""
     environ = {
@@ -69,6 +70,8 @@ def _invoke_app(
         "wsgi.input": io.BytesIO(body_bytes),
         "HTTP_AUTHORIZATION": authorization,
     }
+    for header_name, header_value in (headers or {}).items():
+        environ[f"HTTP_{header_name.upper().replace('-', '_')}"] = header_value
     captured: dict[str, object] = {}
 
     def start_response(status: str, headers: list[tuple[str, str]]) -> None:
@@ -302,6 +305,179 @@ class HarborServiceTests(unittest.TestCase):
             self.assertEqual(deployment.resolved_target.target_id, "compose-123")
             self.assertEqual(inventory.deployment_record_id, deployment.record_id)
             self.assertEqual(inventory.promotion_record_id, "")
+
+    def test_deployment_endpoint_replays_idempotent_write(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            policy = HarborAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/tenant-opw",
+                            "workflow_refs": [
+                                "every/tenant-opw/.github/workflows/deploy-testing.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo"],
+                            "contexts": ["opw"],
+                            "actions": ["deployment.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_harbor_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="every/tenant-opw",
+                        workflow_ref=(
+                            "every/tenant-opw/.github/workflows/deploy-testing.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            request_payload = {
+                "product": "odoo",
+                "deployment": {
+                    "record_id": "deployment-20260420T153000Z-opw-testing",
+                    "artifact_identity": {"artifact_id": "artifact-20260420-a1b2c3d4"},
+                    "context": "opw",
+                    "instance": "testing",
+                    "source_git_ref": "6b3c9d7e8f901234567890abcdef1234567890ab",
+                    "deploy": {
+                        "target_name": "opw-testing",
+                        "target_type": "compose",
+                        "deploy_mode": "dokploy-compose-api",
+                        "deployment_id": "delegated-compose-ship",
+                        "status": "pass",
+                        "started_at": "2026-04-20T15:30:00Z",
+                        "finished_at": "2026-04-20T15:32:10Z",
+                    },
+                    "post_deploy_update": {
+                        "attempted": True,
+                        "status": "pass",
+                        "detail": "Update completed.",
+                    },
+                    "destination_health": {
+                        "verified": True,
+                        "urls": ["https://testing.example.com/web/health"],
+                        "timeout_seconds": 45,
+                        "status": "pass",
+                    },
+                },
+            }
+
+            first_status_code, first_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/evidence/deployments",
+                payload=request_payload,
+                headers={"Idempotency-Key": "deployment-opw-testing-123"},
+            )
+            second_status_code, second_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/evidence/deployments",
+                payload=request_payload,
+                headers={"Idempotency-Key": "deployment-opw-testing-123"},
+            )
+
+            self.assertEqual(first_status_code, 202)
+            self.assertEqual(second_status_code, 202)
+            self.assertEqual(first_payload["records"], second_payload["records"])
+            self.assertTrue(second_payload["replayed"])
+            self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
+
+    def test_deployment_endpoint_rejects_idempotency_key_reuse_for_different_payload(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            policy = HarborAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/tenant-opw",
+                            "workflow_refs": [
+                                "every/tenant-opw/.github/workflows/deploy-testing.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo"],
+                            "contexts": ["opw"],
+                            "actions": ["deployment.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_harbor_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="every/tenant-opw",
+                        workflow_ref=(
+                            "every/tenant-opw/.github/workflows/deploy-testing.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            first_request_payload = {
+                "product": "odoo",
+                "deployment": {
+                    "record_id": "deployment-20260420T153000Z-opw-testing",
+                    "artifact_identity": {"artifact_id": "artifact-20260420-a1b2c3d4"},
+                    "context": "opw",
+                    "instance": "testing",
+                    "source_git_ref": "6b3c9d7e8f901234567890abcdef1234567890ab",
+                    "deploy": {
+                        "target_name": "opw-testing",
+                        "target_type": "compose",
+                        "deploy_mode": "dokploy-compose-api",
+                        "deployment_id": "delegated-compose-ship",
+                        "status": "pass",
+                        "started_at": "2026-04-20T15:30:00Z",
+                        "finished_at": "2026-04-20T15:32:10Z",
+                    },
+                    "post_deploy_update": {
+                        "attempted": True,
+                        "status": "pass",
+                        "detail": "Update completed.",
+                    },
+                    "destination_health": {
+                        "verified": True,
+                        "urls": ["https://testing.example.com/web/health"],
+                        "timeout_seconds": 45,
+                        "status": "pass",
+                    },
+                },
+            }
+            second_request_payload = json.loads(json.dumps(first_request_payload))
+            second_request_payload["deployment"]["record_id"] = "deployment-20260420T153100Z-opw-testing"
+            second_request_payload["deployment"]["artifact_identity"]["artifact_id"] = "artifact-20260420-e5f6g7h8"
+
+            first_status_code, _ = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/evidence/deployments",
+                payload=first_request_payload,
+                headers={"Idempotency-Key": "deployment-opw-testing-123"},
+            )
+            second_status_code, second_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/evidence/deployments",
+                payload=second_request_payload,
+                headers={"Idempotency-Key": "deployment-opw-testing-123"},
+            )
+
+            self.assertEqual(first_status_code, 202)
+            self.assertEqual(second_status_code, 409)
+            self.assertEqual(second_payload["error"]["code"], "idempotency_key_reused")
 
     def test_promotion_endpoint_writes_record_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add `Idempotency-Key` support for Harbor write routes and replay stored successful responses on safe retries
- persist idempotency records in both filesystem and Postgres-backed stores and reject key reuse with a different payload fingerprint
- document the write-route contract and fix the example authz policy for promotion workflows

## Verification
- `uv run python -m unittest tests.test_service tests.test_postgres_store`
- `uv run python -m unittest`
