### PR TITLE
Add Harbor-owned VeriReel preview drivers

### DIFF
--- a/config/harbor-authz.toml.example
+++ b/config/harbor-authz.toml.example
@@ -8,7 +8,7 @@ workflow_refs = [
 event_names = ["pull_request"]
 products = ["verireel"]
 contexts = ["verireel-testing"]
-actions = ["preview_generation.write"]
+actions = ["verireel_preview_refresh.execute", "preview_generation.write"]
 
 [[github_actions]]
 repository = "every/verireel"
@@ -18,7 +18,7 @@ workflow_refs = [
 event_names = ["pull_request"]
 products = ["verireel"]
 contexts = ["verireel-testing"]
-actions = ["preview_destroyed.write"]
+actions = ["verireel_preview_destroy.execute", "preview_destroyed.write"]
 
 [[github_actions]]
 repository = "every/verireel"

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -37,6 +37,12 @@ from control_plane.workflows.verireel_testing_deploy import (
     VeriReelTestingDeployRequest,
     execute_verireel_testing_deploy,
 )
+from control_plane.workflows.verireel_preview_driver import (
+    VeriReelPreviewDestroyRequest,
+    VeriReelPreviewRefreshRequest,
+    execute_verireel_preview_destroy,
+    execute_verireel_preview_refresh,
+)
 
 
 class PreviewGenerationEvidenceEnvelope(BaseModel):
@@ -115,6 +121,34 @@ class VeriReelTestingDeployEnvelope(BaseModel):
     def _validate_alignment(self) -> "VeriReelTestingDeployEnvelope":
         if self.product.strip() != "verireel":
             raise ValueError("VeriReel testing deploy requires product 'verireel'.")
+        return self
+
+
+class VeriReelPreviewRefreshEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    refresh: VeriReelPreviewRefreshRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "VeriReelPreviewRefreshEnvelope":
+        if self.product.strip() != "verireel":
+            raise ValueError("VeriReel preview refresh requires product 'verireel'.")
+        return self
+
+
+class VeriReelPreviewDestroyEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    destroy: VeriReelPreviewDestroyRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "VeriReelPreviewDestroyEnvelope":
+        if self.product.strip() != "verireel":
+            raise ValueError("VeriReel preview destroy requires product 'verireel'.")
         return self
 
 
@@ -423,6 +457,8 @@ def create_harbor_service_app(
         "/v1/evidence/previews/generations",
         "/v1/evidence/previews/destroyed",
         "/v1/evidence/promotions",
+        "/v1/drivers/verireel/preview-refresh",
+        "/v1/drivers/verireel/preview-destroy",
         "/v1/drivers/verireel/testing-deploy",
     }
 
@@ -844,6 +880,84 @@ def create_harbor_service_app(
                     request=request.deploy,
                 )
                 result = {"deployment_record_id": driver_result.deployment_record_id}
+            elif path == "/v1/drivers/verireel/preview-refresh":
+                request = VeriReelPreviewRefreshEnvelope.model_validate(payload)
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="verireel_preview_refresh.execute",
+                    product=request.product,
+                    context=request.refresh.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot execute the VeriReel preview refresh driver"
+                                    " for the requested product/context."
+                                ),
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                driver_result = execute_verireel_preview_refresh(
+                    control_plane_root=resolved_root,
+                    request=request.refresh,
+                )
+                result = {}
+            elif path == "/v1/drivers/verireel/preview-destroy":
+                request = VeriReelPreviewDestroyEnvelope.model_validate(payload)
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="verireel_preview_destroy.execute",
+                    product=request.product,
+                    context=request.destroy.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot execute the VeriReel preview destroy driver"
+                                    " for the requested product/context."
+                                ),
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                driver_result = execute_verireel_preview_destroy(
+                    control_plane_root=resolved_root,
+                    request=request.destroy,
+                )
+                result = {}
             elif path == "/v1/evidence/promotions":
                 request = PromotionEvidenceEnvelope.model_validate(payload)
                 if not authz_policy.allows(

--- a/control_plane/workflows/verireel_preview_driver.py
+++ b/control_plane/workflows/verireel_preview_driver.py
@@ -1,0 +1,971 @@
+from __future__ import annotations
+
+import json
+import secrets
+import shlex
+import time
+from pathlib import Path
+from typing import Literal
+from urllib.error import HTTPError, URLError
+from urllib.parse import parse_qsl, quote, unquote, urlparse, urlunparse
+from urllib.request import Request, urlopen
+
+import click
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane import dokploy as control_plane_dokploy
+from control_plane.dokploy import JsonObject
+from control_plane.workflows.ship import utc_now_timestamp
+
+
+DEFAULT_PREVIEW_TIMEOUT_SECONDS = 300
+PREVIEW_APP_PREFIX = "ver-preview"
+PREVIEW_DATABASE_PREFIX = "verireel_preview_"
+
+
+class VeriReelPreviewRefreshRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    context: str = "verireel-testing"
+    anchor_repo: str = "verireel"
+    anchor_pr_number: int = Field(ge=1)
+    anchor_pr_url: str
+    anchor_head_sha: str
+    preview_slug: str
+    preview_url: str
+    image_reference: str
+    timeout_seconds: int = Field(default=DEFAULT_PREVIEW_TIMEOUT_SECONDS, ge=1)
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "VeriReelPreviewRefreshRequest":
+        if self.context != "verireel-testing":
+            raise ValueError("VeriReel preview refresh requires context 'verireel-testing'.")
+        if self.anchor_repo != "verireel":
+            raise ValueError("VeriReel preview refresh requires anchor_repo 'verireel'.")
+        if not self.anchor_pr_url.strip():
+            raise ValueError("VeriReel preview refresh requires anchor_pr_url.")
+        if not self.anchor_head_sha.strip():
+            raise ValueError("VeriReel preview refresh requires anchor_head_sha.")
+        if not self.preview_slug.strip():
+            raise ValueError("VeriReel preview refresh requires preview_slug.")
+        if not self.image_reference.strip():
+            raise ValueError("VeriReel preview refresh requires image_reference.")
+        _preview_url_host(self.preview_url)
+        return self
+
+
+class VeriReelPreviewDestroyRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    context: str = "verireel-testing"
+    anchor_repo: str = "verireel"
+    anchor_pr_number: int = Field(ge=1)
+    preview_slug: str
+    destroy_reason: str
+    timeout_seconds: int = Field(default=DEFAULT_PREVIEW_TIMEOUT_SECONDS, ge=1)
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "VeriReelPreviewDestroyRequest":
+        if self.context != "verireel-testing":
+            raise ValueError("VeriReel preview destroy requires context 'verireel-testing'.")
+        if self.anchor_repo != "verireel":
+            raise ValueError("VeriReel preview destroy requires anchor_repo 'verireel'.")
+        if not self.preview_slug.strip():
+            raise ValueError("VeriReel preview destroy requires preview_slug.")
+        if not self.destroy_reason.strip():
+            raise ValueError("VeriReel preview destroy requires destroy_reason.")
+        return self
+
+
+class VeriReelPreviewRefreshResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    refresh_status: Literal["pass", "fail"]
+    refresh_started_at: str
+    refresh_finished_at: str
+    application_name: str
+    application_id: str
+    preview_url: str
+    error_message: str = ""
+
+
+class VeriReelPreviewDestroyResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    destroy_status: Literal["pass", "fail"]
+    destroy_started_at: str
+    destroy_finished_at: str
+    application_name: str
+    application_id: str
+    error_message: str = ""
+
+
+class _DatabaseParts(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    host: str
+    port: int
+    database: str
+    username: str
+    password: str
+
+
+def _preview_app_name(preview_slug: str) -> str:
+    return f"{PREVIEW_APP_PREFIX}-{preview_slug}"
+
+
+def _preview_application_name(preview_slug: str) -> str:
+    return f"{_preview_app_name(preview_slug)}-app"
+
+
+def _preview_database_identifiers(preview_slug: str) -> tuple[str, str]:
+    normalized_slug = preview_slug.strip().lower().replace("-", "_")
+    identifier = f"{PREVIEW_DATABASE_PREFIX}{normalized_slug}"[:63]
+    return identifier, identifier
+
+
+def _preview_url_host(preview_url: str) -> str:
+    parsed = urlparse(preview_url.strip())
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("Preview URL must use http or https.")
+    if not parsed.hostname:
+        raise ValueError("Preview URL requires a hostname.")
+    return parsed.hostname
+
+
+def _preview_domain_from_url(preview_url: str) -> str:
+    host = _preview_url_host(preview_url)
+    if "." not in host:
+        raise ValueError("Preview URL hostname must include a preview domain suffix.")
+    return host.split(".", 1)[1]
+
+
+def _parse_database_url(database_url: str) -> _DatabaseParts:
+    parsed = urlparse(database_url.strip())
+    if not parsed.scheme:
+        raise click.ClickException("Preview template DATABASE_URL must include a scheme.")
+    if not parsed.hostname:
+        raise click.ClickException("Preview template DATABASE_URL must include a hostname.")
+    database_name = parsed.path.lstrip("/").strip()
+    if not database_name:
+        raise click.ClickException("Preview template DATABASE_URL must include a database name.")
+    username = unquote(parsed.username or "").strip()
+    password = unquote(parsed.password or "")
+    if not username:
+        raise click.ClickException("Preview template DATABASE_URL must include a username.")
+    return _DatabaseParts(
+        host=parsed.hostname,
+        port=parsed.port or 5432,
+        database=database_name,
+        username=username,
+        password=password,
+    )
+
+
+def _build_admin_database_url(database_url: str) -> str:
+    parsed = urlparse(database_url.strip())
+    query_items = [(key, value) for key, value in parse_qsl(parsed.query, keep_blank_values=True) if key != "schema"]
+    return urlunparse(
+        parsed._replace(
+            path="/postgres",
+            query="&".join(f"{quote(key)}={quote(value)}" for key, value in query_items),
+        )
+    )
+
+
+def _build_preview_database_url(*, host: str, port: int, database_name: str, role_name: str, password: str) -> str:
+    encoded_role = quote(role_name, safe="")
+    encoded_password = quote(password, safe="")
+    encoded_database = quote(database_name, safe="")
+    return (
+        f"postgresql://{encoded_role}:{encoded_password}@{host}:{port}/{encoded_database}?schema=public"
+    )
+
+
+def _random_password(length: int = 32) -> str:
+    return secrets.token_hex(length)[:length]
+
+
+def _template_application_payload(*, control_plane_root: Path, host: str, token: str) -> tuple[control_plane_dokploy.DokployTargetDefinition, JsonObject]:
+    source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
+        control_plane_root=control_plane_root,
+    )
+    target_definition = control_plane_dokploy.find_dokploy_target_definition(
+        source_of_truth,
+        context_name="verireel",
+        instance_name="testing",
+    )
+    if target_definition is None:
+        raise click.ClickException("No Dokploy target definition found for verireel/testing.")
+    if target_definition.target_type != "application":
+        raise click.ClickException("VeriReel preview driver requires the testing target to be a Dokploy application.")
+    if not target_definition.target_id.strip():
+        raise click.ClickException("VeriReel testing target requires a Dokploy target_id before preview execution.")
+    payload = control_plane_dokploy.fetch_dokploy_target_payload(
+        host=host,
+        token=token,
+        target_type="application",
+        target_id=target_definition.target_id,
+    )
+    return target_definition, payload
+
+
+def _find_application_by_name(*, host: str, token: str, application_name: str) -> JsonObject | None:
+    raw_projects = control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/project.all",
+    )
+    if not isinstance(raw_projects, list):
+        return None
+    for raw_project in raw_projects:
+        project = control_plane_dokploy.as_json_object(raw_project)
+        if project is None:
+            continue
+        raw_environments = project.get("environments")
+        if not isinstance(raw_environments, list):
+            continue
+        for raw_environment in raw_environments:
+            environment = control_plane_dokploy.as_json_object(raw_environment)
+            if environment is None:
+                continue
+            raw_applications = environment.get("applications")
+            if not isinstance(raw_applications, list):
+                continue
+            for raw_application in raw_applications:
+                application = control_plane_dokploy.as_json_object(raw_application)
+                if application is None:
+                    continue
+                if str(application.get("name") or "").strip() == application_name:
+                    return application
+    return None
+
+
+def _fetch_application(*, host: str, token: str, application_id: str) -> JsonObject:
+    payload = control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/application.one",
+        query={"applicationId": application_id},
+    )
+    application = control_plane_dokploy.as_json_object(payload)
+    if application is None:
+        raise click.ClickException(f"Dokploy application {application_id!r} returned an invalid payload.")
+    return application
+
+
+def _ensure_application(
+    *,
+    host: str,
+    token: str,
+    application_name: str,
+    app_name: str,
+    description: str,
+    template_application: JsonObject,
+) -> JsonObject:
+    existing = _find_application_by_name(host=host, token=token, application_name=application_name)
+    if existing is not None:
+        application_id = str(existing.get("applicationId") or "").strip()
+        if not application_id:
+            raise click.ClickException(
+                f"Dokploy application {application_name!r} exists but does not expose an applicationId."
+            )
+        return _fetch_application(host=host, token=token, application_id=application_id)
+
+    environment_id = str(template_application.get("environmentId") or "").strip()
+    server_id = str(template_application.get("serverId") or "").strip()
+    if not environment_id:
+        raise click.ClickException("VeriReel preview driver could not resolve the Dokploy testing environmentId.")
+    if not server_id:
+        raise click.ClickException("VeriReel preview driver could not resolve the Dokploy testing serverId.")
+    created = control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/application.create",
+        method="POST",
+        payload={
+            "name": application_name,
+            "appName": app_name,
+            "description": description,
+            "environmentId": environment_id,
+            "serverId": server_id,
+        },
+    )
+    created_application = control_plane_dokploy.as_json_object(created)
+    created_application_id = str((created_application or {}).get("applicationId") or "").strip()
+    if not created_application_id:
+        raise click.ClickException(
+            f"Dokploy did not return an applicationId for preview app {application_name!r}."
+        )
+    return _fetch_application(host=host, token=token, application_id=created_application_id)
+
+
+def _configure_application(
+    *,
+    host: str,
+    token: str,
+    application: JsonObject,
+    template_application: JsonObject,
+    image_reference: str,
+    env_text: str,
+) -> None:
+    application_id = str(application.get("applicationId") or "").strip()
+    if not application_id:
+        raise click.ClickException("Preview application payload is missing applicationId.")
+    control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/application.update",
+        method="POST",
+        payload={
+            "applicationId": application_id,
+            "description": str(application.get("description") or "").strip(),
+            "sourceType": "docker",
+            "autoDeploy": True,
+            "replicas": template_application.get("replicas"),
+            "endpointSpecSwarm": template_application.get("endpointSpecSwarm"),
+            "createEnvFile": template_application.get("createEnvFile"),
+            "triggerType": template_application.get("triggerType"),
+            "enabled": template_application.get("enabled"),
+        },
+    )
+    control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/application.saveBuildType",
+        method="POST",
+        payload={
+            "applicationId": application_id,
+            "buildType": template_application.get("buildType"),
+            "dockerfile": template_application.get("dockerfile"),
+            "dockerContextPath": template_application.get("dockerContextPath"),
+            "dockerBuildStage": template_application.get("dockerBuildStage"),
+            "herokuVersion": template_application.get("herokuVersion"),
+            "railpackVersion": template_application.get("railpackVersion"),
+            "publishDirectory": template_application.get("publishDirectory"),
+            "isStaticSpa": template_application.get("isStaticSpa"),
+        },
+    )
+    control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/application.saveDockerProvider",
+        method="POST",
+        payload={
+            "applicationId": application_id,
+            "dockerImage": image_reference,
+            "username": template_application.get("username"),
+            "password": template_application.get("password"),
+            "registryUrl": template_application.get("registryUrl"),
+        },
+    )
+    control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/application.saveEnvironment",
+        method="POST",
+        payload={
+            "applicationId": application_id,
+            "env": env_text,
+            "buildArgs": template_application.get("buildArgs"),
+            "buildSecrets": template_application.get("buildSecrets"),
+            "createEnvFile": template_application.get("createEnvFile"),
+        },
+    )
+
+
+def _restore_existing_application(
+    *,
+    host: str,
+    token: str,
+    application_snapshot: JsonObject,
+    timeout_seconds: int,
+) -> None:
+    _configure_application(
+        host=host,
+        token=token,
+        application=application_snapshot,
+        template_application=application_snapshot,
+        image_reference=str(application_snapshot.get("dockerImage") or "").strip(),
+        env_text=str(application_snapshot.get("env") or ""),
+    )
+    application_id = str(application_snapshot.get("applicationId") or "").strip()
+    latest_before = control_plane_dokploy.latest_deployment_for_target(
+        host=host,
+        token=token,
+        target_type="application",
+        target_id=application_id,
+    )
+    control_plane_dokploy.trigger_deployment(
+        host=host,
+        token=token,
+        target_type="application",
+        target_id=application_id,
+        no_cache=False,
+    )
+    control_plane_dokploy.wait_for_target_deployment(
+        host=host,
+        token=token,
+        target_type="application",
+        target_id=application_id,
+        before_key=control_plane_dokploy.deployment_key(latest_before),
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def _ensure_domain(*, host: str, token: str, application_id: str, preview_host: str) -> tuple[str, tuple[str, ...]]:
+    raw_domains = control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/domain.byApplicationId",
+        query={"applicationId": application_id},
+    )
+    domains = raw_domains if isinstance(raw_domains, list) else []
+    existing: JsonObject | None = None
+    stale_domain_ids: list[str] = []
+    for raw_domain in domains:
+        domain = control_plane_dokploy.as_json_object(raw_domain)
+        if domain is None:
+            continue
+        domain_host = str(domain.get("host") or "").strip()
+        domain_id = str(domain.get("domainId") or "").strip()
+        if domain_host == preview_host and domain_id:
+            existing = domain
+            continue
+        if domain_id:
+            stale_domain_ids.append(domain_id)
+    payload: JsonObject = {
+        "host": preview_host,
+        "path": "/",
+        "internalPath": "/",
+        "port": 3000,
+        "https": True,
+        "applicationId": application_id,
+        "certificateType": "none",
+        "customCertResolver": None,
+        "composeId": None,
+        "serviceName": None,
+        "domainType": "application",
+        "previewDeploymentId": None,
+        "stripPath": False,
+    }
+    if existing is not None:
+        existing_domain_id = str(existing.get("domainId") or "").strip()
+        control_plane_dokploy.dokploy_request(
+            host=host,
+            token=token,
+            path="/api/domain.update",
+            method="POST",
+            payload={"domainId": existing_domain_id, **payload},
+        )
+        return "", tuple(stale_domain_ids)
+    created = control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/domain.create",
+        method="POST",
+        payload=payload,
+    )
+    created_domain = control_plane_dokploy.as_json_object(created)
+    return str((created_domain or {}).get("domainId") or "").strip(), tuple(stale_domain_ids)
+
+
+def _delete_domain(*, host: str, token: str, domain_id: str) -> None:
+    control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/domain.delete",
+        method="POST",
+        payload={"domainId": domain_id},
+    )
+
+
+def _delete_application(*, host: str, token: str, application_id: str) -> None:
+    control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/application.delete",
+        method="POST",
+        payload={"applicationId": application_id},
+    )
+
+
+def _find_application_schedule(*, host: str, token: str, application_id: str, schedule_name: str) -> JsonObject | None:
+    for schedule in control_plane_dokploy.list_dokploy_schedules(
+        host=host,
+        token=token,
+        target_id=application_id,
+        schedule_type="application",
+    ):
+        if str(schedule.get("name") or "").strip() == schedule_name:
+            return schedule
+    return None
+
+
+def _upsert_application_schedule(
+    *,
+    host: str,
+    token: str,
+    application_id: str,
+    schedule_name: str,
+    command: str,
+) -> str:
+    existing = _find_application_schedule(
+        host=host,
+        token=token,
+        application_id=application_id,
+        schedule_name=schedule_name,
+    )
+    payload: JsonObject = {
+        "name": schedule_name,
+        "cronExpression": control_plane_dokploy.DOKPLOY_MANUAL_ONLY_CRON_EXPRESSION,
+        "scheduleType": "application",
+        "shellType": "sh",
+        "command": command,
+        "applicationId": application_id,
+        "enabled": False,
+        "timezone": "UTC",
+    }
+    if existing is None:
+        control_plane_dokploy.dokploy_request(
+            host=host,
+            token=token,
+            path="/api/schedule.create",
+            method="POST",
+            payload=payload,
+        )
+    else:
+        control_plane_dokploy.dokploy_request(
+            host=host,
+            token=token,
+            path="/api/schedule.update",
+            method="POST",
+            payload={"scheduleId": control_plane_dokploy.schedule_key(existing), **payload},
+        )
+    resolved = _find_application_schedule(
+        host=host,
+        token=token,
+        application_id=application_id,
+        schedule_name=schedule_name,
+    )
+    if resolved is None:
+        raise click.ClickException(
+            f"Dokploy schedule {schedule_name!r} for preview application {application_id!r} could not be resolved."
+        )
+    schedule_id = control_plane_dokploy.schedule_key(resolved)
+    if not schedule_id:
+        raise click.ClickException(
+            f"Dokploy schedule {schedule_name!r} for preview application {application_id!r} did not expose a schedule id."
+        )
+    return schedule_id
+
+
+def _run_application_command(
+    *,
+    host: str,
+    token: str,
+    application_id: str,
+    schedule_name: str,
+    command: str,
+    timeout_seconds: int,
+) -> None:
+    schedule_id = _upsert_application_schedule(
+        host=host,
+        token=token,
+        application_id=application_id,
+        schedule_name=schedule_name,
+        command=command,
+    )
+    latest_before = control_plane_dokploy.latest_deployment_for_schedule(
+        host=host,
+        token=token,
+        schedule_id=schedule_id,
+    )
+    control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/schedule.runManually",
+        method="POST",
+        payload={"scheduleId": schedule_id},
+        timeout_seconds=timeout_seconds,
+    )
+    control_plane_dokploy.wait_for_dokploy_schedule_deployment(
+        host=host,
+        token=token,
+        schedule_id=schedule_id,
+        before_key=control_plane_dokploy.deployment_key(latest_before),
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def _build_preview_database_command(*, action: Literal["ensure", "drop"], admin_database_url: str, database_name: str, role_name: str, password: str = "") -> str:
+    env_parts = [
+        f"ADMIN_DATABASE_URL={shlex.quote(admin_database_url)}",
+        f"DATABASE_NAME={shlex.quote(database_name)}",
+        f"ROLE_NAME={shlex.quote(role_name)}",
+        f"ACTION={shlex.quote(action)}",
+    ]
+    if action == "ensure":
+        env_parts.append(f"ROLE_PASSWORD={shlex.quote(password)}")
+    script = "".join(
+        (
+            "const { Client } = require('pg');",
+            "const qid=(v)=>'\"'+String(v).replace(/\"/g,'\"\"')+'\"';",
+            "const ql=(v)=>\"'\"+String(v).replace(/'/g,\"''\")+\"'\";",
+            "(async()=>{",
+            "const client=new Client({connectionString:process.env.ADMIN_DATABASE_URL});",
+            "await client.connect();",
+            "try{",
+            "if(process.env.ACTION==='ensure'){",
+            "const role=process.env.ROLE_NAME; const db=process.env.DATABASE_NAME; const password=process.env.ROLE_PASSWORD || '';",
+            "const roleExists=await client.query('SELECT 1 FROM pg_roles WHERE rolname = $1',[role]);",
+            "await client.query(roleExists.rowCount===0 ? `CREATE ROLE ${qid(role)} LOGIN PASSWORD ${ql(password)}` : `ALTER ROLE ${qid(role)} WITH LOGIN PASSWORD ${ql(password)}`);",
+            "const dbExists=await client.query('SELECT 1 FROM pg_database WHERE datname = $1',[db]);",
+            "if(dbExists.rowCount===0){ await client.query(`CREATE DATABASE ${qid(db)} OWNER ${qid(role)}`); }",
+            "await client.query(`GRANT ALL PRIVILEGES ON DATABASE ${qid(db)} TO ${qid(role)}`);",
+            "} else {",
+            "const db=process.env.DATABASE_NAME; const role=process.env.ROLE_NAME;",
+            "await client.query('SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()', [db]);",
+            "await client.query(`DROP DATABASE IF EXISTS ${qid(db)}`);",
+            "await client.query(`DROP ROLE IF EXISTS ${qid(role)}`);",
+            "}",
+            "} finally { await client.end(); }",
+            "})().catch((error)=>{ console.error(error instanceof Error ? error.message : String(error)); process.exit(1); });",
+        )
+    )
+    return f"{' '.join(env_parts)} node -e {shlex.quote(script)}"
+
+
+def _wait_for_preview_health(*, preview_url: str, timeout_seconds: int) -> None:
+    health_url = f"{preview_url.rstrip('/')}/api/health"
+    deadline = timeout_seconds
+    request = Request(
+        health_url,
+        headers={
+            "Accept": "application/json",
+            "Cache-Control": "no-store",
+        },
+    )
+    while deadline > 0:
+        try:
+            with urlopen(request, timeout=min(15, deadline)) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+            if payload.get("ok") is True:
+                return
+        except (HTTPError, URLError, TimeoutError, json.JSONDecodeError, ValueError):
+            pass
+        sleep_seconds = min(5, deadline)
+        time.sleep(sleep_seconds)
+        deadline -= sleep_seconds
+    raise click.ClickException(f"Timed out waiting for {health_url} to report ok=true.")
+
+
+def _resolve_existing_preview_database(existing_application: JsonObject | None) -> _DatabaseParts | None:
+    if existing_application is None:
+        return None
+    database_url = control_plane_dokploy.parse_dokploy_env_text(str(existing_application.get("env") or "")).get(
+        "DATABASE_URL",
+        "",
+    )
+    if not database_url:
+        return None
+    return _parse_database_url(database_url)
+
+
+def execute_verireel_preview_refresh(
+    *,
+    control_plane_root: Path,
+    request: VeriReelPreviewRefreshRequest,
+) -> VeriReelPreviewRefreshResult:
+    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
+    template_target, template_application = _template_application_payload(
+        control_plane_root=control_plane_root,
+        host=host,
+        token=token,
+    )
+    template_env_map = control_plane_dokploy.parse_dokploy_env_text(str(template_application.get("env") or ""))
+    template_database_url = str(template_env_map.get("DATABASE_URL") or "").strip()
+    if not template_database_url:
+        raise click.ClickException("VeriReel testing template application is missing DATABASE_URL.")
+    template_database = _parse_database_url(template_database_url)
+
+    started_at = utc_now_timestamp()
+    application_name = _preview_application_name(request.preview_slug)
+    app_name = _preview_app_name(request.preview_slug)
+    preview_host = _preview_url_host(request.preview_url)
+    preview_domain = _preview_domain_from_url(request.preview_url)
+    existing_application = _find_application_by_name(host=host, token=token, application_name=application_name)
+    existing_snapshot = None
+    if existing_application is not None:
+        application_id = str(existing_application.get("applicationId") or "").strip()
+        existing_snapshot = _fetch_application(host=host, token=token, application_id=application_id)
+    existing_database = _resolve_existing_preview_database(existing_snapshot)
+    database_name, role_name = _preview_database_identifiers(request.preview_slug)
+    database_parts = existing_database or _DatabaseParts(
+        host=template_database.host,
+        port=template_database.port,
+        database=database_name,
+        username=role_name,
+        password=_random_password(),
+    )
+    created_preview_database = existing_database is None
+    created_application_id = ""
+    created_domain_id = ""
+    stale_domain_ids: tuple[str, ...] = ()
+    migration_started = False
+
+    try:
+        admin_database_url = _build_admin_database_url(template_database_url)
+        _run_application_command(
+            host=host,
+            token=token,
+            application_id=template_target.target_id,
+            schedule_name=f"{template_target.target_name}-preview-db-bootstrap",
+            command=_build_preview_database_command(
+                action="ensure",
+                admin_database_url=admin_database_url,
+                database_name=database_parts.database,
+                role_name=database_parts.username,
+                password=database_parts.password,
+            ),
+            timeout_seconds=request.timeout_seconds,
+        )
+        env_text = control_plane_dokploy.render_dokploy_env_text_with_overrides(
+            str(template_application.get("env") or ""),
+            updates={
+                "VERIREEL_APP_URL": request.preview_url,
+                "BETTER_AUTH_URL": request.preview_url,
+                "DOKPLOY_PREVIEW_DOMAIN": preview_domain,
+                "NEXT_PUBLIC_DOKPLOY_PREVIEW_DOMAIN": preview_domain,
+                "DATABASE_URL": _build_preview_database_url(
+                    host=database_parts.host,
+                    port=database_parts.port,
+                    database_name=database_parts.database,
+                    role_name=database_parts.username,
+                    password=database_parts.password,
+                ),
+            },
+        )
+        application = _ensure_application(
+            host=host,
+            token=token,
+            application_name=application_name,
+            app_name=app_name,
+            description=f"Preview environment for {request.preview_slug}",
+            template_application=template_application,
+        )
+        application_id = str(application.get("applicationId") or "").strip()
+        if existing_snapshot is None:
+            created_application_id = application_id
+        _configure_application(
+            host=host,
+            token=token,
+            application=application,
+            template_application=template_application,
+            image_reference=request.image_reference,
+            env_text=env_text,
+        )
+        created_domain_id, stale_domain_ids = _ensure_domain(
+            host=host,
+            token=token,
+            application_id=application_id,
+            preview_host=preview_host,
+        )
+        latest_before = control_plane_dokploy.latest_deployment_for_target(
+            host=host,
+            token=token,
+            target_type="application",
+            target_id=application_id,
+        )
+        control_plane_dokploy.trigger_deployment(
+            host=host,
+            token=token,
+            target_type="application",
+            target_id=application_id,
+            no_cache=False,
+        )
+        control_plane_dokploy.wait_for_target_deployment(
+            host=host,
+            token=token,
+            target_type="application",
+            target_id=application_id,
+            before_key=control_plane_dokploy.deployment_key(latest_before),
+            timeout_seconds=request.timeout_seconds,
+        )
+        migration_started = True
+        _run_application_command(
+            host=host,
+            token=token,
+            application_id=application_id,
+            schedule_name=f"{app_name}-migrate",
+            command="npx prisma migrate deploy --config prisma.config.ts",
+            timeout_seconds=request.timeout_seconds,
+        )
+        _run_application_command(
+            host=host,
+            token=token,
+            application_id=application_id,
+            schedule_name=f"{app_name}-seed",
+            command="node prisma/seed.mjs",
+            timeout_seconds=request.timeout_seconds,
+        )
+        _wait_for_preview_health(preview_url=request.preview_url, timeout_seconds=request.timeout_seconds)
+        for stale_domain_id in stale_domain_ids:
+            _delete_domain(host=host, token=token, domain_id=stale_domain_id)
+    except click.ClickException as exc:
+        rollback_errors: list[str] = []
+        if created_domain_id:
+            try:
+                _delete_domain(host=host, token=token, domain_id=created_domain_id)
+            except click.ClickException as rollback_exc:
+                rollback_errors.append(f"domain rollback failed: {rollback_exc}")
+        if created_application_id:
+            try:
+                _delete_application(host=host, token=token, application_id=created_application_id)
+            except click.ClickException as rollback_exc:
+                rollback_errors.append(f"application rollback failed: {rollback_exc}")
+        if existing_snapshot is not None and not migration_started:
+            try:
+                _restore_existing_application(
+                    host=host,
+                    token=token,
+                    application_snapshot=existing_snapshot,
+                    timeout_seconds=request.timeout_seconds,
+                )
+            except click.ClickException as rollback_exc:
+                rollback_errors.append(f"existing preview rollback failed: {rollback_exc}")
+        if created_preview_database:
+            try:
+                _run_application_command(
+                    host=host,
+                    token=token,
+                    application_id=template_target.target_id,
+                    schedule_name=f"{template_target.target_name}-preview-db-rollback",
+                    command=_build_preview_database_command(
+                        action="drop",
+                        admin_database_url=_build_admin_database_url(template_database_url),
+                        database_name=database_parts.database,
+                        role_name=database_parts.username,
+                    ),
+                    timeout_seconds=request.timeout_seconds,
+                )
+            except click.ClickException as rollback_exc:
+                rollback_errors.append(f"database rollback failed: {rollback_exc}")
+        finished_at = utc_now_timestamp()
+        message = str(exc)
+        if rollback_errors:
+            message = f"{message}\n" + "\n".join(rollback_errors)
+        return VeriReelPreviewRefreshResult(
+            refresh_status="fail",
+            refresh_started_at=started_at,
+            refresh_finished_at=finished_at,
+            application_name=application_name,
+            application_id=created_application_id or str((existing_snapshot or {}).get("applicationId") or "").strip(),
+            preview_url=request.preview_url,
+            error_message=message,
+        )
+
+    finished_at = utc_now_timestamp()
+    resolved_application = _find_application_by_name(host=host, token=token, application_name=application_name)
+    return VeriReelPreviewRefreshResult(
+        refresh_status="pass",
+        refresh_started_at=started_at,
+        refresh_finished_at=finished_at,
+        application_name=application_name,
+        application_id=str((resolved_application or {}).get("applicationId") or "").strip(),
+        preview_url=request.preview_url,
+    )
+
+
+def execute_verireel_preview_destroy(
+    *,
+    control_plane_root: Path,
+    request: VeriReelPreviewDestroyRequest,
+) -> VeriReelPreviewDestroyResult:
+    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
+    template_target, template_application = _template_application_payload(
+        control_plane_root=control_plane_root,
+        host=host,
+        token=token,
+    )
+    template_env_map = control_plane_dokploy.parse_dokploy_env_text(str(template_application.get("env") or ""))
+    template_database_url = str(template_env_map.get("DATABASE_URL") or "").strip()
+    if not template_database_url:
+        raise click.ClickException("VeriReel testing template application is missing DATABASE_URL.")
+
+    started_at = utc_now_timestamp()
+    application_name = _preview_application_name(request.preview_slug)
+    application = _find_application_by_name(host=host, token=token, application_name=application_name)
+    application_id = str((application or {}).get("applicationId") or "").strip()
+    database_name, role_name = _preview_database_identifiers(request.preview_slug)
+    existing_database = None
+    if application_id:
+        application_payload = _fetch_application(host=host, token=token, application_id=application_id)
+        existing_database = _resolve_existing_preview_database(application_payload)
+    database_parts = existing_database or _DatabaseParts(
+        host=_parse_database_url(template_database_url).host,
+        port=_parse_database_url(template_database_url).port,
+        database=database_name,
+        username=role_name,
+        password="",
+    )
+
+    cleanup_errors: list[str] = []
+    if application_id:
+        try:
+            raw_domains = control_plane_dokploy.dokploy_request(
+                host=host,
+                token=token,
+                path="/api/domain.byApplicationId",
+                query={"applicationId": application_id},
+            )
+            if isinstance(raw_domains, list):
+                for raw_domain in raw_domains:
+                    domain = control_plane_dokploy.as_json_object(raw_domain)
+                    if domain is None:
+                        continue
+                    domain_id = str(domain.get("domainId") or "").strip()
+                    if domain_id:
+                        _delete_domain(host=host, token=token, domain_id=domain_id)
+        except click.ClickException as exc:
+            cleanup_errors.append(f"domain cleanup failed: {exc}")
+        try:
+            _delete_application(host=host, token=token, application_id=application_id)
+        except click.ClickException as exc:
+            cleanup_errors.append(f"application cleanup failed: {exc}")
+    try:
+        _run_application_command(
+            host=host,
+            token=token,
+            application_id=template_target.target_id,
+            schedule_name=f"{template_target.target_name}-preview-db-drop",
+            command=_build_preview_database_command(
+                action="drop",
+                admin_database_url=_build_admin_database_url(template_database_url),
+                database_name=database_parts.database,
+                role_name=database_parts.username,
+            ),
+            timeout_seconds=request.timeout_seconds,
+        )
+    except click.ClickException as exc:
+        cleanup_errors.append(f"database cleanup failed: {exc}")
+
+    finished_at = utc_now_timestamp()
+    if cleanup_errors:
+        return VeriReelPreviewDestroyResult(
+            destroy_status="fail",
+            destroy_started_at=started_at,
+            destroy_finished_at=finished_at,
+            application_name=application_name,
+            application_id=application_id,
+            error_message="; ".join(cleanup_errors),
+        )
+    return VeriReelPreviewDestroyResult(
+        destroy_status="pass",
+        destroy_started_at=started_at,
+        destroy_finished_at=finished_at,
+        application_name=application_name,
+        application_id=application_id,
+    )

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -128,6 +128,7 @@ event_name: pull_request
 allowed product: verireel
 allowed contexts: verireel-testing
 allowed actions:
+  - verireel_preview_refresh.execute
   - preview_generation.write
 ```
 
@@ -140,6 +141,7 @@ event_name: pull_request
 allowed product: verireel
 allowed contexts: verireel-testing
 allowed actions:
+  - verireel_preview_destroy.execute
   - preview_destroyed.write
 ```
 
@@ -207,9 +209,15 @@ These use the same authn/authz boundary as evidence ingress:
 - `POST /v1/drivers/odoo/...`
 - `POST /v1/drivers/verireel/...`
 
-The first explicit driver route now in service is:
+The first explicit driver routes now in service are:
 
 - `POST /v1/drivers/verireel/testing-deploy`
+- `POST /v1/drivers/verireel/preview-refresh`
+- `POST /v1/drivers/verireel/preview-destroy`
+
+The first preview driver cut stays intentionally narrow: Harbor owns preview
+runtime refresh and teardown, while VeriReel still owns image build/publish,
+browser verification, and the follow-up preview evidence write.
 
 Do not generalize the full driver surface before a few product-specific routes
 have proven the shape.
@@ -239,6 +247,8 @@ Current VeriReel key shapes:
 
 - preview generation: `preview-generation:<product>:<context>:<anchor_repo>:<pr_number>:<sha>`
 - preview destroy: `preview-destroyed:<product>:<context>:<anchor_repo>:<pr_number>:<destroy_reason>`
+- VeriReel preview refresh driver: `verireel-preview-refresh:<product>:<context>:<anchor_repo>:<pr_number>:<sha>`
+- VeriReel preview destroy driver: `verireel-preview-destroy:<product>:<context>:<anchor_repo>:<pr_number>:<destroy_reason>`
 - testing deployment evidence: `testing-deployment:<product>:<context>:<instance>:<record_id>`
 - prod deployment evidence: `prod-deployment:<product>:<context>:<instance>:<record_id>`
 - prod promotion evidence: `prod-promotion:<product>:<context>:<from_instance>:<to_instance>:<record_id>`

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -17,6 +17,10 @@ from control_plane.service import create_harbor_service_app
 from control_plane.service_auth import GitHubActionsIdentity, GitHubOidcVerifier, HarborAuthzPolicy
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.workflows.verireel_preview_driver import (
+    VeriReelPreviewDestroyResult,
+    VeriReelPreviewRefreshResult,
+)
 from control_plane.workflows.verireel_testing_deploy import VeriReelTestingDeployResult
 
 
@@ -798,6 +802,225 @@ class HarborServiceTests(unittest.TestCase):
                     "deploy": {
                         "artifact_id": "ghcr.io/every/verireel-app:sha-abcdef1234567890",
                         "source_git_ref": "abcdef1234567890",
+                    },
+                },
+            )
+
+            self.assertEqual(status_code, 403)
+            self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_verireel_preview_refresh_driver_executes_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = HarborAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel-testing"],
+                            "actions": ["verireel_preview_refresh.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_harbor_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_verireel_preview_refresh",
+                return_value=VeriReelPreviewRefreshResult(
+                    refresh_status="pass",
+                    refresh_started_at="2026-04-21T01:30:00Z",
+                    refresh_finished_at="2026-04-21T01:34:00Z",
+                    application_name="ver-preview-pr-123-app",
+                    application_id="preview-app-123",
+                    preview_url="https://pr-123.ver-preview.shinycomputers.com",
+                ),
+            ) as execute_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/preview-refresh",
+                    payload={
+                        "product": "verireel",
+                        "refresh": {
+                            "anchor_pr_number": 123,
+                            "anchor_pr_url": "https://github.com/every/verireel/pull/123",
+                            "anchor_head_sha": "6b3c9d7e8f901234567890abcdef1234567890ab",
+                            "preview_slug": "pr-123",
+                            "preview_url": "https://pr-123.ver-preview.shinycomputers.com",
+                            "image_reference": "ghcr.io/every/verireel-app:pr-123-sha-6b3c9d7",
+                        },
+                    },
+                )
+
+            self.assertEqual(status_code, 202)
+            self.assertEqual(payload["status"], "accepted")
+            self.assertEqual(payload["records"], {})
+            self.assertEqual(payload["result"]["refresh_status"], "pass")
+            self.assertEqual(payload["result"]["application_id"], "preview-app-123")
+            execute_mock.assert_called_once()
+
+    def test_verireel_preview_refresh_driver_rejects_unauthorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = HarborAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel-testing"],
+                            "actions": ["preview_generation.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_harbor_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/verireel/preview-refresh",
+                payload={
+                    "product": "verireel",
+                    "refresh": {
+                        "anchor_pr_number": 123,
+                        "anchor_pr_url": "https://github.com/every/verireel/pull/123",
+                        "anchor_head_sha": "6b3c9d7e8f901234567890abcdef1234567890ab",
+                        "preview_slug": "pr-123",
+                        "preview_url": "https://pr-123.ver-preview.shinycomputers.com",
+                        "image_reference": "ghcr.io/every/verireel-app:pr-123-sha-6b3c9d7",
+                    },
+                },
+            )
+
+            self.assertEqual(status_code, 403)
+            self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_verireel_preview_destroy_driver_executes_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = HarborAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-cleanup.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel-testing"],
+                            "actions": ["verireel_preview_destroy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_harbor_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/preview-cleanup.yml@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_verireel_preview_destroy",
+                return_value=VeriReelPreviewDestroyResult(
+                    destroy_status="pass",
+                    destroy_started_at="2026-04-21T01:35:00Z",
+                    destroy_finished_at="2026-04-21T01:36:00Z",
+                    application_name="ver-preview-pr-123-app",
+                    application_id="preview-app-123",
+                ),
+            ) as execute_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/preview-destroy",
+                    payload={
+                        "product": "verireel",
+                        "destroy": {
+                            "anchor_pr_number": 123,
+                            "preview_slug": "pr-123",
+                            "destroy_reason": "external_preview_pull_request_closed",
+                        },
+                    },
+                )
+
+            self.assertEqual(status_code, 202)
+            self.assertEqual(payload["status"], "accepted")
+            self.assertEqual(payload["records"], {})
+            self.assertEqual(payload["result"]["destroy_status"], "pass")
+            self.assertEqual(payload["result"]["application_id"], "preview-app-123")
+            execute_mock.assert_called_once()
+
+    def test_verireel_preview_destroy_driver_rejects_unauthorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = HarborAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-cleanup.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel-testing"],
+                            "actions": ["preview_destroyed.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_harbor_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/preview-cleanup.yml@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/verireel/preview-destroy",
+                payload={
+                    "product": "verireel",
+                    "destroy": {
+                        "anchor_pr_number": 123,
+                        "preview_slug": "pr-123",
+                        "destroy_reason": "external_preview_pull_request_closed",
                     },
                 },
             )


### PR DESCRIPTION
## Summary
- add Harbor preview-refresh and preview-destroy driver routes for VeriReel and execute preview runtime through Dokploy instead of repo-local preview scripts
- keep evidence ownership in VeriReel for this first cut while expanding the authz and service-boundary contract for preview driver calls
- cover the new service routes with authorization and accepted-response tests

## Verification
- `uv run python -m unittest tests.test_service`
- `uv run python -m unittest`

## Depends On
- cbusillo/harbor#8
