### PR TITLE
Add VeriReel prod deploy and rollback drivers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
-# Copy to ${XDG_CONFIG_HOME:-$HOME/.config}/launchplane/dokploy.env or export these
-# values directly in the process environment.
+# Bootstrap-only import source for Launchplane-managed Dokploy secrets.
+# Copy to ${XDG_CONFIG_HOME:-$HOME/.config}/launchplane/dokploy.env, import it
+# into the Launchplane store, then stop treating this file as the live runtime
+# contract.
 DOKPLOY_HOST=
 DOKPLOY_TOKEN=
-# Optional ship-mode overrides for planning/execution.
-# DOKPLOY_SHIP_MODE=auto
-# DOKPLOY_SHIP_MODE_OPW_PROD=compose
+# Ship-mode overrides now belong in runtime-environment records rather than
+# bootstrap env.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,10 @@ Treat this file as the launch checklist for every Codex session in
 - Keep cross-repo boundaries explicit; do not move release ownership back into
   tenant, shared-addon, or local-DX repos.
 - Never commit secrets or operator-local overrides.
+- Prefer Launchplane-owned runtime-environment records and managed secret
+  records over ad hoc service-host env for product/runtime configuration.
+- Treat service-host env as bootstrap-only unless a repo doc explicitly calls
+  out a narrower temporary compatibility fallback.
 - Update docs in the same change when behavior or ownership changes.
 - Fix root causes, not symptoms; avoid workaround-only flows unless the
   operator explicitly asks for a time-boxed mitigation.
@@ -64,6 +68,7 @@ Treat this file as the launch checklist for every Codex session in
 - Architecture: `docs/architecture.md`
 - Operations: `docs/operations.md`
 - Records: `docs/records.md`
+- Secrets: `docs/secrets.md`
 - Python style: `docs/style/python.md`
 - Testing style: `docs/style/testing.md`
 - Coding standards: `docs/policies/coding-standards.md`

--- a/config/launchplane-authz.toml.example
+++ b/config/launchplane-authz.toml.example
@@ -61,7 +61,7 @@ workflow_refs = [
 event_names = ["workflow_dispatch"]
 products = ["verireel"]
 contexts = ["verireel"]
-actions = ["promotion.write", "verireel_prod_deploy.execute", "verireel_prod_promotion.execute"]
+actions = ["promotion.write", "verireel_prod_deploy.execute", "verireel_prod_promotion.execute", "verireel_prod_rollback.execute"]
 
 [[github_actions]]
 repository = "example-org/tenant-opw"

--- a/config/launchplane-authz.toml.example
+++ b/config/launchplane-authz.toml.example
@@ -51,7 +51,7 @@ workflow_refs = [
 event_names = ["workflow_dispatch"]
 products = ["verireel"]
 contexts = ["verireel"]
-actions = ["deployment.write"]
+actions = ["deployment.write", "backup_gate.write"]
 
 [[github_actions]]
 repository = "example-org/verireel"
@@ -61,7 +61,7 @@ workflow_refs = [
 event_names = ["workflow_dispatch"]
 products = ["verireel"]
 contexts = ["verireel"]
-actions = ["promotion.write"]
+actions = ["promotion.write", "verireel_prod_deploy.execute", "verireel_prod_promotion.execute"]
 
 [[github_actions]]
 repository = "example-org/tenant-opw"

--- a/config/runtime-environments.toml.example
+++ b/config/runtime-environments.toml.example
@@ -2,6 +2,8 @@ schema_version = 1
 
 [shared_env]
 LAUNCHPLANE_PREVIEW_BASE_URL = "https://launchplane.example.com"
+# Optional global Dokploy execution-mode override for managed routes.
+# DOKPLOY_SHIP_MODE = "auto"
 ODOO_MASTER_PASSWORD = "change_me"
 ODOO_DB_USER = "odoo"
 ODOO_DB_PASSWORD = "change_me"

--- a/config/runtime-environments.toml.example
+++ b/config/runtime-environments.toml.example
@@ -35,3 +35,9 @@ ENV_OVERRIDE_AUTHENTIK__CLIENT_ID = "cm-testing-client-id"
 
 [contexts.cm.instances.prod.env]
 ENV_OVERRIDE_AUTHENTIK__CLIENT_ID = "cm-prod-client-id"
+
+[contexts.verireel.instances.prod.env]
+LAUNCHPLANE_VERIREEL_PROD_ROLLBACK_WORKER_COMMAND = "uv run python -m control_plane.workflows.verireel_prod_rollback_worker"
+VERIREEL_PROD_PROXMOX_HOST = "proxmox.example.com"
+VERIREEL_PROD_PROXMOX_USER = "root"
+VERIREEL_PROD_CT_ID = "200"

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -110,12 +110,6 @@ _RUNTIME_CONTRACT_ENV_KEYS = (
 )
 _DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
 _MASTER_ENCRYPTION_KEY_ENV_KEYS = ("LAUNCHPLANE_MASTER_ENCRYPTION_KEY",)
-_LAUNCHPLANE_SERVICE_REQUIRED_ENV_KEYS = (
-    "LAUNCHPLANE_DATABASE_URL",
-    "LAUNCHPLANE_MASTER_ENCRYPTION_KEY",
-    "DOKPLOY_HOST",
-    "DOKPLOY_TOKEN",
-)
 _LAUNCHPLANE_SERVICE_POLICY_ENV_KEYS = (
     "LAUNCHPLANE_POLICY_TOML",
     "LAUNCHPLANE_POLICY_B64",
@@ -5786,6 +5780,46 @@ def _launchplane_service_any_env_keys_present(*, env_map: dict[str, str], env_ke
     return any(_launchplane_service_env_key_present(env_map=env_map, env_key=env_key) for env_key in env_keys)
 
 
+def _launchplane_managed_store_status(*, database_url: str) -> dict[str, object]:
+    if not database_url.strip():
+        return {"inspectable": False, "error": "", "dokploy_secret_bindings": {}, "runtime_environment_record_count": 0, "dokploy_target_id_record_count": 0}
+    record_store: PostgresRecordStore | None = None
+    try:
+        record_store = PostgresRecordStore(database_url=database_url)
+        record_store.ensure_schema()
+        dokploy_bindings = {
+            binding.binding_key: binding
+            for binding in record_store.list_secret_bindings(integration="dokploy", limit=None)
+            if binding.status == control_plane_secrets.SECRET_STATUS_CONFIGURED
+        }
+        runtime_environment_records = record_store.list_runtime_environment_records()
+        dokploy_target_id_records = record_store.list_dokploy_target_id_records()
+        return {
+            "inspectable": True,
+            "error": "",
+            "dokploy_secret_bindings": {
+                "DOKPLOY_HOST": "DOKPLOY_HOST" in dokploy_bindings,
+                "DOKPLOY_TOKEN": "DOKPLOY_TOKEN" in dokploy_bindings,
+            },
+            "runtime_environment_record_count": len(runtime_environment_records),
+            "dokploy_target_id_record_count": len(dokploy_target_id_records),
+        }
+    except Exception as error:
+        return {
+            "inspectable": False,
+            "error": str(error),
+            "dokploy_secret_bindings": {},
+            "runtime_environment_record_count": 0,
+            "dokploy_target_id_record_count": 0,
+        }
+    finally:
+        if record_store is not None:
+            try:
+                record_store.close()
+            except Exception:
+                pass
+
+
 def _build_launchplane_service_target_preflight(
     *,
     target_type: str,
@@ -5806,6 +5840,9 @@ def _build_launchplane_service_target_preflight(
         parsed_database_url = urlsplit(database_url)
         database_scheme = parsed_database_url.scheme.strip().lower()
         database_host = (parsed_database_url.hostname or "").strip()
+    managed_store_status = _launchplane_managed_store_status(database_url=database_url)
+    managed_secret_bindings = managed_store_status.get("dokploy_secret_bindings", {})
+    assert isinstance(managed_secret_bindings, dict)
 
     git_access_mode = ""
     if custom_git_url.startswith("git@"):
@@ -5817,6 +5854,8 @@ def _build_launchplane_service_target_preflight(
         "database_url_present": bool(database_url),
         "database_scheme": database_scheme,
         "database_host": database_host,
+        "managed_store_inspectable": bool(managed_store_status.get("inspectable")),
+        "managed_store_error": str(managed_store_status.get("error") or ""),
         "master_encryption_key_present": _launchplane_service_env_alias_present(
             env_map=env_map,
             env_keys=_MASTER_ENCRYPTION_KEY_ENV_KEYS,
@@ -5829,18 +5868,30 @@ def _build_launchplane_service_target_preflight(
             env_map=env_map,
             env_key="DOKPLOY_TOKEN",
         ),
+        "dokploy_managed_host_present": bool(managed_secret_bindings.get("DOKPLOY_HOST")),
+        "dokploy_managed_token_present": bool(managed_secret_bindings.get("DOKPLOY_TOKEN")),
         "policy_configured": _launchplane_service_any_env_keys_present(
             env_map=env_map,
             env_keys=_LAUNCHPLANE_SERVICE_POLICY_ENV_KEYS,
         ),
-        "target_ids_configured": _launchplane_service_any_env_keys_present(
+        "target_ids_env_configured": _launchplane_service_any_env_keys_present(
             env_map=env_map,
             env_keys=_LAUNCHPLANE_SERVICE_TARGET_IDS_ENV_KEYS,
         ),
-        "runtime_environments_configured": _launchplane_service_any_env_keys_present(
+        "target_ids_record_count": int(managed_store_status.get("dokploy_target_id_record_count") or 0),
+        "target_ids_configured": _launchplane_service_any_env_keys_present(
+            env_map=env_map,
+            env_keys=_LAUNCHPLANE_SERVICE_TARGET_IDS_ENV_KEYS,
+        ) or int(managed_store_status.get("dokploy_target_id_record_count") or 0) > 0,
+        "runtime_environments_env_configured": _launchplane_service_any_env_keys_present(
             env_map=env_map,
             env_keys=_LAUNCHPLANE_SERVICE_RUNTIME_ENVIRONMENT_ENV_KEYS,
         ),
+        "runtime_environment_record_count": int(managed_store_status.get("runtime_environment_record_count") or 0),
+        "runtime_environments_configured": _launchplane_service_any_env_keys_present(
+            env_map=env_map,
+            env_keys=_LAUNCHPLANE_SERVICE_RUNTIME_ENVIRONMENT_ENV_KEYS,
+        ) or int(managed_store_status.get("runtime_environment_record_count") or 0) > 0,
         "docker_image_reference_present": _launchplane_service_env_key_present(
             env_map=env_map,
             env_key=ARTIFACT_IMAGE_REFERENCE_ENV_KEY,
@@ -5870,9 +5921,26 @@ def _build_launchplane_service_target_preflight(
         blockers.append(
             "Launchplane service target is missing LAUNCHPLANE_MASTER_ENCRYPTION_KEY."
         )
-    for env_key in _LAUNCHPLANE_SERVICE_REQUIRED_ENV_KEYS[2:]:
-        if not _launchplane_service_env_key_present(env_map=env_map, env_key=env_key):
-            blockers.append(f"Launchplane service target is missing {env_key}.")
+    if not runtime_contract["dokploy_host_present"] and not runtime_contract["dokploy_managed_host_present"]:
+        if runtime_contract["managed_store_inspectable"]:
+            blockers.append(
+                "Launchplane service runtime store is missing managed Dokploy binding DOKPLOY_HOST."
+            )
+        else:
+            warnings.append(
+                "Launchplane service target does not expose DOKPLOY_HOST in target env and managed-store inspection was unavailable. "
+                "Confirm the shared store has a configured DOKPLOY_HOST binding before removing legacy bootstrap artifacts."
+            )
+    if not runtime_contract["dokploy_token_present"] and not runtime_contract["dokploy_managed_token_present"]:
+        if runtime_contract["managed_store_inspectable"]:
+            blockers.append(
+                "Launchplane service runtime store is missing managed Dokploy binding DOKPLOY_TOKEN."
+            )
+        else:
+            warnings.append(
+                "Launchplane service target does not expose DOKPLOY_TOKEN in target env and managed-store inspection was unavailable. "
+                "Confirm the shared store has a configured DOKPLOY_TOKEN binding before removing legacy bootstrap artifacts."
+            )
 
     if not runtime_contract["policy_configured"]:
         blockers.append(
@@ -5881,13 +5949,13 @@ def _build_launchplane_service_target_preflight(
         )
     if not runtime_contract["target_ids_configured"]:
         warnings.append(
-            "Launchplane service target does not declare Dokploy target-id catalog env/file inputs. "
-            "Live route resolution depends on a separate mounted file or a future env update."
+            "Launchplane service target does not declare Dokploy target-id env/file inputs and no DB-backed target-id records were confirmed. "
+            "Live route resolution depends on a separate mounted file or a missing store import."
         )
     if not runtime_contract["runtime_environments_configured"]:
         warnings.append(
-            "Launchplane service target does not declare runtime-environment catalog env/file inputs. "
-            "Environment resolution depends on a separate mounted file or a future env update."
+            "Launchplane service target does not declare runtime-environment env/file inputs and no DB-backed runtime-environment records were confirmed. "
+            "Environment resolution depends on a separate mounted file or a missing store import."
         )
     if not runtime_contract["docker_image_reference_present"]:
         warnings.append(
@@ -6105,9 +6173,11 @@ def _resolve_deploy_mode(*, configured_ship_mode: str, target_type: str) -> str:
     return f"dokploy-{configured_ship_mode}-api"
 
 
-def _load_control_plane_environment_values() -> dict[str, str]:
-    return control_plane_dokploy.read_control_plane_environment_values(
+def _load_runtime_environment_values(*, context_name: str, instance_name: str) -> dict[str, str]:
+    return control_plane_runtime_environments.resolve_runtime_environment_values(
         control_plane_root=_control_plane_root(),
+        context_name=context_name,
+        instance_name=instance_name,
     )
 
 
@@ -6164,7 +6234,10 @@ def _resolve_native_ship_request(
         operation_name="Ship",
     )
 
-    environment_values = _load_control_plane_environment_values()
+    environment_values = _load_runtime_environment_values(
+        context_name=context_name,
+        instance_name=instance_name,
+    )
     resolved_source_git_ref = (
         source_git_ref.strip()
         or target_definition.source_git_ref.strip()
@@ -6301,7 +6374,10 @@ def _resolve_native_promotion_request(
         operation_name="Promotion destination",
     )
 
-    environment_values = _load_control_plane_environment_values()
+    environment_values = _load_runtime_environment_values(
+        context_name=context_name,
+        instance_name=to_instance_name,
+    )
     resolved_source_git_ref = (
         source_git_ref.strip()
         or source_target_definition.source_git_ref.strip()

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -22,6 +22,7 @@ from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.deployment_record import ResolvedTargetEvidence
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.github_pull_request_event import GitHubPullRequestEvent
 from control_plane.contracts.github_webhook_replay_envelope import GitHubWebhookReplayEnvelope
@@ -7387,6 +7388,111 @@ def storage_import_core_records(state_dir: Path, database_url: str) -> None:
     postgres_store.ensure_schema()
     counts = postgres_store.import_core_records_from_filesystem(filesystem_store)
     click.echo(json.dumps({"status": "ok", "counts": counts}, indent=2, sort_keys=True))
+
+
+@storage.command("import-dokploy-target-ids")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane Dokploy target-id overrides.",
+)
+@click.option(
+    "--control-plane-root",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Optional Launchplane repo root to scan for the current Dokploy target-id catalog.",
+)
+def storage_import_dokploy_target_ids(database_url: str, control_plane_root: Path | None) -> None:
+    resolved_control_plane_root = control_plane_root or _control_plane_root()
+    source_file_path = control_plane_dokploy.resolve_control_plane_dokploy_source_file(resolved_control_plane_root)
+    target_ids_file_path = control_plane_dokploy.resolve_control_plane_dokploy_target_ids_file(
+        resolved_control_plane_root,
+        source_file_path=source_file_path,
+    )
+    target_id_catalog = control_plane_dokploy.load_dokploy_target_id_catalog(target_ids_file_path)
+    control_plane_dokploy.load_dokploy_source_of_truth(
+        source_file_path,
+        target_id_catalog=target_id_catalog,
+    )
+
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    postgres_store.ensure_schema()
+    imported_count = 0
+    imported_at = utc_now_timestamp()
+    try:
+        for target in target_id_catalog.targets:
+            postgres_store.write_dokploy_target_id_record(
+                DokployTargetIdRecord(
+                    context=target.context,
+                    instance=target.instance,
+                    target_id=target.target_id,
+                    updated_at=imported_at,
+                    source_label=f"import:{target_ids_file_path}",
+                )
+            )
+            imported_count += 1
+    finally:
+        postgres_store.close()
+    click.echo(
+        json.dumps(
+            {
+                "status": "ok",
+                "count": imported_count,
+                "source_file": str(target_ids_file_path),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+@storage.command("import-runtime-environments")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane runtime environment records.",
+)
+@click.option(
+    "--control-plane-root",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Optional Launchplane repo root to scan for the current runtime environments catalog.",
+)
+def storage_import_runtime_environments(database_url: str, control_plane_root: Path | None) -> None:
+    resolved_control_plane_root = control_plane_root or _control_plane_root()
+    definition = control_plane_runtime_environments.load_runtime_environment_definition(
+        control_plane_root=resolved_control_plane_root
+    )
+    environments_file = control_plane_runtime_environments.resolve_runtime_environments_file(resolved_control_plane_root)
+    source_label = f"import:{environments_file}" if environments_file is not None else "import:runtime-environments"
+    records = control_plane_runtime_environments.build_runtime_environment_records_from_definition(
+        definition,
+        updated_at=utc_now_timestamp(),
+        source_label=source_label,
+    )
+
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    postgres_store.ensure_schema()
+    imported_count = 0
+    try:
+        for record in records:
+            postgres_store.write_runtime_environment_record(record)
+            imported_count += 1
+    finally:
+        postgres_store.close()
+    click.echo(
+        json.dumps(
+            {
+                "status": "ok",
+                "count": imported_count,
+                "source_file": str(environments_file) if environments_file is not None else "",
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
 
 
 @secrets.command("import-bootstrap")

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -6174,11 +6174,16 @@ def _resolve_deploy_mode(*, configured_ship_mode: str, target_type: str) -> str:
 
 
 def _load_runtime_environment_values(*, context_name: str, instance_name: str) -> dict[str, str]:
-    return control_plane_runtime_environments.resolve_runtime_environment_values(
-        control_plane_root=_control_plane_root(),
-        context_name=context_name,
-        instance_name=instance_name,
-    )
+    try:
+        return control_plane_runtime_environments.resolve_runtime_environment_values(
+            control_plane_root=_control_plane_root(),
+            context_name=context_name,
+            instance_name=instance_name,
+        )
+    except click.ClickException as error:
+        if str(error).startswith("Missing control-plane runtime environments file."):
+            return {}
+        raise
 
 
 def _require_dokploy_target_definition(

--- a/control_plane/contracts/dokploy_target_id_record.py
+++ b/control_plane/contracts/dokploy_target_id_record.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class DokployTargetIdRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    context: str
+    instance: str
+    target_id: str
+    updated_at: str
+    source_label: str = ""
+
+    @field_validator("context", "instance", "target_id", "updated_at", mode="after")
+    @classmethod
+    def _validate_required_string(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("Dokploy target-id record requires non-empty string fields")
+        return value.strip()
+

--- a/control_plane/contracts/promotion_record.py
+++ b/control_plane/contracts/promotion_record.py
@@ -69,6 +69,25 @@ class PostDeployUpdateEvidence(BaseModel):
         return self
 
 
+class RollbackExecutionEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    attempted: bool = False
+    status: ReleaseStatus = "skipped"
+    detail: str = ""
+    snapshot_name: str = ""
+    started_at: str = ""
+    finished_at: str = ""
+
+    @model_validator(mode="after")
+    def _validate_attempted_rollback(self) -> "RollbackExecutionEvidence":
+        if not self.attempted and self.status != "skipped":
+            raise ValueError("non-attempted rollback must use skipped status")
+        if self.attempted and self.status not in {"pending", "pass", "fail"}:
+            raise ValueError("attempted rollback must use pending/pass/fail status")
+        return self
+
+
 class PromotionRecord(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -85,6 +104,8 @@ class PromotionRecord(BaseModel):
     deploy: DeploymentEvidence
     post_deploy_update: PostDeployUpdateEvidence = Field(default_factory=PostDeployUpdateEvidence)
     destination_health: HealthcheckEvidence = Field(default_factory=HealthcheckEvidence)
+    rollback: RollbackExecutionEvidence = Field(default_factory=RollbackExecutionEvidence)
+    rollback_health: HealthcheckEvidence = Field(default_factory=HealthcheckEvidence)
 
     @model_validator(mode="after")
     def _validate_promotion_path(self) -> "PromotionRecord":

--- a/control_plane/contracts/runtime_environment_record.py
+++ b/control_plane/contracts/runtime_environment_record.py
@@ -1,0 +1,39 @@
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+ScalarValue = str | int | float | bool
+RuntimeEnvironmentScope = Literal["global", "context", "instance"]
+
+
+class RuntimeEnvironmentRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    scope: RuntimeEnvironmentScope
+    context: str = ""
+    instance: str = ""
+    env: dict[str, ScalarValue]
+    updated_at: str
+    source_label: str = ""
+
+    @field_validator("updated_at", mode="after")
+    @classmethod
+    def _validate_updated_at(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("runtime environment record requires updated_at")
+        return value.strip()
+
+    @field_validator("env", mode="after")
+    @classmethod
+    def _validate_env(cls, value: dict[str, ScalarValue]) -> dict[str, ScalarValue]:
+        normalized: dict[str, ScalarValue] = {}
+        for key, item in value.items():
+            normalized_key = key.strip()
+            if not normalized_key:
+                raise ValueError("runtime environment record env keys must be non-empty")
+            normalized[normalized_key] = item
+        if not normalized:
+            raise ValueError("runtime environment record requires at least one env value")
+        return normalized
+

--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -15,6 +15,9 @@ import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane import secrets as control_plane_secrets
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.storage.factory import resolve_database_url
+from control_plane.storage.postgres import PostgresRecordStore
 
 DEFAULT_DOKPLOY_DEPLOY_TIMEOUT_SECONDS = 600
 DEFAULT_DOKPLOY_HEALTH_TIMEOUT_SECONDS = 180
@@ -163,12 +166,11 @@ class DokployTargetIdCatalog(BaseModel):
 def load_dokploy_source_of_truth(
     source_file_path: Path,
     *,
-    target_ids_file_path: Path | None = None,
+    target_id_catalog: DokployTargetIdCatalog | None = None,
 ) -> DokploySourceOfTruth:
     try:
         payload = tomllib.loads(source_file_path.read_text(encoding="utf-8"))
-        if target_ids_file_path is not None:
-            target_id_catalog = load_dokploy_target_id_catalog(target_ids_file_path)
+        if target_id_catalog is not None:
             payload = _apply_dokploy_target_id_catalog(payload, target_id_catalog=target_id_catalog)
         return DokploySourceOfTruth.model_validate(payload)
     except FileNotFoundError as error:
@@ -351,10 +353,69 @@ def read_control_plane_dokploy_source_of_truth(*, control_plane_root: Path) -> D
         source_file_path=source_file_path,
     )
     configured_target_ids_file = os.environ.get(CONTROL_PLANE_DOKPLOY_TARGET_IDS_FILE_ENV_VAR, "").strip()
-    should_load_target_ids = bool(configured_target_ids_file) or target_ids_file_path.exists()
+    target_id_catalog: DokployTargetIdCatalog | None = None
+    if configured_target_ids_file:
+        target_id_catalog = load_dokploy_target_id_catalog(target_ids_file_path)
+    else:
+        file_catalog = load_dokploy_target_id_catalog(target_ids_file_path) if target_ids_file_path.exists() else None
+        database_catalog = _load_optional_dokploy_target_id_catalog_from_database()
+        if database_catalog is not None and file_catalog is not None:
+            target_id_catalog = _merge_dokploy_target_id_catalogs(base_catalog=file_catalog, overlay_catalog=database_catalog)
+        elif database_catalog is not None:
+            target_id_catalog = database_catalog
+        else:
+            target_id_catalog = file_catalog
     return load_dokploy_source_of_truth(
         source_file_path,
-        target_ids_file_path=target_ids_file_path if should_load_target_ids else None,
+        target_id_catalog=target_id_catalog,
+    )
+
+
+def build_dokploy_target_id_catalog_from_records(
+    records: tuple[DokployTargetIdRecord, ...],
+) -> DokployTargetIdCatalog:
+    targets = tuple(
+        DokployTargetIdOverride(context=record.context, instance=record.instance, target_id=record.target_id)
+        for record in sorted(records, key=lambda item: (item.context, item.instance))
+    )
+    return DokployTargetIdCatalog(schema_version=1, targets=targets)
+
+
+def _load_optional_dokploy_target_id_catalog_from_database() -> DokployTargetIdCatalog | None:
+    database_url = resolve_database_url()
+    if not database_url:
+        return None
+    record_store: PostgresRecordStore | None = None
+    try:
+        record_store = PostgresRecordStore(database_url=database_url)
+        record_store.ensure_schema()
+        records = record_store.list_dokploy_target_id_records()
+    except Exception as error:
+        raise click.ClickException(f"Could not load Dokploy target-id overrides from Launchplane Postgres storage: {error}") from error
+    finally:
+        try:
+            if record_store is not None:
+                record_store.close()
+        except Exception:
+            pass
+    if not records:
+        return None
+    return build_dokploy_target_id_catalog_from_records(records)
+
+
+def _merge_dokploy_target_id_catalogs(
+    *,
+    base_catalog: DokployTargetIdCatalog,
+    overlay_catalog: DokployTargetIdCatalog,
+) -> DokployTargetIdCatalog:
+    merged_routes: dict[tuple[str, str], DokployTargetIdOverride] = {
+        (target.context, target.instance): target for target in base_catalog.targets
+    }
+    for target in overlay_catalog.targets:
+        merged_routes[(target.context, target.instance)] = target
+    return DokployTargetIdCatalog(
+        schema_version=max(base_catalog.schema_version, overlay_catalog.schema_version),
+        targets=tuple(merged_routes[key] for key in sorted(merged_routes)),
     )
 
 

--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -293,7 +293,7 @@ def resolve_ship_healthcheck_urls(
     return tuple(f"{base_url}{healthcheck_path}" for base_url in base_urls)
 
 
-def load_runtime_environment_values(
+def load_bootstrap_environment_values(
     *,
     default_env_file: Path | None = None,
     env_file: Path | None = None,
@@ -307,9 +307,28 @@ def load_runtime_environment_values(
     return environment_values
 
 
+def load_operator_environment_values(
+    *,
+    default_env_file: Path | None = None,
+    env_file: Path | None = None,
+) -> dict[str, str]:
+    environment_values: dict[str, str] = {}
+    selected_env_file = env_file if env_file is not None else default_env_file
+    if selected_env_file is not None and selected_env_file.exists():
+        environment_values.update(_parse_env_file(selected_env_file))
+    return environment_values
+
+
+def read_control_plane_bootstrap_environment_values(*, control_plane_root: Path) -> dict[str, str]:
+    control_plane_env_file = resolve_control_plane_env_file(control_plane_root)
+    return load_bootstrap_environment_values(default_env_file=control_plane_env_file)
+
+
 def read_control_plane_environment_values(*, control_plane_root: Path) -> dict[str, str]:
     control_plane_env_file = resolve_control_plane_env_file(control_plane_root)
-    environment_values = load_runtime_environment_values(default_env_file=control_plane_env_file)
+    environment_values: dict[str, str] = {}
+    if resolve_database_url() is None:
+        environment_values = load_operator_environment_values(default_env_file=control_plane_env_file)
     return control_plane_secrets.overlay_dokploy_environment_values(environment_values=environment_values)
 
 
@@ -474,8 +493,8 @@ def read_dokploy_config(*, control_plane_root: Path) -> tuple[str, str]:
         external_env_file = resolve_launchplane_config_dir() / DEFAULT_CONTROL_PLANE_ENV_FILE_BASENAME
         raise click.ClickException(
             "Missing DOKPLOY_HOST or DOKPLOY_TOKEN for control-plane Dokploy execution. "
-            f"Define them in the current process environment, set {CONTROL_PLANE_ENV_FILE_ENV_VAR}, "
-            f"or create {external_env_file}."
+            "Configure Launchplane-managed Dokploy secrets in the shared store, "
+            f"or use {CONTROL_PLANE_ENV_FILE_ENV_VAR}/{external_env_file} only as bootstrap input before import."
         )
     return host, token
 

--- a/control_plane/release_tuples.py
+++ b/control_plane/release_tuples.py
@@ -11,6 +11,8 @@ import click
 
 from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+from control_plane.storage.factory import resolve_database_url
+from control_plane.storage.postgres import PostgresRecordStore
 
 RELEASE_TUPLES_FILE_ENV_VAR = "ODOO_CONTROL_PLANE_RELEASE_TUPLES_FILE"
 DEFAULT_RELEASE_TUPLES_FILE = "config/release-tuples.toml"
@@ -230,17 +232,26 @@ def resolve_release_tuples_file(control_plane_root: Path) -> Path:
 
 
 def load_release_tuple_catalog(*, control_plane_root: Path) -> ReleaseTupleCatalog:
+    configured_file = os.environ.get(RELEASE_TUPLES_FILE_ENV_VAR, "").strip()
+    if configured_file:
+        return _load_release_tuple_catalog_from_file(resolve_release_tuples_file(control_plane_root))
+
+    file_catalog = _load_optional_release_tuple_catalog_from_file(control_plane_root=control_plane_root)
+    database_url = resolve_database_url()
+    if database_url:
+        database_catalog = _load_optional_release_tuple_catalog_from_database(database_url=database_url)
+        if database_catalog is not None and file_catalog is not None:
+            return _merge_release_tuple_catalogs(base_catalog=file_catalog, overlay_catalog=database_catalog)
+        if database_catalog is not None:
+            return database_catalog
+    if file_catalog is not None:
+        return file_catalog
+
     tuples_file = resolve_release_tuples_file(control_plane_root)
-    if not tuples_file.exists():
-        raise click.ClickException(
-            "Missing control-plane release tuples file. "
-            f"Create {tuples_file} or point {RELEASE_TUPLES_FILE_ENV_VAR} at an alternate file."
-        )
-    try:
-        payload = tomllib.loads(tuples_file.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError) as error:
-        raise click.ClickException(f"Invalid release tuples file {tuples_file}: {error}") from error
-    return _parse_release_tuple_catalog(payload, source_file=tuples_file)
+    raise click.ClickException(
+        "Missing control-plane release tuples file. "
+        f"Create {tuples_file} or point {RELEASE_TUPLES_FILE_ENV_VAR} at an alternate file."
+    )
 
 
 def resolve_release_tuple(
@@ -315,6 +326,105 @@ def _parse_release_tuple_catalog(
             channels[normalized_channel_name] = ReleaseTupleDefinition(tuple_id=tuple_id, repo_shas=repo_shas)
         contexts[context_name] = ReleaseTupleContextDefinition(channels=channels)
     return ReleaseTupleCatalog(schema_version=schema_version, contexts=contexts)
+
+
+def _load_release_tuple_catalog_from_file(tuples_file: Path) -> ReleaseTupleCatalog:
+    if not tuples_file.exists():
+        raise click.ClickException(
+            "Missing control-plane release tuples file. "
+            f"Create {tuples_file} or point {RELEASE_TUPLES_FILE_ENV_VAR} at an alternate file."
+        )
+    try:
+        payload = tomllib.loads(tuples_file.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise click.ClickException(f"Invalid release tuples file {tuples_file}: {error}") from error
+    return _parse_release_tuple_catalog(payload, source_file=tuples_file)
+
+
+def _load_optional_release_tuple_catalog_from_file(*, control_plane_root: Path) -> ReleaseTupleCatalog | None:
+    tuples_file = resolve_release_tuples_file(control_plane_root)
+    if not tuples_file.exists():
+        return None
+    return _load_release_tuple_catalog_from_file(tuples_file)
+
+
+def _load_optional_release_tuple_catalog_from_database(*, database_url: str) -> ReleaseTupleCatalog | None:
+    record_store: PostgresRecordStore | None = None
+    try:
+        record_store = PostgresRecordStore(database_url=database_url)
+        record_store.ensure_schema()
+        records = record_store.list_release_tuple_records()
+    except Exception as error:
+        raise click.ClickException(f"Could not load release tuples from Launchplane Postgres storage: {error}") from error
+    finally:
+        try:
+            if record_store is not None:
+                record_store.close()
+        except Exception:
+            pass
+    if not records:
+        return None
+    return build_release_tuple_catalog_from_records(records, source_label="Launchplane Postgres storage")
+
+
+def build_release_tuple_catalog_from_records(
+    records: tuple[ReleaseTupleRecord, ...],
+    *,
+    source_label: str = "Launchplane release tuple records",
+) -> ReleaseTupleCatalog:
+    merged_contexts: dict[str, dict[str, ReleaseTupleDefinition]] = {}
+    seen_tuple_ids: set[str] = set()
+    for record in sorted(records, key=lambda item: (item.context, item.channel)):
+        normalized_channel_name = _require_stable_release_tuple_channel(
+            record.channel,
+            scope=f"{source_label} record {record.tuple_id}",
+        )
+        if record.tuple_id in seen_tuple_ids:
+            raise click.ClickException(f"Duplicate release tuple id {record.tuple_id!r} found in {source_label}.")
+        seen_tuple_ids.add(record.tuple_id)
+        context_channels = merged_contexts.setdefault(record.context, {})
+        context_channels[normalized_channel_name] = ReleaseTupleDefinition(
+            tuple_id=record.tuple_id,
+            repo_shas=dict(record.repo_shas),
+        )
+    return _build_release_tuple_catalog_from_context_map(merged_contexts)
+
+
+def _merge_release_tuple_catalogs(
+    *,
+    base_catalog: ReleaseTupleCatalog,
+    overlay_catalog: ReleaseTupleCatalog,
+) -> ReleaseTupleCatalog:
+    merged_contexts: dict[str, dict[str, ReleaseTupleDefinition]] = {
+        context_name: dict(context_definition.channels)
+        for context_name, context_definition in base_catalog.contexts.items()
+    }
+    for context_name, context_definition in overlay_catalog.contexts.items():
+        merged_contexts.setdefault(context_name, {}).update(context_definition.channels)
+    return _build_release_tuple_catalog_from_context_map(merged_contexts)
+
+
+def _build_release_tuple_catalog_from_context_map(
+    context_map: dict[str, dict[str, ReleaseTupleDefinition]],
+) -> ReleaseTupleCatalog:
+    seen_tuple_ids: set[str] = set()
+    contexts: dict[str, ReleaseTupleContextDefinition] = {}
+    for context_name, channels_map in sorted(context_map.items()):
+        channels: dict[str, ReleaseTupleDefinition] = {}
+        for channel_name, release_tuple in sorted(channels_map.items()):
+            normalized_channel_name = _require_stable_release_tuple_channel(
+                channel_name,
+                scope=f"release tuple catalog merge for context {context_name}",
+            )
+            if release_tuple.tuple_id in seen_tuple_ids:
+                raise click.ClickException(f"Duplicate release tuple id {release_tuple.tuple_id!r} found while merging catalogs.")
+            seen_tuple_ids.add(release_tuple.tuple_id)
+            channels[normalized_channel_name] = ReleaseTupleDefinition(
+                tuple_id=release_tuple.tuple_id,
+                repo_shas=dict(release_tuple.repo_shas),
+            )
+        contexts[context_name] = ReleaseTupleContextDefinition(channels=channels)
+    return ReleaseTupleCatalog(schema_version=1, contexts=contexts)
 
 
 def _read_required_int(source: dict[str, object], key: str, *, scope: str) -> int:

--- a/control_plane/runtime_environments.py
+++ b/control_plane/runtime_environments.py
@@ -9,6 +9,9 @@ import click
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import secrets as control_plane_secrets
+from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
+from control_plane.storage.factory import resolve_database_url
+from control_plane.storage.postgres import PostgresRecordStore
 
 RUNTIME_ENVIRONMENTS_FILE_ENV_VAR = "ODOO_CONTROL_PLANE_RUNTIME_ENVIRONMENTS_FILE"
 DEFAULT_RUNTIME_ENVIRONMENTS_FILE = "config/runtime-environments.toml"
@@ -55,21 +58,29 @@ def resolve_runtime_environments_file(control_plane_root: Path) -> Path | None:
 def load_runtime_environment_definition(
     *, control_plane_root: Path
 ) -> RuntimeEnvironmentDefinition:
-    environments_file = resolve_runtime_environments_file(control_plane_root)
-    if environments_file is None or not environments_file.exists():
-        external_file = control_plane_dokploy.resolve_launchplane_config_dir() / DEFAULT_EXTERNAL_RUNTIME_ENVIRONMENTS_FILE
-        raise click.ClickException(
-            "Missing control-plane runtime environments file. "
-            f"Set {RUNTIME_ENVIRONMENTS_FILE_ENV_VAR}, create {external_file}, "
-            f"or use the legacy repo-local file at {control_plane_root / DEFAULT_RUNTIME_ENVIRONMENTS_FILE}."
-        )
-    try:
-        payload = tomllib.loads(environments_file.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError) as error:
-        raise click.ClickException(
-            f"Invalid runtime environments file {environments_file}: {error}"
-        ) from error
-    return _parse_runtime_environment_definition(payload, source_file=environments_file)
+    configured_file = os.environ.get(RUNTIME_ENVIRONMENTS_FILE_ENV_VAR, "").strip()
+    if configured_file:
+        environments_file = resolve_runtime_environments_file(control_plane_root)
+        assert environments_file is not None
+        return _load_runtime_environment_definition_from_file(environments_file)
+
+    file_definition = _load_optional_runtime_environment_definition_from_file(control_plane_root=control_plane_root)
+    database_url = resolve_database_url()
+    if database_url:
+        database_definition = _load_optional_runtime_environment_definition_from_database(database_url=database_url)
+        if database_definition is not None and file_definition is not None:
+            return _merge_runtime_environment_definitions(base_definition=file_definition, overlay_definition=database_definition)
+        if database_definition is not None:
+            return database_definition
+    if file_definition is not None:
+        return file_definition
+
+    external_file = control_plane_dokploy.resolve_launchplane_config_dir() / DEFAULT_EXTERNAL_RUNTIME_ENVIRONMENTS_FILE
+    raise click.ClickException(
+        "Missing control-plane runtime environments file. "
+        f"Set {RUNTIME_ENVIRONMENTS_FILE_ENV_VAR}, create {external_file}, "
+        f"or use the legacy repo-local file at {control_plane_root / DEFAULT_RUNTIME_ENVIRONMENTS_FILE}."
+    )
 
 
 def resolve_runtime_environment_values(
@@ -191,6 +202,155 @@ def _parse_runtime_environment_definition(
         shared_env=_read_optional_scalar_map(payload, "shared_env", scope="runtime_environments"),
         contexts=contexts,
     )
+
+
+def _load_runtime_environment_definition_from_file(environments_file: Path) -> RuntimeEnvironmentDefinition:
+    try:
+        payload = tomllib.loads(environments_file.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise click.ClickException(
+            f"Invalid runtime environments file {environments_file}: {error}"
+        ) from error
+    return _parse_runtime_environment_definition(payload, source_file=environments_file)
+
+
+def _load_optional_runtime_environment_definition_from_file(
+    *, control_plane_root: Path
+) -> RuntimeEnvironmentDefinition | None:
+    environments_file = resolve_runtime_environments_file(control_plane_root)
+    if environments_file is None or not environments_file.exists():
+        return None
+    return _load_runtime_environment_definition_from_file(environments_file)
+
+
+def _load_optional_runtime_environment_definition_from_database(
+    *, database_url: str
+) -> RuntimeEnvironmentDefinition | None:
+    record_store: PostgresRecordStore | None = None
+    try:
+        record_store = PostgresRecordStore(database_url=database_url)
+        record_store.ensure_schema()
+        records = record_store.list_runtime_environment_records()
+    except Exception as error:
+        raise click.ClickException(
+            f"Could not load runtime environments from Launchplane Postgres storage: {error}"
+        ) from error
+    finally:
+        try:
+            if record_store is not None:
+                record_store.close()
+        except Exception:
+            pass
+    if not records:
+        return None
+    return build_runtime_environment_definition_from_records(records)
+
+
+def build_runtime_environment_definition_from_records(
+    records: tuple[RuntimeEnvironmentRecord, ...],
+) -> RuntimeEnvironmentDefinition:
+    shared_env: ScalarMap = {}
+    contexts: dict[str, RuntimeEnvironmentContextDefinition] = {}
+    for record in sorted(records, key=lambda item: (item.scope, item.context, item.instance)):
+        if record.scope == "global":
+            shared_env.update(record.env)
+            continue
+        context_definition = contexts.setdefault(
+            record.context,
+            RuntimeEnvironmentContextDefinition(shared_env={}, instances={}),
+        )
+        if record.scope == "context":
+            merged_shared_env = dict(context_definition.shared_env)
+            merged_shared_env.update(record.env)
+            contexts[record.context] = RuntimeEnvironmentContextDefinition(
+                shared_env=merged_shared_env,
+                instances=dict(context_definition.instances),
+            )
+            continue
+        instances = dict(context_definition.instances)
+        instances[record.instance] = RuntimeEnvironmentInstanceDefinition(env=dict(record.env))
+        contexts[record.context] = RuntimeEnvironmentContextDefinition(
+            shared_env=dict(context_definition.shared_env),
+            instances=instances,
+        )
+    return RuntimeEnvironmentDefinition(schema_version=1, shared_env=shared_env, contexts=contexts)
+
+
+def build_runtime_environment_records_from_definition(
+    definition: RuntimeEnvironmentDefinition,
+    *,
+    updated_at: str,
+    source_label: str,
+) -> tuple[RuntimeEnvironmentRecord, ...]:
+    records: list[RuntimeEnvironmentRecord] = []
+    if definition.shared_env:
+        records.append(
+            RuntimeEnvironmentRecord(
+                scope="global",
+                env=dict(definition.shared_env),
+                updated_at=updated_at,
+                source_label=source_label,
+            )
+        )
+    for context_name, context_definition in sorted(definition.contexts.items()):
+        if context_definition.shared_env:
+            records.append(
+                RuntimeEnvironmentRecord(
+                    scope="context",
+                    context=context_name,
+                    env=dict(context_definition.shared_env),
+                    updated_at=updated_at,
+                    source_label=source_label,
+                )
+            )
+        for instance_name, instance_definition in sorted(context_definition.instances.items()):
+            if not instance_definition.env:
+                continue
+            records.append(
+                RuntimeEnvironmentRecord(
+                    scope="instance",
+                    context=context_name,
+                    instance=instance_name,
+                    env=dict(instance_definition.env),
+                    updated_at=updated_at,
+                    source_label=source_label,
+                )
+            )
+    return tuple(records)
+
+
+def _merge_runtime_environment_definitions(
+    *,
+    base_definition: RuntimeEnvironmentDefinition,
+    overlay_definition: RuntimeEnvironmentDefinition,
+) -> RuntimeEnvironmentDefinition:
+    shared_env: ScalarMap = dict(base_definition.shared_env)
+    shared_env.update(overlay_definition.shared_env)
+    contexts: dict[str, RuntimeEnvironmentContextDefinition] = {
+        context_name: RuntimeEnvironmentContextDefinition(
+            shared_env=dict(context_definition.shared_env),
+            instances={
+                instance_name: RuntimeEnvironmentInstanceDefinition(env=dict(instance_definition.env))
+                for instance_name, instance_definition in context_definition.instances.items()
+            },
+        )
+        for context_name, context_definition in base_definition.contexts.items()
+    }
+    for context_name, overlay_context in overlay_definition.contexts.items():
+        base_context = contexts.get(
+            context_name,
+            RuntimeEnvironmentContextDefinition(shared_env={}, instances={}),
+        )
+        merged_shared_env = dict(base_context.shared_env)
+        merged_shared_env.update(overlay_context.shared_env)
+        merged_instances = dict(base_context.instances)
+        for instance_name, overlay_instance in overlay_context.instances.items():
+            merged_instances[instance_name] = RuntimeEnvironmentInstanceDefinition(env=dict(overlay_instance.env))
+        contexts[context_name] = RuntimeEnvironmentContextDefinition(
+            shared_env=merged_shared_env,
+            instances=merged_instances,
+        )
+    return RuntimeEnvironmentDefinition(schema_version=max(base_definition.schema_version, overlay_definition.schema_version), shared_env=shared_env, contexts=contexts)
 
 
 def _normalize_scalar_map(raw_values: ScalarMap) -> dict[str, str]:

--- a/control_plane/secrets.py
+++ b/control_plane/secrets.py
@@ -341,7 +341,9 @@ def import_bootstrap_secrets(
         "dokploy": {"imported": 0, "unchanged": 0},
         "runtime_environment": {"imported": 0, "unchanged": 0},
     }
-    environment_values = control_plane_dokploy.read_control_plane_environment_values(control_plane_root=control_plane_root)
+    environment_values = control_plane_dokploy.read_control_plane_bootstrap_environment_values(
+        control_plane_root=control_plane_root
+    )
     for secret_name, binding_key in (("host", "DOKPLOY_HOST"), ("token", "DOKPLOY_TOKEN")):
         value = environment_values.get(binding_key, "").strip()
         if not value:

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -13,6 +13,7 @@ import click
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from control_plane import secrets as control_plane_secrets
+from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.idempotency_record import build_launchplane_idempotency_record_id
@@ -36,6 +37,10 @@ from control_plane.workflows.evidence_ingestion import (
 from control_plane.workflows.verireel_stable_deploy import (
     VeriReelStableDeployRequest,
     execute_verireel_stable_deploy,
+)
+from control_plane.workflows.verireel_prod_promotion import (
+    VeriReelProdPromotionRequest,
+    execute_verireel_prod_promotion,
 )
 from control_plane.workflows.verireel_preview_driver import (
     VeriReelPreviewDestroyRequest,
@@ -96,6 +101,20 @@ class DeploymentEvidenceEnvelope(BaseModel):
         return self
 
 
+class BackupGateEvidenceEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    backup_gate: BackupGateRecord
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "BackupGateEvidenceEnvelope":
+        if not self.product.strip():
+            raise ValueError("backup gate evidence requires product")
+        return self
+
+
 class PromotionEvidenceEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -139,6 +158,20 @@ class VeriReelProdDeployEnvelope(BaseModel):
             raise ValueError("VeriReel prod deploy requires product 'verireel'.")
         if self.deploy.instance != "prod":
             raise ValueError("VeriReel prod deploy requires instance 'prod'.")
+        return self
+
+
+class VeriReelProdPromotionEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    promotion: VeriReelProdPromotionRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "VeriReelProdPromotionEnvelope":
+        if self.product.strip() != "verireel":
+            raise ValueError("VeriReel prod promotion requires product 'verireel'.")
         return self
 
 
@@ -304,6 +337,7 @@ def _accepted_payload(
             if key
             in {
                 "deployment_record_id",
+                "backup_gate_record_id",
                 "inventory_record_id",
                 "preview_id",
                 "generation_id",
@@ -472,6 +506,7 @@ def create_launchplane_service_app(
     storage_backend = storage_backend_name(record_store)
     write_routes = {
         "/v1/evidence/deployments",
+        "/v1/evidence/backup-gates",
         "/v1/evidence/previews/generations",
         "/v1/evidence/previews/destroyed",
         "/v1/evidence/promotions",
@@ -479,6 +514,7 @@ def create_launchplane_service_app(
         "/v1/drivers/verireel/preview-destroy",
         "/v1/drivers/verireel/testing-deploy",
         "/v1/drivers/verireel/prod-deploy",
+        "/v1/drivers/verireel/prod-promotion",
     }
 
     def app(
@@ -859,6 +895,42 @@ def create_launchplane_service_app(
                     record_store=record_store,
                     deployment_record=request.deployment,
                 )
+            elif path == "/v1/evidence/backup-gates":
+                request = BackupGateEvidenceEnvelope.model_validate(payload)
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="backup_gate.write",
+                    product=request.product,
+                    context=request.backup_gate.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot write backup gate evidence for the requested"
+                                    " product/context."
+                                ),
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                record_store.write_backup_gate_record(request.backup_gate)
+                result = {"backup_gate_record_id": request.backup_gate.record_id}
             elif path == "/v1/drivers/verireel/testing-deploy":
                 request = VeriReelTestingDeployEnvelope.model_validate(payload)
                 if not authz_policy.allows(
@@ -939,6 +1011,49 @@ def create_launchplane_service_app(
                     request=request.deploy,
                 )
                 result = {"deployment_record_id": driver_result.deployment_record_id}
+            elif path == "/v1/drivers/verireel/prod-promotion":
+                request = VeriReelProdPromotionEnvelope.model_validate(payload)
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="verireel_prod_promotion.execute",
+                    product=request.product,
+                    context=request.promotion.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot execute the VeriReel prod promotion driver"
+                                    " for the requested product/context."
+                                ),
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                driver_result = execute_verireel_prod_promotion(
+                    control_plane_root=resolved_root,
+                    record_store=record_store,
+                    request=request.promotion,
+                )
+                result = {
+                    "promotion_record_id": driver_result.promotion_record_id,
+                    "deployment_record_id": driver_result.deployment_record_id,
+                }
             elif path == "/v1/drivers/verireel/preview-refresh":
                 request = VeriReelPreviewRefreshEnvelope.model_validate(payload)
                 if not authz_policy.allows(

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -42,6 +42,10 @@ from control_plane.workflows.verireel_prod_promotion import (
     VeriReelProdPromotionRequest,
     execute_verireel_prod_promotion,
 )
+from control_plane.workflows.verireel_prod_rollback import (
+    VeriReelProdRollbackRequest,
+    execute_verireel_prod_rollback,
+)
 from control_plane.workflows.verireel_preview_driver import (
     VeriReelPreviewDestroyRequest,
     VeriReelPreviewRefreshRequest,
@@ -172,6 +176,20 @@ class VeriReelProdPromotionEnvelope(BaseModel):
     def _validate_alignment(self) -> "VeriReelProdPromotionEnvelope":
         if self.product.strip() != "verireel":
             raise ValueError("VeriReel prod promotion requires product 'verireel'.")
+        return self
+
+
+class VeriReelProdRollbackEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    rollback: VeriReelProdRollbackRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "VeriReelProdRollbackEnvelope":
+        if self.product.strip() != "verireel":
+            raise ValueError("VeriReel prod rollback requires product 'verireel'.")
         return self
 
 
@@ -338,6 +356,7 @@ def _accepted_payload(
             in {
                 "deployment_record_id",
                 "backup_gate_record_id",
+                "backup_record_id",
                 "inventory_record_id",
                 "preview_id",
                 "generation_id",
@@ -515,6 +534,7 @@ def create_launchplane_service_app(
         "/v1/drivers/verireel/testing-deploy",
         "/v1/drivers/verireel/prod-deploy",
         "/v1/drivers/verireel/prod-promotion",
+        "/v1/drivers/verireel/prod-rollback",
     }
 
     def app(
@@ -1053,6 +1073,49 @@ def create_launchplane_service_app(
                 result = {
                     "promotion_record_id": driver_result.promotion_record_id,
                     "deployment_record_id": driver_result.deployment_record_id,
+                }
+            elif path == "/v1/drivers/verireel/prod-rollback":
+                request = VeriReelProdRollbackEnvelope.model_validate(payload)
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="verireel_prod_rollback.execute",
+                    product=request.product,
+                    context=request.rollback.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot execute the VeriReel prod rollback driver"
+                                    " for the requested product/context."
+                                ),
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                driver_result = execute_verireel_prod_rollback(
+                    control_plane_root=resolved_root,
+                    record_store=record_store,
+                    request=request.rollback,
+                )
+                result = {
+                    "promotion_record_id": driver_result.promotion_record_id,
+                    "backup_record_id": driver_result.backup_record_id,
                 }
             elif path == "/v1/drivers/verireel/preview-refresh":
                 request = VeriReelPreviewRefreshEnvelope.model_validate(payload)

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -33,9 +33,9 @@ from control_plane.workflows.evidence_ingestion import (
     apply_deployment_evidence,
     apply_promotion_evidence,
 )
-from control_plane.workflows.verireel_testing_deploy import (
-    VeriReelTestingDeployRequest,
-    execute_verireel_testing_deploy,
+from control_plane.workflows.verireel_stable_deploy import (
+    VeriReelStableDeployRequest,
+    execute_verireel_stable_deploy,
 )
 from control_plane.workflows.verireel_preview_driver import (
     VeriReelPreviewDestroyRequest,
@@ -115,12 +115,30 @@ class VeriReelTestingDeployEnvelope(BaseModel):
 
     schema_version: int = Field(default=1, ge=1)
     product: str
-    deploy: VeriReelTestingDeployRequest
+    deploy: VeriReelStableDeployRequest
 
     @model_validator(mode="after")
     def _validate_alignment(self) -> "VeriReelTestingDeployEnvelope":
         if self.product.strip() != "verireel":
             raise ValueError("VeriReel testing deploy requires product 'verireel'.")
+        if self.deploy.instance != "testing":
+            raise ValueError("VeriReel testing deploy requires instance 'testing'.")
+        return self
+
+
+class VeriReelProdDeployEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    deploy: VeriReelStableDeployRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "VeriReelProdDeployEnvelope":
+        if self.product.strip() != "verireel":
+            raise ValueError("VeriReel prod deploy requires product 'verireel'.")
+        if self.deploy.instance != "prod":
+            raise ValueError("VeriReel prod deploy requires instance 'prod'.")
         return self
 
 
@@ -460,6 +478,7 @@ def create_launchplane_service_app(
         "/v1/drivers/verireel/preview-refresh",
         "/v1/drivers/verireel/preview-destroy",
         "/v1/drivers/verireel/testing-deploy",
+        "/v1/drivers/verireel/prod-deploy",
     }
 
     def app(
@@ -874,7 +893,47 @@ def create_launchplane_service_app(
                 )
                 if idempotent_response is not None:
                     return idempotent_response
-                driver_result = execute_verireel_testing_deploy(
+                driver_result = execute_verireel_stable_deploy(
+                    control_plane_root=resolved_root,
+                    record_store=record_store,
+                    request=request.deploy,
+                )
+                result = {"deployment_record_id": driver_result.deployment_record_id}
+            elif path == "/v1/drivers/verireel/prod-deploy":
+                request = VeriReelProdDeployEnvelope.model_validate(payload)
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="verireel_prod_deploy.execute",
+                    product=request.product,
+                    context=request.deploy.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot execute the VeriReel prod deploy driver"
+                                    " for the requested product/context."
+                                ),
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                driver_result = execute_verireel_stable_deploy(
                     control_plane_root=resolved_root,
                     record_store=record_store,
                     request=request.deploy,

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, sess
 
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.idempotency_record import build_launchplane_idempotency_record_id
@@ -17,6 +18,7 @@ from control_plane.contracts.preview_generation_record import PreviewGenerationR
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.contracts.secret_record import SecretAuditEvent, SecretBinding, SecretRecord, SecretVersion
 from control_plane.storage.filesystem import FilesystemRecordStore
 
@@ -156,6 +158,28 @@ class LaunchplaneReleaseTupleRow(Base):
     artifact_id: Mapped[str] = mapped_column(String, nullable=False)
     minted_at: Mapped[str] = mapped_column(String, nullable=False)
     provenance: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneDokployTargetIdRow(Base):
+    __tablename__ = "launchplane_dokploy_target_ids"
+    __table_args__ = (Index("launchplane_dokploy_target_ids_updated_idx", desc("updated_at")),)
+
+    context: Mapped[str] = mapped_column(String, primary_key=True)
+    instance: Mapped[str] = mapped_column(String, primary_key=True)
+    target_id: Mapped[str] = mapped_column(String, nullable=False)
+    updated_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneRuntimeEnvironmentRow(Base):
+    __tablename__ = "launchplane_runtime_environments"
+    __table_args__ = (Index("launchplane_runtime_environments_updated_idx", desc("updated_at")),)
+
+    scope: Mapped[str] = mapped_column(String, primary_key=True)
+    context: Mapped[str] = mapped_column(String, primary_key=True)
+    instance: Mapped[str] = mapped_column(String, primary_key=True)
+    updated_at: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -649,6 +673,56 @@ class PostgresRecordStore:
             model_type=ReleaseTupleRecord,
             orm_model=LaunchplaneReleaseTupleRow,
             order_by=(LaunchplaneReleaseTupleRow.context.asc(), LaunchplaneReleaseTupleRow.channel.asc()),
+        )
+
+    def write_dokploy_target_id_record(self, record: DokployTargetIdRecord) -> None:
+        self._write_row(
+            LaunchplaneDokployTargetIdRow(
+                context=record.context,
+                instance=record.instance,
+                target_id=record.target_id,
+                updated_at=record.updated_at,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def read_dokploy_target_id_record(self, *, context_name: str, instance_name: str) -> DokployTargetIdRecord:
+        return self._read_model(
+            model_type=DokployTargetIdRecord,
+            orm_model=LaunchplaneDokployTargetIdRow,
+            filters=(
+                LaunchplaneDokployTargetIdRow.context == context_name,
+                LaunchplaneDokployTargetIdRow.instance == instance_name,
+            ),
+        )
+
+    def list_dokploy_target_id_records(self) -> tuple[DokployTargetIdRecord, ...]:
+        return self._list_models(
+            model_type=DokployTargetIdRecord,
+            orm_model=LaunchplaneDokployTargetIdRow,
+            order_by=(LaunchplaneDokployTargetIdRow.context.asc(), LaunchplaneDokployTargetIdRow.instance.asc()),
+        )
+
+    def write_runtime_environment_record(self, record: RuntimeEnvironmentRecord) -> None:
+        self._write_row(
+            LaunchplaneRuntimeEnvironmentRow(
+                scope=record.scope,
+                context=record.context,
+                instance=record.instance,
+                updated_at=record.updated_at,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def list_runtime_environment_records(self) -> tuple[RuntimeEnvironmentRecord, ...]:
+        return self._list_models(
+            model_type=RuntimeEnvironmentRecord,
+            orm_model=LaunchplaneRuntimeEnvironmentRow,
+            order_by=(
+                LaunchplaneRuntimeEnvironmentRow.scope.asc(),
+                LaunchplaneRuntimeEnvironmentRow.context.asc(),
+                LaunchplaneRuntimeEnvironmentRow.instance.asc(),
+            ),
         )
 
     def write_secret_record(self, record: SecretRecord) -> None:

--- a/control_plane/workflows/verireel_prod_promotion.py
+++ b/control_plane/workflows/verireel_prod_promotion.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
+import time
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane import dokploy as control_plane_dokploy
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.promotion_record import (
@@ -16,10 +21,26 @@ from control_plane.contracts.promotion_record import (
     PromotionRecord,
 )
 from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.workflows.ship import utc_now_timestamp
 from control_plane.workflows.verireel_stable_deploy import (
     VeriReelStableDeployRequest,
     execute_verireel_stable_deploy,
 )
+
+
+DEFAULT_ROLLOUT_TIMEOUT_SECONDS = 300
+DEFAULT_ROLLOUT_INTERVAL_SECONDS = 5
+DEFAULT_ROLLOUT_PAGE_PATHS = ("/", "/sign-in")
+
+
+class VeriReelRolloutVerificationResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: str
+    base_url: str = ""
+    health_urls: tuple[str, ...] = ()
+    started_at: str = ""
+    finished_at: str = ""
 
 
 class VeriReelProdPromotionRequest(BaseModel):
@@ -33,6 +54,10 @@ class VeriReelProdPromotionRequest(BaseModel):
     source_git_ref: str
     backup_record_id: str
     promotion_record_id: str
+    expected_build_revision: str = ""
+    expected_build_tag: str = ""
+    rollout_timeout_seconds: int = Field(default=DEFAULT_ROLLOUT_TIMEOUT_SECONDS, ge=1)
+    rollout_interval_seconds: int = Field(default=DEFAULT_ROLLOUT_INTERVAL_SECONDS, ge=1)
     no_cache: bool = False
 
     @model_validator(mode="after")
@@ -61,6 +86,7 @@ class VeriReelProdPromotionResult(BaseModel):
     deployment_record_id: str = ""
     backup_record_id: str
     deploy_status: str
+    rollout_status: str = "skipped"
     deploy_started_at: str = ""
     deploy_finished_at: str = ""
     target_name: str
@@ -136,10 +162,27 @@ def _build_promotion_record(
     deploy_status: str,
     deploy_started_at: str,
     deploy_finished_at: str,
+    rollout_result: VeriReelRolloutVerificationResult | None,
 ) -> PromotionRecord:
     deploy_mode = _default_deploy_mode()
     if deployment_record is not None:
         deploy_mode = deployment_record.deploy.deploy_mode
+    destination_health = HealthcheckEvidence(status="skipped")
+    if rollout_result is not None:
+        if rollout_result.status == "pass":
+            destination_health = HealthcheckEvidence(
+                verified=True,
+                urls=rollout_result.health_urls,
+                timeout_seconds=request.rollout_timeout_seconds,
+                status="pass",
+            )
+        elif rollout_result.status == "fail":
+            destination_health = HealthcheckEvidence(
+                verified=True,
+                urls=rollout_result.health_urls,
+                timeout_seconds=request.rollout_timeout_seconds,
+                status="fail",
+            )
     return PromotionRecord(
         record_id=request.promotion_record_id,
         artifact_identity=ArtifactIdentityReference(artifact_id=request.artifact_id),
@@ -164,7 +207,7 @@ def _build_promotion_record(
             finished_at=deploy_finished_at,
         ),
         post_deploy_update=PostDeployUpdateEvidence(),
-        destination_health=HealthcheckEvidence(status="skipped"),
+        destination_health=destination_health,
     )
 
 
@@ -174,20 +217,38 @@ def _write_failed_promotion_record(
     request: VeriReelProdPromotionRequest,
     backup_gate_record: BackupGateRecord | None,
     error_message: str,
+    deployment_record_id: str = "",
+    deploy_status: str = "fail",
+    deploy_started_at: str = "",
+    deploy_finished_at: str = "",
+    target_name: str | None = None,
+    target_type: str | None = None,
+    target_id: str = "",
+    rollout_result: VeriReelRolloutVerificationResult | None = None,
 ) -> None:
+    resolved_target_name = target_name or _default_target_name()
+    resolved_target_type = target_type or _default_target_type()
+    destination_health = HealthcheckEvidence(status="skipped")
+    if rollout_result is not None:
+        destination_health = HealthcheckEvidence(
+            verified=bool(rollout_result.health_urls),
+            urls=rollout_result.health_urls,
+            timeout_seconds=(request.rollout_timeout_seconds if rollout_result.health_urls else None),
+            status="fail" if rollout_result.status == "fail" else rollout_result.status,
+        )
     record_store.write_promotion_record(
         PromotionRecord(
             record_id=request.promotion_record_id,
             artifact_identity=ArtifactIdentityReference(artifact_id=request.artifact_id),
-            deployment_record_id="",
+            deployment_record_id=deployment_record_id,
             backup_record_id=request.backup_record_id,
             context=request.context,
             from_instance=request.from_instance,
             to_instance=request.to_instance,
             source_health=HealthcheckEvidence(status="skipped"),
             backup_gate=BackupGateEvidence(
-                required=True,
-                status="fail",
+                required=(backup_gate_record.required if backup_gate_record is not None else True),
+                status=(backup_gate_record.status if backup_gate_record is not None else "fail"),
                 evidence=(
                     dict(backup_gate_record.evidence)
                     if backup_gate_record is not None
@@ -195,20 +256,163 @@ def _write_failed_promotion_record(
                 ),
             ),
             deploy=DeploymentEvidence(
-                target_name=_default_target_name(),
-                target_type=_default_target_type(),
+                target_name=resolved_target_name,
+                target_type=resolved_target_type,
                 deploy_mode=_default_deploy_mode(),
-                deployment_id="",
-                status="fail",
+                deployment_id=target_id,
+                status=deploy_status,
+                started_at=deploy_started_at,
+                finished_at=deploy_finished_at,
             ),
             post_deploy_update=PostDeployUpdateEvidence(
                 attempted=False,
                 status="skipped",
                 detail=error_message,
             ),
-            destination_health=HealthcheckEvidence(status="skipped"),
+            destination_health=destination_health,
         )
     )
+
+
+def _resolve_rollout_base_urls(
+    *,
+    control_plane_root: Path,
+    request: VeriReelProdPromotionRequest,
+) -> tuple[str, ...]:
+    source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
+        control_plane_root=control_plane_root,
+    )
+    target_definition = control_plane_dokploy.find_dokploy_target_definition(
+        source_of_truth,
+        context_name=request.context,
+        instance_name=request.to_instance,
+    )
+    if target_definition is None:
+        raise click.ClickException(
+            f"No Dokploy target definition found for {request.context}/{request.to_instance}."
+        )
+    environment_values = control_plane_dokploy.read_control_plane_environment_values(
+        control_plane_root=control_plane_root,
+    )
+    base_urls = control_plane_dokploy.resolve_healthcheck_base_urls(
+        target_definition=target_definition,
+        environment_values=environment_values,
+    )
+    if not base_urls:
+        raise click.ClickException(
+            f"No rollout base URL configured for {request.context}/{request.to_instance}."
+        )
+    return base_urls
+
+
+def _fetch_url_text(url: str, *, accept: str) -> tuple[int, str]:
+    request = Request(
+        url,
+        headers={
+            "Accept": accept,
+            "Cache-Control": "no-store",
+        },
+    )
+    with urlopen(request, timeout=15) as response:
+        return response.status, response.read().decode("utf-8")
+
+
+def _validate_health_payload(
+    payload: object,
+    *,
+    health_url: str,
+    expected_build_revision: str,
+    expected_build_tag: str,
+) -> str | None:
+    if not isinstance(payload, dict) or payload.get("ok") is not True:
+        return f"health payload from {health_url} did not report ok=true"
+    if expected_build_revision and payload.get("buildRevision") != expected_build_revision:
+        return (
+            f"health payload from {health_url} reported buildRevision "
+            f"'{payload.get('buildRevision', 'unknown')}' instead of expected "
+            f"'{expected_build_revision}'"
+        )
+    if expected_build_tag and payload.get("buildTag") != expected_build_tag:
+        return (
+            f"health payload from {health_url} reported buildTag "
+            f"'{payload.get('buildTag', 'unknown')}' instead of expected "
+            f"'{expected_build_tag}'"
+        )
+    return None
+
+
+def _assert_rollout_pages(base_url: str) -> None:
+    for page_path in DEFAULT_ROLLOUT_PAGE_PATHS:
+        page_url = f"{base_url.rstrip('/')}{page_path}"
+        try:
+            status_code, response_text = _fetch_url_text(
+                page_url,
+                accept="text/html,application/json",
+            )
+        except (HTTPError, URLError, TimeoutError, ValueError) as exc:
+            raise click.ClickException(
+                f"VeriReel prod rollout page verification failed for {page_url}: {exc}"
+            ) from exc
+        if status_code < 200 or status_code >= 300:
+            raise click.ClickException(
+                f"VeriReel prod rollout page verification expected {page_url} to return 2xx, received {status_code}."
+            )
+        if "VeriReel" not in response_text:
+            raise click.ClickException(
+                f'VeriReel prod rollout page verification expected {page_url} to include "VeriReel".'
+            )
+
+
+def _verify_rollout(
+    *,
+    control_plane_root: Path,
+    request: VeriReelProdPromotionRequest,
+) -> VeriReelRolloutVerificationResult:
+    started_at = utc_now_timestamp()
+    base_urls = _resolve_rollout_base_urls(
+        control_plane_root=control_plane_root,
+        request=request,
+    )
+    health_urls = tuple(f"{base_url.rstrip('/')}/api/health" for base_url in base_urls)
+    last_error = "health endpoint not checked yet"
+    deadline = time.monotonic() + request.rollout_timeout_seconds
+    while time.monotonic() <= deadline:
+        for base_url, health_url in zip(base_urls, health_urls, strict=False):
+            try:
+                status_code, response_text = _fetch_url_text(
+                    health_url,
+                    accept="application/json,text/html",
+                )
+                if status_code < 200 or status_code >= 300:
+                    last_error = f"received {status_code} from {health_url}"
+                    continue
+                payload = json.loads(response_text)
+                validation_error = _validate_health_payload(
+                    payload,
+                    health_url=health_url,
+                    expected_build_revision=request.expected_build_revision,
+                    expected_build_tag=request.expected_build_tag,
+                )
+                if validation_error is not None:
+                    last_error = validation_error
+                    continue
+                _assert_rollout_pages(base_url)
+                return VeriReelRolloutVerificationResult(
+                    status="pass",
+                    base_url=base_url,
+                    health_urls=(health_url,),
+                    started_at=started_at,
+                    finished_at=utc_now_timestamp(),
+                )
+            except (HTTPError, URLError, TimeoutError, json.JSONDecodeError, ValueError) as exc:
+                last_error = str(exc)
+            except click.ClickException as exc:
+                raise click.ClickException(str(exc)) from exc
+        remaining_seconds = deadline - time.monotonic()
+        if remaining_seconds <= 0:
+            break
+        time.sleep(min(request.rollout_interval_seconds, remaining_seconds))
+    raise click.ClickException(f"VeriReel prod rollout verification timed out: {last_error}")
 
 
 def execute_verireel_prod_promotion(
@@ -234,6 +438,7 @@ def execute_verireel_prod_promotion(
             promotion_record_id=request.promotion_record_id,
             backup_record_id=request.backup_record_id,
             deploy_status="fail",
+            rollout_status="skipped",
             target_name=_default_target_name(),
             target_type=_default_target_type(),
             target_id="",
@@ -261,6 +466,83 @@ def execute_verireel_prod_promotion(
         except FileNotFoundError:
             deployment_record = None
 
+    if deployment_result.deploy_status != "pass":
+        promotion_record = _build_promotion_record(
+            request=request,
+            backup_gate_record=backup_gate_record,
+            deployment_record=deployment_record,
+            deployment_record_id=deployment_result.deployment_record_id,
+            target_id=deployment_result.target_id,
+            target_name=deployment_result.target_name,
+            target_type=deployment_result.target_type,
+            deploy_status=deployment_result.deploy_status,
+            deploy_started_at=deployment_result.deploy_started_at,
+            deploy_finished_at=deployment_result.deploy_finished_at,
+            rollout_result=None,
+        )
+        record_store.write_promotion_record(promotion_record)
+        return VeriReelProdPromotionResult(
+            promotion_record_id=request.promotion_record_id,
+            deployment_record_id=deployment_result.deployment_record_id,
+            backup_record_id=backup_gate_record.record_id,
+            deploy_status=deployment_result.deploy_status,
+            rollout_status="skipped",
+            deploy_started_at=deployment_result.deploy_started_at,
+            deploy_finished_at=deployment_result.deploy_finished_at,
+            target_name=deployment_result.target_name,
+            target_type=deployment_result.target_type,
+            target_id=deployment_result.target_id,
+            error_message=deployment_result.error_message,
+        )
+
+    try:
+        rollout_result = _verify_rollout(
+            control_plane_root=control_plane_root,
+            request=request,
+        )
+    except click.ClickException as exc:
+        error_message = str(exc)
+        failed_rollout_result = VeriReelRolloutVerificationResult(status="fail")
+        try:
+            base_urls = _resolve_rollout_base_urls(
+                control_plane_root=control_plane_root,
+                request=request,
+            )
+            failed_rollout_result = VeriReelRolloutVerificationResult(
+                status="fail",
+                base_url=base_urls[0],
+                health_urls=(f"{base_urls[0].rstrip('/')}/api/health",),
+            )
+        except click.ClickException:
+            pass
+        _write_failed_promotion_record(
+            record_store=record_store,
+            request=request,
+            backup_gate_record=backup_gate_record,
+            error_message=error_message,
+            deployment_record_id=deployment_result.deployment_record_id,
+            deploy_status="pass",
+            deploy_started_at=deployment_result.deploy_started_at,
+            deploy_finished_at=deployment_result.deploy_finished_at,
+            target_name=deployment_result.target_name,
+            target_type=deployment_result.target_type,
+            target_id=deployment_result.target_id,
+            rollout_result=failed_rollout_result,
+        )
+        return VeriReelProdPromotionResult(
+            promotion_record_id=request.promotion_record_id,
+            deployment_record_id=deployment_result.deployment_record_id,
+            backup_record_id=backup_gate_record.record_id,
+            deploy_status=deployment_result.deploy_status,
+            rollout_status="fail",
+            deploy_started_at=deployment_result.deploy_started_at,
+            deploy_finished_at=deployment_result.deploy_finished_at,
+            target_name=deployment_result.target_name,
+            target_type=deployment_result.target_type,
+            target_id=deployment_result.target_id,
+            error_message=error_message,
+        )
+
     promotion_record = _build_promotion_record(
         request=request,
         backup_gate_record=backup_gate_record,
@@ -272,6 +554,7 @@ def execute_verireel_prod_promotion(
         deploy_status=deployment_result.deploy_status,
         deploy_started_at=deployment_result.deploy_started_at,
         deploy_finished_at=deployment_result.deploy_finished_at,
+        rollout_result=rollout_result,
     )
     record_store.write_promotion_record(promotion_record)
     return VeriReelProdPromotionResult(
@@ -279,6 +562,7 @@ def execute_verireel_prod_promotion(
         deployment_record_id=deployment_result.deployment_record_id,
         backup_record_id=backup_gate_record.record_id,
         deploy_status=deployment_result.deploy_status,
+        rollout_status=rollout_result.status,
         deploy_started_at=deployment_result.deploy_started_at,
         deploy_finished_at=deployment_result.deploy_finished_at,
         target_name=deployment_result.target_name,

--- a/control_plane/workflows/verireel_prod_promotion.py
+++ b/control_plane/workflows/verireel_prod_promotion.py
@@ -10,6 +10,7 @@ import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane import dokploy as control_plane_dokploy
+from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.promotion_record import (
@@ -336,8 +337,10 @@ def _resolve_rollout_base_urls(
         raise click.ClickException(
             f"No Dokploy target definition found for {request.context}/{request.to_instance}."
         )
-    environment_values = control_plane_dokploy.read_control_plane_environment_values(
+    environment_values = control_plane_runtime_environments.resolve_runtime_environment_values(
         control_plane_root=control_plane_root,
+        context_name=request.context,
+        instance_name=request.to_instance,
     )
     base_urls = control_plane_dokploy.resolve_healthcheck_base_urls(
         target_definition=target_definition,

--- a/control_plane/workflows/verireel_prod_promotion.py
+++ b/control_plane/workflows/verireel_prod_promotion.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.backup_gate_record import BackupGateRecord
+from control_plane.contracts.deployment_record import DeploymentRecord
+from control_plane.contracts.promotion_record import (
+    ArtifactIdentityReference,
+    BackupGateEvidence,
+    DeploymentEvidence,
+    HealthcheckEvidence,
+    PostDeployUpdateEvidence,
+    PromotionRecord,
+)
+from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.workflows.verireel_stable_deploy import (
+    VeriReelStableDeployRequest,
+    execute_verireel_stable_deploy,
+)
+
+
+class VeriReelProdPromotionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    context: str = "verireel"
+    from_instance: str = "testing"
+    to_instance: str = "prod"
+    artifact_id: str
+    source_git_ref: str
+    backup_record_id: str
+    promotion_record_id: str
+    no_cache: bool = False
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "VeriReelProdPromotionRequest":
+        if self.context != "verireel":
+            raise ValueError("VeriReel prod promotion requires context 'verireel'.")
+        if self.from_instance != "testing":
+            raise ValueError("VeriReel prod promotion requires from_instance 'testing'.")
+        if self.to_instance != "prod":
+            raise ValueError("VeriReel prod promotion requires to_instance 'prod'.")
+        if not self.artifact_id.strip():
+            raise ValueError("VeriReel prod promotion requires artifact_id.")
+        if not self.source_git_ref.strip():
+            raise ValueError("VeriReel prod promotion requires source_git_ref.")
+        if not self.backup_record_id.strip():
+            raise ValueError("VeriReel prod promotion requires backup_record_id.")
+        if not self.promotion_record_id.strip():
+            raise ValueError("VeriReel prod promotion requires promotion_record_id.")
+        return self
+
+
+class VeriReelProdPromotionResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    promotion_record_id: str
+    deployment_record_id: str = ""
+    backup_record_id: str
+    deploy_status: str
+    deploy_started_at: str = ""
+    deploy_finished_at: str = ""
+    target_name: str
+    target_type: str
+    target_id: str
+    error_message: str = ""
+
+
+def _default_target_name() -> str:
+    return "ver-prod-app"
+
+
+def _default_target_type() -> str:
+    return "application"
+
+
+def _default_deploy_mode() -> str:
+    return "dokploy-application-api"
+
+
+def _read_backup_gate_record(
+    *,
+    record_store: FilesystemRecordStore,
+    record_id: str,
+) -> BackupGateRecord:
+    try:
+        return record_store.read_backup_gate_record(record_id)
+    except FileNotFoundError as exc:
+        raise click.ClickException(
+            f"VeriReel prod promotion requires stored backup gate record '{record_id}'."
+        ) from exc
+
+
+def _resolve_backup_gate_record(
+    *,
+    record_store: FilesystemRecordStore,
+    request: VeriReelProdPromotionRequest,
+) -> BackupGateRecord:
+    backup_gate_record = _read_backup_gate_record(
+        record_store=record_store,
+        record_id=request.backup_record_id,
+    )
+    if backup_gate_record.context != request.context:
+        raise click.ClickException(
+            "Backup gate record context does not match VeriReel prod promotion request. "
+            f"Record={backup_gate_record.context} request={request.context}."
+        )
+    if backup_gate_record.instance != request.to_instance:
+        raise click.ClickException(
+            "Backup gate record instance does not match VeriReel prod promotion destination. "
+            f"Record={backup_gate_record.instance} request={request.to_instance}."
+        )
+    if not backup_gate_record.required:
+        raise click.ClickException(
+            f"Backup gate record '{backup_gate_record.record_id}' is marked required=false and cannot authorize VeriReel prod promotion."
+        )
+    if backup_gate_record.status != "pass":
+        raise click.ClickException(
+            f"Backup gate record '{backup_gate_record.record_id}' must have status=pass before VeriReel prod promotion."
+        )
+    return backup_gate_record
+
+
+def _build_promotion_record(
+    *,
+    request: VeriReelProdPromotionRequest,
+    backup_gate_record: BackupGateRecord,
+    deployment_record: DeploymentRecord | None,
+    deployment_record_id: str,
+    target_id: str,
+    target_name: str,
+    target_type: str,
+    deploy_status: str,
+    deploy_started_at: str,
+    deploy_finished_at: str,
+) -> PromotionRecord:
+    deploy_mode = _default_deploy_mode()
+    if deployment_record is not None:
+        deploy_mode = deployment_record.deploy.deploy_mode
+    return PromotionRecord(
+        record_id=request.promotion_record_id,
+        artifact_identity=ArtifactIdentityReference(artifact_id=request.artifact_id),
+        deployment_record_id=deployment_record_id,
+        backup_record_id=backup_gate_record.record_id,
+        context=request.context,
+        from_instance=request.from_instance,
+        to_instance=request.to_instance,
+        source_health=HealthcheckEvidence(status="skipped"),
+        backup_gate=BackupGateEvidence(
+            required=backup_gate_record.required,
+            status=backup_gate_record.status,
+            evidence=dict(backup_gate_record.evidence),
+        ),
+        deploy=DeploymentEvidence(
+            target_name=target_name,
+            target_type=target_type,
+            deploy_mode=deploy_mode,
+            deployment_id=target_id,
+            status="pass" if deploy_status == "pass" else "fail",
+            started_at=deploy_started_at,
+            finished_at=deploy_finished_at,
+        ),
+        post_deploy_update=PostDeployUpdateEvidence(),
+        destination_health=HealthcheckEvidence(status="skipped"),
+    )
+
+
+def _write_failed_promotion_record(
+    *,
+    record_store: FilesystemRecordStore,
+    request: VeriReelProdPromotionRequest,
+    backup_gate_record: BackupGateRecord | None,
+    error_message: str,
+) -> None:
+    record_store.write_promotion_record(
+        PromotionRecord(
+            record_id=request.promotion_record_id,
+            artifact_identity=ArtifactIdentityReference(artifact_id=request.artifact_id),
+            deployment_record_id="",
+            backup_record_id=request.backup_record_id,
+            context=request.context,
+            from_instance=request.from_instance,
+            to_instance=request.to_instance,
+            source_health=HealthcheckEvidence(status="skipped"),
+            backup_gate=BackupGateEvidence(
+                required=True,
+                status="fail",
+                evidence=(
+                    dict(backup_gate_record.evidence)
+                    if backup_gate_record is not None
+                    else {"backup_record_id": request.backup_record_id, "error": error_message}
+                ),
+            ),
+            deploy=DeploymentEvidence(
+                target_name=_default_target_name(),
+                target_type=_default_target_type(),
+                deploy_mode=_default_deploy_mode(),
+                deployment_id="",
+                status="fail",
+            ),
+            post_deploy_update=PostDeployUpdateEvidence(
+                attempted=False,
+                status="skipped",
+                detail=error_message,
+            ),
+            destination_health=HealthcheckEvidence(status="skipped"),
+        )
+    )
+
+
+def execute_verireel_prod_promotion(
+    *,
+    control_plane_root: Path,
+    record_store: FilesystemRecordStore,
+    request: VeriReelProdPromotionRequest,
+) -> VeriReelProdPromotionResult:
+    try:
+        backup_gate_record = _resolve_backup_gate_record(
+            record_store=record_store,
+            request=request,
+        )
+    except click.ClickException as exc:
+        error_message = str(exc)
+        _write_failed_promotion_record(
+            record_store=record_store,
+            request=request,
+            backup_gate_record=None,
+            error_message=error_message,
+        )
+        return VeriReelProdPromotionResult(
+            promotion_record_id=request.promotion_record_id,
+            backup_record_id=request.backup_record_id,
+            deploy_status="fail",
+            target_name=_default_target_name(),
+            target_type=_default_target_type(),
+            target_id="",
+            error_message=error_message,
+        )
+
+    deployment_result = execute_verireel_stable_deploy(
+        control_plane_root=control_plane_root,
+        record_store=record_store,
+        request=VeriReelStableDeployRequest(
+            context=request.context,
+            instance=request.to_instance,
+            artifact_id=request.artifact_id,
+            source_git_ref=request.source_git_ref,
+            no_cache=request.no_cache,
+        ),
+    )
+
+    deployment_record = None
+    if deployment_result.deployment_record_id:
+        try:
+            deployment_record = record_store.read_deployment_record(
+                deployment_result.deployment_record_id
+            )
+        except FileNotFoundError:
+            deployment_record = None
+
+    promotion_record = _build_promotion_record(
+        request=request,
+        backup_gate_record=backup_gate_record,
+        deployment_record=deployment_record,
+        deployment_record_id=deployment_result.deployment_record_id,
+        target_id=deployment_result.target_id,
+        target_name=deployment_result.target_name,
+        target_type=deployment_result.target_type,
+        deploy_status=deployment_result.deploy_status,
+        deploy_started_at=deployment_result.deploy_started_at,
+        deploy_finished_at=deployment_result.deploy_finished_at,
+    )
+    record_store.write_promotion_record(promotion_record)
+    return VeriReelProdPromotionResult(
+        promotion_record_id=request.promotion_record_id,
+        deployment_record_id=deployment_result.deployment_record_id,
+        backup_record_id=backup_gate_record.record_id,
+        deploy_status=deployment_result.deploy_status,
+        deploy_started_at=deployment_result.deploy_started_at,
+        deploy_finished_at=deployment_result.deploy_finished_at,
+        target_name=deployment_result.target_name,
+        target_type=deployment_result.target_type,
+        target_id=deployment_result.target_id,
+        error_message=deployment_result.error_message,
+    )

--- a/control_plane/workflows/verireel_prod_promotion.py
+++ b/control_plane/workflows/verireel_prod_promotion.py
@@ -87,6 +87,8 @@ class VeriReelProdPromotionResult(BaseModel):
     backup_record_id: str
     deploy_status: str
     rollout_status: str = "skipped"
+    migration_status: str = "skipped"
+    health_status: str = "skipped"
     deploy_started_at: str = ""
     deploy_finished_at: str = ""
     target_name: str
@@ -105,6 +107,14 @@ def _default_target_type() -> str:
 
 def _default_deploy_mode() -> str:
     return "dokploy-application-api"
+
+
+def _default_migration_command() -> str:
+    return "npx prisma migrate deploy --config prisma.config.ts"
+
+
+def _default_migration_schedule_name() -> str:
+    return "ver-apply-prisma-migrations"
 
 
 def _read_backup_gate_record(
@@ -162,27 +172,22 @@ def _build_promotion_record(
     deploy_status: str,
     deploy_started_at: str,
     deploy_finished_at: str,
-    rollout_result: VeriReelRolloutVerificationResult | None,
+    migration_status: str,
+    migration_detail: str,
+    health_result: VeriReelRolloutVerificationResult | None,
 ) -> PromotionRecord:
     deploy_mode = _default_deploy_mode()
     if deployment_record is not None:
         deploy_mode = deployment_record.deploy.deploy_mode
-    destination_health = HealthcheckEvidence(status="skipped")
-    if rollout_result is not None:
-        if rollout_result.status == "pass":
-            destination_health = HealthcheckEvidence(
-                verified=True,
-                urls=rollout_result.health_urls,
-                timeout_seconds=request.rollout_timeout_seconds,
-                status="pass",
-            )
-        elif rollout_result.status == "fail":
-            destination_health = HealthcheckEvidence(
-                verified=True,
-                urls=rollout_result.health_urls,
-                timeout_seconds=request.rollout_timeout_seconds,
-                status="fail",
-            )
+    destination_health = _build_destination_health(
+        request=request,
+        health_result=health_result,
+    )
+    post_deploy_update = _build_post_deploy_update(
+        instance_name=request.to_instance,
+        migration_status=migration_status,
+        migration_detail=migration_detail,
+    )
     return PromotionRecord(
         record_id=request.promotion_record_id,
         artifact_identity=ArtifactIdentityReference(artifact_id=request.artifact_id),
@@ -206,8 +211,50 @@ def _build_promotion_record(
             started_at=deploy_started_at,
             finished_at=deploy_finished_at,
         ),
-        post_deploy_update=PostDeployUpdateEvidence(),
+        post_deploy_update=post_deploy_update,
         destination_health=destination_health,
+    )
+
+
+def _build_post_deploy_update(
+    *,
+    instance_name: str,
+    migration_status: str,
+    migration_detail: str,
+) -> PostDeployUpdateEvidence:
+    if migration_status == "skipped":
+        return PostDeployUpdateEvidence(
+            attempted=False,
+            status="skipped",
+            detail=migration_detail,
+        )
+    detail = migration_detail
+    if not detail:
+        if migration_status == "pass":
+            detail = f"Prisma migrations completed on {instance_name}."
+        elif migration_status == "fail":
+            detail = f"Prisma migrations failed on {instance_name}."
+    return PostDeployUpdateEvidence(
+        attempted=True,
+        status=migration_status,
+        detail=detail,
+    )
+
+
+def _build_destination_health(
+    *,
+    request: VeriReelProdPromotionRequest,
+    health_result: VeriReelRolloutVerificationResult | None,
+) -> HealthcheckEvidence:
+    if health_result is None:
+        return HealthcheckEvidence(status="skipped")
+    if not health_result.health_urls:
+        return HealthcheckEvidence(status=health_result.status)
+    return HealthcheckEvidence(
+        verified=True,
+        urls=health_result.health_urls,
+        timeout_seconds=request.rollout_timeout_seconds,
+        status=health_result.status,
     )
 
 
@@ -224,18 +271,16 @@ def _write_failed_promotion_record(
     target_name: str | None = None,
     target_type: str | None = None,
     target_id: str = "",
-    rollout_result: VeriReelRolloutVerificationResult | None = None,
+    migration_status: str = "skipped",
+    migration_detail: str = "",
+    health_result: VeriReelRolloutVerificationResult | None = None,
 ) -> None:
     resolved_target_name = target_name or _default_target_name()
     resolved_target_type = target_type or _default_target_type()
-    destination_health = HealthcheckEvidence(status="skipped")
-    if rollout_result is not None:
-        destination_health = HealthcheckEvidence(
-            verified=bool(rollout_result.health_urls),
-            urls=rollout_result.health_urls,
-            timeout_seconds=(request.rollout_timeout_seconds if rollout_result.health_urls else None),
-            status="fail" if rollout_result.status == "fail" else rollout_result.status,
-        )
+    destination_health = _build_destination_health(
+        request=request,
+        health_result=health_result,
+    )
     record_store.write_promotion_record(
         PromotionRecord(
             record_id=request.promotion_record_id,
@@ -264,10 +309,10 @@ def _write_failed_promotion_record(
                 started_at=deploy_started_at,
                 finished_at=deploy_finished_at,
             ),
-            post_deploy_update=PostDeployUpdateEvidence(
-                attempted=False,
-                status="skipped",
-                detail=error_message,
+            post_deploy_update=_build_post_deploy_update(
+                instance_name=request.to_instance,
+                migration_status=migration_status,
+                migration_detail=(migration_detail or error_message),
             ),
             destination_health=destination_health,
         )
@@ -415,6 +460,173 @@ def _verify_rollout(
     raise click.ClickException(f"VeriReel prod rollout verification timed out: {last_error}")
 
 
+def _resolve_application_id(
+    *,
+    control_plane_root: Path,
+    request: VeriReelProdPromotionRequest,
+    target_type: str,
+    target_id: str,
+) -> str:
+    if target_type == "application" and target_id.strip():
+        return target_id.strip()
+    source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
+        control_plane_root=control_plane_root,
+    )
+    target_definition = control_plane_dokploy.find_dokploy_target_definition(
+        source_of_truth,
+        context_name=request.context,
+        instance_name=request.to_instance,
+    )
+    if target_definition is None or target_definition.target_type != "application" or not target_definition.target_id.strip():
+        raise click.ClickException(
+            f"VeriReel prod promotion post-deploy update requires an application target for {request.context}/{request.to_instance}."
+        )
+    return target_definition.target_id.strip()
+
+
+def _find_application_schedule(*, host: str, token: str, application_id: str, schedule_name: str) -> dict[str, object] | None:
+    for schedule in control_plane_dokploy.list_dokploy_schedules(
+        host=host,
+        token=token,
+        target_id=application_id,
+        schedule_type="application",
+    ):
+        if str(schedule.get("name") or "").strip() == schedule_name:
+            return dict(schedule)
+    return None
+
+
+def _upsert_application_schedule(
+    *,
+    host: str,
+    token: str,
+    application_id: str,
+    schedule_name: str,
+    command: str,
+) -> str:
+    existing_schedule = _find_application_schedule(
+        host=host,
+        token=token,
+        application_id=application_id,
+        schedule_name=schedule_name,
+    )
+    payload: dict[str, object] = {
+        "name": schedule_name,
+        "cronExpression": control_plane_dokploy.DOKPLOY_MANUAL_ONLY_CRON_EXPRESSION,
+        "scheduleType": "application",
+        "shellType": "sh",
+        "command": command,
+        "applicationId": application_id,
+        "enabled": False,
+        "timezone": "UTC",
+    }
+    if existing_schedule is None:
+        control_plane_dokploy.dokploy_request(
+            host=host,
+            token=token,
+            path="/api/schedule.create",
+            method="POST",
+            payload=payload,
+        )
+    else:
+        control_plane_dokploy.dokploy_request(
+            host=host,
+            token=token,
+            path="/api/schedule.update",
+            method="POST",
+            payload={"scheduleId": control_plane_dokploy.schedule_key(existing_schedule), **payload},
+        )
+    resolved_schedule = _find_application_schedule(
+        host=host,
+        token=token,
+        application_id=application_id,
+        schedule_name=schedule_name,
+    )
+    if resolved_schedule is None:
+        raise click.ClickException(
+            f"Dokploy schedule {schedule_name!r} for application {application_id!r} could not be resolved."
+        )
+    schedule_id = control_plane_dokploy.schedule_key(resolved_schedule)
+    if not schedule_id:
+        raise click.ClickException(
+            f"Dokploy schedule {schedule_name!r} for application {application_id!r} did not expose a schedule id."
+        )
+    return schedule_id
+
+
+def _run_application_command_with_retries(
+    *,
+    host: str,
+    token: str,
+    application_id: str,
+    schedule_name: str,
+    command: str,
+    timeout_seconds: int,
+    attempts: int = 4,
+    retry_delay_seconds: float = 5.0,
+) -> None:
+    if attempts < 1:
+        raise ValueError("attempts must be at least 1")
+    for attempt in range(1, attempts + 1):
+        try:
+            schedule_id = _upsert_application_schedule(
+                host=host,
+                token=token,
+                application_id=application_id,
+                schedule_name=schedule_name,
+                command=command,
+            )
+            latest_before = control_plane_dokploy.latest_deployment_for_schedule(
+                host=host,
+                token=token,
+                schedule_id=schedule_id,
+            )
+            control_plane_dokploy.dokploy_request(
+                host=host,
+                token=token,
+                path="/api/schedule.runManually",
+                method="POST",
+                payload={"scheduleId": schedule_id},
+                timeout_seconds=timeout_seconds,
+            )
+            control_plane_dokploy.wait_for_dokploy_schedule_deployment(
+                host=host,
+                token=token,
+                schedule_id=schedule_id,
+                before_key=control_plane_dokploy.deployment_key(latest_before),
+                timeout_seconds=timeout_seconds,
+            )
+            return
+        except click.ClickException:
+            if attempt >= attempts:
+                raise
+            time.sleep(retry_delay_seconds)
+
+
+def _run_prisma_migrations(
+    *,
+    control_plane_root: Path,
+    request: VeriReelProdPromotionRequest,
+    target_type: str,
+    target_id: str,
+) -> None:
+    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
+    application_id = _resolve_application_id(
+        control_plane_root=control_plane_root,
+        request=request,
+        target_type=target_type,
+        target_id=target_id,
+    )
+    _run_application_command_with_retries(
+        host=host,
+        token=token,
+        application_id=application_id,
+        schedule_name=_default_migration_schedule_name(),
+        command=_default_migration_command(),
+        timeout_seconds=request.rollout_timeout_seconds,
+    )
+
+
 def execute_verireel_prod_promotion(
     *,
     control_plane_root: Path,
@@ -439,6 +651,8 @@ def execute_verireel_prod_promotion(
             backup_record_id=request.backup_record_id,
             deploy_status="fail",
             rollout_status="skipped",
+            migration_status="skipped",
+            health_status="skipped",
             target_name=_default_target_name(),
             target_type=_default_target_type(),
             target_id="",
@@ -478,7 +692,9 @@ def execute_verireel_prod_promotion(
             deploy_status=deployment_result.deploy_status,
             deploy_started_at=deployment_result.deploy_started_at,
             deploy_finished_at=deployment_result.deploy_finished_at,
-            rollout_result=None,
+            migration_status="skipped",
+            migration_detail="",
+            health_result=None,
         )
         record_store.write_promotion_record(promotion_record)
         return VeriReelProdPromotionResult(
@@ -487,6 +703,8 @@ def execute_verireel_prod_promotion(
             backup_record_id=backup_gate_record.record_id,
             deploy_status=deployment_result.deploy_status,
             rollout_status="skipped",
+            migration_status="skipped",
+            health_status="skipped",
             deploy_started_at=deployment_result.deploy_started_at,
             deploy_finished_at=deployment_result.deploy_finished_at,
             target_name=deployment_result.target_name,
@@ -527,7 +745,7 @@ def execute_verireel_prod_promotion(
             target_name=deployment_result.target_name,
             target_type=deployment_result.target_type,
             target_id=deployment_result.target_id,
-            rollout_result=failed_rollout_result,
+            health_result=failed_rollout_result,
         )
         return VeriReelProdPromotionResult(
             promotion_record_id=request.promotion_record_id,
@@ -535,6 +753,101 @@ def execute_verireel_prod_promotion(
             backup_record_id=backup_gate_record.record_id,
             deploy_status=deployment_result.deploy_status,
             rollout_status="fail",
+            migration_status="skipped",
+            health_status="skipped",
+            deploy_started_at=deployment_result.deploy_started_at,
+            deploy_finished_at=deployment_result.deploy_finished_at,
+            target_name=deployment_result.target_name,
+            target_type=deployment_result.target_type,
+            target_id=deployment_result.target_id,
+            error_message=error_message,
+        )
+
+    try:
+        _run_prisma_migrations(
+            control_plane_root=control_plane_root,
+            request=request,
+            target_type=deployment_result.target_type,
+            target_id=deployment_result.target_id,
+        )
+    except click.ClickException as exc:
+        error_message = str(exc)
+        _write_failed_promotion_record(
+            record_store=record_store,
+            request=request,
+            backup_gate_record=backup_gate_record,
+            error_message=error_message,
+            deployment_record_id=deployment_result.deployment_record_id,
+            deploy_status="pass",
+            deploy_started_at=deployment_result.deploy_started_at,
+            deploy_finished_at=deployment_result.deploy_finished_at,
+            target_name=deployment_result.target_name,
+            target_type=deployment_result.target_type,
+            target_id=deployment_result.target_id,
+            migration_status="fail",
+            migration_detail=error_message,
+            health_result=None,
+        )
+        return VeriReelProdPromotionResult(
+            promotion_record_id=request.promotion_record_id,
+            deployment_record_id=deployment_result.deployment_record_id,
+            backup_record_id=backup_gate_record.record_id,
+            deploy_status=deployment_result.deploy_status,
+            rollout_status=rollout_result.status,
+            migration_status="fail",
+            health_status="skipped",
+            deploy_started_at=deployment_result.deploy_started_at,
+            deploy_finished_at=deployment_result.deploy_finished_at,
+            target_name=deployment_result.target_name,
+            target_type=deployment_result.target_type,
+            target_id=deployment_result.target_id,
+            error_message=error_message,
+        )
+
+    try:
+        health_result = _verify_rollout(
+            control_plane_root=control_plane_root,
+            request=request,
+        )
+    except click.ClickException as exc:
+        error_message = str(exc)
+        failed_health_result = VeriReelRolloutVerificationResult(status="fail")
+        try:
+            base_urls = _resolve_rollout_base_urls(
+                control_plane_root=control_plane_root,
+                request=request,
+            )
+            failed_health_result = VeriReelRolloutVerificationResult(
+                status="fail",
+                base_url=base_urls[0],
+                health_urls=(f"{base_urls[0].rstrip('/')}/api/health",),
+            )
+        except click.ClickException:
+            pass
+        _write_failed_promotion_record(
+            record_store=record_store,
+            request=request,
+            backup_gate_record=backup_gate_record,
+            error_message=error_message,
+            deployment_record_id=deployment_result.deployment_record_id,
+            deploy_status="pass",
+            deploy_started_at=deployment_result.deploy_started_at,
+            deploy_finished_at=deployment_result.deploy_finished_at,
+            target_name=deployment_result.target_name,
+            target_type=deployment_result.target_type,
+            target_id=deployment_result.target_id,
+            migration_status="pass",
+            migration_detail="",
+            health_result=failed_health_result,
+        )
+        return VeriReelProdPromotionResult(
+            promotion_record_id=request.promotion_record_id,
+            deployment_record_id=deployment_result.deployment_record_id,
+            backup_record_id=backup_gate_record.record_id,
+            deploy_status=deployment_result.deploy_status,
+            rollout_status=rollout_result.status,
+            migration_status="pass",
+            health_status="fail",
             deploy_started_at=deployment_result.deploy_started_at,
             deploy_finished_at=deployment_result.deploy_finished_at,
             target_name=deployment_result.target_name,
@@ -554,7 +867,9 @@ def execute_verireel_prod_promotion(
         deploy_status=deployment_result.deploy_status,
         deploy_started_at=deployment_result.deploy_started_at,
         deploy_finished_at=deployment_result.deploy_finished_at,
-        rollout_result=rollout_result,
+        migration_status="pass",
+        migration_detail="",
+        health_result=health_result,
     )
     record_store.write_promotion_record(promotion_record)
     return VeriReelProdPromotionResult(
@@ -563,6 +878,8 @@ def execute_verireel_prod_promotion(
         backup_record_id=backup_gate_record.record_id,
         deploy_status=deployment_result.deploy_status,
         rollout_status=rollout_result.status,
+        migration_status="pass",
+        health_status=health_result.status,
         deploy_started_at=deployment_result.deploy_started_at,
         deploy_finished_at=deployment_result.deploy_finished_at,
         target_name=deployment_result.target_name,

--- a/control_plane/workflows/verireel_prod_rollback.py
+++ b/control_plane/workflows/verireel_prod_rollback.py
@@ -11,6 +11,7 @@ from urllib.error import HTTPError, URLError
 import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.promotion_record import HealthcheckEvidence, PromotionRecord, RollbackExecutionEvidence
 from control_plane.storage.filesystem import FilesystemRecordStore
@@ -90,6 +91,16 @@ class VeriReelProdRollbackResult(BaseModel):
     rollback_started_at: str = ""
     rollback_finished_at: str = ""
     error_message: str = ""
+
+
+WORKER_COMMAND_ENV_VAR = "LAUNCHPLANE_VERIREEL_PROD_ROLLBACK_WORKER_COMMAND"
+WORKER_RUNTIME_ENV_KEYS = (
+    WORKER_COMMAND_ENV_VAR,
+    "VERIREEL_PROD_PROXMOX_HOST",
+    "VERIREEL_PROD_PROXMOX_USER",
+    "VERIREEL_PROD_CT_ID",
+    "VERIREEL_PROD_GATE_LOCAL",
+)
 
 
 def _read_promotion_record(
@@ -253,31 +264,72 @@ def _write_promotion_rollback_state(
     record_store.write_promotion_record(updated_record)
 
 
-def _worker_command() -> list[str]:
-    raw_value = os.environ.get("LAUNCHPLANE_VERIREEL_PROD_ROLLBACK_WORKER_COMMAND", "").strip()
+def _resolve_worker_runtime_environment(
+    *,
+    control_plane_root: Path,
+    request: VeriReelProdRollbackWorkerRequest,
+) -> dict[str, str]:
+    try:
+        resolved_values = control_plane_runtime_environments.resolve_runtime_environment_values(
+            control_plane_root=control_plane_root,
+            context_name=request.context,
+            instance_name=request.instance,
+        )
+    except click.ClickException:
+        return {}
+    return {
+        key: value
+        for key, value in resolved_values.items()
+        if key in WORKER_RUNTIME_ENV_KEYS and str(value).strip()
+    }
+
+
+def _worker_environment(
+    *,
+    control_plane_root: Path,
+    request: VeriReelProdRollbackWorkerRequest,
+) -> dict[str, str]:
+    environment = dict(os.environ)
+    environment.update(
+        _resolve_worker_runtime_environment(
+            control_plane_root=control_plane_root,
+            request=request,
+        )
+    )
+    return environment
+
+
+def _worker_command(*, environment: dict[str, str]) -> list[str]:
+    raw_value = environment.get(WORKER_COMMAND_ENV_VAR, "").strip()
     if not raw_value:
         raise click.ClickException(
-            "Missing LAUNCHPLANE_VERIREEL_PROD_ROLLBACK_WORKER_COMMAND for VeriReel prod rollback execution."
+            f"Missing {WORKER_COMMAND_ENV_VAR} for VeriReel prod rollback execution."
         )
     command = shlex.split(raw_value)
     if not command:
         raise click.ClickException(
-            "LAUNCHPLANE_VERIREEL_PROD_ROLLBACK_WORKER_COMMAND did not resolve to an executable command."
+            f"{WORKER_COMMAND_ENV_VAR} did not resolve to an executable command."
         )
     return command
 
 
 def _run_delegated_worker(
     *,
+    control_plane_root: Path,
     request: VeriReelProdRollbackWorkerRequest,
 ) -> VeriReelProdRollbackWorkerResult:
+    worker_environment = _worker_environment(
+        control_plane_root=control_plane_root,
+        request=request,
+    )
     completed = subprocess.run(
-        _worker_command(),
+        _worker_command(environment=worker_environment),
         input=request.model_dump_json(),
         text=True,
         capture_output=True,
         timeout=max(request.timeout_seconds, 1),
         check=False,
+        env=worker_environment,
     )
     stdout = completed.stdout.strip()
     if not stdout:
@@ -384,17 +436,42 @@ def execute_verireel_prod_rollback(
             error_message=error_message,
         )
 
-    worker_result = _run_delegated_worker(
-        request=VeriReelProdRollbackWorkerRequest(
-            context=request.context,
-            instance=request.instance,
+    try:
+        worker_result = _run_delegated_worker(
+            control_plane_root=control_plane_root,
+            request=VeriReelProdRollbackWorkerRequest(
+                context=request.context,
+                instance=request.instance,
+                promotion_record_id=request.promotion_record_id,
+                backup_record_id=request.backup_record_id,
+                snapshot_name=snapshot_name,
+                start_after_rollback=request.start_after_rollback,
+                timeout_seconds=request.rollout_timeout_seconds,
+            ),
+        )
+    except click.ClickException as exc:
+        error_message = str(exc)
+        _write_promotion_rollback_state(
+            record_store=record_store,
+            promotion_record=promotion_record,
+            request=request,
+            snapshot_name=snapshot_name,
+            rollback_status="fail",
+            rollback_health_status="skipped",
+            rollback_started_at="",
+            rollback_finished_at="",
+            detail=error_message,
+            health_result=None,
+        )
+        return VeriReelProdRollbackResult(
             promotion_record_id=request.promotion_record_id,
             backup_record_id=request.backup_record_id,
             snapshot_name=snapshot_name,
-            start_after_rollback=request.start_after_rollback,
-            timeout_seconds=request.rollout_timeout_seconds,
+            rollback_status="fail",
+            rollback_health_status="skipped",
+            error_message=error_message,
         )
-    )
+
     if worker_result.status != "pass":
         detail = worker_result.detail or "VeriReel prod rollback worker reported failure."
         _write_promotion_rollback_state(

--- a/control_plane/workflows/verireel_prod_rollback.py
+++ b/control_plane/workflows/verireel_prod_rollback.py
@@ -1,0 +1,487 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import time
+from urllib.error import HTTPError, URLError
+
+import click
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.backup_gate_record import BackupGateRecord
+from control_plane.contracts.promotion_record import HealthcheckEvidence, PromotionRecord, RollbackExecutionEvidence
+from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.workflows.ship import utc_now_timestamp
+from control_plane.workflows.verireel_prod_promotion import (
+    DEFAULT_ROLLOUT_INTERVAL_SECONDS,
+    DEFAULT_ROLLOUT_TIMEOUT_SECONDS,
+    VeriReelRolloutVerificationResult,
+    _assert_rollout_pages,
+    _fetch_url_text,
+    _read_backup_gate_record,
+    _resolve_rollout_base_urls,
+    _validate_health_payload,
+)
+
+
+class VeriReelProdRollbackRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    context: str = "verireel"
+    instance: str = "prod"
+    promotion_record_id: str
+    backup_record_id: str
+    snapshot_name: str = ""
+    expected_build_revision: str = ""
+    expected_build_tag: str = ""
+    rollout_timeout_seconds: int = Field(default=DEFAULT_ROLLOUT_TIMEOUT_SECONDS, ge=1)
+    rollout_interval_seconds: int = Field(default=DEFAULT_ROLLOUT_INTERVAL_SECONDS, ge=1)
+    start_after_rollback: bool = True
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "VeriReelProdRollbackRequest":
+        if self.context != "verireel":
+            raise ValueError("VeriReel prod rollback requires context 'verireel'.")
+        if self.instance != "prod":
+            raise ValueError("VeriReel prod rollback requires instance 'prod'.")
+        if not self.promotion_record_id.strip():
+            raise ValueError("VeriReel prod rollback requires promotion_record_id.")
+        if not self.backup_record_id.strip():
+            raise ValueError("VeriReel prod rollback requires backup_record_id.")
+        return self
+
+
+class VeriReelProdRollbackWorkerRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    context: str
+    instance: str
+    promotion_record_id: str
+    backup_record_id: str
+    snapshot_name: str
+    start_after_rollback: bool = True
+    timeout_seconds: int = Field(default=DEFAULT_ROLLOUT_TIMEOUT_SECONDS, ge=1)
+
+
+class VeriReelProdRollbackWorkerResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    status: str
+    snapshot_name: str
+    started_at: str = ""
+    finished_at: str = ""
+    detail: str = ""
+
+
+class VeriReelProdRollbackResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    promotion_record_id: str
+    backup_record_id: str
+    snapshot_name: str = ""
+    rollback_status: str
+    rollback_health_status: str = "skipped"
+    rollback_started_at: str = ""
+    rollback_finished_at: str = ""
+    error_message: str = ""
+
+
+def _read_promotion_record(
+    *,
+    record_store: FilesystemRecordStore,
+    record_id: str,
+) -> PromotionRecord:
+    try:
+        return record_store.read_promotion_record(record_id)
+    except FileNotFoundError as exc:
+        raise click.ClickException(
+            f"VeriReel prod rollback requires stored promotion record '{record_id}'."
+        ) from exc
+
+
+def _resolve_backup_gate_record(
+    *,
+    record_store: FilesystemRecordStore,
+    request: VeriReelProdRollbackRequest,
+) -> BackupGateRecord:
+    backup_gate_record = _read_backup_gate_record(
+        record_store=record_store,
+        record_id=request.backup_record_id,
+    )
+    if backup_gate_record.context != request.context:
+        raise click.ClickException(
+            "Backup gate record context does not match VeriReel prod rollback request. "
+            f"Record={backup_gate_record.context} request={request.context}."
+        )
+    if backup_gate_record.instance != request.instance:
+        raise click.ClickException(
+            "Backup gate record instance does not match VeriReel prod rollback destination. "
+            f"Record={backup_gate_record.instance} request={request.instance}."
+        )
+    if backup_gate_record.status != "pass":
+        raise click.ClickException(
+            f"Backup gate record '{backup_gate_record.record_id}' must have status=pass before VeriReel prod rollback."
+        )
+    return backup_gate_record
+
+
+def _resolve_snapshot_name(
+    *,
+    request: VeriReelProdRollbackRequest,
+    backup_gate_record: BackupGateRecord,
+) -> str:
+    explicit_name = request.snapshot_name.strip()
+    if explicit_name:
+        return explicit_name
+    snapshot_name = str(backup_gate_record.evidence.get("snapshot_name") or "").strip()
+    if snapshot_name:
+        return snapshot_name
+    raise click.ClickException(
+        f"Backup gate record '{backup_gate_record.record_id}' does not include snapshot_name evidence required for VeriReel prod rollback."
+    )
+
+
+def _verify_post_rollback_health(
+    *,
+    control_plane_root: Path,
+    request: VeriReelProdRollbackRequest,
+) -> VeriReelRolloutVerificationResult:
+    started_at = utc_now_timestamp()
+    base_urls = _resolve_rollout_base_urls(
+        control_plane_root=control_plane_root,
+        request=request,
+    )
+    health_urls = tuple(f"{base_url.rstrip('/')}/api/health" for base_url in base_urls)
+    last_error = "health endpoint not checked yet"
+    deadline = time.monotonic() + request.rollout_timeout_seconds
+    while time.monotonic() <= deadline:
+        for base_url, health_url in zip(base_urls, health_urls, strict=False):
+            try:
+                status_code, response_text = _fetch_url_text(
+                    health_url,
+                    accept="application/json,text/html",
+                )
+                if status_code < 200 or status_code >= 300:
+                    last_error = f"received {status_code} from {health_url}"
+                    continue
+                payload = json.loads(response_text)
+                validation_error = _validate_health_payload(
+                    payload,
+                    health_url=health_url,
+                    expected_build_revision=request.expected_build_revision,
+                    expected_build_tag=request.expected_build_tag,
+                )
+                if validation_error is not None:
+                    last_error = validation_error
+                    continue
+                _assert_rollout_pages(base_url)
+                return VeriReelRolloutVerificationResult(
+                    status="pass",
+                    base_url=base_url,
+                    health_urls=(health_url,),
+                    started_at=started_at,
+                    finished_at=utc_now_timestamp(),
+                )
+            except (HTTPError, URLError, TimeoutError, json.JSONDecodeError, ValueError) as exc:
+                last_error = str(exc)
+            except click.ClickException as exc:
+                raise click.ClickException(str(exc)) from exc
+        remaining_seconds = deadline - time.monotonic()
+        if remaining_seconds <= 0:
+            break
+        time.sleep(min(request.rollout_interval_seconds, remaining_seconds))
+    raise click.ClickException(f"VeriReel prod rollback health verification timed out: {last_error}")
+
+
+def _build_health_evidence(
+    *,
+    request: VeriReelProdRollbackRequest,
+    health_result: VeriReelRolloutVerificationResult | None,
+) -> HealthcheckEvidence:
+    if health_result is None:
+        return HealthcheckEvidence(status="skipped")
+    if not health_result.health_urls:
+        return HealthcheckEvidence(status=health_result.status)
+    return HealthcheckEvidence(
+        verified=True,
+        urls=health_result.health_urls,
+        timeout_seconds=request.rollout_timeout_seconds,
+        status=health_result.status,
+    )
+
+
+def _write_promotion_rollback_state(
+    *,
+    record_store: FilesystemRecordStore,
+    promotion_record: PromotionRecord,
+    request: VeriReelProdRollbackRequest,
+    snapshot_name: str,
+    rollback_status: str,
+    rollback_health_status: str,
+    rollback_started_at: str,
+    rollback_finished_at: str,
+    detail: str,
+    health_result: VeriReelRolloutVerificationResult | None,
+) -> None:
+    updated_record = promotion_record.model_copy(
+        update={
+            "rollback": RollbackExecutionEvidence(
+                attempted=True,
+                status=rollback_status,
+                detail=detail,
+                snapshot_name=snapshot_name,
+                started_at=rollback_started_at,
+                finished_at=rollback_finished_at,
+            ),
+            "rollback_health": _build_health_evidence(
+                request=request,
+                health_result=(
+                    health_result
+                    if rollback_health_status in {"pass", "fail"}
+                    else None
+                ),
+            ),
+        },
+        deep=True,
+    )
+    record_store.write_promotion_record(updated_record)
+
+
+def _worker_command() -> list[str]:
+    raw_value = os.environ.get("LAUNCHPLANE_VERIREEL_PROD_ROLLBACK_WORKER_COMMAND", "").strip()
+    if not raw_value:
+        raise click.ClickException(
+            "Missing LAUNCHPLANE_VERIREEL_PROD_ROLLBACK_WORKER_COMMAND for VeriReel prod rollback execution."
+        )
+    command = shlex.split(raw_value)
+    if not command:
+        raise click.ClickException(
+            "LAUNCHPLANE_VERIREEL_PROD_ROLLBACK_WORKER_COMMAND did not resolve to an executable command."
+        )
+    return command
+
+
+def _run_delegated_worker(
+    *,
+    request: VeriReelProdRollbackWorkerRequest,
+) -> VeriReelProdRollbackWorkerResult:
+    completed = subprocess.run(
+        _worker_command(),
+        input=request.model_dump_json(),
+        text=True,
+        capture_output=True,
+        timeout=max(request.timeout_seconds, 1),
+        check=False,
+    )
+    stdout = completed.stdout.strip()
+    if not stdout:
+        detail = completed.stderr.strip() or "VeriReel prod rollback worker returned no JSON payload."
+        raise click.ClickException(detail)
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise click.ClickException(
+            f"VeriReel prod rollback worker returned invalid JSON: {stdout}"
+        ) from exc
+    try:
+        result = VeriReelProdRollbackWorkerResult.model_validate(payload)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(
+            f"VeriReel prod rollback worker returned invalid result payload: {payload}"
+        ) from exc
+    if completed.returncode != 0 and result.status != "pass":
+        return result
+    if completed.returncode != 0:
+        detail = result.detail or completed.stderr.strip() or stdout
+        raise click.ClickException(detail)
+    return result
+
+
+def execute_verireel_prod_rollback(
+    *,
+    control_plane_root: Path,
+    record_store: FilesystemRecordStore,
+    request: VeriReelProdRollbackRequest,
+) -> VeriReelProdRollbackResult:
+    try:
+        promotion_record = _read_promotion_record(
+            record_store=record_store,
+            record_id=request.promotion_record_id,
+        )
+        backup_gate_record = _resolve_backup_gate_record(
+            record_store=record_store,
+            request=request,
+        )
+        snapshot_name = _resolve_snapshot_name(
+            request=request,
+            backup_gate_record=backup_gate_record,
+        )
+    except click.ClickException as exc:
+        return VeriReelProdRollbackResult(
+            promotion_record_id=request.promotion_record_id,
+            backup_record_id=request.backup_record_id,
+            rollback_status="fail",
+            rollback_health_status="skipped",
+            error_message=str(exc),
+        )
+
+    if promotion_record.context != request.context or promotion_record.to_instance != request.instance:
+        error_message = (
+            "Promotion record does not match VeriReel prod rollback request. "
+            f"Record={promotion_record.context}/{promotion_record.to_instance} "
+            f"request={request.context}/{request.instance}."
+        )
+        _write_promotion_rollback_state(
+            record_store=record_store,
+            promotion_record=promotion_record,
+            request=request,
+            snapshot_name=snapshot_name,
+            rollback_status="fail",
+            rollback_health_status="skipped",
+            rollback_started_at="",
+            rollback_finished_at="",
+            detail=error_message,
+            health_result=None,
+        )
+        return VeriReelProdRollbackResult(
+            promotion_record_id=request.promotion_record_id,
+            backup_record_id=request.backup_record_id,
+            snapshot_name=snapshot_name,
+            rollback_status="fail",
+            rollback_health_status="skipped",
+            error_message=error_message,
+        )
+
+    if promotion_record.backup_record_id and promotion_record.backup_record_id != request.backup_record_id:
+        error_message = (
+            "Promotion record backup_record_id does not match VeriReel prod rollback request. "
+            f"Record={promotion_record.backup_record_id} request={request.backup_record_id}."
+        )
+        _write_promotion_rollback_state(
+            record_store=record_store,
+            promotion_record=promotion_record,
+            request=request,
+            snapshot_name=snapshot_name,
+            rollback_status="fail",
+            rollback_health_status="skipped",
+            rollback_started_at="",
+            rollback_finished_at="",
+            detail=error_message,
+            health_result=None,
+        )
+        return VeriReelProdRollbackResult(
+            promotion_record_id=request.promotion_record_id,
+            backup_record_id=request.backup_record_id,
+            snapshot_name=snapshot_name,
+            rollback_status="fail",
+            rollback_health_status="skipped",
+            error_message=error_message,
+        )
+
+    worker_result = _run_delegated_worker(
+        request=VeriReelProdRollbackWorkerRequest(
+            context=request.context,
+            instance=request.instance,
+            promotion_record_id=request.promotion_record_id,
+            backup_record_id=request.backup_record_id,
+            snapshot_name=snapshot_name,
+            start_after_rollback=request.start_after_rollback,
+            timeout_seconds=request.rollout_timeout_seconds,
+        )
+    )
+    if worker_result.status != "pass":
+        detail = worker_result.detail or "VeriReel prod rollback worker reported failure."
+        _write_promotion_rollback_state(
+            record_store=record_store,
+            promotion_record=promotion_record,
+            request=request,
+            snapshot_name=snapshot_name,
+            rollback_status="fail",
+            rollback_health_status="skipped",
+            rollback_started_at=worker_result.started_at,
+            rollback_finished_at=worker_result.finished_at,
+            detail=detail,
+            health_result=None,
+        )
+        return VeriReelProdRollbackResult(
+            promotion_record_id=request.promotion_record_id,
+            backup_record_id=request.backup_record_id,
+            snapshot_name=snapshot_name,
+            rollback_status="fail",
+            rollback_health_status="skipped",
+            rollback_started_at=worker_result.started_at,
+            rollback_finished_at=worker_result.finished_at,
+            error_message=detail,
+        )
+
+    try:
+        health_result = _verify_post_rollback_health(
+            control_plane_root=control_plane_root,
+            request=request,
+        )
+    except click.ClickException as exc:
+        error_message = str(exc)
+        failed_health_result = VeriReelRolloutVerificationResult(status="fail")
+        try:
+            base_urls = _resolve_rollout_base_urls(
+                control_plane_root=control_plane_root,
+                request=request,
+            )
+            failed_health_result = VeriReelRolloutVerificationResult(
+                status="fail",
+                base_url=base_urls[0],
+                health_urls=(f"{base_urls[0].rstrip('/')}/api/health",),
+            )
+        except click.ClickException:
+            pass
+        _write_promotion_rollback_state(
+            record_store=record_store,
+            promotion_record=promotion_record,
+            request=request,
+            snapshot_name=snapshot_name,
+            rollback_status="pass",
+            rollback_health_status="fail",
+            rollback_started_at=worker_result.started_at,
+            rollback_finished_at=worker_result.finished_at,
+            detail=worker_result.detail,
+            health_result=failed_health_result,
+        )
+        return VeriReelProdRollbackResult(
+            promotion_record_id=request.promotion_record_id,
+            backup_record_id=request.backup_record_id,
+            snapshot_name=snapshot_name,
+            rollback_status="pass",
+            rollback_health_status="fail",
+            rollback_started_at=worker_result.started_at,
+            rollback_finished_at=worker_result.finished_at,
+            error_message=error_message,
+        )
+
+    _write_promotion_rollback_state(
+        record_store=record_store,
+        promotion_record=promotion_record,
+        request=request,
+        snapshot_name=snapshot_name,
+        rollback_status="pass",
+        rollback_health_status=health_result.status,
+        rollback_started_at=worker_result.started_at,
+        rollback_finished_at=worker_result.finished_at,
+        detail=worker_result.detail,
+        health_result=health_result,
+    )
+    return VeriReelProdRollbackResult(
+        promotion_record_id=request.promotion_record_id,
+        backup_record_id=request.backup_record_id,
+        snapshot_name=snapshot_name,
+        rollback_status="pass",
+        rollback_health_status=health_result.status,
+        rollback_started_at=worker_result.started_at,
+        rollback_finished_at=worker_result.finished_at,
+        error_message="",
+    )

--- a/control_plane/workflows/verireel_prod_rollback_worker.py
+++ b/control_plane/workflows/verireel_prod_rollback_worker.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import click
+
+from control_plane.workflows.verireel_prod_rollback import (
+    VeriReelProdRollbackWorkerRequest,
+    VeriReelProdRollbackWorkerResult,
+)
+from control_plane.workflows.ship import utc_now_timestamp
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    raw_value = os.environ.get(name, "").strip().lower()
+    if not raw_value:
+        return default
+    if raw_value in {"1", "true", "yes", "on"}:
+        return True
+    if raw_value in {"0", "false", "no", "off"}:
+        return False
+    raise click.ClickException(f"Invalid boolean value for {name}: {raw_value}")
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise click.ClickException(f"Missing required env var: {name}")
+    return value
+
+
+def _build_proxmox_command(command_args: list[str]) -> list[str]:
+    if _env_flag("VERIREEL_PROD_GATE_LOCAL", default=False):
+        return ["sudo", "-n", *command_args]
+    host = _required_env("VERIREEL_PROD_PROXMOX_HOST")
+    user = _required_env("VERIREEL_PROD_PROXMOX_USER")
+    return ["ssh", f"{user}@{host}", "sudo", "-n", *command_args]
+
+
+def _run_proxmox_command(command_args: list[str], *, timeout_seconds: int) -> None:
+    completed = subprocess.run(
+        _build_proxmox_command(command_args),
+        capture_output=True,
+        text=True,
+        timeout=max(timeout_seconds, 1),
+        check=False,
+    )
+    if completed.returncode == 0:
+        return
+    detail = completed.stderr.strip() or completed.stdout.strip() or "unknown error"
+    raise click.ClickException(detail)
+
+
+def execute_worker(request: VeriReelProdRollbackWorkerRequest) -> VeriReelProdRollbackWorkerResult:
+    ctid = _required_env("VERIREEL_PROD_CT_ID")
+    started_at = utc_now_timestamp()
+    _run_proxmox_command(
+        ["pct", "rollback", ctid, request.snapshot_name],
+        timeout_seconds=request.timeout_seconds,
+    )
+    if request.start_after_rollback:
+        _run_proxmox_command(
+            ["pct", "start", ctid],
+            timeout_seconds=request.timeout_seconds,
+        )
+    finished_at = utc_now_timestamp()
+    return VeriReelProdRollbackWorkerResult(
+        status="pass",
+        snapshot_name=request.snapshot_name,
+        started_at=started_at,
+        finished_at=finished_at,
+        detail=f"Rolled back prod CT {ctid} to snapshot {request.snapshot_name}.",
+    )
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+        request = VeriReelProdRollbackWorkerRequest.model_validate(payload)
+        result = execute_worker(request)
+        sys.stdout.write(f"{result.model_dump_json()}\n")
+    except Exception as exc:  # noqa: BLE001
+        message = str(exc)
+        failure = VeriReelProdRollbackWorkerResult(
+            status="fail",
+            snapshot_name=str(getattr(locals().get("request", None), "snapshot_name", "") or ""),
+            started_at="",
+            finished_at=utc_now_timestamp(),
+            detail=message,
+        )
+        sys.stdout.write(f"{failure.model_dump_json()}\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/control_plane/workflows/verireel_stable_deploy.py
+++ b/control_plane/workflows/verireel_stable_deploy.py
@@ -14,31 +14,34 @@ from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.ship import build_deployment_record, generate_deployment_record_id, utc_now_timestamp
 
 
-class VeriReelTestingDeployRequest(BaseModel):
+StableInstanceName = Literal["testing", "prod"]
+
+
+class VeriReelStableDeployRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     schema_version: int = Field(default=1, ge=1)
     context: str = "verireel"
-    instance: str = "testing"
+    instance: StableInstanceName = "testing"
     artifact_id: str
     source_git_ref: str
     timeout_seconds: int | None = Field(default=None, ge=1)
     no_cache: bool = False
 
     @model_validator(mode="after")
-    def _validate_request(self) -> "VeriReelTestingDeployRequest":
+    def _validate_request(self) -> "VeriReelStableDeployRequest":
         if self.context != "verireel":
-            raise ValueError("VeriReel testing deploy requires context 'verireel'.")
-        if self.instance != "testing":
-            raise ValueError("VeriReel testing deploy requires instance 'testing'.")
+            raise ValueError("VeriReel stable deploy requires context 'verireel'.")
+        if self.instance not in {"testing", "prod"}:
+            raise ValueError("VeriReel stable deploy requires instance 'testing' or 'prod'.")
         if not self.artifact_id.strip():
-            raise ValueError("VeriReel testing deploy requires artifact_id.")
+            raise ValueError("VeriReel stable deploy requires artifact_id.")
         if not self.source_git_ref.strip():
-            raise ValueError("VeriReel testing deploy requires source_git_ref.")
+            raise ValueError("VeriReel stable deploy requires source_git_ref.")
         return self
 
 
-class VeriReelTestingDeployResult(BaseModel):
+class VeriReelStableDeployResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     deployment_record_id: str
@@ -57,13 +60,20 @@ def _resolve_deploy_mode(*, configured_ship_mode: str, target_type: str) -> str:
     return f"dokploy-{configured_ship_mode}-api"
 
 
-def _fallback_ship_request(request: VeriReelTestingDeployRequest) -> ShipRequest:
+def _default_target_name_for_instance(instance_name: StableInstanceName) -> str:
+    return {
+        "testing": "ver-testing-app",
+        "prod": "ver-prod-app",
+    }[instance_name]
+
+
+def _fallback_ship_request(request: VeriReelStableDeployRequest) -> ShipRequest:
     return ShipRequest(
         artifact_id=request.artifact_id,
         context=request.context,
         instance=request.instance,
         source_git_ref=request.source_git_ref,
-        target_name="ver-testing-app",
+        target_name=_default_target_name_for_instance(request.instance),
         target_type="application",
         deploy_mode="dokploy-application-api",
         wait=True,
@@ -77,7 +87,7 @@ def _fallback_ship_request(request: VeriReelTestingDeployRequest) -> ShipRequest
 def _resolve_ship_request(
     *,
     control_plane_root: Path,
-    request: VeriReelTestingDeployRequest,
+    request: VeriReelStableDeployRequest,
 ) -> tuple[ShipRequest, ResolvedTargetEvidence, int]:
     source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
         control_plane_root=control_plane_root,
@@ -108,7 +118,7 @@ def _resolve_ship_request(
         context=request.context,
         instance=request.instance,
         source_git_ref=request.source_git_ref,
-        target_name=target_definition.target_name.strip() or f"{request.context}-{request.instance}",
+        target_name=target_definition.target_name.strip() or _default_target_name_for_instance(request.instance),
         target_type=target_definition.target_type,
         deploy_mode=deploy_mode,
         wait=True,
@@ -160,12 +170,12 @@ def _execute_dokploy_deploy(
     )
 
 
-def execute_verireel_testing_deploy(
+def execute_verireel_stable_deploy(
     *,
     control_plane_root: Path,
     record_store: FilesystemRecordStore,
-    request: VeriReelTestingDeployRequest,
-) -> VeriReelTestingDeployResult:
+    request: VeriReelStableDeployRequest,
+) -> VeriReelStableDeployResult:
     record_id = generate_deployment_record_id(
         context_name=request.context,
         instance_name=request.instance,
@@ -190,7 +200,7 @@ def execute_verireel_testing_deploy(
                 finished_at=finished_at,
             )
         )
-        return VeriReelTestingDeployResult(
+        return VeriReelStableDeployResult(
             deployment_record_id=record_id,
             deploy_status="fail",
             deploy_started_at=started_at,
@@ -233,7 +243,7 @@ def execute_verireel_testing_deploy(
                 resolved_target=resolved_target,
             )
         )
-        return VeriReelTestingDeployResult(
+        return VeriReelStableDeployResult(
             deployment_record_id=record_id,
             deploy_status="fail",
             deploy_started_at=started_at,
@@ -256,7 +266,7 @@ def execute_verireel_testing_deploy(
             resolved_target=resolved_target,
         )
     )
-    return VeriReelTestingDeployResult(
+    return VeriReelStableDeployResult(
         deployment_record_id=record_id,
         deploy_status="pass",
         deploy_started_at=started_at,

--- a/control_plane/workflows/verireel_stable_deploy.py
+++ b/control_plane/workflows/verireel_stable_deploy.py
@@ -7,6 +7,7 @@ import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane import dokploy as control_plane_dokploy
+from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane.contracts.deployment_record import ResolvedTargetEvidence
 from control_plane.contracts.promotion_record import HealthcheckEvidence
 from control_plane.contracts.ship_request import ShipRequest
@@ -102,8 +103,10 @@ def _resolve_ship_request(
             f"No Dokploy target definition found for {request.context}/{request.instance}."
         )
 
-    environment_values = control_plane_dokploy.read_control_plane_environment_values(
+    environment_values = control_plane_runtime_environments.resolve_runtime_environment_values(
         control_plane_root=control_plane_root,
+        context_name=request.context,
+        instance_name=request.instance,
     )
     deploy_mode = _resolve_deploy_mode(
         configured_ship_mode=control_plane_dokploy.resolve_dokploy_ship_mode(

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,9 @@ Use these docs as the source of truth for `launchplane`.
 - [service-boundary.md](service-boundary.md) — Launchplane HTTP ingress, GitHub
   OIDC trust, and first API contracts.
 - [operations.md](operations.md) — operator workflows and runtime boundary rules.
+- [verireel-prod-rollback-runtime.md](verireel-prod-rollback-runtime.md) —
+  proposed runtime contract for moving VeriReel prod rollback behind
+  Launchplane-owned execution.
 - [records.md](records.md) — persisted record formats and storage policy.
 - [public-readiness.md](public-readiness.md) — current blockers and exit criteria
   before making Launchplane public.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,6 +64,10 @@ promotion behavior.
 - Repo-specific variation should enter Launchplane as thin repo extensions,
   declarative config, or small driver inputs, not as a full second copy of the
   same operational workflow in every product repo.
+- When a product-specific operation needs materially different network reach or
+  host-local authority, Launchplane should prefer a narrow delegated worker
+  contract over teaching the main API host to absorb every privileged runtime
+  concern directly.
 
 ## Launchplane Shape Today
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -83,6 +83,7 @@ Current implementation scope:
 - `POST /v1/evidence/previews/generations`
 - `POST /v1/evidence/previews/destroyed`
 - `POST /v1/drivers/verireel/testing-deploy`
+- `POST /v1/drivers/verireel/prod-deploy`
 
 The service currently uses a static authz policy file and GitHub OIDC bearer
 tokens. Additional evidence routes should land against the same authn/authz
@@ -172,10 +173,11 @@ Current derived-state behavior:
   that `context/instance`
 - accepted promotion evidence refreshes destination inventory when the
   promotion record includes valid `deployment_record_id` linkage
-- Launchplane can also execute the first explicit driver action directly:
-  `POST /v1/drivers/verireel/testing-deploy` triggers the shared testing deploy,
-  writes an initial deployment record, and returns deploy timing/status for the
-  caller to thread into later evidence reporting.
+- Launchplane can now execute the first explicit VeriReel driver actions
+  directly: `POST /v1/drivers/verireel/testing-deploy` and
+  `POST /v1/drivers/verireel/prod-deploy` trigger the shared testing and prod
+  deploys, write initial deployment records, and return deploy timing/status for
+  the caller to thread into later verification or promotion evidence.
 
 ## Core Rules
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -164,9 +164,22 @@ uv run launchplane service inspect-dokploy-target \
 
 That command reports only non-secret metadata and fails closed when the live
 Launchplane target is missing critical runtime pieces such as `LAUNCHPLANE_DATABASE_URL`,
-`LAUNCHPLANE_MASTER_ENCRYPTION_KEY`, `DOKPLOY_HOST`, `DOKPLOY_TOKEN`, or a Dokploy
-SSH key for a private `git@github.com:...` compose source. The GitHub deploy
-workflow now runs that same preflight before it builds or deploys a new image.
+`LAUNCHPLANE_MASTER_ENCRYPTION_KEY`, Launchplane-managed Dokploy secret bindings,
+or a Dokploy SSH key for a private `git@github.com:...` compose source. The
+GitHub deploy workflow now runs that same preflight before it builds or deploys
+a new image.
+
+The intended live service contract is now bootstrap-only target env plus
+DB-backed Launchplane records:
+
+- keep bootstrap/process inputs such as `LAUNCHPLANE_DATABASE_URL`,
+  `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`, and policy selectors on the service
+  target
+- move Dokploy credentials into Launchplane-managed secret records
+- move per-context runtime values, ship-mode overrides, preview base URLs, and
+  product-specific worker config into Launchplane runtime-environment records
+- use target-id records in the shared store when possible instead of relying on
+  env-carried target-id catalogs
 
 Two deployment prerequisites remain Dokploy-side operational contracts rather
 than Launchplane CLI validations:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -78,12 +78,14 @@ repo/workflow values before using it.
 Current implementation scope:
 
 - `GET /v1/health`
+- `POST /v1/evidence/backup-gates`
 - `POST /v1/evidence/deployments`
 - `POST /v1/evidence/promotions`
 - `POST /v1/evidence/previews/generations`
 - `POST /v1/evidence/previews/destroyed`
 - `POST /v1/drivers/verireel/testing-deploy`
 - `POST /v1/drivers/verireel/prod-deploy`
+- `POST /v1/drivers/verireel/prod-promotion`
 
 The service currently uses a static authz policy file and GitHub OIDC bearer
 tokens. Additional evidence routes should land against the same authn/authz

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -86,11 +86,13 @@ Current implementation scope:
 - `POST /v1/drivers/verireel/testing-deploy`
 - `POST /v1/drivers/verireel/prod-deploy`
 - `POST /v1/drivers/verireel/prod-promotion`
+- `POST /v1/drivers/verireel/prod-rollback`
 
-VeriReel prod rollback remains outside the current service execution surface.
-That is deliberate: the remaining gap is a privileged runtime contract for
-Proxmox access, not just another request parser. The proposed next boundary is
-documented in [`verireel-prod-rollback-runtime.md`](verireel-prod-rollback-runtime.md).
+VeriReel prod rollback now has a dedicated Launchplane route, but the
+privileged Proxmox path is still intended to stay behind a narrow delegated
+worker contract rather than being absorbed into the main API host. That runtime
+posture is documented in
+[`verireel-prod-rollback-runtime.md`](verireel-prod-rollback-runtime.md).
 
 The service currently uses a static authz policy file and GitHub OIDC bearer
 tokens. Additional evidence routes should land against the same authn/authz

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -87,6 +87,11 @@ Current implementation scope:
 - `POST /v1/drivers/verireel/prod-deploy`
 - `POST /v1/drivers/verireel/prod-promotion`
 
+VeriReel prod rollback remains outside the current service execution surface.
+That is deliberate: the remaining gap is a privileged runtime contract for
+Proxmox access, not just another request parser. The proposed next boundary is
+documented in [`verireel-prod-rollback-runtime.md`](verireel-prod-rollback-runtime.md).
+
 The service currently uses a static authz policy file and GitHub OIDC bearer
 tokens. Additional evidence routes should land against the same authn/authz
 boundary rather than creating separate ad hoc ingress patterns.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -33,6 +33,11 @@ title: Secrets
 - Launchplane preview routing now uses a dedicated `LAUNCHPLANE_PREVIEW_BASE_URL`
   runtime-environment value instead of piggybacking on ordinary live-instance
   web base URLs.
+- VeriReel prod rollback worker dispatch now resolves
+  `LAUNCHPLANE_VERIREEL_PROD_ROLLBACK_WORKER_COMMAND`,
+  `VERIREEL_PROD_PROXMOX_HOST`, `VERIREEL_PROD_PROXMOX_USER`, and
+  `VERIREEL_PROD_CT_ID` from the `verireel/prod` runtime-environment contract,
+  with managed-secret overlays still available for secret-looking keys.
 - If you need a non-default secret file location, set
   `ODOO_CONTROL_PLANE_ENV_FILE` to an alternate untracked env file path.
 - If you need a non-default runtime environments file location, set

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -14,22 +14,19 @@ title: Secrets
   backend when `LAUNCHPLANE_DATABASE_URL` is configured.
 - Managed secret values are encrypted before Launchplane stores them; the master key
   stays outside the database in `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`.
-- Keep existing bootstrap values in the current process environment or in an
-  external Launchplane config file such as
-  `${XDG_CONFIG_HOME:-$HOME/.config}/launchplane/dokploy.env` until they have been
-  imported into Launchplane-managed secret records.
+- Keep existing bootstrap values only long enough to import them into
+  Launchplane-managed secret records, using the current process environment or
+  an external bootstrap file such as
+  `${XDG_CONFIG_HOME:-$HOME/.config}/launchplane/dokploy.env`.
 - Local runtime environment truth should live outside the repo checkout, such
   as `${XDG_CONFIG_HOME:-$HOME/.config}/launchplane/runtime-environments.toml`.
 - Live Dokploy `target_id` values belong in the control-plane repo's untracked
   `config/dokploy-targets.toml`.
-- `DOKPLOY_HOST` and `DOKPLOY_TOKEN` may also be provided through the current
-  process environment.
 - Launchplane can import the current `DOKPLOY_HOST` / `DOKPLOY_TOKEN` values with
   `uv run launchplane secrets import-bootstrap --database-url ...` so the first
   shared-service bring-up does not require manual secret re-entry.
-- Optional ship-mode overrides such as `DOKPLOY_SHIP_MODE` and
-  `DOKPLOY_SHIP_MODE_<CONTEXT>_<INSTANCE>` are also read from the same
-  control-plane env surface.
+- Optional ship-mode overrides such as `DOKPLOY_SHIP_MODE` now belong in
+  runtime-environment records instead of the service host env surface.
 - Launchplane preview routing now uses a dedicated `LAUNCHPLANE_PREVIEW_BASE_URL`
   runtime-environment value instead of piggybacking on ordinary live-instance
   web base URLs.
@@ -56,6 +53,28 @@ title: Secrets
 - Secret status surfaces return metadata only. Launchplane does not expose routine
   plaintext read commands or service endpoints.
 
+## Bootstrap-Only Env
+
+- Treat these as bootstrap/process concerns, not product runtime truth:
+  - `LAUNCHPLANE_DATABASE_URL`
+  - `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`
+  - policy/bootstrap selectors such as `LAUNCHPLANE_POLICY_*`
+  - operator override selectors such as `ODOO_CONTROL_PLANE_ENV_FILE`,
+    `ODOO_CONTROL_PLANE_RUNTIME_ENVIRONMENTS_FILE`,
+    `ODOO_CONTROL_PLANE_DOKPLOY_SOURCE_FILE`, and
+    `ODOO_CONTROL_PLANE_DOKPLOY_TARGET_IDS_FILE`
+- Treat these as DB-backed Launchplane-owned data instead of live service-host
+  env once the shared store is available:
+  - `DOKPLOY_HOST`
+  - `DOKPLOY_TOKEN`
+  - `DOKPLOY_SHIP_MODE`
+  - per-context/runtime values such as `LAUNCHPLANE_PREVIEW_BASE_URL`,
+    `GITHUB_TOKEN`, `GITHUB_WEBHOOK_SECRET`, and tenant/product env keys
+  - rollback worker values such as
+    `LAUNCHPLANE_VERIREEL_PROD_ROLLBACK_WORKER_COMMAND`,
+    `VERIREEL_PROD_PROXMOX_HOST`, `VERIREEL_PROD_PROXMOX_USER`, and
+    `VERIREEL_PROD_CT_ID`
+
 ## Rules
 
 - Do not keep real secret files in the repo checkout.
@@ -68,9 +87,10 @@ title: Secrets
 - Missing Dokploy credentials are a hard error, not a silent fallback.
 - Missing `LAUNCHPLANE_MASTER_ENCRYPTION_KEY` is a hard error when Launchplane needs to
   read or write DB-backed managed secrets.
-- The live Launchplane Dokploy target should expose `LAUNCHPLANE_DATABASE_URL`,
-  `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`, `DOKPLOY_HOST`, and `DOKPLOY_TOKEN` through
-  target env or an equivalent mounted runtime contract.
+- The live Launchplane Dokploy target should expose bootstrap env such as
+  `LAUNCHPLANE_DATABASE_URL` and `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`, while
+  Dokploy credentials and runtime/product values should resolve from
+  Launchplane-managed records instead of target env.
 - Use `uv run launchplane service inspect-dokploy-target ...` to verify that the
   live Launchplane target has the required secret-backed contract without printing
   plaintext secret values.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -172,7 +172,9 @@ event_name: workflow_dispatch
 allowed product: verireel
 allowed contexts: verireel
 allowed actions:
+  - backup_gate.write
   - verireel_prod_deploy.execute
+  - verireel_prod_promotion.execute
   - deployment.write
   - promotion.write
 ```

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -26,18 +26,24 @@ The first service slice is now implemented locally in this repo:
 - CLI: `uv run launchplane service serve`
 - health route: `GET /v1/health`
 - authenticated evidence routes:
+  - `POST /v1/evidence/backup-gates`
   - `POST /v1/evidence/deployments`
   - `POST /v1/evidence/promotions`
   - `POST /v1/evidence/previews/generations`
   - `POST /v1/evidence/previews/destroyed`
-- first driver route:
+- product driver routes:
   - `POST /v1/drivers/verireel/testing-deploy`
+  - `POST /v1/drivers/verireel/prod-deploy`
+  - `POST /v1/drivers/verireel/prod-promotion`
+  - `POST /v1/drivers/verireel/preview-refresh`
+  - `POST /v1/drivers/verireel/preview-destroy`
 
-That slice now covers the first documented evidence surface end to end plus the
-first explicit Launchplane-owned driver action. Launchplane can verify GitHub OIDC,
-authorize workflow identity claims, accept deployment/promotion/preview
-lifecycle evidence over HTTP, and execute the VeriReel shared testing deploy as
-an authenticated Launchplane route.
+That slice now covers the first documented evidence surface end to end plus
+the current VeriReel-specific driver routes. Launchplane can verify GitHub
+OIDC, authorize workflow identity claims, accept
+deployment/promotion/preview lifecycle evidence over HTTP, and execute the
+current VeriReel deploy, promotion, and preview mutations as authenticated
+Launchplane routes.
 
 ## First Host Assumption
 
@@ -182,6 +188,7 @@ writes, not on every possible operator action.
 ### Evidence ingress endpoints
 
 - `POST /v1/evidence/deployments`
+- `POST /v1/evidence/backup-gates`
 - `POST /v1/evidence/promotions`
 - `POST /v1/evidence/previews/generations`
 - `POST /v1/evidence/previews/destroyed`
@@ -216,6 +223,7 @@ The first explicit driver routes now in service are:
 
 - `POST /v1/drivers/verireel/testing-deploy`
 - `POST /v1/drivers/verireel/prod-deploy`
+- `POST /v1/drivers/verireel/prod-promotion`
 - `POST /v1/drivers/verireel/preview-refresh`
 - `POST /v1/drivers/verireel/preview-destroy`
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -35,6 +35,7 @@ The first service slice is now implemented locally in this repo:
   - `POST /v1/drivers/verireel/testing-deploy`
   - `POST /v1/drivers/verireel/prod-deploy`
   - `POST /v1/drivers/verireel/prod-promotion`
+  - `POST /v1/drivers/verireel/prod-rollback`
   - `POST /v1/drivers/verireel/preview-refresh`
   - `POST /v1/drivers/verireel/preview-destroy`
 
@@ -175,6 +176,7 @@ allowed actions:
   - backup_gate.write
   - verireel_prod_deploy.execute
   - verireel_prod_promotion.execute
+  - verireel_prod_rollback.execute
   - deployment.write
   - promotion.write
 ```
@@ -226,6 +228,7 @@ The first explicit driver routes now in service are:
 - `POST /v1/drivers/verireel/testing-deploy`
 - `POST /v1/drivers/verireel/prod-deploy`
 - `POST /v1/drivers/verireel/prod-promotion`
+- `POST /v1/drivers/verireel/prod-rollback`
 - `POST /v1/drivers/verireel/preview-refresh`
 - `POST /v1/drivers/verireel/preview-destroy`
 
@@ -233,10 +236,11 @@ The first preview driver cut stays intentionally narrow: Launchplane owns previe
 runtime refresh and teardown, while VeriReel still owns image build/publish,
 browser verification, and the follow-up preview evidence write.
 
-The remaining VeriReel prod rollback tail is intentionally not yet folded into
-that driver list. It needs a privileged runtime contract for Proxmox access,
-not only another HTTP route. The current proposed execution model and decision
-points are captured in [`verireel-prod-rollback-runtime.md`](verireel-prod-rollback-runtime.md).
+VeriReel prod rollback now has a dedicated Launchplane driver route, but it
+still depends on a privileged delegated-worker runtime contract for Proxmox
+access rather than folding that authority into the main API host. The runtime
+posture and remaining decisions are captured in
+[`verireel-prod-rollback-runtime.md`](verireel-prod-rollback-runtime.md).
 
 Do not generalize the full driver surface before a few product-specific routes
 have proven the shape.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -233,6 +233,11 @@ The first preview driver cut stays intentionally narrow: Launchplane owns previe
 runtime refresh and teardown, while VeriReel still owns image build/publish,
 browser verification, and the follow-up preview evidence write.
 
+The remaining VeriReel prod rollback tail is intentionally not yet folded into
+that driver list. It needs a privileged runtime contract for Proxmox access,
+not only another HTTP route. The current proposed execution model and decision
+points are captured in [`verireel-prod-rollback-runtime.md`](verireel-prod-rollback-runtime.md).
+
 Do not generalize the full driver surface before a few product-specific routes
 have proven the shape.
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -76,8 +76,9 @@ temporary repo or local CLI name.
 
 ## Authorization Model
 
-Launchplane should authorize machine callers from workflow identity claims, not from
-human repo-admin status and not from copied long-lived service tokens.
+Launchplane should authorize machine callers from workflow identity claims,
+not from human repo-admin status and not from copied long-lived service
+tokens.
 
 The first policy model should be allow-list based and fail closed.
 
@@ -165,6 +166,7 @@ event_name: workflow_dispatch
 allowed product: verireel
 allowed contexts: verireel
 allowed actions:
+  - verireel_prod_deploy.execute
   - deployment.write
   - promotion.write
 ```
@@ -198,9 +200,10 @@ writes, not on every possible operator action.
 
 These operator reads use the same Launchplane authn/authz boundary as evidence
 ingress. The intent is to give operators a minimal typed read surface for the
-current Launchplane record nouns without forcing them to infer state from workflow
-logs or host-local files. Secret status reads return metadata only: Launchplane does
-not expose plaintext secret retrieval through the service boundary.
+current Launchplane record nouns without forcing them to infer state from
+workflow logs or host-local files. Secret status reads return metadata only:
+Launchplane does not expose plaintext secret retrieval through the service
+boundary.
 
 ### Driver execution endpoints
 
@@ -212,6 +215,7 @@ These use the same authn/authz boundary as evidence ingress:
 The first explicit driver routes now in service are:
 
 - `POST /v1/drivers/verireel/testing-deploy`
+- `POST /v1/drivers/verireel/prod-deploy`
 - `POST /v1/drivers/verireel/preview-refresh`
 - `POST /v1/drivers/verireel/preview-destroy`
 
@@ -227,7 +231,8 @@ have proven the shape.
 - Requests and responses are JSON.
 - Evidence endpoints should be idempotent from Launchplane's perspective when the
   same product/workflow submits the same stable identity twice.
-- Launchplane should support an explicit idempotency key header for workflow retries.
+- Launchplane should support an explicit idempotency key header for workflow
+  retries.
 - Launchplane should return durable record identifiers, not local file paths.
 - Launchplane should include a request or trace id in every response.
 
@@ -237,22 +242,27 @@ Recommended first headers:
 - `Content-Type: application/json`
 - `Idempotency-Key: <stable-retry-key>`
 
-The current Launchplane service implementation now honors `Idempotency-Key` for all
-write routes. Launchplane replays the first successful accepted response when the
-same authenticated workflow scope retries the same route with the same key and
-the same request fingerprint. Launchplane rejects reuse of the same key for a
-different payload on the same route.
+The current Launchplane service implementation now honors `Idempotency-Key`
+for all write routes. Launchplane replays the first successful accepted
+response when the same authenticated workflow scope retries the same route
+with the same key and the same request fingerprint. Launchplane rejects reuse
+of the same key for a different payload on the same route.
 
 Current VeriReel key shapes:
 
 - preview generation: `preview-generation:<product>:<context>:<anchor_repo>:<pr_number>:<sha>`
 - preview destroy: `preview-destroyed:<product>:<context>:<anchor_repo>:<pr_number>:<destroy_reason>`
-- VeriReel preview refresh driver: `verireel-preview-refresh:<product>:<context>:<anchor_repo>:<pr_number>:<sha>`
-- VeriReel preview destroy driver: `verireel-preview-destroy:<product>:<context>:<anchor_repo>:<pr_number>:<destroy_reason>`
+- VeriReel preview refresh driver:
+  `verireel-preview-refresh:<product>:<context>:<anchor_repo>:<pr_number>:<sha>`
+- VeriReel preview destroy driver:
+  `verireel-preview-destroy:<product>:<context>:<anchor_repo>:<pr_number>:<destroy_reason>`
 - testing deployment evidence: `testing-deployment:<product>:<context>:<instance>:<record_id>`
 - prod deployment evidence: `prod-deployment:<product>:<context>:<instance>:<record_id>`
 - prod promotion evidence: `prod-promotion:<product>:<context>:<from_instance>:<to_instance>:<record_id>`
-- VeriReel testing deploy driver: `verireel-testing-deploy:<product>:<context>:<instance>:<artifact_id>:<source_git_ref>`
+- VeriReel testing deploy driver:
+  `verireel-testing-deploy:<product>:<context>:<instance>:<artifact_id>:<source_git_ref>`
+- VeriReel prod deploy driver:
+  `verireel-prod-deploy:<product>:<context>:<instance>:<artifact_id>:<source_git_ref>`
 
 Recommended first success shape:
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -271,6 +271,8 @@ Current VeriReel key shapes:
   `verireel-testing-deploy:<product>:<context>:<instance>:<artifact_id>:<source_git_ref>`
 - VeriReel prod deploy driver:
   `verireel-prod-deploy:<product>:<context>:<instance>:<artifact_id>:<source_git_ref>`
+- VeriReel prod promotion driver:
+  `verireel-prod-promotion:<product>:<context>:<from_instance>:<to_instance>:<artifact_id>:<source_git_ref>:<backup_record_id>:<promotion_record_id>:<expected_build_revision>:<expected_build_tag>`
 
 Recommended first success shape:
 

--- a/docs/verireel-prod-rollback-runtime.md
+++ b/docs/verireel-prod-rollback-runtime.md
@@ -1,0 +1,286 @@
+---
+title: VeriReel Prod Rollback Runtime
+---
+
+## Purpose
+
+This document defines the next Launchplane boundary required to move VeriReel
+production rollback behind Launchplane-owned execution.
+
+The current gap is no longer about deploy or promotion evidence. Launchplane now
+owns VeriReel prod deploy, rollout verification, Prisma migration, and final
+post-migration health verification. The remaining repo-owned operational tail is
+rollback after failed final health.
+
+That rollback path currently depends on repo-local runtime assumptions:
+
+- a dedicated GitHub self-hosted runner label
+- repo-local `.env` default loading
+- direct Proxmox `ssh`, `sudo`, and `pct rollback` execution
+
+This document exists to turn that tail into an explicit Launchplane runtime
+contract instead of letting those assumptions leak across the service boundary.
+
+## Current State
+
+Today the rollback path lives in VeriReel's product repo:
+
+- workflow: `.github/workflows/promote-image.yml`
+- implementation: `scripts/ops/prod-gate.mjs`
+
+That path currently does four jobs:
+
+1. resolve Proxmox connection and container inputs
+2. locate or accept the stored rollback point
+3. execute `pct rollback` through SSH and sudo on the Proxmox host
+4. verify that production is healthy after rollback
+
+Launchplane does not yet own the runtime authority needed for step 3, even
+though it now owns the surrounding promotion transaction.
+
+## Goal
+
+Move VeriReel prod rollback into Launchplane so that:
+
+- the product workflow sends an authenticated rollback request rather than
+  shelling into Proxmox directly
+- Launchplane owns the rollback result, timestamps, and operator-visible
+  evidence
+- rollback failure and rollback-health failure remain distinct recorded states
+- Launchplane, not the repo, owns the secret and runtime contract needed to
+  reach Proxmox safely
+
+## Non-Goals
+
+- building a generic arbitrary remote shell framework
+- moving GitHub release publication into Launchplane
+- rewriting the already-landed prod promotion flow
+- forcing a cross-product rollback abstraction before the VeriReel path proves
+  the execution model
+
+## Runtime Model Options
+
+### Option A: direct Launchplane host execution
+
+Launchplane itself would hold the SSH and sudo contract needed to reach the
+Proxmox host and run rollback commands.
+
+Pros:
+
+- simple request path
+- no second runtime to coordinate
+- easier end-to-end traceability inside one service
+
+Cons:
+
+- couples the main Launchplane service host to Proxmox network reach and sudo
+  authority
+- raises the blast radius of a Launchplane compromise
+- makes future runtime separation harder if more products need privileged ops
+
+### Option B: Launchplane-owned delegated worker
+
+Launchplane would remain the control-plane ingress and record owner, but it
+would dispatch rollback execution to a Launchplane-controlled worker that holds
+the Proxmox network and sudo contract.
+
+Pros:
+
+- keeps the main Launchplane service boundary narrower
+- matches the reality that rollback has a different trust and network profile
+  than HTTP evidence ingress
+- creates a reusable shape for future privileged stable-lane actions without
+  making the API server itself the privileged host
+
+Cons:
+
+- adds a worker runtime contract and dispatch path
+- requires explicit job/result handoff between service and worker
+
+### Option C: keep GitHub runner execution but rebrand it as Launchplane
+
+Launchplane would still depend on the repo-triggered GitHub runner to perform
+rollback, with Launchplane only coordinating or recording the request.
+
+This is not recommended. It keeps the core operational dependency where it is
+today and only moves names around.
+
+## Recommended Direction
+
+Prefer **Option B: Launchplane-owned delegated worker**.
+
+The reason is boundary discipline. VeriReel rollback needs privileged network
+reach and host-local behavior that are materially different from Launchplane's
+normal service ingress. A delegated worker lets Launchplane own the operation
+without making the API server itself the privileged execution host.
+
+That still leaves room to start with a very small worker surface:
+
+- accept a single Launchplane-issued rollback job shape
+- execute a constrained Proxmox rollback command set
+- return structured result data only
+
+If operational reality later proves that the main Launchplane host is already the
+right privileged environment, the worker contract can collapse inward. The
+reverse move would be harder.
+
+## Proposed Boundary
+
+```text
+GitHub workflow
+  -> Launchplane OIDC-authenticated rollback request
+  -> Launchplane authn/authz and record creation
+  -> Launchplane rollback dispatcher
+  -> Launchplane-owned rollback worker
+  -> Proxmox host via SSH/sudo
+  -> Launchplane post-rollback health verification
+  -> durable rollback result on the promotion record
+```
+
+The product workflow should stop owning Proxmox SSH and sudo behavior. It
+should own only:
+
+- the decision to request rollback after failed final prod health
+- the authenticated Launchplane request
+- any remaining GitHub-only concerns such as release publication
+
+## Proposed Route Shape
+
+Two shapes are reasonable:
+
+### Shape 1: dedicated rollback driver
+
+- `POST /v1/drivers/verireel/prod-rollback`
+
+Use this when the repo workflow remains responsible for deciding whether to roll
+back after a failed promotion.
+
+Recommended request inputs:
+
+- `context`
+- `instance`
+- `promotion_record_id`
+- `backup_record_id`
+- `rollback_record_id` or idempotency key
+- `expected_build_revision` and `expected_build_tag` for post-rollback checks
+- optional explicit snapshot reference when the stored backup gate points at
+  more than one rollback candidate
+
+Recommended result fields:
+
+- `rollback_status`
+- `rollback_health_status`
+- `started_at`
+- `finished_at`
+- `snapshot_name`
+- `error_message`
+
+### Shape 2: rollback branch inside prod promotion
+
+The existing `POST /v1/drivers/verireel/prod-promotion` route would optionally
+perform rollback when final health fails.
+
+Use this only if Launchplane should own the entire production finalize
+transaction as one atomic control-plane action.
+
+This can be attractive later, but it couples the current next slice to a bigger
+transactional decision. The dedicated rollback driver is the cleaner immediate
+fit.
+
+## Secret And Config Contract
+
+The rollback secret/config surface should move into Launchplane-owned runtime
+configuration rather than product-repo `.env` defaults.
+
+Required runtime inputs:
+
+- `VERIREEL_PROD_PROXMOX_HOST`
+- `VERIREEL_PROD_PROXMOX_USER`
+- `VERIREEL_PROD_CT_ID`
+- allowed sudo command contract for `pct rollback`
+- SSH private key or equivalent Launchplane-managed credential
+- host key trust policy
+- snapshot prefix and retention policy when Launchplane later also owns capture
+
+Rules:
+
+- do not read rollback authority from a repo-local `.env`
+- do not make GitHub Actions the long-term source of privileged rollback
+  secrets once Launchplane owns execution
+- keep the live privileged contract outside the checked-in repo, with metadata
+  visible through Launchplane read surfaces but plaintext secret values hidden
+
+## Record And Evidence Shape
+
+Rollback should become durable Launchplane state, not just a workflow log.
+
+Minimum required distinctions:
+
+- `rollback_status=pass|fail|skipped`
+- `rollback_health_status=pass|fail|skipped`
+- rollback target metadata
+- rollback snapshot metadata
+- rollback timestamps
+- structured error message or failure detail
+
+The important rule is that these states must not collapse into one generic
+promotion failure. Operators need to distinguish:
+
+- deploy failed
+- rollout failed
+- migration failed
+- final health failed
+- rollback command failed
+- rollback completed but health stayed failed
+
+The existing promotion record may be sufficient if it gains explicit rollback
+fields. If not, add a dedicated rollback record linked from the promotion.
+
+## Worker Constraints
+
+If Launchplane uses a delegated worker, keep the first worker contract narrow.
+
+Allowed responsibilities:
+
+- fetch or receive a typed rollback job
+- execute the constrained Proxmox rollback command path
+- return structured command/result status
+
+Not allowed in the first cut:
+
+- arbitrary shell access
+- product-repo checkout and `.env` loading
+- direct GitHub decision-making
+- broad infrastructure mutation outside the constrained rollback path
+
+## Testing And Validation
+
+Required validation before implementation is considered complete:
+
+- Launchplane unit tests for rollback request parsing and result shaping
+- driver tests for rollback success
+- driver tests for rollback command failure
+- driver tests for rollback success followed by failed health verification
+- failure tests for missing or invalid snapshot metadata
+- request-client tests in VeriReel for surfaced rollback statuses
+- workflow YAML parse after repo rollback-job simplification
+- one operator dry-run against the real Proxmox path
+
+## Open Decisions
+
+- Should rollback remain a dedicated explicit driver or move into prod-promotion
+  once the runtime contract is proven?
+- Does the first worker execute only VeriReel prod rollback, or is the worker
+  contract named more generally from day one?
+- When Launchplane later owns snapshot capture too, should backup and rollback
+  share one privileged worker contract or remain separate operations?
+
+## Immediate Next Step
+
+Before writing code, choose the execution posture explicitly:
+
+- **preferred**: Launchplane-owned delegated worker
+- **acceptable only with explicit approval**: direct Launchplane host execution
+
+Once that decision is made, the next implementation doc should define the exact
+job payload, record schema, and authz action names for the first rollback route.

--- a/docs/verireel-prod-rollback-runtime.md
+++ b/docs/verireel-prod-rollback-runtime.md
@@ -204,10 +204,24 @@ Required runtime inputs:
 - `VERIREEL_PROD_PROXMOX_HOST`
 - `VERIREEL_PROD_PROXMOX_USER`
 - `VERIREEL_PROD_CT_ID`
+- `LAUNCHPLANE_VERIREEL_PROD_ROLLBACK_WORKER_COMMAND`
 - allowed sudo command contract for `pct rollback`
 - SSH private key or equivalent Launchplane-managed credential
 - host key trust policy
 - snapshot prefix and retention policy when Launchplane later also owns capture
+
+Launchplane now resolves the rollback worker contract from the `verireel/prod`
+runtime-environment definition before invoking the delegated worker. That means
+the worker command and Proxmox target metadata can live in the existing
+runtime-environment file or in DB-backed runtime-environment records, with any
+secret-looking values overlaid from Launchplane-managed secret records when the
+service is running with `LAUNCHPLANE_DATABASE_URL` and
+`LAUNCHPLANE_MASTER_ENCRYPTION_KEY`.
+
+For compatibility during migration, Launchplane still falls back to inherited
+process env when those rollback worker keys are not present in the runtime
+environment contract yet. The intended end state remains Launchplane-owned
+runtime records plus managed secrets, not ad hoc service-host env.
 
 Rules:
 

--- a/docs/verireel-prod-rollback-runtime.md
+++ b/docs/verireel-prod-rollback-runtime.md
@@ -109,6 +109,13 @@ today and only moves names around.
 
 Prefer **Option B: Launchplane-owned delegated worker**.
 
+This is now the locked direction for the first implementation cut. The first
+rollback route should be a dedicated driver,
+`POST /v1/drivers/verireel/prod-rollback`, with Launchplane owning request
+authorization, durable rollback state, and post-rollback health verification,
+while a narrow Launchplane-owned worker owns the privileged Proxmox rollback
+command path.
+
 The reason is boundary discipline. VeriReel rollback needs privileged network
 reach and host-local behavior that are materially different from Launchplane's
 normal service ingress. A delegated worker lets Launchplane own the operation
@@ -184,8 +191,8 @@ Use this only if Launchplane should own the entire production finalize
 transaction as one atomic control-plane action.
 
 This can be attractive later, but it couples the current next slice to a bigger
-transactional decision. The dedicated rollback driver is the cleaner immediate
-fit.
+transactional decision. The dedicated rollback driver is the locked immediate
+fit for the first implementation cut.
 
 ## Secret And Config Contract
 
@@ -266,21 +273,25 @@ Required validation before implementation is considered complete:
 - workflow YAML parse after repo rollback-job simplification
 - one operator dry-run against the real Proxmox path
 
-## Open Decisions
+## Remaining Decisions
 
-- Should rollback remain a dedicated explicit driver or move into prod-promotion
-  once the runtime contract is proven?
-- Does the first worker execute only VeriReel prod rollback, or is the worker
-  contract named more generally from day one?
+- Should rollback remain a dedicated explicit driver long-term, or move into
+  prod-promotion once the runtime contract is proven?
 - When Launchplane later owns snapshot capture too, should backup and rollback
   share one privileged worker contract or remain separate operations?
 
 ## Immediate Next Step
 
-Before writing code, choose the execution posture explicitly:
+The execution posture is now chosen:
 
-- **preferred**: Launchplane-owned delegated worker
-- **acceptable only with explicit approval**: direct Launchplane host execution
+- use a Launchplane-owned delegated worker
+- do not keep GitHub as the privileged rollback execution plane
+- do not fold privileged Proxmox authority into the main Launchplane API host
 
-Once that decision is made, the next implementation doc should define the exact
-job payload, record schema, and authz action names for the first rollback route.
+The next implementation work should define and ship the exact job payload,
+record schema, authz action names, and worker command contract for the first
+rollback route.
+
+That first route now exists as `POST /v1/drivers/verireel/prod-rollback`.
+Launchplane still requires explicit worker runtime configuration before the
+route can execute real Proxmox rollback operations outside tests.

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -623,7 +623,7 @@ target_id = "compose-456"
         self.assertEqual(host, "https://dokploy.control-plane.example")
         self.assertEqual(token, "control-plane-token")
 
-    def test_read_dokploy_config_uses_process_environment_over_file(self) -> None:
+    def test_read_dokploy_config_runtime_ignores_process_environment_over_file(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
             (control_plane_root / ".env").write_text(
@@ -641,8 +641,8 @@ target_id = "compose-456"
             ):
                 host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
 
-        self.assertEqual(host, "https://dokploy.process.example")
-        self.assertEqual(token, "process-token")
+        self.assertEqual(host, "https://dokploy.control-plane.example")
+        self.assertEqual(token, "control-plane-token")
 
     def test_read_dokploy_config_supports_explicit_control_plane_env_file(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -690,7 +690,7 @@ target_id = "compose-456"
         self.assertEqual(host, "https://dokploy.external.example")
         self.assertEqual(token, "external-token")
 
-    def test_read_control_plane_environment_values_includes_process_overrides(self) -> None:
+    def test_read_control_plane_bootstrap_environment_values_includes_process_overrides(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
             (control_plane_root / ".env").write_text(
@@ -705,11 +705,34 @@ target_id = "compose-456"
                 },
                 clear=True,
             ):
-                environment_values = control_plane_dokploy.read_control_plane_environment_values(
+                environment_values = control_plane_dokploy.read_control_plane_bootstrap_environment_values(
                     control_plane_root=control_plane_root
                 )
 
         self.assertEqual(environment_values["DOKPLOY_SHIP_MODE"], "application")
+
+    def test_read_control_plane_environment_values_runtime_ignores_process_overrides(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            (control_plane_root / ".env").write_text(
+                "DOKPLOY_HOST=https://dokploy.file.example\nDOKPLOY_TOKEN=file-token\n",
+                encoding="utf-8",
+            )
+
+            with patch.dict(
+                os.environ,
+                {
+                    "DOKPLOY_HOST": "https://dokploy.process.example",
+                    "DOKPLOY_TOKEN": "process-token",
+                },
+                clear=True,
+            ):
+                environment_values = control_plane_dokploy.read_control_plane_environment_values(
+                    control_plane_root=control_plane_root
+                )
+
+        self.assertEqual(environment_values["DOKPLOY_HOST"], "https://dokploy.file.example")
+        self.assertEqual(environment_values["DOKPLOY_TOKEN"], "file-token")
 
     def test_read_dokploy_config_fails_closed_without_control_plane_secret_source(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -10,6 +10,12 @@ from click.testing import CliRunner
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane.cli import main
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.storage.postgres import PostgresRecordStore
+
+
+def _sqlite_database_url(database_path: Path) -> str:
+    return f"sqlite+pysqlite:///{database_path}"
 
 
 class DokployConfigTests(unittest.TestCase):
@@ -221,6 +227,189 @@ target_id = "compose-123"
 
         self.assertEqual(len(source_of_truth.targets), 1)
         self.assertEqual(source_of_truth.targets[0].target_id, "compose-123")
+
+    def test_read_control_plane_dokploy_source_of_truth_merges_postgres_target_ids_over_file_catalog(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            source_file = control_plane_root / "config" / "dokploy.toml"
+            target_ids_file = control_plane_root / "config" / "dokploy-targets.toml"
+            source_file.parent.mkdir(parents=True, exist_ok=True)
+            source_file.write_text(
+                """
+schema_version = 2
+
+[[targets]]
+context = "opw"
+instance = "prod"
+target_type = "compose"
+
+[[targets]]
+context = "cm"
+instance = "testing"
+target_type = "compose"
+""".strip(),
+                encoding="utf-8",
+            )
+            target_ids_file.write_text(
+                """
+schema_version = 1
+
+[[targets]]
+context = "opw"
+instance = "prod"
+target_id = "compose-file"
+""".strip(),
+                encoding="utf-8",
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_dokploy_target_id_record(
+                DokployTargetIdRecord(
+                    context="opw",
+                    instance="prod",
+                    target_id="compose-db",
+                    updated_at="2026-04-21T19:00:00Z",
+                    source_label="import:test",
+                )
+            )
+            store.write_dokploy_target_id_record(
+                DokployTargetIdRecord(
+                    context="cm",
+                    instance="testing",
+                    target_id="compose-cm-db",
+                    updated_at="2026-04-21T19:00:00Z",
+                    source_label="import:test",
+                )
+            )
+            store.close()
+
+            with patch.dict(os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True):
+                source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
+                    control_plane_root=control_plane_root
+                )
+
+        self.assertEqual([(target.context, target.instance, target.target_id) for target in source_of_truth.targets], [("opw", "prod", "compose-db"), ("cm", "testing", "compose-cm-db")])
+
+    def test_read_control_plane_dokploy_source_of_truth_explicit_target_id_catalog_wins_over_postgres(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            source_file = control_plane_root / "config" / "dokploy.toml"
+            explicit_target_ids_file = control_plane_root / "tmp" / "dokploy-targets.toml"
+            source_file.parent.mkdir(parents=True, exist_ok=True)
+            explicit_target_ids_file.parent.mkdir(parents=True, exist_ok=True)
+            source_file.write_text(
+                """
+schema_version = 2
+
+[[targets]]
+context = "opw"
+instance = "prod"
+target_type = "compose"
+""".strip(),
+                encoding="utf-8",
+            )
+            explicit_target_ids_file.write_text(
+                """
+schema_version = 1
+
+[[targets]]
+context = "opw"
+instance = "prod"
+target_id = "compose-file"
+""".strip(),
+                encoding="utf-8",
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_dokploy_target_id_record(
+                DokployTargetIdRecord(
+                    context="opw",
+                    instance="prod",
+                    target_id="compose-db",
+                    updated_at="2026-04-21T19:00:00Z",
+                    source_label="import:test",
+                )
+            )
+            store.close()
+
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_DATABASE_URL": database_url,
+                    control_plane_dokploy.CONTROL_PLANE_DOKPLOY_TARGET_IDS_FILE_ENV_VAR: str(explicit_target_ids_file),
+                },
+                clear=True,
+            ):
+                source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
+                    control_plane_root=control_plane_root
+                )
+
+        self.assertEqual(source_of_truth.targets[0].target_id, "compose-file")
+
+    def test_storage_import_dokploy_target_ids_writes_records_to_postgres(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            source_file = control_plane_root / "config" / "dokploy.toml"
+            target_ids_file = control_plane_root / "config" / "dokploy-targets.toml"
+            source_file.parent.mkdir(parents=True, exist_ok=True)
+            source_file.write_text(
+                """
+schema_version = 2
+
+[[targets]]
+context = "opw"
+instance = "prod"
+target_type = "compose"
+
+[[targets]]
+context = "cm"
+instance = "testing"
+target_type = "compose"
+""".strip(),
+                encoding="utf-8",
+            )
+            target_ids_file.write_text(
+                """
+schema_version = 1
+
+[[targets]]
+context = "opw"
+instance = "prod"
+target_id = "compose-123"
+
+[[targets]]
+context = "cm"
+instance = "testing"
+target_id = "compose-456"
+""".strip(),
+                encoding="utf-8",
+            )
+
+            result = runner.invoke(
+                main,
+                [
+                    "storage",
+                    "import-dokploy-target-ids",
+                    "--database-url",
+                    database_url,
+                    "--control-plane-root",
+                    str(control_plane_root),
+                ],
+            )
+
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            listed_records = store.list_dokploy_target_id_records()
+            store.close()
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["count"], 2)
+        self.assertEqual([(record.context, record.instance, record.target_id) for record in listed_records], [("cm", "testing", "compose-456"), ("opw", "prod", "compose-123")])
 
     def test_read_control_plane_dokploy_source_of_truth_prefers_explicit_source_file(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 from control_plane.cli import main
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.idempotency_record import build_launchplane_idempotency_record_id
@@ -22,6 +23,7 @@ from control_plane.contracts.promotion_record import (
     PromotionRecord,
 )
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.contracts.secret_record import SecretAuditEvent, SecretBinding, SecretRecord, SecretVersion
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
@@ -93,6 +95,33 @@ def _inventory_record() -> EnvironmentInventory:
         ),
         updated_at="2026-04-20T15:33:00Z",
         deployment_record_id="deployment-20260420T153000Z-opw-testing",
+    )
+
+
+def _dokploy_target_id_record(*, context: str = "opw", instance: str = "prod", target_id: str = "compose-123") -> DokployTargetIdRecord:
+    return DokployTargetIdRecord(
+        context=context,
+        instance=instance,
+        target_id=target_id,
+        updated_at="2026-04-21T18:30:00Z",
+        source_label="import:test",
+    )
+
+
+def _runtime_environment_record(
+    *,
+    scope: str = "instance",
+    context: str = "opw",
+    instance: str = "local",
+    env: dict[str, str | int | float | bool] | None = None,
+) -> RuntimeEnvironmentRecord:
+    return RuntimeEnvironmentRecord(
+        scope=scope,
+        context=context if scope != "global" else "",
+        instance=instance if scope == "instance" else "",
+        env=env or {"ODOO_DB_PASSWORD": "local-secret"},
+        updated_at="2026-04-21T18:30:00Z",
+        source_label="import:test",
     )
 
 
@@ -343,6 +372,45 @@ class PostgresRecordStoreTests(unittest.TestCase):
                 "preview-verireel-testing-verireel-pr-102",
                 "preview-verireel-testing-verireel-pr-103",
             ],
+        )
+
+    def test_write_and_list_dokploy_target_id_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+            store.write_dokploy_target_id_record(
+                _dokploy_target_id_record(context="opw", instance="prod", target_id="compose-123")
+            )
+            store.write_dokploy_target_id_record(
+                _dokploy_target_id_record(context="cm", instance="testing", target_id="compose-456")
+            )
+            loaded_record = store.read_dokploy_target_id_record(context_name="opw", instance_name="prod")
+            listed_records = store.list_dokploy_target_id_records()
+            store.close()
+
+        self.assertEqual(loaded_record.target_id, "compose-123")
+        self.assertEqual([(record.context, record.instance) for record in listed_records], [("cm", "testing"), ("opw", "prod")])
+
+    def test_write_and_list_runtime_environment_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+            store.write_runtime_environment_record(
+                _runtime_environment_record(scope="global", env={"ODOO_MASTER_PASSWORD": "shared-master"})
+            )
+            store.write_runtime_environment_record(
+                _runtime_environment_record(scope="instance", context="opw", instance="local", env={"ODOO_DB_PASSWORD": "local-secret"})
+            )
+            listed_records = store.list_runtime_environment_records()
+            store.close()
+
+        self.assertEqual(
+            [(record.scope, record.context, record.instance) for record in listed_records],
+            [("global", "", ""), ("instance", "opw", "local")],
         )
 
     def test_secret_records_round_trip_and_find_latest(self) -> None:

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -10,6 +10,7 @@ import click
 from click.testing import CliRunner
 
 from control_plane import dokploy as control_plane_dokploy
+from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane.cli import (
     _resolve_dokploy_target,
     _resolve_native_promotion_request,
@@ -2872,20 +2873,22 @@ deploy_timeout_seconds = 7200
 healthcheck_timeout_seconds = 55
 """,
             )
-            control_plane_env_file = repo_root / "control-plane.env"
-            control_plane_env_file.write_text(
-                "\n".join(
-                    (
-                        "ENV_OVERRIDE_CONFIG_PARAM__WEB__BASE__URL=prod.example.com",
-                        "DOKPLOY_SHIP_MODE=auto",
-                    )
-                ),
+            runtime_environments_file = repo_root / "runtime-environments.toml"
+            runtime_environments_file.write_text(
+                """
+schema_version = 1
+
+[contexts.opw.instances.prod.env]
+ENV_OVERRIDE_CONFIG_PARAM__WEB__BASE__URL = "prod.example.com"
+DOKPLOY_SHIP_MODE = "auto"
+""".strip()
+                + "\n",
                 encoding="utf-8",
             )
 
             with patch.dict(os.environ, {
                 control_plane_dokploy.CONTROL_PLANE_DOKPLOY_SOURCE_FILE_ENV_VAR: str(source_file),
-                control_plane_dokploy.CONTROL_PLANE_ENV_FILE_ENV_VAR: str(control_plane_env_file),
+                control_plane_runtime_environments.RUNTIME_ENVIRONMENTS_FILE_ENV_VAR: str(runtime_environments_file),
             }):
                 ship_request = _resolve_native_ship_request(
                     context_name="opw",

--- a/tests/test_release_tuples.py
+++ b/tests/test_release_tuples.py
@@ -9,6 +9,11 @@ from unittest.mock import patch
 from control_plane import release_tuples as control_plane_release_tuples
 from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+from control_plane.storage.postgres import PostgresRecordStore
+
+
+def _sqlite_database_url(database_path: Path) -> str:
+    return f"sqlite+pysqlite:///{database_path}"
 
 
 class ReleaseTupleTests(unittest.TestCase):
@@ -85,6 +90,97 @@ shared-addons = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                 )
 
         self.assertEqual(release_tuple.tuple_id, "cm-prod-2026-04-13")
+
+    def test_load_release_tuple_catalog_merges_postgres_records_over_file_catalog(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            tuples_file = control_plane_root / "config" / "release-tuples.toml"
+            tuples_file.parent.mkdir(parents=True, exist_ok=True)
+            tuples_file.write_text(
+                """
+schema_version = 1
+
+[contexts.opw.channels.testing]
+tuple_id = "opw-testing-file"
+
+[contexts.opw.channels.testing.repo_shas]
+tenant-opw = "1111111111111111111111111111111111111111"
+
+[contexts.opw.channels.prod]
+tuple_id = "opw-prod-file"
+
+[contexts.opw.channels.prod.repo_shas]
+tenant-opw = "2222222222222222222222222222222222222222"
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_release_tuple_record(
+                ReleaseTupleRecord(
+                    tuple_id="opw-testing-db",
+                    context="opw",
+                    channel="testing",
+                    artifact_id="artifact-testing",
+                    repo_shas={"tenant-opw": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+                    provenance="ship",
+                    minted_at="2026-04-21T18:00:00Z",
+                )
+            )
+            store.close()
+
+            with patch.dict(os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True):
+                catalog = control_plane_release_tuples.load_release_tuple_catalog(control_plane_root=control_plane_root)
+
+        self.assertEqual(catalog.contexts["opw"].channels["testing"].tuple_id, "opw-testing-db")
+        self.assertEqual(catalog.contexts["opw"].channels["prod"].tuple_id, "opw-prod-file")
+
+    def test_load_release_tuple_catalog_explicit_file_override_wins_over_postgres(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            custom_file = control_plane_root / "custom-tuples.toml"
+            custom_file.write_text(
+                """
+schema_version = 1
+
+[contexts.cm.channels.testing]
+tuple_id = "cm-testing-file"
+
+[contexts.cm.channels.testing.repo_shas]
+tenant-cm = "3333333333333333333333333333333333333333"
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_release_tuple_record(
+                ReleaseTupleRecord(
+                    tuple_id="cm-testing-db",
+                    context="cm",
+                    channel="testing",
+                    artifact_id="artifact-testing",
+                    repo_shas={"tenant-cm": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+                    provenance="ship",
+                    minted_at="2026-04-21T18:00:00Z",
+                )
+            )
+            store.close()
+
+            with patch.dict(
+                os.environ,
+                {
+                    control_plane_release_tuples.RELEASE_TUPLES_FILE_ENV_VAR: str(custom_file),
+                    "LAUNCHPLANE_DATABASE_URL": database_url,
+                },
+                clear=True,
+            ):
+                catalog = control_plane_release_tuples.load_release_tuple_catalog(control_plane_root=control_plane_root)
+
+        self.assertEqual(catalog.contexts["cm"].channels["testing"].tuple_id, "cm-testing-file")
 
     def test_resolve_release_tuple_fails_closed_when_channel_missing(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_runtime_environments.py
+++ b/tests/test_runtime_environments.py
@@ -11,6 +11,11 @@ from click.testing import CliRunner
 
 from control_plane.cli import main
 from control_plane import runtime_environments as control_plane_runtime_environments
+from control_plane.storage.postgres import PostgresRecordStore
+
+
+def _sqlite_database_url(database_path: Path) -> str:
+    return f"sqlite+pysqlite:///{database_path}"
 
 
 class RuntimeEnvironmentTests(unittest.TestCase):
@@ -189,6 +194,174 @@ ODOO_DB_PASSWORD = "local-secret"
 
         self.assertEqual(resolved_values["ODOO_MASTER_PASSWORD"], "shared-master")
         self.assertEqual(resolved_values["ODOO_DB_PASSWORD"], "local-secret")
+
+    def test_load_runtime_environment_definition_merges_postgres_records_over_file_definition(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            environments_file = control_plane_root / "config" / "runtime-environments.toml"
+            environments_file.parent.mkdir(parents=True, exist_ok=True)
+            environments_file.write_text(
+                """
+schema_version = 1
+
+[shared_env]
+ODOO_MASTER_PASSWORD = "shared-master"
+
+[contexts.opw.instances.local.env]
+ODOO_DB_PASSWORD = "file-secret"
+
+[contexts.cm.instances.testing.env]
+ODOO_DB_PASSWORD = "cm-file-secret"
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            for record in control_plane_runtime_environments.build_runtime_environment_records_from_definition(
+                control_plane_runtime_environments.RuntimeEnvironmentDefinition(
+                    schema_version=1,
+                    shared_env={"ODOO_MASTER_PASSWORD": "db-master"},
+                    contexts={
+                        "opw": control_plane_runtime_environments.RuntimeEnvironmentContextDefinition(
+                            shared_env={},
+                            instances={
+                                "local": control_plane_runtime_environments.RuntimeEnvironmentInstanceDefinition(
+                                    env={"ODOO_DB_PASSWORD": "db-secret"}
+                                )
+                            },
+                        )
+                    },
+                ),
+                updated_at="2026-04-21T19:00:00Z",
+                source_label="import:test",
+            ):
+                store.write_runtime_environment_record(record)
+            store.close()
+
+            with patch.dict(os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True):
+                resolved_values = control_plane_runtime_environments.resolve_runtime_environment_values(
+                    control_plane_root=control_plane_root,
+                    context_name="opw",
+                    instance_name="local",
+                )
+                cm_values = control_plane_runtime_environments.resolve_runtime_environment_values(
+                    control_plane_root=control_plane_root,
+                    context_name="cm",
+                    instance_name="testing",
+                )
+
+        self.assertEqual(resolved_values["ODOO_MASTER_PASSWORD"], "db-master")
+        self.assertEqual(resolved_values["ODOO_DB_PASSWORD"], "db-secret")
+        self.assertEqual(cm_values["ODOO_DB_PASSWORD"], "cm-file-secret")
+
+    def test_load_runtime_environment_definition_explicit_file_override_wins_over_postgres(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            custom_file = control_plane_root / "custom-runtime-environments.toml"
+            custom_file.write_text(
+                """
+schema_version = 1
+
+[shared_env]
+ODOO_MASTER_PASSWORD = "file-master"
+
+[contexts.opw.instances.local.env]
+ODOO_DB_PASSWORD = "file-secret"
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            for record in control_plane_runtime_environments.build_runtime_environment_records_from_definition(
+                control_plane_runtime_environments.RuntimeEnvironmentDefinition(
+                    schema_version=1,
+                    shared_env={"ODOO_MASTER_PASSWORD": "db-master"},
+                    contexts={
+                        "opw": control_plane_runtime_environments.RuntimeEnvironmentContextDefinition(
+                            shared_env={},
+                            instances={
+                                "local": control_plane_runtime_environments.RuntimeEnvironmentInstanceDefinition(
+                                    env={"ODOO_DB_PASSWORD": "db-secret"}
+                                )
+                            },
+                        )
+                    },
+                ),
+                updated_at="2026-04-21T19:00:00Z",
+                source_label="import:test",
+            ):
+                store.write_runtime_environment_record(record)
+            store.close()
+
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_DATABASE_URL": database_url,
+                    control_plane_runtime_environments.RUNTIME_ENVIRONMENTS_FILE_ENV_VAR: str(custom_file),
+                },
+                clear=True,
+            ):
+                resolved_values = control_plane_runtime_environments.resolve_runtime_environment_values(
+                    control_plane_root=control_plane_root,
+                    context_name="opw",
+                    instance_name="local",
+                )
+
+        self.assertEqual(resolved_values["ODOO_MASTER_PASSWORD"], "file-master")
+        self.assertEqual(resolved_values["ODOO_DB_PASSWORD"], "file-secret")
+
+    def test_storage_import_runtime_environments_writes_records_to_postgres(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            environments_file = control_plane_root / "config" / "runtime-environments.toml"
+            environments_file.parent.mkdir(parents=True, exist_ok=True)
+            environments_file.write_text(
+                """
+schema_version = 1
+
+[shared_env]
+ODOO_MASTER_PASSWORD = "shared-master"
+
+[contexts.opw.shared_env]
+ENV_OVERRIDE_DISABLE_CRON = true
+
+[contexts.opw.instances.local.env]
+ODOO_DB_PASSWORD = "local-secret"
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            result = runner.invoke(
+                main,
+                [
+                    "storage",
+                    "import-runtime-environments",
+                    "--database-url",
+                    database_url,
+                    "--control-plane-root",
+                    str(control_plane_root),
+                ],
+            )
+
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            listed_records = store.list_runtime_environment_records()
+            store.close()
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["count"], 3)
+        self.assertEqual(
+            [(record.scope, record.context, record.instance) for record in listed_records],
+            [("context", "opw", ""), ("global", "", ""), ("instance", "opw", "local")],
+        )
 
     def test_environments_resolve_command_emits_json_payload(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from control_plane import secrets as control_plane_secrets
+from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord, PreviewPullRequestSummary
@@ -21,6 +22,7 @@ from control_plane.workflows.verireel_preview_driver import (
     VeriReelPreviewDestroyResult,
     VeriReelPreviewRefreshResult,
 )
+from control_plane.workflows.verireel_prod_promotion import VeriReelProdPromotionResult
 from control_plane.workflows.verireel_stable_deploy import VeriReelStableDeployResult
 
 
@@ -637,6 +639,89 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(inventory.promotion_record_id, promotion.record_id)
             self.assertEqual(inventory.promoted_from_instance, "testing")
 
+    def test_backup_gate_endpoint_writes_record_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/promote-image.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel"],
+                            "actions": ["backup_gate.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/promote-image.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/evidence/backup-gates",
+                payload={
+                    "product": "verireel",
+                    "backup_gate": {
+                        "record_id": "backup-gate-verireel-prod-run-12345-attempt-1",
+                        "context": "verireel",
+                        "instance": "prod",
+                        "created_at": "2026-04-21T18:05:00Z",
+                        "source": "verireel-prod-gate",
+                        "status": "pass",
+                        "evidence": {
+                            "snapshot_name": "ver-predeploy-20260421T180500Z",
+                            "manifest_path": "scratch/prod-gates/ver-predeploy-20260421T180500Z.json",
+                        },
+                    },
+                },
+            )
+
+            self.assertEqual(status_code, 202)
+            self.assertEqual(payload["status"], "accepted")
+            self.assertEqual(
+                payload["records"],
+                {
+                    "backup_gate_record_id": "backup-gate-verireel-prod-run-12345-attempt-1",
+                },
+            )
+            store = FilesystemRecordStore(state_dir=state_dir)
+            backup_gate = store.read_backup_gate_record(
+                "backup-gate-verireel-prod-run-12345-attempt-1"
+            )
+            self.assertEqual(
+                backup_gate,
+                BackupGateRecord(
+                    record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                    context="verireel",
+                    instance="prod",
+                    created_at="2026-04-21T18:05:00Z",
+                    source="verireel-prod-gate",
+                    status="pass",
+                    evidence={
+                        "snapshot_name": "ver-predeploy-20260421T180500Z",
+                        "manifest_path": "scratch/prod-gates/ver-predeploy-20260421T180500Z.json",
+                    },
+                ),
+            )
+
     def test_preview_destroyed_endpoint_writes_records_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -956,6 +1041,135 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "instance": "prod",
                         "artifact_id": "ghcr.io/every/verireel-app:sha-abcdef1234567890",
                         "source_git_ref": "abcdef1234567890",
+                    },
+                },
+            )
+
+            self.assertEqual(status_code, 403)
+            self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_verireel_prod_promotion_driver_executes_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/promote-image.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel"],
+                            "actions": ["verireel_prod_promotion.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/promote-image.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_verireel_prod_promotion",
+                return_value=VeriReelProdPromotionResult(
+                    promotion_record_id="promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                    deployment_record_id="deployment-verireel-prod-run-12345-attempt-1",
+                    backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                    deploy_status="pass",
+                    deploy_started_at="2026-04-21T18:20:00Z",
+                    deploy_finished_at="2026-04-21T18:21:15Z",
+                    target_name="ver-prod-app",
+                    target_type="application",
+                    target_id="prod-app-123",
+                ),
+            ) as execute_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/prod-promotion",
+                    payload={
+                        "product": "verireel",
+                        "promotion": {
+                            "artifact_id": "ghcr.io/every/verireel-app:sha-abcdef1234567890",
+                            "source_git_ref": "abcdef1234567890",
+                            "backup_record_id": "backup-gate-verireel-prod-run-12345-attempt-1",
+                            "promotion_record_id": "promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                        },
+                    },
+                )
+
+            self.assertEqual(status_code, 202)
+            self.assertEqual(payload["status"], "accepted")
+            self.assertEqual(
+                payload["records"],
+                {
+                    "promotion_record_id": "promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                    "deployment_record_id": "deployment-verireel-prod-run-12345-attempt-1",
+                },
+            )
+            self.assertEqual(payload["result"]["deploy_status"], "pass")
+            self.assertEqual(
+                payload["result"]["promotion_record_id"],
+                "promotion-verireel-testing-to-prod-run-12345-attempt-1",
+            )
+            execute_mock.assert_called_once()
+
+    def test_verireel_prod_promotion_driver_rejects_unauthorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/promote-image.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate(
+                    {
+                        "github_actions": [
+                            {
+                                "repository": "every/verireel",
+                                "workflow_refs": [
+                                    "every/verireel/.github/workflows/promote-image.yml@refs/heads/main"
+                                ],
+                                "event_names": ["workflow_dispatch"],
+                                "products": ["verireel"],
+                                "contexts": ["verireel"],
+                                "actions": ["promotion.write"],
+                            }
+                        ]
+                    }
+                ),
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/verireel/prod-promotion",
+                payload={
+                    "product": "verireel",
+                    "promotion": {
+                        "artifact_id": "ghcr.io/every/verireel-app:sha-abcdef1234567890",
+                        "source_git_ref": "abcdef1234567890",
+                        "backup_record_id": "backup-gate-verireel-prod-run-12345-attempt-1",
+                        "promotion_record_id": "promotion-verireel-testing-to-prod-run-12345-attempt-1",
                     },
                 },
             )

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -21,7 +21,7 @@ from control_plane.workflows.verireel_preview_driver import (
     VeriReelPreviewDestroyResult,
     VeriReelPreviewRefreshResult,
 )
-from control_plane.workflows.verireel_testing_deploy import VeriReelTestingDeployResult
+from control_plane.workflows.verireel_stable_deploy import VeriReelStableDeployResult
 
 
 class _StubVerifier:
@@ -760,8 +760,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
 
             with patch(
-                "control_plane.service.execute_verireel_testing_deploy",
-                return_value=VeriReelTestingDeployResult(
+                "control_plane.service.execute_verireel_stable_deploy",
+                return_value=VeriReelStableDeployResult(
                     deployment_record_id="deployment-verireel-testing-run-12345-attempt-1",
                     deploy_status="pass",
                     deploy_started_at="2026-04-20T18:20:00Z",
@@ -834,6 +834,126 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 payload={
                     "product": "verireel",
                     "deploy": {
+                        "artifact_id": "ghcr.io/every/verireel-app:sha-abcdef1234567890",
+                        "source_git_ref": "abcdef1234567890",
+                    },
+                },
+            )
+
+            self.assertEqual(status_code, 403)
+            self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_verireel_prod_deploy_driver_executes_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/promote-image.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel"],
+                            "actions": ["verireel_prod_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/promote-image.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_verireel_stable_deploy",
+                return_value=VeriReelStableDeployResult(
+                    deployment_record_id="deployment-verireel-prod-run-12345-attempt-1",
+                    deploy_status="pass",
+                    deploy_started_at="2026-04-20T19:20:00Z",
+                    deploy_finished_at="2026-04-20T19:21:15Z",
+                    target_name="ver-prod-app",
+                    target_type="application",
+                    target_id="prod-app-123",
+                ),
+            ) as execute_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/prod-deploy",
+                    payload={
+                        "product": "verireel",
+                        "deploy": {
+                            "instance": "prod",
+                            "artifact_id": "ghcr.io/every/verireel-app:sha-abcdef1234567890",
+                            "source_git_ref": "abcdef1234567890",
+                        },
+                    },
+                )
+
+            self.assertEqual(status_code, 202)
+            self.assertEqual(payload["status"], "accepted")
+            self.assertEqual(
+                payload["records"],
+                {"deployment_record_id": "deployment-verireel-prod-run-12345-attempt-1"},
+            )
+            self.assertEqual(payload["result"]["deploy_status"], "pass")
+            self.assertEqual(payload["result"]["target_id"], "prod-app-123")
+            execute_mock.assert_called_once()
+
+    def test_verireel_prod_deploy_driver_rejects_unauthorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/promote-image.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel"],
+                            "actions": ["promotion.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/promote-image.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/verireel/prod-deploy",
+                payload={
+                    "product": "verireel",
+                    "deploy": {
+                        "instance": "prod",
                         "artifact_id": "ghcr.io/every/verireel-app:sha-abcdef1234567890",
                         "source_git_ref": "abcdef1234567890",
                     },

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -23,6 +23,7 @@ from control_plane.workflows.verireel_preview_driver import (
     VeriReelPreviewRefreshResult,
 )
 from control_plane.workflows.verireel_prod_promotion import VeriReelProdPromotionResult
+from control_plane.workflows.verireel_prod_rollback import VeriReelProdRollbackResult
 from control_plane.workflows.verireel_stable_deploy import VeriReelStableDeployResult
 
 
@@ -1170,6 +1171,125 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "source_git_ref": "abcdef1234567890",
                         "backup_record_id": "backup-gate-verireel-prod-run-12345-attempt-1",
                         "promotion_record_id": "promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                    },
+                },
+            )
+
+            self.assertEqual(status_code, 403)
+            self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_verireel_prod_rollback_driver_executes_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/promote-image.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel"],
+                            "actions": ["verireel_prod_rollback.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/promote-image.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_verireel_prod_rollback",
+                return_value=VeriReelProdRollbackResult(
+                    promotion_record_id="promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                    backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                    snapshot_name="ver-predeploy-20260421-180000",
+                    rollback_status="pass",
+                    rollback_health_status="pass",
+                    rollback_started_at="2026-04-21T18:20:00Z",
+                    rollback_finished_at="2026-04-21T18:21:00Z",
+                ),
+            ) as execute_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/prod-rollback",
+                    payload={
+                        "product": "verireel",
+                        "rollback": {
+                            "promotion_record_id": "promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                            "backup_record_id": "backup-gate-verireel-prod-run-12345-attempt-1",
+                        },
+                    },
+                )
+
+            self.assertEqual(status_code, 202)
+            self.assertEqual(payload["status"], "accepted")
+            self.assertEqual(
+                payload["records"],
+                {
+                    "promotion_record_id": "promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                    "backup_record_id": "backup-gate-verireel-prod-run-12345-attempt-1",
+                },
+            )
+            self.assertEqual(payload["result"]["rollback_status"], "pass")
+            execute_mock.assert_called_once()
+
+    def test_verireel_prod_rollback_driver_rejects_unauthorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/promote-image.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate(
+                    {
+                        "github_actions": [
+                            {
+                                "repository": "every/verireel",
+                                "workflow_refs": [
+                                    "every/verireel/.github/workflows/promote-image.yml@refs/heads/main"
+                                ],
+                                "event_names": ["workflow_dispatch"],
+                                "products": ["verireel"],
+                                "contexts": ["verireel"],
+                                "actions": ["promotion.write"],
+                            }
+                        ]
+                    }
+                ),
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/verireel/prod-rollback",
+                payload={
+                    "product": "verireel",
+                    "rollback": {
+                        "promotion_record_id": "promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                        "backup_record_id": "backup-gate-verireel-prod-run-12345-attempt-1",
                     },
                 },
             )

--- a/tests/test_verireel_prod_promotion.py
+++ b/tests/test_verireel_prod_promotion.py
@@ -3,12 +3,15 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
+import click
+
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.promotion_record import DeploymentEvidence
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.verireel_prod_promotion import (
     VeriReelProdPromotionRequest,
+    VeriReelRolloutVerificationResult,
     execute_verireel_prod_promotion,
 )
 from control_plane.workflows.verireel_stable_deploy import VeriReelStableDeployResult
@@ -62,6 +65,8 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                 source_git_ref="abcdef1234567890",
                 backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
                 promotion_record_id="promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                expected_build_revision="abcdef1234567890",
+                expected_build_tag="sha-abcdef1234567890",
             )
 
             with patch(
@@ -74,6 +79,15 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                     target_name="ver-prod-app",
                     target_type="application",
                     target_id="prod-app-123",
+                ),
+            ), patch(
+                "control_plane.workflows.verireel_prod_promotion._verify_rollout",
+                return_value=VeriReelRolloutVerificationResult(
+                    status="pass",
+                    base_url="https://ver-prod.shinycomputers.com",
+                    health_urls=("https://ver-prod.shinycomputers.com/api/health",),
+                    started_at="2026-04-21T18:21:16Z",
+                    finished_at="2026-04-21T18:21:45Z",
                 ),
             ):
                 result = execute_verireel_prod_promotion(
@@ -91,6 +105,7 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                 "deployment-verireel-prod-run-12345-attempt-1",
             )
             self.assertEqual(result.deploy_status, "pass")
+            self.assertEqual(result.rollout_status, "pass")
             promotion = store.read_promotion_record(
                 "promotion-verireel-testing-to-prod-run-12345-attempt-1"
             )
@@ -99,6 +114,74 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
             self.assertEqual(promotion.deploy.deployment_id, "prod-app-123")
             self.assertEqual(promotion.deploy.started_at, "2026-04-21T18:20:00Z")
             self.assertEqual(promotion.deploy.finished_at, "2026-04-21T18:21:15Z")
+            self.assertEqual(promotion.destination_health.status, "pass")
+            self.assertEqual(
+                promotion.destination_health.urls,
+                ("https://ver-prod.shinycomputers.com/api/health",),
+            )
+
+    def test_execute_writes_failed_rollout_status_when_rollout_verification_fails(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_backup_gate_record(
+                BackupGateRecord(
+                    record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                    context="verireel",
+                    instance="prod",
+                    created_at="2026-04-21T18:05:00Z",
+                    source="verireel-prod-gate",
+                    status="pass",
+                    evidence={"snapshot_name": "ver-predeploy-20260421T180500Z"},
+                )
+            )
+            request = VeriReelProdPromotionRequest(
+                artifact_id="ghcr.io/every/verireel-app:sha-abcdef1234567890",
+                source_git_ref="abcdef1234567890",
+                backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                promotion_record_id="promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                expected_build_revision="abcdef1234567890",
+                expected_build_tag="sha-abcdef1234567890",
+            )
+
+            with patch(
+                "control_plane.workflows.verireel_prod_promotion.execute_verireel_stable_deploy",
+                return_value=VeriReelStableDeployResult(
+                    deployment_record_id="deployment-verireel-prod-run-12345-attempt-1",
+                    deploy_status="pass",
+                    deploy_started_at="2026-04-21T18:20:00Z",
+                    deploy_finished_at="2026-04-21T18:21:15Z",
+                    target_name="ver-prod-app",
+                    target_type="application",
+                    target_id="prod-app-123",
+                ),
+            ), patch(
+                "control_plane.workflows.verireel_prod_promotion._verify_rollout",
+                side_effect=click.ClickException("VeriReel prod rollout page verification expected https://ver-prod.shinycomputers.com/ to include \"VeriReel\"."),
+            ), patch(
+                "control_plane.workflows.verireel_prod_promotion._resolve_rollout_base_urls",
+                return_value=("https://ver-prod.shinycomputers.com",),
+            ):
+                result = execute_verireel_prod_promotion(
+                    control_plane_root=root,
+                    record_store=store,
+                    request=request,
+                )
+
+            self.assertEqual(result.deploy_status, "pass")
+            self.assertEqual(result.rollout_status, "fail")
+            self.assertIn("rollout page verification", result.error_message)
+            promotion = store.read_promotion_record(
+                "promotion-verireel-testing-to-prod-run-12345-attempt-1"
+            )
+            self.assertEqual(promotion.backup_gate.status, "pass")
+            self.assertEqual(promotion.deploy.status, "pass")
+            self.assertEqual(promotion.destination_health.status, "fail")
+            self.assertEqual(
+                promotion.destination_health.urls,
+                ("https://ver-prod.shinycomputers.com/api/health",),
+            )
 
     def test_execute_writes_failed_promotion_record_when_backup_gate_is_missing(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_verireel_prod_promotion.py
+++ b/tests/test_verireel_prod_promotion.py
@@ -1,0 +1,128 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from control_plane.contracts.backup_gate_record import BackupGateRecord
+from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
+from control_plane.contracts.promotion_record import DeploymentEvidence
+from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.workflows.verireel_prod_promotion import (
+    VeriReelProdPromotionRequest,
+    execute_verireel_prod_promotion,
+)
+from control_plane.workflows.verireel_stable_deploy import VeriReelStableDeployResult
+
+
+class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
+    def test_execute_writes_promotion_record_after_passing_backup_gate(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_backup_gate_record(
+                BackupGateRecord(
+                    record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                    context="verireel",
+                    instance="prod",
+                    created_at="2026-04-21T18:05:00Z",
+                    source="verireel-prod-gate",
+                    status="pass",
+                    evidence={
+                        "snapshot_name": "ver-predeploy-20260421T180500Z",
+                        "manifest_path": "scratch/prod-gates/ver-predeploy-20260421T180500Z.json",
+                    },
+                )
+            )
+            store.write_deployment_record(
+                DeploymentRecord(
+                    record_id="deployment-verireel-prod-run-12345-attempt-1",
+                    artifact_identity={"artifact_id": "ghcr.io/every/verireel-app:sha-abcdef1234567890"},
+                    context="verireel",
+                    instance="prod",
+                    source_git_ref="abcdef1234567890",
+                    resolved_target=ResolvedTargetEvidence(
+                        target_type="application",
+                        target_id="prod-app-123",
+                        target_name="ver-prod-app",
+                    ),
+                    deploy=DeploymentEvidence(
+                        target_name="ver-prod-app",
+                        target_type="application",
+                        deploy_mode="dokploy-application-api",
+                        deployment_id="control-plane-dokploy",
+                        status="pass",
+                        started_at="2026-04-21T18:20:00Z",
+                        finished_at="2026-04-21T18:21:15Z",
+                    ),
+                )
+            )
+            request = VeriReelProdPromotionRequest(
+                artifact_id="ghcr.io/every/verireel-app:sha-abcdef1234567890",
+                source_git_ref="abcdef1234567890",
+                backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                promotion_record_id="promotion-verireel-testing-to-prod-run-12345-attempt-1",
+            )
+
+            with patch(
+                "control_plane.workflows.verireel_prod_promotion.execute_verireel_stable_deploy",
+                return_value=VeriReelStableDeployResult(
+                    deployment_record_id="deployment-verireel-prod-run-12345-attempt-1",
+                    deploy_status="pass",
+                    deploy_started_at="2026-04-21T18:20:00Z",
+                    deploy_finished_at="2026-04-21T18:21:15Z",
+                    target_name="ver-prod-app",
+                    target_type="application",
+                    target_id="prod-app-123",
+                ),
+            ):
+                result = execute_verireel_prod_promotion(
+                    control_plane_root=root,
+                    record_store=store,
+                    request=request,
+                )
+
+            self.assertEqual(
+                result.promotion_record_id,
+                "promotion-verireel-testing-to-prod-run-12345-attempt-1",
+            )
+            self.assertEqual(
+                result.deployment_record_id,
+                "deployment-verireel-prod-run-12345-attempt-1",
+            )
+            self.assertEqual(result.deploy_status, "pass")
+            promotion = store.read_promotion_record(
+                "promotion-verireel-testing-to-prod-run-12345-attempt-1"
+            )
+            self.assertEqual(promotion.backup_record_id, "backup-gate-verireel-prod-run-12345-attempt-1")
+            self.assertEqual(promotion.deploy.status, "pass")
+            self.assertEqual(promotion.deploy.deployment_id, "prod-app-123")
+            self.assertEqual(promotion.deploy.started_at, "2026-04-21T18:20:00Z")
+            self.assertEqual(promotion.deploy.finished_at, "2026-04-21T18:21:15Z")
+
+    def test_execute_writes_failed_promotion_record_when_backup_gate_is_missing(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            request = VeriReelProdPromotionRequest(
+                artifact_id="ghcr.io/every/verireel-app:sha-abcdef1234567890",
+                source_git_ref="abcdef1234567890",
+                backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                promotion_record_id="promotion-verireel-testing-to-prod-run-12345-attempt-1",
+            )
+
+            result = execute_verireel_prod_promotion(
+                control_plane_root=root,
+                record_store=store,
+                request=request,
+            )
+
+            self.assertEqual(result.deploy_status, "fail")
+            self.assertIn("requires stored backup gate record", result.error_message)
+            promotion = store.read_promotion_record(
+                "promotion-verireel-testing-to-prod-run-12345-attempt-1"
+            )
+            self.assertEqual(promotion.deploy.status, "fail")
+            self.assertEqual(promotion.backup_gate.status, "fail")
+            self.assertEqual(promotion.deployment_record_id, "")

--- a/tests/test_verireel_prod_promotion.py
+++ b/tests/test_verireel_prod_promotion.py
@@ -81,14 +81,26 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                     target_id="prod-app-123",
                 ),
             ), patch(
+                "control_plane.workflows.verireel_prod_promotion._run_prisma_migrations",
+                return_value=None,
+            ), patch(
                 "control_plane.workflows.verireel_prod_promotion._verify_rollout",
-                return_value=VeriReelRolloutVerificationResult(
-                    status="pass",
-                    base_url="https://ver-prod.shinycomputers.com",
-                    health_urls=("https://ver-prod.shinycomputers.com/api/health",),
-                    started_at="2026-04-21T18:21:16Z",
-                    finished_at="2026-04-21T18:21:45Z",
-                ),
+                side_effect=[
+                    VeriReelRolloutVerificationResult(
+                        status="pass",
+                        base_url="https://ver-prod.shinycomputers.com",
+                        health_urls=("https://ver-prod.shinycomputers.com/api/health",),
+                        started_at="2026-04-21T18:21:16Z",
+                        finished_at="2026-04-21T18:21:45Z",
+                    ),
+                    VeriReelRolloutVerificationResult(
+                        status="pass",
+                        base_url="https://ver-prod.shinycomputers.com",
+                        health_urls=("https://ver-prod.shinycomputers.com/api/health",),
+                        started_at="2026-04-21T18:21:46Z",
+                        finished_at="2026-04-21T18:22:15Z",
+                    ),
+                ],
             ):
                 result = execute_verireel_prod_promotion(
                     control_plane_root=root,
@@ -106,6 +118,8 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
             )
             self.assertEqual(result.deploy_status, "pass")
             self.assertEqual(result.rollout_status, "pass")
+            self.assertEqual(result.migration_status, "pass")
+            self.assertEqual(result.health_status, "pass")
             promotion = store.read_promotion_record(
                 "promotion-verireel-testing-to-prod-run-12345-attempt-1"
             )
@@ -114,11 +128,151 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
             self.assertEqual(promotion.deploy.deployment_id, "prod-app-123")
             self.assertEqual(promotion.deploy.started_at, "2026-04-21T18:20:00Z")
             self.assertEqual(promotion.deploy.finished_at, "2026-04-21T18:21:15Z")
+            self.assertEqual(promotion.post_deploy_update.status, "pass")
             self.assertEqual(promotion.destination_health.status, "pass")
             self.assertEqual(
                 promotion.destination_health.urls,
                 ("https://ver-prod.shinycomputers.com/api/health",),
             )
+
+    def test_execute_writes_failed_promotion_record_when_prisma_migration_fails(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_backup_gate_record(
+                BackupGateRecord(
+                    record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                    context="verireel",
+                    instance="prod",
+                    created_at="2026-04-21T18:05:00Z",
+                    source="verireel-prod-gate",
+                    status="pass",
+                    evidence={"snapshot_name": "ver-predeploy-20260421T180500Z"},
+                )
+            )
+            request = VeriReelProdPromotionRequest(
+                artifact_id="ghcr.io/every/verireel-app:sha-abcdef1234567890",
+                source_git_ref="abcdef1234567890",
+                backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                promotion_record_id="promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                expected_build_revision="abcdef1234567890",
+                expected_build_tag="sha-abcdef1234567890",
+            )
+
+            with patch(
+                "control_plane.workflows.verireel_prod_promotion.execute_verireel_stable_deploy",
+                return_value=VeriReelStableDeployResult(
+                    deployment_record_id="deployment-verireel-prod-run-12345-attempt-1",
+                    deploy_status="pass",
+                    deploy_started_at="2026-04-21T18:20:00Z",
+                    deploy_finished_at="2026-04-21T18:21:15Z",
+                    target_name="ver-prod-app",
+                    target_type="application",
+                    target_id="prod-app-123",
+                ),
+            ), patch(
+                "control_plane.workflows.verireel_prod_promotion._verify_rollout",
+                return_value=VeriReelRolloutVerificationResult(
+                    status="pass",
+                    base_url="https://ver-prod.shinycomputers.com",
+                    health_urls=("https://ver-prod.shinycomputers.com/api/health",),
+                    started_at="2026-04-21T18:21:16Z",
+                    finished_at="2026-04-21T18:21:45Z",
+                ),
+            ), patch(
+                "control_plane.workflows.verireel_prod_promotion._run_prisma_migrations",
+                side_effect=click.ClickException("Dokploy schedule deployment failed during Prisma migration."),
+            ):
+                result = execute_verireel_prod_promotion(
+                    control_plane_root=root,
+                    record_store=store,
+                    request=request,
+                )
+
+            self.assertEqual(result.deploy_status, "pass")
+            self.assertEqual(result.rollout_status, "pass")
+            self.assertEqual(result.migration_status, "fail")
+            self.assertEqual(result.health_status, "skipped")
+            self.assertIn("Prisma migration", result.error_message)
+            promotion = store.read_promotion_record(
+                "promotion-verireel-testing-to-prod-run-12345-attempt-1"
+            )
+            self.assertEqual(promotion.backup_gate.status, "pass")
+            self.assertEqual(promotion.deploy.status, "pass")
+            self.assertEqual(promotion.post_deploy_update.status, "fail")
+            self.assertEqual(promotion.destination_health.status, "skipped")
+
+    def test_execute_writes_failed_promotion_record_when_final_health_fails(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_backup_gate_record(
+                BackupGateRecord(
+                    record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                    context="verireel",
+                    instance="prod",
+                    created_at="2026-04-21T18:05:00Z",
+                    source="verireel-prod-gate",
+                    status="pass",
+                    evidence={"snapshot_name": "ver-predeploy-20260421T180500Z"},
+                )
+            )
+            request = VeriReelProdPromotionRequest(
+                artifact_id="ghcr.io/every/verireel-app:sha-abcdef1234567890",
+                source_git_ref="abcdef1234567890",
+                backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                promotion_record_id="promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                expected_build_revision="abcdef1234567890",
+                expected_build_tag="sha-abcdef1234567890",
+            )
+
+            with patch(
+                "control_plane.workflows.verireel_prod_promotion.execute_verireel_stable_deploy",
+                return_value=VeriReelStableDeployResult(
+                    deployment_record_id="deployment-verireel-prod-run-12345-attempt-1",
+                    deploy_status="pass",
+                    deploy_started_at="2026-04-21T18:20:00Z",
+                    deploy_finished_at="2026-04-21T18:21:15Z",
+                    target_name="ver-prod-app",
+                    target_type="application",
+                    target_id="prod-app-123",
+                ),
+            ), patch(
+                "control_plane.workflows.verireel_prod_promotion._run_prisma_migrations",
+                return_value=None,
+            ), patch(
+                "control_plane.workflows.verireel_prod_promotion._verify_rollout",
+                side_effect=[
+                    VeriReelRolloutVerificationResult(
+                        status="pass",
+                        base_url="https://ver-prod.shinycomputers.com",
+                        health_urls=("https://ver-prod.shinycomputers.com/api/health",),
+                        started_at="2026-04-21T18:21:16Z",
+                        finished_at="2026-04-21T18:21:45Z",
+                    ),
+                    click.ClickException("VeriReel prod rollout verification timed out: health payload mismatch."),
+                ],
+            ), patch(
+                "control_plane.workflows.verireel_prod_promotion._resolve_rollout_base_urls",
+                return_value=("https://ver-prod.shinycomputers.com",),
+            ):
+                result = execute_verireel_prod_promotion(
+                    control_plane_root=root,
+                    record_store=store,
+                    request=request,
+                )
+
+            self.assertEqual(result.deploy_status, "pass")
+            self.assertEqual(result.rollout_status, "pass")
+            self.assertEqual(result.migration_status, "pass")
+            self.assertEqual(result.health_status, "fail")
+            promotion = store.read_promotion_record(
+                "promotion-verireel-testing-to-prod-run-12345-attempt-1"
+            )
+            self.assertEqual(promotion.post_deploy_update.status, "pass")
+            self.assertEqual(promotion.destination_health.status, "fail")
 
     def test_execute_writes_failed_rollout_status_when_rollout_verification_fails(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_verireel_prod_rollback.py
+++ b/tests/test_verireel_prod_rollback.py
@@ -1,0 +1,181 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import click
+
+from control_plane.contracts.backup_gate_record import BackupGateRecord
+from control_plane.contracts.promotion_record import (
+    ArtifactIdentityReference,
+    DeploymentEvidence,
+    PromotionRecord,
+)
+from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.workflows.verireel_prod_rollback import (
+    VeriReelProdRollbackRequest,
+    VeriReelProdRollbackWorkerResult,
+    execute_verireel_prod_rollback,
+)
+from control_plane.workflows.verireel_prod_promotion import VeriReelRolloutVerificationResult
+
+
+class VeriReelProdRollbackWorkflowTests(unittest.TestCase):
+    def _record_store(self, root: Path) -> FilesystemRecordStore:
+        return FilesystemRecordStore(root / "state")
+
+    def _write_backup_gate(self, record_store: FilesystemRecordStore) -> None:
+        record_store.write_backup_gate_record(
+            BackupGateRecord(
+                record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                context="verireel",
+                instance="prod",
+                created_at="2026-04-21T18:00:00Z",
+                source="verireel-prod-gate",
+                required=True,
+                status="pass",
+                evidence={"snapshot_name": "ver-predeploy-20260421-180000"},
+            )
+        )
+
+    def _write_promotion(self, record_store: FilesystemRecordStore) -> None:
+        record_store.write_promotion_record(
+            PromotionRecord(
+                record_id="promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                artifact_identity=ArtifactIdentityReference(
+                    artifact_id="ghcr.io/every/verireel-app:sha-abcdef1234567890"
+                ),
+                deployment_record_id="deployment-verireel-prod-run-12345-attempt-1",
+                backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                context="verireel",
+                from_instance="testing",
+                to_instance="prod",
+                deploy=DeploymentEvidence(
+                    target_name="ver-prod-app",
+                    target_type="application",
+                    deploy_mode="dokploy-application-api",
+                    deployment_id="prod-app-123",
+                    status="pass",
+                    started_at="2026-04-21T18:10:00Z",
+                    finished_at="2026-04-21T18:11:00Z",
+                ),
+            )
+        )
+
+    def test_execute_verireel_prod_rollback_records_pass_statuses(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            record_store = self._record_store(root)
+            self._write_backup_gate(record_store)
+            self._write_promotion(record_store)
+
+            with patch(
+                "control_plane.workflows.verireel_prod_rollback._run_delegated_worker",
+                return_value=VeriReelProdRollbackWorkerResult(
+                    status="pass",
+                    snapshot_name="ver-predeploy-20260421-180000",
+                    started_at="2026-04-21T18:20:00Z",
+                    finished_at="2026-04-21T18:21:00Z",
+                    detail="Rollback completed.",
+                ),
+            ), patch(
+                "control_plane.workflows.verireel_prod_rollback._verify_post_rollback_health",
+                return_value=VeriReelRolloutVerificationResult(
+                    status="pass",
+                    base_url="https://ver-prod.shinycomputers.com",
+                    health_urls=("https://ver-prod.shinycomputers.com/api/health",),
+                    started_at="2026-04-21T18:21:00Z",
+                    finished_at="2026-04-21T18:22:00Z",
+                ),
+            ):
+                result = execute_verireel_prod_rollback(
+                    control_plane_root=root,
+                    record_store=record_store,
+                    request=VeriReelProdRollbackRequest(
+                        promotion_record_id="promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                        backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                    ),
+                )
+
+            self.assertEqual(result.rollback_status, "pass")
+            self.assertEqual(result.rollback_health_status, "pass")
+            updated_record = record_store.read_promotion_record(result.promotion_record_id)
+            self.assertEqual(updated_record.rollback.status, "pass")
+            self.assertEqual(updated_record.rollback.snapshot_name, "ver-predeploy-20260421-180000")
+            self.assertEqual(updated_record.rollback_health.status, "pass")
+
+    def test_execute_verireel_prod_rollback_records_worker_failure(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            record_store = self._record_store(root)
+            self._write_backup_gate(record_store)
+            self._write_promotion(record_store)
+
+            with patch(
+                "control_plane.workflows.verireel_prod_rollback._run_delegated_worker",
+                return_value=VeriReelProdRollbackWorkerResult(
+                    status="fail",
+                    snapshot_name="ver-predeploy-20260421-180000",
+                    started_at="2026-04-21T18:20:00Z",
+                    finished_at="2026-04-21T18:20:30Z",
+                    detail="pct rollback failed",
+                ),
+            ):
+                result = execute_verireel_prod_rollback(
+                    control_plane_root=root,
+                    record_store=record_store,
+                    request=VeriReelProdRollbackRequest(
+                        promotion_record_id="promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                        backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                    ),
+                )
+
+            self.assertEqual(result.rollback_status, "fail")
+            self.assertEqual(result.rollback_health_status, "skipped")
+            self.assertEqual(result.error_message, "pct rollback failed")
+            updated_record = record_store.read_promotion_record(result.promotion_record_id)
+            self.assertEqual(updated_record.rollback.status, "fail")
+            self.assertEqual(updated_record.rollback_health.status, "skipped")
+
+    def test_execute_verireel_prod_rollback_records_health_failure(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            record_store = self._record_store(root)
+            self._write_backup_gate(record_store)
+            self._write_promotion(record_store)
+
+            with patch(
+                "control_plane.workflows.verireel_prod_rollback._run_delegated_worker",
+                return_value=VeriReelProdRollbackWorkerResult(
+                    status="pass",
+                    snapshot_name="ver-predeploy-20260421-180000",
+                    started_at="2026-04-21T18:20:00Z",
+                    finished_at="2026-04-21T18:21:00Z",
+                    detail="Rollback completed.",
+                ),
+            ), patch(
+                "control_plane.workflows.verireel_prod_rollback._resolve_rollout_base_urls",
+                return_value=("https://ver-prod.shinycomputers.com",),
+            ), patch(
+                "control_plane.workflows.verireel_prod_rollback._verify_post_rollback_health",
+                side_effect=click.ClickException("health still failed after rollback"),
+            ):
+                result = execute_verireel_prod_rollback(
+                    control_plane_root=root,
+                    record_store=record_store,
+                    request=VeriReelProdRollbackRequest(
+                        promotion_record_id="promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                        backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                    ),
+                )
+
+            self.assertEqual(result.rollback_status, "pass")
+            self.assertEqual(result.rollback_health_status, "fail")
+            self.assertEqual(result.error_message, "health still failed after rollback")
+            updated_record = record_store.read_promotion_record(result.promotion_record_id)
+            self.assertEqual(updated_record.rollback.status, "pass")
+            self.assertEqual(updated_record.rollback_health.status, "fail")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_verireel_prod_rollback.py
+++ b/tests/test_verireel_prod_rollback.py
@@ -1,4 +1,5 @@
 import unittest
+from subprocess import CompletedProcess
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
@@ -14,7 +15,9 @@ from control_plane.contracts.promotion_record import (
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.verireel_prod_rollback import (
     VeriReelProdRollbackRequest,
+    VeriReelProdRollbackWorkerRequest,
     VeriReelProdRollbackWorkerResult,
+    _run_delegated_worker,
     execute_verireel_prod_rollback,
 )
 from control_plane.workflows.verireel_prod_promotion import VeriReelRolloutVerificationResult
@@ -61,6 +64,123 @@ class VeriReelProdRollbackWorkflowTests(unittest.TestCase):
                 ),
             )
         )
+
+    def test_run_delegated_worker_prefers_runtime_environment_values(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            environments_file = root / "config" / "runtime-environments.toml"
+            environments_file.parent.mkdir(parents=True, exist_ok=True)
+            environments_file.write_text(
+                """
+schema_version = 1
+
+[contexts.verireel.instances.prod.env]
+LAUNCHPLANE_VERIREEL_PROD_ROLLBACK_WORKER_COMMAND = "uv run python -m control_plane.workflows.verireel_prod_rollback_worker"
+VERIREEL_PROD_PROXMOX_HOST = "proxmox.runtime.example"
+VERIREEL_PROD_PROXMOX_USER = "runtime-user"
+VERIREEL_PROD_CT_ID = "211"
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            captured: dict[str, object] = {}
+
+            def _fake_run(command: list[str], **kwargs: object) -> CompletedProcess[str]:
+                captured["command"] = command
+                captured["env"] = kwargs["env"]
+                return CompletedProcess(
+                    args=command,
+                    returncode=0,
+                    stdout=(
+                        '{"schema_version":1,"status":"pass","snapshot_name":"ver-predeploy-20260421-180000",'
+                        '"started_at":"2026-04-21T18:20:00Z","finished_at":"2026-04-21T18:21:00Z",'
+                        '"detail":"Rollback completed."}\n'
+                    ),
+                    stderr="",
+                )
+
+            with patch(
+                "control_plane.workflows.verireel_prod_rollback.subprocess.run",
+                side_effect=_fake_run,
+            ), patch.dict(
+                "os.environ",
+                {
+                    "LAUNCHPLANE_VERIREEL_PROD_ROLLBACK_WORKER_COMMAND": "legacy worker",
+                    "VERIREEL_PROD_PROXMOX_HOST": "legacy.example",
+                    "VERIREEL_PROD_PROXMOX_USER": "legacy-user",
+                    "VERIREEL_PROD_CT_ID": "999",
+                },
+                clear=True,
+            ):
+                result = _run_delegated_worker(
+                    control_plane_root=root,
+                    request=VeriReelProdRollbackWorkerRequest(
+                        context="verireel",
+                        instance="prod",
+                        promotion_record_id="promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                        backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                        snapshot_name="ver-predeploy-20260421-180000",
+                    ),
+                )
+
+        self.assertEqual(result.status, "pass")
+        self.assertEqual(
+            captured["command"],
+            ["uv", "run", "python", "-m", "control_plane.workflows.verireel_prod_rollback_worker"],
+        )
+        worker_env = captured["env"]
+        assert isinstance(worker_env, dict)
+        self.assertEqual(worker_env["VERIREEL_PROD_PROXMOX_HOST"], "proxmox.runtime.example")
+        self.assertEqual(worker_env["VERIREEL_PROD_PROXMOX_USER"], "runtime-user")
+        self.assertEqual(worker_env["VERIREEL_PROD_CT_ID"], "211")
+
+    def test_run_delegated_worker_falls_back_to_process_environment(self) -> None:
+        captured: dict[str, object] = {}
+
+        def _fake_run(command: list[str], **kwargs: object) -> CompletedProcess[str]:
+            captured["command"] = command
+            captured["env"] = kwargs["env"]
+            return CompletedProcess(
+                args=command,
+                returncode=0,
+                stdout=(
+                    '{"schema_version":1,"status":"pass","snapshot_name":"ver-predeploy-20260421-180000",'
+                    '"started_at":"2026-04-21T18:20:00Z","finished_at":"2026-04-21T18:21:00Z",'
+                    '"detail":"Rollback completed."}\n'
+                ),
+                stderr="",
+            )
+
+        with TemporaryDirectory() as temporary_directory_name, patch(
+            "control_plane.workflows.verireel_prod_rollback.subprocess.run",
+            side_effect=_fake_run,
+        ), patch.dict(
+            "os.environ",
+            {
+                "LAUNCHPLANE_VERIREEL_PROD_ROLLBACK_WORKER_COMMAND": "python worker.py",
+                "VERIREEL_PROD_PROXMOX_HOST": "legacy.example",
+                "VERIREEL_PROD_PROXMOX_USER": "legacy-user",
+                "VERIREEL_PROD_CT_ID": "999",
+            },
+            clear=True,
+        ):
+            result = _run_delegated_worker(
+                control_plane_root=Path(temporary_directory_name),
+                request=VeriReelProdRollbackWorkerRequest(
+                    context="verireel",
+                    instance="prod",
+                    promotion_record_id="promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                    backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                    snapshot_name="ver-predeploy-20260421-180000",
+                ),
+            )
+
+        self.assertEqual(result.status, "pass")
+        self.assertEqual(captured["command"], ["python", "worker.py"])
+        worker_env = captured["env"]
+        assert isinstance(worker_env, dict)
+        self.assertEqual(worker_env["VERIREEL_PROD_PROXMOX_HOST"], "legacy.example")
 
     def test_execute_verireel_prod_rollback_records_pass_statuses(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_verireel_testing_deploy.py
+++ b/tests/test_verireel_testing_deploy.py
@@ -9,9 +9,9 @@ from control_plane.contracts.deployment_record import ResolvedTargetEvidence
 from control_plane.contracts.promotion_record import HealthcheckEvidence
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.storage.filesystem import FilesystemRecordStore
-from control_plane.workflows.verireel_testing_deploy import (
-    VeriReelTestingDeployRequest,
-    execute_verireel_testing_deploy,
+from control_plane.workflows.verireel_stable_deploy import (
+    VeriReelStableDeployRequest,
+    execute_verireel_stable_deploy,
 )
 
 
@@ -21,7 +21,7 @@ class VeriReelTestingDeployWorkflowTests(unittest.TestCase):
             root = Path(temporary_directory_name)
             state_dir = root / "state"
             store = FilesystemRecordStore(state_dir=state_dir)
-            request = VeriReelTestingDeployRequest(
+            request = VeriReelStableDeployRequest(
                 artifact_id="ghcr.io/every/verireel-app:sha-abcdef1234567890",
                 source_git_ref="abcdef1234567890",
             )
@@ -39,16 +39,16 @@ class VeriReelTestingDeployWorkflowTests(unittest.TestCase):
             )
 
             with patch(
-                "control_plane.workflows.verireel_testing_deploy.generate_deployment_record_id",
+                "control_plane.workflows.verireel_stable_deploy.generate_deployment_record_id",
                 return_value="deployment-verireel-testing-run-12345-attempt-1",
             ), patch(
-                "control_plane.workflows.verireel_testing_deploy.utc_now_timestamp",
+                "control_plane.workflows.verireel_stable_deploy.utc_now_timestamp",
                 side_effect=[
                     "2026-04-20T18:20:00Z",
                     "2026-04-20T18:21:15Z",
                 ],
             ), patch(
-                "control_plane.workflows.verireel_testing_deploy._resolve_ship_request",
+                "control_plane.workflows.verireel_stable_deploy._resolve_ship_request",
                 return_value=(
                     ship_request,
                     ResolvedTargetEvidence(
@@ -59,9 +59,9 @@ class VeriReelTestingDeployWorkflowTests(unittest.TestCase):
                     300,
                 ),
             ), patch(
-                "control_plane.workflows.verireel_testing_deploy._execute_dokploy_deploy"
+                "control_plane.workflows.verireel_stable_deploy._execute_dokploy_deploy"
             ):
-                result = execute_verireel_testing_deploy(
+                result = execute_verireel_stable_deploy(
                     control_plane_root=root,
                     record_store=store,
                     request=request,
@@ -81,7 +81,7 @@ class VeriReelTestingDeployWorkflowTests(unittest.TestCase):
             root = Path(temporary_directory_name)
             state_dir = root / "state"
             store = FilesystemRecordStore(state_dir=state_dir)
-            request = VeriReelTestingDeployRequest(
+            request = VeriReelStableDeployRequest(
                 artifact_id="ghcr.io/every/verireel-app:sha-abcdef1234567890",
                 source_git_ref="abcdef1234567890",
             )
@@ -99,16 +99,16 @@ class VeriReelTestingDeployWorkflowTests(unittest.TestCase):
             )
 
             with patch(
-                "control_plane.workflows.verireel_testing_deploy.generate_deployment_record_id",
+                "control_plane.workflows.verireel_stable_deploy.generate_deployment_record_id",
                 return_value="deployment-verireel-testing-run-12345-attempt-1",
             ), patch(
-                "control_plane.workflows.verireel_testing_deploy.utc_now_timestamp",
+                "control_plane.workflows.verireel_stable_deploy.utc_now_timestamp",
                 side_effect=[
                     "2026-04-20T18:20:00Z",
                     "2026-04-20T18:21:15Z",
                 ],
             ), patch(
-                "control_plane.workflows.verireel_testing_deploy._resolve_ship_request",
+                "control_plane.workflows.verireel_stable_deploy._resolve_ship_request",
                 return_value=(
                     ship_request,
                     ResolvedTargetEvidence(
@@ -119,10 +119,10 @@ class VeriReelTestingDeployWorkflowTests(unittest.TestCase):
                     300,
                 ),
             ), patch(
-                "control_plane.workflows.verireel_testing_deploy._execute_dokploy_deploy",
+                "control_plane.workflows.verireel_stable_deploy._execute_dokploy_deploy",
                 side_effect=click.ClickException("deploy failed"),
             ):
-                result = execute_verireel_testing_deploy(
+                result = execute_verireel_stable_deploy(
                     control_plane_root=root,
                     record_store=store,
                     request=request,


### PR DESCRIPTION
## Summary
- add the Launchplane-owned VeriReel production promotion and rollback drivers plus service boundary/docs coverage
- resolve rollback and runtime Dokploy config from Launchplane runtime-environment and managed-secret records instead of legacy host env defaults
- update preflight, examples, and operations docs so bootstrap env stays minimal and runtime values move into the DB-backed store

## Verification
- `uv run python -m unittest tests.test_dokploy tests.test_promote tests.test_secrets tests.test_runtime_environments tests.test_verireel_testing_deploy tests.test_verireel_prod_promotion tests.test_verireel_prod_rollback`
- `uv run python -m py_compile control_plane/dokploy.py control_plane/secrets.py control_plane/cli.py control_plane/workflows/verireel_stable_deploy.py control_plane/workflows/verireel_prod_promotion.py`
- `git diff --check`

## Follow-up
- the repo-side migration is in this PR, but the live Launchplane Dokploy target still needs the in-network import of runtime-environment, target-id, and managed-secret records before the remaining legacy target env artifacts can be removed
