### PR TITLE
Restore bootstrap Dokploy credentials for deploy jobs

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -490,11 +490,19 @@ def read_dokploy_config(*, control_plane_root: Path) -> tuple[str, str]:
     host = environment_values.get("DOKPLOY_HOST", "").strip()
     token = environment_values.get("DOKPLOY_TOKEN", "").strip()
     if not host or not token:
+        bootstrap_environment_values = read_control_plane_bootstrap_environment_values(
+            control_plane_root=control_plane_root
+        )
+        if not host:
+            host = bootstrap_environment_values.get("DOKPLOY_HOST", "").strip()
+        if not token:
+            token = bootstrap_environment_values.get("DOKPLOY_TOKEN", "").strip()
+    if not host or not token:
         external_env_file = resolve_launchplane_config_dir() / DEFAULT_CONTROL_PLANE_ENV_FILE_BASENAME
         raise click.ClickException(
             "Missing DOKPLOY_HOST or DOKPLOY_TOKEN for control-plane Dokploy execution. "
             "Configure Launchplane-managed Dokploy secrets in the shared store, "
-            f"or use {CONTROL_PLANE_ENV_FILE_ENV_VAR}/{external_env_file} only as bootstrap input before import."
+            f"or use {CONTROL_PLANE_ENV_FILE_ENV_VAR} or {external_env_file} only as bootstrap input before import."
         )
     return host, token
 

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -644,6 +644,25 @@ target_id = "compose-456"
         self.assertEqual(host, "https://dokploy.control-plane.example")
         self.assertEqual(token, "control-plane-token")
 
+    def test_read_dokploy_config_falls_back_to_process_environment_bootstrap(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            xdg_config_home = control_plane_root / "xdg"
+
+            with patch.dict(
+                os.environ,
+                {
+                    "DOKPLOY_HOST": "https://dokploy.process.example",
+                    "DOKPLOY_TOKEN": "process-token",
+                    "XDG_CONFIG_HOME": str(xdg_config_home),
+                },
+                clear=True,
+            ):
+                host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
+
+        self.assertEqual(host, "https://dokploy.process.example")
+        self.assertEqual(token, "process-token")
+
     def test_read_dokploy_config_supports_explicit_control_plane_env_file(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- let operator-side Dokploy execution fall back to bootstrap environment values when managed Dokploy secrets are not yet available
- keep managed secret values as the preferred source when the shared store is populated
- add coverage for the GitHub Actions style process-env bootstrap path

## Why
The `Deploy Launchplane` workflow passes `DOKPLOY_HOST` and `DOKPLOY_TOKEN` as job environment variables. After the runtime-config sweep, Dokploy preflight stopped reading that bootstrap source and the automatic deploy from `main` failed during `inspect-dokploy-target`.

## Verification
- `uv run python -m unittest tests.test_dokploy`
- `uv run python -m unittest`
- `git diff --check`
