### PR TITLE
Skip empty runtime secrets during bootstrap import

### DIFF
--- a/control_plane/secrets.py
+++ b/control_plane/secrets.py
@@ -305,15 +305,20 @@ def _import_runtime_environment_scope(
 ) -> dict[str, int]:
     imported = 0
     unchanged = 0
+    skipped_empty = 0
     for key_name, raw_value in values.items():
         if not _runtime_environment_key_is_secret(key_name):
+            continue
+        plaintext_value = str(raw_value).strip()
+        if not plaintext_value:
+            skipped_empty += 1
             continue
         result = write_secret_value(
             record_store=record_store,
             scope=scope,
             integration=RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
             name=key_name,
-            plaintext_value=str(raw_value),
+            plaintext_value=plaintext_value,
             binding_key=key_name,
             context_name=context_name,
             instance_name=instance_name,
@@ -325,7 +330,7 @@ def _import_runtime_environment_scope(
             unchanged += 1
         else:
             imported += 1
-    return {"imported": imported, "unchanged": unchanged}
+    return {"imported": imported, "unchanged": unchanged, "skipped_empty": skipped_empty}
 
 
 def import_bootstrap_secrets(
@@ -339,7 +344,7 @@ def import_bootstrap_secrets(
 
     summary: dict[str, object] = {
         "dokploy": {"imported": 0, "unchanged": 0},
-        "runtime_environment": {"imported": 0, "unchanged": 0},
+        "runtime_environment": {"imported": 0, "unchanged": 0, "skipped_empty": 0},
     }
     environment_values = control_plane_dokploy.read_control_plane_bootstrap_environment_values(
         control_plane_root=control_plane_root
@@ -377,6 +382,7 @@ def import_bootstrap_secrets(
     assert isinstance(runtime_summary, dict)
     runtime_summary["imported"] = int(runtime_summary["imported"]) + shared_summary["imported"]
     runtime_summary["unchanged"] = int(runtime_summary["unchanged"]) + shared_summary["unchanged"]
+    runtime_summary["skipped_empty"] = int(runtime_summary["skipped_empty"]) + shared_summary["skipped_empty"]
     for context_name, context_definition in definition.contexts.items():
         context_summary = _import_runtime_environment_scope(
             record_store=record_store,
@@ -387,6 +393,7 @@ def import_bootstrap_secrets(
         )
         runtime_summary["imported"] = int(runtime_summary["imported"]) + context_summary["imported"]
         runtime_summary["unchanged"] = int(runtime_summary["unchanged"]) + context_summary["unchanged"]
+        runtime_summary["skipped_empty"] = int(runtime_summary["skipped_empty"]) + context_summary["skipped_empty"]
         for instance_name, instance_definition in context_definition.instances.items():
             instance_summary = _import_runtime_environment_scope(
                 record_store=record_store,
@@ -398,6 +405,7 @@ def import_bootstrap_secrets(
             )
             runtime_summary["imported"] = int(runtime_summary["imported"]) + instance_summary["imported"]
             runtime_summary["unchanged"] = int(runtime_summary["unchanged"]) + instance_summary["unchanged"]
+            runtime_summary["skipped_empty"] = int(runtime_summary["skipped_empty"]) + instance_summary["skipped_empty"]
     return summary
 
 

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -177,6 +177,7 @@ ODOO_DB_PASSWORD = "instance-password"
                 statuses = control_plane_secrets.list_secret_statuses(store, context_name="opw", instance_name="testing")
                 self.assertEqual(summary["dokploy"]["imported"], 2)
                 self.assertEqual(summary["runtime_environment"]["imported"], 3)
+                self.assertEqual(summary["runtime_environment"]["skipped_empty"], 0)
                 self.assertEqual(
                     {status["binding"]["binding_key"] for status in statuses if status["binding"] is not None},
                     {
@@ -187,6 +188,46 @@ ODOO_DB_PASSWORD = "instance-password"
                         "ODOO_DB_PASSWORD",
                     },
                 )
+            store.close()
+
+    def test_import_bootstrap_secrets_skips_empty_runtime_secret_values(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            xdg_config_home = control_plane_root / "xdg"
+            runtime_environments_file = control_plane_root / "config" / "runtime-environments.toml"
+            runtime_environments_file.parent.mkdir(parents=True, exist_ok=True)
+            runtime_environments_file.write_text(
+                """
+schema_version = 1
+
+[contexts.opw.instances.prod.env]
+ENV_OVERRIDE_SHOPIFY__API_TOKEN = ""
+ENV_OVERRIDE_SHOPIFY__SHOP_URL_KEY = ""
+ENV_OVERRIDE_SHOPIFY__WEBHOOK_KEY = ""
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            with patch.dict(
+                os.environ,
+                {
+                    control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                    "XDG_CONFIG_HOME": str(xdg_config_home),
+                },
+                clear=True,
+            ):
+                summary = control_plane_secrets.import_bootstrap_secrets(
+                    record_store=store,
+                    control_plane_root=control_plane_root,
+                    actor="bootstrap-test",
+                )
+                statuses = control_plane_secrets.list_secret_statuses(store, context_name="opw", instance_name="prod")
+                self.assertEqual(summary["runtime_environment"]["imported"], 0)
+                self.assertEqual(summary["runtime_environment"]["skipped_empty"], 3)
+                self.assertEqual(statuses, [])
             store.close()
 
     def test_secrets_cli_import_bootstrap_reports_summary(self) -> None:


### PR DESCRIPTION
## Summary
- skip empty secret-shaped runtime values during bootstrap import instead of failing the whole import
- report skipped empty values in the bootstrap summary
- add coverage for both the normal import path and the empty-value edge case

## Why
The live Launchplane runtime catalog currently includes intentionally blank secret-shaped values in at least one instance scope. During the in-network store migration, `launchplane secrets import-bootstrap` failed on those blanks because managed secret writes require non-empty plaintext.

## Verification
- `uv run python -m unittest tests.test_secrets`
- `uv run python -m unittest`
- `git diff --check`
