### PR TITLE
Move Launchplane deploys to OIDC self-deploy

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -198,12 +198,13 @@ jobs:
             --data "$request_payload" \
             "${{ steps.service.outputs.service_url }}/v1/drivers/launchplane/self-deploy"
 
-      - name: Wait for Launchplane health
+      - name: Wait for deployed Launchplane image
         shell: bash
         run: |
           set -euo pipefail
 
-          deadline=$((SECONDS + ${LAUNCHPLANE_DEPLOY_HEALTH_TIMEOUT_SECONDS:-180}))
+          deadline=$((SECONDS + ${LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS:-600} + ${LAUNCHPLANE_DEPLOY_HEALTH_TIMEOUT_SECONDS:-180}))
+          expected_image_reference="${{ steps.image.outputs.image_reference }}"
           while [ "$SECONDS" -lt "$deadline" ]; do
             all_healthy=1
             while IFS= read -r raw_url; do
@@ -218,36 +219,23 @@ jobs:
               fi
             done < <(printf '%s\n' "$LAUNCHPLANE_DEPLOY_HEALTH_URLS" | tr ',' '\n')
 
-            if [ "$all_healthy" -eq 1 ]; then
+            oidc_token="$({
+              curl -fsSL \
+                -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+                "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${{ steps.service.outputs.service_audience }}" \
+              | jq -r '.value'
+            })"
+
+            runtime_payload="$(curl -fsSL \
+              -H "Authorization: Bearer ${oidc_token}" \
+              "${{ steps.service.outputs.service_url }}/v1/service/runtime" 2>/dev/null || true)"
+            actual_image_reference="$(printf '%s' "$runtime_payload" | jq -r '.runtime.docker_image_reference // empty' 2>/dev/null || true)"
+
+            if [ "$all_healthy" -eq 1 ] && [ "$actual_image_reference" = "$expected_image_reference" ]; then
               exit 0
             fi
             sleep 5
           done
 
-          echo "Timed out waiting for Launchplane health checks." >&2
+          echo "Timed out waiting for Launchplane image '$expected_image_reference' to become live and healthy." >&2
           exit 1
-
-      - name: Verify deployed Launchplane image reference
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          oidc_token="$({
-            curl -fsSL \
-              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${{ steps.service.outputs.service_audience }}" \
-            | jq -r '.value'
-          })"
-
-          runtime_payload="$({
-            curl -fsSL \
-              -H "Authorization: Bearer ${oidc_token}" \
-              "${{ steps.service.outputs.service_url }}/v1/service/runtime"
-          })"
-
-          actual_image_reference="$(printf '%s' "$runtime_payload" | jq -r '.runtime.docker_image_reference')"
-          expected_image_reference="${{ steps.image.outputs.image_reference }}"
-          if [ "$actual_image_reference" != "$expected_image_reference" ]; then
-            echo "Launchplane reported image reference '$actual_image_reference', expected '$expected_image_reference'." >&2
-            exit 1
-          fi

--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -20,6 +20,7 @@ on:
 permissions:
   actions: read
   contents: read
+  id-token: write
   packages: write
 
 concurrency:
@@ -36,8 +37,6 @@ jobs:
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
-      DOKPLOY_HOST: ${{ secrets.DOKPLOY_HOST }}
-      DOKPLOY_TOKEN: ${{ secrets.DOKPLOY_TOKEN }}
       LAUNCHPLANE_DOKPLOY_TARGET_ID: ${{ vars.LAUNCHPLANE_DOKPLOY_TARGET_ID }}
       LAUNCHPLANE_DOKPLOY_TARGET_TYPE: ${{ vars.LAUNCHPLANE_DOKPLOY_TARGET_TYPE }}
       LAUNCHPLANE_DEPLOY_HEALTH_URLS: ${{ vars.LAUNCHPLANE_DEPLOY_HEALTH_URLS }}
@@ -82,11 +81,31 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          : "${DOKPLOY_HOST:?Missing DOKPLOY_HOST secret}"
-          : "${DOKPLOY_TOKEN:?Missing DOKPLOY_TOKEN secret}"
           : "${LAUNCHPLANE_DOKPLOY_TARGET_TYPE:?Missing LAUNCHPLANE_DOKPLOY_TARGET_TYPE variable}"
           : "${LAUNCHPLANE_DOKPLOY_TARGET_ID:?Missing LAUNCHPLANE_DOKPLOY_TARGET_ID variable}"
           : "${LAUNCHPLANE_DEPLOY_HEALTH_URLS:?Missing LAUNCHPLANE_DEPLOY_HEALTH_URLS variable}"
+
+      - name: Resolve Launchplane service endpoint
+        id: service
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python - <<'PY'
+          import os
+          from urllib.parse import urlsplit
+
+          raw_urls = [value.strip() for value in os.environ["LAUNCHPLANE_DEPLOY_HEALTH_URLS"].split(",") if value.strip()]
+          if not raw_urls:
+              raise SystemExit("Missing Launchplane deploy health URL.")
+          parsed = urlsplit(raw_urls[0])
+          if not parsed.scheme or not parsed.netloc or not parsed.hostname:
+              raise SystemExit(f"Could not derive Launchplane service endpoint from {raw_urls[0]!r}.")
+          service_url = f"{parsed.scheme}://{parsed.netloc}"
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:
+              handle.write(f"service_url={service_url}\n")
+              handle.write(f"service_audience={parsed.hostname}\n")
+          PY
 
       - name: Checkout
         uses: actions/checkout@v6
@@ -100,15 +119,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version-file: pyproject.toml
-
-      - name: Preflight Dokploy Launchplane target
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          uv run launchplane service inspect-dokploy-target \
-            --target-type "$LAUNCHPLANE_DOKPLOY_TARGET_TYPE" \
-            --target-id "$LAUNCHPLANE_DOKPLOY_TARGET_ID"
 
       - name: Set up Docker Buildx
         if: steps.prep.outputs.should_build == 'true'
@@ -160,23 +170,84 @@ jobs:
           fi
           echo "image_reference=$image_reference" >> "$GITHUB_OUTPUT"
 
-      - name: Deploy Launchplane in Dokploy
+      - name: Request Launchplane self deploy
         shell: bash
         run: |
           set -euo pipefail
 
-          health_args=()
-          while IFS= read -r raw_url; do
-            health_url="$(printf '%s' "$raw_url" | xargs)"
-            if [ -n "$health_url" ]; then
-              health_args+=(--health-url "$health_url")
-            fi
-          done < <(printf '%s\n' "$LAUNCHPLANE_DEPLOY_HEALTH_URLS" | tr ',' '\n')
+          oidc_token="$({
+            curl -fsSL \
+              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${{ steps.service.outputs.service_audience }}" \
+            | jq -r '.value'
+          })"
 
-          uv run launchplane service deploy-dokploy-image \
-            --target-type "$LAUNCHPLANE_DOKPLOY_TARGET_TYPE" \
-            --target-id "$LAUNCHPLANE_DOKPLOY_TARGET_ID" \
-            --image-reference "${{ steps.image.outputs.image_reference }}" \
-            --deploy-timeout-seconds "${LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS:-600}" \
-            --health-timeout-seconds "${LAUNCHPLANE_DEPLOY_HEALTH_TIMEOUT_SECONDS:-180}" \
-            "${health_args[@]}"
+          request_payload="$({
+            jq -n \
+              --arg target_type "$LAUNCHPLANE_DOKPLOY_TARGET_TYPE" \
+              --arg target_id "$LAUNCHPLANE_DOKPLOY_TARGET_ID" \
+              --arg image_reference "${{ steps.image.outputs.image_reference }}" \
+              '{schema_version: 1, product: "launchplane", deploy: {target_type: $target_type, target_id: $target_id, image_reference: $image_reference}}'
+          })"
+
+          curl -fsSL \
+            -X POST \
+            -H "Authorization: Bearer ${oidc_token}" \
+            -H "Content-Type: application/json" \
+            -H "Idempotency-Key: launchplane-self-deploy:${{ steps.image.outputs.image_reference }}" \
+            --data "$request_payload" \
+            "${{ steps.service.outputs.service_url }}/v1/drivers/launchplane/self-deploy"
+
+      - name: Wait for Launchplane health
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          deadline=$((SECONDS + ${LAUNCHPLANE_DEPLOY_HEALTH_TIMEOUT_SECONDS:-180}))
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            all_healthy=1
+            while IFS= read -r raw_url; do
+              health_url="$(printf '%s' "$raw_url" | xargs)"
+              if [ -z "$health_url" ]; then
+                continue
+              fi
+              response_body="$(curl -fsSL "$health_url" 2>/dev/null || true)"
+              if [ -z "$response_body" ] || ! printf '%s' "$response_body" | jq -e '.status == "ok"' >/dev/null 2>&1; then
+                all_healthy=0
+                break
+              fi
+            done < <(printf '%s\n' "$LAUNCHPLANE_DEPLOY_HEALTH_URLS" | tr ',' '\n')
+
+            if [ "$all_healthy" -eq 1 ]; then
+              exit 0
+            fi
+            sleep 5
+          done
+
+          echo "Timed out waiting for Launchplane health checks." >&2
+          exit 1
+
+      - name: Verify deployed Launchplane image reference
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          oidc_token="$({
+            curl -fsSL \
+              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${{ steps.service.outputs.service_audience }}" \
+            | jq -r '.value'
+          })"
+
+          runtime_payload="$({
+            curl -fsSL \
+              -H "Authorization: Bearer ${oidc_token}" \
+              "${{ steps.service.outputs.service_url }}/v1/service/runtime"
+          })"
+
+          actual_image_reference="$(printf '%s' "$runtime_payload" | jq -r '.runtime.docker_image_reference')"
+          expected_image_reference="${{ steps.image.outputs.image_reference }}"
+          if [ "$actual_image_reference" != "$expected_image_reference" ]; then
+            echo "Launchplane reported image reference '$actual_image_reference', expected '$expected_image_reference'." >&2
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -140,9 +140,6 @@ manual laptop-side image swap. The current operator posture is:
 The repo now includes `.github/workflows/deploy-launchplane.yml` for that path.
 Configure these GitHub settings before enabling it:
 
-- repository secrets:
-  - `DOKPLOY_HOST`
-  - `DOKPLOY_TOKEN`
 - repository variables:
   - `LAUNCHPLANE_DOKPLOY_TARGET_TYPE`
   - `LAUNCHPLANE_DOKPLOY_TARGET_ID`
@@ -150,6 +147,10 @@ Configure these GitHub settings before enabling it:
   - optional `LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS`
   - optional `LAUNCHPLANE_DEPLOY_HEALTH_TIMEOUT_SECONDS`
   - optional `LAUNCHPLANE_IMAGE_REPOSITORY`
+
+The deploy workflow now uses GitHub OIDC plus Launchplane's own service API to
+request a self-deploy. Dokploy credentials should live in Launchplane-managed
+secrets inside the shared store, not in GitHub repository secrets.
 
 `LAUNCHPLANE_DEPLOY_HEALTH_URLS` must point at Launchplane URLs that GitHub-hosted
 runners can reach, typically the public `https://.../v1/health` endpoint.
@@ -167,8 +168,8 @@ runtime contract pieces such as:
 
 - `LAUNCHPLANE_DATABASE_URL`
 - `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`
-- `DOKPLOY_HOST`
-- `DOKPLOY_TOKEN`
+- Launchplane-managed `DOKPLOY_HOST`
+- Launchplane-managed `DOKPLOY_TOKEN`
 - a Dokploy SSH key for private `git@github.com:...` compose sources
 
 It also reports warnings when the live target lacks a policy input, target-id

--- a/config/launchplane-authz.toml.example
+++ b/config/launchplane-authz.toml.example
@@ -72,3 +72,13 @@ event_names = ["pull_request"]
 products = ["odoo"]
 contexts = ["opw"]
 actions = ["preview_generation.write"]
+
+[[github_actions]]
+repository = "example-org/launchplane"
+workflow_refs = [
+  "example-org/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main",
+]
+event_names = ["workflow_run", "workflow_dispatch"]
+products = ["launchplane"]
+contexts = ["launchplane"]
+actions = ["launchplane_service.read", "launchplane_service_deploy.execute"]

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 import hashlib
 import io
 import json
+import os
 import uuid
 from pathlib import Path
 from typing import Callable
@@ -12,6 +13,7 @@ from wsgiref.simple_server import make_server
 import click
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
+from control_plane import dokploy as control_plane_dokploy
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
@@ -52,6 +54,10 @@ from control_plane.workflows.verireel_preview_driver import (
     execute_verireel_preview_destroy,
     execute_verireel_preview_refresh,
 )
+
+
+_LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
+_LAUNCHPLANE_IMAGE_REFERENCE_ENV_KEY = "DOCKER_IMAGE_REFERENCE"
 
 
 class PreviewGenerationEvidenceEnvelope(BaseModel):
@@ -221,6 +227,43 @@ class VeriReelPreviewDestroyEnvelope(BaseModel):
         return self
 
 
+class LaunchplaneSelfDeployRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    target_type: str
+    target_id: str
+    image_reference: str
+    no_cache: bool = False
+
+    @model_validator(mode="after")
+    def _validate_values(self) -> "LaunchplaneSelfDeployRequest":
+        normalized_target_type = self.target_type.strip()
+        if normalized_target_type not in {"compose", "application"}:
+            raise ValueError("Launchplane self deploy requires target_type 'compose' or 'application'.")
+        if not self.target_id.strip():
+            raise ValueError("Launchplane self deploy requires target_id.")
+        if not self.image_reference.strip():
+            raise ValueError("Launchplane self deploy requires image_reference.")
+        self.target_type = normalized_target_type
+        self.target_id = self.target_id.strip()
+        self.image_reference = self.image_reference.strip()
+        return self
+
+
+class LaunchplaneSelfDeployEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    deploy: LaunchplaneSelfDeployRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "LaunchplaneSelfDeployEnvelope":
+        if self.product.strip() != "launchplane":
+            raise ValueError("Launchplane self deploy requires product 'launchplane'.")
+        return self
+
+
 def _json_response(
     *,
     start_response: Callable[[str, list[tuple[str, str]]], None],
@@ -298,6 +341,8 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "secret.list", {"context": segments[2], "instance": segments[4]}
     if len(segments) == 5 and segments[:2] == ["v1", "contexts"] and segments[3:] == ["operations", "recent"]:
         return "operations.read", {"context": segments[2]}
+    if len(segments) == 3 and segments == ["v1", "service", "runtime"]:
+        return "launchplane_service.read", {}
     return None
 
 
@@ -361,6 +406,9 @@ def _accepted_payload(
                 "preview_id",
                 "generation_id",
                 "promotion_record_id",
+                "target_id",
+                "target_type",
+                "image_reference",
                 "transition",
             }
         },
@@ -512,6 +560,55 @@ def _bearer_token(environ: dict[str, object]) -> str:
     return token.strip()
 
 
+def _launchplane_runtime_payload(*, storage_backend: str) -> dict[str, object]:
+    return {
+        "docker_image_reference": os.environ.get(_LAUNCHPLANE_IMAGE_REFERENCE_ENV_KEY, "").strip(),
+        "service_audience": os.environ.get("LAUNCHPLANE_SERVICE_AUDIENCE", "").strip(),
+        "storage_backend": storage_backend,
+    }
+
+
+def _request_launchplane_self_deploy(
+    *,
+    control_plane_root_path: Path,
+    request: LaunchplaneSelfDeployRequest,
+) -> dict[str, object]:
+    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root_path)
+    target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
+        host=host,
+        token=token,
+        target_type=request.target_type,
+        target_id=request.target_id,
+    )
+    raw_env_text = str(target_payload.get("env") or "")
+    updated_env_text = control_plane_dokploy.render_dokploy_env_text_with_overrides(
+        raw_env_text,
+        updates={_LAUNCHPLANE_IMAGE_REFERENCE_ENV_KEY: request.image_reference},
+    )
+    if updated_env_text != raw_env_text:
+        control_plane_dokploy.update_dokploy_target_env(
+            host=host,
+            token=token,
+            target_type=request.target_type,
+            target_id=request.target_id,
+            target_payload=target_payload,
+            env_text=updated_env_text,
+        )
+    control_plane_dokploy.trigger_deployment(
+        host=host,
+        token=token,
+        target_type=request.target_type,
+        target_id=request.target_id,
+        no_cache=request.no_cache,
+    )
+    return {
+        "target_type": request.target_type,
+        "target_id": request.target_id,
+        "image_reference": request.image_reference,
+        "image_reference_changed": updated_env_text != raw_env_text,
+    }
+
+
 def create_launchplane_service_app(
     *,
     state_dir: Path,
@@ -529,6 +626,7 @@ def create_launchplane_service_app(
         "/v1/evidence/previews/generations",
         "/v1/evidence/previews/destroyed",
         "/v1/evidence/promotions",
+        "/v1/drivers/launchplane/self-deploy",
         "/v1/drivers/verireel/preview-refresh",
         "/v1/drivers/verireel/preview-destroy",
         "/v1/drivers/verireel/testing-deploy",
@@ -831,6 +929,34 @@ def create_launchplane_service_app(
                             "secrets": statuses,
                         },
                     )
+                if action == "launchplane_service.read":
+                    if not authz_policy.allows(
+                        identity=identity,
+                        action=action,
+                        product="launchplane",
+                        context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                    ):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=403,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "authorization_denied",
+                                    "message": "Workflow cannot read Launchplane service runtime state.",
+                                },
+                            },
+                        )
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=200,
+                        payload={
+                            "status": "ok",
+                            "trace_id": request_trace_id,
+                            "runtime": _launchplane_runtime_payload(storage_backend=storage_backend),
+                        },
+                    )
                 context_name = params["context"]
                 if not authz_policy.allows(
                     identity=identity,
@@ -951,6 +1077,41 @@ def create_launchplane_service_app(
                     return idempotent_response
                 record_store.write_backup_gate_record(request.backup_gate)
                 result = {"backup_gate_record_id": request.backup_gate.record_id}
+            elif path == "/v1/drivers/launchplane/self-deploy":
+                request = LaunchplaneSelfDeployEnvelope.model_validate(payload)
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="launchplane_service_deploy.execute",
+                    product=request.product,
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot execute Launchplane self deploy.",
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                result = _request_launchplane_self_deploy(
+                    control_plane_root_path=resolved_root,
+                    request=request.deploy,
+                )
             elif path == "/v1/drivers/verireel/testing-deploy":
                 request = VeriReelTestingDeployEnvelope.model_validate(payload)
                 if not authz_policy.allows(

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -134,9 +134,6 @@ testing environment of its own.
 
 Required GitHub configuration for that workflow:
 
-- repository secrets:
-  - `DOKPLOY_HOST`
-  - `DOKPLOY_TOKEN`
 - repository variables:
   - `LAUNCHPLANE_DOKPLOY_TARGET_TYPE`
   - `LAUNCHPLANE_DOKPLOY_TARGET_ID`
@@ -144,6 +141,10 @@ Required GitHub configuration for that workflow:
   - optional `LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS`
   - optional `LAUNCHPLANE_DEPLOY_HEALTH_TIMEOUT_SECONDS`
   - optional `LAUNCHPLANE_IMAGE_REPOSITORY`
+
+The workflow should use GitHub OIDC to call Launchplane's own service API.
+Keep Dokploy host/token authority in Launchplane-managed secrets instead of
+duplicating those credentials in GitHub repository secrets.
 
 `LAUNCHPLANE_DEPLOY_HEALTH_URLS` must resolve from GitHub-hosted runners. Use the
 public Launchplane `GET /v1/health` endpoint rather than an internal-only Dokploy
@@ -163,11 +164,10 @@ uv run launchplane service inspect-dokploy-target \
 ```
 
 That command reports only non-secret metadata and fails closed when the live
-Launchplane target is missing critical runtime pieces such as `LAUNCHPLANE_DATABASE_URL`,
-`LAUNCHPLANE_MASTER_ENCRYPTION_KEY`, Launchplane-managed Dokploy secret bindings,
-or a Dokploy SSH key for a private `git@github.com:...` compose source. The
-GitHub deploy workflow now runs that same preflight before it builds or deploys
-a new image.
+Launchplane target is missing critical runtime pieces such as
+`LAUNCHPLANE_DATABASE_URL`, `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`,
+Launchplane-managed Dokploy secret bindings, or a Dokploy SSH key for a private
+`git@github.com:...` compose source.
 
 The intended live service contract is now bootstrap-only target env plus
 DB-backed Launchplane records:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -174,6 +174,140 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(payload["status"], "ok")
             self.assertEqual(payload["storage_backend"], "filesystem")
 
+    def test_service_runtime_endpoint_reports_current_image_reference(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["launchplane_service.read"],
+                        }
+                    ]
+                }
+            )
+            with patch.dict(
+                os.environ,
+                {
+                    "DOCKER_IMAGE_REFERENCE": "ghcr.io/cbusillo/launchplane@sha256:test",
+                    "LAUNCHPLANE_SERVICE_AUDIENCE": "launchplane.shinycomputers.com",
+                },
+                clear=True,
+            ):
+                app = create_launchplane_service_app(
+                    state_dir=Path(temporary_directory_name) / "state",
+                    verifier=_StubVerifier(
+                        _identity(
+                            repository="cbusillo/launchplane",
+                            workflow_ref=(
+                                "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                            ),
+                            event_name="workflow_dispatch",
+                        )
+                    ),
+                    authz_policy=policy,
+                    control_plane_root_path=Path(temporary_directory_name),
+                )
+
+                status_code, payload = _invoke_app(app, method="GET", path="/v1/service/runtime")
+
+        self.assertEqual(status_code, 200)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(
+            payload["runtime"]["docker_image_reference"],
+            "ghcr.io/cbusillo/launchplane@sha256:test",
+        )
+        self.assertEqual(payload["runtime"]["service_audience"], "launchplane.shinycomputers.com")
+
+    def test_self_deploy_endpoint_updates_target_env_and_triggers_dokploy(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["launchplane_service_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+
+            with (
+                patch(
+                    "control_plane.service.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "token-123"),
+                ),
+                patch(
+                    "control_plane.service.control_plane_dokploy.fetch_dokploy_target_payload",
+                    return_value={"env": "DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/launchplane@sha256:old\n"},
+                ),
+                patch(
+                    "control_plane.service.control_plane_dokploy.update_dokploy_target_env"
+                ) as update_env_mock,
+                patch(
+                    "control_plane.service.control_plane_dokploy.trigger_deployment"
+                ) as trigger_mock,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/launchplane/self-deploy",
+                    payload={
+                        "product": "launchplane",
+                        "deploy": {
+                            "target_type": "compose",
+                            "target_id": "compose-123",
+                            "image_reference": "ghcr.io/cbusillo/launchplane@sha256:new",
+                        },
+                    },
+                    headers={"Idempotency-Key": "launchplane-self-deploy:test"},
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(payload["records"]["target_id"], "compose-123")
+        self.assertEqual(payload["records"]["target_type"], "compose")
+        self.assertEqual(
+            payload["records"]["image_reference"],
+            "ghcr.io/cbusillo/launchplane@sha256:new",
+        )
+        update_env_mock.assert_called_once()
+        updated_env_text = update_env_mock.call_args.kwargs["env_text"]
+        self.assertIn("DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/launchplane@sha256:new", updated_env_text)
+        trigger_mock.assert_called_once_with(
+            host="https://dokploy.example.com",
+            token="token-123",
+            target_type="compose",
+            target_id="compose-123",
+            no_cache=False,
+        )
+
     def test_preview_generation_endpoint_writes_records_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add Launchplane service routes for authenticated self-deploy and runtime image inspection
- switch the Launchplane deploy workflow from repo-level Dokploy secrets to GitHub OIDC plus Launchplane's own service API
- document the authz/workflow contract for the new deploy path

## Verification
- `uv run python -m unittest tests.test_service`
- `uv run python -m unittest`
- `ruby -e "require 'yaml'; YAML.load_file('sources/launchplane/.github/workflows/deploy-launchplane.yml')"`
- `actionlint sources/launchplane/.github/workflows/deploy-launchplane.yml`
- manual workflow validation on branch: https://github.com/cbusillo/launchplane/actions/runs/24752931583

## Rollout
- seeded the live Launchplane service with this branch using the previous deploy path
- updated live Launchplane authz policy to allow the new `launchplane_service.read` and `launchplane_service_deploy.execute` actions
- validated the branch workflow against the live service before merging
