### PR TITLE
Add runtime environment import CLI

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -50,6 +50,7 @@ from control_plane.contracts.promotion_record import (
     ReleaseStatus,
 )
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.launchplane_mutations import (
     apply_launchplane_destroy_preview as shared_apply_launchplane_destroy_preview,
@@ -7487,6 +7488,20 @@ def _build_runtime_environment_rows(
     ]
 
 
+def _summarize_runtime_environment_record(
+    record: RuntimeEnvironmentRecord,
+) -> dict[str, object]:
+    return {
+        "scope": record.scope,
+        "context": record.context,
+        "instance": record.instance,
+        "updated_at": record.updated_at,
+        "source_label": record.source_label,
+        "env_keys": sorted(record.env.keys()),
+        "env_value_count": len(record.env),
+    }
+
+
 @click.group()
 def main() -> None:
     """Control-plane CLI."""
@@ -9388,6 +9403,83 @@ def _apply_launchplane_pr_event_intent(
 @main.group()
 def environments() -> None:
     """Runtime environment contract commands."""
+
+
+@environments.command("import")
+@click.option(
+    "--file",
+    "runtime_environments_file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+)
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane runtime-environment records.",
+)
+@click.option("--source-label", default="", show_default=False)
+def environments_import(
+    runtime_environments_file: Path,
+    database_url: str,
+    source_label: str,
+) -> None:
+    definition = control_plane_runtime_environments.load_runtime_environment_definition_from_file(
+        runtime_environments_file
+    )
+    records = control_plane_runtime_environments.build_runtime_environment_records_from_definition(
+        definition,
+        updated_at=utc_now_timestamp(),
+        source_label=source_label.strip() or str(runtime_environments_file),
+    )
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    postgres_store.ensure_schema()
+    try:
+        for record in records:
+            postgres_store.write_runtime_environment_record(record)
+    finally:
+        postgres_store.close()
+    click.echo(
+        json.dumps(
+            {
+                "status": "ok",
+                "count": len(records),
+                "records": [
+                    _summarize_runtime_environment_record(record) for record in records
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+@environments.command("list")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane runtime-environment records.",
+)
+def environments_list(database_url: str) -> None:
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    try:
+        records = postgres_store.list_runtime_environment_records()
+    finally:
+        postgres_store.close()
+    click.echo(
+        json.dumps(
+            {
+                "status": "ok",
+                "count": len(records),
+                "records": [
+                    _summarize_runtime_environment_record(record) for record in records
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
 
 
 @environments.command("resolve")

--- a/control_plane/runtime_environments.py
+++ b/control_plane/runtime_environments.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+import tomllib
 
 import click
 
@@ -49,6 +50,25 @@ def load_runtime_environment_definition(
 
     raise click.ClickException(
         "Missing Launchplane runtime environment authority. Configure DB-backed runtime environment records."
+    )
+
+
+def load_runtime_environment_definition_from_file(
+    runtime_environments_file: Path,
+) -> RuntimeEnvironmentDefinition:
+    try:
+        payload = tomllib.loads(runtime_environments_file.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise click.ClickException(
+            f"Missing runtime environments file: {runtime_environments_file}"
+        ) from error
+    except tomllib.TOMLDecodeError as error:
+        raise click.ClickException(
+            f"Could not parse runtime environments file {runtime_environments_file}: {error}"
+        ) from error
+    return _parse_runtime_environment_definition(
+        payload,
+        source_file=runtime_environments_file,
     )
 
 

--- a/tests/test_runtime_environments.py
+++ b/tests/test_runtime_environments.py
@@ -70,6 +70,90 @@ def _seed_dokploy_target_records(*, database_url: str, payload: str) -> None:
 
 
 class RuntimeEnvironmentTests(unittest.TestCase):
+    def test_environments_import_writes_records_without_echoing_values(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            runtime_environments_file = control_plane_root / "runtime-environments.toml"
+            with runtime_environments_file.open("w", encoding="utf-8") as handle:
+                handle.write(
+                    'schema_version = 1\n\n'
+                    '[shared_env]\n'
+                    'LAUNCHPLANE_PREVIEW_BASE_URL = "https://preview.example.com"\n\n'
+                    '[contexts.verireel.instances.prod.env]\n'
+                    'LAUNCHPLANE_VERIREEL_PROD_ROLLBACK_WORKER_COMMAND = "uv run python -m control_plane.workflows.verireel_prod_rollback_worker"\n'
+                    'VERIREEL_PROD_CT_ID = "101"\n'
+                    'VERIREEL_PROD_PROXMOX_HOST = "proxmox.example.com"\n'
+                    'VERIREEL_PROD_PROXMOX_USER = "root"\n'
+                )
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "environments",
+                    "import",
+                    "--file",
+                    str(runtime_environments_file),
+                    "--database-url",
+                    database_url,
+                    "--source-label",
+                    "operator-test",
+                ],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertNotIn("proxmox.example.com", result.output)
+            payload = json.loads(result.output)
+            self.assertEqual(payload["status"], "ok")
+            self.assertEqual(payload["count"], 2)
+            self.assertEqual(payload["records"][0]["source_label"], "operator-test")
+
+            with patch.dict(os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True):
+                resolved_values = control_plane_runtime_environments.resolve_runtime_environment_values(
+                    control_plane_root=control_plane_root,
+                    context_name="verireel",
+                    instance_name="prod",
+                )
+
+        self.assertEqual(resolved_values["VERIREEL_PROD_CT_ID"], "101")
+        self.assertEqual(
+            resolved_values["LAUNCHPLANE_VERIREEL_PROD_ROLLBACK_WORKER_COMMAND"],
+            "uv run python -m control_plane.workflows.verireel_prod_rollback_worker",
+        )
+
+    def test_environments_list_redacts_values(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            _seed_runtime_environment_records(
+                database_url=database_url,
+                definition=control_plane_runtime_environments.RuntimeEnvironmentDefinition(
+                    schema_version=1,
+                    shared_env={},
+                    contexts={
+                        "verireel": control_plane_runtime_environments.RuntimeEnvironmentContextDefinition(
+                            shared_env={},
+                            instances={
+                                "prod": control_plane_runtime_environments.RuntimeEnvironmentInstanceDefinition(
+                                    env={"VERIREEL_PROD_PROXMOX_HOST": "proxmox.example.com"}
+                                )
+                            },
+                        )
+                    },
+                ),
+            )
+
+            result = CliRunner().invoke(
+                main,
+                ["environments", "list", "--database-url", database_url],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn("proxmox.example.com", result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["records"][0]["env_keys"], ["VERIREEL_PROD_PROXMOX_HOST"])
+
     def test_resolve_runtime_environment_values_merges_shared_context_and_instance_values(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- add an operator CLI command to import runtime-environment TOML into DB-backed records
- add a redacted runtime-environment record listing command for verification
- keep command output to keys/counts only so runtime values are not echoed

## Verification
- uv run python -m unittest tests.test_runtime_environments tests.test_verireel_prod_rollback
- uv run python -m unittest

## Notes
- ruff format --check still wants to reflow pre-existing long lines in touched files, so formatting was intentionally left surgical.