### PR TITLE
Add DB-native runtime environment put command

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ target records, and Dokploy target-id records are DB-backed concerns;
 bootstrap stays in process env long enough to bring the service up and write
 the real records.
 
+Use `uv run launchplane environments put --scope ... --set KEY=VALUE` to write
+non-secret runtime values directly into DB-backed runtime-environment records;
+secret-shaped keys are rejected there. Use `uv run launchplane secrets put ...`
+for managed secret values. TOML/env files are not supported runtime import
+surfaces outside bootstrap policy/env.
+
 For the first local Launchplane service run, copy
 `config/launchplane-authz.toml.example` to a real local policy file such as
 `${XDG_CONFIG_HOME:-$HOME/.config}/launchplane/launchplane-authz.toml`, then replace the

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -116,6 +116,7 @@ _LAUNCHPLANE_SERVICE_POLICY_ENV_KEYS = (
 )
 _SERVICE_TARGET_TYPE_ENV_KEYS = ("LAUNCHPLANE_DOKPLOY_TARGET_TYPE",)
 _SERVICE_TARGET_ID_ENV_KEYS = ("LAUNCHPLANE_DOKPLOY_TARGET_ID",)
+_SECRET_SHAPED_RUNTIME_ENV_KEY_PARTS = {"PASSWORD", "TOKEN", "SECRET", "KEY"}
 _SUCCESSFUL_DOKPLOY_STATUSES = {"success", "succeeded", "done", "completed", "healthy", "finished"}
 
 
@@ -7502,6 +7503,80 @@ def _summarize_runtime_environment_record(
     }
 
 
+def _parse_runtime_environment_assignment(raw_assignment: str) -> tuple[str, str]:
+    key_name, separator, value = raw_assignment.partition("=")
+    normalized_key = key_name.strip()
+    if not separator or not normalized_key:
+        raise click.ClickException("Runtime environment values must be provided as KEY=VALUE.")
+    if _runtime_environment_key_requires_secret_store(normalized_key):
+        raise click.ClickException(
+            f"Runtime environment key {normalized_key!r} must be written with launchplane secrets put."
+        )
+    return normalized_key, value
+
+
+def _runtime_environment_key_requires_secret_store(key_name: str) -> bool:
+    return any(
+        key_part in _SECRET_SHAPED_RUNTIME_ENV_KEY_PARTS
+        for key_part in key_name.strip().upper().split("_")
+    )
+
+
+def _runtime_environment_record_matches(
+    record: RuntimeEnvironmentRecord,
+    *,
+    scope: str,
+    context_name: str,
+    instance_name: str,
+) -> bool:
+    return record.scope == scope and record.context == context_name and record.instance == instance_name
+
+
+def _build_runtime_environment_record_for_put(
+    *,
+    existing_records: tuple[RuntimeEnvironmentRecord, ...],
+    scope: str,
+    context_name: str,
+    instance_name: str,
+    assignments: tuple[str, ...],
+    source_label: str,
+) -> RuntimeEnvironmentRecord:
+    if scope == "global":
+        if context_name or instance_name:
+            raise click.ClickException("Global runtime environment records do not accept --context or --instance.")
+    elif scope == "context":
+        if not context_name or instance_name:
+            raise click.ClickException("Context runtime environment records require --context and do not accept --instance.")
+    elif scope == "instance":
+        if not context_name or not instance_name:
+            raise click.ClickException("Instance runtime environment records require --context and --instance.")
+    else:
+        raise click.ClickException(f"Unsupported runtime environment scope: {scope}")
+
+    env_values: dict[str, object] = {}
+    for record in existing_records:
+        if _runtime_environment_record_matches(
+            record,
+            scope=scope,
+            context_name=context_name,
+            instance_name=instance_name,
+        ):
+            env_values.update(record.env)
+            break
+    for raw_assignment in assignments:
+        key_name, value = _parse_runtime_environment_assignment(raw_assignment)
+        env_values[key_name] = value
+
+    return RuntimeEnvironmentRecord(
+        scope=scope,
+        context=context_name,
+        instance=instance_name,
+        env=env_values,
+        updated_at=utc_now_timestamp(),
+        source_label=source_label.strip() or "cli",
+    )
+
+
 @click.group()
 def main() -> None:
     """Control-plane CLI."""
@@ -9403,6 +9478,53 @@ def _apply_launchplane_pr_event_intent(
 @main.group()
 def environments() -> None:
     """Runtime environment contract commands."""
+
+
+@environments.command("put")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane runtime-environment records.",
+)
+@click.option("--scope", type=click.Choice(["global", "context", "instance"]), required=True)
+@click.option("--context", "context_name", default="")
+@click.option("--instance", "instance_name", default="")
+@click.option("--set", "assignments", multiple=True, required=True, help="Runtime value assignment as KEY=VALUE.")
+@click.option("--source-label", default="cli", show_default=True)
+def environments_put(
+    database_url: str,
+    scope: str,
+    context_name: str,
+    instance_name: str,
+    assignments: tuple[str, ...],
+    source_label: str,
+) -> None:
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    postgres_store.ensure_schema()
+    try:
+        existing_records = postgres_store.list_runtime_environment_records()
+        record = _build_runtime_environment_record_for_put(
+            existing_records=existing_records,
+            scope=scope,
+            context_name=context_name.strip(),
+            instance_name=instance_name.strip(),
+            assignments=assignments,
+            source_label=source_label,
+        )
+        postgres_store.write_runtime_environment_record(record)
+    finally:
+        postgres_store.close()
+    click.echo(
+        json.dumps(
+            {
+                "status": "ok",
+                "record": _summarize_runtime_environment_record(record),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
 
 
 @environments.command("list")

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -16,7 +16,8 @@ boundary for Launchplane.
 - `artifacts`: write, ingest, and inspect artifact manifests.
 - `backup-gates`: write and inspect backup-gate records.
 - `deployments`: write and inspect deployment records.
-- `environments`: resolve runtime environment contracts.
+- `environments`: write, list, and resolve DB-backed runtime environment
+  contracts.
 - `launchplane-previews`: inspect, mutate, render, ingest, and replay Launchplane preview
   state.
 - `inventory`: inspect current environment inventory.
@@ -257,8 +258,16 @@ Current derived-state behavior:
 
 ## Runtime Environment Contracts
 
+- `environments put` writes explicit non-secret `KEY=VALUE` runtime settings
+  directly into DB-backed runtime-environment records for `global`, `context`,
+  or `instance` scope. It rejects secret-shaped keys and returns key metadata
+  only, not plaintext values.
+- `environments list` shows DB-backed runtime-environment record metadata and
+  keys without echoing plaintext values.
 - `environments resolve` reads the control-plane-owned runtime environment
   contract for a context and instance.
+- TOML/env files are not runtime import surfaces; use DB-native
+  runtime-environment records and managed secrets instead.
 - `environments show-live-target` reads the live Dokploy target payload for a
   tracked route and reports whether the target is ready for artifact-backed
   split-repo execution.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -84,6 +84,10 @@ title: Secrets
 - `uv run launchplane environments resolve --context <ctx> --instance
 <instance> --json-output`
   emits the resolved runtime environment payload for a tenant environment.
+- `uv run launchplane environments put --scope <scope> --set KEY=VALUE` writes
+  non-secret runtime values directly to DB-backed runtime-environment records
+  and redacts values from command output. Secret-shaped keys are rejected and
+  should be written with `secrets put`.
 - In steady state that payload comes from Launchplane DB-backed runtime
   environment records.
 - Launchplane preview write/build helpers read `LAUNCHPLANE_PREVIEW_BASE_URL` from the

--- a/tests/test_runtime_environments.py
+++ b/tests/test_runtime_environments.py
@@ -76,6 +76,157 @@ class RuntimeEnvironmentTests(unittest.TestCase):
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn("No such command", result.output)
 
+    def test_environments_put_writes_db_record_without_echoing_values(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "environments",
+                    "put",
+                    "--database-url",
+                    database_url,
+                    "--scope",
+                    "instance",
+                    "--context",
+                    "verireel",
+                    "--instance",
+                    "prod",
+                    "--set",
+                    "VERIREEL_PROD_PROXMOX_HOST=proxmox.example.com",
+                    "--set",
+                    "VERIREEL_PROD_CT_ID=101",
+                    "--source-label",
+                    "operator-cli",
+                ],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertNotIn("proxmox.example.com", result.output)
+            self.assertNotIn("101", result.output)
+            payload = json.loads(result.output)
+            self.assertEqual(payload["status"], "ok")
+            self.assertEqual(payload["record"]["source_label"], "operator-cli")
+            self.assertEqual(
+                payload["record"]["env_keys"],
+                ["VERIREEL_PROD_CT_ID", "VERIREEL_PROD_PROXMOX_HOST"],
+            )
+
+            with patch.dict(os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True):
+                resolved_values = control_plane_runtime_environments.resolve_runtime_environment_values(
+                    control_plane_root=control_plane_root,
+                    context_name="verireel",
+                    instance_name="prod",
+                )
+
+        self.assertEqual(resolved_values["VERIREEL_PROD_PROXMOX_HOST"], "proxmox.example.com")
+        self.assertEqual(resolved_values["VERIREEL_PROD_CT_ID"], "101")
+
+    def test_environments_put_merges_existing_record_values(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            _seed_runtime_environment_records(
+                database_url=database_url,
+                definition=control_plane_runtime_environments.RuntimeEnvironmentDefinition(
+                    schema_version=1,
+                    shared_env={},
+                    contexts={
+                        "verireel": control_plane_runtime_environments.RuntimeEnvironmentContextDefinition(
+                            shared_env={},
+                            instances={
+                                "prod": control_plane_runtime_environments.RuntimeEnvironmentInstanceDefinition(
+                                    env={"VERIREEL_PROD_PROXMOX_HOST": "proxmox.example.com"}
+                                )
+                            },
+                        )
+                    },
+                ),
+            )
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "environments",
+                    "put",
+                    "--database-url",
+                    database_url,
+                    "--scope",
+                    "instance",
+                    "--context",
+                    "verireel",
+                    "--instance",
+                    "prod",
+                    "--set",
+                    "VERIREEL_PROD_CT_ID=101",
+                ],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertNotIn("proxmox.example.com", result.output)
+            payload = json.loads(result.output)
+            self.assertEqual(
+                payload["record"]["env_keys"],
+                ["VERIREEL_PROD_CT_ID", "VERIREEL_PROD_PROXMOX_HOST"],
+            )
+
+            with patch.dict(os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True):
+                resolved_values = control_plane_runtime_environments.resolve_runtime_environment_values(
+                    control_plane_root=control_plane_root,
+                    context_name="verireel",
+                    instance_name="prod",
+                )
+
+        self.assertEqual(resolved_values["VERIREEL_PROD_PROXMOX_HOST"], "proxmox.example.com")
+        self.assertEqual(resolved_values["VERIREEL_PROD_CT_ID"], "101")
+
+    def test_environments_put_rejects_instance_scope_without_instance(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(Path(temporary_directory_name) / "launchplane.sqlite3")
+            result = CliRunner().invoke(
+                main,
+                [
+                    "environments",
+                    "put",
+                    "--database-url",
+                    database_url,
+                    "--scope",
+                    "instance",
+                    "--context",
+                    "verireel",
+                    "--set",
+                    "VERIREEL_PROD_CT_ID=101",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("require --context and --instance", result.output)
+
+    def test_environments_put_rejects_secret_shaped_keys(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(Path(temporary_directory_name) / "launchplane.sqlite3")
+            result = CliRunner().invoke(
+                main,
+                [
+                    "environments",
+                    "put",
+                    "--database-url",
+                    database_url,
+                    "--scope",
+                    "context",
+                    "--context",
+                    "verireel",
+                    "--set",
+                    "GITHUB_TOKEN=secret-value",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("must be written with launchplane secrets put", result.output)
+        self.assertNotIn("secret-value", result.output)
+
     def test_environments_list_redacts_values(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add `launchplane environments put` for DB-native runtime-environment record writes
- merge explicit `KEY=VALUE` assignments into existing global/context/instance records without reading TOML/env files
- reject secret-shaped runtime keys and direct operators to managed secrets instead
- keep command output redacted to record metadata and env key names
- document the forward-only DB runtime write path

## Verification
- `uv run python -m unittest tests.test_runtime_environments`
- `uv run python -m unittest`
- `uv run ruff format --check control_plane/cli.py tests/test_runtime_environments.py` (reports pre-existing reformat wants; not applied to avoid broad churn)
- `uv run ruff check control_plane/cli.py tests/test_runtime_environments.py`
- `git diff --check`
