### PR TITLE
Add DB-native runtime environment unset command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ Use `uv run launchplane environments put --scope ... --set KEY=VALUE` to write
 non-secret runtime values directly into DB-backed runtime-environment records;
 secret-shaped keys are rejected there. Use `uv run launchplane secrets put ...`
 for managed secret values. TOML/env files are not supported runtime import
-surfaces outside bootstrap policy/env.
+surfaces outside bootstrap policy/env. Use `uv run launchplane environments
+unset --scope ... --key KEY` to remove stale runtime keys without reading or
+printing plaintext values.
 
 For the first local Launchplane service run, copy
 `config/launchplane-authz.toml.example` to a real local policy file such as

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -7522,6 +7522,27 @@ def _runtime_environment_key_requires_secret_store(key_name: str) -> bool:
     )
 
 
+def _validate_runtime_environment_scope_route(
+    *,
+    scope: str,
+    context_name: str,
+    instance_name: str,
+) -> None:
+    if scope == "global":
+        if context_name or instance_name:
+            raise click.ClickException("Global runtime environment records do not accept --context or --instance.")
+        return
+    if scope == "context":
+        if not context_name or instance_name:
+            raise click.ClickException("Context runtime environment records require --context and do not accept --instance.")
+        return
+    if scope == "instance":
+        if not context_name or not instance_name:
+            raise click.ClickException("Instance runtime environment records require --context and --instance.")
+        return
+    raise click.ClickException(f"Unsupported runtime environment scope: {scope}")
+
+
 def _runtime_environment_record_matches(
     record: RuntimeEnvironmentRecord,
     *,
@@ -7541,17 +7562,11 @@ def _build_runtime_environment_record_for_put(
     assignments: tuple[str, ...],
     source_label: str,
 ) -> RuntimeEnvironmentRecord:
-    if scope == "global":
-        if context_name or instance_name:
-            raise click.ClickException("Global runtime environment records do not accept --context or --instance.")
-    elif scope == "context":
-        if not context_name or instance_name:
-            raise click.ClickException("Context runtime environment records require --context and do not accept --instance.")
-    elif scope == "instance":
-        if not context_name or not instance_name:
-            raise click.ClickException("Instance runtime environment records require --context and --instance.")
-    else:
-        raise click.ClickException(f"Unsupported runtime environment scope: {scope}")
+    _validate_runtime_environment_scope_route(
+        scope=scope,
+        context_name=context_name,
+        instance_name=instance_name,
+    )
 
     env_values: dict[str, object] = {}
     for record in existing_records:
@@ -7574,6 +7589,81 @@ def _build_runtime_environment_record_for_put(
         env=env_values,
         updated_at=utc_now_timestamp(),
         source_label=source_label.strip() or "cli",
+    )
+
+
+def _normalize_runtime_environment_key(raw_key: str) -> str:
+    normalized_key = raw_key.strip()
+    if not normalized_key:
+        raise click.ClickException("Runtime environment keys must be non-empty.")
+    return normalized_key
+
+
+def _find_runtime_environment_record(
+    *,
+    existing_records: tuple[RuntimeEnvironmentRecord, ...],
+    scope: str,
+    context_name: str,
+    instance_name: str,
+) -> RuntimeEnvironmentRecord | None:
+    for record in existing_records:
+        if _runtime_environment_record_matches(
+            record,
+            scope=scope,
+            context_name=context_name,
+            instance_name=instance_name,
+        ):
+            return record
+    return None
+
+
+def _build_runtime_environment_record_for_unset(
+    *,
+    existing_records: tuple[RuntimeEnvironmentRecord, ...],
+    scope: str,
+    context_name: str,
+    instance_name: str,
+    keys: tuple[str, ...],
+    source_label: str,
+) -> tuple[RuntimeEnvironmentRecord, tuple[str, ...], tuple[str, ...]]:
+    _validate_runtime_environment_scope_route(
+        scope=scope,
+        context_name=context_name,
+        instance_name=instance_name,
+    )
+    target_record = _find_runtime_environment_record(
+        existing_records=existing_records,
+        scope=scope,
+        context_name=context_name,
+        instance_name=instance_name,
+    )
+    if target_record is None:
+        raise click.ClickException("Missing DB-backed runtime environment record for the requested scope.")
+
+    requested_keys = tuple(_normalize_runtime_environment_key(key_name) for key_name in keys)
+    env_values = dict(target_record.env)
+    removed_keys: list[str] = []
+    missing_keys: list[str] = []
+    for key_name in requested_keys:
+        if key_name in env_values:
+            removed_keys.append(key_name)
+            del env_values[key_name]
+        else:
+            missing_keys.append(key_name)
+    if not env_values:
+        raise click.ClickException("Refusing to leave an empty runtime environment record.")
+
+    return (
+        RuntimeEnvironmentRecord(
+            scope=target_record.scope,
+            context=target_record.context,
+            instance=target_record.instance,
+            env=env_values,
+            updated_at=utc_now_timestamp(),
+            source_label=source_label.strip() or "cli",
+        ),
+        tuple(sorted(removed_keys)),
+        tuple(sorted(missing_keys)),
     )
 
 
@@ -9520,6 +9610,55 @@ def environments_put(
             {
                 "status": "ok",
                 "record": _summarize_runtime_environment_record(record),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+@environments.command("unset")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane runtime-environment records.",
+)
+@click.option("--scope", type=click.Choice(["global", "context", "instance"]), required=True)
+@click.option("--context", "context_name", default="")
+@click.option("--instance", "instance_name", default="")
+@click.option("--key", "keys", multiple=True, required=True, help="Runtime value key to remove from the record.")
+@click.option("--source-label", default="cli", show_default=True)
+def environments_unset(
+    database_url: str,
+    scope: str,
+    context_name: str,
+    instance_name: str,
+    keys: tuple[str, ...],
+    source_label: str,
+) -> None:
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    postgres_store.ensure_schema()
+    try:
+        existing_records = postgres_store.list_runtime_environment_records()
+        record, removed_keys, missing_keys = _build_runtime_environment_record_for_unset(
+            existing_records=existing_records,
+            scope=scope,
+            context_name=context_name.strip(),
+            instance_name=instance_name.strip(),
+            keys=keys,
+            source_label=source_label,
+        )
+        postgres_store.write_runtime_environment_record(record)
+    finally:
+        postgres_store.close()
+    click.echo(
+        json.dumps(
+            {
+                "status": "ok",
+                "record": _summarize_runtime_environment_record(record),
+                "removed_keys": removed_keys,
+                "missing_keys": missing_keys,
             },
             indent=2,
             sort_keys=True,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -262,6 +262,8 @@ Current derived-state behavior:
   directly into DB-backed runtime-environment records for `global`, `context`,
   or `instance` scope. It rejects secret-shaped keys and returns key metadata
   only, not plaintext values.
+- `environments unset` removes named keys from a DB-backed runtime-environment
+  record without reading or printing plaintext values.
 - `environments list` shows DB-backed runtime-environment record metadata and
   keys without echoing plaintext values.
 - `environments resolve` reads the control-plane-owned runtime environment

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -88,6 +88,9 @@ title: Secrets
   non-secret runtime values directly to DB-backed runtime-environment records
   and redacts values from command output. Secret-shaped keys are rejected and
   should be written with `secrets put`.
+- `uv run launchplane environments unset --scope <scope> --key KEY` removes
+  stale keys from DB-backed runtime-environment records without reading or
+  printing plaintext values.
 - In steady state that payload comes from Launchplane DB-backed runtime
   environment records.
 - Launchplane preview write/build helpers read `LAUNCHPLANE_PREVIEW_BASE_URL` from the

--- a/tests/test_runtime_environments.py
+++ b/tests/test_runtime_environments.py
@@ -227,6 +227,102 @@ class RuntimeEnvironmentTests(unittest.TestCase):
         self.assertIn("must be written with launchplane secrets put", result.output)
         self.assertNotIn("secret-value", result.output)
 
+    def test_environments_unset_removes_keys_without_echoing_values(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            _seed_runtime_environment_records(
+                database_url=database_url,
+                definition=control_plane_runtime_environments.RuntimeEnvironmentDefinition(
+                    schema_version=1,
+                    shared_env={},
+                    contexts={
+                        "verireel": control_plane_runtime_environments.RuntimeEnvironmentContextDefinition(
+                            shared_env={},
+                            instances={
+                                "prod": control_plane_runtime_environments.RuntimeEnvironmentInstanceDefinition(
+                                    env={
+                                        "VERIREEL_PROD_CT_ID": "101",
+                                        "VERIREEL_PROD_PROXMOX_HOST": "proxmox.example.com",
+                                    }
+                                )
+                            },
+                        )
+                    },
+                ),
+            )
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "environments",
+                    "unset",
+                    "--database-url",
+                    database_url,
+                    "--scope",
+                    "instance",
+                    "--context",
+                    "verireel",
+                    "--instance",
+                    "prod",
+                    "--key",
+                    "VERIREEL_PROD_CT_ID",
+                    "--key",
+                    "MISSING_KEY",
+                    "--source-label",
+                    "operator-cli",
+                ],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertNotIn("proxmox.example.com", result.output)
+            self.assertNotIn("101", result.output)
+            payload = json.loads(result.output)
+            self.assertEqual(payload["record"]["source_label"], "operator-cli")
+            self.assertEqual(payload["record"]["env_keys"], ["VERIREEL_PROD_PROXMOX_HOST"])
+            self.assertEqual(payload["removed_keys"], ["VERIREEL_PROD_CT_ID"])
+            self.assertEqual(payload["missing_keys"], ["MISSING_KEY"])
+
+            with patch.dict(os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True):
+                resolved_values = control_plane_runtime_environments.resolve_runtime_environment_values(
+                    control_plane_root=control_plane_root,
+                    context_name="verireel",
+                    instance_name="prod",
+                )
+
+        self.assertNotIn("VERIREEL_PROD_CT_ID", resolved_values)
+        self.assertEqual(resolved_values["VERIREEL_PROD_PROXMOX_HOST"], "proxmox.example.com")
+
+    def test_environments_unset_rejects_empty_result_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(Path(temporary_directory_name) / "launchplane.sqlite3")
+            _seed_runtime_environment_records(
+                database_url=database_url,
+                definition=control_plane_runtime_environments.RuntimeEnvironmentDefinition(
+                    schema_version=1,
+                    shared_env={"ONLY_KEY": "only-value"},
+                    contexts={},
+                ),
+            )
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "environments",
+                    "unset",
+                    "--database-url",
+                    database_url,
+                    "--scope",
+                    "global",
+                    "--key",
+                    "ONLY_KEY",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Refusing to leave an empty runtime environment record", result.output)
+        self.assertNotIn("only-value", result.output)
+
     def test_environments_list_redacts_values(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add `launchplane environments unset` for DB-native runtime-environment key removal
- keep unset output redacted to metadata, removed key names, and missing key names
- refuse to leave an empty runtime-environment record rather than creating invalid state
- document `unset` as the forward-only cleanup path for stale runtime keys

## Verification
- `uv run python -m unittest tests.test_runtime_environments`
- `uv run python -m unittest`
- `uv run ruff format --check control_plane/cli.py tests/test_runtime_environments.py` (reports pre-existing reformat wants; not applied to avoid broad churn)
- `uv run ruff check control_plane/cli.py tests/test_runtime_environments.py`
- `git diff --check`
