### PR TITLE
Add runtime environment relabel command

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ secret-shaped keys are rejected there. Use `uv run launchplane secrets put ...`
 for managed secret values. TOML/env files are not supported runtime import
 surfaces outside bootstrap policy/env. Use `uv run launchplane environments
 unset --scope ... --key KEY` to remove stale runtime keys without reading or
-printing plaintext values.
+printing plaintext values. Use `uv run launchplane environments relabel` to
+correct stale record metadata without changing runtime values.
 
 For the first local Launchplane service run, copy
 `config/launchplane-authz.toml.example` to a real local policy file such as

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -7667,6 +7667,37 @@ def _build_runtime_environment_record_for_unset(
     )
 
 
+def _build_runtime_environment_record_for_relabel(
+    *,
+    existing_records: tuple[RuntimeEnvironmentRecord, ...],
+    scope: str,
+    context_name: str,
+    instance_name: str,
+    source_label: str,
+) -> RuntimeEnvironmentRecord:
+    _validate_runtime_environment_scope_route(
+        scope=scope,
+        context_name=context_name,
+        instance_name=instance_name,
+    )
+    target_record = _find_runtime_environment_record(
+        existing_records=existing_records,
+        scope=scope,
+        context_name=context_name,
+        instance_name=instance_name,
+    )
+    if target_record is None:
+        raise click.ClickException("Missing DB-backed runtime environment record for the requested scope.")
+    return RuntimeEnvironmentRecord(
+        scope=target_record.scope,
+        context=target_record.context,
+        instance=target_record.instance,
+        env=dict(target_record.env),
+        updated_at=utc_now_timestamp(),
+        source_label=source_label.strip() or "cli",
+    )
+
+
 @click.group()
 def main() -> None:
     """Control-plane CLI."""
@@ -9659,6 +9690,50 @@ def environments_unset(
                 "record": _summarize_runtime_environment_record(record),
                 "removed_keys": removed_keys,
                 "missing_keys": missing_keys,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+@environments.command("relabel")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane runtime-environment records.",
+)
+@click.option("--scope", type=click.Choice(["global", "context", "instance"]), required=True)
+@click.option("--context", "context_name", default="")
+@click.option("--instance", "instance_name", default="")
+@click.option("--source-label", required=True)
+def environments_relabel(
+    database_url: str,
+    scope: str,
+    context_name: str,
+    instance_name: str,
+    source_label: str,
+) -> None:
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    postgres_store.ensure_schema()
+    try:
+        existing_records = postgres_store.list_runtime_environment_records()
+        record = _build_runtime_environment_record_for_relabel(
+            existing_records=existing_records,
+            scope=scope,
+            context_name=context_name.strip(),
+            instance_name=instance_name.strip(),
+            source_label=source_label,
+        )
+        postgres_store.write_runtime_environment_record(record)
+    finally:
+        postgres_store.close()
+    click.echo(
+        json.dumps(
+            {
+                "status": "ok",
+                "record": _summarize_runtime_environment_record(record),
             },
             indent=2,
             sort_keys=True,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -264,6 +264,8 @@ Current derived-state behavior:
   only, not plaintext values.
 - `environments unset` removes named keys from a DB-backed runtime-environment
   record without reading or printing plaintext values.
+- `environments relabel` updates runtime-environment record source metadata
+  without reading or printing plaintext values.
 - `environments list` shows DB-backed runtime-environment record metadata and
   keys without echoing plaintext values.
 - `environments resolve` reads the control-plane-owned runtime environment

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -91,6 +91,8 @@ title: Secrets
 - `uv run launchplane environments unset --scope <scope> --key KEY` removes
   stale keys from DB-backed runtime-environment records without reading or
   printing plaintext values.
+- `uv run launchplane environments relabel --scope <scope> --source-label ...`
+  updates stale source metadata without changing runtime values.
 - In steady state that payload comes from Launchplane DB-backed runtime
   environment records.
 - Launchplane preview write/build helpers read `LAUNCHPLANE_PREVIEW_BASE_URL` from the

--- a/tests/test_runtime_environments.py
+++ b/tests/test_runtime_environments.py
@@ -323,6 +323,39 @@ class RuntimeEnvironmentTests(unittest.TestCase):
         self.assertIn("Refusing to leave an empty runtime environment record", result.output)
         self.assertNotIn("only-value", result.output)
 
+    def test_environments_relabel_updates_metadata_without_echoing_values(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(Path(temporary_directory_name) / "launchplane.sqlite3")
+            _seed_runtime_environment_records(
+                database_url=database_url,
+                definition=control_plane_runtime_environments.RuntimeEnvironmentDefinition(
+                    schema_version=1,
+                    shared_env={"ODOO_DB_USER": "odoo"},
+                    contexts={},
+                ),
+                source_label="legacy-source",
+            )
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "environments",
+                    "relabel",
+                    "--database-url",
+                    database_url,
+                    "--scope",
+                    "global",
+                    "--source-label",
+                    "operator:db-native",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn("odoo", result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["record"]["source_label"], "operator:db-native")
+        self.assertEqual(payload["record"]["env_keys"], ["ODOO_DB_USER"])
+
     def test_environments_list_redacts_values(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add `launchplane environments relabel` for DB-native runtime-environment metadata cleanup
- preserve existing runtime values while updating `source_label` and `updated_at`
- keep command output redacted to record metadata and env key names
- document relabel alongside put/unset

## Verification
- `uv run python -m unittest tests.test_runtime_environments`
- `uv run python -m unittest`
- `uv run ruff format --check control_plane/cli.py tests/test_runtime_environments.py` (reports pre-existing reformat wants; not applied to avoid broad churn)
- `uv run ruff check control_plane/cli.py tests/test_runtime_environments.py`
- `git diff --check`
