### PR TITLE
Add GitHub repo workflow config

### DIFF
--- a/.github/github-repo-workflow.json
+++ b/.github/github-repo-workflow.json
@@ -1,0 +1,24 @@
+{
+  "defaultBranch": "main",
+  "importantWorkflows": ["CI", "Deploy Launchplane"],
+  "qaLabels": [],
+  "deployLabels": [],
+  "healthUrls": [
+    {
+      "name": "launchplane",
+      "url": "https://launchplane.shinycomputers.com/v1/health"
+    }
+  ],
+  "relatedRepos": [
+    "verireel",
+    "odoo-devkit",
+    "odoo-shared-addons",
+    "odoo-tenant-cm",
+    "odoo-tenant-opw"
+  ],
+  "validatedThrough": [],
+  "cleanup": {
+    "deleteMergedLocalBranches": false,
+    "removeMergedCleanWorktrees": false
+  }
+}


### PR DESCRIPTION
## Summary
- add shared GitHub repo workflow metadata for Launchplane
- record the important CI/deploy workflows, Launchplane health URL, related repos, and conservative cleanup defaults

## Verification
- config is JSON-only metadata for the repo workflow helper
- no runtime code paths changed