### PR TITLE
Send typed Odoo override payload to Odoo

### DIFF
--- a/control_plane/odoo_instance_overrides.py
+++ b/control_plane/odoo_instance_overrides.py
@@ -1,3 +1,5 @@
+import base64
+import json
 from dataclasses import dataclass
 
 import click
@@ -6,6 +8,7 @@ from control_plane.contracts.odoo_instance_override_record import OdooInstanceOv
 from control_plane.contracts.odoo_instance_override_record import OdooOverrideValue
 
 ODOO_CONFIG_PARAMETER_ENV_PREFIX = "ENV_OVERRIDE_CONFIG_PARAM__"
+ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY = "ODOO_INSTANCE_OVERRIDES_PAYLOAD_B64"
 ODOO_ADDON_ENV_PREFIXES = {
     "authentik": "ENV_OVERRIDE_AUTHENTIK__",
     "authentik_sso": "ENV_OVERRIDE_AUTHENTIK__",
@@ -17,6 +20,57 @@ ODOO_ADDON_ENV_PREFIXES = {
 class PostDeployOverrideEnvironment:
     inline_environment: dict[str, str]
     required_container_environment_keys: tuple[str, ...]
+
+
+def _payload_override_value(*, value: OdooOverrideValue, environment_key: str | None = None) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "source": value.source,
+    }
+    if value.source == "literal":
+        payload["value"] = value.value
+        return payload
+    payload["secret_binding_id"] = value.secret_binding_id
+    if not environment_key:
+        raise click.ClickException("Secret-backed Odoo overrides require a runtime environment key.")
+    payload["environment_variable"] = environment_key
+    return payload
+
+
+def render_post_deploy_payload(record: OdooInstanceOverrideRecord) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "context": record.context,
+        "instance": record.instance,
+        "config_parameters": [],
+        "addon_settings": [],
+    }
+    config_parameters: list[dict[str, object]] = []
+    for override in record.config_parameters:
+        environment_key = config_parameter_env_key(override.key)
+        config_parameters.append(
+            {
+                "key": override.key,
+                "value": _payload_override_value(value=override.value, environment_key=environment_key),
+            }
+        )
+    addon_settings: list[dict[str, object]] = []
+    for override in record.addon_settings:
+        environment_key = addon_setting_env_key(addon_name=override.addon, setting_name=override.setting)
+        addon_settings.append(
+            {
+                "addon": override.addon,
+                "setting": override.setting,
+                "value": _payload_override_value(value=override.value, environment_key=environment_key),
+            }
+        )
+    payload["config_parameters"] = config_parameters
+    payload["addon_settings"] = addon_settings
+    return payload
+
+
+def _encode_post_deploy_payload(payload: dict[str, object]) -> str:
+    encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return base64.b64encode(encoded).decode("ascii")
 
 
 def config_parameter_env_key(config_parameter_key: str) -> str:
@@ -38,45 +92,21 @@ def addon_setting_env_key(*, addon_name: str, setting_name: str) -> str:
         raise click.ClickException("Odoo addon setting override requires a non-empty setting.")
     return f"{prefix}{suffix}"
 
-
-def _apply_override_value(
-    *,
-    environment_key: str,
-    value: OdooOverrideValue,
-    override_name: str,
-    inline_environment: dict[str, str],
-    required_container_environment_keys: list[str],
-) -> None:
-    if value.source == "secret_binding":
-        _ = override_name
-        required_container_environment_keys.append(environment_key)
-        return
-    if value.value is None:
-        raise click.ClickException(f"Odoo override {override_name!r} is missing a literal value.")
-    inline_environment[environment_key] = str(value.value)
-
-
 def build_post_deploy_environment(record: OdooInstanceOverrideRecord) -> PostDeployOverrideEnvironment:
-    inline_environment: dict[str, str] = {}
+    payload = render_post_deploy_payload(record)
+    inline_environment: dict[str, str] = {
+        ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY: _encode_post_deploy_payload(payload),
+    }
     required_container_environment_keys: list[str] = []
     for override in record.config_parameters:
-        environment_key = config_parameter_env_key(override.key)
-        _apply_override_value(
-            environment_key=environment_key,
-            value=override.value,
-            override_name=override.key,
-            inline_environment=inline_environment,
-            required_container_environment_keys=required_container_environment_keys,
-        )
+        if override.value.source != "secret_binding":
+            continue
+        required_container_environment_keys.append(config_parameter_env_key(override.key))
     for override in record.addon_settings:
-        override_name = f"{override.addon}.{override.setting}"
-        environment_key = addon_setting_env_key(addon_name=override.addon, setting_name=override.setting)
-        _apply_override_value(
-            environment_key=environment_key,
-            value=override.value,
-            override_name=override_name,
-            inline_environment=inline_environment,
-            required_container_environment_keys=required_container_environment_keys,
+        if override.value.source != "secret_binding":
+            continue
+        required_container_environment_keys.append(
+            addon_setting_env_key(addon_name=override.addon, setting_name=override.setting)
         )
     return PostDeployOverrideEnvironment(
         inline_environment=inline_environment,

--- a/control_plane/odoo_instance_overrides.py
+++ b/control_plane/odoo_instance_overrides.py
@@ -73,6 +73,26 @@ def _encode_post_deploy_payload(payload: dict[str, object]) -> str:
     return base64.b64encode(encoded).decode("ascii")
 
 
+def _render_legacy_literal_environment(record: OdooInstanceOverrideRecord) -> dict[str, str]:
+    legacy_environment: dict[str, str] = {}
+    for override in record.config_parameters:
+        if override.value.source != "literal":
+            continue
+        if override.value.value is None:
+            raise click.ClickException(f"Odoo override {override.key!r} is missing a literal value.")
+        legacy_environment[config_parameter_env_key(override.key)] = str(override.value.value)
+    for override in record.addon_settings:
+        if override.value.source != "literal":
+            continue
+        override_name = f"{override.addon}.{override.setting}"
+        if override.value.value is None:
+            raise click.ClickException(f"Odoo override {override_name!r} is missing a literal value.")
+        legacy_environment[
+            addon_setting_env_key(addon_name=override.addon, setting_name=override.setting)
+        ] = str(override.value.value)
+    return legacy_environment
+
+
 def config_parameter_env_key(config_parameter_key: str) -> str:
     suffix = config_parameter_key.strip().upper().replace(".", "__")
     if not suffix:
@@ -97,6 +117,7 @@ def build_post_deploy_environment(record: OdooInstanceOverrideRecord) -> PostDep
     inline_environment: dict[str, str] = {
         ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY: _encode_post_deploy_payload(payload),
     }
+    inline_environment.update(_render_legacy_literal_environment(record))
     required_container_environment_keys: list[str] = []
     for override in record.config_parameters:
         if override.value.source != "secret_binding":

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -301,14 +301,17 @@ Current derived-state behavior:
   record, giving the future Odoo driver a tested result-write path.
 - Compose post-deploy updates consume deploy-phase overrides from these records
   and pass them to the Odoo data-workflow runner as one typed payload env var.
+- During the rollout window, Launchplane also emits legacy literal
+  `ENV_OVERRIDE_*` values for non-secret overrides so older Odoo consumers keep
+  applying the same settings until the typed payload path is everywhere.
 - Secret-backed overrides are still not rendered into schedule scripts as
   plaintext. The payload references the already-present script-runner
   environment key for each managed secret binding, and the workflow asserts
   those keys before Odoo starts.
-- This keeps record authority in Launchplane while moving Odoo off the
-  temporary literal `ENV_OVERRIDE_*` transport bridge. Those names now remain
-  only as secret-binding landing zones to retire in a later managed-binding
-  slice.
+- This keeps record authority in Launchplane while moving Odoo toward the
+  typed payload contract. The remaining literal `ENV_OVERRIDE_*` bridge is now
+  compatibility-only and can be deleted once the typed consumer is deployed
+  everywhere.
 
 Artifact handoff example:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -299,14 +299,16 @@ Current derived-state behavior:
   binding ids.
 - `odoo-overrides mark-apply` updates the latest apply status metadata for a
   record, giving the future Odoo driver a tested result-write path.
-- Compose post-deploy updates consume deploy-phase literal overrides from these
-  records and pass them to the current Odoo data-workflow runner as transient
-  environment transport. Secret-backed overrides are not rendered into schedule
-  scripts; the bridge requires their mapped keys to already exist in the
-  script-runner container environment, where managed runtime secrets are already
-  expected to land.
-- This is a migration bridge: record authority belongs to Launchplane, while
-  `ENV_OVERRIDE_*` names remain only the current Odoo runner transport to retire.
+- Compose post-deploy updates consume deploy-phase overrides from these records
+  and pass them to the Odoo data-workflow runner as one typed payload env var.
+- Secret-backed overrides are still not rendered into schedule scripts as
+  plaintext. The payload references the already-present script-runner
+  environment key for each managed secret binding, and the workflow asserts
+  those keys before Odoo starts.
+- This keeps record authority in Launchplane while moving Odoo off the
+  temporary literal `ENV_OVERRIDE_*` transport bridge. Those names now remain
+  only as secret-binding landing zones to retire in a later managed-binding
+  slice.
 
 Artifact handoff example:
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -174,9 +174,12 @@ state/
 - This record is the target authority for the Odoo driver. Runtime-environment
   `ENV_OVERRIDE_*` keys remain a migration input to retire, not the final
   override model.
-- The first compose post-deploy bridge renders literal values into the current
-  data-workflow runner transport. Secret-backed values are passed as required
-  container environment keys, not as plaintext in the Dokploy schedule payload.
+- The compose post-deploy bridge now renders one typed Odoo override payload
+  for the data-workflow runner instead of flattening literal record intent into
+  `ENV_OVERRIDE_*` transport keys.
+- Secret-backed values still avoid Dokploy schedule plaintext. The payload
+  points at the already-present container environment key for each managed
+  secret binding, and the driver asserts those keys before invoking Odoo.
 
 ## Launchplane Preview Record
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -175,8 +175,8 @@ state/
   `ENV_OVERRIDE_*` keys remain a migration input to retire, not the final
   override model.
 - The compose post-deploy bridge now renders one typed Odoo override payload
-  for the data-workflow runner instead of flattening literal record intent into
-  `ENV_OVERRIDE_*` transport keys.
+  for the data-workflow runner and, during the compatibility window, also emits
+  legacy literal `ENV_OVERRIDE_*` keys for non-secret values.
 - Secret-backed values still avoid Dokploy schedule plaintext. The payload
   points at the already-present container environment key for each managed
   secret binding, and the driver asserts those keys before invoking Odoo.

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -961,12 +961,17 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
             data_workflow_lock_path="/volumes/data/.data_workflow_in_progress",
             workflow_environment_overrides={
                 ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY: "payload-value",
+                "ENV_OVERRIDE_CONFIG_PARAM__WEB__BASE__URL": "https://opw-prod.example.com",
             },
             required_workflow_environment_keys=("ENV_OVERRIDE_SHOPIFY__API_TOKEN",),
         )
 
         self.assertIn(
             f"workflow_environment+=(-e {ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY}=payload-value)",
+            script,
+        )
+        self.assertIn(
+            "workflow_environment+=(-e ENV_OVERRIDE_CONFIG_PARAM__WEB__BASE__URL=https://opw-prod.example.com)",
             script,
         )
         self.assertIn("required_workflow_environment_keys+=(ENV_OVERRIDE_SHOPIFY__API_TOKEN)", script)

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -11,6 +11,7 @@ from click.testing import CliRunner
 from pydantic import ValidationError
 
 from control_plane import dokploy as control_plane_dokploy
+from control_plane.odoo_instance_overrides import ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY
 from control_plane import secrets as control_plane_secrets
 from control_plane.cli import main
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
@@ -959,13 +960,13 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
             clear_stale_lock=False,
             data_workflow_lock_path="/volumes/data/.data_workflow_in_progress",
             workflow_environment_overrides={
-                "ENV_OVERRIDE_CONFIG_PARAM__WEB__BASE__URL": "https://opw-prod.example.com",
+                ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY: "payload-value",
             },
             required_workflow_environment_keys=("ENV_OVERRIDE_SHOPIFY__API_TOKEN",),
         )
 
         self.assertIn(
-            "workflow_environment+=(-e ENV_OVERRIDE_CONFIG_PARAM__WEB__BASE__URL=https://opw-prod.example.com)",
+            f"workflow_environment+=(-e {ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY}=payload-value)",
             script,
         )
         self.assertIn("required_workflow_environment_keys+=(ENV_OVERRIDE_SHOPIFY__API_TOKEN)", script)

--- a/tests/test_odoo_instance_override_rendering.py
+++ b/tests/test_odoo_instance_override_rendering.py
@@ -85,6 +85,10 @@ class OdooInstanceOverrideRenderingTests(unittest.TestCase):
         decoded_payload = json.loads(base64.b64decode(encoded_payload).decode("utf-8"))
 
         self.assertEqual(decoded_payload, render_post_deploy_payload(record))
+        self.assertEqual(
+            environment.inline_environment["ENV_OVERRIDE_CONFIG_PARAM__WEB__BASE__URL"],
+            "https://opw-prod.example.com",
+        )
 
     def test_build_post_deploy_environment_requires_container_env_for_secret_backed_values(self) -> None:
         record = OdooInstanceOverrideRecord(

--- a/tests/test_odoo_instance_override_rendering.py
+++ b/tests/test_odoo_instance_override_rendering.py
@@ -1,6 +1,12 @@
+import base64
+import json
 import unittest
 
-from control_plane.odoo_instance_overrides import build_post_deploy_environment, render_post_deploy_environment
+from control_plane.odoo_instance_overrides import (
+    ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY,
+    build_post_deploy_environment,
+    render_post_deploy_payload,
+)
 from control_plane.contracts.odoo_instance_override_record import (
     OdooAddonSettingOverride,
     OdooConfigParameterOverride,
@@ -10,7 +16,7 @@ from control_plane.contracts.odoo_instance_override_record import (
 
 
 class OdooInstanceOverrideRenderingTests(unittest.TestCase):
-    def test_render_post_deploy_environment_maps_literal_overrides_to_current_transport_keys(self) -> None:
+    def test_render_post_deploy_payload_preserves_typed_override_shapes(self) -> None:
         record = OdooInstanceOverrideRecord(
             context="opw",
             instance="prod",
@@ -30,15 +36,55 @@ class OdooInstanceOverrideRenderingTests(unittest.TestCase):
             updated_at="2026-04-23T12:00:00Z",
         )
 
-        environment = render_post_deploy_environment(record)
+        payload = render_post_deploy_payload(record)
 
         self.assertEqual(
-            environment,
+            payload,
             {
-                "ENV_OVERRIDE_CONFIG_PARAM__WEB__BASE__URL": "https://opw-prod.example.com",
-                "ENV_OVERRIDE_AUTHENTIK__BASE_URL": "https://auth.example.com",
+                "schema_version": 1,
+                "context": "opw",
+                "instance": "prod",
+                "config_parameters": [
+                    {
+                        "key": "web.base.url",
+                        "value": {
+                            "source": "literal",
+                            "value": "https://opw-prod.example.com",
+                        },
+                    }
+                ],
+                "addon_settings": [
+                    {
+                        "addon": "authentik_sso",
+                        "setting": "base_url",
+                        "value": {
+                            "source": "literal",
+                            "value": "https://auth.example.com",
+                        },
+                    }
+                ],
             },
         )
+
+    def test_build_post_deploy_environment_sets_base64_payload_env(self) -> None:
+        record = OdooInstanceOverrideRecord(
+            context="opw",
+            instance="prod",
+            config_parameters=(
+                OdooConfigParameterOverride(
+                    key="web.base.url",
+                    value=OdooOverrideValue(source="literal", value="https://opw-prod.example.com"),
+                ),
+            ),
+            updated_at="2026-04-23T12:00:00Z",
+        )
+
+        environment = build_post_deploy_environment(record)
+
+        encoded_payload = environment.inline_environment[ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY]
+        decoded_payload = json.loads(base64.b64decode(encoded_payload).decode("utf-8"))
+
+        self.assertEqual(decoded_payload, render_post_deploy_payload(record))
 
     def test_build_post_deploy_environment_requires_container_env_for_secret_backed_values(self) -> None:
         record = OdooInstanceOverrideRecord(
@@ -59,7 +105,7 @@ class OdooInstanceOverrideRenderingTests(unittest.TestCase):
 
         environment = build_post_deploy_environment(record)
 
-        self.assertEqual(environment.inline_environment, {})
+        self.assertIn(ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY, environment.inline_environment)
         self.assertEqual(environment.required_container_environment_keys, ("ENV_OVERRIDE_SHOPIFY__API_TOKEN",))
 
 

--- a/tests/test_odoo_instance_overrides.py
+++ b/tests/test_odoo_instance_overrides.py
@@ -287,6 +287,10 @@ class OdooInstanceOverrideTests(unittest.TestCase):
                 }
             ],
         )
+        self.assertEqual(
+            captured_workflow_environment["ENV_OVERRIDE_CONFIG_PARAM__WEB__BASE__URL"],
+            "https://opw-prod.example.com",
+        )
         self.assertEqual(stored_record.last_apply.status, "pass")
 
     def test_post_deploy_update_requires_container_env_for_secret_backed_odoo_overrides(self) -> None:

--- a/tests/test_odoo_instance_overrides.py
+++ b/tests/test_odoo_instance_overrides.py
@@ -1,9 +1,11 @@
+import base64
 import json
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
+from control_plane.odoo_instance_overrides import ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY
 from click.testing import CliRunner
 from pydantic import ValidationError
 
@@ -270,9 +272,20 @@ class OdooInstanceOverrideTests(unittest.TestCase):
             stored_record = store.read_odoo_instance_override_record(context_name="opw", instance_name="prod")
             store.close()
 
+        payload = json.loads(
+            base64.b64decode(captured_workflow_environment[ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY]).decode("utf-8")
+        )
         self.assertEqual(
-            captured_workflow_environment,
-            {"ENV_OVERRIDE_CONFIG_PARAM__WEB__BASE__URL": "https://opw-prod.example.com"},
+            payload["config_parameters"],
+            [
+                {
+                    "key": "web.base.url",
+                    "value": {
+                        "source": "literal",
+                        "value": "https://opw-prod.example.com",
+                    },
+                }
+            ],
         )
         self.assertEqual(stored_record.last_apply.status, "pass")
 


### PR DESCRIPTION
## Summary
- replace the old post-deploy record bridge with a typed Odoo override payload env var
- keep secret-backed values out of Dokploy schedule payloads by referencing the already-present container env key and asserting it before Odoo runs
- preserve legacy literal `ENV_OVERRIDE_*` transport for non-secret values during rollout so older Odoo consumers keep working

## Verification
- `uv run python -m unittest tests.test_odoo_instance_override_rendering tests.test_odoo_instance_overrides tests.test_dokploy`
- `uv run python -m unittest`

## Rollout
- Safe to merge now that Launchplane sends both the typed payload and the legacy literal transport for non-secret values.
- After the typed consumer is confirmed everywhere, the compatibility-only literal bridge can be removed in a later cleanup slice.