### PR TITLE
Run Launchplane workflows on chris-testing

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+---
+self-hosted-runner:
+  labels:
+    - chris-testing
+    - chris-testing-launchplane

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - chris-testing
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
+      - name: Install Python
+        run: uv python install 3.13
 
       - name: Run unit tests
         run: uv run python -m unittest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,30 @@ on:
 
 jobs:
   test:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on:
       - self-hosted
       - chris-testing
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install Python
+        run: uv python install 3.13
+
+      - name: Run unit tests
+        run: uv run python -m unittest
+
+  test_fork:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version-file: pyproject.toml
+          python-version: "3.13"
 
       - name: Run unit tests
         run: uv run python -m unittest

--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -117,10 +117,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
+      - name: Install Python
+        run: uv python install 3.13
 
       - name: Render bootstrap authz policy
         id: policy

--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -35,7 +35,9 @@ jobs:
        github.event.workflow_run.event == 'push' &&
        github.event.workflow_run.head_branch == 'main') ||
       github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - chris-testing
     env:
       LAUNCHPLANE_DOKPLOY_TARGET_ID: ${{ vars.LAUNCHPLANE_DOKPLOY_TARGET_ID }}
       LAUNCHPLANE_DOKPLOY_TARGET_TYPE: ${{ vars.LAUNCHPLANE_DOKPLOY_TARGET_TYPE }}

--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version-file: pyproject.toml
+          python-version: "3.13"
 
       - name: Render bootstrap authz policy
         id: policy

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -177,9 +177,9 @@ during the same reviewed rollout as the image digest change. Keep Dokploy
 host/token authority in Launchplane-managed secrets instead of duplicating
 those credentials in GitHub repository secrets.
 
-`LAUNCHPLANE_DEPLOY_HEALTH_URLS` must resolve from GitHub-hosted runners. Use the
-public Launchplane `GET /v1/health` endpoint rather than an internal-only Dokploy
-network hostname.
+`LAUNCHPLANE_DEPLOY_HEALTH_URLS` must resolve from the `chris-testing`
+self-hosted GitHub runner. Use the public Launchplane `GET /v1/health` endpoint
+rather than an internal-only Dokploy network hostname.
 
 The Dokploy-hosted Launchplane target should consume `DOCKER_IMAGE_REFERENCE` from
 its env so deploy automation can switch the service by immutable digest and


### PR DESCRIPTION
## Summary
- run trusted Launchplane CI and deploy workflows on the `self-hosted` / `chris-testing` runner lane
- keep fork-origin PR code on `ubuntu-latest` instead of the persistent self-hosted runner
- add actionlint runner-label configuration for `chris-testing` and `chris-testing-launchplane`
- update operations docs so deploy health expectations reference the self-hosted runner

## Runner setup
- registered `chris-testing-launchplane` on the `chris-testing` host for `cbusillo/launchplane`
- confirmed GitHub reports it online with labels `self-hosted`, `Linux`, `X64`, `chris-testing`, and `chris-testing-launchplane`

## Verification
- `actionlint -config-file .github/actionlint.yaml .github/workflows/ci.yml .github/workflows/deploy-launchplane.yml`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "#{path}: ok" }' .github/workflows/ci.yml .github/workflows/deploy-launchplane.yml .github/actionlint.yaml`
- `git diff --check -- .github/workflows/ci.yml .github/workflows/deploy-launchplane.yml .github/actionlint.yaml docs/operations.md`
- PR CI passed on `chris-testing`: https://github.com/cbusillo/launchplane/actions/runs/24968310660
