### PR TITLE
Use python3 in deploy workflow bootstrap

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          python - <<'PY'
+          python3 - <<'PY'
           import os
           from urllib.parse import urlsplit
 


### PR DESCRIPTION
## Summary
- use `python3` for the early deploy workflow endpoint-resolution script
- fixes self-hosted runner deploy bootstrap before `uv python install 3.13` runs

## Verification
- `actionlint -config-file .github/actionlint.yaml .github/workflows/ci.yml .github/workflows/deploy-launchplane.yml`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "#{path}: ok" }' .github/workflows/deploy-launchplane.yml`
- `git diff --check -- .github/workflows/deploy-launchplane.yml`
