### PR TITLE
Add Odoo prod rollback CLI

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -105,6 +105,10 @@ from control_plane.workflows.odoo_prod_backup_gate import (
     OdooProdBackupGateRequest,
     execute_odoo_prod_backup_gate,
 )
+from control_plane.workflows.odoo_prod_rollback import (
+    OdooProdRollbackRequest,
+    execute_odoo_prod_rollback,
+)
 from control_plane.workflows.promote import (
     build_executed_promotion_record,
     build_promotion_record,
@@ -8729,6 +8733,11 @@ def odoo_backup_gates() -> None:
     """Odoo backup-gate driver commands."""
 
 
+@main.group("odoo-rollbacks")
+def odoo_rollbacks() -> None:
+    """Odoo rollback driver commands."""
+
+
 @main.group()
 def service() -> None:
     """Launchplane service commands."""
@@ -9291,6 +9300,60 @@ def odoo_backup_gates_capture(
     click.echo(json.dumps(result.model_dump(mode="json"), indent=2, sort_keys=True))
     if result.backup_status != "pass":
         raise click.ClickException(result.error_message or "Odoo backup gate failed.")
+
+
+@odoo_rollbacks.command("execute")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane rollback records.",
+)
+@click.option("--context", required=True)
+@click.option("--instance", default="prod", show_default=True)
+@click.option("--source-channel", default="testing", show_default=True)
+@click.option("--promotion-record-id", default="")
+@click.option("--artifact-id", default="")
+@click.option("--reason", default="")
+@click.option("--wait/--no-wait", default=True, show_default=True)
+@click.option("--timeout", "timeout_seconds", type=int, default=None)
+@click.option("--verify-health/--no-verify-health", default=True, show_default=True)
+@click.option("--health-timeout", "health_timeout_seconds", type=int, default=None)
+@click.option("--no-cache", is_flag=True, default=False)
+def odoo_rollbacks_execute(
+    database_url: str,
+    context: str,
+    instance: str,
+    source_channel: str,
+    promotion_record_id: str,
+    artifact_id: str,
+    reason: str,
+    wait: bool,
+    timeout_seconds: int | None,
+    verify_health: bool,
+    health_timeout_seconds: int | None,
+    no_cache: bool,
+) -> None:
+    result = execute_odoo_prod_rollback(
+        control_plane_root=_control_plane_root(),
+        record_store=_store(Path("state"), database_url=database_url),
+        request=OdooProdRollbackRequest(
+            context=context,
+            instance=instance,
+            source_channel=source_channel,
+            promotion_record_id=promotion_record_id,
+            artifact_id=artifact_id,
+            reason=reason,
+            wait=wait,
+            timeout_seconds=timeout_seconds,
+            verify_health=verify_health,
+            health_timeout_seconds=health_timeout_seconds,
+            no_cache=no_cache,
+        ),
+    )
+    click.echo(json.dumps(result.model_dump(mode="json"), indent=2, sort_keys=True))
+    if result.rollback_status != "pass":
+        raise click.ClickException(result.error_message or "Odoo prod rollback failed.")
 
 
 @main.group("release-tuples")

--- a/tests/test_odoo_prod_rollback.py
+++ b/tests/test_odoo_prod_rollback.py
@@ -3,7 +3,9 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import click
+from click.testing import CliRunner
 
+from control_plane.cli import main
 from control_plane.contracts.artifact_identity import (
     ArtifactIdentityManifest,
     ArtifactImageReference,
@@ -321,6 +323,54 @@ class OdooProdRollbackWorkflowTests(unittest.TestCase):
         self.assertIn("deploy failed", result.error_message)
         final_promotion = record_store.write_promotion_record.call_args_list[-1].args[0]
         self.assertEqual(final_promotion.rollback.status, "fail")
+
+    def test_rollback_cli_executes_driver(self) -> None:
+        with (
+            patch(
+                "control_plane.cli.execute_odoo_prod_rollback",
+                return_value=Mock(
+                    rollback_status="pass",
+                    model_dump=Mock(
+                        return_value={
+                            "context": "cm",
+                            "instance": "prod",
+                            "artifact_id": "artifact-cm-previous",
+                            "promotion_record_id": "promotion-cm-prod",
+                            "deployment_record_id": "deployment-cm-prod",
+                            "release_tuple_id": "cm-prod-artifact-cm-previous",
+                            "rollback_status": "pass",
+                            "rollback_health_status": "pass",
+                            "post_deploy_status": "pass",
+                            "error_message": "",
+                        }
+                    ),
+                ),
+            ) as execute_mock,
+            patch("control_plane.cli._store", return_value=Mock()),
+        ):
+            result = CliRunner().invoke(
+                main,
+                [
+                    "odoo-rollbacks",
+                    "execute",
+                    "--database-url",
+                    "postgresql://launchplane.example/db",
+                    "--context",
+                    "cm",
+                    "--artifact-id",
+                    "artifact-cm-previous",
+                    "--reason",
+                    "drill",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("artifact-cm-previous", result.output)
+        execute_mock.assert_called_once()
+        request = execute_mock.call_args.kwargs["request"]
+        self.assertEqual(request.context, "cm")
+        self.assertEqual(request.artifact_id, "artifact-cm-previous")
+        self.assertEqual(request.reason, "drill")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a first-class `odoo-rollbacks execute` CLI for operator-driven Odoo rollback drills
- wire the CLI to the existing Launchplane Odoo prod rollback workflow and DB-backed store
- cover the CLI request wiring in the targeted rollback tests

## Tests
- uv run python -m unittest tests.test_odoo_prod_rollback
- uv run ruff format --check control_plane/cli.py tests/test_odoo_prod_rollback.py
- uv run ruff check control_plane/cli.py tests/test_odoo_prod_rollback.py