### PR TITLE
ci: add private security checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,83 @@
+---
 name: CI
 
-on:
+"on":
   push:
     branches:
       - main
   pull_request:
 
 jobs:
+  static_checks:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on:
+      - self-hosted
+      - chris-testing
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install Python
+        run: uv python install 3.13
+
+      - name: Run Ruff
+        run: uv run ruff check .
+
+      - name: Audit Python dependencies
+        run: uv run --with pip-audit pip-audit
+
+  static_checks_fork:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install Python
+        run: uv python install 3.13
+
+      - name: Run Ruff
+        run: uv run ruff check .
+
+      - name: Audit Python dependencies
+        run: uv run --with pip-audit pip-audit
+
+  container_scan:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on:
+      - self-hosted
+      - chris-testing
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build runtime image
+        run: docker build -t launchplane-ci:test .
+
+      - name: Scan runtime image
+        run: |
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "${RUNNER_TEMP}/trivy-cache:/root/.cache" \
+            aquasec/trivy:0.70.0 image \
+            --scanners vulnerability \
+            --ignore-unfixed \
+            --severity HIGH,CRITICAL \
+            --exit-code 1 \
+            launchplane-ci:test
+
   test:
     if: >-
       github.event_name != 'pull_request' ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: uv python install 3.13
 
       - name: Run Ruff
-        run: uv run ruff check .
+        run: uv run --extra dev ruff check .
 
       - name: Audit Python dependencies
         run: uv run --with pip-audit pip-audit
@@ -47,7 +47,7 @@ jobs:
         run: uv python install 3.13
 
       - name: Run Ruff
-        run: uv run ruff check .
+        run: uv run --extra dev ruff check .
 
       - name: Audit Python dependencies
         run: uv run --with pip-audit pip-audit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,67 @@
+---
+name: Security
+
+"on":
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  workflow_lint:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on:
+      - self-hosted
+      - chris-testing
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Lint GitHub Actions workflows
+        run: |
+          docker run --rm \
+            -v "${PWD}:/repo" \
+            -w /repo \
+            rhysd/actionlint:1.7.12 \
+            -config-file .github/actionlint.yaml
+
+  secret_scan:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on:
+      - self-hosted
+      - chris-testing
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Scan current tree for committed secrets
+        run: |
+          scan_path="${RUNNER_TEMP}/gitleaks-source"
+          rm -rf "${scan_path}"
+          mkdir -p "${scan_path}"
+          git ls-files -z | rsync -a --files-from=- --from0 ./ "${scan_path}/"
+
+          docker run --rm \
+            -v "${scan_path}:/repo:ro" \
+            -w /repo \
+            ghcr.io/gitleaks/gitleaks:v8.30.1 detect \
+            --source . \
+            --no-git \
+            --redact \
+            --verbose

--- a/control_plane/workflows/launchplane.py
+++ b/control_plane/workflows/launchplane.py
@@ -1263,12 +1263,10 @@ def resolve_launchplane_preview_base_url(*, control_plane_root: Path, context_na
         context_name=context_name,
     )
     preview_base_url = ""
-    preview_base_url_env_key = LAUNCHPLANE_PREVIEW_BASE_URL_ENV_KEYS[0]
     for environment_key in LAUNCHPLANE_PREVIEW_BASE_URL_ENV_KEYS:
         configured_value = context_values.get(environment_key, "").strip()
         if configured_value:
             preview_base_url = configured_value
-            preview_base_url_env_key = environment_key
             break
     if not preview_base_url:
         raise click.ClickException(

--- a/tests/test_release_tuples.py
+++ b/tests/test_release_tuples.py
@@ -77,13 +77,9 @@ class ReleaseTupleTests(unittest.TestCase):
         )
 
     def test_load_release_tuple_catalog_requires_database_url(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            control_plane_root = Path(temporary_directory_name)
-
-            with patch.dict(os.environ, {}, clear=True):
-                with self.assertRaisesRegex(Exception, "LAUNCHPLANE_DATABASE_URL"):
-                    control_plane_release_tuples.load_release_tuple_catalog(
-                    )
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(Exception, "LAUNCHPLANE_DATABASE_URL"):
+                control_plane_release_tuples.load_release_tuple_catalog()
 
     def test_load_release_tuple_catalog_requires_stored_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add CI static checks for Ruff and project dependency audit with `pip-audit`
- add a container image build and Trivy high/critical vulnerability scan
- add a separate Security workflow for actionlint and gitleaks over tracked files
- clean up two unused variables surfaced by Ruff

## Verification
- `actionlint -config-file .github/actionlint.yaml .github/workflows/ci.yml .github/workflows/security.yml`
- `uv run ruff check .`
- `uv run --with pip-audit pip-audit`
- `uv run python -m unittest`
- gitleaks over a tracked-file staging directory: no leaks found
- `docker build -t launchplane-ci:test .`
- `trivy image --scanners vulnerability --ignore-unfixed --severity HIGH,CRITICAL --exit-code 1 launchplane-ci:test`

## Notes
- `ruff format --check` is not enabled because it would reformat 37 existing files.
- `mypy` is not enabled because current strict typing reports broad existing debt.
- Work was done in a separate worktree at `/Users/cbusillo/Developer/launchplane-security-checks` to avoid disturbing the active `launchplane` checkout.
- JetBrains inspection was not run because this worktree is not open in JetBrains.
