### PR TITLE
docs: document retired driver migration plan

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -228,10 +228,23 @@ The first concrete HTTP/OIDC/API shape for that boundary is defined in
   tests, and emergency diagnostics only.
 - New cross-product integrations should target the Launchplane service boundary
   and GitHub OIDC, not repo-local CLI mutation.
-- Launchplane does not yet have a formal schema migration system.
-- Until that migration story exists, schema changes for DB-backed Launchplane state
-  should remain additive and backward-compatible so deploy rollback can safely
-  return to the previous Launchplane image.
+- Use SQLAlchemy ORM models plus Alembic migrations for shared-service schema
+  changes. Compatibility `ensure_schema()` paths are for local, test, and
+  bootstrap tolerance, not the production migration strategy.
+- Keep schema changes backward-compatible enough that deploy rollback can safely
+  return to the previous Launchplane image when possible.
+
+## Driver Migration Status
+
+The first Odoo and VeriReel driver migration is complete enough that the old
+driver-migration working plan has been retired. Product repos now keep source,
+build, verification, and thin OIDC request wrappers, while Launchplane owns the
+durable service routes, DB-backed records, managed-secret/runtime authority,
+driver execution, and operator read models for the current Odoo and VeriReel
+deployment, promotion, rollback, backup, and preview paths.
+
+Future driver work should be incremental capability expansion behind the same
+service/read-model contract, not a second migration track.
 
 See [compatibility-retirement.md](compatibility-retirement.md) for the checkpoint
 rules that decide whether a local CLI/file-backed compatibility path can remain.

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -47,6 +47,9 @@ Keep a compatibility surface only when it is one of these:
 - `control_plane` remains the Python package name for now. Do not add public
   `odoo-control-plane` names, env vars, or docs; prefer Launchplane wording for
   product/operator surfaces.
+- The first driver-migration working plan is retired. New driver work should be
+  tracked as capability expansion in the active Launchplane GUI/driver plan or
+  in focused PRs/issues, not by reopening the old migration checklist.
 
 ## Review Cadence
 

--- a/docs/ui-standards.md
+++ b/docs/ui-standards.md
@@ -8,6 +8,9 @@ Launchplane UI work must read as a tenant environment control plane, not a
 generic dashboard and not a preview-only queue. The first screen should make the
 operator's current product, lane state, and next safe action obvious.
 
+Use this document as the Launchplane UI quality gate. UI slices that pass tests
+but fail this rubric are not complete.
+
 ## Product Objects
 
 Every UI slice declares one primary object before implementation:
@@ -34,6 +37,22 @@ as evidence around it.
   weight comparable to preview creation or teardown.
 - Secret safety: show binding status, validation, rotation, and audit metadata;
   do not normalize plaintext reveal in the default UI.
+- Driver-shaped: render from Launchplane driver descriptors and read models
+  where possible, so Odoo, VeriReel, and future products share the same shell
+  instead of drifting into separate hard-coded pages.
+
+## Slice Brief
+
+Before implementation, each meaningful UI slice should declare:
+
+- primary object: tenant, environment lane, preview, promotion, policy, or
+  secret/integration status
+- first-screen hierarchy: what must be visible without hunting
+- primary action and safety level
+- explicit anti-goals, such as avoiding fleet-first framing, preview-only
+  framing, generic card grids, plaintext secret reveal, or provider-native
+  vocabulary as the main UI model
+- required evidence states: pass, fail, pending, unknown, blocked, and missing
 
 ## Anti-Slop Gate
 
@@ -54,8 +73,14 @@ Before committing a meaningful UI slice, check it against this rubric:
 ## Review Workflow
 
 - Use browser screenshots for every substantial UI change.
+- Regenerate and reopen the page before judging screenshots; stale screenshots
+  are not acceptance evidence.
 - Critique the visible result, not only the HTML or tests.
-- Keep implementation deterministic and repo-local; use model critique as review
-  input, not as a replacement for the rubric.
+- Keep implementation deterministic and repo-local. Model critique can help with
+  art direction or screenshot review, but the rubric and browser evidence decide
+  acceptance.
 - If UI needs new evidence, add minimal typed read-model fields instead of
   inferring production truth from logs or free-form text.
+- Browser-review desktop and narrow/mobile widths for every committed UI slice.
+- Update the active Launchplane plan when a UI issue is really a product-framing
+  or read-model contract gap instead of a local visual patch.


### PR DESCRIPTION
## Summary
- document the retired driver migration direction for the Launchplane GUI driver system

## Verification
- docs-only change; no runtime checks run