### PR TITLE
Serve operator UI at root route

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ similar long-running hosts:
 - `frontend/`
 
 The service image builds the Vite/React operator UI in a Node 22 stage, copies
-only the static bundle into the Python runtime image, and serves it at `/ui`.
+only the static bundle into the Python runtime image, and serves it at `/` and
+`/ui`. Built assets stay under `/ui/assets/...`; versioned API ingress remains
+under `/v1`.
 The compose service now expects the Launchplane container image through
 `DOCKER_IMAGE_REFERENCE`. Dokploy should set that to an immutable GHCR digest
 for real Launchplane deploys. For purely local compose usage, build a local image

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -577,7 +577,7 @@ def _serve_ui_route(
     if not index_path.is_file():
         return _not_found_response(start_response=start_response, trace_id=trace_id, path=path)
 
-    if path in {"/ui", "/ui/"}:
+    if path in {"/", "/ui", "/ui/"}:
         return _ui_file_response(
             start_response=start_response,
             file_path=index_path,
@@ -1009,7 +1009,7 @@ def create_launchplane_service_app(
         request_trace_id = _trace_id()
         method = str(environ.get("REQUEST_METHOD", "GET")).upper()
         path = str(environ.get("PATH_INFO", ""))
-        if method == "GET" and (path == "/ui" or path.startswith("/ui/")):
+        if method == "GET" and (path == "/" or path == "/ui" or path.startswith("/ui/")):
             return _serve_ui_route(
                 start_response=start_response,
                 trace_id=request_trace_id,

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -55,9 +55,10 @@ deployment/promotion/preview lifecycle evidence over HTTP, and executes the
 current Odoo/VeriReel artifact, deploy, backup, promotion, rollback, maintenance,
 and preview mutations as authenticated Launchplane routes.
 
-The service also serves the built operator UI shell under `/ui`. Built assets
-live under `/ui/assets/...`, while `/ui/*` falls back to the app shell so the
-frontend can own client-side routes.
+The service also serves the built operator UI shell at `/`, with `/ui` retained
+as a compatibility alias. Built assets live under `/ui/assets/...`, while
+`/ui/*` falls back to the app shell so the frontend can own client-side routes.
+Versioned API ingress remains under `/v1`.
 
 ## First Host Assumption
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -320,6 +320,29 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertIn(b"launchplane ui", asset_body)
         self.assertEqual(asset_headers["Cache-Control"], "public, max-age=31536000, immutable")
 
+    def test_root_route_serves_ui_shell_without_authentication(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            ui_root = root / "control_plane" / "ui_static"
+            ui_root.mkdir(parents=True)
+            (ui_root / "index.html").write_text(
+                '<html><head><script type="module" src="/ui/assets/app.js"></script></head></html>',
+                encoding="utf-8",
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=root,
+            )
+
+            status_code, headers, body = _invoke_raw_app(app, method="GET", path="/")
+
+        self.assertEqual(status_code, 200)
+        self.assertEqual(headers["Content-Type"], "text/html")
+        self.assertEqual(headers["Cache-Control"], "no-store")
+        self.assertIn(b"/ui/assets/app.js", body)
+
     def test_ui_route_falls_back_to_shell_for_nested_paths(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary

- serve the operator UI app shell from `/`
- keep `/ui` and `/ui/*` as compatibility routes for the existing UI path and client routes
- preserve `/v1/...` as the stable API namespace
- document the root UI route and add focused service coverage

## Verification

- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_root_route_serves_ui_shell_without_authentication tests.test_service.LaunchplaneServiceTests.test_ui_route_serves_static_shell_without_authentication tests.test_service.LaunchplaneServiceTests.test_ui_route_falls_back_to_shell_for_nested_paths tests.test_service.LaunchplaneServiceTests.test_ui_asset_route_rejects_parent_directory_segments` passed
- `uv run python -m unittest` passed, 422 tests
- `npx pnpm@10.10.0 --dir frontend validate` passed
  - local Node emits the expected engine warning because this machine is on Node v25; CI uses Node 22
- `git diff --check` passed
