### PR TITLE
Add GitHub OAuth browser sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,19 @@ reach DB-backed runtime authority:
 - `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`
 - `LAUNCHPLANE_POLICY_TOML` or `LAUNCHPLANE_POLICY_B64`
 
+The browser operator UI uses GitHub OAuth when these additional inputs are set:
+
+- `LAUNCHPLANE_GITHUB_CLIENT_ID`
+- `LAUNCHPLANE_GITHUB_CLIENT_SECRET`
+- `LAUNCHPLANE_PUBLIC_URL`
+- `LAUNCHPLANE_SESSION_SECRET`
+- optional `LAUNCHPLANE_COOKIE_SECURE` for local HTTP development
+
+Human browser sessions use signed cookies backed by the Launchplane database when
+`LAUNCHPLANE_DATABASE_URL` is configured. Human roles are authorized through
+`github_humans` rules in the same Launchplane authz policy. Machine writes
+continue to use GitHub Actions OIDC bearer tokens.
+
 Launchplane now fails closed at startup when no explicit policy input is provided.
 Do not point `LAUNCHPLANE_POLICY_FILE` at `config/launchplane-authz.toml.example`.
 Use `config/launchplane-authz.toml` for this repo's reviewed bootstrap policy,

--- a/config/launchplane-authz.toml
+++ b/config/launchplane-authz.toml
@@ -203,3 +203,8 @@ event_names = ["workflow_run", "workflow_dispatch"]
 products = ["launchplane"]
 contexts = ["launchplane"]
 actions = ["launchplane_service.read", "launchplane_service_deploy.execute"]
+
+[[github_humans]]
+logins = ["cbusillo"]
+roles = ["admin"]
+products = ["launchplane"]

--- a/config/launchplane-authz.toml.example
+++ b/config/launchplane-authz.toml.example
@@ -182,3 +182,21 @@ event_names = ["workflow_run", "workflow_dispatch"]
 products = ["launchplane"]
 contexts = ["launchplane"]
 actions = ["launchplane_service.read", "launchplane_service_deploy.execute"]
+
+[[github_humans]]
+teams = ["example-org/launchplane-admins"]
+roles = ["admin"]
+products = ["launchplane"]
+
+[[github_humans]]
+teams = ["example-org/launchplane-readers"]
+roles = ["read_only"]
+products = ["launchplane"]
+actions = [
+  "deployment.read",
+  "driver.read",
+  "inventory.read",
+  "operations.read",
+  "preview.read",
+  "promotion.read",
+]

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -7,12 +7,13 @@ import io
 import json
 import mimetypes
 import os
+import secrets
 from socketserver import ThreadingMixIn
 import traceback
 import uuid
 from pathlib import Path
 from typing import Callable
-from urllib.parse import unquote
+from urllib.parse import parse_qs, unquote
 from wsgiref.simple_server import WSGIServer, make_server
 
 import click
@@ -42,10 +43,23 @@ from control_plane.launchplane_mutations import (
     control_plane_root,
 )
 from control_plane.service_auth import (
+    GitHubActionsIdentity,
+    GitHubHumanIdentity,
     LaunchplaneAuthzPolicy,
+    LaunchplaneIdentity,
     TokenVerifier,
     load_authz_policy,
     parse_authz_policy_toml,
+)
+from control_plane.service_human_auth import (
+    GitHubOAuthClient,
+    GitHubOAuthConfig,
+    HumanSessionManager,
+    HumanSessionStore,
+    InMemoryHumanSessionStore,
+    OAuthLoginStateStore,
+    build_pkce_verifier,
+    load_github_oauth_config_from_env,
 )
 from control_plane.storage.factory import build_record_store, storage_backend_name
 from control_plane.workflows.evidence_ingestion import (
@@ -478,17 +492,30 @@ def _json_response(
     start_response: Callable[[str, list[tuple[str, str]]], None],
     status_code: int,
     payload: dict[str, object],
+    headers: list[tuple[str, str]] | None = None,
 ) -> list[bytes]:
     encoded = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
     status_line = f"{status_code} {_http_status_text(status_code)}"
-    start_response(
-        status_line,
-        [
-            ("Content-Type", "application/json"),
-            ("Content-Length", str(len(encoded))),
-        ],
-    )
+    response_headers = [
+        ("Content-Type", "application/json"),
+        ("Content-Length", str(len(encoded))),
+    ]
+    response_headers.extend(headers or [])
+    start_response(status_line, response_headers)
     return [encoded]
+
+
+def _redirect_response(
+    *,
+    start_response: Callable[[str, list[tuple[str, str]]], None],
+    location: str,
+    headers: list[tuple[str, str]] | None = None,
+) -> list[bytes]:
+    body = b""
+    response_headers = [("Location", location), ("Content-Length", "0")]
+    response_headers.extend(headers or [])
+    start_response("302 Found", response_headers)
+    return [body]
 
 
 def _http_status_text(status_code: int) -> str:
@@ -669,6 +696,15 @@ def _idempotency_capable_store(record_store: object):
         record_store, "write_idempotency_record"
     ):
         return record_store
+    return None
+
+
+def _human_session_capable_store(record_store: object) -> HumanSessionStore | None:
+    if all(
+        hasattr(record_store, method_name)
+        for method_name in ("write_session", "read_session", "delete_session")
+    ):
+        return record_store  # type: ignore[return-value]
     return None
 
 
@@ -876,6 +912,48 @@ def _bearer_token(environ: dict[str, object]) -> str:
     return token.strip()
 
 
+def _session_identity(
+    *, environ: dict[str, object], session_manager: HumanSessionManager | None
+) -> GitHubHumanIdentity | None:
+    if session_manager is None:
+        return None
+    session = session_manager.read_cookie(str(environ.get("HTTP_COOKIE", "")))
+    return session.identity if session is not None else None
+
+
+def _read_identity(
+    *,
+    environ: dict[str, object],
+    verifier: TokenVerifier,
+    session_manager: HumanSessionManager | None,
+) -> LaunchplaneIdentity:
+    human_identity = _session_identity(environ=environ, session_manager=session_manager)
+    if human_identity is not None:
+        return human_identity
+    token = _bearer_token(environ)
+    return verifier.verify(token)
+
+
+def _human_identity_payload(identity: GitHubHumanIdentity) -> dict[str, object]:
+    return {
+        "provider": "github",
+        "login": identity.login,
+        "github_id": identity.github_id,
+        "name": identity.name,
+        "email": identity.email,
+        "organizations": sorted(identity.organizations),
+        "teams": sorted(identity.teams),
+        "role": identity.role,
+    }
+
+
+def _safe_return_to(value: str) -> str:
+    normalized = value.strip() or "/"
+    if not normalized.startswith("/") or normalized.startswith("//"):
+        return "/"
+    return normalized
+
+
 def _launchplane_policy_sha256_from_env() -> str:
     policy_toml = os.environ.get("LAUNCHPLANE_POLICY_TOML", "").strip()
     if policy_toml:
@@ -972,11 +1050,37 @@ def create_launchplane_service_app(
     authz_policy: LaunchplaneAuthzPolicy,
     control_plane_root_path: Path | None = None,
     database_url: str | None = None,
+    github_oauth_config: GitHubOAuthConfig | None = None,
+    github_oauth_client: GitHubOAuthClient | None = None,
+    human_session_store: HumanSessionStore | None = None,
 ):
     resolved_root = control_plane_root_path or control_plane_root()
     ui_static_root = resolved_root / "control_plane" / "ui_static"
     record_store = build_record_store(state_dir=state_dir, database_url=database_url)
     storage_backend = storage_backend_name(record_store)
+    resolved_github_oauth_config = github_oauth_config or load_github_oauth_config_from_env()
+    oauth_login_states = OAuthLoginStateStore()
+    session_manager = (
+        HumanSessionManager(
+            config=resolved_github_oauth_config,
+            session_store=(
+                human_session_store
+                or _human_session_capable_store(record_store)
+                or InMemoryHumanSessionStore()
+            ),
+        )
+        if resolved_github_oauth_config is not None
+        else None
+    )
+    resolved_github_oauth_client = (
+        github_oauth_client
+        if github_oauth_client is not None
+        else (
+            GitHubOAuthClient(resolved_github_oauth_config)
+            if resolved_github_oauth_config is not None
+            else None
+        )
+    )
     write_routes = {
         "/v1/evidence/deployments",
         "/v1/evidence/backup-gates",
@@ -1009,6 +1113,138 @@ def create_launchplane_service_app(
         request_trace_id = _trace_id()
         method = str(environ.get("REQUEST_METHOD", "GET")).upper()
         path = str(environ.get("PATH_INFO", ""))
+        query = parse_qs(str(environ.get("QUERY_STRING", "")), keep_blank_values=True)
+        if method == "GET" and path == "/auth/github/login":
+            if resolved_github_oauth_config is None or resolved_github_oauth_client is None:
+                return _json_response(
+                    start_response=start_response,
+                    status_code=503,
+                    payload={
+                        "status": "rejected",
+                        "trace_id": request_trace_id,
+                        "error": {
+                            "code": "auth_not_configured",
+                            "message": "GitHub OAuth is not configured for Launchplane.",
+                        },
+                    },
+                )
+            state = secrets.token_urlsafe(32)
+            code_verifier, code_challenge = build_pkce_verifier()
+            return_to = _safe_return_to((query.get("return_to") or ["/"])[0])
+            oauth_login_states.put(
+                state=state,
+                code_verifier=code_verifier,
+                return_to=return_to,
+            )
+            return _redirect_response(
+                start_response=start_response,
+                location=resolved_github_oauth_client.authorization_url(
+                    state=state,
+                    code_challenge=code_challenge,
+                ),
+            )
+        if method == "GET" and path == "/auth/github/callback":
+            if session_manager is None or resolved_github_oauth_client is None:
+                return _json_response(
+                    start_response=start_response,
+                    status_code=503,
+                    payload={
+                        "status": "rejected",
+                        "trace_id": request_trace_id,
+                        "error": {
+                            "code": "auth_not_configured",
+                            "message": "GitHub OAuth is not configured for Launchplane.",
+                        },
+                    },
+                )
+            code = str((query.get("code") or [""])[0]).strip()
+            state = str((query.get("state") or [""])[0]).strip()
+            login_state = oauth_login_states.pop(state)
+            if not code or login_state is None:
+                return _json_response(
+                    start_response=start_response,
+                    status_code=400,
+                    payload={
+                        "status": "rejected",
+                        "trace_id": request_trace_id,
+                        "error": {
+                            "code": "invalid_oauth_callback",
+                            "message": "GitHub OAuth callback is missing a valid code or state.",
+                        },
+                    },
+                )
+            try:
+                human_identity = resolved_github_oauth_client.fetch_identity(
+                    code=code,
+                    code_verifier=login_state.code_verifier,
+                    authz_policy=authz_policy,
+                )
+            except PermissionError as exc:
+                return _json_response(
+                    start_response=start_response,
+                    status_code=403,
+                    payload={
+                        "status": "rejected",
+                        "trace_id": request_trace_id,
+                        "error": {"code": "authorization_denied", "message": str(exc)},
+                    },
+                )
+            except Exception as exc:  # noqa: BLE001
+                return _json_response(
+                    start_response=start_response,
+                    status_code=400,
+                    payload={
+                        "status": "rejected",
+                        "trace_id": request_trace_id,
+                        "error": {
+                            "code": "invalid_oauth_callback",
+                            "message": f"GitHub OAuth callback could not be completed: {exc}",
+                        },
+                    },
+                )
+            session = session_manager.issue(human_identity)
+            return _redirect_response(
+                start_response=start_response,
+                location=login_state.return_to,
+                headers=[("Set-Cookie", session_manager.session_cookie_header(session))],
+            )
+        if method == "POST" and path == "/auth/logout":
+            if session_manager is not None:
+                session_manager.delete_cookie_session(str(environ.get("HTTP_COOKIE", "")))
+                clear_cookie = session_manager.clear_cookie_header()
+            else:
+                clear_cookie = "launchplane_session=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax"
+            return _json_response(
+                start_response=start_response,
+                status_code=200,
+                payload={"status": "ok", "trace_id": request_trace_id},
+                headers=[("Set-Cookie", clear_cookie)],
+            )
+        if method == "GET" and path == "/v1/auth/session":
+            human_identity = _session_identity(environ=environ, session_manager=session_manager)
+            if human_identity is None:
+                return _json_response(
+                    start_response=start_response,
+                    status_code=401,
+                    payload={
+                        "status": "rejected",
+                        "trace_id": request_trace_id,
+                        "configured": resolved_github_oauth_config is not None,
+                        "error": {
+                            "code": "authentication_required",
+                            "message": "Sign in with GitHub to access Launchplane.",
+                        },
+                    },
+                )
+            return _json_response(
+                start_response=start_response,
+                status_code=200,
+                payload={
+                    "status": "ok",
+                    "trace_id": request_trace_id,
+                    "identity": _human_identity_payload(human_identity),
+                },
+            )
         if method == "GET" and (path == "/" or path == "/ui" or path.startswith("/ui/")):
             return _serve_ui_route(
                 start_response=start_response,
@@ -1073,8 +1309,17 @@ def create_launchplane_service_app(
                 },
             )
         try:
-            token = _bearer_token(environ)
-            identity = verifier.verify(token)
+            if method == "GET":
+                identity = _read_identity(
+                    environ=environ,
+                    verifier=verifier,
+                    session_manager=session_manager,
+                )
+            else:
+                token = _bearer_token(environ)
+                identity = verifier.verify(token)
+                if not isinstance(identity, GitHubActionsIdentity):
+                    raise PermissionError("Mutation routes require GitHub Actions OIDC.")
             if method == "GET":
                 assert read_route is not None
                 action, params = read_route

--- a/control_plane/service_auth.py
+++ b/control_plane/service_auth.py
@@ -4,7 +4,7 @@ from fnmatch import fnmatchcase
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Literal, Protocol
 
 import jwt
 from pydantic import BaseModel, ConfigDict, Field
@@ -26,6 +26,20 @@ class GitHubActionsIdentity:
     subject: str
     sha: str
     raw_claims: dict[str, object]
+
+
+@dataclass(frozen=True)
+class GitHubHumanIdentity:
+    login: str
+    github_id: int
+    name: str
+    email: str
+    organizations: frozenset[str]
+    teams: frozenset[str]
+    role: Literal["read_only", "admin"]
+
+
+LaunchplaneIdentity = GitHubActionsIdentity | GitHubHumanIdentity
 
 
 class TokenVerifier(Protocol):
@@ -125,19 +139,110 @@ class GitHubActionsPolicyRule(BaseModel):
         return True
 
 
+class GitHubHumanPolicyRule(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    logins: tuple[str, ...] = ()
+    organizations: tuple[str, ...] = ()
+    teams: tuple[str, ...] = ()
+    roles: tuple[Literal["read_only", "admin"], ...] = ()
+    products: tuple[str, ...] = ()
+    contexts: tuple[str, ...] = ()
+    actions: tuple[str, ...] = ()
+
+    @staticmethod
+    def _matches_any(value: str, allowed_values: tuple[str, ...]) -> bool:
+        normalized_value = value.strip()
+        return any(fnmatchcase(normalized_value, allowed_value) for allowed_value in allowed_values)
+
+    @staticmethod
+    def _intersects(values: frozenset[str], allowed_values: tuple[str, ...]) -> bool:
+        return any(
+            fnmatchcase(value.strip(), allowed_value)
+            for value in values
+            for allowed_value in allowed_values
+        )
+
+    def allows(
+        self, *, identity: GitHubHumanIdentity, action: str, product: str, context: str
+    ) -> bool:
+        if self.logins and not self._matches_any(identity.login, self.logins):
+            return False
+        if self.organizations and not self._intersects(identity.organizations, self.organizations):
+            return False
+        if self.teams and not self._intersects(identity.teams, self.teams):
+            return False
+        if self.roles and identity.role not in self.roles:
+            return False
+        if self.products and product not in self.products:
+            return False
+        if self.contexts and context not in self.contexts:
+            return False
+        if self.actions and action not in self.actions:
+            return False
+        return True
+
+    def matches_principal(
+        self,
+        *,
+        login: str,
+        organizations: frozenset[str],
+        teams: frozenset[str],
+        role: Literal["read_only", "admin"],
+    ) -> bool:
+        if self.logins and not self._matches_any(login, self.logins):
+            return False
+        if self.organizations and not self._intersects(organizations, self.organizations):
+            return False
+        if self.teams and not self._intersects(teams, self.teams):
+            return False
+        if self.roles and role not in self.roles:
+            return False
+        return True
+
+
 class LaunchplaneAuthzPolicy(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     schema_version: int = Field(default=1, ge=1)
     github_actions: tuple[GitHubActionsPolicyRule, ...] = ()
+    github_humans: tuple[GitHubHumanPolicyRule, ...] = ()
 
     def allows(
-        self, *, identity: GitHubActionsIdentity, action: str, product: str, context: str
+        self, *, identity: LaunchplaneIdentity, action: str, product: str, context: str
     ) -> bool:
+        if isinstance(identity, GitHubHumanIdentity):
+            return any(
+                rule.allows(identity=identity, action=action, product=product, context=context)
+                for rule in self.github_humans
+            )
         return any(
             rule.allows(identity=identity, action=action, product=product, context=context)
             for rule in self.github_actions
         )
+
+    def human_role_for(
+        self,
+        *,
+        login: str,
+        organizations: frozenset[str],
+        teams: frozenset[str],
+    ) -> Literal["read_only", "admin"] | None:
+        if any(
+            rule.matches_principal(
+                login=login, organizations=organizations, teams=teams, role="admin"
+            )
+            for rule in self.github_humans
+        ):
+            return "admin"
+        if any(
+            rule.matches_principal(
+                login=login, organizations=organizations, teams=teams, role="read_only"
+            )
+            for rule in self.github_humans
+        ):
+            return "read_only"
+        return None
 
 
 def parse_authz_policy_toml(policy_toml: str) -> LaunchplaneAuthzPolicy:

--- a/control_plane/service_human_auth.py
+++ b/control_plane/service_human_auth.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from collections.abc import Callable
+from datetime import datetime, timedelta, timezone
+import base64
+import hashlib
+import hmac
+import os
+import secrets
+import warnings
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from authlib.integrations.requests_client import (  # type: ignore[import-untyped]
+        OAuth2Session as OAuth2SessionType,
+    )
+else:
+    OAuth2SessionType = Any
+
+from control_plane.service_auth import GitHubHumanIdentity, LaunchplaneAuthzPolicy
+
+
+GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
+GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"
+GITHUB_USER_URL = "https://api.github.com/user"
+GITHUB_ORGS_URL = "https://api.github.com/user/orgs"
+GITHUB_TEAMS_URL = "https://api.github.com/user/teams"
+SESSION_COOKIE_NAME = "launchplane_session"
+SESSION_TTL_SECONDS = 12 * 60 * 60
+OAUTH_STATE_TTL_SECONDS = 10 * 60
+
+
+@dataclass(frozen=True)
+class GitHubOAuthConfig:
+    client_id: str
+    client_secret: str
+    public_url: str
+    session_secret: str
+    cookie_secure: bool = True
+    scopes: tuple[str, ...] = ("read:user", "read:org")
+
+    @property
+    def redirect_uri(self) -> str:
+        return f"{self.public_url.rstrip('/')}/auth/github/callback"
+
+
+@dataclass(frozen=True)
+class OAuthLoginState:
+    state: str
+    code_verifier: str
+    return_to: str
+    expires_at: datetime
+
+
+@dataclass(frozen=True)
+class LaunchplaneHumanSession:
+    session_id: str
+    identity: GitHubHumanIdentity
+    created_at: datetime
+    expires_at: datetime
+
+
+class HumanSessionStore(Protocol):
+    def write_session(self, session: LaunchplaneHumanSession) -> None: ...
+
+    def read_session(self, session_id: str) -> LaunchplaneHumanSession | None: ...
+
+    def delete_session(self, session_id: str) -> None: ...
+
+
+class InMemoryHumanSessionStore:
+    def __init__(self) -> None:
+        self._sessions: dict[str, LaunchplaneHumanSession] = {}
+
+    def write_session(self, session: LaunchplaneHumanSession) -> None:
+        self._sessions[session.session_id] = session
+
+    def read_session(self, session_id: str) -> LaunchplaneHumanSession | None:
+        session = self._sessions.get(session_id)
+        if session is None:
+            return None
+        if session.expires_at <= datetime.now(timezone.utc):
+            self._sessions.pop(session_id, None)
+            return None
+        return session
+
+    def delete_session(self, session_id: str) -> None:
+        self._sessions.pop(session_id, None)
+
+
+class OAuthLoginStateStore:
+    def __init__(self) -> None:
+        self._states: dict[str, OAuthLoginState] = {}
+
+    def put(self, *, state: str, code_verifier: str, return_to: str) -> OAuthLoginState:
+        login_state = OAuthLoginState(
+            state=state,
+            code_verifier=code_verifier,
+            return_to=return_to or "/",
+            expires_at=datetime.now(timezone.utc) + timedelta(seconds=OAUTH_STATE_TTL_SECONDS),
+        )
+        self._states[state] = login_state
+        return login_state
+
+    def pop(self, state: str) -> OAuthLoginState | None:
+        login_state = self._states.pop(state, None)
+        if login_state is None:
+            return None
+        if login_state.expires_at <= datetime.now(timezone.utc):
+            return None
+        return login_state
+
+
+def load_github_oauth_config_from_env() -> GitHubOAuthConfig | None:
+    client_id = os.environ.get("LAUNCHPLANE_GITHUB_CLIENT_ID", "").strip()
+    client_secret = os.environ.get("LAUNCHPLANE_GITHUB_CLIENT_SECRET", "").strip()
+    public_url = os.environ.get("LAUNCHPLANE_PUBLIC_URL", "").strip().rstrip("/")
+    session_secret = os.environ.get("LAUNCHPLANE_SESSION_SECRET", "").strip()
+    if not (client_id and client_secret and public_url and session_secret):
+        return None
+    secure_env = os.environ.get("LAUNCHPLANE_COOKIE_SECURE", "").strip().lower()
+    cookie_secure = secure_env not in {"0", "false", "no"}
+    return GitHubOAuthConfig(
+        client_id=client_id,
+        client_secret=client_secret,
+        public_url=public_url,
+        session_secret=session_secret,
+        cookie_secure=cookie_secure,
+    )
+
+
+def build_pkce_verifier() -> tuple[str, str]:
+    verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+    return verifier, challenge
+
+
+class GitHubOAuthClient:
+    def __init__(self, config: GitHubOAuthConfig) -> None:
+        self._config = config
+
+    @staticmethod
+    def _new_session(
+        *, client_id: str, client_secret: str, scope: str, redirect_uri: str
+    ) -> OAuth2SessionType:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            from authlib.integrations.requests_client import OAuth2Session  # type: ignore[import-untyped]
+
+        return OAuth2Session(
+            client_id=client_id,
+            client_secret=client_secret,
+            scope=scope,
+            redirect_uri=redirect_uri,
+        )
+
+    def authorization_url(self, *, state: str, code_challenge: str) -> str:
+        client = self._new_session(
+            client_id=self._config.client_id,
+            client_secret=self._config.client_secret,
+            scope=" ".join(self._config.scopes),
+            redirect_uri=self._config.redirect_uri,
+        )
+        authorization_url, _ = client.create_authorization_url(
+            GITHUB_AUTHORIZE_URL,
+            state=state,
+            code_challenge=code_challenge,
+            code_challenge_method="S256",
+        )
+        return str(authorization_url)
+
+    def fetch_identity(
+        self,
+        *,
+        code: str,
+        code_verifier: str,
+        authz_policy: LaunchplaneAuthzPolicy,
+    ) -> GitHubHumanIdentity:
+        client = self._new_session(
+            client_id=self._config.client_id,
+            client_secret=self._config.client_secret,
+            scope=" ".join(self._config.scopes),
+            redirect_uri=self._config.redirect_uri,
+        )
+        client.fetch_token(GITHUB_TOKEN_URL, code=code, code_verifier=code_verifier)
+        user_payload = client.get(GITHUB_USER_URL).json()
+        org_payload = client.get(GITHUB_ORGS_URL).json()
+        team_payload = client.get(GITHUB_TEAMS_URL).json()
+        login = str(user_payload.get("login", "")).strip()
+        if not login:
+            raise ValueError("GitHub OAuth user response did not include a login.")
+        organizations = frozenset(
+            str(org.get("login", "")).strip()
+            for org in org_payload
+            if isinstance(org, dict) and str(org.get("login", "")).strip()
+        )
+        teams = frozenset(_team_names(team_payload))
+        role = authz_policy.human_role_for(
+            login=login,
+            organizations=organizations,
+            teams=teams,
+        )
+        if role is None:
+            raise PermissionError("GitHub user is not authorized for Launchplane.")
+        return GitHubHumanIdentity(
+            login=login,
+            github_id=int(user_payload.get("id") or 0),
+            name=str(user_payload.get("name") or "").strip(),
+            email=str(user_payload.get("email") or "").strip(),
+            organizations=organizations,
+            teams=teams,
+            role=role,
+        )
+
+
+def _team_names(team_payload: object) -> tuple[str, ...]:
+    if not isinstance(team_payload, list):
+        return ()
+    names: list[str] = []
+    for team in team_payload:
+        if not isinstance(team, dict):
+            continue
+        slug = str(team.get("slug") or "").strip()
+        organization = team.get("organization")
+        org_login = ""
+        if isinstance(organization, dict):
+            org_login = str(organization.get("login") or "").strip()
+        if slug:
+            names.append(slug)
+        if slug and org_login:
+            names.append(f"{org_login}/{slug}")
+    return tuple(names)
+
+
+class HumanSessionManager:
+    def __init__(
+        self,
+        *,
+        config: GitHubOAuthConfig,
+        session_store: HumanSessionStore,
+        now: CallableNow | None = None,
+    ) -> None:
+        self._config = config
+        self._session_store = session_store
+        self._now = now or _utc_now
+
+    def issue(self, identity: GitHubHumanIdentity) -> LaunchplaneHumanSession:
+        now = self._now()
+        session = LaunchplaneHumanSession(
+            session_id=secrets.token_urlsafe(32),
+            identity=identity,
+            created_at=now,
+            expires_at=now + timedelta(seconds=SESSION_TTL_SECONDS),
+        )
+        self._session_store.write_session(session)
+        return session
+
+    def read_cookie(self, cookie_header: str) -> LaunchplaneHumanSession | None:
+        signed_session_id = _cookie_value(cookie_header, SESSION_COOKIE_NAME)
+        if not signed_session_id:
+            return None
+        session_id = self._verify_cookie_value(signed_session_id)
+        if not session_id:
+            return None
+        return self._session_store.read_session(session_id)
+
+    def delete_cookie_session(self, cookie_header: str) -> None:
+        signed_session_id = _cookie_value(cookie_header, SESSION_COOKIE_NAME)
+        if not signed_session_id:
+            return
+        session_id = self._verify_cookie_value(signed_session_id)
+        if session_id:
+            self._session_store.delete_session(session_id)
+
+    def session_cookie_header(self, session: LaunchplaneHumanSession) -> str:
+        return _build_cookie_header(
+            name=SESSION_COOKIE_NAME,
+            value=self._sign_cookie_value(session.session_id),
+            max_age=SESSION_TTL_SECONDS,
+            secure=self._config.cookie_secure,
+        )
+
+    def clear_cookie_header(self) -> str:
+        return _build_cookie_header(
+            name=SESSION_COOKIE_NAME,
+            value="",
+            max_age=0,
+            secure=self._config.cookie_secure,
+        )
+
+    def _sign_cookie_value(self, session_id: str) -> str:
+        signature = hmac.new(
+            self._config.session_secret.encode("utf-8"),
+            session_id.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        return f"{session_id}.{signature}"
+
+    def _verify_cookie_value(self, signed_session_id: str) -> str:
+        session_id, separator, signature = signed_session_id.partition(".")
+        if not separator or not session_id or not signature:
+            return ""
+        expected = hmac.new(
+            self._config.session_secret.encode("utf-8"),
+            session_id.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        if not hmac.compare_digest(signature, expected):
+            return ""
+        return session_id
+
+
+CallableNow = Callable[[], datetime]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _cookie_value(cookie_header: str, name: str) -> str:
+    for part in cookie_header.split(";"):
+        cookie_name, separator, cookie_value = part.strip().partition("=")
+        if separator and cookie_name == name:
+            return cookie_value.strip()
+    return ""
+
+
+def _build_cookie_header(*, name: str, value: str, max_age: int, secure: bool) -> str:
+    parts = [
+        f"{name}={value}",
+        "Path=/",
+        f"Max-Age={max_age}",
+        "HttpOnly",
+        "SameSite=Lax",
+    ]
+    if secure:
+        parts.append("Secure")
+    return "; ".join(parts)

--- a/control_plane/storage/migrations/versions/a2b4c6d8e9f0_add_human_sessions.py
+++ b/control_plane/storage/migrations/versions/a2b4c6d8e9f0_add_human_sessions.py
@@ -1,0 +1,59 @@
+"""add human sessions
+
+Revision ID: a2b4c6d8e9f0
+Revises: fe94a0486977
+Create Date: 2026-04-29 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "a2b4c6d8e9f0"
+down_revision: str | None = "fe94a0486977"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "launchplane_human_sessions",
+        sa.Column("session_id", sa.String(), nullable=False),
+        sa.Column("login", sa.String(), nullable=False),
+        sa.Column("github_id", sa.Integer(), nullable=False),
+        sa.Column("role", sa.String(), nullable=False),
+        sa.Column("created_at", sa.String(), nullable=False),
+        sa.Column("expires_at", sa.String(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("session_id"),
+    )
+    op.create_index(
+        "launchplane_human_sessions_expires_idx",
+        "launchplane_human_sessions",
+        [sa.text("expires_at DESC")],
+    )
+    op.create_index(
+        "launchplane_human_sessions_login_idx",
+        "launchplane_human_sessions",
+        ["login", sa.text("created_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "launchplane_human_sessions_login_idx",
+        table_name="launchplane_human_sessions",
+    )
+    op.drop_index(
+        "launchplane_human_sessions_expires_idx",
+        table_name="launchplane_human_sessions",
+    )
+    op.drop_table("launchplane_human_sessions")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from datetime import datetime, timezone
 from typing import Any, TypeVar
 
 from pydantic import BaseModel
-from sqlalchemy import JSON, Index, Integer, String, create_engine, desc, select
+from sqlalchemy import JSON, Index, Integer, String, create_engine, delete, desc, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, sessionmaker
 
@@ -30,6 +31,8 @@ from control_plane.contracts.secret_record import (
     SecretRecord,
     SecretVersion,
 )
+from control_plane.service_auth import GitHubHumanIdentity
+from control_plane.service_human_auth import HumanSessionStore, LaunchplaneHumanSession
 from control_plane.storage.filesystem import FilesystemRecordStore
 
 RecordModel = TypeVar("RecordModel", bound=BaseModel)
@@ -252,6 +255,22 @@ class LaunchplaneIdempotencyRow(Base):
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
+class LaunchplaneHumanSessionRow(Base):
+    __tablename__ = "launchplane_human_sessions"
+    __table_args__ = (
+        Index("launchplane_human_sessions_login_idx", "login", desc("created_at")),
+        Index("launchplane_human_sessions_expires_idx", desc("expires_at")),
+    )
+
+    session_id: Mapped[str] = mapped_column(String, primary_key=True)
+    login: Mapped[str] = mapped_column(String, nullable=False)
+    github_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    role: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[str] = mapped_column(String, nullable=False)
+    expires_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
 class LaunchplaneSecretRow(Base):
     __tablename__ = "launchplane_secrets"
     __table_args__ = (
@@ -340,6 +359,45 @@ def _artifact_id_from_model(model: BaseModel) -> str:
     return artifact_id if isinstance(artifact_id, str) else ""
 
 
+def _human_session_payload(session: LaunchplaneHumanSession) -> PayloadDict:
+    return {
+        "session_id": session.session_id,
+        "created_at": session.created_at.isoformat(),
+        "expires_at": session.expires_at.isoformat(),
+        "identity": {
+            "login": session.identity.login,
+            "github_id": session.identity.github_id,
+            "name": session.identity.name,
+            "email": session.identity.email,
+            "organizations": sorted(session.identity.organizations),
+            "teams": sorted(session.identity.teams),
+            "role": session.identity.role,
+        },
+    }
+
+
+def _human_session_from_payload(payload: PayloadDict) -> LaunchplaneHumanSession:
+    identity_payload = payload.get("identity")
+    if not isinstance(identity_payload, dict):
+        raise ValueError("Launchplane human session payload is missing identity.")
+    return LaunchplaneHumanSession(
+        session_id=str(payload.get("session_id") or ""),
+        created_at=datetime.fromisoformat(str(payload.get("created_at") or "")),
+        expires_at=datetime.fromisoformat(str(payload.get("expires_at") or "")),
+        identity=GitHubHumanIdentity(
+            login=str(identity_payload.get("login") or ""),
+            github_id=int(identity_payload.get("github_id") or 0),
+            name=str(identity_payload.get("name") or ""),
+            email=str(identity_payload.get("email") or ""),
+            organizations=frozenset(
+                str(value) for value in identity_payload.get("organizations", [])
+            ),
+            teams=frozenset(str(value) for value in identity_payload.get("teams", [])),
+            role="admin" if identity_payload.get("role") == "admin" else "read_only",
+        ),
+    )
+
+
 def _build_engine(database_url: str, *, connection_factory: ConnectionFactory | None = None):
     engine_kwargs: dict[str, Any] = {}
     if connection_factory is not None:
@@ -349,7 +407,7 @@ def _build_engine(database_url: str, *, connection_factory: ConnectionFactory | 
     return create_engine(database_url, **engine_kwargs)
 
 
-class PostgresRecordStore:
+class PostgresRecordStore(HumanSessionStore):
     def __init__(
         self,
         *,
@@ -544,6 +602,45 @@ class PostgresRecordStore:
             if row is None:
                 return None
             return self._read_payload(model_type=LaunchplaneIdempotencyRecord, payload=row.payload)
+
+    def write_session(self, session: LaunchplaneHumanSession) -> None:
+        self._write_row(
+            LaunchplaneHumanSessionRow(
+                session_id=session.session_id,
+                login=session.identity.login,
+                github_id=session.identity.github_id,
+                role=session.identity.role,
+                created_at=session.created_at.isoformat(),
+                expires_at=session.expires_at.isoformat(),
+                payload=_human_session_payload(session),
+            )
+        )
+
+    def read_session(self, session_id: str) -> LaunchplaneHumanSession | None:
+        statement = (
+            select(LaunchplaneHumanSessionRow)
+            .where(LaunchplaneHumanSessionRow.session_id == session_id)
+            .limit(1)
+        )
+        with self._session_factory() as session:
+            row = session.scalar(statement)
+            if row is None:
+                return None
+            human_session = _human_session_from_payload(row.payload)
+            if human_session.expires_at <= datetime.now(timezone.utc):
+                session.delete(row)
+                session.commit()
+                return None
+            return human_session
+
+    def delete_session(self, session_id: str) -> None:
+        with self._session_factory() as session:
+            session.execute(
+                delete(LaunchplaneHumanSessionRow).where(
+                    LaunchplaneHumanSessionRow.session_id == session_id
+                )
+            )
+            session.commit()
 
     def write_deployment_record(self, record: DeploymentRecord) -> None:
         self._write_row(

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -81,6 +81,12 @@ GitHub Actions workflow
 
 Machine callers should authenticate with GitHub Actions OIDC.
 
+Human browser callers authenticate with GitHub OAuth. Launchplane owns the
+browser session after OAuth callback and sets an `HttpOnly`, `SameSite=Lax`
+session cookie. Sessions are backed by the Launchplane database when
+`LAUNCHPLANE_DATABASE_URL` is configured. GitHub access tokens stay server-side
+and are not exposed to the React operator UI.
+
 Launchplane should verify:
 
 - `iss` is GitHub's OIDC issuer
@@ -225,6 +231,12 @@ allowed actions:
 
 The initial policy engine can be config-backed and static. It does not need a
 full RBAC system yet.
+
+Human policy rules use the same reviewed policy file under `github_humans`.
+The first supported roles are `read_only` and `admin`. Browser sessions can
+authorize read endpoints, but POST mutation routes remain GitHub Actions OIDC
+only until browser-initiated mutation workflows get a dedicated CSRF and audit
+design.
 
 ## First API Surface
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import {
   Eye,
   GitCompareArrows,
   KeyRound,
+  LogOut,
   Loader2,
   Moon,
   RefreshCw,
@@ -18,9 +19,10 @@ import {
   TerminalSquare,
   XCircle
 } from "lucide-react";
-import { FormEvent, ReactNode, useEffect, useMemo, useState } from "react";
-import { LaunchplaneApiError, listDrivers, readDriverView } from "./api";
+import { ReactNode, useEffect, useMemo, useState } from "react";
+import { LaunchplaneApiError, listDrivers, logout, readAuthSession, readDriverView } from "./api";
 import type {
+  AuthIdentity,
   DriverActionDescriptor,
   DriverContextView,
   DriverDescriptor,
@@ -32,6 +34,7 @@ import type {
 } from "./types";
 
 type Theme = "dark" | "light";
+type AuthStatus = "checking" | "signed_out" | "signed_in";
 type DriverChoice = {
   driverId: string;
   context: string;
@@ -69,7 +72,6 @@ type EvidenceFact = {
   status?: Status | string;
 };
 
-const TOKEN_STORAGE_KEY = "launchplane.operatorToken";
 const THEME_STORAGE_KEY = "launchplane.theme";
 const DEFAULT_CHOICES: DriverChoice[] = [
   { driverId: "verireel", context: "verireel", label: "VeriReel" },
@@ -131,8 +133,8 @@ export function App() {
   const [theme, setTheme] = useState<Theme>(() => {
     return window.sessionStorage.getItem(THEME_STORAGE_KEY) === "light" ? "light" : "dark";
   });
-  const [token, setToken] = useState(() => window.sessionStorage.getItem(TOKEN_STORAGE_KEY) ?? "");
-  const [tokenDraft, setTokenDraft] = useState(token);
+  const [authStatus, setAuthStatus] = useState<AuthStatus>("checking");
+  const [identity, setIdentity] = useState<AuthIdentity | null>(null);
   const [drivers, setDrivers] = useState<DriverDescriptor[]>([]);
   const [selected, setSelected] = useState<DriverChoice>(DEFAULT_CHOICES[0]);
   const [prodView, setProdView] = useState<DriverContextView | null>(null);
@@ -141,6 +143,7 @@ export function App() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>("");
   const [traceId, setTraceId] = useState<string>("");
+  const [refreshKey, setRefreshKey] = useState(0);
   const [reviewAction, setReviewAction] = useState<DriverActionDescriptor | null>(null);
   const [selectedEvidence, setSelectedEvidence] = useState<EvidenceRow | null>(null);
 
@@ -150,7 +153,34 @@ export function App() {
   }, [theme]);
 
   useEffect(() => {
-    if (!token) {
+    let active = true;
+    setAuthStatus("checking");
+    readAuthSession()
+      .then((payload) => {
+        if (!active) {
+          return;
+        }
+        setIdentity(payload.identity);
+        setAuthStatus("signed_in");
+      })
+      .catch((apiError: unknown) => {
+        if (!active) {
+          return;
+        }
+        setIdentity(null);
+        setAuthStatus("signed_out");
+        if (apiError instanceof LaunchplaneApiError && apiError.statusCode !== 401) {
+          setError(apiError.message);
+          setTraceId(apiError.traceId);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (authStatus !== "signed_in") {
       setDrivers([]);
       setProdView(null);
       setTestingView(null);
@@ -164,11 +194,11 @@ export function App() {
     setError("");
     setTraceId("");
     Promise.all([
-      listDrivers(token),
-      readDriverView(token, selected.context, "prod"),
-      readDriverView(token, selected.context, "testing"),
+      listDrivers(),
+      readDriverView(selected.context, "prod"),
+      readDriverView(selected.context, "testing"),
       selected.driverId === "verireel"
-        ? readDriverView(token, "verireel-testing", "")
+        ? readDriverView("verireel-testing", "")
         : Promise.resolve(null)
     ])
       .then(([driverPayload, prodPayload, testingPayload, previewPayload]) => {
@@ -200,7 +230,7 @@ export function App() {
       });
 
     return () => controller.abort();
-  }, [selected, token]);
+  }, [authStatus, selected, refreshKey]);
 
   const choices = useMemo(() => {
     if (!drivers.length) {
@@ -232,17 +262,15 @@ export function App() {
   );
   const nextAction = pickNextAction(actions, promotionDecision.verdict);
 
-  function submitToken(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    const normalizedToken = tokenDraft.trim();
-    window.sessionStorage.setItem(TOKEN_STORAGE_KEY, normalizedToken);
-    setToken(normalizedToken);
-  }
-
-  function clearToken() {
-    window.sessionStorage.removeItem(TOKEN_STORAGE_KEY);
-    setToken("");
-    setTokenDraft("");
+  function signOut() {
+    logout().finally(() => {
+      setIdentity(null);
+      setAuthStatus("signed_out");
+      setDrivers([]);
+      setProdView(null);
+      setTestingView(null);
+      setPreviewView(null);
+    });
   }
 
   return (
@@ -254,18 +282,20 @@ export function App() {
         theme={theme}
         onThemeChange={setTheme}
         loading={loading}
-        onRefresh={() => setSelected({ ...selected })}
+        identity={identity}
+        onLogout={signOut}
+        onRefresh={() => setRefreshKey((value) => value + 1)}
       />
       <main className="operator-main">
-        {!token ? (
+        {authStatus !== "signed_in" ? (
           showFixtureGallery ? (
             <StateFixtureGallery actions={FIXTURE_ACTIONS} />
           ) : (
-            <AuthPanel tokenDraft={tokenDraft} setTokenDraft={setTokenDraft} onSubmit={submitToken} />
+            <AuthPanel checking={authStatus === "checking"} />
           )
         ) : (
           <>
-            {error ? <ApiErrorPanel message={error} traceId={traceId} onClearToken={clearToken} /> : null}
+            {error ? <ApiErrorPanel message={error} traceId={traceId} onClearToken={signOut} /> : null}
             <section className="lane-grid" aria-busy={loading}>
               <LanePanel
                 title="Prod"
@@ -321,6 +351,8 @@ function Header({
   theme,
   onThemeChange,
   loading,
+  identity,
+  onLogout,
   onRefresh
 }: {
   choices: DriverChoice[];
@@ -329,6 +361,8 @@ function Header({
   theme: Theme;
   onThemeChange: (theme: Theme) => void;
   loading: boolean;
+  identity: AuthIdentity | null;
+  onLogout: () => void;
   onRefresh: () => void;
 }) {
   const selectedValue = `${selected.driverId}:${selected.context}`;
@@ -349,6 +383,12 @@ function Header({
         </div>
       </div>
       <div className="topbar-controls">
+        {identity ? (
+          <div className="operator-chip" title={identity.login}>
+            <span>{identity.login}</span>
+            <strong>{identity.role === "admin" ? "Admin" : "Read only"}</strong>
+          </div>
+        ) : null}
         <label className="select-label">
           <span>Context</span>
           <select
@@ -379,6 +419,17 @@ function Header({
         >
           {loading ? <Loader2 className="spin" size={16} /> : <RefreshCw size={16} />}
         </button>
+        {identity ? (
+          <button
+            className="icon-button"
+            type="button"
+            title="Sign out"
+            aria-label="Sign out of Launchplane"
+            onClick={onLogout}
+          >
+            <LogOut size={16} />
+          </button>
+        ) : null}
         <button
           className="icon-button"
           type="button"
@@ -403,15 +454,8 @@ function Header({
   );
 }
 
-function AuthPanel({
-  tokenDraft,
-  setTokenDraft,
-  onSubmit
-}: {
-  tokenDraft: string;
-  setTokenDraft: (value: string) => void;
-  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
-}) {
+function AuthPanel({ checking }: { checking: boolean }) {
+  const loginHref = `/auth/github/login?return_to=${encodeURIComponent(window.location.pathname || "/")}`;
   return (
     <section className="auth-panel" aria-labelledby="auth-heading">
       <div className="section-heading">
@@ -421,22 +465,12 @@ function AuthPanel({
         </div>
         <ShieldCheck size={22} aria-hidden="true" />
       </div>
-      <form className="auth-form" onSubmit={onSubmit}>
-        <label>
-          <span>Bearer token</span>
-          <input
-            type="password"
-            value={tokenDraft}
-            onChange={(event) => setTokenDraft(event.target.value)}
-            autoComplete="off"
-            spellCheck={false}
-          />
-        </label>
-        <button className="button button-primary" type="submit" disabled={!tokenDraft.trim()}>
-          <RefreshCw size={15} />
-          <span>Load console</span>
-        </button>
-      </form>
+      <div className="auth-form">
+        <a className="button button-primary" href={loginHref} aria-disabled={checking}>
+          {checking ? <Loader2 className="spin" size={15} /> : <KeyRound size={15} />}
+          <span>{checking ? "Checking session" : "Sign in with GitHub"}</span>
+        </a>
+      </div>
     </section>
   );
 }
@@ -458,7 +492,7 @@ function ApiErrorPanel({
         {traceId ? <code>{traceId}</code> : null}
       </div>
       <button className="button" type="button" onClick={onClearToken}>
-        Clear token
+        Sign out
       </button>
     </section>
   );

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,10 @@
-import type { ApiErrorPayload, DriverListPayload, DriverViewPayload } from "./types";
+import type {
+  ApiErrorPayload,
+  AuthSessionPayload,
+  DriverListPayload,
+  DriverViewPayload,
+  LogoutPayload
+} from "./types";
 
 export class LaunchplaneApiError extends Error {
   statusCode: number;
@@ -12,12 +18,12 @@ export class LaunchplaneApiError extends Error {
   }
 }
 
-async function readJson<T>(path: string, bearerToken: string): Promise<T> {
+async function requestJson<T>(path: string, method: "GET" | "POST" = "GET"): Promise<T> {
   const response = await fetch(path, {
-    method: "GET",
+    method,
+    credentials: "same-origin",
     headers: {
-      Accept: "application/json",
-      Authorization: `Bearer ${bearerToken}`
+      Accept: "application/json"
     }
   });
   const payload = (await response.json()) as T | ApiErrorPayload;
@@ -32,21 +38,24 @@ async function readJson<T>(path: string, bearerToken: string): Promise<T> {
   return payload as T;
 }
 
-export function listDrivers(bearerToken: string): Promise<DriverListPayload> {
-  return readJson<DriverListPayload>("/v1/drivers", bearerToken);
+export function readAuthSession(): Promise<AuthSessionPayload> {
+  return requestJson<AuthSessionPayload>("/v1/auth/session");
 }
 
-export function readDriverView(
-  bearerToken: string,
-  context: string,
-  instance: string
-): Promise<DriverViewPayload> {
+export function logout(): Promise<LogoutPayload> {
+  return requestJson<LogoutPayload>("/auth/logout", "POST");
+}
+
+export function listDrivers(): Promise<DriverListPayload> {
+  return requestJson<DriverListPayload>("/v1/drivers");
+}
+
+export function readDriverView(context: string, instance: string): Promise<DriverViewPayload> {
   const encodedContext = encodeURIComponent(context);
   if (!instance) {
-    return readJson<DriverViewPayload>(`/v1/contexts/${encodedContext}/driver-view`, bearerToken);
+    return requestJson<DriverViewPayload>(`/v1/contexts/${encodedContext}/driver-view`);
   }
-  return readJson<DriverViewPayload>(
-    `/v1/contexts/${encodedContext}/instances/${encodeURIComponent(instance)}/driver-view`,
-    bearerToken
+  return requestJson<DriverViewPayload>(
+    `/v1/contexts/${encodedContext}/instances/${encodeURIComponent(instance)}/driver-view`
   );
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -181,6 +181,36 @@ p {
   min-width: 0;
 }
 
+.operator-chip {
+  display: grid;
+  min-height: 34px;
+  align-content: center;
+  border: 1px solid var(--hair);
+  border-radius: 6px;
+  background: var(--bg-1);
+  padding: 4px 10px;
+}
+
+.operator-chip span,
+.operator-chip strong {
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.operator-chip span {
+  color: var(--fg);
+  font-size: 12px;
+}
+
+.operator-chip strong {
+  color: var(--fg-muted);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
 .select-label {
   position: relative;
   display: grid;
@@ -803,7 +833,7 @@ p {
 
 .auth-form {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr);
   gap: 10px;
   padding: 14px;
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -217,6 +217,28 @@ export interface DriverViewPayload {
   view: DriverContextView;
 }
 
+export interface AuthIdentity {
+  provider: "github";
+  login: string;
+  github_id: number;
+  name: string;
+  email: string;
+  organizations: string[];
+  teams: string[];
+  role: "read_only" | "admin";
+}
+
+export interface AuthSessionPayload {
+  status: "ok";
+  trace_id: string;
+  identity: AuthIdentity;
+}
+
+export interface LogoutPayload {
+  status: "ok";
+  trace_id: string;
+}
+
 export interface ApiErrorPayload {
   status: "rejected";
   trace_id?: string;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,12 @@ version = "0.1.0"
 description = "Launchplane control-plane contracts and workflows for deployment truth and promotion"
 requires-python = ">=3.13"
 dependencies = [
+    "Authlib>=1.7.0",
     "click>=8.3.3",
     "pydantic>=2.13.3",
     "psycopg[binary]>=3.3.3",
     "pyjwt[crypto]>=2.12.1",
+    "requests>=2.32.0",
     "sqlalchemy>=2.0",
     "alembic>=1.18.4",
 ]

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import Mock, patch
@@ -41,6 +42,8 @@ from control_plane.contracts.secret_record import (
     SecretRecord,
     SecretVersion,
 )
+from control_plane.service_auth import GitHubHumanIdentity
+from control_plane.service_human_auth import LaunchplaneHumanSession
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
 
@@ -315,6 +318,24 @@ def _secret_audit_event(*, event_id: str, secret_id: str, recorded_at: str) -> S
     )
 
 
+def _human_session(*, session_id: str = "session-1") -> LaunchplaneHumanSession:
+    created_at = datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
+    return LaunchplaneHumanSession(
+        session_id=session_id,
+        created_at=created_at,
+        expires_at=created_at + timedelta(hours=12),
+        identity=GitHubHumanIdentity(
+            login="alice",
+            github_id=123,
+            name="Alice Operator",
+            email="alice@example.com",
+            organizations=frozenset({"shinycomputers"}),
+            teams=frozenset({"shinycomputers/launchplane-admins"}),
+            role="admin",
+        ),
+    )
+
+
 class PostgresRecordStoreTests(unittest.TestCase):
     def test_alembic_baseline_creates_schema_used_by_record_store(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -450,6 +471,43 @@ class PostgresRecordStoreTests(unittest.TestCase):
             assert loaded is not None
             self.assertEqual(loaded.request_fingerprint, "fingerprint-123")
             self.assertEqual(loaded.response_payload["records"]["preview_id"], "preview-35")
+
+    def test_human_sessions_round_trip_and_delete(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            store = PostgresRecordStore(database_url=_sqlite_database_url(database_path))
+            store.ensure_schema()
+
+            session = _human_session()
+            store.write_session(session)
+            loaded = store.read_session(session.session_id)
+            store.delete_session(session.session_id)
+            deleted = store.read_session(session.session_id)
+
+        self.assertIsNotNone(loaded)
+        assert loaded is not None
+        self.assertEqual(loaded.identity.login, "alice")
+        self.assertEqual(loaded.identity.role, "admin")
+        self.assertEqual(loaded.identity.teams, frozenset({"shinycomputers/launchplane-admins"}))
+        self.assertIsNone(deleted)
+
+    def test_expired_human_session_reads_as_missing(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            store = PostgresRecordStore(database_url=_sqlite_database_url(database_path))
+            store.ensure_schema()
+            created_at = datetime(2020, 1, 1, tzinfo=timezone.utc)
+            expired_session = LaunchplaneHumanSession(
+                session_id="expired-session",
+                created_at=created_at,
+                expires_at=created_at + timedelta(minutes=1),
+                identity=_human_session().identity,
+            )
+
+            store.write_session(expired_session)
+            loaded = store.read_session(expired_session.session_id)
+
+        self.assertIsNone(loaded)
 
     def test_storage_import_core_records_command_reports_counts(self) -> None:
         runner = CliRunner()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -7,6 +7,8 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
+from typing import Literal
+from urllib.parse import parse_qs, urlparse
 from unittest.mock import Mock, patch
 
 from control_plane import secrets as control_plane_secrets
@@ -26,9 +28,11 @@ from control_plane.contracts.promotion_record import (
 from control_plane.service import create_launchplane_service_app
 from control_plane.service_auth import (
     GitHubActionsIdentity,
+    GitHubHumanIdentity,
     GitHubOidcVerifier,
     LaunchplaneAuthzPolicy,
 )
+from control_plane.service_human_auth import GitHubOAuthConfig
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.verireel_preview_driver import (
@@ -60,6 +64,27 @@ class _StubVerifier:
         return self.identity
 
 
+class _StubGitHubOAuthClient:
+    def __init__(self, identity: GitHubHumanIdentity):
+        self.identity = identity
+        self.code_verifier = ""
+
+    def authorization_url(self, *, state: str, code_challenge: str) -> str:
+        return f"https://github.example/authorize?state={state}&challenge={code_challenge}"
+
+    def fetch_identity(
+        self,
+        *,
+        code: str,
+        code_verifier: str,
+        authz_policy: LaunchplaneAuthzPolicy,
+    ) -> GitHubHumanIdentity:
+        self.code_verifier = code_verifier
+        if code != "github-code":
+            raise ValueError("unexpected code")
+        return self.identity
+
+
 def _identity(
     *,
     repository: str = "every/verireel",
@@ -80,6 +105,28 @@ def _identity(
         subject="repo:every/verireel:pull_request",
         sha="6b3c9d7e8f901234567890abcdef1234567890ab",
         raw_claims={"repository": repository, "workflow_ref": workflow_ref},
+    )
+
+
+def _human_identity(*, role: Literal["read_only", "admin"] = "read_only") -> GitHubHumanIdentity:
+    return GitHubHumanIdentity(
+        login="alice",
+        github_id=123,
+        name="Alice Operator",
+        email="alice@example.com",
+        organizations=frozenset({"shinycomputers"}),
+        teams=frozenset({"launchplane-readers", "shinycomputers/launchplane-readers"}),
+        role=role,
+    )
+
+
+def _github_oauth_config() -> GitHubOAuthConfig:
+    return GitHubOAuthConfig(
+        client_id="client-id",
+        client_secret="client-secret",
+        public_url="https://launchplane.example",
+        session_secret="test-session-secret",
+        cookie_secure=False,
     )
 
 
@@ -118,14 +165,19 @@ def _invoke_raw_app(
     method: str,
     path: str,
     authorization: str = "",
+    query_string: str = "",
+    headers: dict[str, str] | None = None,
 ):
     environ = {
         "REQUEST_METHOD": method,
         "PATH_INFO": path,
+        "QUERY_STRING": query_string,
         "CONTENT_LENGTH": "0",
         "wsgi.input": io.BytesIO(b""),
         "HTTP_AUTHORIZATION": authorization,
     }
+    for header_name, header_value in (headers or {}).items():
+        environ[f"HTTP_{header_name.upper().replace('-', '_')}"] = header_value
     captured: dict[str, object] = {}
 
     def start_response(status: str, headers: list[tuple[str, str]]) -> None:
@@ -207,6 +259,216 @@ class GitHubOidcVerifierTests(unittest.TestCase):
                 context="verireel-testing",
             )
         )
+
+
+class GitHubHumanAuthTests(unittest.TestCase):
+    def _signed_in_cookie(
+        self,
+        app,
+    ) -> str:
+        _, login_headers, _ = _invoke_raw_app(app, method="GET", path="/auth/github/login")
+        state = parse_qs(urlparse(login_headers["Location"]).query)["state"][0]
+        _, callback_headers, _ = _invoke_raw_app(
+            app,
+            method="GET",
+            path="/auth/github/callback",
+            query_string=f"code=github-code&state={state}",
+        )
+        return callback_headers["Set-Cookie"]
+
+    def test_github_oauth_callback_issues_session_cookie(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {"github_humans": [{"logins": ["alice"], "roles": ["read_only"]}]}
+        )
+        oauth_client = _StubGitHubOAuthClient(_human_identity())
+        with TemporaryDirectory() as tmpdir:
+            app = create_launchplane_service_app(
+                state_dir=Path(tmpdir),
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=oauth_client,  # type: ignore[arg-type]
+            )
+            status_code, headers, _ = _invoke_raw_app(
+                app,
+                method="GET",
+                path="/auth/github/login",
+                query_string="return_to=/ui",
+            )
+            self.assertEqual(status_code, 302)
+            state = parse_qs(urlparse(headers["Location"]).query)["state"][0]
+
+            status_code, headers, _ = _invoke_raw_app(
+                app,
+                method="GET",
+                path="/auth/github/callback",
+                query_string=f"code=github-code&state={state}",
+            )
+
+        self.assertEqual(status_code, 302)
+        self.assertEqual(headers["Location"], "/ui")
+        self.assertIn("launchplane_session=", headers["Set-Cookie"])
+        self.assertIn("HttpOnly", headers["Set-Cookie"])
+        self.assertTrue(oauth_client.code_verifier)
+
+    def test_session_endpoint_reads_github_human_session(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {"github_humans": [{"logins": ["alice"], "roles": ["read_only"]}]}
+        )
+        oauth_client = _StubGitHubOAuthClient(_human_identity())
+        with TemporaryDirectory() as tmpdir:
+            app = create_launchplane_service_app(
+                state_dir=Path(tmpdir),
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=oauth_client,  # type: ignore[arg-type]
+            )
+            cookie = self._signed_in_cookie(app)
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/auth/session",
+                authorization="",
+                headers={"Cookie": cookie},
+            )
+
+        self.assertEqual(status_code, 200)
+        self.assertEqual(payload["identity"]["login"], "alice")
+        self.assertEqual(payload["identity"]["role"], "read_only")
+
+    def test_database_backed_human_session_survives_app_recreation(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {"github_humans": [{"logins": ["alice"], "roles": ["read_only"]}]}
+        )
+        oauth_client = _StubGitHubOAuthClient(_human_identity())
+        with TemporaryDirectory() as tmpdir:
+            database_url = f"sqlite+pysqlite:///{Path(tmpdir) / 'launchplane.sqlite3'}"
+            app = create_launchplane_service_app(
+                state_dir=Path(tmpdir) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                database_url=database_url,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=oauth_client,  # type: ignore[arg-type]
+            )
+            cookie = self._signed_in_cookie(app)
+            recreated_app = create_launchplane_service_app(
+                state_dir=Path(tmpdir) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                database_url=database_url,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=oauth_client,  # type: ignore[arg-type]
+            )
+
+            status_code, payload = _invoke_app(
+                recreated_app,
+                method="GET",
+                path="/v1/auth/session",
+                authorization="",
+                headers={"Cookie": cookie},
+            )
+
+        self.assertEqual(status_code, 200)
+        self.assertEqual(payload["identity"]["login"], "alice")
+
+    def test_human_session_can_read_allowed_driver_metadata(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_humans": [
+                    {
+                        "logins": ["alice"],
+                        "roles": ["read_only"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["driver.read"],
+                    }
+                ]
+            }
+        )
+        oauth_client = _StubGitHubOAuthClient(_human_identity())
+        with TemporaryDirectory() as tmpdir:
+            app = create_launchplane_service_app(
+                state_dir=Path(tmpdir),
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=oauth_client,  # type: ignore[arg-type]
+            )
+            cookie = self._signed_in_cookie(app)
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/drivers",
+                authorization="",
+                headers={"Cookie": cookie},
+            )
+
+        self.assertEqual(status_code, 200)
+        self.assertEqual(payload["status"], "ok")
+        self.assertIn("drivers", payload)
+
+    def test_read_only_human_session_rejects_runtime_read(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_humans": [
+                    {
+                        "logins": ["alice"],
+                        "roles": ["read_only"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["driver.read"],
+                    }
+                ]
+            }
+        )
+        oauth_client = _StubGitHubOAuthClient(_human_identity())
+        with TemporaryDirectory() as tmpdir:
+            app = create_launchplane_service_app(
+                state_dir=Path(tmpdir),
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=oauth_client,  # type: ignore[arg-type]
+            )
+            cookie = self._signed_in_cookie(app)
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/service/runtime",
+                authorization="",
+                headers={"Cookie": cookie},
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_human_session_does_not_authorize_post_mutations(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {"github_humans": [{"logins": ["alice"], "roles": ["admin"]}]}
+        )
+        oauth_client = _StubGitHubOAuthClient(_human_identity(role="admin"))
+        with TemporaryDirectory() as tmpdir:
+            app = create_launchplane_service_app(
+                state_dir=Path(tmpdir),
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=oauth_client,  # type: ignore[arg-type]
+            )
+            cookie = self._signed_in_cookie(app)
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/verireel/preview-inventory",
+                payload={"schema_version": 1, "context": "verireel-testing"},
+                authorization="",
+                headers={"Cookie": cookie},
+            )
+
+        self.assertEqual(status_code, 401)
+        self.assertEqual(payload["error"]["code"], "authentication_required")
 
 
 class LaunchplaneServiceTests(unittest.TestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -30,6 +30,28 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/82/4d0603f30c1b4629b1f091bb266b0d7986434891d6940a8c87f8098db24e/authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5", size = 175890, upload-time = "2026-04-18T11:00:28.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/48/c954218b2a250e23f178f10167c4173fecb5a75d2c206f0a67ba58006c26/authlib-1.7.0-py2.py3-none-any.whl", hash = "sha256:e36817afb02f6f0b6bf55f150782499ddd6ddf44b402bb055d3263cc65ac9ae0", size = 258779, upload-time = "2026-04-18T11:00:26.64Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
 name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -72,6 +94,63 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
     { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
     { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -186,15 +265,38 @@ wheels = [
 ]
 
 [[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
+]
+
+[[package]]
 name = "launchplane"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "authlib" },
     { name = "click" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
     { name = "sqlalchemy" },
 ]
 
@@ -207,11 +309,13 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
+    { name = "authlib", specifier = ">=1.7.0" },
     { name = "click", specifier = ">=8.3.3" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.20.2" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.3" },
     { name = "pydantic", specifier = ">=2.13.3" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.12.1" },
+    { name = "requests", specifier = ">=2.32.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.11" },
     { name = "sqlalchemy", specifier = ">=2.0" },
 ]
@@ -523,6 +627,21 @@ crypto = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.11"
 source = { registry = "https://pypi.org/simple" }
@@ -614,4 +733,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]


### PR DESCRIPTION
## Summary
- add GitHub OAuth login/logout/session routes with Launchplane-owned signed browser sessions
- extend authz policy for github_humans read_only/admin roles while keeping mutation routes on GitHub Actions OIDC
- add DB-backed human session storage with Alembic migration and service fallback to in-memory for no-DB local runs
- replace pasted bearer-token UI with same-origin cookie-backed GitHub sign-in flow

## Verification
- uv run python -m unittest
- npx pnpm@10.10.0 --dir frontend validate
- git diff --check
- docker build -t launchplane-github-auth-db-sessions-test .

Note: local Node is v25.8.0, so pnpm emits the existing Node 22 engine warning during frontend validation.