### PR TITLE
Add GitHub OAuth bootstrap admin env sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,14 @@ DOKPLOY_HOST=
 DOKPLOY_TOKEN=
 # Ship-mode overrides now belong in runtime-environment records rather than
 # bootstrap env.
+
+# Browser operator UI GitHub OAuth.
+LAUNCHPLANE_GITHUB_CLIENT_ID=
+LAUNCHPLANE_GITHUB_CLIENT_SECRET=
+LAUNCHPLANE_PUBLIC_URL=https://launchplane.example.com
+LAUNCHPLANE_SESSION_SECRET=
+LAUNCHPLANE_COOKIE_SECURE=true
+
+# Comma-separated verified GitHub email addresses that receive the initial
+# Launchplane admin role even before github_humans policy rules exist.
+LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS=

--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -45,6 +45,12 @@ jobs:
       LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS: ${{ vars.LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS }}
       LAUNCHPLANE_DEPLOY_HEALTH_TIMEOUT_SECONDS: ${{ vars.LAUNCHPLANE_DEPLOY_HEALTH_TIMEOUT_SECONDS }}
       LAUNCHPLANE_IMAGE_REPOSITORY: ${{ vars.LAUNCHPLANE_IMAGE_REPOSITORY }}
+      LAUNCHPLANE_GITHUB_CLIENT_ID: ${{ vars.LAUNCHPLANE_GITHUB_CLIENT_ID }}
+      LAUNCHPLANE_PUBLIC_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+      LAUNCHPLANE_COOKIE_SECURE: ${{ vars.LAUNCHPLANE_COOKIE_SECURE }}
+      LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS: ${{ vars.LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS }}
+      LAUNCHPLANE_GITHUB_CLIENT_SECRET: ${{ secrets.LAUNCHPLANE_GITHUB_CLIENT_SECRET }}
+      LAUNCHPLANE_SESSION_SECRET: ${{ secrets.LAUNCHPLANE_SESSION_SECRET }}
     steps:
       - name: Resolve deploy inputs
         id: prep
@@ -194,6 +200,7 @@ jobs:
             local response_file="$2"
             local request_payload=""
             local idempotency_key=""
+            local oauth_env_json=""
             local oidc_token=""
 
             oidc_token="$({
@@ -204,13 +211,31 @@ jobs:
             })"
 
             if [ "$mode" = "with-policy" ]; then
+              oauth_env_json="$({
+                jq -n \
+                  --arg github_client_id "${LAUNCHPLANE_GITHUB_CLIENT_ID:-}" \
+                  --arg github_client_secret "${LAUNCHPLANE_GITHUB_CLIENT_SECRET:-}" \
+                  --arg public_url "${LAUNCHPLANE_PUBLIC_URL:-}" \
+                  --arg session_secret "${LAUNCHPLANE_SESSION_SECRET:-}" \
+                  --arg cookie_secure "${LAUNCHPLANE_COOKIE_SECURE:-}" \
+                  --arg bootstrap_admin_emails "${LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS:-}" \
+                  '{
+                    LAUNCHPLANE_GITHUB_CLIENT_ID: $github_client_id,
+                    LAUNCHPLANE_GITHUB_CLIENT_SECRET: $github_client_secret,
+                    LAUNCHPLANE_PUBLIC_URL: $public_url,
+                    LAUNCHPLANE_SESSION_SECRET: $session_secret,
+                    LAUNCHPLANE_COOKIE_SECURE: $cookie_secure,
+                    LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS: $bootstrap_admin_emails
+                  } | with_entries(select(.value != ""))'
+              })"
               request_payload="$({
                 jq -n \
                   --arg target_type "$LAUNCHPLANE_DOKPLOY_TARGET_TYPE" \
                   --arg target_id "$LAUNCHPLANE_DOKPLOY_TARGET_ID" \
                   --arg image_reference "${{ steps.image.outputs.image_reference }}" \
                   --arg policy_b64 "${{ steps.policy.outputs.policy_b64 }}" \
-                  '{schema_version: 1, product: "launchplane", deploy: {target_type: $target_type, target_id: $target_id, image_reference: $image_reference, policy_b64: $policy_b64}}'
+                  --argjson oauth_env "$oauth_env_json" \
+                  '{schema_version: 1, product: "launchplane", deploy: ({target_type: $target_type, target_id: $target_id, image_reference: $image_reference, policy_b64: $policy_b64} + (if ($oauth_env | length) > 0 then {oauth_env: $oauth_env} else {} end))}'
               })"
               idempotency_key="launchplane-self-deploy:${{ steps.image.outputs.image_reference }}:${{ steps.policy.outputs.policy_sha256 }}"
             else
@@ -359,13 +384,32 @@ jobs:
             | jq -r '.value'
           })"
 
+          oauth_env_json="$({
+            jq -n \
+              --arg github_client_id "${LAUNCHPLANE_GITHUB_CLIENT_ID:-}" \
+              --arg github_client_secret "${LAUNCHPLANE_GITHUB_CLIENT_SECRET:-}" \
+              --arg public_url "${LAUNCHPLANE_PUBLIC_URL:-}" \
+              --arg session_secret "${LAUNCHPLANE_SESSION_SECRET:-}" \
+              --arg cookie_secure "${LAUNCHPLANE_COOKIE_SECURE:-}" \
+              --arg bootstrap_admin_emails "${LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS:-}" \
+              '{
+                LAUNCHPLANE_GITHUB_CLIENT_ID: $github_client_id,
+                LAUNCHPLANE_GITHUB_CLIENT_SECRET: $github_client_secret,
+                LAUNCHPLANE_PUBLIC_URL: $public_url,
+                LAUNCHPLANE_SESSION_SECRET: $session_secret,
+                LAUNCHPLANE_COOKIE_SECURE: $cookie_secure,
+                LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS: $bootstrap_admin_emails
+              } | with_entries(select(.value != ""))'
+          })"
+
           request_payload="$({
             jq -n \
               --arg target_type "$LAUNCHPLANE_DOKPLOY_TARGET_TYPE" \
               --arg target_id "$LAUNCHPLANE_DOKPLOY_TARGET_ID" \
               --arg image_reference "${{ steps.image.outputs.image_reference }}" \
               --arg policy_b64 "${{ steps.policy.outputs.policy_b64 }}" \
-              '{schema_version: 1, product: "launchplane", deploy: {target_type: $target_type, target_id: $target_id, image_reference: $image_reference, policy_b64: $policy_b64}}'
+              --argjson oauth_env "$oauth_env_json" \
+              '{schema_version: 1, product: "launchplane", deploy: ({target_type: $target_type, target_id: $target_id, image_reference: $image_reference, policy_b64: $policy_b64} + (if ($oauth_env | length) > 0 then {oauth_env: $oauth_env} else {} end))}'
           })"
 
           response_file="$(mktemp)"

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ frontend/node_modules/
 control_plane/ui_static/
 
 # Local env and secrets
+.env
 config/dokploy-targets.toml
 
 # Local state and scratch artifacts

--- a/README.md
+++ b/README.md
@@ -134,11 +134,14 @@ The browser operator UI uses GitHub OAuth when these additional inputs are set:
 - `LAUNCHPLANE_PUBLIC_URL`
 - `LAUNCHPLANE_SESSION_SECRET`
 - optional `LAUNCHPLANE_COOKIE_SECURE` for local HTTP development
+- optional `LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS` for comma-separated verified
+  GitHub email addresses that receive the initial `admin` role
 
 Human browser sessions use signed cookies backed by the Launchplane database when
 `LAUNCHPLANE_DATABASE_URL` is configured. Human roles are authorized through
-`github_humans` rules in the same Launchplane authz policy. Machine writes
-continue to use GitHub Actions OIDC bearer tokens.
+`github_humans` rules in the same Launchplane authz policy, with the bootstrap
+admin email list available for first-access recovery. Machine writes continue to
+use GitHub Actions OIDC bearer tokens.
 
 Launchplane now fails closed at startup when no explicit policy input is provided.
 Do not point `LAUNCHPLANE_POLICY_FILE` at `config/launchplane-authz.toml.example`.
@@ -175,13 +178,22 @@ Configure these GitHub settings before enabling it:
   - optional `LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS`
   - optional `LAUNCHPLANE_DEPLOY_HEALTH_TIMEOUT_SECONDS`
   - optional `LAUNCHPLANE_IMAGE_REPOSITORY`
+  - optional `LAUNCHPLANE_GITHUB_CLIENT_ID`
+  - optional `LAUNCHPLANE_PUBLIC_URL`
+  - optional `LAUNCHPLANE_COOKIE_SECURE`
+  - optional `LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS`
+- repository secrets:
+  - optional `LAUNCHPLANE_GITHUB_CLIENT_SECRET`
+  - optional `LAUNCHPLANE_SESSION_SECRET`
 
 The deploy workflow now uses GitHub OIDC plus Launchplane's own service API to
 request a self-deploy. It renders `config/launchplane-authz.toml` into
 `LAUNCHPLANE_POLICY_B64` during the same rollout so bootstrap policy changes and
-image changes follow one reviewed deploy contract. Dokploy credentials should
-live in Launchplane-managed secrets inside the shared store, not in GitHub
-repository secrets.
+image changes follow one reviewed deploy contract. When GitHub OAuth settings
+are configured in repository variables/secrets, that same self-deploy request
+syncs only the known OAuth env keys onto the live Dokploy target. Dokploy
+credentials should live in Launchplane-managed secrets inside the shared store,
+not in GitHub repository secrets.
 
 `LAUNCHPLANE_DEPLOY_HEALTH_URLS` must point at Launchplane URLs that GitHub-hosted
 runners can reach, typically the public `https://.../v1/health` endpoint.

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -124,6 +124,16 @@ from control_plane.workflows.verireel_preview_driver import (
 
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 _LAUNCHPLANE_IMAGE_REFERENCE_ENV_KEY = "DOCKER_IMAGE_REFERENCE"
+_LAUNCHPLANE_SELF_DEPLOY_OAUTH_ENV_KEYS = frozenset(
+    {
+        "LAUNCHPLANE_GITHUB_CLIENT_ID",
+        "LAUNCHPLANE_GITHUB_CLIENT_SECRET",
+        "LAUNCHPLANE_PUBLIC_URL",
+        "LAUNCHPLANE_SESSION_SECRET",
+        "LAUNCHPLANE_COOKIE_SECURE",
+        "LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS",
+    }
+)
 
 
 class PreviewGenerationEvidenceEnvelope(BaseModel):
@@ -444,6 +454,7 @@ class LaunchplaneSelfDeployRequest(BaseModel):
     target_id: str
     image_reference: str
     policy_b64: str = ""
+    oauth_env: dict[str, str] = Field(default_factory=dict)
     no_cache: bool = False
 
     @model_validator(mode="after")
@@ -470,6 +481,21 @@ class LaunchplaneSelfDeployRequest(BaseModel):
         self.target_id = self.target_id.strip()
         self.image_reference = self.image_reference.strip()
         self.policy_b64 = normalized_policy_b64
+        normalized_oauth_env: dict[str, str] = {}
+        for env_key, raw_value in self.oauth_env.items():
+            normalized_key = env_key.strip()
+            if normalized_key not in _LAUNCHPLANE_SELF_DEPLOY_OAUTH_ENV_KEYS:
+                raise ValueError(
+                    f"Launchplane self deploy does not accept oauth_env key {normalized_key!r}."
+                )
+            normalized_value = raw_value.strip()
+            if "\n" in normalized_value or "\r" in normalized_value:
+                raise ValueError(
+                    f"Launchplane self deploy oauth_env key {normalized_key!r} must be a single line."
+                )
+            if normalized_value:
+                normalized_oauth_env[normalized_key] = normalized_value
+        self.oauth_env = normalized_oauth_env
         return self
 
 
@@ -1002,6 +1028,7 @@ def _request_launchplane_self_deploy(
     raw_env_text = str(target_payload.get("env") or "")
     previous_env_map = control_plane_dokploy.parse_dokploy_env_text(raw_env_text)
     updates = {_LAUNCHPLANE_IMAGE_REFERENCE_ENV_KEY: request.image_reference}
+    updates.update(request.oauth_env)
     removals: tuple[str, ...] = ()
     if request.policy_b64:
         updates["LAUNCHPLANE_POLICY_B64"] = request.policy_b64
@@ -1039,6 +1066,11 @@ def _request_launchplane_self_deploy(
             hashlib.sha256(base64.b64decode(request.policy_b64, validate=True)).hexdigest()
             if request.policy_b64
             else ""
+        ),
+        "oauth_env_keys_changed": sorted(
+            env_key
+            for env_key in request.oauth_env
+            if previous_env_map.get(env_key, "") != request.oauth_env[env_key]
         ),
     }
 

--- a/control_plane/service_human_auth.py
+++ b/control_plane/service_human_auth.py
@@ -26,6 +26,7 @@ GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"
 GITHUB_USER_URL = "https://api.github.com/user"
 GITHUB_ORGS_URL = "https://api.github.com/user/orgs"
 GITHUB_TEAMS_URL = "https://api.github.com/user/teams"
+GITHUB_EMAILS_URL = "https://api.github.com/user/emails"
 SESSION_COOKIE_NAME = "launchplane_session"
 SESSION_TTL_SECONDS = 12 * 60 * 60
 OAUTH_STATE_TTL_SECONDS = 10 * 60
@@ -38,7 +39,8 @@ class GitHubOAuthConfig:
     public_url: str
     session_secret: str
     cookie_secure: bool = True
-    scopes: tuple[str, ...] = ("read:user", "read:org")
+    scopes: tuple[str, ...] = ("read:user", "read:org", "user:email")
+    bootstrap_admin_emails: frozenset[str] = frozenset()
 
     @property
     def redirect_uri(self) -> str:
@@ -121,12 +123,19 @@ def load_github_oauth_config_from_env() -> GitHubOAuthConfig | None:
         return None
     secure_env = os.environ.get("LAUNCHPLANE_COOKIE_SECURE", "").strip().lower()
     cookie_secure = secure_env not in {"0", "false", "no"}
+    bootstrap_admin_emails = frozenset(
+        email.lower()
+        for email in _split_env_values(
+            os.environ.get("LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS", "")
+        )
+    )
     return GitHubOAuthConfig(
         client_id=client_id,
         client_secret=client_secret,
         public_url=public_url,
         session_secret=session_secret,
         cookie_secure=cookie_secure,
+        bootstrap_admin_emails=bootstrap_admin_emails,
     )
 
 
@@ -188,31 +197,69 @@ class GitHubOAuthClient:
         user_payload = client.get(GITHUB_USER_URL).json()
         org_payload = client.get(GITHUB_ORGS_URL).json()
         team_payload = client.get(GITHUB_TEAMS_URL).json()
+        email_payload = client.get(GITHUB_EMAILS_URL).json()
         login = str(user_payload.get("login", "")).strip()
         if not login:
             raise ValueError("GitHub OAuth user response did not include a login.")
+        public_email = str(user_payload.get("email") or "").strip()
+        verified_emails = _verified_email_addresses(email_payload)
+        primary_email = _primary_email_address(email_payload)
+        email_candidates = {email.lower() for email in verified_emails}
+        if public_email:
+            email_candidates.add(public_email.lower())
         organizations = frozenset(
             str(org.get("login", "")).strip()
             for org in org_payload
             if isinstance(org, dict) and str(org.get("login", "")).strip()
         )
         teams = frozenset(_team_names(team_payload))
-        role = authz_policy.human_role_for(
-            login=login,
-            organizations=organizations,
-            teams=teams,
-        )
+        if self._config.bootstrap_admin_emails.intersection(email_candidates):
+            role: str | None = "admin"
+        else:
+            role = authz_policy.human_role_for(
+                login=login,
+                organizations=organizations,
+                teams=teams,
+            )
         if role is None:
             raise PermissionError("GitHub user is not authorized for Launchplane.")
         return GitHubHumanIdentity(
             login=login,
             github_id=int(user_payload.get("id") or 0),
             name=str(user_payload.get("name") or "").strip(),
-            email=str(user_payload.get("email") or "").strip(),
+            email=primary_email or public_email or next(iter(verified_emails), ""),
             organizations=organizations,
             teams=teams,
             role=role,
         )
+
+
+def _split_env_values(raw_value: str) -> tuple[str, ...]:
+    return tuple(value.strip() for value in raw_value.split(",") if value.strip())
+
+
+def _verified_email_addresses(email_payload: object) -> tuple[str, ...]:
+    if not isinstance(email_payload, list):
+        return ()
+    emails: list[str] = []
+    for item in email_payload:
+        if not isinstance(item, dict) or item.get("verified") is not True:
+            continue
+        email = str(item.get("email") or "").strip()
+        if email:
+            emails.append(email)
+    return tuple(emails)
+
+
+def _primary_email_address(email_payload: object) -> str:
+    if not isinstance(email_payload, list):
+        return ""
+    for item in email_payload:
+        if not isinstance(item, dict):
+            continue
+        if item.get("primary") is True and item.get("verified") is True:
+            return str(item.get("email") or "").strip()
+    return ""
 
 
 def _team_names(team_payload: object) -> tuple[str, ...]:

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -238,6 +238,11 @@ authorize read endpoints, but POST mutation routes remain GitHub Actions OIDC
 only until browser-initiated mutation workflows get a dedicated CSRF and audit
 design.
 
+For first access, `LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS` may name comma-separated
+verified GitHub email addresses that receive the `admin` role even before a
+matching `github_humans` rule exists. The GitHub OAuth client requests
+`user:email` so that this bootstrap path works for private profile emails.
+
 ## First API Surface
 
 The first Launchplane service surface should focus on evidence ingress and record

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -32,7 +32,15 @@ from control_plane.service_auth import (
     GitHubOidcVerifier,
     LaunchplaneAuthzPolicy,
 )
-from control_plane.service_human_auth import GitHubOAuthConfig
+from control_plane.service_human_auth import (
+    GITHUB_EMAILS_URL,
+    GITHUB_ORGS_URL,
+    GITHUB_TEAMS_URL,
+    GITHUB_USER_URL,
+    GitHubOAuthClient,
+    GitHubOAuthConfig,
+    load_github_oauth_config_from_env,
+)
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.verireel_preview_driver import (
@@ -83,6 +91,32 @@ class _StubGitHubOAuthClient:
         if code != "github-code":
             raise ValueError("unexpected code")
         return self.identity
+
+
+class _FakeGitHubResponse:
+    def __init__(self, payload: object):
+        self._payload = payload
+
+    def json(self) -> object:
+        return self._payload
+
+
+class _FakeOAuth2Session:
+    def __init__(self, payloads: dict[str, object]):
+        self.payloads = payloads
+        self.requested_urls: list[str] = []
+        self.token_request: dict[str, str] = {}
+
+    def fetch_token(self, url: str, *, code: str, code_verifier: str) -> None:
+        self.token_request = {
+            "url": url,
+            "code": code,
+            "code_verifier": code_verifier,
+        }
+
+    def get(self, url: str) -> _FakeGitHubResponse:
+        self.requested_urls.append(url)
+        return _FakeGitHubResponse(self.payloads[url])
 
 
 def _identity(
@@ -262,6 +296,79 @@ class GitHubOidcVerifierTests(unittest.TestCase):
 
 
 class GitHubHumanAuthTests(unittest.TestCase):
+    def test_github_oauth_config_loads_bootstrap_admin_emails(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "LAUNCHPLANE_GITHUB_CLIENT_ID": "client-id",
+                "LAUNCHPLANE_GITHUB_CLIENT_SECRET": "client-secret",
+                "LAUNCHPLANE_PUBLIC_URL": "https://launchplane.example/",
+                "LAUNCHPLANE_SESSION_SECRET": "session-secret",
+                "LAUNCHPLANE_COOKIE_SECURE": "false",
+                "LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS": (
+                    " Info@ShinyComputers.com, ops@example.com "
+                ),
+            },
+            clear=True,
+        ):
+            config = load_github_oauth_config_from_env()
+
+        self.assertIsNotNone(config)
+        assert config is not None
+        self.assertFalse(config.cookie_secure)
+        self.assertEqual(config.public_url, "https://launchplane.example")
+        self.assertIn("user:email", config.scopes)
+        self.assertEqual(
+            config.bootstrap_admin_emails,
+            frozenset({"info@shinycomputers.com", "ops@example.com"}),
+        )
+
+    def test_github_oauth_bootstrap_admin_can_use_verified_private_email(self) -> None:
+        config = GitHubOAuthConfig(
+            client_id="client-id",
+            client_secret="client-secret",
+            public_url="https://launchplane.example",
+            session_secret="session-secret",
+            bootstrap_admin_emails=frozenset({"info@shinycomputers.com"}),
+        )
+        oauth_session = _FakeOAuth2Session(
+            {
+                GITHUB_USER_URL: {
+                    "login": "bootstrapper",
+                    "id": 987,
+                    "name": "Bootstrap Operator",
+                    "email": None,
+                },
+                GITHUB_ORGS_URL: [],
+                GITHUB_TEAMS_URL: [],
+                GITHUB_EMAILS_URL: [
+                    {
+                        "email": "info@shinycomputers.com",
+                        "primary": True,
+                        "verified": True,
+                    },
+                    {
+                        "email": "unverified@example.com",
+                        "primary": False,
+                        "verified": False,
+                    },
+                ],
+            }
+        )
+        client = GitHubOAuthClient(config)
+
+        with patch.object(GitHubOAuthClient, "_new_session", return_value=oauth_session):
+            identity = client.fetch_identity(
+                code="github-code",
+                code_verifier="verifier",
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_humans": []}),
+            )
+
+        self.assertEqual(identity.login, "bootstrapper")
+        self.assertEqual(identity.email, "info@shinycomputers.com")
+        self.assertEqual(identity.role, "admin")
+        self.assertIn(GITHUB_EMAILS_URL, oauth_session.requested_urls)
+
     def _signed_in_cookie(
         self,
         app,
@@ -1004,6 +1111,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
                             "target_id": "compose-123",
                             "image_reference": "ghcr.io/cbusillo/launchplane@sha256:new",
                             "policy_b64": policy_b64,
+                            "oauth_env": {
+                                "LAUNCHPLANE_GITHUB_CLIENT_ID": "client-id",
+                                "LAUNCHPLANE_PUBLIC_URL": "https://launchplane.example",
+                                "LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS": (
+                                    "info@shinycomputers.com"
+                                ),
+                            },
                         },
                     },
                     headers={"Idempotency-Key": "launchplane-self-deploy:test"},
@@ -1023,6 +1137,12 @@ class LaunchplaneServiceTests(unittest.TestCase):
             "DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/launchplane@sha256:new", updated_env_text
         )
         self.assertIn(f"LAUNCHPLANE_POLICY_B64={policy_b64}", updated_env_text)
+        self.assertIn("LAUNCHPLANE_GITHUB_CLIENT_ID=client-id", updated_env_text)
+        self.assertIn("LAUNCHPLANE_PUBLIC_URL=https://launchplane.example", updated_env_text)
+        self.assertIn(
+            "LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS=info@shinycomputers.com",
+            updated_env_text,
+        )
         self.assertNotIn("LAUNCHPLANE_POLICY_TOML=", updated_env_text)
         self.assertNotIn("LAUNCHPLANE_POLICY_FILE=", updated_env_text)
         trigger_mock.assert_called_once_with(
@@ -1032,6 +1152,58 @@ class LaunchplaneServiceTests(unittest.TestCase):
             target_id="compose-123",
             no_cache=False,
         )
+
+    def test_self_deploy_endpoint_rejects_unknown_oauth_env_keys(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["launchplane_service_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/launchplane/self-deploy",
+                payload={
+                    "product": "launchplane",
+                    "deploy": {
+                        "target_type": "compose",
+                        "target_id": "compose-123",
+                        "image_reference": "ghcr.io/cbusillo/launchplane@sha256:new",
+                        "oauth_env": {"DOKPLOY_TOKEN": "nope"},
+                    },
+                },
+                headers={"Idempotency-Key": "launchplane-self-deploy:bad-oauth-env"},
+            )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_request")
 
     def test_preview_generation_endpoint_writes_records_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- request verified GitHub email scope and use verified private emails for bootstrap admin access
- add a narrow self-deploy OAuth env sync path for the known Launchplane GitHub OAuth env keys
- document the OAuth env contract and ignore local .env files

## Verification
- uv run python -m unittest
- npx pnpm@10.10.0 --dir frontend validate
- git diff --check
- docker build -t launchplane-oauth-bootstrap-admin-test .
- actionlint .github/workflows/deploy-launchplane.yml