### PR TITLE
Add operator data freshness provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,20 @@ when the target lacks a policy input, DB-backed target-id records, DB-backed
 runtime-environment records, or an existing `DOCKER_IMAGE_REFERENCE` rollback
 baseline.
 
+Operator UI data is record-backed evidence rather than an unlabeled live provider
+poll. Use the data freshness report to confirm visible surfaces carry provenance
+before launch or handoff:
+
+```bash
+uv run launchplane service inspect-data-freshness \
+  --context verireel \
+  --preview-context verireel-testing
+```
+
+The first freshness gate reports lane and preview surfaces, their source record,
+and whether provenance is present. The UI renders the same provenance as compact
+`verified`, `recorded`, `stale`, `missing`, or `unsupported` trust labels.
+
 The deploy path still depends on two Dokploy-side prerequisites that Launchplane can
 document but cannot fully validate through the current Dokploy API surface:
 

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -62,6 +62,7 @@ from control_plane.contracts.promotion_record import (
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.contracts.ship_request import ShipRequest
+from control_plane.drivers.registry import build_driver_context_view
 from control_plane.launchplane_mutations import (
     apply_launchplane_destroy_preview as shared_apply_launchplane_destroy_preview,
     apply_launchplane_generation_evidence as shared_apply_launchplane_generation_evidence,
@@ -9382,6 +9383,156 @@ def service_inspect_config_boundary(control_plane_root: Path | None) -> None:
     launchplane_root = control_plane_root or _control_plane_root()
     payload = _inspect_local_launchplane_config_boundary(control_plane_root=launchplane_root)
     click.echo(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _first_driver_payload(view_payload: object, *, driver_id: str) -> dict[str, object] | None:
+    if not hasattr(view_payload, "drivers"):
+        return None
+    for driver_view in view_payload.drivers:
+        if getattr(driver_view, "driver_id", "") == driver_id:
+            return driver_view.model_dump(mode="json")
+    return None
+
+
+def _provenance_payload(raw_value: object) -> dict[str, object] | None:
+    if not isinstance(raw_value, dict):
+        return None
+    provenance = raw_value.get("provenance")
+    return provenance if isinstance(provenance, dict) else None
+
+
+def _freshness_surface(
+    *, name: str, driver_id: str, raw_value: object, unsupported: bool = False
+) -> dict[str, object]:
+    if unsupported:
+        return {
+            "name": name,
+            "driver_id": driver_id,
+            "freshness_status": "unsupported",
+            "source_kind": "unsupported",
+            "source_record_id": "",
+            "recorded_at": "",
+            "stale_after": "",
+            "has_provenance": True,
+        }
+    provenance = _provenance_payload(raw_value)
+    if provenance is None:
+        return {
+            "name": name,
+            "driver_id": driver_id,
+            "freshness_status": "missing",
+            "source_kind": "record",
+            "source_record_id": "",
+            "recorded_at": "",
+            "stale_after": "",
+            "has_provenance": False,
+        }
+    return {
+        "name": name,
+        "driver_id": driver_id,
+        "freshness_status": str(provenance.get("freshness_status") or "missing"),
+        "source_kind": str(provenance.get("source_kind") or "record"),
+        "source_record_id": str(provenance.get("source_record_id") or ""),
+        "recorded_at": str(provenance.get("recorded_at") or ""),
+        "stale_after": str(provenance.get("stale_after") or ""),
+        "has_provenance": True,
+    }
+
+
+def _build_data_freshness_report(
+    *, record_store: object, context_name: str, preview_context_name: str
+) -> dict[str, object]:
+    surfaces: list[dict[str, object]] = []
+    for instance_name in ("prod", "testing"):
+        view = build_driver_context_view(
+            record_store=record_store,
+            context_name=context_name,
+            instance_name=instance_name,
+        )
+        driver = _first_driver_payload(view, driver_id="verireel")
+        lane_summary = driver.get("lane_summary") if isinstance(driver, dict) else None
+        surfaces.append(
+            _freshness_surface(
+                name=f"{context_name}/{instance_name}/lane",
+                driver_id="verireel",
+                raw_value=lane_summary,
+            )
+        )
+
+    preview_view = build_driver_context_view(
+        record_store=record_store,
+        context_name=preview_context_name,
+    )
+    preview_driver = _first_driver_payload(preview_view, driver_id="verireel")
+    preview_summaries = (
+        preview_driver.get("preview_summaries") if isinstance(preview_driver, dict) else None
+    )
+    if isinstance(preview_summaries, list) and preview_summaries:
+        for summary in preview_summaries:
+            preview = summary.get("preview") if isinstance(summary, dict) else None
+            preview_id = "unknown-preview"
+            if isinstance(preview, dict):
+                preview_id = str(preview.get("preview_id") or preview_id)
+            surfaces.append(
+                _freshness_surface(
+                    name=f"{preview_context_name}/{preview_id}",
+                    driver_id="verireel",
+                    raw_value=summary,
+                )
+            )
+    else:
+        surfaces.append(
+            _freshness_surface(
+                name=f"{preview_context_name}/preview-inventory",
+                driver_id="verireel",
+                raw_value={
+                    "provenance": {
+                        "source_kind": "record",
+                        "freshness_status": "missing",
+                        "source_record_id": "",
+                        "recorded_at": "",
+                        "stale_after": "",
+                    }
+                },
+            )
+        )
+
+    missing_provenance = [surface for surface in surfaces if not surface["has_provenance"]]
+    return {
+        "status": "ok" if not missing_provenance else "rejected",
+        "context": context_name,
+        "preview_context": preview_context_name,
+        "surface_count": len(surfaces),
+        "missing_provenance_count": len(missing_provenance),
+        "surfaces": surfaces,
+    }
+
+
+@service.command("inspect-data-freshness")
+@click.option(
+    "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
+)
+@click.option("--database-url", envvar=_DATABASE_URL_ENV_KEYS, default="", show_default=False)
+@click.option("--context", "context_name", default="verireel", show_default=True)
+@click.option(
+    "--preview-context", "preview_context_name", default="verireel-testing", show_default=True
+)
+def service_inspect_data_freshness(
+    state_dir: Path, database_url: str, context_name: str, preview_context_name: str
+) -> None:
+    record_store = _store(state_dir, database_url=database_url)
+    try:
+        payload = _build_data_freshness_report(
+            record_store=record_store,
+            context_name=context_name,
+            preview_context_name=preview_context_name,
+        )
+    finally:
+        if hasattr(record_store, "close"):
+            record_store.close()
+    click.echo(json.dumps(payload, indent=2, sort_keys=True))
+    if payload["status"] != "ok":
+        raise click.ClickException("Launchplane data freshness report is missing provenance.")
 
 
 @artifacts.command("write")

--- a/control_plane/contracts/data_provenance.py
+++ b/control_plane/contracts/data_provenance.py
@@ -1,0 +1,19 @@
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+
+FreshnessStatus = Literal["verified", "recorded", "stale", "missing", "unsupported"]
+SourceKind = Literal["record", "provider", "descriptor", "unsupported"]
+
+
+class DataProvenance(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_kind: SourceKind
+    source_record_id: str = ""
+    recorded_at: str = ""
+    refreshed_at: str = ""
+    freshness_status: FreshnessStatus
+    stale_after: str = ""
+    detail: str = ""

--- a/control_plane/contracts/lane_summary.py
+++ b/control_plane/contracts/lane_summary.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, ConfigDict
 
 from control_plane.contracts.backup_gate_record import BackupGateRecord
+from control_plane.contracts.data_provenance import DataProvenance
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
@@ -27,3 +28,8 @@ class LaunchplaneLaneSummary(BaseModel):
     runtime_environment_records: tuple[RuntimeEnvironmentRecord, ...] = ()
     odoo_instance_override: OdooInstanceOverrideRecord | None = None
     secret_bindings: tuple[SecretBinding, ...] = ()
+    provenance: DataProvenance = DataProvenance(
+        source_kind="record",
+        freshness_status="missing",
+        detail="Launchplane has not recorded lane evidence for this context and instance.",
+    )

--- a/control_plane/contracts/preview_summary.py
+++ b/control_plane/contracts/preview_summary.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, ConfigDict, Field
 
+from control_plane.contracts.data_provenance import DataProvenance
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
 from control_plane.contracts.preview_record import PreviewRecord
 
@@ -10,3 +11,8 @@ class LaunchplanePreviewSummary(BaseModel):
     preview: PreviewRecord
     latest_generation: PreviewGenerationRecord | None = None
     recent_generations: tuple[PreviewGenerationRecord, ...] = Field(default_factory=tuple)
+    provenance: DataProvenance = DataProvenance(
+        source_kind="record",
+        freshness_status="missing",
+        detail="Launchplane has not recorded preview generation evidence.",
+    )

--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from fnmatch import fnmatchcase
 from typing import Any, Literal
 
+from control_plane.contracts.data_provenance import DataProvenance, FreshnessStatus
 from control_plane.contracts.driver_descriptor import (
     DriverActionDescriptor,
     DriverActionSafety,
@@ -21,6 +23,8 @@ PROVIDER_BOUNDARY_NOTE = (
     "Launchplane exposes product capabilities and evidence; runtime-provider details stay behind "
     "backend adapters and evidence records."
 )
+LANE_STALE_AFTER = timedelta(minutes=30)
+PREVIEW_STALE_AFTER = timedelta(minutes=30)
 
 
 def _action(
@@ -315,16 +319,124 @@ def _optional_call(method: Any, **kwargs: object) -> object | None:
         return None
 
 
+def _parse_timestamp(value: str) -> datetime | None:
+    normalized_value = value.strip()
+    if not normalized_value:
+        return None
+    try:
+        if normalized_value.endswith("Z"):
+            normalized_value = f"{normalized_value[:-1]}+00:00"
+        parsed = datetime.fromisoformat(normalized_value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _format_timestamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _freshness_status(
+    *, recorded_at: str, stale_after: timedelta, verified: bool
+) -> tuple[FreshnessStatus, str]:
+    recorded_timestamp = _parse_timestamp(recorded_at)
+    if recorded_timestamp is None:
+        return "recorded", ""
+    stale_at = recorded_timestamp + stale_after
+    if datetime.now(timezone.utc) > stale_at:
+        return "stale", _format_timestamp(stale_at)
+    return ("verified" if verified else "recorded"), _format_timestamp(stale_at)
+
+
+def _lane_provenance(summary: LaunchplaneLaneSummary) -> DataProvenance:
+    if summary.inventory is not None:
+        status, stale_after = _freshness_status(
+            recorded_at=summary.inventory.updated_at,
+            stale_after=LANE_STALE_AFTER,
+            verified=summary.inventory.destination_health.verified,
+        )
+        return DataProvenance(
+            source_kind="record",
+            source_record_id=summary.inventory.deployment_record_id,
+            recorded_at=summary.inventory.updated_at,
+            refreshed_at=summary.inventory.updated_at,
+            freshness_status=status,
+            stale_after=stale_after,
+            detail="Launchplane environment inventory record.",
+        )
+    if summary.latest_deployment is not None:
+        recorded_at = (
+            summary.latest_deployment.deploy.finished_at
+            or summary.latest_deployment.deploy.started_at
+        )
+        status, stale_after = _freshness_status(
+            recorded_at=recorded_at,
+            stale_after=LANE_STALE_AFTER,
+            verified=summary.latest_deployment.destination_health.verified,
+        )
+        return DataProvenance(
+            source_kind="record",
+            source_record_id=summary.latest_deployment.record_id,
+            recorded_at=recorded_at,
+            refreshed_at=recorded_at,
+            freshness_status=status,
+            stale_after=stale_after,
+            detail="Latest Launchplane deployment record; environment inventory is missing.",
+        )
+    return DataProvenance(
+        source_kind="record",
+        freshness_status="missing",
+        detail="Launchplane has not recorded lane evidence for this context and instance.",
+    )
+
+
+def _preview_provenance(summary: LaunchplanePreviewSummary) -> DataProvenance:
+    if summary.latest_generation is not None:
+        generation = summary.latest_generation
+        recorded_at = generation.finished_at or generation.ready_at or generation.requested_at
+        status, stale_after = _freshness_status(
+            recorded_at=recorded_at,
+            stale_after=PREVIEW_STALE_AFTER,
+            verified=generation.overall_health_status == "pass",
+        )
+        return DataProvenance(
+            source_kind="record",
+            source_record_id=generation.generation_id,
+            recorded_at=recorded_at,
+            refreshed_at=recorded_at,
+            freshness_status=status,
+            stale_after=stale_after,
+            detail="Latest Launchplane preview generation record.",
+        )
+    status, stale_after = _freshness_status(
+        recorded_at=summary.preview.updated_at,
+        stale_after=PREVIEW_STALE_AFTER,
+        verified=False,
+    )
+    return DataProvenance(
+        source_kind="record",
+        source_record_id=summary.preview.preview_id,
+        recorded_at=summary.preview.updated_at,
+        refreshed_at=summary.preview.updated_at,
+        freshness_status=status,
+        stale_after=stale_after,
+        detail="Preview identity record exists, but no generation evidence is recorded.",
+    )
+
+
 def _read_lane_summary(
     *, record_store: object, context_name: str, instance_name: str
 ) -> LaunchplaneLaneSummary | None:
     if not instance_name:
         return None
     if hasattr(record_store, "read_lane_summary"):
-        return getattr(record_store, "read_lane_summary")(
+        summary = getattr(record_store, "read_lane_summary")(
             context_name=context_name,
             instance_name=instance_name,
         )
+        return summary.model_copy(update={"provenance": _lane_provenance(summary)})
 
     inventory = None
     if hasattr(record_store, "read_environment_inventory"):
@@ -384,7 +496,7 @@ def _read_lane_summary(
             instance_name=instance_name,
         )
 
-    return LaunchplaneLaneSummary(
+    summary = LaunchplaneLaneSummary(
         context=context_name,
         instance=instance_name,
         inventory=inventory,
@@ -394,15 +506,20 @@ def _read_lane_summary(
         latest_backup_gate=latest_backup_gate,
         odoo_instance_override=odoo_instance_override,
     )
+    return summary.model_copy(update={"provenance": _lane_provenance(summary)})
 
 
 def _list_preview_summaries(
     *, record_store: object, context_name: str
 ) -> tuple[LaunchplanePreviewSummary, ...]:
     if hasattr(record_store, "list_preview_summaries"):
-        return getattr(record_store, "list_preview_summaries")(
+        summaries = getattr(record_store, "list_preview_summaries")(
             context_name=context_name,
             generation_limit=1,
+        )
+        return tuple(
+            summary.model_copy(update={"provenance": _preview_provenance(summary)})
+            for summary in summaries
         )
     if not hasattr(record_store, "list_preview_records"):
         return ()
@@ -415,13 +532,12 @@ def _list_preview_summaries(
                 preview_id=preview.preview_id,
                 limit=1,
             )
-        summaries.append(
-            LaunchplanePreviewSummary(
-                preview=preview,
-                latest_generation=next(iter(generations), None),
-                recent_generations=generations,
-            )
+        summary = LaunchplanePreviewSummary(
+            preview=preview,
+            latest_generation=next(iter(generations), None),
+            recent_generations=generations,
         )
+        summaries.append(summary.model_copy(update={"provenance": _preview_provenance(summary)}))
     return tuple(summaries)
 
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "node": ">=22 <23"
   },
   "scripts": {
-    "build": "pnpm typecheck && vite build",
+    "build": "pnpm typecheck && vite build && node scripts/assert-production-fixtures.mjs",
     "dev": "vite --host 127.0.0.1",
     "preview": "vite preview --host 127.0.0.1",
     "typecheck": "tsc --noEmit",

--- a/frontend/scripts/assert-production-fixtures.mjs
+++ b/frontend/scripts/assert-production-fixtures.mjs
@@ -1,0 +1,15 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const assetDir = new URL("../../control_plane/ui_static/assets/", import.meta.url);
+const javascriptAssets = readdirSync(assetDir).filter((name) => name.endsWith(".js"));
+const forbiddenNeedles = ["development fixtures", "fixture evidence", "Operator state coverage"];
+
+for (const assetName of javascriptAssets) {
+  const assetText = readFileSync(join(assetDir.pathname, assetName), "utf8");
+  for (const needle of forbiddenNeedles) {
+    if (assetText.includes(needle)) {
+      throw new Error(`Production UI asset ${assetName} contains dev fixture text: ${needle}`);
+    }
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import { ReactNode, useEffect, useMemo, useState } from "react";
 import { LaunchplaneApiError, listDrivers, logout, readAuthSession, readDriverView } from "./api";
 import type {
   AuthIdentity,
+  DataProvenance,
   DriverActionDescriptor,
   DriverContextView,
   DriverDescriptor,
@@ -30,7 +31,8 @@ import type {
   LaneSummary,
   PreviewSummary,
   Safety,
-  Status
+  Status,
+  FreshnessStatus
 } from "./types";
 
 type Theme = "dark" | "light";
@@ -520,7 +522,16 @@ function LanePanel({
 
   return (
     <section className={`panel lane-panel lane-${laneKind}`}>
-      <PanelHead eyebrow="environment lane" title={title} right={<StatusPill status={worstStatus([deployStatus, healthStatus])} />} />
+      <PanelHead
+        eyebrow="environment lane"
+        title={title}
+        right={(
+          <div className="panel-badges">
+            <TrustBadge provenance={lane?.provenance ?? null} />
+            <StatusPill status={worstStatus([deployStatus, healthStatus])} />
+          </div>
+        )}
+      />
       {loading ? (
         <SkeletonRows />
       ) : (
@@ -649,7 +660,12 @@ function PreviewInventory({
       <PanelHead
         eyebrow="preview lane"
         title={exposesPreviews ? "Preview inventory" : "Previews not exposed"}
-        right={exposesPreviews ? <span className="count-chip">{previews.length} active</span> : null}
+        right={(
+          <div className="panel-badges">
+            <TrustBadge provenance={previewInventoryProvenance(exposesPreviews, latestPreview)} />
+            {exposesPreviews ? <span className="count-chip">{previews.length} active</span> : null}
+          </div>
+        )}
       />
       {loading ? (
         <SkeletonRows />
@@ -668,7 +684,10 @@ function PreviewInventory({
                   <a href={summary.preview.anchor_pr_url}>{summary.preview.anchor_repo}#{summary.preview.anchor_pr_number}</a>
                 </div>
                 <code>{summary.latest_generation?.artifact_id ?? summary.preview.preview_id}</code>
-                <StatusPill status={health} />
+                <div className="preview-status-stack">
+                  <TrustBadge provenance={summary.provenance} compact />
+                  <StatusPill status={health} />
+                </div>
               </article>
             );
           })}
@@ -690,6 +709,92 @@ function PreviewInventory({
       </div>
     </section>
   );
+}
+
+function TrustBadge({ provenance, compact = false }: { provenance: DataProvenance | null; compact?: boolean }) {
+  const status = provenance?.freshness_status ?? "missing";
+  return (
+    <span
+      className={`trust-badge trust-${status}${compact ? " trust-compact" : ""}`}
+      title={provenanceDetail(provenance)}
+      data-freshness={status}
+    >
+      <span>{freshnessLabel(status)}</span>
+      {!compact ? <em>{provenanceSubLabel(provenance)}</em> : null}
+    </span>
+  );
+}
+
+function previewInventoryProvenance(exposesPreviews: boolean, latestPreview: PreviewSummary | undefined): DataProvenance {
+  if (!exposesPreviews) {
+    return {
+      source_kind: "unsupported",
+      source_record_id: "",
+      recorded_at: "",
+      refreshed_at: "",
+      freshness_status: "unsupported",
+      stale_after: "",
+      detail: "Driver does not expose preview lifecycle."
+    };
+  }
+  if (!latestPreview) {
+    return {
+      source_kind: "record",
+      source_record_id: "",
+      recorded_at: "",
+      refreshed_at: "",
+      freshness_status: "missing",
+      stale_after: "",
+      detail: "Launchplane has not recorded active preview inventory for this context."
+    };
+  }
+  return latestPreview.provenance;
+}
+
+function freshnessLabel(status: FreshnessStatus): string {
+  if (status === "verified") {
+    return "verified";
+  }
+  if (status === "recorded") {
+    return "recorded";
+  }
+  if (status === "stale") {
+    return "stale";
+  }
+  if (status === "unsupported") {
+    return "unsupported";
+  }
+  return "missing";
+}
+
+function provenanceSubLabel(provenance: DataProvenance | null): string {
+  if (!provenance) {
+    return "no evidence";
+  }
+  if (provenance.freshness_status === "unsupported") {
+    return provenance.source_kind;
+  }
+  if (provenance.refreshed_at) {
+    return formatTime(provenance.refreshed_at);
+  }
+  if (provenance.recorded_at) {
+    return formatTime(provenance.recorded_at);
+  }
+  return provenance.source_record_id ? "recorded" : "no evidence";
+}
+
+function provenanceDetail(provenance: DataProvenance | null): string {
+  if (!provenance) {
+    return "Launchplane has not recorded provenance for this surface.";
+  }
+  const parts = [provenance.detail];
+  if (provenance.source_record_id) {
+    parts.push(`source: ${provenance.source_record_id}`);
+  }
+  if (provenance.stale_after) {
+    parts.push(`stale after: ${formatTime(provenance.stale_after)}`);
+  }
+  return parts.filter(Boolean).join(" | ");
 }
 
 function ActionList({
@@ -1414,7 +1519,16 @@ function fixtureLane({
           evidence: backupStatus === "pass" ? { snapshot: "fixture-prod" } : {}
         }
       : null,
-    secret_bindings: []
+    secret_bindings: [],
+    provenance: {
+      source_kind: "record",
+      source_record_id: `fixture-deployment-${instance}`,
+      recorded_at: deploy.finished_at,
+      refreshed_at: deploy.finished_at,
+      freshness_status: "verified",
+      stale_after: "2026-04-28T15:35:00Z",
+      detail: "Development fixture lane evidence."
+    }
   };
 }
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -128,6 +128,7 @@ p {
 .icon-button,
 .command-button,
 .status-pill,
+.trust-badge,
 .count-chip,
 .action-group-title,
 .bridge-delta,
@@ -370,6 +371,19 @@ p {
   min-height: 28px;
 }
 
+.panel-badges,
+.preview-status-stack {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  min-width: 0;
+}
+
+.panel-badges {
+  flex-wrap: wrap;
+}
+
 .lane-body,
 .gate-list,
 .action-groups,
@@ -514,6 +528,60 @@ p {
   white-space: nowrap;
 }
 
+.trust-badge {
+  gap: 5px;
+  min-height: 24px;
+  max-width: 190px;
+  border: 1px solid var(--hair);
+  border-radius: 5px;
+  background: var(--bg-2);
+  padding: 2px 7px;
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.trust-badge span,
+.trust-badge em {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.trust-badge span {
+  text-transform: uppercase;
+}
+
+.trust-badge em {
+  color: var(--fg-faint);
+  font-style: normal;
+}
+
+.trust-compact {
+  max-width: 96px;
+}
+
+.trust-verified {
+  border-color: color-mix(in oklab, var(--status-ok) 45%, var(--hair));
+  color: var(--status-ok);
+}
+
+.trust-recorded {
+  border-color: color-mix(in oklab, var(--lane-preview) 42%, var(--hair));
+  color: var(--lane-preview);
+}
+
+.trust-stale {
+  border-color: color-mix(in oklab, var(--status-warn) 48%, var(--hair));
+  color: var(--status-warn);
+}
+
+.trust-missing,
+.trust-unsupported {
+  border-color: color-mix(in oklab, var(--status-unknown) 42%, var(--hair));
+}
+
 [data-status="pass"],
 [data-status="ready"] {
   color: var(--status-ok);
@@ -622,7 +690,7 @@ p {
 
 .preview-row {
   display: grid;
-  grid-template-columns: minmax(160px, 0.8fr) minmax(0, 1fr) auto;
+  grid-template-columns: minmax(160px, 0.8fr) minmax(0, 1fr) minmax(118px, auto);
   gap: 12px;
   align-items: center;
   min-height: 48px;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,5 +1,16 @@
 export type Safety = "read" | "safe_write" | "mutation" | "destructive";
 export type Status = "pass" | "fail" | "pending" | "skipped" | "unknown" | "blocked";
+export type FreshnessStatus = "verified" | "recorded" | "stale" | "missing" | "unsupported";
+
+export interface DataProvenance {
+  source_kind: "record" | "provider" | "descriptor" | "unsupported";
+  source_record_id: string;
+  recorded_at: string;
+  refreshed_at: string;
+  freshness_status: FreshnessStatus;
+  stale_after: string;
+  detail: string;
+}
 
 export interface DriverActionDescriptor {
   action_id: string;
@@ -153,6 +164,7 @@ export interface LaneSummary {
   latest_backup_gate?: BackupGateRecord | null;
   odoo_instance_override?: unknown | null;
   secret_bindings: SecretBinding[];
+  provenance: DataProvenance;
 }
 
 export interface PreviewRecord {
@@ -188,6 +200,7 @@ export interface PreviewSummary {
   preview: PreviewRecord;
   latest_generation?: PreviewGenerationRecord | null;
   recent_generations: PreviewGenerationRecord[];
+  provenance: DataProvenance;
 }
 
 export interface DriverView {

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -11,6 +11,9 @@ from typing import Literal
 from urllib.parse import parse_qs, urlparse
 from unittest.mock import Mock, patch
 
+from click.testing import CliRunner
+
+from control_plane.cli import main
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
@@ -924,6 +927,15 @@ class LaunchplaneServiceTests(unittest.TestCase):
             driver["lane_summary"]["inventory"]["artifact_identity"]["artifact_id"],
             "artifact-20260420-a1b2c3d4",
         )
+        self.assertEqual(driver["lane_summary"]["provenance"]["source_kind"], "record")
+        self.assertEqual(
+            driver["lane_summary"]["provenance"]["source_record_id"],
+            "deployment-20260420T153000Z-opw-testing",
+        )
+        self.assertIn(
+            driver["lane_summary"]["provenance"]["freshness_status"],
+            {"verified", "recorded", "stale"},
+        )
 
     def test_driver_context_view_endpoint_returns_preview_summaries(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -1001,12 +1013,111 @@ class LaunchplaneServiceTests(unittest.TestCase):
         driver = payload["view"]["drivers"][0]
         self.assertEqual(driver["driver_id"], "verireel")
         self.assertEqual(driver["preview_summaries"][0]["latest_generation"]["state"], "ready")
+        self.assertEqual(
+            driver["preview_summaries"][0]["provenance"]["source_record_id"],
+            "preview-verireel-testing-verireel-pr-123-generation-0001",
+        )
+        self.assertIn(
+            driver["preview_summaries"][0]["provenance"]["freshness_status"],
+            {"verified", "recorded", "stale"},
+        )
         destructive_actions = [
             action for action in driver["available_actions"] if action["safety"] == "destructive"
         ]
         self.assertEqual(
             {action["action_id"] for action in destructive_actions},
             {"prod_rollback", "preview_destroy"},
+        )
+
+    def test_data_freshness_report_covers_visible_surfaces(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            for instance_name in ("prod", "testing"):
+                store.write_environment_inventory(
+                    EnvironmentInventory(
+                        context="verireel",
+                        instance=instance_name,
+                        artifact_identity=ArtifactIdentityReference(
+                            artifact_id=f"artifact-verireel-{instance_name}"
+                        ),
+                        source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
+                        deploy=DeploymentEvidence(
+                            target_name=f"verireel-{instance_name}",
+                            target_type="application",
+                            deploy_mode="runtime-provider-api",
+                            deployment_id=f"provider-{instance_name}",
+                            status="pass",
+                            started_at="2026-04-20T15:30:00Z",
+                            finished_at="2026-04-20T15:32:00Z",
+                        ),
+                        updated_at="2026-04-20T15:33:00Z",
+                        deployment_record_id=f"deployment-verireel-{instance_name}",
+                    )
+                )
+            store.write_preview_record(
+                PreviewRecord(
+                    preview_id="preview-verireel-testing-verireel-pr-123",
+                    context="verireel-testing",
+                    anchor_repo="verireel",
+                    anchor_pr_number=123,
+                    anchor_pr_url="https://github.com/every/verireel/pull/123",
+                    preview_label="verireel/pr-123",
+                    canonical_url="https://pr-123.ver-preview.shinycomputers.com",
+                    state="active",
+                    created_at="2026-04-20T10:00:00Z",
+                    updated_at="2026-04-20T10:05:00Z",
+                    eligible_at="2026-04-20T10:05:00Z",
+                )
+            )
+            store.write_preview_generation_record(
+                PreviewGenerationRecord(
+                    generation_id="preview-verireel-testing-verireel-pr-123-generation-0001",
+                    preview_id="preview-verireel-testing-verireel-pr-123",
+                    sequence=1,
+                    state="ready",
+                    requested_reason="external_preview_refresh",
+                    requested_at="2026-04-20T10:01:00Z",
+                    ready_at="2026-04-20T10:05:00Z",
+                    finished_at="2026-04-20T10:05:00Z",
+                    resolved_manifest_fingerprint="preview-manifest-123",
+                    artifact_id="ghcr.io/every/verireel-app:pr-123",
+                    anchor_summary=PreviewPullRequestSummary(
+                        repo="verireel",
+                        pr_number=123,
+                        head_sha="6b3c9d7e8f901234567890abcdef1234567890ab",
+                        pr_url="https://github.com/every/verireel/pull/123",
+                    ),
+                    deploy_status="pass",
+                    verify_status="pass",
+                    overall_health_status="pass",
+                )
+            )
+
+            result = runner.invoke(
+                main,
+                [
+                    "service",
+                    "inspect-data-freshness",
+                    "--state-dir",
+                    str(state_dir),
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["surface_count"], 3)
+        self.assertEqual(payload["missing_provenance_count"], 0)
+        self.assertEqual(
+            {surface["name"] for surface in payload["surfaces"]},
+            {
+                "verireel/prod/lane",
+                "verireel/testing/lane",
+                "verireel-testing/preview-verireel-testing-verireel-pr-123",
+            },
         )
 
     def test_driver_context_view_endpoint_rejects_unauthorized_context(self) -> None:


### PR DESCRIPTION
## Summary
- add a DataProvenance contract to lane and preview read models
- render compact verified/recorded/stale/missing/unsupported trust labels in the operator UI
- add service inspect-data-freshness as the first provenance readiness report
- add production-build assertion that dev fixture text is absent from shipped UI assets

## Verification
- uv run python -m unittest
- npx pnpm@10.10.0 --dir frontend validate
- git diff --check
- docker build -t launchplane-data-freshness-test .