### PR TITLE
Record preview inventory scan provenance

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -9427,15 +9427,21 @@ def _freshness_surface(
             "stale_after": "",
             "has_provenance": False,
         }
+    freshness_status = str(provenance.get("freshness_status") or "missing")
+    source_kind = str(provenance.get("source_kind") or "record")
+    source_record_id = str(provenance.get("source_record_id") or "")
+    has_provenance = freshness_status != "missing" and (
+        source_kind != "record" or bool(source_record_id)
+    )
     return {
         "name": name,
         "driver_id": driver_id,
-        "freshness_status": str(provenance.get("freshness_status") or "missing"),
-        "source_kind": str(provenance.get("source_kind") or "record"),
-        "source_record_id": str(provenance.get("source_record_id") or ""),
+        "freshness_status": freshness_status,
+        "source_kind": source_kind,
+        "source_record_id": source_record_id,
         "recorded_at": str(provenance.get("recorded_at") or ""),
         "stale_after": str(provenance.get("stale_after") or ""),
-        "has_provenance": True,
+        "has_provenance": has_provenance,
     }
 
 
@@ -9464,6 +9470,11 @@ def _build_data_freshness_report(
         context_name=preview_context_name,
     )
     preview_driver = _first_driver_payload(preview_view, driver_id="verireel")
+    inventory_provenance = (
+        preview_driver.get("preview_inventory_provenance")
+        if isinstance(preview_driver, dict)
+        else None
+    )
     preview_summaries = (
         preview_driver.get("preview_summaries") if isinstance(preview_driver, dict) else None
     )
@@ -9485,15 +9496,9 @@ def _build_data_freshness_report(
             _freshness_surface(
                 name=f"{preview_context_name}/preview-inventory",
                 driver_id="verireel",
-                raw_value={
-                    "provenance": {
-                        "source_kind": "record",
-                        "freshness_status": "missing",
-                        "source_record_id": "",
-                        "recorded_at": "",
-                        "stale_after": "",
-                    }
-                },
+                raw_value={"provenance": inventory_provenance}
+                if isinstance(inventory_provenance, dict)
+                else None,
             )
         )
 

--- a/control_plane/contracts/driver_descriptor.py
+++ b/control_plane/contracts/driver_descriptor.py
@@ -2,6 +2,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from control_plane.contracts.data_provenance import DataProvenance
 from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
 from control_plane.contracts.preview_summary import LaunchplanePreviewSummary
 
@@ -81,6 +82,7 @@ class DriverView(BaseModel):
     available_actions: tuple[DriverActionDescriptor, ...] = ()
     lane_summary: LaunchplaneLaneSummary | None = None
     preview_summaries: tuple[LaunchplanePreviewSummary, ...] = ()
+    preview_inventory_provenance: DataProvenance | None = None
 
 
 class DriverContextView(BaseModel):

--- a/control_plane/contracts/preview_inventory_scan_record.py
+++ b/control_plane/contracts/preview_inventory_scan_record.py
@@ -1,0 +1,46 @@
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+PreviewInventoryScanStatus = Literal["pass", "fail"]
+
+
+class PreviewInventoryScanRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    scan_id: str
+    context: str
+    scanned_at: str
+    source: str
+    status: PreviewInventoryScanStatus
+    preview_count: int = Field(ge=0)
+    preview_slugs: tuple[str, ...] = ()
+    error_message: str = ""
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "PreviewInventoryScanRecord":
+        if not self.scan_id.strip():
+            raise ValueError("preview inventory scan record requires scan_id")
+        if not self.context.strip():
+            raise ValueError("preview inventory scan record requires context")
+        if not self.scanned_at.strip():
+            raise ValueError("preview inventory scan record requires scanned_at")
+        if not self.source.strip():
+            raise ValueError("preview inventory scan record requires source")
+        if self.preview_count != len(self.preview_slugs):
+            raise ValueError("preview inventory scan record preview_count must match preview_slugs")
+        return self
+
+
+def build_preview_inventory_scan_id(*, context_name: str, scanned_at: str) -> str:
+    normalized_timestamp = (
+        scanned_at.strip()
+        .replace(":", "")
+        .replace("-", "")
+        .replace(".", "")
+        .replace("+", "")
+        .replace("Z", "Z")
+    )
+    return f"preview-inventory-scan-{context_name}-{normalized_timestamp}"

--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -426,6 +426,46 @@ def _preview_provenance(summary: LaunchplanePreviewSummary) -> DataProvenance:
     )
 
 
+def _preview_inventory_provenance(
+    *,
+    record_store: object,
+    context_name: str,
+    preview_summaries: tuple[LaunchplanePreviewSummary, ...],
+) -> DataProvenance:
+    if hasattr(record_store, "list_preview_inventory_scan_records"):
+        scans = getattr(record_store, "list_preview_inventory_scan_records")(
+            context_name=context_name,
+            limit=1,
+        )
+        latest_scan = next(iter(scans), None)
+        if latest_scan is not None:
+            status, stale_after = _freshness_status(
+                recorded_at=latest_scan.scanned_at,
+                stale_after=PREVIEW_STALE_AFTER,
+                verified=latest_scan.status == "pass",
+            )
+            return DataProvenance(
+                source_kind="record",
+                source_record_id=latest_scan.scan_id,
+                recorded_at=latest_scan.scanned_at,
+                refreshed_at=latest_scan.scanned_at,
+                freshness_status=status,
+                stale_after=stale_after,
+                detail=(
+                    "Latest Launchplane preview inventory scan; "
+                    f"{latest_scan.preview_count} preview(s) observed."
+                ),
+            )
+    latest_preview = next(iter(preview_summaries), None)
+    if latest_preview is not None:
+        return latest_preview.provenance
+    return DataProvenance(
+        source_kind="record",
+        freshness_status="missing",
+        detail="Launchplane has not recorded a preview inventory scan for this context.",
+    )
+
+
 def _read_lane_summary(
     *, record_store: object, context_name: str, instance_name: str
 ) -> LaunchplaneLaneSummary | None:
@@ -562,6 +602,13 @@ def build_driver_context_view(
                 record_store=record_store,
                 context_name=context_name,
             )
+        preview_inventory_provenance = None
+        if descriptor.driver_id == "verireel":
+            preview_inventory_provenance = _preview_inventory_provenance(
+                record_store=record_store,
+                context_name=context_name,
+                preview_summaries=preview_summaries,
+            )
         drivers.append(
             DriverView(
                 driver_id=descriptor.driver_id,
@@ -569,6 +616,7 @@ def build_driver_context_view(
                 available_actions=descriptor.actions,
                 lane_summary=lane_summary,
                 preview_summaries=preview_summaries,
+                preview_inventory_provenance=preview_inventory_provenance,
             )
         )
     return DriverContextView(context=context_name, instance=instance_name, drivers=tuple(drivers))

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -31,6 +31,10 @@ from control_plane.contracts.preview_mutation_request import (
     PreviewGenerationMutationRequest,
     PreviewMutationRequest,
 )
+from control_plane.contracts.preview_inventory_scan_record import (
+    PreviewInventoryScanRecord,
+    build_preview_inventory_scan_id,
+)
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.drivers.registry import (
     build_driver_context_view,
@@ -1073,6 +1077,31 @@ def _request_launchplane_self_deploy(
             if previous_env_map.get(env_key, "") != request.oauth_env[env_key]
         ),
     }
+
+
+def _write_preview_inventory_scan_if_supported(
+    *,
+    record_store: object,
+    result: VeriReelPreviewInventoryResult,
+) -> None:
+    if not hasattr(record_store, "write_preview_inventory_scan_record"):
+        return
+    scanned_at = _utc_now_timestamp()
+    preview_slugs = tuple(item.previewSlug for item in result.previews)
+    getattr(record_store, "write_preview_inventory_scan_record")(
+        PreviewInventoryScanRecord(
+            scan_id=build_preview_inventory_scan_id(
+                context_name=result.context,
+                scanned_at=scanned_at,
+            ),
+            context=result.context,
+            scanned_at=scanned_at,
+            source="verireel-preview-inventory",
+            status="pass",
+            preview_count=len(preview_slugs),
+            preview_slugs=preview_slugs,
+        )
+    )
 
 
 def create_launchplane_service_app(
@@ -2447,6 +2476,10 @@ def create_launchplane_service_app(
                 driver_result = execute_verireel_preview_inventory(
                     control_plane_root=resolved_root,
                     request=request.inventory,
+                )
+                _write_preview_inventory_scan_if_supported(
+                    record_store=record_store,
+                    result=driver_result,
                 )
                 result = {}
             elif path == "/v1/drivers/verireel/preview-destroy":

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -118,6 +118,7 @@ from control_plane.workflows.verireel_prod_rollback import (
 )
 from control_plane.workflows.verireel_preview_driver import (
     VeriReelPreviewDestroyRequest,
+    VeriReelPreviewInventoryResult,
     VeriReelPreviewInventoryRequest,
     VeriReelPreviewRefreshRequest,
     execute_verireel_preview_destroy,

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -13,6 +13,7 @@ from control_plane.contracts.idempotency_record import build_launchplane_idempot
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.preview_enablement_record import PreviewEnablementRecord
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
+from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
@@ -303,6 +304,27 @@ class FilesystemRecordStore:
             if not preview_id or record.preview_id == preview_id
         ]
         records.sort(key=lambda record: (record.sequence, record.generation_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def write_preview_inventory_scan_record(self, record: PreviewInventoryScanRecord) -> Path:
+        return self._write_model("launchplane_preview_inventory_scans", record.scan_id, record)
+
+    def list_preview_inventory_scan_records(
+        self,
+        *,
+        context_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[PreviewInventoryScanRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                PreviewInventoryScanRecord, "launchplane_preview_inventory_scans"
+            )
+            if not context_name or record.context == context_name
+        ]
+        records.sort(key=lambda record: (record.scanned_at, record.scan_id), reverse=True)
         if limit is not None:
             records = records[:limit]
         return tuple(records)

--- a/control_plane/storage/migrations/versions/b3c5d7e9f1a2_add_preview_inventory_scans.py
+++ b/control_plane/storage/migrations/versions/b3c5d7e9f1a2_add_preview_inventory_scans.py
@@ -1,0 +1,50 @@
+"""add preview inventory scans
+
+Revision ID: b3c5d7e9f1a2
+Revises: a2b4c6d8e9f0
+Create Date: 2026-04-29 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "b3c5d7e9f1a2"
+down_revision: str | None = "a2b4c6d8e9f0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "launchplane_preview_inventory_scans",
+        sa.Column("scan_id", sa.String(), nullable=False),
+        sa.Column("context", sa.String(), nullable=False),
+        sa.Column("scanned_at", sa.String(), nullable=False),
+        sa.Column("source", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("preview_count", sa.Integer(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("scan_id"),
+    )
+    op.create_index(
+        "launchplane_preview_inventory_scans_context_idx",
+        "launchplane_preview_inventory_scans",
+        ["context", sa.text("scanned_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "launchplane_preview_inventory_scans_context_idx",
+        table_name="launchplane_preview_inventory_scans",
+    )
+    op.drop_table("launchplane_preview_inventory_scans")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -20,6 +20,7 @@ from control_plane.contracts.idempotency_record import build_launchplane_idempot
 from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
+from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.preview_summary import LaunchplanePreviewSummary
 from control_plane.contracts.promotion_record import PromotionRecord
@@ -174,6 +175,25 @@ class LaunchplanePreviewGenerationRow(Base):
     requested_at: Mapped[str] = mapped_column(String, nullable=False)
     finished_at: Mapped[str] = mapped_column(String, nullable=False)
     artifact_id: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplanePreviewInventoryScanRow(Base):
+    __tablename__ = "launchplane_preview_inventory_scans"
+    __table_args__ = (
+        Index(
+            "launchplane_preview_inventory_scans_context_idx",
+            "context",
+            desc("scanned_at"),
+        ),
+    )
+
+    scan_id: Mapped[str] = mapped_column(String, primary_key=True)
+    context: Mapped[str] = mapped_column(String, nullable=False)
+    scanned_at: Mapped[str] = mapped_column(String, nullable=False)
+    source: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    preview_count: Mapped[int] = mapped_column(Integer, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -860,6 +880,39 @@ class PostgresRecordStore(HumanSessionStore):
             limit=limit,
         )
 
+    def write_preview_inventory_scan_record(self, record: PreviewInventoryScanRecord) -> None:
+        self._write_row(
+            LaunchplanePreviewInventoryScanRow(
+                scan_id=record.scan_id,
+                context=record.context,
+                scanned_at=record.scanned_at,
+                source=record.source,
+                status=record.status,
+                preview_count=record.preview_count,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def list_preview_inventory_scan_records(
+        self,
+        *,
+        context_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[PreviewInventoryScanRecord, ...]:
+        filters: list[object] = []
+        if context_name:
+            filters.append(LaunchplanePreviewInventoryScanRow.context == context_name)
+        return self._list_models(
+            model_type=PreviewInventoryScanRecord,
+            orm_model=LaunchplanePreviewInventoryScanRow,
+            filters=filters,
+            order_by=(
+                LaunchplanePreviewInventoryScanRow.scanned_at.desc(),
+                LaunchplanePreviewInventoryScanRow.scan_id.desc(),
+            ),
+            limit=limit,
+        )
+
     def read_preview_summary(
         self,
         *,
@@ -1337,6 +1390,7 @@ class PostgresRecordStore(HumanSessionStore):
             "odoo_instance_overrides": 0,
             "preview_records": 0,
             "preview_generations": 0,
+            "preview_inventory_scans": 0,
             "release_tuples": 0,
         }
         for record in filesystem_store.list_artifact_manifests():
@@ -1363,6 +1417,10 @@ class PostgresRecordStore(HumanSessionStore):
         for record in filesystem_store.list_preview_generation_records():
             self.write_preview_generation_record(record)
             counts["preview_generations"] += 1
+        if hasattr(filesystem_store, "list_preview_inventory_scan_records"):
+            for record in filesystem_store.list_preview_inventory_scan_records():
+                self.write_preview_inventory_scan_record(record)
+                counts["preview_inventory_scans"] += 1
         for record in filesystem_store.list_release_tuple_records():
             self.write_release_tuple_record(record)
             counts["release_tuples"] += 1

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -324,6 +324,7 @@ export function App() {
               <PreviewInventory
                 driver={currentDriver ?? null}
                 previews={previewDriverView?.preview_summaries ?? []}
+                inventoryProvenance={previewDriverView?.preview_inventory_provenance ?? null}
                 loading={loading}
               />
               <ActionList actions={actions} nextAction={nextAction} loading={loading} onAction={setReviewAction} />
@@ -637,10 +638,12 @@ function PromotionBridge({
 function PreviewInventory({
   driver,
   previews,
+  inventoryProvenance,
   loading
 }: {
   driver: DriverDescriptor | null;
   previews: PreviewSummary[];
+  inventoryProvenance: DataProvenance | null;
   loading: boolean;
 }) {
   const exposesPreviews = Boolean(
@@ -662,7 +665,7 @@ function PreviewInventory({
         title={exposesPreviews ? "Preview inventory" : "Previews not exposed"}
         right={(
           <div className="panel-badges">
-            <TrustBadge provenance={previewInventoryProvenance(exposesPreviews, latestPreview)} />
+            <TrustBadge provenance={previewInventoryProvenance(exposesPreviews, latestPreview, inventoryProvenance)} />
             {exposesPreviews ? <span className="count-chip">{previews.length} active</span> : null}
           </div>
         )}
@@ -725,7 +728,11 @@ function TrustBadge({ provenance, compact = false }: { provenance: DataProvenanc
   );
 }
 
-function previewInventoryProvenance(exposesPreviews: boolean, latestPreview: PreviewSummary | undefined): DataProvenance {
+function previewInventoryProvenance(
+  exposesPreviews: boolean,
+  latestPreview: PreviewSummary | undefined,
+  inventoryProvenance: DataProvenance | null
+): DataProvenance {
   if (!exposesPreviews) {
     return {
       source_kind: "unsupported",
@@ -736,6 +743,9 @@ function previewInventoryProvenance(exposesPreviews: boolean, latestPreview: Pre
       stale_after: "",
       detail: "Driver does not expose preview lifecycle."
     };
+  }
+  if (inventoryProvenance) {
+    return inventoryProvenance;
   }
   if (!latestPreview) {
     return {
@@ -1029,10 +1039,10 @@ function StateFixtureGallery({ actions }: { actions: DriverActionDescriptor[] })
           <LanePanel title="Failed testing lane" laneKind="testing" lane={failedTesting} loading={false} />
         </div>
         <div className="fixture-card">
-          <PreviewInventory driver={FIXTURE_VERIREEL_DRIVER} previews={[]} loading={false} />
+          <PreviewInventory driver={FIXTURE_VERIREEL_DRIVER} previews={[]} inventoryProvenance={null} loading={false} />
         </div>
         <div className="fixture-card">
-          <PreviewInventory driver={FIXTURE_ODOO_DRIVER} previews={[]} loading={false} />
+          <PreviewInventory driver={FIXTURE_ODOO_DRIVER} previews={[]} inventoryProvenance={null} loading={false} />
         </div>
       </div>
     </section>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -209,6 +209,7 @@ export interface DriverView {
   available_actions: DriverActionDescriptor[];
   lane_summary?: LaneSummary | null;
   preview_summaries: PreviewSummary[];
+  preview_inventory_provenance?: DataProvenance | null;
 }
 
 export interface DriverContextView {

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -28,6 +28,7 @@ from control_plane.contracts.preview_generation_record import (
     PreviewGenerationRecord,
     PreviewPullRequestSummary,
 )
+from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
@@ -669,6 +670,49 @@ class PostgresRecordStoreTests(unittest.TestCase):
         self.assertEqual(len(listed_summaries[0].recent_generations), 1)
         self.assertEqual(listed_summaries[0].latest_generation.sequence, 2)
 
+    def test_preview_inventory_scan_records_round_trip(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_preview_inventory_scan_record(
+                PreviewInventoryScanRecord(
+                    scan_id="preview-inventory-scan-verireel-testing-20260420T100500Z",
+                    context="verireel-testing",
+                    scanned_at="2026-04-20T10:05:00Z",
+                    source="verireel-preview-inventory",
+                    status="pass",
+                    preview_count=2,
+                    preview_slugs=("pr-123", "pr-124"),
+                )
+            )
+            store.write_preview_inventory_scan_record(
+                PreviewInventoryScanRecord(
+                    scan_id="preview-inventory-scan-verireel-testing-20260420T100600Z",
+                    context="verireel-testing",
+                    scanned_at="2026-04-20T10:06:00Z",
+                    source="verireel-preview-inventory",
+                    status="pass",
+                    preview_count=0,
+                    preview_slugs=(),
+                )
+            )
+            listed_records = store.list_preview_inventory_scan_records(
+                context_name="verireel-testing",
+                limit=1,
+            )
+            store.close()
+
+        self.assertEqual(len(listed_records), 1)
+        self.assertEqual(
+            listed_records[0].scan_id,
+            "preview-inventory-scan-verireel-testing-20260420T100600Z",
+        )
+        self.assertEqual(listed_records[0].preview_count, 0)
+
     def test_write_and_list_dokploy_target_id_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(
@@ -958,6 +1002,17 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     preview_id="preview-verireel-testing-verireel-pr-123",
                 )
             )
+            filesystem_store.write_preview_inventory_scan_record(
+                PreviewInventoryScanRecord(
+                    scan_id="preview-inventory-scan-verireel-testing-20260420T100500Z",
+                    context="verireel-testing",
+                    scanned_at="2026-04-20T10:05:00Z",
+                    source="verireel-preview-inventory",
+                    status="pass",
+                    preview_count=1,
+                    preview_slugs=("pr-123",),
+                )
+            )
             filesystem_store.write_release_tuple_record(_release_tuple_record())
 
             counts = store.import_core_records_from_filesystem(filesystem_store)
@@ -972,6 +1027,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     "odoo_instance_overrides": 1,
                     "preview_records": 1,
                     "preview_generations": 1,
+                    "preview_inventory_scans": 1,
                     "release_tuples": 1,
                 },
             )
@@ -986,5 +1042,12 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     "preview-verireel-testing-verireel-pr-123-generation-0001"
                 ).state,
                 "ready",
+            )
+            self.assertEqual(
+                store.list_preview_inventory_scan_records(
+                    context_name="verireel-testing",
+                    limit=1,
+                )[0].scan_id,
+                "preview-inventory-scan-verireel-testing-20260420T100500Z",
             )
             store.close()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -22,6 +22,7 @@ from control_plane.contracts.preview_generation_record import (
     PreviewGenerationRecord,
     PreviewPullRequestSummary,
 )
+from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
@@ -1119,6 +1120,48 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 "verireel-testing/preview-verireel-testing-verireel-pr-123",
             },
         )
+
+    def test_data_freshness_report_uses_empty_preview_inventory_scan(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_preview_inventory_scan_record(
+                PreviewInventoryScanRecord(
+                    scan_id="preview-inventory-scan-verireel-testing-20260420T100500Z",
+                    context="verireel-testing",
+                    scanned_at="2026-04-20T10:05:00Z",
+                    source="verireel-preview-inventory",
+                    status="pass",
+                    preview_count=0,
+                    preview_slugs=(),
+                )
+            )
+
+            result = runner.invoke(
+                main,
+                [
+                    "service",
+                    "inspect-data-freshness",
+                    "--state-dir",
+                    str(state_dir),
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 1, msg=result.output)
+        payload = json.loads(result.output.split("\nError:", maxsplit=1)[0])
+        self.assertEqual(payload["status"], "rejected")
+        preview_surface = next(
+            surface
+            for surface in payload["surfaces"]
+            if surface["name"] == "verireel-testing/preview-inventory"
+        )
+        self.assertTrue(preview_surface["has_provenance"])
+        self.assertEqual(
+            preview_surface["source_record_id"],
+            "preview-inventory-scan-verireel-testing-20260420T100500Z",
+        )
+        self.assertEqual(payload["missing_provenance_count"], 2)
 
     def test_driver_context_view_endpoint_rejects_unauthorized_context(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -2402,6 +2445,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(payload["status"], "accepted")
             self.assertEqual(payload["result"]["previews"][0]["previewSlug"], "pr-42")
             execute_mock.assert_called_once()
+            scan_records = FilesystemRecordStore(
+                state_dir=root / "state"
+            ).list_preview_inventory_scan_records(context_name="verireel-testing")
+
+            self.assertEqual(len(scan_records), 1)
+            self.assertEqual(scan_records[0].preview_count, 1)
+            self.assertEqual(scan_records[0].preview_slugs, ("pr-42",))
 
     def test_verireel_preview_inventory_driver_does_not_replay_cached_inventory(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add durable preview inventory scan records to filesystem and Postgres storage
- write a scan record whenever the authorized VeriReel preview inventory route asks the provider
- surface scan provenance in the driver view, UI trust badge, and data freshness report so empty inventory can be verified instead of ambiguous

## Verification
- uv run python -m unittest
- npx pnpm@10.10.0 --dir frontend validate
- git diff --check
- docker build -t launchplane-preview-inventory-scan-test .
- browser smoke on /ui/?fixtures=1