### PR TITLE
Add report-only preview lifecycle planning

### DIFF
--- a/config/launchplane-authz.toml
+++ b/config/launchplane-authz.toml
@@ -22,7 +22,7 @@ workflow_refs = [
 event_names = ["pull_request"]
 products = ["verireel"]
 contexts = ["verireel-testing"]
-actions = ["verireel_preview_inventory.read", "verireel_preview_destroy.execute", "preview_destroyed.write"]
+actions = ["verireel_preview_inventory.read", "verireel_preview_destroy.execute", "preview_destroyed.write", "preview_lifecycle.plan"]
 
 [[github_actions]]
 repository = "cbusillo/verireel"
@@ -32,7 +32,7 @@ workflow_refs = [
 event_names = ["schedule", "workflow_dispatch"]
 products = ["verireel"]
 contexts = ["verireel-testing"]
-actions = ["verireel_preview_inventory.read", "verireel_preview_destroy.execute", "preview_destroyed.write"]
+actions = ["verireel_preview_inventory.read", "verireel_preview_destroy.execute", "preview_destroyed.write", "preview_lifecycle.plan"]
 
 [[github_actions]]
 repository = "cbusillo/verireel"

--- a/config/launchplane-authz.toml.example
+++ b/config/launchplane-authz.toml.example
@@ -21,7 +21,7 @@ workflow_refs = [
 event_names = ["pull_request"]
 products = ["verireel"]
 contexts = ["verireel-testing"]
-actions = ["verireel_preview_inventory.read", "verireel_preview_destroy.execute", "preview_destroyed.write"]
+actions = ["verireel_preview_inventory.read", "verireel_preview_destroy.execute", "preview_destroyed.write", "preview_lifecycle.plan"]
 
 [[github_actions]]
 repository = "example-org/verireel"
@@ -31,7 +31,7 @@ workflow_refs = [
 event_names = ["schedule", "workflow_dispatch"]
 products = ["verireel"]
 contexts = ["verireel-testing"]
-actions = ["verireel_preview_inventory.read", "verireel_preview_destroy.execute", "preview_destroyed.write"]
+actions = ["verireel_preview_inventory.read", "verireel_preview_destroy.execute", "preview_destroyed.write", "preview_lifecycle.plan"]
 
 [[github_actions]]
 repository = "example-org/verireel"

--- a/control_plane/contracts/preview_lifecycle_plan_record.py
+++ b/control_plane/contracts/preview_lifecycle_plan_record.py
@@ -1,0 +1,73 @@
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+PreviewLifecyclePlanStatus = Literal["pass", "missing_inventory", "fail"]
+
+
+class PreviewLifecycleDesiredPreview(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    preview_slug: str
+    anchor_repo: str = ""
+    anchor_pr_number: int | None = Field(default=None, ge=1)
+    anchor_pr_url: str = ""
+    head_sha: str = ""
+
+    @model_validator(mode="after")
+    def _validate_preview(self) -> "PreviewLifecycleDesiredPreview":
+        if not self.preview_slug.strip():
+            raise ValueError("preview lifecycle desired preview requires preview_slug")
+        return self
+
+
+class PreviewLifecyclePlanRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    plan_id: str
+    product: str
+    context: str
+    planned_at: str
+    source: str
+    status: PreviewLifecyclePlanStatus
+    inventory_scan_id: str = ""
+    desired_previews: tuple[PreviewLifecycleDesiredPreview, ...] = ()
+    desired_slugs: tuple[str, ...] = ()
+    actual_slugs: tuple[str, ...] = ()
+    keep_slugs: tuple[str, ...] = ()
+    orphaned_slugs: tuple[str, ...] = ()
+    missing_slugs: tuple[str, ...] = ()
+    error_message: str = ""
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "PreviewLifecyclePlanRecord":
+        if not self.plan_id.strip():
+            raise ValueError("preview lifecycle plan requires plan_id")
+        if not self.product.strip():
+            raise ValueError("preview lifecycle plan requires product")
+        if not self.context.strip():
+            raise ValueError("preview lifecycle plan requires context")
+        if not self.planned_at.strip():
+            raise ValueError("preview lifecycle plan requires planned_at")
+        if not self.source.strip():
+            raise ValueError("preview lifecycle plan requires source")
+        desired_from_previews = tuple(preview.preview_slug for preview in self.desired_previews)
+        if desired_from_previews and desired_from_previews != self.desired_slugs:
+            raise ValueError("preview lifecycle plan desired_slugs must match desired_previews")
+        if self.status == "pass" and not self.inventory_scan_id.strip():
+            raise ValueError("passing preview lifecycle plan requires inventory_scan_id")
+        return self
+
+
+def build_preview_lifecycle_plan_id(*, context_name: str, planned_at: str) -> str:
+    normalized_timestamp = (
+        planned_at.strip()
+        .replace(":", "")
+        .replace("-", "")
+        .replace(".", "")
+        .replace("+", "")
+        .replace("Z", "Z")
+    )
+    return f"preview-lifecycle-plan-{context_name}-{normalized_timestamp}"

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -35,6 +35,10 @@ from control_plane.contracts.preview_inventory_scan_record import (
     PreviewInventoryScanRecord,
     build_preview_inventory_scan_id,
 )
+from control_plane.contracts.preview_lifecycle_plan_record import (
+    PreviewLifecycleDesiredPreview,
+    PreviewLifecyclePlanRecord,
+)
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.drivers.registry import (
     build_driver_context_view,
@@ -70,6 +74,7 @@ from control_plane.workflows.evidence_ingestion import (
     apply_deployment_evidence,
     apply_promotion_evidence,
 )
+from control_plane.workflows.preview_lifecycle import build_preview_lifecycle_plan
 from control_plane.workflows.odoo_artifact_publish import (
     OdooArtifactPublishEvidenceRequest,
     OdooArtifactPublishInputsRequest,
@@ -203,6 +208,26 @@ class BackupGateEvidenceEnvelope(BaseModel):
     def _validate_alignment(self) -> "BackupGateEvidenceEnvelope":
         if not self.product.strip():
             raise ValueError("backup gate evidence requires product")
+        return self
+
+
+class PreviewLifecyclePlanEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    context: str
+    desired_previews: tuple[PreviewLifecycleDesiredPreview, ...] = ()
+    source: str = "workflow"
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "PreviewLifecyclePlanEnvelope":
+        if not self.product.strip():
+            raise ValueError("preview lifecycle plan requires product")
+        if not self.context.strip():
+            raise ValueError("preview lifecycle plan requires context")
+        if not self.source.strip():
+            raise ValueError("preview lifecycle plan requires source")
         return self
 
 
@@ -787,6 +812,7 @@ def _accepted_payload(
                 "inventory_record_id",
                 "preview_id",
                 "preview_inventory_scan_id",
+                "preview_lifecycle_plan_id",
                 "generation_id",
                 "promotion_record_id",
                 "target_id",
@@ -1108,6 +1134,27 @@ def _write_preview_inventory_scan_if_supported(
     return scan_id
 
 
+def _latest_preview_inventory_scan(
+    *, record_store: object, context_name: str
+) -> PreviewInventoryScanRecord | None:
+    if not hasattr(record_store, "list_preview_inventory_scan_records"):
+        return None
+    scans = getattr(record_store, "list_preview_inventory_scan_records")(
+        context_name=context_name,
+        limit=1,
+    )
+    return next(iter(scans), None)
+
+
+def _write_preview_lifecycle_plan_if_supported(
+    *, record_store: object, record: PreviewLifecyclePlanRecord
+) -> str:
+    if not hasattr(record_store, "write_preview_lifecycle_plan_record"):
+        return ""
+    getattr(record_store, "write_preview_lifecycle_plan_record")(record)
+    return record.plan_id
+
+
 def create_launchplane_service_app(
     *,
     state_dir: Path,
@@ -1151,6 +1198,7 @@ def create_launchplane_service_app(
         "/v1/evidence/backup-gates",
         "/v1/evidence/previews/generations",
         "/v1/evidence/previews/destroyed",
+        "/v1/previews/lifecycle-plan",
         "/v1/evidence/promotions",
         "/v1/drivers/launchplane/self-deploy",
         "/v1/drivers/odoo/artifact-publish-inputs",
@@ -2603,6 +2651,56 @@ def create_launchplane_service_app(
                     preview_request=request.preview,
                     generation_request=request.generation,
                 )
+            elif path == "/v1/previews/lifecycle-plan":
+                request = PreviewLifecyclePlanEnvelope.model_validate(payload)
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="preview_lifecycle.plan",
+                    product=request.product,
+                    context=request.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot plan preview lifecycle for the requested"
+                                    " product/context."
+                                ),
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                driver_result = build_preview_lifecycle_plan(
+                    product=request.product,
+                    context=request.context,
+                    planned_at=_utc_now_timestamp(),
+                    source=request.source,
+                    desired_previews=request.desired_previews,
+                    latest_inventory_scan=_latest_preview_inventory_scan(
+                        record_store=record_store,
+                        context_name=request.context,
+                    ),
+                )
+                preview_lifecycle_plan_id = _write_preview_lifecycle_plan_if_supported(
+                    record_store=record_store,
+                    record=driver_result,
+                )
+                result = {"preview_lifecycle_plan_id": preview_lifecycle_plan_id}
             else:
                 request = PreviewDestroyedEvidenceEnvelope.model_validate(payload)
                 if not authz_policy.allows(

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -14,6 +14,7 @@ from control_plane.contracts.odoo_instance_override_record import OdooInstanceOv
 from control_plane.contracts.preview_enablement_record import PreviewEnablementRecord
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
 from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
+from control_plane.contracts.preview_lifecycle_plan_record import PreviewLifecyclePlanRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
@@ -325,6 +326,27 @@ class FilesystemRecordStore:
             if not context_name or record.context == context_name
         ]
         records.sort(key=lambda record: (record.scanned_at, record.scan_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def write_preview_lifecycle_plan_record(self, record: PreviewLifecyclePlanRecord) -> Path:
+        return self._write_model("launchplane_preview_lifecycle_plans", record.plan_id, record)
+
+    def list_preview_lifecycle_plan_records(
+        self,
+        *,
+        context_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[PreviewLifecyclePlanRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                PreviewLifecyclePlanRecord, "launchplane_preview_lifecycle_plans"
+            )
+            if not context_name or record.context == context_name
+        ]
+        records.sort(key=lambda record: (record.planned_at, record.plan_id), reverse=True)
         if limit is not None:
             records = records[:limit]
         return tuple(records)

--- a/control_plane/storage/migrations/versions/c4d6e8f0a1b2_add_preview_lifecycle_plans.py
+++ b/control_plane/storage/migrations/versions/c4d6e8f0a1b2_add_preview_lifecycle_plans.py
@@ -1,0 +1,50 @@
+"""add preview lifecycle plans
+
+Revision ID: c4d6e8f0a1b2
+Revises: b3c5d7e9f1a2
+Create Date: 2026-04-29 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "c4d6e8f0a1b2"
+down_revision: str | None = "b3c5d7e9f1a2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "launchplane_preview_lifecycle_plans",
+        sa.Column("plan_id", sa.String(), nullable=False),
+        sa.Column("product", sa.String(), nullable=False),
+        sa.Column("context", sa.String(), nullable=False),
+        sa.Column("planned_at", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("inventory_scan_id", sa.String(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("plan_id"),
+    )
+    op.create_index(
+        "launchplane_preview_lifecycle_plans_context_idx",
+        "launchplane_preview_lifecycle_plans",
+        ["context", sa.text("planned_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "launchplane_preview_lifecycle_plans_context_idx",
+        table_name="launchplane_preview_lifecycle_plans",
+    )
+    op.drop_table("launchplane_preview_lifecycle_plans")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -21,6 +21,7 @@ from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
 from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
+from control_plane.contracts.preview_lifecycle_plan_record import PreviewLifecyclePlanRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.preview_summary import LaunchplanePreviewSummary
 from control_plane.contracts.promotion_record import PromotionRecord
@@ -194,6 +195,25 @@ class LaunchplanePreviewInventoryScanRow(Base):
     source: Mapped[str] = mapped_column(String, nullable=False)
     status: Mapped[str] = mapped_column(String, nullable=False)
     preview_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplanePreviewLifecyclePlanRow(Base):
+    __tablename__ = "launchplane_preview_lifecycle_plans"
+    __table_args__ = (
+        Index(
+            "launchplane_preview_lifecycle_plans_context_idx",
+            "context",
+            desc("planned_at"),
+        ),
+    )
+
+    plan_id: Mapped[str] = mapped_column(String, primary_key=True)
+    product: Mapped[str] = mapped_column(String, nullable=False)
+    context: Mapped[str] = mapped_column(String, nullable=False)
+    planned_at: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    inventory_scan_id: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -913,6 +933,39 @@ class PostgresRecordStore(HumanSessionStore):
             limit=limit,
         )
 
+    def write_preview_lifecycle_plan_record(self, record: PreviewLifecyclePlanRecord) -> None:
+        self._write_row(
+            LaunchplanePreviewLifecyclePlanRow(
+                plan_id=record.plan_id,
+                product=record.product,
+                context=record.context,
+                planned_at=record.planned_at,
+                status=record.status,
+                inventory_scan_id=record.inventory_scan_id,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def list_preview_lifecycle_plan_records(
+        self,
+        *,
+        context_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[PreviewLifecyclePlanRecord, ...]:
+        filters: list[object] = []
+        if context_name:
+            filters.append(LaunchplanePreviewLifecyclePlanRow.context == context_name)
+        return self._list_models(
+            model_type=PreviewLifecyclePlanRecord,
+            orm_model=LaunchplanePreviewLifecyclePlanRow,
+            filters=filters,
+            order_by=(
+                LaunchplanePreviewLifecyclePlanRow.planned_at.desc(),
+                LaunchplanePreviewLifecyclePlanRow.plan_id.desc(),
+            ),
+            limit=limit,
+        )
+
     def read_preview_summary(
         self,
         *,
@@ -1391,6 +1444,7 @@ class PostgresRecordStore(HumanSessionStore):
             "preview_records": 0,
             "preview_generations": 0,
             "preview_inventory_scans": 0,
+            "preview_lifecycle_plans": 0,
             "release_tuples": 0,
         }
         for record in filesystem_store.list_artifact_manifests():
@@ -1421,6 +1475,10 @@ class PostgresRecordStore(HumanSessionStore):
             for record in filesystem_store.list_preview_inventory_scan_records():
                 self.write_preview_inventory_scan_record(record)
                 counts["preview_inventory_scans"] += 1
+        if hasattr(filesystem_store, "list_preview_lifecycle_plan_records"):
+            for record in filesystem_store.list_preview_lifecycle_plan_records():
+                self.write_preview_lifecycle_plan_record(record)
+                counts["preview_lifecycle_plans"] += 1
         for record in filesystem_store.list_release_tuple_records():
             self.write_release_tuple_record(record)
             counts["release_tuples"] += 1

--- a/control_plane/workflows/preview_lifecycle.py
+++ b/control_plane/workflows/preview_lifecycle.py
@@ -1,0 +1,58 @@
+from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
+from control_plane.contracts.preview_lifecycle_plan_record import (
+    PreviewLifecycleDesiredPreview,
+    PreviewLifecyclePlanRecord,
+    build_preview_lifecycle_plan_id,
+)
+
+
+def build_preview_lifecycle_plan(
+    *,
+    product: str,
+    context: str,
+    planned_at: str,
+    source: str,
+    desired_previews: tuple[PreviewLifecycleDesiredPreview, ...],
+    latest_inventory_scan: PreviewInventoryScanRecord | None,
+) -> PreviewLifecyclePlanRecord:
+    desired_by_slug = {
+        preview.preview_slug.strip(): preview.model_copy(
+            update={"preview_slug": preview.preview_slug.strip()}
+        )
+        for preview in desired_previews
+    }
+    desired_slugs = tuple(sorted(desired_by_slug))
+    normalized_desired_previews = tuple(desired_by_slug[slug] for slug in desired_slugs)
+    plan_id = build_preview_lifecycle_plan_id(context_name=context, planned_at=planned_at)
+    if latest_inventory_scan is None:
+        return PreviewLifecyclePlanRecord(
+            plan_id=plan_id,
+            product=product,
+            context=context,
+            planned_at=planned_at,
+            source=source,
+            status="missing_inventory",
+            desired_previews=normalized_desired_previews,
+            desired_slugs=desired_slugs,
+            error_message="Launchplane has not recorded a preview inventory scan for this context.",
+        )
+
+    actual_slugs = tuple(sorted(set(latest_inventory_scan.preview_slugs)))
+    desired_set = set(desired_slugs)
+    actual_set = set(actual_slugs)
+    return PreviewLifecyclePlanRecord(
+        plan_id=plan_id,
+        product=product,
+        context=context,
+        planned_at=planned_at,
+        source=source,
+        status="pass" if latest_inventory_scan.status == "pass" else "fail",
+        inventory_scan_id=latest_inventory_scan.scan_id,
+        desired_previews=normalized_desired_previews,
+        desired_slugs=desired_slugs,
+        actual_slugs=actual_slugs,
+        keep_slugs=tuple(sorted(desired_set & actual_set)),
+        orphaned_slugs=tuple(sorted(actual_set - desired_set)),
+        missing_slugs=tuple(sorted(desired_set - actual_set)),
+        error_message=latest_inventory_scan.error_message,
+    )

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -84,6 +84,7 @@ Current implementation scope:
 - `POST /v1/evidence/promotions`
 - `POST /v1/evidence/previews/generations`
 - `POST /v1/evidence/previews/destroyed`
+- `POST /v1/previews/lifecycle-plan`
 - `POST /v1/drivers/verireel/preview-refresh`
 - `POST /v1/drivers/verireel/preview-destroy`
 - `POST /v1/drivers/verireel/testing-deploy`
@@ -474,6 +475,14 @@ the app repo sends PR/image intent, Launchplane derives the live preview URL
 from `LAUNCHPLANE_PREVIEW_BASE_URL`, and evidence stores that returned URL with
 generation status and cleanup outcome.
 
+Launchplane now owns the first report-only preview lifecycle planning boundary:
+`POST /v1/previews/lifecycle-plan`. Product repos can send desired preview
+anchors while Launchplane compares them against the latest recorded provider
+inventory scan, writes a durable lifecycle plan, and returns keep/orphaned/missing
+sets without executing cleanup. This is the first extraction step toward a
+cross-repo preview system; product repos remain thin adapters for labels,
+artifact build facts, and product-specific health/config hints.
+
 ### VeriReel Preview Evidence Handoff
 
 VeriReel already computes the route, PR slug, image tags, and workflow run URL
@@ -481,11 +490,13 @@ inside `.github/workflows/preview-control-plane.yml` and
 `.github/workflows/preview-cleanup.yml`. The scheduled orphan backstop in
 `.github/workflows/preview-janitor.yml` should use the same Launchplane destroy
 and evidence contract rather than keeping a second repo-local teardown path.
-Launchplane's handoff contract should stay at that evidence and driver layer
-instead of asking VeriReel to adopt Launchplane-owned preview provisioning
-first. The target integration is OIDC-authenticated HTTP into Launchplane. The
-local CLI examples below exist only to pin the payload shape while the
-Launchplane service ingress is still under construction.
+Launchplane's handoff contract is moving from evidence-only toward reusable
+preview lifecycle ownership. The first safe step is report-only planning in
+Launchplane; cleanup execution and PR feedback ownership should move later after
+the durable plan record has proven useful. The target integration is
+OIDC-authenticated HTTP into Launchplane. The local CLI examples below exist only
+to pin the payload shape while the Launchplane service ingress continues to
+absorb the reusable lifecycle behavior.
 
 For a successful or failed preview refresh, emit two JSON payloads and hand
 them to Launchplane's preview-generation evidence ingress. The current local adapter

--- a/docs/records.md
+++ b/docs/records.md
@@ -382,6 +382,27 @@ state/
 - PR ingest and `launchplane-previews write-enablement` write the same typed record
   shape so webhook and non-webhook flows preserve comparable evidence.
 
+## Launchplane Preview Inventory Scan Record
+
+- One append-only record per provider inventory scan for a preview context.
+- Record the scan id, context, scanned timestamp, source, pass/fail status,
+  observed preview slugs, and failure message when the scan could not complete.
+- A zero-preview scan is valid evidence and should be distinguished from missing
+  inventory. Read models and readiness checks should use the latest scan to
+  decide whether an empty preview inventory is verified or unknown.
+
+## Launchplane Preview Lifecycle Plan Record
+
+- One append-only report-only decision record per preview lifecycle planning run.
+- Record the desired preview anchors submitted by a product repo, the latest
+  inventory scan used as current provider state, and the derived keep/orphaned/
+  missing slug sets.
+- The first implementation must not execute cleanup. It exists to move reusable
+  desired-vs-actual preview decisions into Launchplane before cleanup execution,
+  PR feedback, or scheduling are centralized.
+- Product repos should eventually submit thin desired-state adapters to this
+  boundary instead of each owning a separate preview janitor implementation.
+
 ## Inventory
 
 - Inventory records are keyed by environment.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -169,6 +169,7 @@ event_name: pull_request
 allowed product: verireel
 allowed contexts: verireel-testing
 allowed actions:
+  - preview_lifecycle.plan
   - verireel_preview_destroy.execute
   - preview_destroyed.write
 ```
@@ -256,6 +257,17 @@ writes, not on every possible operator action.
 - `POST /v1/evidence/previews/generations`
 - `POST /v1/evidence/previews/destroyed`
 
+### Preview lifecycle endpoints
+
+- `POST /v1/previews/lifecycle-plan`
+
+The first preview lifecycle endpoint is intentionally report-only. Product repos
+send desired preview anchors, Launchplane compares those desired previews with
+the latest recorded provider inventory scan, writes a durable lifecycle plan,
+and returns keep/orphaned/missing sets. It does not destroy previews. Cleanup
+execution and PR feedback ownership should move into Launchplane only after this
+durable decision record is proven by the VeriReel adapter.
+
 ### Operator read endpoints
 
 - `GET /v1/previews/{preview_id}`
@@ -304,6 +316,11 @@ The first explicit driver routes now in service are:
 - `POST /v1/drivers/verireel/preview-refresh`
 - `POST /v1/drivers/verireel/preview-inventory`
 - `POST /v1/drivers/verireel/preview-destroy`
+
+The product-neutral preview lifecycle route should become the common boundary
+for preview desired/current-state comparison. Product-specific driver routes can
+continue to perform provider runtime work, but repos should not each reimplement
+orphan detection once they can submit desired preview anchors to Launchplane.
 
 ### Driver discovery endpoints
 

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -29,6 +29,10 @@ from control_plane.contracts.preview_generation_record import (
     PreviewPullRequestSummary,
 )
 from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
+from control_plane.contracts.preview_lifecycle_plan_record import (
+    PreviewLifecycleDesiredPreview,
+    PreviewLifecyclePlanRecord,
+)
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
@@ -713,6 +717,43 @@ class PostgresRecordStoreTests(unittest.TestCase):
         )
         self.assertEqual(listed_records[0].preview_count, 0)
 
+    def test_preview_lifecycle_plan_records_round_trip(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_preview_lifecycle_plan_record(
+                PreviewLifecyclePlanRecord(
+                    plan_id="preview-lifecycle-plan-verireel-testing-20260420T100500Z",
+                    product="verireel",
+                    context="verireel-testing",
+                    planned_at="2026-04-20T10:05:00Z",
+                    source="preview-janitor",
+                    status="pass",
+                    inventory_scan_id="preview-inventory-scan-verireel-testing-20260420T100500Z",
+                    desired_previews=(PreviewLifecycleDesiredPreview(preview_slug="pr-123"),),
+                    desired_slugs=("pr-123",),
+                    actual_slugs=("pr-122", "pr-123"),
+                    keep_slugs=("pr-123",),
+                    orphaned_slugs=("pr-122",),
+                )
+            )
+            listed_records = store.list_preview_lifecycle_plan_records(
+                context_name="verireel-testing",
+                limit=1,
+            )
+            store.close()
+
+        self.assertEqual(len(listed_records), 1)
+        self.assertEqual(
+            listed_records[0].plan_id,
+            "preview-lifecycle-plan-verireel-testing-20260420T100500Z",
+        )
+        self.assertEqual(listed_records[0].orphaned_slugs, ("pr-122",))
+
     def test_write_and_list_dokploy_target_id_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(
@@ -1013,6 +1054,21 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     preview_slugs=("pr-123",),
                 )
             )
+            filesystem_store.write_preview_lifecycle_plan_record(
+                PreviewLifecyclePlanRecord(
+                    plan_id="preview-lifecycle-plan-verireel-testing-20260420T100600Z",
+                    product="verireel",
+                    context="verireel-testing",
+                    planned_at="2026-04-20T10:06:00Z",
+                    source="preview-janitor",
+                    status="pass",
+                    inventory_scan_id="preview-inventory-scan-verireel-testing-20260420T100500Z",
+                    desired_previews=(PreviewLifecycleDesiredPreview(preview_slug="pr-123"),),
+                    desired_slugs=("pr-123",),
+                    actual_slugs=("pr-123",),
+                    keep_slugs=("pr-123",),
+                )
+            )
             filesystem_store.write_release_tuple_record(_release_tuple_record())
 
             counts = store.import_core_records_from_filesystem(filesystem_store)
@@ -1028,6 +1084,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     "preview_records": 1,
                     "preview_generations": 1,
                     "preview_inventory_scans": 1,
+                    "preview_lifecycle_plans": 1,
                     "release_tuples": 1,
                 },
             )
@@ -1049,5 +1106,12 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     limit=1,
                 )[0].scan_id,
                 "preview-inventory-scan-verireel-testing-20260420T100500Z",
+            )
+            self.assertEqual(
+                store.list_preview_lifecycle_plan_records(
+                    context_name="verireel-testing",
+                    limit=1,
+                )[0].plan_id,
+                "preview-lifecycle-plan-verireel-testing-20260420T100600Z",
             )
             store.close()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2527,6 +2527,179 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(second_payload["result"]["previews"], [])
             self.assertEqual(execute_mock.call_count, 2)
 
+    def test_preview_lifecycle_plan_endpoint_records_report_only_plan(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_preview_inventory_scan_record(
+                PreviewInventoryScanRecord(
+                    scan_id="preview-inventory-scan-verireel-testing-20260429T192315Z",
+                    context="verireel-testing",
+                    scanned_at="2026-04-29T19:23:15Z",
+                    source="verireel-preview-inventory",
+                    status="pass",
+                    preview_count=2,
+                    preview_slugs=("pr-41", "pr-42"),
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-janitor.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel-testing"],
+                            "actions": ["preview_lifecycle.plan"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/preview-janitor.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/lifecycle-plan",
+                payload={
+                    "product": "verireel",
+                    "context": "verireel-testing",
+                    "source": "preview-janitor",
+                    "desired_previews": [
+                        {"preview_slug": "pr-42", "anchor_repo": "verireel", "anchor_pr_number": 42},
+                        {"preview_slug": "pr-43", "anchor_repo": "verireel", "anchor_pr_number": 43},
+                    ],
+                },
+            )
+
+            plan_records = FilesystemRecordStore(
+                state_dir=root / "state"
+            ).list_preview_lifecycle_plan_records(context_name="verireel-testing")
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(payload["records"]["preview_lifecycle_plan_id"], plan_records[0].plan_id)
+        self.assertEqual(
+            payload["result"]["inventory_scan_id"],
+            "preview-inventory-scan-verireel-testing-20260429T192315Z",
+        )
+        self.assertEqual(payload["result"]["keep_slugs"], ["pr-42"])
+        self.assertEqual(payload["result"]["orphaned_slugs"], ["pr-41"])
+        self.assertEqual(payload["result"]["missing_slugs"], ["pr-43"])
+        self.assertEqual(len(plan_records), 1)
+        self.assertEqual(plan_records[0].source, "preview-janitor")
+
+    def test_preview_lifecycle_plan_endpoint_rejects_unauthorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-janitor.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel-testing"],
+                            "actions": ["verireel_preview_inventory.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/preview-janitor.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/lifecycle-plan",
+                payload={
+                    "product": "verireel",
+                    "context": "verireel-testing",
+                    "desired_previews": [{"preview_slug": "pr-42"}],
+                },
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_preview_lifecycle_plan_endpoint_records_missing_inventory(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-janitor.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel-testing"],
+                            "actions": ["preview_lifecycle.plan"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/preview-janitor.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/lifecycle-plan",
+                payload={
+                    "product": "verireel",
+                    "context": "verireel-testing",
+                    "desired_previews": [{"preview_slug": "pr-42"}],
+                },
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["status"], "missing_inventory")
+        self.assertEqual(payload["result"]["orphaned_slugs"], [])
+        self.assertIn("has not recorded", payload["result"]["error_message"])
+
     def test_verireel_prod_deploy_driver_executes_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add durable preview lifecycle plan records and Postgres migration
- add report-only POST /v1/previews/lifecycle-plan to compare desired previews with latest inventory scan
- authorize preview_lifecycle.plan for VeriReel preview cleanup/janitor workflows
- document Launchplane-owned preview lifecycle centralization as the next reusable boundary

## Verification
- uv run --extra dev ruff check .
- uv run python -m unittest
- npx pnpm@10.10.0 --dir frontend validate
- git diff --check
- docker build -t launchplane-preview-lifecycle-plan-test .