### PR TITLE
Add preview lifecycle cleanup records

### DIFF
--- a/config/launchplane-authz.toml
+++ b/config/launchplane-authz.toml
@@ -22,7 +22,7 @@ workflow_refs = [
 event_names = ["pull_request"]
 products = ["verireel"]
 contexts = ["verireel-testing"]
-actions = ["verireel_preview_inventory.read", "verireel_preview_destroy.execute", "preview_destroyed.write", "preview_lifecycle.plan"]
+actions = ["verireel_preview_inventory.read", "verireel_preview_destroy.execute", "preview_destroyed.write", "preview_lifecycle.plan", "preview_lifecycle.cleanup"]
 
 [[github_actions]]
 repository = "cbusillo/verireel"
@@ -32,7 +32,7 @@ workflow_refs = [
 event_names = ["schedule", "workflow_dispatch"]
 products = ["verireel"]
 contexts = ["verireel-testing"]
-actions = ["verireel_preview_inventory.read", "verireel_preview_destroy.execute", "preview_destroyed.write", "preview_lifecycle.plan"]
+actions = ["verireel_preview_inventory.read", "verireel_preview_destroy.execute", "preview_destroyed.write", "preview_lifecycle.plan", "preview_lifecycle.cleanup"]
 
 [[github_actions]]
 repository = "cbusillo/verireel"

--- a/config/launchplane-authz.toml.example
+++ b/config/launchplane-authz.toml.example
@@ -21,7 +21,7 @@ workflow_refs = [
 event_names = ["pull_request"]
 products = ["verireel"]
 contexts = ["verireel-testing"]
-actions = ["verireel_preview_inventory.read", "verireel_preview_destroy.execute", "preview_destroyed.write", "preview_lifecycle.plan"]
+actions = ["verireel_preview_inventory.read", "verireel_preview_destroy.execute", "preview_destroyed.write", "preview_lifecycle.plan", "preview_lifecycle.cleanup"]
 
 [[github_actions]]
 repository = "example-org/verireel"
@@ -31,7 +31,7 @@ workflow_refs = [
 event_names = ["schedule", "workflow_dispatch"]
 products = ["verireel"]
 contexts = ["verireel-testing"]
-actions = ["verireel_preview_inventory.read", "verireel_preview_destroy.execute", "preview_destroyed.write", "preview_lifecycle.plan"]
+actions = ["verireel_preview_inventory.read", "verireel_preview_destroy.execute", "preview_destroyed.write", "preview_lifecycle.plan", "preview_lifecycle.cleanup"]
 
 [[github_actions]]
 repository = "example-org/verireel"

--- a/control_plane/contracts/preview_lifecycle_cleanup_record.py
+++ b/control_plane/contracts/preview_lifecycle_cleanup_record.py
@@ -1,0 +1,75 @@
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+PreviewLifecycleCleanupStatus = Literal["report_only", "pass", "fail", "blocked"]
+PreviewLifecycleCleanupResultStatus = Literal["planned", "destroyed", "failed", "blocked"]
+
+
+class PreviewLifecycleCleanupResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    preview_slug: str
+    anchor_repo: str = ""
+    anchor_pr_number: int | None = Field(default=None, ge=1)
+    status: PreviewLifecycleCleanupResultStatus
+    application_name: str = ""
+    application_id: str = ""
+    preview_url: str = ""
+    error_message: str = ""
+
+    @model_validator(mode="after")
+    def _validate_result(self) -> "PreviewLifecycleCleanupResult":
+        if not self.preview_slug.strip():
+            raise ValueError("preview lifecycle cleanup result requires preview_slug")
+        return self
+
+
+class PreviewLifecycleCleanupRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    cleanup_id: str
+    product: str
+    context: str
+    plan_id: str
+    inventory_scan_id: str = ""
+    requested_at: str
+    source: str
+    apply: bool = False
+    status: PreviewLifecycleCleanupStatus
+    planned_slugs: tuple[str, ...] = ()
+    destroyed_slugs: tuple[str, ...] = ()
+    failed_slugs: tuple[str, ...] = ()
+    blocked_slugs: tuple[str, ...] = ()
+    results: tuple[PreviewLifecycleCleanupResult, ...] = ()
+    error_message: str = ""
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "PreviewLifecycleCleanupRecord":
+        if not self.cleanup_id.strip():
+            raise ValueError("preview lifecycle cleanup requires cleanup_id")
+        if not self.product.strip():
+            raise ValueError("preview lifecycle cleanup requires product")
+        if not self.context.strip():
+            raise ValueError("preview lifecycle cleanup requires context")
+        if not self.plan_id.strip():
+            raise ValueError("preview lifecycle cleanup requires plan_id")
+        if not self.requested_at.strip():
+            raise ValueError("preview lifecycle cleanup requires requested_at")
+        if not self.source.strip():
+            raise ValueError("preview lifecycle cleanup requires source")
+        return self
+
+
+def build_preview_lifecycle_cleanup_id(*, context_name: str, requested_at: str) -> str:
+    normalized_timestamp = (
+        requested_at.strip()
+        .replace(":", "")
+        .replace("-", "")
+        .replace(".", "")
+        .replace("+", "")
+        .replace("Z", "Z")
+    )
+    return f"preview-lifecycle-cleanup-{context_name}-{normalized_timestamp}"

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -39,6 +39,7 @@ from control_plane.contracts.preview_lifecycle_plan_record import (
     PreviewLifecycleDesiredPreview,
     PreviewLifecyclePlanRecord,
 )
+from control_plane.contracts.preview_lifecycle_cleanup_record import PreviewLifecycleCleanupRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.drivers.registry import (
     build_driver_context_view,
@@ -75,6 +76,9 @@ from control_plane.workflows.evidence_ingestion import (
     apply_promotion_evidence,
 )
 from control_plane.workflows.preview_lifecycle import build_preview_lifecycle_plan
+from control_plane.workflows.preview_lifecycle_cleanup import (
+    build_preview_lifecycle_cleanup_record,
+)
 from control_plane.workflows.odoo_artifact_publish import (
     OdooArtifactPublishEvidenceRequest,
     OdooArtifactPublishInputsRequest,
@@ -228,6 +232,33 @@ class PreviewLifecyclePlanEnvelope(BaseModel):
             raise ValueError("preview lifecycle plan requires context")
         if not self.source.strip():
             raise ValueError("preview lifecycle plan requires source")
+        return self
+
+
+class PreviewLifecycleCleanupEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    context: str
+    plan_id: str
+    source: str = "workflow"
+    apply: bool = False
+    destroy_reason: str = "preview_lifecycle_cleanup"
+    timeout_seconds: int = Field(default=300, ge=1)
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "PreviewLifecycleCleanupEnvelope":
+        if not self.product.strip():
+            raise ValueError("preview lifecycle cleanup requires product")
+        if not self.context.strip():
+            raise ValueError("preview lifecycle cleanup requires context")
+        if not self.plan_id.strip():
+            raise ValueError("preview lifecycle cleanup requires plan_id")
+        if not self.source.strip():
+            raise ValueError("preview lifecycle cleanup requires source")
+        if not self.destroy_reason.strip():
+            raise ValueError("preview lifecycle cleanup requires destroy_reason")
         return self
 
 
@@ -812,6 +843,7 @@ def _accepted_payload(
                 "inventory_record_id",
                 "preview_id",
                 "preview_inventory_scan_id",
+                "preview_lifecycle_cleanup_id",
                 "preview_lifecycle_plan_id",
                 "generation_id",
                 "promotion_record_id",
@@ -1155,6 +1187,27 @@ def _write_preview_lifecycle_plan_if_supported(
     return record.plan_id
 
 
+def _latest_preview_lifecycle_plan(
+    *, record_store: object, context_name: str, plan_id: str
+) -> PreviewLifecyclePlanRecord | None:
+    if not hasattr(record_store, "list_preview_lifecycle_plan_records"):
+        return None
+    records = getattr(record_store, "list_preview_lifecycle_plan_records")(
+        context_name=context_name,
+        limit=None,
+    )
+    return next((record for record in records if record.plan_id == plan_id), None)
+
+
+def _write_preview_lifecycle_cleanup_if_supported(
+    *, record_store: object, record: PreviewLifecycleCleanupRecord
+) -> str:
+    if not hasattr(record_store, "write_preview_lifecycle_cleanup_record"):
+        return ""
+    getattr(record_store, "write_preview_lifecycle_cleanup_record")(record)
+    return record.cleanup_id
+
+
 def create_launchplane_service_app(
     *,
     state_dir: Path,
@@ -1198,6 +1251,7 @@ def create_launchplane_service_app(
         "/v1/evidence/backup-gates",
         "/v1/evidence/previews/generations",
         "/v1/evidence/previews/destroyed",
+        "/v1/previews/lifecycle-cleanup",
         "/v1/previews/lifecycle-plan",
         "/v1/evidence/promotions",
         "/v1/drivers/launchplane/self-deploy",
@@ -2701,6 +2755,73 @@ def create_launchplane_service_app(
                     record=driver_result,
                 )
                 result = {"preview_lifecycle_plan_id": preview_lifecycle_plan_id}
+            elif path == "/v1/previews/lifecycle-cleanup":
+                request = PreviewLifecycleCleanupEnvelope.model_validate(payload)
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="preview_lifecycle.cleanup",
+                    product=request.product,
+                    context=request.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot clean preview lifecycle for the requested"
+                                    " product/context."
+                                ),
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                plan = _latest_preview_lifecycle_plan(
+                    record_store=record_store,
+                    context_name=request.context,
+                    plan_id=request.plan_id,
+                )
+                if plan is None or plan.product != request.product:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=404,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "not_found",
+                                "message": "Preview lifecycle cleanup requires an existing plan for the requested product/context.",
+                            },
+                        },
+                    )
+                driver_result = build_preview_lifecycle_cleanup_record(
+                    plan=plan,
+                    requested_at=_utc_now_timestamp(),
+                    source=request.source,
+                    apply=request.apply,
+                    destroy_reason=request.destroy_reason,
+                    control_plane_root=resolved_root,
+                    record_store=record_store,
+                    timeout_seconds=request.timeout_seconds,
+                )
+                preview_lifecycle_cleanup_id = _write_preview_lifecycle_cleanup_if_supported(
+                    record_store=record_store,
+                    record=driver_result,
+                )
+                result = {"preview_lifecycle_cleanup_id": preview_lifecycle_cleanup_id}
             else:
                 request = PreviewDestroyedEvidenceEnvelope.model_validate(payload)
                 if not authz_policy.allows(

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -14,6 +14,7 @@ from control_plane.contracts.odoo_instance_override_record import OdooInstanceOv
 from control_plane.contracts.preview_enablement_record import PreviewEnablementRecord
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
 from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
+from control_plane.contracts.preview_lifecycle_cleanup_record import PreviewLifecycleCleanupRecord
 from control_plane.contracts.preview_lifecycle_plan_record import PreviewLifecyclePlanRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.promotion_record import PromotionRecord
@@ -347,6 +348,29 @@ class FilesystemRecordStore:
             if not context_name or record.context == context_name
         ]
         records.sort(key=lambda record: (record.planned_at, record.plan_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def write_preview_lifecycle_cleanup_record(
+        self, record: PreviewLifecycleCleanupRecord
+    ) -> Path:
+        return self._write_model("launchplane_preview_lifecycle_cleanups", record.cleanup_id, record)
+
+    def list_preview_lifecycle_cleanup_records(
+        self,
+        *,
+        context_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[PreviewLifecycleCleanupRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                PreviewLifecycleCleanupRecord, "launchplane_preview_lifecycle_cleanups"
+            )
+            if not context_name or record.context == context_name
+        ]
+        records.sort(key=lambda record: (record.requested_at, record.cleanup_id), reverse=True)
         if limit is not None:
             records = records[:limit]
         return tuple(records)

--- a/control_plane/storage/migrations/versions/d5e7f9a1b2c3_add_preview_lifecycle_cleanups.py
+++ b/control_plane/storage/migrations/versions/d5e7f9a1b2c3_add_preview_lifecycle_cleanups.py
@@ -1,0 +1,59 @@
+"""add preview lifecycle cleanups
+
+Revision ID: d5e7f9a1b2c3
+Revises: c4d6e8f0a1b2
+Create Date: 2026-04-29 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "d5e7f9a1b2c3"
+down_revision: str | None = "c4d6e8f0a1b2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "launchplane_preview_lifecycle_cleanups",
+        sa.Column("cleanup_id", sa.String(), nullable=False),
+        sa.Column("product", sa.String(), nullable=False),
+        sa.Column("context", sa.String(), nullable=False),
+        sa.Column("plan_id", sa.String(), nullable=False),
+        sa.Column("requested_at", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("cleanup_id"),
+    )
+    op.create_index(
+        "launchplane_preview_lifecycle_cleanups_context_idx",
+        "launchplane_preview_lifecycle_cleanups",
+        ["context", sa.text("requested_at DESC")],
+    )
+    op.create_index(
+        "launchplane_preview_lifecycle_cleanups_plan_idx",
+        "launchplane_preview_lifecycle_cleanups",
+        ["plan_id", sa.text("requested_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "launchplane_preview_lifecycle_cleanups_plan_idx",
+        table_name="launchplane_preview_lifecycle_cleanups",
+    )
+    op.drop_index(
+        "launchplane_preview_lifecycle_cleanups_context_idx",
+        table_name="launchplane_preview_lifecycle_cleanups",
+    )
+    op.drop_table("launchplane_preview_lifecycle_cleanups")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -21,6 +21,7 @@ from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
 from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
+from control_plane.contracts.preview_lifecycle_cleanup_record import PreviewLifecycleCleanupRecord
 from control_plane.contracts.preview_lifecycle_plan_record import PreviewLifecyclePlanRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.preview_summary import LaunchplanePreviewSummary
@@ -214,6 +215,30 @@ class LaunchplanePreviewLifecyclePlanRow(Base):
     planned_at: Mapped[str] = mapped_column(String, nullable=False)
     status: Mapped[str] = mapped_column(String, nullable=False)
     inventory_scan_id: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplanePreviewLifecycleCleanupRow(Base):
+    __tablename__ = "launchplane_preview_lifecycle_cleanups"
+    __table_args__ = (
+        Index(
+            "launchplane_preview_lifecycle_cleanups_context_idx",
+            "context",
+            desc("requested_at"),
+        ),
+        Index(
+            "launchplane_preview_lifecycle_cleanups_plan_idx",
+            "plan_id",
+            desc("requested_at"),
+        ),
+    )
+
+    cleanup_id: Mapped[str] = mapped_column(String, primary_key=True)
+    product: Mapped[str] = mapped_column(String, nullable=False)
+    context: Mapped[str] = mapped_column(String, nullable=False)
+    plan_id: Mapped[str] = mapped_column(String, nullable=False)
+    requested_at: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -966,6 +991,41 @@ class PostgresRecordStore(HumanSessionStore):
             limit=limit,
         )
 
+    def write_preview_lifecycle_cleanup_record(
+        self, record: PreviewLifecycleCleanupRecord
+    ) -> None:
+        self._write_row(
+            LaunchplanePreviewLifecycleCleanupRow(
+                cleanup_id=record.cleanup_id,
+                product=record.product,
+                context=record.context,
+                plan_id=record.plan_id,
+                requested_at=record.requested_at,
+                status=record.status,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def list_preview_lifecycle_cleanup_records(
+        self,
+        *,
+        context_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[PreviewLifecycleCleanupRecord, ...]:
+        filters: list[object] = []
+        if context_name:
+            filters.append(LaunchplanePreviewLifecycleCleanupRow.context == context_name)
+        return self._list_models(
+            model_type=PreviewLifecycleCleanupRecord,
+            orm_model=LaunchplanePreviewLifecycleCleanupRow,
+            filters=filters,
+            order_by=(
+                LaunchplanePreviewLifecycleCleanupRow.requested_at.desc(),
+                LaunchplanePreviewLifecycleCleanupRow.cleanup_id.desc(),
+            ),
+            limit=limit,
+        )
+
     def read_preview_summary(
         self,
         *,
@@ -1444,6 +1504,7 @@ class PostgresRecordStore(HumanSessionStore):
             "preview_records": 0,
             "preview_generations": 0,
             "preview_inventory_scans": 0,
+            "preview_lifecycle_cleanups": 0,
             "preview_lifecycle_plans": 0,
             "release_tuples": 0,
         }
@@ -1479,6 +1540,10 @@ class PostgresRecordStore(HumanSessionStore):
             for record in filesystem_store.list_preview_lifecycle_plan_records():
                 self.write_preview_lifecycle_plan_record(record)
                 counts["preview_lifecycle_plans"] += 1
+        if hasattr(filesystem_store, "list_preview_lifecycle_cleanup_records"):
+            for record in filesystem_store.list_preview_lifecycle_cleanup_records():
+                self.write_preview_lifecycle_cleanup_record(record)
+                counts["preview_lifecycle_cleanups"] += 1
         for record in filesystem_store.list_release_tuple_records():
             self.write_release_tuple_record(record)
             counts["release_tuples"] += 1

--- a/control_plane/workflows/preview_lifecycle_cleanup.py
+++ b/control_plane/workflows/preview_lifecycle_cleanup.py
@@ -1,0 +1,236 @@
+import re
+from pathlib import Path
+from typing import Any
+
+import click
+
+from control_plane.contracts.preview_lifecycle_cleanup_record import (
+    PreviewLifecycleCleanupRecord,
+    PreviewLifecycleCleanupResult,
+    build_preview_lifecycle_cleanup_id,
+)
+from control_plane.contracts.preview_lifecycle_plan_record import PreviewLifecyclePlanRecord
+from control_plane.contracts.preview_mutation_request import PreviewDestroyMutationRequest
+from control_plane.launchplane_mutations import apply_launchplane_destroy_preview
+from control_plane.workflows.launchplane import find_preview_record
+from control_plane.workflows.verireel_preview_driver import (
+    VeriReelPreviewDestroyRequest,
+    execute_verireel_preview_destroy,
+)
+
+_VERIREEL_PREVIEW_SLUG_PATTERN = re.compile(r"^pr-(?P<number>[1-9][0-9]*)$")
+
+
+def _verireel_anchor_pr_number(preview_slug: str) -> int:
+    match = _VERIREEL_PREVIEW_SLUG_PATTERN.fullmatch(preview_slug.strip())
+    if match is None:
+        raise ValueError(f"VeriReel preview cleanup only supports PR preview slugs: {preview_slug}")
+    return int(match.group("number"))
+
+
+def _planned_results(plan: PreviewLifecyclePlanRecord) -> tuple[PreviewLifecycleCleanupResult, ...]:
+    return tuple(
+        PreviewLifecycleCleanupResult(
+            preview_slug=preview_slug,
+            status="planned",
+        )
+        for preview_slug in plan.orphaned_slugs
+    )
+
+
+def _blocked_record(
+    *,
+    plan: PreviewLifecyclePlanRecord,
+    requested_at: str,
+    source: str,
+    apply: bool,
+    error_message: str,
+) -> PreviewLifecycleCleanupRecord:
+    return PreviewLifecycleCleanupRecord(
+        cleanup_id=build_preview_lifecycle_cleanup_id(
+            context_name=plan.context,
+            requested_at=requested_at,
+        ),
+        product=plan.product,
+        context=plan.context,
+        plan_id=plan.plan_id,
+        inventory_scan_id=plan.inventory_scan_id,
+        requested_at=requested_at,
+        source=source,
+        apply=apply,
+        status="blocked",
+        planned_slugs=plan.orphaned_slugs,
+        blocked_slugs=plan.orphaned_slugs,
+        results=tuple(
+            PreviewLifecycleCleanupResult(
+                preview_slug=preview_slug,
+                status="blocked",
+                error_message=error_message,
+            )
+            for preview_slug in plan.orphaned_slugs
+        ),
+        error_message=error_message,
+    )
+
+
+def build_preview_lifecycle_cleanup_record(
+    *,
+    plan: PreviewLifecyclePlanRecord,
+    requested_at: str,
+    source: str,
+    apply: bool,
+    destroy_reason: str,
+    control_plane_root: Path,
+    record_store: Any,
+    timeout_seconds: int,
+) -> PreviewLifecycleCleanupRecord:
+    cleanup_id = build_preview_lifecycle_cleanup_id(
+        context_name=plan.context,
+        requested_at=requested_at,
+    )
+    if plan.status != "pass":
+        return _blocked_record(
+            plan=plan,
+            requested_at=requested_at,
+            source=source,
+            apply=apply,
+            error_message=f"Preview lifecycle plan status is {plan.status}; cleanup requires pass.",
+        )
+    if not apply:
+        return PreviewLifecycleCleanupRecord(
+            cleanup_id=cleanup_id,
+            product=plan.product,
+            context=plan.context,
+            plan_id=plan.plan_id,
+            inventory_scan_id=plan.inventory_scan_id,
+            requested_at=requested_at,
+            source=source,
+            apply=False,
+            status="report_only",
+            planned_slugs=plan.orphaned_slugs,
+            results=_planned_results(plan),
+        )
+    if plan.product != "verireel" or plan.context != "verireel-testing":
+        return _blocked_record(
+            plan=plan,
+            requested_at=requested_at,
+            source=source,
+            apply=True,
+            error_message="Preview lifecycle cleanup execution is currently implemented for verireel-testing only.",
+        )
+
+    parsed_previews: list[tuple[str, int]] = []
+    for preview_slug in plan.orphaned_slugs:
+        try:
+            anchor_pr_number = _verireel_anchor_pr_number(preview_slug)
+        except ValueError as exc:
+            return _blocked_record(
+                plan=plan,
+                requested_at=requested_at,
+                source=source,
+                apply=True,
+                error_message=str(exc),
+            )
+        preview = find_preview_record(
+            record_store=record_store,
+            context_name=plan.context,
+            anchor_repo="verireel",
+            anchor_pr_number=anchor_pr_number,
+        )
+        if preview is None:
+            return _blocked_record(
+                plan=plan,
+                requested_at=requested_at,
+                source=source,
+                apply=True,
+                error_message=(
+                    "Launchplane will not destroy preview provider state without a matching "
+                    f"stored preview record for {plan.context}/verireel/{preview_slug}."
+                ),
+            )
+        parsed_previews.append((preview_slug, anchor_pr_number))
+
+    results: list[PreviewLifecycleCleanupResult] = []
+    destroyed_slugs: list[str] = []
+    failed_slugs: list[str] = []
+    for preview_slug, anchor_pr_number in parsed_previews:
+        destroy_result = execute_verireel_preview_destroy(
+            control_plane_root=control_plane_root,
+            request=VeriReelPreviewDestroyRequest(
+                context=plan.context,
+                anchor_repo="verireel",
+                anchor_pr_number=anchor_pr_number,
+                preview_slug=preview_slug,
+                destroy_reason=destroy_reason,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+        if destroy_result.destroy_status == "pass":
+            try:
+                apply_launchplane_destroy_preview(
+                    record_store=record_store,
+                    request=PreviewDestroyMutationRequest(
+                        context=plan.context,
+                        anchor_repo="verireel",
+                        anchor_pr_number=anchor_pr_number,
+                        destroyed_at=destroy_result.destroy_finished_at,
+                        destroy_reason=destroy_reason,
+                    ),
+                )
+                destroyed_slugs.append(preview_slug)
+                results.append(
+                    PreviewLifecycleCleanupResult(
+                        preview_slug=preview_slug,
+                        anchor_repo="verireel",
+                        anchor_pr_number=anchor_pr_number,
+                        status="destroyed",
+                        application_name=destroy_result.application_name,
+                        application_id=destroy_result.application_id,
+                        preview_url=destroy_result.preview_url,
+                    )
+                )
+            except click.ClickException as exc:
+                failed_slugs.append(preview_slug)
+                results.append(
+                    PreviewLifecycleCleanupResult(
+                        preview_slug=preview_slug,
+                        anchor_repo="verireel",
+                        anchor_pr_number=anchor_pr_number,
+                        status="failed",
+                        application_name=destroy_result.application_name,
+                        application_id=destroy_result.application_id,
+                        preview_url=destroy_result.preview_url,
+                        error_message=str(exc),
+                    )
+                )
+            continue
+        failed_slugs.append(preview_slug)
+        results.append(
+            PreviewLifecycleCleanupResult(
+                preview_slug=preview_slug,
+                anchor_repo="verireel",
+                anchor_pr_number=anchor_pr_number,
+                status="failed",
+                application_name=destroy_result.application_name,
+                application_id=destroy_result.application_id,
+                preview_url=destroy_result.preview_url,
+                error_message=destroy_result.error_message,
+            )
+        )
+
+    return PreviewLifecycleCleanupRecord(
+        cleanup_id=cleanup_id,
+        product=plan.product,
+        context=plan.context,
+        plan_id=plan.plan_id,
+        inventory_scan_id=plan.inventory_scan_id,
+        requested_at=requested_at,
+        source=source,
+        apply=True,
+        status="pass" if not failed_slugs else "fail",
+        planned_slugs=plan.orphaned_slugs,
+        destroyed_slugs=tuple(destroyed_slugs),
+        failed_slugs=tuple(failed_slugs),
+        results=tuple(results),
+        error_message="" if not failed_slugs else "One or more preview cleanup actions failed.",
+    )

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -475,11 +475,14 @@ the app repo sends PR/image intent, Launchplane derives the live preview URL
 from `LAUNCHPLANE_PREVIEW_BASE_URL`, and evidence stores that returned URL with
 generation status and cleanup outcome.
 
-Launchplane now owns the first report-only preview lifecycle planning boundary:
+Launchplane now owns the preview lifecycle planning boundary:
 `POST /v1/previews/lifecycle-plan`. Product repos can send desired preview
 anchors while Launchplane compares them against the latest recorded provider
 inventory scan, writes a durable lifecycle plan, and returns keep/orphaned/missing
-sets without executing cleanup. This is the first extraction step toward a
+sets. Cleanup requests go through `POST /v1/previews/lifecycle-cleanup`, which
+requires an existing plan id, defaults to report-only, and records cleanup
+results. Destructive provider cleanup still requires explicit `apply=true` from
+an authorized GitHub Actions workflow. This is the next extraction step toward a
 cross-repo preview system; product repos remain thin adapters for labels,
 artifact build facts, and product-specific health/config hints.
 
@@ -491,9 +494,7 @@ inside `.github/workflows/preview-control-plane.yml` and
 `.github/workflows/preview-janitor.yml` should use the same Launchplane destroy
 and evidence contract rather than keeping a second repo-local teardown path.
 Launchplane's handoff contract is moving from evidence-only toward reusable
-preview lifecycle ownership. The first safe step is report-only planning in
-Launchplane; cleanup execution and PR feedback ownership should move later after
-the durable plan record has proven useful. The target integration is
+preview lifecycle ownership. The target integration is
 OIDC-authenticated HTTP into Launchplane. The local CLI examples below exist only
 to pin the payload shape while the Launchplane service ingress continues to
 absorb the reusable lifecycle behavior.

--- a/docs/records.md
+++ b/docs/records.md
@@ -393,15 +393,23 @@ state/
 
 ## Launchplane Preview Lifecycle Plan Record
 
-- One append-only report-only decision record per preview lifecycle planning run.
+- One append-only decision record per preview lifecycle planning run.
 - Record the desired preview anchors submitted by a product repo, the latest
   inventory scan used as current provider state, and the derived keep/orphaned/
   missing slug sets.
-- The first implementation must not execute cleanup. It exists to move reusable
-  desired-vs-actual preview decisions into Launchplane before cleanup execution,
-  PR feedback, or scheduling are centralized.
-- Product repos should eventually submit thin desired-state adapters to this
-  boundary instead of each owning a separate preview janitor implementation.
+- The plan record is the required input for cleanup execution. Product repos
+  should eventually submit thin desired-state adapters to this boundary instead
+  of each owning a separate preview janitor implementation.
+
+## Launchplane Preview Lifecycle Cleanup Record
+
+- One append-only cleanup record per lifecycle cleanup request.
+- Record the source plan id, inventory scan id, requested source, whether
+  `apply=true` was explicitly requested, the planned orphan slugs, and per-slug
+  cleanup results.
+- `apply=false` is the default report-only mode. Destructive provider cleanup is
+  only allowed through an authorized workflow request with `apply=true` and an
+  existing passing lifecycle plan.
 
 ## Inventory
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -170,6 +170,7 @@ allowed product: verireel
 allowed contexts: verireel-testing
 allowed actions:
   - preview_lifecycle.plan
+  - preview_lifecycle.cleanup
   - verireel_preview_destroy.execute
   - preview_destroyed.write
 ```
@@ -183,6 +184,8 @@ event_name: schedule or workflow_dispatch
 allowed product: verireel
 allowed contexts: verireel-testing
 allowed actions:
+  - preview_lifecycle.plan
+  - preview_lifecycle.cleanup
   - verireel_preview_destroy.execute
   - preview_destroyed.write
 ```
@@ -260,13 +263,16 @@ writes, not on every possible operator action.
 ### Preview lifecycle endpoints
 
 - `POST /v1/previews/lifecycle-plan`
+- `POST /v1/previews/lifecycle-cleanup`
 
-The first preview lifecycle endpoint is intentionally report-only. Product repos
-send desired preview anchors, Launchplane compares those desired previews with
-the latest recorded provider inventory scan, writes a durable lifecycle plan,
-and returns keep/orphaned/missing sets. It does not destroy previews. Cleanup
-execution and PR feedback ownership should move into Launchplane only after this
-durable decision record is proven by the VeriReel adapter.
+The first preview lifecycle endpoint remains the source of the durable decision:
+product repos send desired preview anchors, Launchplane compares those desired
+previews with the latest recorded provider inventory scan, writes a durable
+lifecycle plan, and returns keep/orphaned/missing sets. Cleanup execution uses a
+second endpoint that requires an existing lifecycle `plan_id`; it defaults to
+`apply=false` report-only behavior and records the cleanup request/result next to
+the plan. Destructive provider cleanup is only attempted when `apply=true` is
+explicitly supplied by an authorized GitHub Actions workflow.
 
 ### Operator read endpoints
 

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -29,6 +29,10 @@ from control_plane.contracts.preview_generation_record import (
     PreviewPullRequestSummary,
 )
 from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
+from control_plane.contracts.preview_lifecycle_cleanup_record import (
+    PreviewLifecycleCleanupRecord,
+    PreviewLifecycleCleanupResult,
+)
 from control_plane.contracts.preview_lifecycle_plan_record import (
     PreviewLifecycleDesiredPreview,
     PreviewLifecyclePlanRecord,
@@ -754,6 +758,58 @@ class PostgresRecordStoreTests(unittest.TestCase):
         )
         self.assertEqual(listed_records[0].orphaned_slugs, ("pr-122",))
 
+    def test_preview_lifecycle_cleanup_records_round_trip(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_preview_lifecycle_cleanup_record(
+                PreviewLifecycleCleanupRecord(
+                    cleanup_id="preview-lifecycle-cleanup-verireel-testing-20260420T100500Z",
+                    product="verireel",
+                    context="verireel-testing",
+                    plan_id="preview-lifecycle-plan-verireel-testing-20260420T100500Z",
+                    inventory_scan_id="preview-inventory-scan-verireel-testing-20260420T100500Z",
+                    requested_at="2026-04-20T10:05:00Z",
+                    source="preview-janitor",
+                    apply=True,
+                    status="pass",
+                    planned_slugs=("pr-122",),
+                    destroyed_slugs=("pr-122",),
+                    results=(
+                        PreviewLifecycleCleanupResult(
+                            preview_slug="pr-122",
+                            anchor_repo="verireel",
+                            anchor_pr_number=122,
+                            status="destroyed",
+                            application_name="ver-preview-pr-122-app",
+                            application_id="app-122",
+                            preview_url="https://pr-122.preview.example",
+                        ),
+                    ),
+                )
+            )
+            listed_records = store.list_preview_lifecycle_cleanup_records(
+                context_name="verireel-testing",
+                limit=1,
+            )
+            store.close()
+
+        self.assertEqual(len(listed_records), 1)
+        self.assertEqual(
+            listed_records[0].cleanup_id,
+            "preview-lifecycle-cleanup-verireel-testing-20260420T100500Z",
+        )
+        self.assertEqual(
+            listed_records[0].plan_id,
+            "preview-lifecycle-plan-verireel-testing-20260420T100500Z",
+        )
+        self.assertEqual(listed_records[0].destroyed_slugs, ("pr-122",))
+        self.assertEqual(listed_records[0].results[0].application_id, "app-122")
+
     def test_write_and_list_dokploy_target_id_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(
@@ -1069,6 +1125,19 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     keep_slugs=("pr-123",),
                 )
             )
+            filesystem_store.write_preview_lifecycle_cleanup_record(
+                PreviewLifecycleCleanupRecord(
+                    cleanup_id="preview-lifecycle-cleanup-verireel-testing-20260420T100700Z",
+                    product="verireel",
+                    context="verireel-testing",
+                    plan_id="preview-lifecycle-plan-verireel-testing-20260420T100600Z",
+                    inventory_scan_id="preview-inventory-scan-verireel-testing-20260420T100500Z",
+                    requested_at="2026-04-20T10:07:00Z",
+                    source="preview-janitor",
+                    apply=False,
+                    status="report_only",
+                )
+            )
             filesystem_store.write_release_tuple_record(_release_tuple_record())
 
             counts = store.import_core_records_from_filesystem(filesystem_store)
@@ -1084,6 +1153,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     "preview_records": 1,
                     "preview_generations": 1,
                     "preview_inventory_scans": 1,
+                    "preview_lifecycle_cleanups": 1,
                     "preview_lifecycle_plans": 1,
                     "release_tuples": 1,
                 },
@@ -1113,5 +1183,12 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     limit=1,
                 )[0].plan_id,
                 "preview-lifecycle-plan-verireel-testing-20260420T100600Z",
+            )
+            self.assertEqual(
+                store.list_preview_lifecycle_cleanup_records(
+                    context_name="verireel-testing",
+                    limit=1,
+                )[0].cleanup_id,
+                "preview-lifecycle-cleanup-verireel-testing-20260420T100700Z",
             )
             store.close()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -23,6 +23,7 @@ from control_plane.contracts.preview_generation_record import (
     PreviewPullRequestSummary,
 )
 from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
+from control_plane.contracts.preview_lifecycle_plan_record import PreviewLifecyclePlanRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
@@ -2699,6 +2700,229 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["result"]["status"], "missing_inventory")
         self.assertEqual(payload["result"]["orphaned_slugs"], [])
         self.assertIn("has not recorded", payload["result"]["error_message"])
+
+    def test_preview_lifecycle_cleanup_endpoint_records_report_only_cleanup(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_preview_lifecycle_plan_record(
+                PreviewLifecyclePlanRecord(
+                    plan_id="preview-lifecycle-plan-verireel-testing-20260429T195838Z",
+                    product="verireel",
+                    context="verireel-testing",
+                    planned_at="2026-04-29T19:58:38Z",
+                    source="preview-janitor",
+                    status="pass",
+                    inventory_scan_id="preview-inventory-scan-verireel-testing-20260429T195837Z",
+                    actual_slugs=("pr-41",),
+                    orphaned_slugs=("pr-41",),
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-janitor.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel-testing"],
+                            "actions": ["preview_lifecycle.cleanup"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/preview-janitor.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/lifecycle-cleanup",
+                payload={
+                    "product": "verireel",
+                    "context": "verireel-testing",
+                    "plan_id": "preview-lifecycle-plan-verireel-testing-20260429T195838Z",
+                    "source": "preview-janitor",
+                    "apply": False,
+                },
+            )
+
+            cleanup_records = FilesystemRecordStore(
+                state_dir=root / "state"
+            ).list_preview_lifecycle_cleanup_records(context_name="verireel-testing")
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["records"]["preview_lifecycle_cleanup_id"], cleanup_records[0].cleanup_id)
+        self.assertEqual(payload["result"]["status"], "report_only")
+        self.assertEqual(payload["result"]["planned_slugs"], ["pr-41"])
+        self.assertEqual(cleanup_records[0].apply, False)
+        self.assertEqual(cleanup_records[0].plan_id, "preview-lifecycle-plan-verireel-testing-20260429T195838Z")
+
+    def test_preview_lifecycle_cleanup_endpoint_executes_and_records_destroyed_preview(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_preview_record(
+                PreviewRecord(
+                    preview_id="preview-verireel-testing-verireel-pr-41",
+                    context="verireel-testing",
+                    anchor_repo="verireel",
+                    anchor_pr_number=41,
+                    anchor_pr_url="https://github.example/every/verireel/pull/41",
+                    preview_label="verireel-testing/verireel#41",
+                    canonical_url="https://pr-41.preview.example",
+                    state="active",
+                    created_at="2026-04-20T10:00:00Z",
+                    updated_at="2026-04-20T10:00:00Z",
+                    eligible_at="2026-04-20T10:00:00Z",
+                )
+            )
+            store.write_preview_lifecycle_plan_record(
+                PreviewLifecyclePlanRecord(
+                    plan_id="preview-lifecycle-plan-verireel-testing-20260429T195838Z",
+                    product="verireel",
+                    context="verireel-testing",
+                    planned_at="2026-04-29T19:58:38Z",
+                    source="preview-janitor",
+                    status="pass",
+                    inventory_scan_id="preview-inventory-scan-verireel-testing-20260429T195837Z",
+                    actual_slugs=("pr-41",),
+                    orphaned_slugs=("pr-41",),
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-janitor.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel-testing"],
+                            "actions": ["preview_lifecycle.cleanup"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/preview-janitor.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.workflows.preview_lifecycle_cleanup.execute_verireel_preview_destroy",
+                return_value=VeriReelPreviewDestroyResult(
+                    destroy_status="pass",
+                    destroy_started_at="2026-04-29T20:00:00Z",
+                    destroy_finished_at="2026-04-29T20:00:05Z",
+                    application_name="ver-preview-pr-41-app",
+                    application_id="app-41",
+                    preview_url="https://pr-41.preview.example",
+                ),
+            ) as execute_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/previews/lifecycle-cleanup",
+                    payload={
+                        "product": "verireel",
+                        "context": "verireel-testing",
+                        "plan_id": "preview-lifecycle-plan-verireel-testing-20260429T195838Z",
+                        "source": "preview-janitor",
+                        "apply": True,
+                        "destroy_reason": "external_preview_janitor_cleanup_completed",
+                    },
+                )
+
+            updated_preview = FilesystemRecordStore(state_dir=root / "state").read_preview_record(
+                "preview-verireel-testing-verireel-pr-41"
+            )
+            cleanup_records = FilesystemRecordStore(
+                state_dir=root / "state"
+            ).list_preview_lifecycle_cleanup_records(context_name="verireel-testing")
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["status"], "pass")
+        self.assertEqual(payload["result"]["destroyed_slugs"], ["pr-41"])
+        self.assertEqual(execute_mock.call_count, 1)
+        self.assertEqual(updated_preview.state, "destroyed")
+        self.assertEqual(updated_preview.destroyed_at, "2026-04-29T20:00:05Z")
+        self.assertEqual(cleanup_records[0].status, "pass")
+
+    def test_preview_lifecycle_cleanup_endpoint_rejects_unauthorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-janitor.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel-testing"],
+                            "actions": ["preview_lifecycle.plan"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/preview-janitor.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/lifecycle-cleanup",
+                payload={
+                    "product": "verireel",
+                    "context": "verireel-testing",
+                    "plan_id": "preview-lifecycle-plan-verireel-testing-20260429T195838Z",
+                    "apply": False,
+                },
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
 
     def test_verireel_prod_deploy_driver_executes_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add a durable preview lifecycle cleanup record contract, storage, and migration
- add POST /v1/previews/lifecycle-cleanup gated by existing lifecycle plans and apply=false by default
- document the plan-backed cleanup boundary and authz action

## Validation
- uv run --extra dev ruff check --diff control_plane/contracts/preview_lifecycle_cleanup_record.py control_plane/workflows/preview_lifecycle_cleanup.py control_plane/service.py control_plane/storage/filesystem.py control_plane/storage/postgres.py tests/test_service.py tests/test_postgres_store.py
- uv run --extra dev ruff check control_plane/contracts/preview_lifecycle_cleanup_record.py control_plane/workflows/preview_lifecycle_cleanup.py control_plane/service.py control_plane/storage/filesystem.py control_plane/storage/postgres.py tests/test_service.py tests/test_postgres_store.py
- uv run python -m unittest
- npx pnpm@10.10.0 --dir frontend validate
- git diff --check
- docker build -t launchplane-preview-lifecycle-cleanup-test .

Note: full mypy was also run and still reports existing baseline errors across unrelated modules; the new cleanup workflow file passes targeted mypy.