### PR TITLE
Add Launchplane preview PR feedback endpoint

### DIFF
--- a/config/launchplane-authz.toml
+++ b/config/launchplane-authz.toml
@@ -12,7 +12,7 @@ workflow_refs = [
 event_names = ["pull_request"]
 products = ["verireel"]
 contexts = ["verireel-testing"]
-actions = ["verireel_preview_refresh.execute", "verireel_app_maintenance.execute", "preview_generation.write"]
+actions = ["verireel_preview_refresh.execute", "verireel_app_maintenance.execute", "preview_generation.write", "preview_pr_feedback.write"]
 
 [[github_actions]]
 repository = "cbusillo/verireel"
@@ -22,7 +22,7 @@ workflow_refs = [
 event_names = ["pull_request"]
 products = ["verireel"]
 contexts = ["verireel-testing"]
-actions = ["verireel_preview_inventory.read", "verireel_preview_destroy.execute", "preview_destroyed.write", "preview_lifecycle.plan", "preview_lifecycle.cleanup"]
+actions = ["verireel_preview_inventory.read", "verireel_preview_destroy.execute", "preview_destroyed.write", "preview_lifecycle.plan", "preview_lifecycle.cleanup", "preview_pr_feedback.write"]
 
 [[github_actions]]
 repository = "cbusillo/verireel"

--- a/config/launchplane-authz.toml.example
+++ b/config/launchplane-authz.toml.example
@@ -11,7 +11,7 @@ workflow_refs = [
 event_names = ["pull_request"]
 products = ["verireel"]
 contexts = ["verireel-testing"]
-actions = ["verireel_preview_refresh.execute", "verireel_app_maintenance.execute", "preview_generation.write"]
+actions = ["verireel_preview_refresh.execute", "verireel_app_maintenance.execute", "preview_generation.write", "preview_pr_feedback.write"]
 
 [[github_actions]]
 repository = "example-org/verireel"
@@ -21,7 +21,7 @@ workflow_refs = [
 event_names = ["pull_request"]
 products = ["verireel"]
 contexts = ["verireel-testing"]
-actions = ["verireel_preview_inventory.read", "verireel_preview_destroy.execute", "preview_destroyed.write", "preview_lifecycle.plan", "preview_lifecycle.cleanup"]
+actions = ["verireel_preview_inventory.read", "verireel_preview_destroy.execute", "preview_destroyed.write", "preview_lifecycle.plan", "preview_lifecycle.cleanup", "preview_pr_feedback.write"]
 
 [[github_actions]]
 repository = "example-org/verireel"

--- a/control_plane/contracts/preview_pr_feedback_record.py
+++ b/control_plane/contracts/preview_pr_feedback_record.py
@@ -1,0 +1,72 @@
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+PreviewPrFeedbackStatus = Literal["ready", "destroyed", "failed", "cleanup_failed"]
+PreviewPrFeedbackDeliveryStatus = Literal["delivered", "skipped", "failed"]
+
+
+class PreviewPrFeedbackRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    feedback_id: str
+    product: str
+    context: str
+    source: str
+    requested_at: str
+    repository: str
+    anchor_repo: str
+    anchor_pr_number: int = Field(ge=1)
+    anchor_pr_url: str
+    status: PreviewPrFeedbackStatus
+    marker: str
+    comment_markdown: str
+    preview_url: str = ""
+    immutable_image_reference: str = ""
+    refresh_image_reference: str = ""
+    revision: str = ""
+    run_url: str = ""
+    failure_summary: str = ""
+    delivery_status: PreviewPrFeedbackDeliveryStatus
+    delivery_action: str = ""
+    comment_id: int = 0
+    comment_url: str = ""
+    error_message: str = ""
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "PreviewPrFeedbackRecord":
+        if not self.feedback_id.strip():
+            raise ValueError("preview PR feedback requires feedback_id")
+        if not self.product.strip():
+            raise ValueError("preview PR feedback requires product")
+        if not self.context.strip():
+            raise ValueError("preview PR feedback requires context")
+        if not self.source.strip():
+            raise ValueError("preview PR feedback requires source")
+        if not self.requested_at.strip():
+            raise ValueError("preview PR feedback requires requested_at")
+        if not self.repository.strip():
+            raise ValueError("preview PR feedback requires repository")
+        if not self.anchor_repo.strip():
+            raise ValueError("preview PR feedback requires anchor_repo")
+        if not self.anchor_pr_url.strip():
+            raise ValueError("preview PR feedback requires anchor_pr_url")
+        if not self.marker.strip():
+            raise ValueError("preview PR feedback requires marker")
+        if not self.comment_markdown.strip():
+            raise ValueError("preview PR feedback requires comment_markdown")
+        return self
+
+
+def build_preview_pr_feedback_id(*, context_name: str, anchor_pr_number: int, requested_at: str) -> str:
+    normalized_timestamp = (
+        requested_at.strip()
+        .replace(":", "")
+        .replace("-", "")
+        .replace(".", "")
+        .replace("+", "")
+        .replace("Z", "Z")
+    )
+    return f"preview-pr-feedback-{context_name}-pr-{anchor_pr_number}-{normalized_timestamp}"

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -40,6 +40,10 @@ from control_plane.contracts.preview_lifecycle_plan_record import (
     PreviewLifecyclePlanRecord,
 )
 from control_plane.contracts.preview_lifecycle_cleanup_record import PreviewLifecycleCleanupRecord
+from control_plane.contracts.preview_pr_feedback_record import (
+    PreviewPrFeedbackRecord,
+    PreviewPrFeedbackStatus,
+)
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.drivers.registry import (
     build_driver_context_view,
@@ -78,6 +82,10 @@ from control_plane.workflows.evidence_ingestion import (
 from control_plane.workflows.preview_lifecycle import build_preview_lifecycle_plan
 from control_plane.workflows.preview_lifecycle_cleanup import (
     build_preview_lifecycle_cleanup_record,
+)
+from control_plane.workflows.preview_pr_feedback import (
+    DEFAULT_PREVIEW_FEEDBACK_MARKER,
+    build_preview_pr_feedback_record,
 )
 from control_plane.workflows.odoo_artifact_publish import (
     OdooArtifactPublishEvidenceRequest,
@@ -259,6 +267,45 @@ class PreviewLifecycleCleanupEnvelope(BaseModel):
             raise ValueError("preview lifecycle cleanup requires source")
         if not self.destroy_reason.strip():
             raise ValueError("preview lifecycle cleanup requires destroy_reason")
+        return self
+
+
+class PreviewPrFeedbackEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    context: str
+    source: str = "workflow"
+    repository: str
+    anchor_repo: str
+    anchor_pr_number: int = Field(ge=1)
+    anchor_pr_url: str
+    status: PreviewPrFeedbackStatus
+    marker: str = DEFAULT_PREVIEW_FEEDBACK_MARKER
+    preview_url: str = ""
+    immutable_image_reference: str = ""
+    refresh_image_reference: str = ""
+    revision: str = ""
+    run_url: str = ""
+    failure_summary: str = ""
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "PreviewPrFeedbackEnvelope":
+        if not self.product.strip():
+            raise ValueError("preview PR feedback requires product")
+        if not self.context.strip():
+            raise ValueError("preview PR feedback requires context")
+        if not self.source.strip():
+            raise ValueError("preview PR feedback requires source")
+        if not self.repository.strip():
+            raise ValueError("preview PR feedback requires repository")
+        if not self.anchor_repo.strip():
+            raise ValueError("preview PR feedback requires anchor_repo")
+        if not self.anchor_pr_url.strip():
+            raise ValueError("preview PR feedback requires anchor_pr_url")
+        if not self.marker.strip():
+            raise ValueError("preview PR feedback requires marker")
         return self
 
 
@@ -843,6 +890,7 @@ def _accepted_payload(
                 "inventory_record_id",
                 "preview_id",
                 "preview_inventory_scan_id",
+                "preview_pr_feedback_id",
                 "preview_lifecycle_cleanup_id",
                 "preview_lifecycle_plan_id",
                 "generation_id",
@@ -1208,6 +1256,15 @@ def _write_preview_lifecycle_cleanup_if_supported(
     return record.cleanup_id
 
 
+def _write_preview_pr_feedback_if_supported(
+    *, record_store: object, record: PreviewPrFeedbackRecord
+) -> str:
+    if not hasattr(record_store, "write_preview_pr_feedback_record"):
+        return ""
+    getattr(record_store, "write_preview_pr_feedback_record")(record)
+    return record.feedback_id
+
+
 def create_launchplane_service_app(
     *,
     state_dir: Path,
@@ -1251,6 +1308,7 @@ def create_launchplane_service_app(
         "/v1/evidence/backup-gates",
         "/v1/evidence/previews/generations",
         "/v1/evidence/previews/destroyed",
+        "/v1/previews/pr-feedback",
         "/v1/previews/lifecycle-cleanup",
         "/v1/previews/lifecycle-plan",
         "/v1/evidence/promotions",
@@ -2755,6 +2813,64 @@ def create_launchplane_service_app(
                     record=driver_result,
                 )
                 result = {"preview_lifecycle_plan_id": preview_lifecycle_plan_id}
+            elif path == "/v1/previews/pr-feedback":
+                request = PreviewPrFeedbackEnvelope.model_validate(payload)
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="preview_pr_feedback.write",
+                    product=request.product,
+                    context=request.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot write preview PR feedback for the requested"
+                                    " product/context."
+                                ),
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                driver_result = build_preview_pr_feedback_record(
+                    control_plane_root=resolved_root,
+                    product=request.product,
+                    context=request.context,
+                    source=request.source,
+                    requested_at=_utc_now_timestamp(),
+                    repository=request.repository,
+                    anchor_repo=request.anchor_repo,
+                    anchor_pr_number=request.anchor_pr_number,
+                    anchor_pr_url=request.anchor_pr_url,
+                    status=request.status,
+                    marker=request.marker,
+                    preview_url=request.preview_url,
+                    immutable_image_reference=request.immutable_image_reference,
+                    refresh_image_reference=request.refresh_image_reference,
+                    revision=request.revision,
+                    run_url=request.run_url,
+                    failure_summary=request.failure_summary,
+                )
+                preview_pr_feedback_id = _write_preview_pr_feedback_if_supported(
+                    record_store=record_store,
+                    record=driver_result,
+                )
+                result = {"preview_pr_feedback_id": preview_pr_feedback_id}
             elif path == "/v1/previews/lifecycle-cleanup":
                 request = PreviewLifecycleCleanupEnvelope.model_validate(payload)
                 if not authz_policy.allows(

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -16,6 +16,7 @@ from control_plane.contracts.preview_generation_record import PreviewGenerationR
 from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
 from control_plane.contracts.preview_lifecycle_cleanup_record import PreviewLifecycleCleanupRecord
 from control_plane.contracts.preview_lifecycle_plan_record import PreviewLifecyclePlanRecord
+from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedbackRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
@@ -371,6 +372,27 @@ class FilesystemRecordStore:
             if not context_name or record.context == context_name
         ]
         records.sort(key=lambda record: (record.requested_at, record.cleanup_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def write_preview_pr_feedback_record(self, record: PreviewPrFeedbackRecord) -> Path:
+        return self._write_model("launchplane_preview_pr_feedback", record.feedback_id, record)
+
+    def list_preview_pr_feedback_records(
+        self,
+        *,
+        context_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[PreviewPrFeedbackRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                PreviewPrFeedbackRecord, "launchplane_preview_pr_feedback"
+            )
+            if not context_name or record.context == context_name
+        ]
+        records.sort(key=lambda record: (record.requested_at, record.feedback_id), reverse=True)
         if limit is not None:
             records = records[:limit]
         return tuple(records)

--- a/control_plane/storage/migrations/versions/e6f8a0b2c3d4_add_preview_pr_feedback.py
+++ b/control_plane/storage/migrations/versions/e6f8a0b2c3d4_add_preview_pr_feedback.py
@@ -1,0 +1,61 @@
+"""add preview pr feedback
+
+Revision ID: e6f8a0b2c3d4
+Revises: d5e7f9a1b2c3
+Create Date: 2026-04-29 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "e6f8a0b2c3d4"
+down_revision: str | None = "d5e7f9a1b2c3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "launchplane_preview_pr_feedback",
+        sa.Column("feedback_id", sa.String(), nullable=False),
+        sa.Column("product", sa.String(), nullable=False),
+        sa.Column("context", sa.String(), nullable=False),
+        sa.Column("anchor_repo", sa.String(), nullable=False),
+        sa.Column("anchor_pr_number", sa.Integer(), nullable=False),
+        sa.Column("requested_at", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("delivery_status", sa.String(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("feedback_id"),
+    )
+    op.create_index(
+        "launchplane_preview_pr_feedback_context_idx",
+        "launchplane_preview_pr_feedback",
+        ["context", sa.text("requested_at DESC")],
+    )
+    op.create_index(
+        "launchplane_preview_pr_feedback_anchor_idx",
+        "launchplane_preview_pr_feedback",
+        ["anchor_repo", "anchor_pr_number", sa.text("requested_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "launchplane_preview_pr_feedback_anchor_idx",
+        table_name="launchplane_preview_pr_feedback",
+    )
+    op.drop_index(
+        "launchplane_preview_pr_feedback_context_idx",
+        table_name="launchplane_preview_pr_feedback",
+    )
+    op.drop_table("launchplane_preview_pr_feedback")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -23,6 +23,7 @@ from control_plane.contracts.preview_generation_record import PreviewGenerationR
 from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
 from control_plane.contracts.preview_lifecycle_cleanup_record import PreviewLifecycleCleanupRecord
 from control_plane.contracts.preview_lifecycle_plan_record import PreviewLifecyclePlanRecord
+from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedbackRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.preview_summary import LaunchplanePreviewSummary
 from control_plane.contracts.promotion_record import PromotionRecord
@@ -239,6 +240,33 @@ class LaunchplanePreviewLifecycleCleanupRow(Base):
     plan_id: Mapped[str] = mapped_column(String, nullable=False)
     requested_at: Mapped[str] = mapped_column(String, nullable=False)
     status: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplanePreviewPrFeedbackRow(Base):
+    __tablename__ = "launchplane_preview_pr_feedback"
+    __table_args__ = (
+        Index(
+            "launchplane_preview_pr_feedback_context_idx",
+            "context",
+            desc("requested_at"),
+        ),
+        Index(
+            "launchplane_preview_pr_feedback_anchor_idx",
+            "anchor_repo",
+            "anchor_pr_number",
+            desc("requested_at"),
+        ),
+    )
+
+    feedback_id: Mapped[str] = mapped_column(String, primary_key=True)
+    product: Mapped[str] = mapped_column(String, nullable=False)
+    context: Mapped[str] = mapped_column(String, nullable=False)
+    anchor_repo: Mapped[str] = mapped_column(String, nullable=False)
+    anchor_pr_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    requested_at: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    delivery_status: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -1026,6 +1054,41 @@ class PostgresRecordStore(HumanSessionStore):
             limit=limit,
         )
 
+    def write_preview_pr_feedback_record(self, record: PreviewPrFeedbackRecord) -> None:
+        self._write_row(
+            LaunchplanePreviewPrFeedbackRow(
+                feedback_id=record.feedback_id,
+                product=record.product,
+                context=record.context,
+                anchor_repo=record.anchor_repo,
+                anchor_pr_number=record.anchor_pr_number,
+                requested_at=record.requested_at,
+                status=record.status,
+                delivery_status=record.delivery_status,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def list_preview_pr_feedback_records(
+        self,
+        *,
+        context_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[PreviewPrFeedbackRecord, ...]:
+        filters: list[object] = []
+        if context_name:
+            filters.append(LaunchplanePreviewPrFeedbackRow.context == context_name)
+        return self._list_models(
+            model_type=PreviewPrFeedbackRecord,
+            orm_model=LaunchplanePreviewPrFeedbackRow,
+            filters=filters,
+            order_by=(
+                LaunchplanePreviewPrFeedbackRow.requested_at.desc(),
+                LaunchplanePreviewPrFeedbackRow.feedback_id.desc(),
+            ),
+            limit=limit,
+        )
+
     def read_preview_summary(
         self,
         *,
@@ -1506,6 +1569,7 @@ class PostgresRecordStore(HumanSessionStore):
             "preview_inventory_scans": 0,
             "preview_lifecycle_cleanups": 0,
             "preview_lifecycle_plans": 0,
+            "preview_pr_feedback": 0,
             "release_tuples": 0,
         }
         for record in filesystem_store.list_artifact_manifests():
@@ -1544,6 +1608,10 @@ class PostgresRecordStore(HumanSessionStore):
             for record in filesystem_store.list_preview_lifecycle_cleanup_records():
                 self.write_preview_lifecycle_cleanup_record(record)
                 counts["preview_lifecycle_cleanups"] += 1
+        if hasattr(filesystem_store, "list_preview_pr_feedback_records"):
+            for record in filesystem_store.list_preview_pr_feedback_records():
+                self.write_preview_pr_feedback_record(record)
+                counts["preview_pr_feedback"] += 1
         for record in filesystem_store.list_release_tuple_records():
             self.write_release_tuple_record(record)
             counts["release_tuples"] += 1

--- a/control_plane/workflows/preview_pr_feedback.py
+++ b/control_plane/workflows/preview_pr_feedback.py
@@ -1,0 +1,230 @@
+from pathlib import Path
+
+import click
+
+from control_plane.contracts.preview_pr_feedback_record import (
+    PreviewPrFeedbackRecord,
+    PreviewPrFeedbackStatus,
+    build_preview_pr_feedback_id,
+)
+from control_plane.workflows.launchplane import (
+    create_github_issue_comment,
+    find_github_issue_comment_by_marker,
+    github_pull_request_reference,
+    resolve_launchplane_github_token,
+    update_github_issue_comment,
+)
+
+DEFAULT_PREVIEW_FEEDBACK_MARKER = "<!-- verireel-preview-control -->"
+
+
+def _comment_url(payload: dict[str, object]) -> str:
+    html_url = payload.get("html_url")
+    return html_url if isinstance(html_url, str) else ""
+
+
+def _render_preview_pr_feedback_markdown(
+    *,
+    marker: str,
+    status: PreviewPrFeedbackStatus,
+    anchor_pr_number: int,
+    preview_url: str,
+    immutable_image_reference: str,
+    refresh_image_reference: str,
+    revision: str,
+    run_url: str,
+    failure_summary: str,
+) -> str:
+    lines = [marker]
+    if status == "ready":
+        lines.extend(
+            [
+                f"Launchplane preview is ready for PR #{anchor_pr_number}.",
+                "",
+            ]
+        )
+    elif status == "destroyed":
+        lines.extend(
+            [
+                f"Launchplane retired the preview for PR #{anchor_pr_number}.",
+                "",
+            ]
+        )
+    elif status == "cleanup_failed":
+        lines.extend(
+            [
+                f"Launchplane preview cleanup failed for PR #{anchor_pr_number}.",
+                "",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                f"Launchplane preview refresh failed for PR #{anchor_pr_number}.",
+                "",
+            ]
+        )
+    if preview_url:
+        lines.append(f"- Preview URL: {preview_url}")
+    if immutable_image_reference:
+        lines.append(f"- Immutable image: `{immutable_image_reference}`")
+    if refresh_image_reference:
+        lines.append(f"- Refresh tag: `{refresh_image_reference}`")
+    if revision:
+        lines.append(f"- Revision: `{revision}`")
+    if run_url:
+        lines.append(f"- Workflow run: {run_url}")
+    if failure_summary:
+        lines.append(f"- Failure summary: {failure_summary}")
+
+    if status == "ready":
+        lines.extend(
+            [
+                "",
+                "The preview passed the remote creator/public verification gate.",
+                "",
+                "Controls:",
+                "- Push new commits while the `preview` label stays applied to refresh this preview.",
+                "- Remove the `preview` label or close the PR to destroy it.",
+                "- Preview inventory, lifecycle plans, and cleanup evidence are recorded in Launchplane.",
+            ]
+        )
+    elif status == "destroyed":
+        lines.extend(
+            [
+                "",
+                "Launchplane recorded the cleanup result for this preview lifecycle.",
+            ]
+        )
+    elif status == "cleanup_failed":
+        lines.extend(
+            [
+                "",
+                "The preview may still exist. Check the Launchplane cleanup record before retrying.",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "",
+                "No fresh preview link is being advertised from this run. Treat any older preview as stale until a later refresh succeeds.",
+            ]
+        )
+    return "\n".join(line for line in lines if line is not None)
+
+
+def build_preview_pr_feedback_record(
+    *,
+    control_plane_root: Path,
+    product: str,
+    context: str,
+    source: str,
+    requested_at: str,
+    repository: str,
+    anchor_repo: str,
+    anchor_pr_number: int,
+    anchor_pr_url: str,
+    status: PreviewPrFeedbackStatus,
+    marker: str = DEFAULT_PREVIEW_FEEDBACK_MARKER,
+    preview_url: str = "",
+    immutable_image_reference: str = "",
+    refresh_image_reference: str = "",
+    revision: str = "",
+    run_url: str = "",
+    failure_summary: str = "",
+) -> PreviewPrFeedbackRecord:
+    comment_markdown = _render_preview_pr_feedback_markdown(
+        marker=marker,
+        status=status,
+        anchor_pr_number=anchor_pr_number,
+        preview_url=preview_url.strip(),
+        immutable_image_reference=immutable_image_reference.strip(),
+        refresh_image_reference=refresh_image_reference.strip(),
+        revision=revision.strip(),
+        run_url=run_url.strip(),
+        failure_summary=failure_summary.strip(),
+    )
+    delivery_status = "skipped"
+    delivery_action = ""
+    comment_id = 0
+    comment_url = ""
+    error_message = ""
+    github_reference = github_pull_request_reference(pr_url=anchor_pr_url)
+    github_token = resolve_launchplane_github_token(
+        control_plane_root=control_plane_root,
+        context_name=context,
+    )
+    if github_reference is None:
+        error_message = "anchor_pr_url must be a GitHub pull request URL"
+    elif not github_token:
+        error_message = "Launchplane runtime records do not expose GITHUB_TOKEN for this context"
+    else:
+        try:
+            existing_comment = find_github_issue_comment_by_marker(
+                owner=github_reference["owner"],
+                repo=github_reference["repo"],
+                issue_number=github_reference["pr_number"],
+                token=github_token,
+                marker=marker,
+            )
+            if existing_comment is not None:
+                existing_comment_id = existing_comment.get("id")
+                if not isinstance(existing_comment_id, int):
+                    raise click.ClickException("Existing preview feedback comment is missing a numeric id.")
+                updated_comment = update_github_issue_comment(
+                    owner=github_reference["owner"],
+                    repo=github_reference["repo"],
+                    comment_id=existing_comment_id,
+                    token=github_token,
+                    body=comment_markdown,
+                )
+                delivery_status = "delivered"
+                delivery_action = "updated_comment"
+                comment_id = existing_comment_id
+                comment_url = _comment_url(updated_comment)
+            else:
+                created_comment = create_github_issue_comment(
+                    owner=github_reference["owner"],
+                    repo=github_reference["repo"],
+                    issue_number=github_reference["pr_number"],
+                    token=github_token,
+                    body=comment_markdown,
+                )
+                created_comment_id = created_comment.get("id")
+                delivery_status = "delivered"
+                delivery_action = "created_comment"
+                comment_id = created_comment_id if isinstance(created_comment_id, int) else 0
+                comment_url = _comment_url(created_comment)
+        except click.ClickException as exc:
+            delivery_status = "failed"
+            error_message = str(exc)
+
+    return PreviewPrFeedbackRecord(
+        feedback_id=build_preview_pr_feedback_id(
+            context_name=context,
+            anchor_pr_number=anchor_pr_number,
+            requested_at=requested_at,
+        ),
+        product=product,
+        context=context,
+        source=source,
+        requested_at=requested_at,
+        repository=repository,
+        anchor_repo=anchor_repo,
+        anchor_pr_number=anchor_pr_number,
+        anchor_pr_url=anchor_pr_url,
+        status=status,
+        marker=marker,
+        comment_markdown=comment_markdown,
+        preview_url=preview_url,
+        immutable_image_reference=immutable_image_reference,
+        refresh_image_reference=refresh_image_reference,
+        revision=revision,
+        run_url=run_url,
+        failure_summary=failure_summary,
+        delivery_status=delivery_status,
+        delivery_action=delivery_action,
+        comment_id=comment_id,
+        comment_url=comment_url,
+        error_message=error_message,
+    )

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -482,9 +482,12 @@ inventory scan, writes a durable lifecycle plan, and returns keep/orphaned/missi
 sets. Cleanup requests go through `POST /v1/previews/lifecycle-cleanup`, which
 requires an existing plan id, defaults to report-only, and records cleanup
 results. Destructive provider cleanup still requires explicit `apply=true` from
-an authorized GitHub Actions workflow. This is the next extraction step toward a
-cross-repo preview system; product repos remain thin adapters for labels,
-artifact build facts, and product-specific health/config hints.
+an authorized GitHub Actions workflow. PR feedback goes through
+`POST /v1/previews/pr-feedback`; Launchplane renders and upserts the anchored PR
+comment when runtime GitHub credentials are available, then records delivery
+status. This is the next extraction step toward a cross-repo preview system;
+product repos remain thin adapters for labels, artifact build facts, and
+product-specific health/config hints.
 
 ### VeriReel Preview Evidence Handoff
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -411,6 +411,17 @@ state/
   only allowed through an authorized workflow request with `apply=true` and an
   existing passing lifecycle plan.
 
+## Launchplane Preview PR Feedback Record
+
+- One append-only record per attempt to publish preview status back to an anchor
+  pull request.
+- Record the product/context/source, anchor repository and PR, preview status,
+  rendered comment markdown, delivery status, delivery action, GitHub comment id
+  and URL, and any skip/failure reason.
+- Product repos should send outcome facts rather than hand-rendering or upserting
+  GitHub comments themselves. This keeps PR feedback aligned with Launchplane's
+  durable preview lifecycle records.
+
 ## Inventory
 
 - Inventory records are keyed by environment.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -264,6 +264,7 @@ writes, not on every possible operator action.
 
 - `POST /v1/previews/lifecycle-plan`
 - `POST /v1/previews/lifecycle-cleanup`
+- `POST /v1/previews/pr-feedback`
 
 The first preview lifecycle endpoint remains the source of the durable decision:
 product repos send desired preview anchors, Launchplane compares those desired
@@ -273,6 +274,12 @@ second endpoint that requires an existing lifecycle `plan_id`; it defaults to
 `apply=false` report-only behavior and records the cleanup request/result next to
 the plan. Destructive provider cleanup is only attempted when `apply=true` is
 explicitly supplied by an authorized GitHub Actions workflow.
+
+PR feedback delivery is part of the same preview lifecycle boundary. Product
+repos submit thin preview outcome facts to `POST /v1/previews/pr-feedback`;
+Launchplane renders the review comment, upserts the anchored GitHub PR comment
+when its runtime token is available, and stores an append-only feedback record
+with the comment body, delivery action, comment URL, and any skip/failure reason.
 
 ### Operator read endpoints
 

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -37,6 +37,7 @@ from control_plane.contracts.preview_lifecycle_plan_record import (
     PreviewLifecycleDesiredPreview,
     PreviewLifecyclePlanRecord,
 )
+from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedbackRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
@@ -810,6 +811,53 @@ class PostgresRecordStoreTests(unittest.TestCase):
         self.assertEqual(listed_records[0].destroyed_slugs, ("pr-122",))
         self.assertEqual(listed_records[0].results[0].application_id, "app-122")
 
+    def test_preview_pr_feedback_records_round_trip(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_preview_pr_feedback_record(
+                PreviewPrFeedbackRecord(
+                    feedback_id="preview-pr-feedback-verireel-testing-pr-123-20260420T100800Z",
+                    product="verireel",
+                    context="verireel-testing",
+                    source="preview-control-plane",
+                    requested_at="2026-04-20T10:08:00Z",
+                    repository="every/verireel",
+                    anchor_repo="verireel",
+                    anchor_pr_number=123,
+                    anchor_pr_url="https://github.com/every/verireel/pull/123",
+                    status="ready",
+                    marker="<!-- verireel-preview-control -->",
+                    comment_markdown="<!-- verireel-preview-control -->\nPreview ready.",
+                    preview_url="https://pr-123.preview.example",
+                    immutable_image_reference="ghcr.io/every/verireel:pr-123-a1b2c3d4",
+                    refresh_image_reference="ghcr.io/every/verireel:preview-pr-123",
+                    revision="a1b2c3d4",
+                    run_url="https://github.com/every/verireel/actions/runs/123",
+                    delivery_status="delivered",
+                    delivery_action="updated_comment",
+                    comment_id=456,
+                    comment_url="https://github.com/every/verireel/pull/123#issuecomment-456",
+                )
+            )
+            listed_records = store.list_preview_pr_feedback_records(
+                context_name="verireel-testing",
+                limit=1,
+            )
+            store.close()
+
+        self.assertEqual(len(listed_records), 1)
+        self.assertEqual(
+            listed_records[0].feedback_id,
+            "preview-pr-feedback-verireel-testing-pr-123-20260420T100800Z",
+        )
+        self.assertEqual(listed_records[0].delivery_status, "delivered")
+        self.assertEqual(listed_records[0].comment_id, 456)
+
     def test_write_and_list_dokploy_target_id_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(
@@ -1138,6 +1186,24 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     status="report_only",
                 )
             )
+            filesystem_store.write_preview_pr_feedback_record(
+                PreviewPrFeedbackRecord(
+                    feedback_id="preview-pr-feedback-verireel-testing-pr-123-20260420T100800Z",
+                    product="verireel",
+                    context="verireel-testing",
+                    source="preview-control-plane",
+                    requested_at="2026-04-20T10:08:00Z",
+                    repository="every/verireel",
+                    anchor_repo="verireel",
+                    anchor_pr_number=123,
+                    anchor_pr_url="https://github.com/every/verireel/pull/123",
+                    status="ready",
+                    marker="<!-- verireel-preview-control -->",
+                    comment_markdown="<!-- verireel-preview-control -->\nPreview ready.",
+                    delivery_status="skipped",
+                    error_message="Launchplane runtime records do not expose GITHUB_TOKEN for this context",
+                )
+            )
             filesystem_store.write_release_tuple_record(_release_tuple_record())
 
             counts = store.import_core_records_from_filesystem(filesystem_store)
@@ -1155,6 +1221,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     "preview_inventory_scans": 1,
                     "preview_lifecycle_cleanups": 1,
                     "preview_lifecycle_plans": 1,
+                    "preview_pr_feedback": 1,
                     "release_tuples": 1,
                 },
             )
@@ -1190,5 +1257,12 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     limit=1,
                 )[0].cleanup_id,
                 "preview-lifecycle-cleanup-verireel-testing-20260420T100700Z",
+            )
+            self.assertEqual(
+                store.list_preview_pr_feedback_records(
+                    context_name="verireel-testing",
+                    limit=1,
+                )[0].feedback_id,
+                "preview-pr-feedback-verireel-testing-pr-123-20260420T100800Z",
             )
             store.close()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2701,6 +2701,123 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["result"]["orphaned_slugs"], [])
         self.assertIn("has not recorded", payload["result"]["error_message"])
 
+    def test_preview_pr_feedback_endpoint_records_skipped_delivery_without_token(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/pull/42/merge"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel-testing"],
+                            "actions": ["preview_pr_feedback.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/pull/42/merge"
+                        ),
+                        event_name="pull_request",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/pr-feedback",
+                payload={
+                    "product": "verireel",
+                    "context": "verireel-testing",
+                    "source": "preview-control-plane",
+                    "repository": "every/verireel",
+                    "anchor_repo": "verireel",
+                    "anchor_pr_number": 42,
+                    "anchor_pr_url": "https://github.com/every/verireel/pull/42",
+                    "status": "ready",
+                    "preview_url": "https://pr-42.preview.example",
+                    "immutable_image_reference": "ghcr.io/every/verireel:pr-42-a1b2c3d4",
+                    "refresh_image_reference": "ghcr.io/every/verireel:preview-pr-42",
+                    "revision": "a1b2c3d4",
+                    "run_url": "https://github.com/every/verireel/actions/runs/123",
+                },
+            )
+
+            feedback_records = FilesystemRecordStore(
+                state_dir=root / "state"
+            ).list_preview_pr_feedback_records(context_name="verireel-testing")
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(payload["records"]["preview_pr_feedback_id"], feedback_records[0].feedback_id)
+        self.assertEqual(payload["result"]["delivery_status"], "skipped")
+        self.assertIn("Launchplane preview is ready", payload["result"]["comment_markdown"])
+        self.assertIn("GITHUB_TOKEN", feedback_records[0].error_message)
+        self.assertEqual(feedback_records[0].anchor_pr_number, 42)
+
+    def test_preview_pr_feedback_endpoint_rejects_unauthorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/pull/42/merge"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel-testing"],
+                            "actions": ["preview_generation.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/pull/42/merge"
+                        ),
+                        event_name="pull_request",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/pr-feedback",
+                payload={
+                    "product": "verireel",
+                    "context": "verireel-testing",
+                    "repository": "every/verireel",
+                    "anchor_repo": "verireel",
+                    "anchor_pr_number": 42,
+                    "anchor_pr_url": "https://github.com/every/verireel/pull/42",
+                    "status": "ready",
+                },
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
     def test_preview_lifecycle_cleanup_endpoint_records_report_only_cleanup(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add a preview PR feedback record contract, Postgres/filesystem storage, and migration
- expose POST /v1/previews/pr-feedback with OIDC authz and idempotent accepted responses
- document the endpoint as the Launchplane-owned PR comment boundary

## Validation
- uv run --extra dev ruff check control_plane/contracts/preview_pr_feedback_record.py control_plane/workflows/preview_pr_feedback.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/service.py tests/test_service.py tests/test_postgres_store.py control_plane/storage/migrations/versions/e6f8a0b2c3d4_add_preview_pr_feedback.py
- uv run python -m unittest
- npx pnpm@10.10.0 --dir frontend validate
- git diff --check
- docker build -t launchplane-preview-pr-feedback-test .