### PR TITLE
Support unsupported preview PR feedback

### DIFF
--- a/control_plane/contracts/preview_pr_feedback_record.py
+++ b/control_plane/contracts/preview_pr_feedback_record.py
@@ -3,7 +3,14 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
-PreviewPrFeedbackStatus = Literal["ready", "destroyed", "failed", "cleanup_failed"]
+PreviewPrFeedbackStatus = Literal[
+    "ready",
+    "destroyed",
+    "failed",
+    "cleanup_failed",
+    "unsupported",
+    "cleared",
+]
 PreviewPrFeedbackDeliveryStatus = Literal["delivered", "skipped", "failed"]
 
 

--- a/control_plane/workflows/launchplane.py
+++ b/control_plane/workflows/launchplane.py
@@ -884,6 +884,18 @@ def update_github_issue_comment(
     return payload
 
 
+def delete_github_issue_comment(*, owner: str, repo: str, comment_id: int, token: str) -> None:
+    payload = github_api_request(
+        path=f"/repos/{owner}/{repo}/issues/comments/{comment_id}",
+        token=token,
+        method="DELETE",
+    )
+    if payload is not None:
+        raise click.ClickException(
+            f"GitHub comment delete response for {owner}/{repo} comment {comment_id} must be empty."
+        )
+
+
 def github_api_request(
     *, path: str, token: str, method: str = "GET", body: dict[str, object] | None = None
 ) -> object:
@@ -904,7 +916,8 @@ def github_api_request(
     )
     try:
         with urlopen(request, timeout=15) as response:
-            return json.loads(response.read().decode("utf-8"))
+            response_text = response.read().decode("utf-8")
+            return json.loads(response_text) if response_text.strip() else None
     except (HTTPError, URLError, OSError, json.JSONDecodeError) as exc:
         raise click.ClickException(f"GitHub API request failed for {path}: {exc}") from exc
 

--- a/control_plane/workflows/preview_pr_feedback.py
+++ b/control_plane/workflows/preview_pr_feedback.py
@@ -9,6 +9,7 @@ from control_plane.contracts.preview_pr_feedback_record import (
 )
 from control_plane.workflows.launchplane import (
     create_github_issue_comment,
+    delete_github_issue_comment,
     find_github_issue_comment_by_marker,
     github_pull_request_reference,
     resolve_launchplane_github_token,
@@ -57,6 +58,20 @@ def _render_preview_pr_feedback_markdown(
                 "",
             ]
         )
+    elif status == "unsupported":
+        lines.extend(
+            [
+                f"Launchplane preview automation is unavailable for PR #{anchor_pr_number}.",
+                "",
+            ]
+        )
+    elif status == "cleared":
+        lines.extend(
+            [
+                f"Launchplane cleared preview feedback for PR #{anchor_pr_number}.",
+                "",
+            ]
+        )
     else:
         lines.extend(
             [
@@ -101,6 +116,20 @@ def _render_preview_pr_feedback_markdown(
             [
                 "",
                 "The preview may still exist. Check the Launchplane cleanup record before retrying.",
+            ]
+        )
+    elif status == "unsupported":
+        lines.extend(
+            [
+                "",
+                "No preview environment was requested because this pull request cannot use the protected preview provisioning path.",
+            ]
+        )
+    elif status == "cleared":
+        lines.extend(
+            [
+                "",
+                "Launchplane keeps this record as evidence of the cleared PR feedback request.",
             ]
         )
     else:
@@ -171,17 +200,30 @@ def build_preview_pr_feedback_record(
                 existing_comment_id = existing_comment.get("id")
                 if not isinstance(existing_comment_id, int):
                     raise click.ClickException("Existing preview feedback comment is missing a numeric id.")
-                updated_comment = update_github_issue_comment(
-                    owner=github_reference["owner"],
-                    repo=github_reference["repo"],
-                    comment_id=existing_comment_id,
-                    token=github_token,
-                    body=comment_markdown,
-                )
-                delivery_status = "delivered"
-                delivery_action = "updated_comment"
-                comment_id = existing_comment_id
-                comment_url = _comment_url(updated_comment)
+                if status == "cleared":
+                    delete_github_issue_comment(
+                        owner=github_reference["owner"],
+                        repo=github_reference["repo"],
+                        comment_id=existing_comment_id,
+                        token=github_token,
+                    )
+                    delivery_status = "delivered"
+                    delivery_action = "deleted_comment"
+                    comment_id = existing_comment_id
+                else:
+                    updated_comment = update_github_issue_comment(
+                        owner=github_reference["owner"],
+                        repo=github_reference["repo"],
+                        comment_id=existing_comment_id,
+                        token=github_token,
+                        body=comment_markdown,
+                    )
+                    delivery_status = "delivered"
+                    delivery_action = "updated_comment"
+                    comment_id = existing_comment_id
+                    comment_url = _comment_url(updated_comment)
+            elif status == "cleared":
+                delivery_action = "no_existing_comment"
             else:
                 created_comment = create_github_issue_comment(
                     owner=github_reference["owner"],

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -331,7 +331,7 @@ def _secret_audit_event(*, event_id: str, secret_id: str, recorded_at: str) -> S
 
 
 def _human_session(*, session_id: str = "session-1") -> LaunchplaneHumanSession:
-    created_at = datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
+    created_at = datetime.now(timezone.utc).replace(microsecond=0)
     return LaunchplaneHumanSession(
         session_id=session_id,
         created_at=created_at,

--- a/tests/test_preview_pr_feedback.py
+++ b/tests/test_preview_pr_feedback.py
@@ -1,0 +1,101 @@
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from control_plane.workflows.preview_pr_feedback import build_preview_pr_feedback_record
+
+
+class PreviewPrFeedbackWorkflowTests(unittest.TestCase):
+    def test_cleared_feedback_deletes_existing_comment(self) -> None:
+        with (
+            patch(
+                "control_plane.workflows.preview_pr_feedback.resolve_launchplane_github_token",
+                return_value="github-token",
+            ),
+            patch(
+                "control_plane.workflows.preview_pr_feedback.find_github_issue_comment_by_marker",
+                return_value={"id": 123, "body": "<!-- verireel-preview-unsupported -->\nold"},
+            ) as find_comment,
+            patch(
+                "control_plane.workflows.preview_pr_feedback.delete_github_issue_comment"
+            ) as delete_comment,
+            patch(
+                "control_plane.workflows.preview_pr_feedback.create_github_issue_comment"
+            ) as create_comment,
+            patch(
+                "control_plane.workflows.preview_pr_feedback.update_github_issue_comment"
+            ) as update_comment,
+        ):
+            record = build_preview_pr_feedback_record(
+                control_plane_root=Path("."),
+                product="verireel",
+                context="verireel-testing",
+                source="preview-fork-notice",
+                requested_at="2026-04-30T00:00:00Z",
+                repository="every/verireel",
+                anchor_repo="verireel",
+                anchor_pr_number=43,
+                anchor_pr_url="https://github.com/every/verireel/pull/43",
+                status="cleared",
+                marker="<!-- verireel-preview-unsupported -->",
+            )
+
+        self.assertEqual(record.status, "cleared")
+        self.assertEqual(record.delivery_status, "delivered")
+        self.assertEqual(record.delivery_action, "deleted_comment")
+        self.assertEqual(record.comment_id, 123)
+        find_comment.assert_called_once_with(
+            owner="every",
+            repo="verireel",
+            issue_number=43,
+            token="github-token",
+            marker="<!-- verireel-preview-unsupported -->",
+        )
+        delete_comment.assert_called_once_with(
+            owner="every",
+            repo="verireel",
+            comment_id=123,
+            token="github-token",
+        )
+        create_comment.assert_not_called()
+        update_comment.assert_not_called()
+
+    def test_cleared_feedback_skips_when_comment_is_missing(self) -> None:
+        with (
+            patch(
+                "control_plane.workflows.preview_pr_feedback.resolve_launchplane_github_token",
+                return_value="github-token",
+            ),
+            patch(
+                "control_plane.workflows.preview_pr_feedback.find_github_issue_comment_by_marker",
+                return_value=None,
+            ),
+            patch(
+                "control_plane.workflows.preview_pr_feedback.delete_github_issue_comment"
+            ) as delete_comment,
+            patch(
+                "control_plane.workflows.preview_pr_feedback.create_github_issue_comment"
+            ) as create_comment,
+        ):
+            record = build_preview_pr_feedback_record(
+                control_plane_root=Path("."),
+                product="verireel",
+                context="verireel-testing",
+                source="preview-fork-notice",
+                requested_at="2026-04-30T00:00:00Z",
+                repository="every/verireel",
+                anchor_repo="verireel",
+                anchor_pr_number=43,
+                anchor_pr_url="https://github.com/every/verireel/pull/43",
+                status="cleared",
+                marker="<!-- verireel-preview-unsupported -->",
+            )
+
+        self.assertEqual(record.delivery_status, "skipped")
+        self.assertEqual(record.delivery_action, "no_existing_comment")
+        delete_comment.assert_not_called()
+        create_comment.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2971,6 +2971,68 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertIn("GITHUB_TOKEN", feedback_records[0].error_message)
         self.assertEqual(feedback_records[0].anchor_pr_number, 42)
 
+    def test_preview_pr_feedback_endpoint_records_unsupported_notice(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-fork-notice.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request_target"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel-testing"],
+                            "actions": ["preview_pr_feedback.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/preview-fork-notice.yml@refs/heads/main"
+                        ),
+                        event_name="pull_request_target",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/pr-feedback",
+                payload={
+                    "product": "verireel",
+                    "context": "verireel-testing",
+                    "source": "preview-fork-notice",
+                    "repository": "every/verireel",
+                    "anchor_repo": "verireel",
+                    "anchor_pr_number": 43,
+                    "anchor_pr_url": "https://github.com/every/verireel/pull/43",
+                    "status": "unsupported",
+                    "run_url": "https://github.com/every/verireel/actions/runs/124",
+                    "failure_summary": "Preview automation is unavailable for forked pull requests.",
+                },
+            )
+
+            feedback_records = FilesystemRecordStore(
+                state_dir=root / "state"
+            ).list_preview_pr_feedback_records(context_name="verireel-testing")
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(feedback_records[0].status, "unsupported")
+        self.assertIn("preview automation is unavailable", payload["result"]["comment_markdown"])
+        self.assertIn("protected preview provisioning path", payload["result"]["comment_markdown"])
+        self.assertEqual(payload["result"]["delivery_status"], "skipped")
+
     def test_preview_pr_feedback_endpoint_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add an unsupported status to Launchplane preview PR feedback records
- render unsupported preview notices through the Launchplane feedback path
- make the human-session store test fixture time-stable again

## Verification
- uv run --extra dev ruff check .
- uv run python -m unittest
- npx pnpm@10.10.0 --dir frontend validate
- git diff --check
- docker build -t launchplane-preview-feedback-unsupported-test .