### PR TITLE
Add generic web driver profiles

### DIFF
--- a/control_plane/contracts/driver_descriptor.py
+++ b/control_plane/contracts/driver_descriptor.py
@@ -64,6 +64,7 @@ class DriverDescriptor(BaseModel):
 
     schema_version: int = Field(default=1, ge=1)
     driver_id: str
+    base_driver_id: str = ""
     label: str
     product: str
     description: str

--- a/control_plane/contracts/product_profile_record.py
+++ b/control_plane/contracts/product_profile_record.py
@@ -1,0 +1,81 @@
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ProductImageProfile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    repository: str
+
+    @model_validator(mode="after")
+    def _validate_image(self) -> "ProductImageProfile":
+        if not self.repository.strip():
+            raise ValueError("product image profile requires repository")
+        return self
+
+
+class ProductLaneProfile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    instance: str
+    context: str
+    base_url: str = ""
+    health_url: str = ""
+
+    @model_validator(mode="after")
+    def _validate_lane(self) -> "ProductLaneProfile":
+        if not self.instance.strip():
+            raise ValueError("product lane profile requires instance")
+        if not self.context.strip():
+            raise ValueError("product lane profile requires context")
+        return self
+
+
+class ProductPreviewProfile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    context: str = ""
+    slug_template: str = "pr-{number}"
+
+    @model_validator(mode="after")
+    def _validate_preview(self) -> "ProductPreviewProfile":
+        if self.enabled and not self.context.strip():
+            raise ValueError("enabled product preview profile requires context")
+        if self.enabled and "{number}" not in self.slug_template:
+            raise ValueError("enabled product preview profile slug_template requires {number}")
+        return self
+
+
+class LaunchplaneProductProfileRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    display_name: str
+    repository: str
+    driver_id: str
+    image: ProductImageProfile
+    runtime_port: int = Field(ge=1, le=65535)
+    health_path: str
+    lanes: tuple[ProductLaneProfile, ...] = ()
+    preview: ProductPreviewProfile = Field(default_factory=ProductPreviewProfile)
+    updated_at: str
+    source: str
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "LaunchplaneProductProfileRecord":
+        if not self.product.strip():
+            raise ValueError("product profile requires product")
+        if not self.display_name.strip():
+            raise ValueError("product profile requires display_name")
+        if not self.repository.strip():
+            raise ValueError("product profile requires repository")
+        if not self.driver_id.strip():
+            raise ValueError("product profile requires driver_id")
+        if not self.health_path.startswith("/"):
+            raise ValueError("product profile health_path must start with /")
+        if not self.updated_at.strip():
+            raise ValueError("product profile requires updated_at")
+        if not self.source.strip():
+            raise ValueError("product profile requires source")
+        return self

--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -25,6 +25,7 @@ PROVIDER_BOUNDARY_NOTE = (
 )
 LANE_STALE_AFTER = timedelta(minutes=30)
 PREVIEW_STALE_AFTER = timedelta(minutes=30)
+PREVIEW_CAPABILITY_IDS = {"preview_lifecycle", "previewable", "preview_inventory_managed"}
 
 
 def _action(
@@ -48,6 +49,51 @@ def _action(
         route_path=route_path,
         writes_records=writes_records,
     )
+
+
+GENERIC_WEB_DRIVER = DriverDescriptor(
+    driver_id="generic-web",
+    label="Generic web",
+    product="generic-web",
+    description=(
+        "Reusable containerized web-app lifecycle driver for image deploys, "
+        "health checks, previews, and PR feedback."
+    ),
+    context_patterns=(),
+    provider_boundary=PROVIDER_BOUNDARY_NOTE,
+    capabilities=(
+        DriverCapabilityDescriptor(
+            capability_id="image_deployable",
+            label="Image deployable",
+            description="Deploy immutable container images and record stable-lane deployment evidence.",
+            panels=("lane_health", "deployment_evidence"),
+        ),
+        DriverCapabilityDescriptor(
+            capability_id="health_checked",
+            label="Health checked",
+            description="Verify HTTP health endpoints and surface freshness through Launchplane read models.",
+            panels=("lane_health",),
+        ),
+        DriverCapabilityDescriptor(
+            capability_id="previewable",
+            label="Previewable",
+            description="Model desired preview state, creation, refresh, cleanup, and preview evidence for web products.",
+            panels=("preview_inventory", "deployment_evidence", "audit"),
+        ),
+        DriverCapabilityDescriptor(
+            capability_id="preview_inventory_managed",
+            label="Preview inventory managed",
+            description="Read provider inventory and reconcile current preview state through Launchplane records.",
+            panels=("preview_inventory", "deployment_evidence", "audit"),
+        ),
+        DriverCapabilityDescriptor(
+            capability_id="pr_feedback",
+            label="PR feedback",
+            description="Render and persist pull-request feedback from Launchplane preview and deploy records.",
+            panels=("audit",),
+        ),
+    ),
+)
 
 
 ODOO_DRIVER = DriverDescriptor(
@@ -157,6 +203,7 @@ ODOO_DRIVER = DriverDescriptor(
 
 VERIREEL_DRIVER = DriverDescriptor(
     driver_id="verireel",
+    base_driver_id="generic-web",
     label="VeriReel",
     product="verireel",
     description="VeriReel stable-lane and preview lifecycle driver.",
@@ -292,7 +339,11 @@ VERIREEL_DRIVER = DriverDescriptor(
     ),
 )
 
-_DESCRIPTORS: tuple[DriverDescriptor, ...] = (ODOO_DRIVER, VERIREEL_DRIVER)
+_DESCRIPTORS: tuple[DriverDescriptor, ...] = (
+    GENERIC_WEB_DRIVER,
+    ODOO_DRIVER,
+    VERIREEL_DRIVER,
+)
 
 
 def list_driver_descriptors() -> tuple[DriverDescriptor, ...]:
@@ -581,6 +632,13 @@ def _list_preview_summaries(
     return tuple(summaries)
 
 
+def _driver_exposes_preview_inventory(descriptor: DriverDescriptor) -> bool:
+    capability_ids = {capability.capability_id for capability in descriptor.capabilities}
+    if capability_ids.intersection(PREVIEW_CAPABILITY_IDS):
+        return True
+    return any("preview_inventory" in capability.panels for capability in descriptor.capabilities)
+
+
 def build_driver_context_view(
     *,
     record_store: object,
@@ -597,13 +655,13 @@ def build_driver_context_view(
             instance_name=instance_name,
         )
         preview_summaries = ()
-        if descriptor.driver_id == "verireel":
+        if _driver_exposes_preview_inventory(descriptor):
             preview_summaries = _list_preview_summaries(
                 record_store=record_store,
                 context_name=context_name,
             )
         preview_inventory_provenance = None
-        if descriptor.driver_id == "verireel":
+        if _driver_exposes_preview_inventory(descriptor):
             preview_inventory_provenance = _preview_inventory_provenance(
                 record_store=record_store,
                 context_name=context_name,

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -19,6 +19,7 @@ from control_plane.contracts.preview_lifecycle_cleanup_record import PreviewLife
 from control_plane.contracts.preview_lifecycle_plan_record import PreviewLifecyclePlanRecord
 from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedbackRecord
 from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
 
@@ -82,6 +83,31 @@ class FilesystemRecordStore:
 
     def write_authz_policy_record(self, record: LaunchplaneAuthzPolicyRecord) -> Path:
         return self._write_model("launchplane_authz_policies", record.record_id, record)
+
+    def write_product_profile_record(self, record: LaunchplaneProductProfileRecord) -> Path:
+        return self._write_model("launchplane_product_profiles", record.product, record)
+
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
+        return LaunchplaneProductProfileRecord.model_validate(
+            self._read_model(
+                LaunchplaneProductProfileRecord, "launchplane_product_profiles", product
+            ).model_dump(mode="json")
+        )
+
+    def list_product_profile_records(
+        self,
+        *,
+        driver_id: str = "",
+    ) -> tuple[LaunchplaneProductProfileRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                LaunchplaneProductProfileRecord, "launchplane_product_profiles"
+            )
+            if not driver_id or record.driver_id == driver_id
+        ]
+        records.sort(key=lambda record: record.product)
+        return tuple(records)
 
     def list_authz_policy_records(
         self,

--- a/control_plane/storage/migrations/versions/b9c1d3e5f7a9_add_product_profiles.py
+++ b/control_plane/storage/migrations/versions/b9c1d3e5f7a9_add_product_profiles.py
@@ -1,0 +1,46 @@
+"""add product profiles
+
+Revision ID: b9c1d3e5f7a9
+Revises: a8b0c2d4e6f8
+Create Date: 2026-04-30 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "b9c1d3e5f7a9"
+down_revision: str | None = "a8b0c2d4e6f8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "launchplane_product_profiles",
+        sa.Column("product", sa.String(), nullable=False),
+        sa.Column("display_name", sa.String(), nullable=False),
+        sa.Column("repository", sa.String(), nullable=False),
+        sa.Column("driver_id", sa.String(), nullable=False),
+        sa.Column("updated_at", sa.String(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("product"),
+    )
+    op.create_index(
+        "launchplane_product_profiles_driver_idx",
+        "launchplane_product_profiles",
+        ["driver_id", sa.text("updated_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("launchplane_product_profiles_driver_idx", table_name="launchplane_product_profiles")
+    op.drop_table("launchplane_product_profiles")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -27,6 +27,7 @@ from control_plane.contracts.preview_lifecycle_plan_record import PreviewLifecyc
 from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedbackRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.preview_summary import LaunchplanePreviewSummary
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
@@ -314,6 +315,20 @@ class LaunchplaneAuthzPolicyRow(Base):
     source: Mapped[str] = mapped_column(String, nullable=False)
     updated_at: Mapped[str] = mapped_column(String, nullable=False)
     policy_sha256: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneProductProfileRow(Base):
+    __tablename__ = "launchplane_product_profiles"
+    __table_args__ = (
+        Index("launchplane_product_profiles_driver_idx", "driver_id", desc("updated_at")),
+    )
+
+    product: Mapped[str] = mapped_column(String, primary_key=True)
+    display_name: Mapped[str] = mapped_column(String, nullable=False)
+    repository: Mapped[str] = mapped_column(String, nullable=False)
+    driver_id: Mapped[str] = mapped_column(String, nullable=False)
+    updated_at: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -1266,6 +1281,40 @@ class PostgresRecordStore(HumanSessionStore):
             return records[:limit]
         return records
 
+    def write_product_profile_record(self, record: LaunchplaneProductProfileRecord) -> None:
+        self._write_row(
+            LaunchplaneProductProfileRow(
+                product=record.product,
+                display_name=record.display_name,
+                repository=record.repository,
+                driver_id=record.driver_id,
+                updated_at=record.updated_at,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
+        return self._read_model(
+            model_type=LaunchplaneProductProfileRecord,
+            orm_model=LaunchplaneProductProfileRow,
+            filters=(LaunchplaneProductProfileRow.product == product,),
+        )
+
+    def list_product_profile_records(
+        self,
+        *,
+        driver_id: str = "",
+    ) -> tuple[LaunchplaneProductProfileRecord, ...]:
+        filters: list[object] = []
+        if driver_id:
+            filters.append(LaunchplaneProductProfileRow.driver_id == driver_id)
+        return self._list_models(
+            model_type=LaunchplaneProductProfileRecord,
+            orm_model=LaunchplaneProductProfileRow,
+            filters=filters,
+            order_by=(LaunchplaneProductProfileRow.product.asc(),),
+        )
+
     def write_dokploy_target_id_record(self, record: DokployTargetIdRecord) -> None:
         self._write_row(
             LaunchplaneDokployTargetIdRow(
@@ -1667,6 +1716,7 @@ class PostgresRecordStore(HumanSessionStore):
             "promotions": 0,
             "inventory": 0,
             "odoo_instance_overrides": 0,
+            "product_profiles": 0,
             "preview_records": 0,
             "preview_generations": 0,
             "preview_desired_states": 0,
@@ -1697,6 +1747,9 @@ class PostgresRecordStore(HumanSessionStore):
         for record in filesystem_store.list_odoo_instance_override_records():
             self.write_odoo_instance_override_record(record)
             counts["odoo_instance_overrides"] += 1
+        for record in filesystem_store.list_product_profile_records():
+            self.write_product_profile_record(record)
+            counts["product_profiles"] += 1
         for record in filesystem_store.list_preview_records():
             self.write_preview_record(record)
             counts["preview_records"] += 1

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -29,8 +29,8 @@ frontend plugin system.
 The descriptor contracts live in
 `control_plane/contracts/driver_descriptor.py`.
 
-- `DriverDescriptor`: static driver metadata, context patterns, capabilities,
-  actions, and setting groups.
+- `DriverDescriptor`: static driver metadata, optional base driver id, context
+  patterns, capabilities, actions, and setting groups.
 - `DriverCapabilityDescriptor`: grouped product capability such as stable
   promotion, artifact publish, preview lifecycle, or post-deploy settings.
 - `DriverActionDescriptor`: read-only action metadata, route path, method,
@@ -52,14 +52,16 @@ Action safety levels are intentionally coarse:
 ## Registry
 
 The v1 registry is in code at `control_plane/drivers/registry.py`. It contains
-Odoo and VeriReel descriptors and composes driver views from existing storage
-repository methods:
+the reusable generic-web base descriptor plus Odoo and VeriReel descriptors, and
+composes driver views from existing storage repository methods:
 
 - `LaunchplaneLaneSummary` for stable lane state.
 - `LaunchplanePreviewSummary` for preview lifecycle state.
 
 The registry is deliberately not a database table yet. Driver descriptor shape
-should stabilize before Launchplane adds writable driver metadata.
+should stabilize before Launchplane adds writable driver metadata. Product and
+lane configuration still belongs in DB-backed Launchplane records, not in
+repo-local Launchplane TOML manifests.
 
 ## Read Endpoints
 
@@ -79,6 +81,18 @@ inspect JSONB payloads directly.
 
 ## Initial Drivers
 
+Generic web exposes base capabilities without executable routes yet:
+
+- image deployment evidence
+- HTTP health checking
+- preview lifecycle and inventory read models
+- PR feedback ownership
+
+Product drivers can declare `base_driver_id="generic-web"` when they reuse the
+generic web lifecycle and add named product-specific gates or runtime actions.
+The relationship is explicit metadata; product-specific capabilities are still
+declared directly on the product driver.
+
 Odoo exposes:
 
 - artifact publish handoff
@@ -97,3 +111,8 @@ VeriReel exposes:
 
 These descriptors intentionally reference Launchplane routes, not runtime
 provider concepts, as the future GUI-facing action surface.
+
+Preview read models are capability-driven. A driver that exposes
+`previewable`, `preview_inventory_managed`, legacy `preview_lifecycle`, or the
+`preview_inventory` panel receives preview summaries without being named VeriReel
+in the registry.

--- a/docs/records.md
+++ b/docs/records.md
@@ -124,6 +124,19 @@ order, join, authorize, constrain, display it regularly, or drive an action from
 it. Keep unstable provider envelopes, replay/debug context, and raw evidence in
 JSONB until they graduate into normal product behavior.
 
+## Product Profiles
+
+Product profile records are DB-backed Launchplane configuration for product
+identity and driver selection. They hold product key, display name, owning repo,
+driver id, image repository, runtime port, health path, stable lane bindings,
+and preview context policy.
+
+These records replace repo-local Launchplane lifecycle manifests. Product repos
+still own their normal app/runtime contract, such as Dockerfile, image publish,
+health endpoint, tests, and source/build inputs. Launchplane owns the product
+profile that maps those app facts into preview, deploy, promotion, and evidence
+behavior.
+
 This file layout describes today's local Launchplane implementation, not the
 final cross-product communication boundary. The stable long-term contract should
 be Launchplane's authenticated service ingress plus the durable record semantics

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -104,6 +104,7 @@ const FIXTURE_ACTIONS: DriverActionDescriptor[] = [
 const FIXTURE_VERIREEL_DRIVER: DriverDescriptor = {
   schema_version: 1,
   driver_id: "verireel",
+  base_driver_id: "generic-web",
   label: "VeriReel",
   product: "verireel",
   description: "Fixture VeriReel driver.",
@@ -124,6 +125,7 @@ const FIXTURE_VERIREEL_DRIVER: DriverDescriptor = {
 const FIXTURE_ODOO_DRIVER: DriverDescriptor = {
   ...FIXTURE_VERIREEL_DRIVER,
   driver_id: "odoo",
+  base_driver_id: "",
   label: "Odoo",
   product: "odoo",
   capabilities: [],
@@ -646,9 +648,8 @@ function PreviewInventory({
   inventoryProvenance: DataProvenance | null;
   loading: boolean;
 }) {
-  const exposesPreviews = Boolean(
-    driver?.capabilities.some((capability) => capability.capability_id === "preview_lifecycle")
-  );
+  const previewCapabilityId = previewInventoryCapabilityId(driver);
+  const exposesPreviews = Boolean(previewCapabilityId);
   const latestPreview = previews
     .slice()
     .sort((left, right) => {
@@ -699,7 +700,7 @@ function PreviewInventory({
       <div className="preview-footer">
         <KeyValue
           label="Capability"
-          value={exposesPreviews ? "preview_lifecycle" : "not exposed by driver"}
+          value={previewCapabilityId || "not exposed by driver"}
           mono
           status={exposesPreviews ? "pass" : "unknown"}
         />
@@ -712,6 +713,13 @@ function PreviewInventory({
       </div>
     </section>
   );
+}
+
+function previewInventoryCapabilityId(driver: DriverDescriptor | null): string {
+  const previewCapabilityIds = new Set(["previewable", "preview_inventory_managed", "preview_lifecycle"]);
+  return driver?.capabilities.find((capability) => {
+    return previewCapabilityIds.has(capability.capability_id) || capability.panels.includes("preview_inventory");
+  })?.capability_id ?? "";
 }
 
 function TrustBadge({ provenance, compact = false }: { provenance: DataProvenance | null; compact?: boolean }) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -43,6 +43,7 @@ export interface DriverSettingGroupDescriptor {
 export interface DriverDescriptor {
   schema_version: number;
   driver_id: string;
+  base_driver_id: string;
   label: string;
   product: string;
   description: string;

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -1,14 +1,52 @@
 import json
 import unittest
+from unittest.mock import patch
 
-from control_plane.drivers.registry import list_driver_descriptors, read_driver_descriptor
+from control_plane.contracts.driver_descriptor import (
+    DriverCapabilityDescriptor,
+    DriverDescriptor,
+)
+from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.contracts.preview_summary import LaunchplanePreviewSummary
+from control_plane.drivers import registry
+from control_plane.drivers.registry import (
+    build_driver_context_view,
+    list_driver_descriptors,
+    read_driver_descriptor,
+)
+
+
+class _PreviewStore:
+    def list_preview_summaries(
+        self, *, context_name: str, generation_limit: int
+    ) -> tuple[LaunchplanePreviewSummary, ...]:
+        return (
+            LaunchplanePreviewSummary(
+                preview=PreviewRecord(
+                    preview_id="preview-web-pr-7",
+                    context=context_name,
+                    anchor_repo="every/web",
+                    anchor_pr_number=7,
+                    anchor_pr_url="https://github.com/every/web/pull/7",
+                    preview_label="preview",
+                    canonical_url="https://pr-7.example.test",
+                    state="active",
+                    created_at="2026-04-30T20:00:00Z",
+                    updated_at="2026-04-30T20:01:00Z",
+                    eligible_at="2026-04-30T20:00:00Z",
+                )
+            ),
+        )
 
 
 class DriverDescriptorRegistryTests(unittest.TestCase):
     def test_registry_lists_product_drivers_without_provider_vocabulary(self) -> None:
         descriptors = list_driver_descriptors()
 
-        self.assertEqual([descriptor.driver_id for descriptor in descriptors], ["odoo", "verireel"])
+        self.assertEqual(
+            [descriptor.driver_id for descriptor in descriptors],
+            ["generic-web", "odoo", "verireel"],
+        )
         descriptor_json = json.dumps(
             [descriptor.model_dump(mode="json") for descriptor in descriptors], sort_keys=True
         )
@@ -28,10 +66,56 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         descriptor = read_driver_descriptor("verireel")
         actions = {action.action_id: action for action in descriptor.actions}
 
+        self.assertEqual(descriptor.base_driver_id, "generic-web")
         self.assertEqual(actions["preview_inventory"].safety, "read")
         self.assertEqual(actions["preview_refresh"].scope, "preview")
         self.assertEqual(actions["preview_destroy"].safety, "destructive")
         self.assertEqual(actions["prod_rollback"].safety, "destructive")
+
+    def test_generic_web_descriptor_is_provider_neutral_base_driver(self) -> None:
+        descriptor = read_driver_descriptor("generic-web")
+        capability_ids = {capability.capability_id for capability in descriptor.capabilities}
+
+        self.assertEqual(descriptor.base_driver_id, "")
+        self.assertEqual(descriptor.context_patterns, ())
+        self.assertIn("image_deployable", capability_ids)
+        self.assertIn("health_checked", capability_ids)
+        self.assertIn("previewable", capability_ids)
+        self.assertIn("preview_inventory_managed", capability_ids)
+        self.assertIn("pr_feedback", capability_ids)
+        self.assertEqual(descriptor.actions, ())
+
+    def test_preview_read_model_is_capability_driven_not_verireel_named(self) -> None:
+        descriptor = DriverDescriptor(
+            driver_id="custom-web",
+            base_driver_id="generic-web",
+            label="Custom web",
+            product="custom-web",
+            description="Custom web product extending generic-web.",
+            context_patterns=("custom-web-preview",),
+            provider_boundary=registry.PROVIDER_BOUNDARY_NOTE,
+            capabilities=(
+                DriverCapabilityDescriptor(
+                    capability_id="preview_lifecycle",
+                    label="Preview lifecycle",
+                    description="Preview lifecycle for a custom web product.",
+                    panels=("preview_inventory",),
+                ),
+            ),
+        )
+
+        with patch.object(registry, "_DESCRIPTORS", (descriptor,)):
+            view = build_driver_context_view(
+                record_store=_PreviewStore(),
+                context_name="custom-web-preview",
+            )
+
+        self.assertEqual(view.drivers[0].driver_id, "custom-web")
+        self.assertEqual(view.drivers[0].preview_summaries[0].preview.preview_id, "preview-web-pr-7")
+        self.assertEqual(
+            view.drivers[0].preview_inventory_provenance.detail,
+            "Preview identity record exists, but no generation evidence is recorded.",
+        )
 
     def test_unknown_driver_descriptor_is_missing(self) -> None:
         with self.assertRaises(FileNotFoundError):

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -13,12 +13,49 @@ from control_plane.contracts.odoo_instance_override_record import OdooAddonSetti
 from control_plane.contracts.odoo_instance_override_record import OdooConfigParameterOverride
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.odoo_instance_override_record import OdooOverrideValue
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductImageProfile,
+    ProductLaneProfile,
+    ProductPreviewProfile,
+)
 from control_plane.contracts.promotion_record import DeploymentEvidence, PromotionRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
 from control_plane.storage.filesystem import FilesystemRecordStore
 
 
 class FilesystemRecordStoreTests(unittest.TestCase):
+    def test_write_and_read_product_profile_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            record = LaunchplaneProductProfileRecord(
+                product="sellyouroutboard",
+                display_name="SellYourOutboard.com",
+                repository="cbusillo/sellyouroutboard",
+                driver_id="generic-web",
+                image=ProductImageProfile(repository="ghcr.io/cbusillo/sellyouroutboard"),
+                runtime_port=3000,
+                health_path="/api/health",
+                lanes=(ProductLaneProfile(instance="testing", context="sellyouroutboard"),),
+                preview=ProductPreviewProfile(
+                    enabled=True,
+                    context="sellyouroutboard-testing",
+                    slug_template="pr-{number}",
+                ),
+                updated_at="2026-04-30T20:00:00Z",
+                source="operator:test",
+            )
+
+            written_path = store.write_product_profile_record(record)
+            loaded_record = store.read_product_profile_record("sellyouroutboard")
+            listed_records = store.list_product_profile_records(driver_id="generic-web")
+            self.assertTrue(written_path.exists())
+
+        self.assertEqual(loaded_record.driver_id, "generic-web")
+        self.assertEqual(loaded_record.preview.context, "sellyouroutboard-testing")
+        self.assertEqual([listed_record.product for listed_record in listed_records], ["sellyouroutboard"])
+
     def test_write_and_read_artifact_manifest(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name)

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -41,6 +41,12 @@ from control_plane.contracts.preview_lifecycle_plan_record import (
 )
 from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedbackRecord
 from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductImageProfile,
+    ProductLaneProfile,
+    ProductPreviewProfile,
+)
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
     DeploymentEvidence,
@@ -64,6 +70,33 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 def _sqlite_database_url(database_path: Path) -> str:
     return f"sqlite+pysqlite:///{database_path}"
+
+
+def _product_profile_record(*, product: str = "sellyouroutboard") -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord(
+        product=product,
+        display_name="SellYourOutboard.com",
+        repository="cbusillo/sellyouroutboard",
+        driver_id="generic-web",
+        image=ProductImageProfile(repository="ghcr.io/cbusillo/sellyouroutboard"),
+        runtime_port=3000,
+        health_path="/api/health",
+        lanes=(
+            ProductLaneProfile(
+                instance="testing",
+                context=product,
+                base_url="https://sellyouroutboard-testing.shinycomputers.com",
+                health_url="https://sellyouroutboard-testing.shinycomputers.com/api/health",
+            ),
+        ),
+        preview=ProductPreviewProfile(
+            enabled=True,
+            context=f"{product}-testing",
+            slug_template="pr-{number}",
+        ),
+        updated_at="2026-04-30T20:00:00Z",
+        source="operator:test",
+    )
 
 
 def _alembic_config(database_url: str) -> AlembicConfig:
@@ -762,6 +795,25 @@ class PostgresRecordStoreTests(unittest.TestCase):
         self.assertEqual(listed_records[0].record_id, "launchplane-authz-policy-20260420T100500Z-test")
         self.assertEqual(listed_records[0].policy.github_actions[0].repository, "cbusillo/launchplane")
 
+    def test_product_profile_records_round_trip(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_product_profile_record(_product_profile_record())
+            store.write_product_profile_record(_product_profile_record(product="internal-tool"))
+            loaded_record = store.read_product_profile_record("sellyouroutboard")
+            listed_records = store.list_product_profile_records(driver_id="generic-web")
+            store.close()
+
+        self.assertEqual(loaded_record.driver_id, "generic-web")
+        self.assertEqual(loaded_record.image.repository, "ghcr.io/cbusillo/sellyouroutboard")
+        self.assertEqual(loaded_record.preview.context, "sellyouroutboard-testing")
+        self.assertEqual([record.product for record in listed_records], ["internal-tool", "sellyouroutboard"])
+
     def test_preview_lifecycle_plan_records_round_trip(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(
@@ -1297,6 +1349,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
                 )
             )
             filesystem_store.write_release_tuple_record(_release_tuple_record())
+            filesystem_store.write_product_profile_record(_product_profile_record())
 
             counts = store.import_core_records_from_filesystem(filesystem_store)
             self.assertEqual(
@@ -1309,6 +1362,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     "promotions": 1,
                     "inventory": 1,
                     "odoo_instance_overrides": 1,
+                    "product_profiles": 1,
                     "preview_records": 1,
                     "preview_generations": 1,
                     "preview_desired_states": 1,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -853,7 +853,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(list_status_code, 200)
         self.assertEqual(
-            [driver["driver_id"] for driver in list_payload["drivers"]], ["odoo", "verireel"]
+            [driver["driver_id"] for driver in list_payload["drivers"]],
+            ["generic-web", "odoo", "verireel"],
         )
         self.assertNotIn("Dokploy", json.dumps(list_payload["drivers"]))
         self.assertEqual(show_status_code, 200)


### PR DESCRIPTION
## Summary
- add provider-neutral generic-web driver descriptor and base-driver metadata
- make preview inventory read models capability-driven instead of VeriReel-name-driven
- add DB-backed product profile records, filesystem/Postgres storage, and migration
- document generic-web extension model and product profile records

Closes #84

## Validation
- uv run --extra dev ruff check .
- uv run python -m unittest
- npx pnpm@10.10.0 --dir frontend validate
- git diff --check
- docker build -t launchplane-generic-web-driver-test .