### PR TITLE
Expose product profile service API

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -50,6 +50,7 @@ from control_plane.contracts.preview_pr_feedback_record import (
     PreviewPrFeedbackRecord,
     PreviewPrFeedbackStatus,
 )
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.drivers.registry import (
     build_driver_context_view,
@@ -857,6 +858,10 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "operations.read", {"context": segments[2]}
     if len(segments) == 3 and segments == ["v1", "service", "runtime"]:
         return "launchplane_service.read", {}
+    if len(segments) == 2 and segments == ["v1", "product-profiles"]:
+        return "product_profile.read", {}
+    if len(segments) == 3 and segments[:2] == ["v1", "product-profiles"]:
+        return "product_profile.read", {"product": segments[2]}
     return None
 
 
@@ -935,6 +940,7 @@ def _accepted_payload(
                 "preview_pr_feedback_id",
                 "preview_lifecycle_cleanup_id",
                 "preview_lifecycle_plan_id",
+                "product_profile",
                 "generation_id",
                 "promotion_record_id",
                 "target_id",
@@ -1415,6 +1421,7 @@ def create_launchplane_service_app(
         "/v1/previews/pr-feedback",
         "/v1/previews/lifecycle-cleanup",
         "/v1/previews/lifecycle-plan",
+        "/v1/product-profiles",
         "/v1/evidence/promotions",
         "/v1/drivers/launchplane/self-deploy",
         "/v1/drivers/odoo/artifact-publish-inputs",
@@ -1975,6 +1982,66 @@ def create_launchplane_service_app(
                                 authz_policy_sha256_value=resolved_authz_policy_sha256,
                                 authz_policy_source=resolved_authz_policy_source,
                             ),
+                        },
+                    )
+                if action == "product_profile.read":
+                    if "product" in params:
+                        profile = record_store.read_product_profile_record(params["product"])
+                        if not authz_policy.allows(
+                            identity=identity,
+                            action=action,
+                            product=profile.product,
+                            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                        ):
+                            return _json_response(
+                                start_response=start_response,
+                                status_code=403,
+                                payload={
+                                    "status": "rejected",
+                                    "trace_id": request_trace_id,
+                                    "error": {
+                                        "code": "authorization_denied",
+                                        "message": "Workflow cannot read the requested product profile.",
+                                    },
+                                },
+                            )
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=200,
+                            payload={
+                                "status": "ok",
+                                "trace_id": request_trace_id,
+                                "profile": profile.model_dump(mode="json"),
+                            },
+                        )
+                    if not authz_policy.allows(
+                        identity=identity,
+                        action=action,
+                        product="launchplane",
+                        context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                    ):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=403,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "authorization_denied",
+                                    "message": "Workflow cannot list Launchplane product profiles.",
+                                },
+                            },
+                        )
+                    driver_id_filter = str((query.get("driver_id") or [""])[0] or "").strip()
+                    profiles = record_store.list_product_profile_records(driver_id=driver_id_filter)
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=200,
+                        payload={
+                            "status": "ok",
+                            "trace_id": request_trace_id,
+                            "driver_id": driver_id_filter,
+                            "profiles": [profile.model_dump(mode="json") for profile in profiles],
                         },
                     )
                 context_name = params["context"]
@@ -2795,6 +2862,39 @@ def create_launchplane_service_app(
                     request=request.destroy,
                 )
                 result = {}
+            elif path == "/v1/product-profiles":
+                request = LaunchplaneProductProfileRecord.model_validate(payload)
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="product_profile.write",
+                    product=request.product,
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot write the requested product profile.",
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                record_store.write_product_profile_record(request)
+                result = {"product_profile": request.product}
             elif path == "/v1/evidence/promotions":
                 request = PromotionEvidenceEnvelope.model_validate(payload)
                 if not authz_policy.allows(

--- a/docs/records.md
+++ b/docs/records.md
@@ -137,6 +137,11 @@ health endpoint, tests, and source/build inputs. Launchplane owns the product
 profile that maps those app facts into preview, deploy, promotion, and evidence
 behavior.
 
+The service exposes product profile records through `GET /v1/product-profiles`,
+`GET /v1/product-profiles/{product}`, and `POST /v1/product-profiles`. Writes
+require the `product_profile.write` action for the target product in the
+Launchplane service context; reads use `product_profile.read`.
+
 This file layout describes today's local Launchplane implementation, not the
 final cross-product communication boundary. The stable long-term contract should
 be Launchplane's authenticated service ingress plus the durable record semantics

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -32,6 +32,10 @@ VeriReel product paths:
   - `POST /v1/evidence/promotions`
   - `POST /v1/evidence/previews/generations`
   - `POST /v1/evidence/previews/destroyed`
+- product profile routes:
+  - `GET /v1/product-profiles`
+  - `GET /v1/product-profiles/{product}`
+  - `POST /v1/product-profiles`
 - product driver routes:
   - `POST /v1/drivers/odoo/artifact-publish-inputs`
   - `POST /v1/drivers/odoo/artifact-publish`
@@ -282,6 +286,16 @@ repos submit thin preview outcome facts to `POST /v1/previews/pr-feedback`;
 Launchplane renders the review comment, upserts the anchored GitHub PR comment
 when its runtime token is available, and stores an append-only feedback record
 with the comment body, delivery action, comment URL, and any skip/failure reason.
+
+### Product profile endpoints
+
+- `GET /v1/product-profiles`
+- `GET /v1/product-profiles/{product}`
+- `POST /v1/product-profiles`
+
+Product profiles are Launchplane-owned product/driver bindings. They are written
+through authenticated service ingress and stored in Launchplane records; product
+repos do not carry repo-local Launchplane lifecycle manifests.
 
 ### Operator read endpoints
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -174,6 +174,34 @@ def _github_oauth_config() -> GitHubOAuthConfig:
     )
 
 
+def _product_profile_payload(product: str = "sellyouroutboard") -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "product": product,
+        "display_name": "Sell Your Outboard",
+        "repository": f"cbusillo/{product}",
+        "driver_id": "generic-web",
+        "image": {"repository": f"ghcr.io/cbusillo/{product}"},
+        "runtime_port": 3000,
+        "health_path": "/api/health",
+        "lanes": (
+            {
+                "instance": "testing",
+                "context": f"{product}-testing",
+                "base_url": "https://testing.sellyouroutboard.com",
+                "health_url": "https://testing.sellyouroutboard.com/api/health",
+            },
+        ),
+        "preview": {
+            "enabled": True,
+            "context": f"{product}-testing",
+            "slug_template": "pr-{number}",
+        },
+        "updated_at": "2026-04-30T21:30:00Z",
+        "source": "test",
+    }
+
+
 def _invoke_app(
     app,
     *,
@@ -899,6 +927,101 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 404)
         self.assertEqual(payload["error"]["code"], "not_found")
+
+    def test_product_profile_endpoints_round_trip_authorized_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["launchplane", "sellyouroutboard"],
+                            "contexts": ["launchplane"],
+                            "actions": ["product_profile.write", "product_profile.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            write_status_code, write_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/product-profiles",
+                payload=_product_profile_payload(),
+                headers={"Idempotency-Key": "profile-sellyouroutboard"},
+            )
+            show_status_code, show_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/product-profiles/sellyouroutboard",
+            )
+            list_status_code, _, list_body = _invoke_raw_app(
+                app,
+                method="GET",
+                path="/v1/product-profiles",
+                authorization="Bearer valid-token",
+                query_string="driver_id=generic-web",
+            )
+            list_payload = json.loads(list_body.decode("utf-8"))
+
+        self.assertEqual(write_status_code, 202)
+        self.assertEqual(write_payload["records"], {"product_profile": "sellyouroutboard"})
+        self.assertEqual(show_status_code, 200)
+        self.assertEqual(show_payload["profile"]["driver_id"], "generic-web")
+        self.assertEqual(show_payload["profile"]["preview"]["slug_template"], "pr-{number}")
+        self.assertEqual(list_status_code, 200)
+        self.assertEqual(list_payload["driver_id"], "generic-web")
+        self.assertEqual(
+            [profile["product"] for profile in list_payload["profiles"]],
+            ["sellyouroutboard"],
+        )
+
+    def test_product_profile_write_rejects_unauthorized_product(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["verireel"],
+                            "contexts": ["launchplane"],
+                            "actions": ["product_profile.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/product-profiles",
+                payload=_product_profile_payload(),
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
 
     def test_driver_context_view_endpoint_returns_lane_summary(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add authenticated product profile read/write endpoints
- support listing profiles with an optional driver_id filter
- document product profile service routes and authz actions
- cover authorized round-trip and unauthorized write behavior

Refs #84

## Validation
- uv run --extra dev ruff check .
- uv run python -m unittest
- npx pnpm@10.10.0 --dir frontend validate
- git diff --check
- docker build -t launchplane-product-profile-api-test .