### PR TITLE
Add generic web deploy driver

### DIFF
--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -66,6 +66,7 @@ GENERIC_WEB_DRIVER = DriverDescriptor(
             capability_id="image_deployable",
             label="Image deployable",
             description="Deploy immutable container images and record stable-lane deployment evidence.",
+            actions=("stable_deploy",),
             panels=("lane_health", "deployment_evidence"),
         ),
         DriverCapabilityDescriptor(
@@ -91,6 +92,17 @@ GENERIC_WEB_DRIVER = DriverDescriptor(
             label="PR feedback",
             description="Render and persist pull-request feedback from Launchplane preview and deploy records.",
             panels=("audit",),
+        ),
+    ),
+    actions=(
+        _action(
+            "stable_deploy",
+            "Deploy lane",
+            "Deploy an immutable container image to a configured generic-web product lane.",
+            safety="mutation",
+            scope="instance",
+            route_path="/v1/drivers/generic-web/deploy",
+            writes_records=("deployment",),
         ),
     ),
 )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -86,6 +86,11 @@ from control_plane.workflows.evidence_ingestion import (
     apply_deployment_evidence,
     apply_promotion_evidence,
 )
+from control_plane.workflows.generic_web_deploy import (
+    GenericWebDeployRequest,
+    execute_generic_web_deploy,
+    resolve_generic_web_profile_lane,
+)
 from control_plane.workflows.preview_desired_state import discover_github_preview_desired_state
 from control_plane.workflows.preview_lifecycle import build_preview_lifecycle_plan
 from control_plane.workflows.preview_lifecycle_cleanup import (
@@ -215,6 +220,22 @@ class DeploymentEvidenceEnvelope(BaseModel):
     def _validate_alignment(self) -> "DeploymentEvidenceEnvelope":
         if not self.product.strip():
             raise ValueError("deployment evidence requires product")
+        return self
+
+
+class GenericWebDeployEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    deploy: GenericWebDeployRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "GenericWebDeployEnvelope":
+        if not self.product.strip():
+            raise ValueError("generic web deploy requires product")
+        if self.product.strip() != self.deploy.product.strip():
+            raise ValueError("generic web deploy requires matching product values")
         return self
 
 
@@ -1424,6 +1445,7 @@ def create_launchplane_service_app(
         "/v1/product-profiles",
         "/v1/evidence/promotions",
         "/v1/drivers/launchplane/self-deploy",
+        "/v1/drivers/generic-web/deploy",
         "/v1/drivers/odoo/artifact-publish-inputs",
         "/v1/drivers/odoo/artifact-publish",
         "/v1/drivers/odoo/post-deploy",
@@ -2207,6 +2229,52 @@ def create_launchplane_service_app(
                     control_plane_root_path=resolved_root,
                     request=request.deploy,
                 )
+            elif path == "/v1/drivers/generic-web/deploy":
+                request = GenericWebDeployEnvelope.model_validate(payload)
+                profile, lane = resolve_generic_web_profile_lane(
+                    record_store=record_store,
+                    request=request.deploy,
+                )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="generic_web_deploy.execute",
+                    product=profile.product,
+                    context=lane.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot execute the generic web deploy driver"
+                                    " for the requested product/context."
+                                ),
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                driver_result = execute_generic_web_deploy(
+                    control_plane_root=resolved_root,
+                    record_store=record_store,
+                    request=request.deploy,
+                    profile=profile,
+                    lane=lane,
+                )
+                result = {"deployment_record_id": driver_result.deployment_record_id}
             elif path == "/v1/drivers/odoo/post-deploy":
                 request = OdooPostDeployEnvelope.model_validate(payload)
                 if not authz_policy.allows(

--- a/control_plane/workflows/dokploy_deploy.py
+++ b/control_plane/workflows/dokploy_deploy.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import click
+
+from control_plane import dokploy as control_plane_dokploy
+from control_plane.contracts.deployment_record import ResolvedTargetEvidence
+from control_plane.contracts.ship_request import ShipRequest
+
+
+def update_dokploy_target_artifact(
+    *,
+    host: str,
+    token: str,
+    target_type: str,
+    target_id: str,
+    artifact_id: str,
+) -> None:
+    target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
+        host=host,
+        token=token,
+        target_type=target_type,
+        target_id=target_id,
+    )
+    if target_type == "application":
+        control_plane_dokploy.dokploy_request(
+            host=host,
+            token=token,
+            path="/api/application.saveDockerProvider",
+            method="POST",
+            payload={
+                "applicationId": target_id,
+                "dockerImage": artifact_id,
+                "username": target_payload.get("username"),
+                "password": target_payload.get("password"),
+                "registryUrl": target_payload.get("registryUrl"),
+            },
+        )
+        return
+
+    if target_type == "compose":
+        env_text = control_plane_dokploy.render_dokploy_env_text_with_overrides(
+            str(target_payload.get("env") or ""),
+            updates={"DOCKER_IMAGE_REFERENCE": artifact_id},
+        )
+        control_plane_dokploy.update_dokploy_target_env(
+            host=host,
+            token=token,
+            target_type=target_type,
+            target_id=target_id,
+            target_payload=target_payload,
+            env_text=env_text,
+        )
+        return
+
+    raise click.ClickException(f"Unsupported Dokploy target type: {target_type}")
+
+
+def execute_dokploy_artifact_deploy(
+    *,
+    host: str,
+    token: str,
+    ship_request: ShipRequest,
+    resolved_target: ResolvedTargetEvidence,
+    deploy_timeout_seconds: int,
+) -> None:
+    latest_before = control_plane_dokploy.latest_deployment_for_target(
+        host=host,
+        token=token,
+        target_type=resolved_target.target_type,
+        target_id=resolved_target.target_id,
+    )
+    update_dokploy_target_artifact(
+        host=host,
+        token=token,
+        target_type=resolved_target.target_type,
+        target_id=resolved_target.target_id,
+        artifact_id=ship_request.artifact_id,
+    )
+    control_plane_dokploy.trigger_deployment(
+        host=host,
+        token=token,
+        target_type=resolved_target.target_type,
+        target_id=resolved_target.target_id,
+        no_cache=ship_request.no_cache,
+    )
+    control_plane_dokploy.wait_for_target_deployment(
+        host=host,
+        token=token,
+        target_type=resolved_target.target_type,
+        target_id=resolved_target.target_id,
+        before_key=control_plane_dokploy.deployment_key(latest_before),
+        timeout_seconds=deploy_timeout_seconds,
+    )

--- a/control_plane/workflows/generic_web_deploy.py
+++ b/control_plane/workflows/generic_web_deploy.py
@@ -9,51 +9,70 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane.contracts.deployment_record import ResolvedTargetEvidence
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductLaneProfile,
+)
 from control_plane.contracts.promotion_record import HealthcheckEvidence
 from control_plane.contracts.ship_request import ShipRequest
-from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.dokploy_deploy import execute_dokploy_artifact_deploy
 from control_plane.workflows.ship import build_deployment_record, generate_deployment_record_id, utc_now_timestamp
 
 
-StableInstanceName = Literal["testing", "prod"]
-
-
-class VeriReelStableDeployRequest(BaseModel):
+class GenericWebDeployRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     schema_version: int = Field(default=1, ge=1)
-    context: str = "verireel"
-    instance: StableInstanceName = "testing"
+    product: str
+    instance: str
     artifact_id: str
     source_git_ref: str
     timeout_seconds: int | None = Field(default=None, ge=1)
     no_cache: bool = False
 
     @model_validator(mode="after")
-    def _validate_request(self) -> "VeriReelStableDeployRequest":
-        if self.context != "verireel":
-            raise ValueError("VeriReel stable deploy requires context 'verireel'.")
-        if self.instance not in {"testing", "prod"}:
-            raise ValueError("VeriReel stable deploy requires instance 'testing' or 'prod'.")
+    def _validate_request(self) -> "GenericWebDeployRequest":
+        if not self.product.strip():
+            raise ValueError("Generic web deploy requires product.")
+        if not self.instance.strip():
+            raise ValueError("Generic web deploy requires instance.")
         if not self.artifact_id.strip():
-            raise ValueError("VeriReel stable deploy requires artifact_id.")
+            raise ValueError("Generic web deploy requires artifact_id.")
         if not self.source_git_ref.strip():
-            raise ValueError("VeriReel stable deploy requires source_git_ref.")
+            raise ValueError("Generic web deploy requires source_git_ref.")
         return self
 
 
-class VeriReelStableDeployResult(BaseModel):
+class GenericWebDeployResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     deployment_record_id: str
     deploy_status: Literal["pass", "fail"]
     deploy_started_at: str
     deploy_finished_at: str
-    target_name: str
-    target_type: str
-    target_id: str
+    product: str
+    context: str
+    instance: str
+    target_name: str = ""
+    target_type: str = ""
+    target_id: str = ""
     error_message: str = ""
+
+
+def resolve_generic_web_profile_lane(
+    *, record_store: object, request: GenericWebDeployRequest
+) -> tuple[LaunchplaneProductProfileRecord, ProductLaneProfile]:
+    profile = record_store.read_product_profile_record(request.product)
+    if profile.driver_id != "generic-web":
+        raise click.ClickException(
+            f"Product {profile.product!r} is configured for driver {profile.driver_id!r}, not generic-web."
+        )
+    for lane in profile.lanes:
+        if lane.instance == request.instance:
+            return profile, lane
+    raise click.ClickException(
+        f"Product {profile.product!r} has no generic-web lane for instance {request.instance!r}."
+    )
 
 
 def _resolve_deploy_mode(*, configured_ship_mode: str, target_type: str) -> str:
@@ -62,20 +81,19 @@ def _resolve_deploy_mode(*, configured_ship_mode: str, target_type: str) -> str:
     return f"dokploy-{configured_ship_mode}-api"
 
 
-def _default_target_name_for_instance(instance_name: StableInstanceName) -> str:
-    return {
-        "testing": "ver-testing-app",
-        "prod": "ver-prod-app",
-    }[instance_name]
+def _fallback_target_name(*, profile: LaunchplaneProductProfileRecord, lane: ProductLaneProfile) -> str:
+    return f"{profile.product}-{lane.instance}"
 
 
-def _fallback_ship_request(request: VeriReelStableDeployRequest) -> ShipRequest:
+def _fallback_ship_request(
+    *, request: GenericWebDeployRequest, profile: LaunchplaneProductProfileRecord, lane: ProductLaneProfile
+) -> ShipRequest:
     return ShipRequest(
         artifact_id=request.artifact_id,
-        context=request.context,
-        instance=request.instance,
+        context=lane.context,
+        instance=lane.instance,
         source_git_ref=request.source_git_ref,
-        target_name=_default_target_name_for_instance(request.instance),
+        target_name=_fallback_target_name(profile=profile, lane=lane),
         target_type="application",
         deploy_mode="dokploy-application-api",
         wait=True,
@@ -89,40 +107,45 @@ def _fallback_ship_request(request: VeriReelStableDeployRequest) -> ShipRequest:
 def _resolve_ship_request(
     *,
     control_plane_root: Path,
-    request: VeriReelStableDeployRequest,
+    request: GenericWebDeployRequest,
+    profile: LaunchplaneProductProfileRecord,
+    lane: ProductLaneProfile,
 ) -> tuple[ShipRequest, ResolvedTargetEvidence, int]:
     source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
         control_plane_root=control_plane_root,
     )
     target_definition = control_plane_dokploy.find_dokploy_target_definition(
         source_of_truth,
-        context_name=request.context,
-        instance_name=request.instance,
+        context_name=lane.context,
+        instance_name=lane.instance,
     )
     if target_definition is None:
         raise click.ClickException(
-            f"No Dokploy target definition found for {request.context}/{request.instance}."
+            f"No Dokploy target definition found for {lane.context}/{lane.instance}."
         )
 
     environment_values = control_plane_runtime_environments.resolve_runtime_environment_values(
         control_plane_root=control_plane_root,
-        context_name=request.context,
-        instance_name=request.instance,
+        context_name=lane.context,
+        instance_name=lane.instance,
     )
     deploy_mode = _resolve_deploy_mode(
         configured_ship_mode=control_plane_dokploy.resolve_dokploy_ship_mode(
-            request.context,
-            request.instance,
+            lane.context,
+            lane.instance,
             environment_values,
         ),
         target_type=target_definition.target_type,
     )
+    target_name = target_definition.target_name.strip() or _fallback_target_name(
+        profile=profile, lane=lane
+    )
     ship_request = ShipRequest(
         artifact_id=request.artifact_id,
-        context=request.context,
-        instance=request.instance,
+        context=lane.context,
+        instance=lane.instance,
         source_git_ref=request.source_git_ref,
-        target_name=target_definition.target_name.strip() or _default_target_name_for_instance(request.instance),
+        target_name=target_name,
         target_type=target_definition.target_type,
         deploy_mode=deploy_mode,
         wait=True,
@@ -134,7 +157,7 @@ def _resolve_ship_request(
     resolved_target = ResolvedTargetEvidence(
         target_type=target_definition.target_type,
         target_id=target_definition.target_id,
-        target_name=target_definition.target_name.strip() or ship_request.target_name,
+        target_name=target_name,
     )
     deploy_timeout_seconds = control_plane_dokploy.resolve_ship_timeout_seconds(
         timeout_override_seconds=request.timeout_seconds,
@@ -143,40 +166,39 @@ def _resolve_ship_request(
     return ship_request, resolved_target, deploy_timeout_seconds
 
 
-def _execute_dokploy_deploy(
+def execute_generic_web_deploy(
     *,
     control_plane_root: Path,
-    ship_request: ShipRequest,
-    resolved_target: ResolvedTargetEvidence,
-    deploy_timeout_seconds: int,
-) -> None:
-    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
-    execute_dokploy_artifact_deploy(
-        host=host,
-        token=token,
-        ship_request=ship_request,
-        resolved_target=resolved_target,
-        deploy_timeout_seconds=deploy_timeout_seconds,
-    )
+    record_store: object,
+    request: GenericWebDeployRequest,
+    profile: LaunchplaneProductProfileRecord | None = None,
+    lane: ProductLaneProfile | None = None,
+) -> GenericWebDeployResult:
+    resolved_profile = profile
+    resolved_lane = lane
+    if resolved_profile is None or resolved_lane is None:
+        resolved_profile, resolved_lane = resolve_generic_web_profile_lane(
+            record_store=record_store,
+            request=request,
+        )
 
-
-def execute_verireel_stable_deploy(
-    *,
-    control_plane_root: Path,
-    record_store: FilesystemRecordStore,
-    request: VeriReelStableDeployRequest,
-) -> VeriReelStableDeployResult:
     record_id = generate_deployment_record_id(
-        context_name=request.context,
-        instance_name=request.instance,
+        context_name=resolved_lane.context,
+        instance_name=resolved_lane.instance,
     )
     started_at = utc_now_timestamp()
-    fallback_request = _fallback_ship_request(request)
+    fallback_request = _fallback_ship_request(
+        request=request,
+        profile=resolved_profile,
+        lane=resolved_lane,
+    )
 
     try:
         ship_request, resolved_target, deploy_timeout_seconds = _resolve_ship_request(
             control_plane_root=control_plane_root,
             request=request,
+            profile=resolved_profile,
+            lane=resolved_lane,
         )
     except click.ClickException as exc:
         finished_at = utc_now_timestamp()
@@ -190,32 +212,22 @@ def execute_verireel_stable_deploy(
                 finished_at=finished_at,
             )
         )
-        return VeriReelStableDeployResult(
+        return GenericWebDeployResult(
             deployment_record_id=record_id,
             deploy_status="fail",
             deploy_started_at=started_at,
             deploy_finished_at=finished_at,
-            target_name=fallback_request.target_name,
-            target_type=fallback_request.target_type,
-            target_id="",
+            product=resolved_profile.product,
+            context=resolved_lane.context,
+            instance=resolved_lane.instance,
             error_message=str(exc),
         )
 
-    record_store.write_deployment_record(
-        build_deployment_record(
-            request=ship_request,
-            record_id=record_id,
-            deployment_id="control-plane-dokploy",
-            deployment_status="pending",
-            started_at=started_at,
-            finished_at="",
-            resolved_target=resolved_target,
-        )
-    )
-
     try:
-        _execute_dokploy_deploy(
-            control_plane_root=control_plane_root,
+        host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
+        execute_dokploy_artifact_deploy(
+            host=host,
+            token=token,
             ship_request=ship_request,
             resolved_target=resolved_target,
             deploy_timeout_seconds=deploy_timeout_seconds,
@@ -233,11 +245,14 @@ def execute_verireel_stable_deploy(
                 resolved_target=resolved_target,
             )
         )
-        return VeriReelStableDeployResult(
+        return GenericWebDeployResult(
             deployment_record_id=record_id,
             deploy_status="fail",
             deploy_started_at=started_at,
             deploy_finished_at=finished_at,
+            product=resolved_profile.product,
+            context=resolved_lane.context,
+            instance=resolved_lane.instance,
             target_name=resolved_target.target_name,
             target_type=resolved_target.target_type,
             target_id=resolved_target.target_id,
@@ -256,11 +271,14 @@ def execute_verireel_stable_deploy(
             resolved_target=resolved_target,
         )
     )
-    return VeriReelStableDeployResult(
+    return GenericWebDeployResult(
         deployment_record_id=record_id,
         deploy_status="pass",
         deploy_started_at=started_at,
         deploy_finished_at=finished_at,
+        product=resolved_profile.product,
+        context=resolved_lane.context,
+        instance=resolved_lane.instance,
         target_name=resolved_target.target_name,
         target_type=resolved_target.target_type,
         target_id=resolved_target.target_id,

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -81,12 +81,16 @@ inspect JSONB payloads directly.
 
 ## Initial Drivers
 
-Generic web exposes base capabilities without executable routes yet:
+Generic web exposes base capabilities and the first common deploy action:
 
 - image deployment evidence
 - HTTP health checking
 - preview lifecycle and inventory read models
 - PR feedback ownership
+
+The `stable_deploy` action routes to `POST /v1/drivers/generic-web/deploy`. The
+route resolves product lane context from DB-backed product profile records and
+runtime target bindings from DB-backed Dokploy target records.
 
 Product drivers can declare `base_driver_id="generic-web"` when they reuse the
 generic web lifecycle and add named product-specific gates or runtime actions.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -37,6 +37,7 @@ VeriReel product paths:
   - `GET /v1/product-profiles/{product}`
   - `POST /v1/product-profiles`
 - product driver routes:
+  - `POST /v1/drivers/generic-web/deploy`
   - `POST /v1/drivers/odoo/artifact-publish-inputs`
   - `POST /v1/drivers/odoo/artifact-publish`
   - `POST /v1/drivers/odoo/post-deploy`
@@ -296,6 +297,11 @@ with the comment body, delivery action, comment URL, and any skip/failure reason
 Product profiles are Launchplane-owned product/driver bindings. They are written
 through authenticated service ingress and stored in Launchplane records; product
 repos do not carry repo-local Launchplane lifecycle manifests.
+
+Generic web deploys use `POST /v1/drivers/generic-web/deploy`. The request names
+the product, target instance, immutable artifact/image reference, and source ref;
+Launchplane resolves the context from the DB-backed product profile lane and the
+runtime target from DB-backed Dokploy target records.
 
 ### Operator read endpoints
 

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -83,7 +83,9 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         self.assertIn("previewable", capability_ids)
         self.assertIn("preview_inventory_managed", capability_ids)
         self.assertIn("pr_feedback", capability_ids)
-        self.assertEqual(descriptor.actions, ())
+        actions = {action.action_id: action for action in descriptor.actions}
+        self.assertEqual(actions["stable_deploy"].route_path, "/v1/drivers/generic-web/deploy")
+        self.assertEqual(actions["stable_deploy"].safety, "mutation")
 
     def test_preview_read_model_is_capability_driven_not_verireel_named(self) -> None:
         descriptor = DriverDescriptor(

--- a/tests/test_generic_web_deploy.py
+++ b/tests/test_generic_web_deploy.py
@@ -1,0 +1,161 @@
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import click
+
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductImageProfile,
+    ProductLaneProfile,
+    ProductPreviewProfile,
+)
+from control_plane.dokploy import DokploySourceOfTruth, DokployTargetDefinition
+from control_plane.workflows.generic_web_deploy import (
+    GenericWebDeployRequest,
+    execute_generic_web_deploy,
+    resolve_generic_web_profile_lane,
+)
+
+
+class _GenericWebDeployStore:
+    def __init__(self, profile: LaunchplaneProductProfileRecord) -> None:
+        self.profile = profile
+        self.deployments = []
+
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
+        if product != self.profile.product:
+            raise FileNotFoundError(product)
+        return self.profile
+
+    def write_deployment_record(self, record) -> None:
+        self.deployments.append(record)
+
+
+def _profile() -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord(
+        product="sellyouroutboard",
+        display_name="SellYourOutboard.com",
+        repository="cbusillo/sellyouroutboard",
+        driver_id="generic-web",
+        image=ProductImageProfile(repository="ghcr.io/cbusillo/sellyouroutboard"),
+        runtime_port=3000,
+        health_path="/api/health",
+        lanes=(
+            ProductLaneProfile(
+                instance="testing",
+                context="sellyouroutboard-testing",
+                base_url="https://testing.sellyouroutboard.com",
+                health_url="https://testing.sellyouroutboard.com/api/health",
+            ),
+        ),
+        preview=ProductPreviewProfile(
+            enabled=True,
+            context="sellyouroutboard-testing",
+            slug_template="pr-{number}",
+        ),
+        updated_at="2026-04-30T21:00:00Z",
+        source="test",
+    )
+
+
+def _request(instance: str = "testing") -> GenericWebDeployRequest:
+    return GenericWebDeployRequest(
+        product="sellyouroutboard",
+        instance=instance,
+        artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+        source_git_ref="abc123",
+    )
+
+
+def _source_of_truth() -> DokploySourceOfTruth:
+    return DokploySourceOfTruth(
+        schema_version=1,
+        targets=(
+            DokployTargetDefinition(
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_type="application",
+                target_id="target-123",
+                target_name="sellyouroutboard-testing-app",
+            ),
+        ),
+    )
+
+
+class GenericWebDeployTests(unittest.TestCase):
+    def test_execute_generic_web_deploy_writes_pass_record_for_profile_lane(self) -> None:
+        store = _GenericWebDeployStore(_profile())
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                return_value=_source_of_truth(),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_deploy.control_plane_runtime_environments.resolve_runtime_environment_values",
+                return_value={},
+            ),
+            patch(
+                "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch("control_plane.workflows.generic_web_deploy.execute_dokploy_artifact_deploy") as deploy,
+        ):
+            result = execute_generic_web_deploy(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=_request(),
+            )
+
+        self.assertEqual(result.deploy_status, "pass")
+        self.assertEqual(result.context, "sellyouroutboard-testing")
+        self.assertEqual(result.target_id, "target-123")
+        self.assertEqual(len(store.deployments), 1)
+        self.assertEqual(store.deployments[0].deploy.status, "pass")
+        self.assertEqual(store.deployments[0].resolved_target.target_name, "sellyouroutboard-testing-app")
+        deploy.assert_called_once()
+
+    def test_execute_generic_web_deploy_records_failure_when_provider_fails(self) -> None:
+        store = _GenericWebDeployStore(_profile())
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                return_value=_source_of_truth(),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_deploy.control_plane_runtime_environments.resolve_runtime_environment_values",
+                return_value={},
+            ),
+            patch(
+                "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_deploy.execute_dokploy_artifact_deploy",
+                side_effect=click.ClickException("provider failed"),
+            ),
+        ):
+            result = execute_generic_web_deploy(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=_request(),
+            )
+
+        self.assertEqual(result.deploy_status, "fail")
+        self.assertEqual(result.error_message, "provider failed")
+        self.assertEqual(len(store.deployments), 1)
+        self.assertEqual(store.deployments[0].deploy.status, "fail")
+
+    def test_resolve_generic_web_profile_lane_rejects_missing_lane(self) -> None:
+        store = _GenericWebDeployStore(_profile())
+
+        with self.assertRaises(click.ClickException):
+            resolve_generic_web_profile_lane(record_store=store, request=_request(instance="prod"))
+
+        self.assertEqual(store.deployments, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -30,6 +30,7 @@ from control_plane.contracts.preview_lifecycle_plan_record import (
     PreviewLifecyclePlanRecord,
 )
 from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
     DeploymentEvidence,
@@ -1018,6 +1019,116 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 method="POST",
                 path="/v1/product-profiles",
                 payload=_product_profile_payload(),
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_generic_web_deploy_route_uses_profile_lane_for_authorization(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["generic_web_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            driver_result = SimpleNamespace(deployment_record_id="deployment-syo-testing")
+
+            with patch(
+                "control_plane.service.execute_generic_web_deploy",
+                return_value=driver_result,
+            ) as deploy:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/deploy",
+                    payload={
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "deploy": {
+                            "schema_version": 1,
+                            "product": "sellyouroutboard",
+                            "instance": "testing",
+                            "artifact_id": "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+                            "source_git_ref": "abc123",
+                        },
+                    },
+                    headers={"Idempotency-Key": "generic-web-deploy-syo-testing"},
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["records"]["deployment_record_id"], "deployment-syo-testing")
+        deploy.assert_called_once()
+        _, kwargs = deploy.call_args
+        self.assertEqual(kwargs["profile"].product, "sellyouroutboard")
+        self.assertEqual(kwargs["lane"].context, "sellyouroutboard-testing")
+
+    def test_generic_web_deploy_route_rejects_wrong_product_context(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["different-context"],
+                            "actions": ["generic_web_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/generic-web/deploy",
+                payload={
+                    "schema_version": 1,
+                    "product": "sellyouroutboard",
+                    "deploy": {
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "instance": "testing",
+                        "artifact_id": "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+                        "source_git_ref": "abc123",
+                    },
+                },
             )
 
         self.assertEqual(status_code, 403)


### PR DESCRIPTION
## Summary
- add a generic-web stable deploy route that resolves product/context from DB-backed product profiles
- factor shared Dokploy artifact deploy execution out of the VeriReel workflow
- document the new driver action and cover workflow/service behavior with tests

## Validation
- `uv run --extra dev ruff check .`
- `uv run python -m unittest`
- `npx pnpm@10.10.0 --dir frontend validate`
- `git diff --check`
- `docker build -t launchplane-generic-web-deploy-test .`

Refs #84
