### PR TITLE
Add generic web preview desired state

### DIFF
--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -79,6 +79,7 @@ GENERIC_WEB_DRIVER = DriverDescriptor(
             capability_id="previewable",
             label="Previewable",
             description="Model desired preview state, creation, refresh, cleanup, and preview evidence for web products.",
+            actions=("preview_desired_state",),
             panels=("preview_inventory", "deployment_evidence", "audit"),
         ),
         DriverCapabilityDescriptor(
@@ -103,6 +104,15 @@ GENERIC_WEB_DRIVER = DriverDescriptor(
             scope="instance",
             route_path="/v1/drivers/generic-web/deploy",
             writes_records=("deployment",),
+        ),
+        _action(
+            "preview_desired_state",
+            "Discover desired previews",
+            "Discover labeled pull requests for a generic-web product profile and record desired preview state.",
+            safety="safe_write",
+            scope="context",
+            route_path="/v1/drivers/generic-web/preview-desired-state",
+            writes_records=("preview_desired_state",),
         ),
     ),
 )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -91,6 +91,11 @@ from control_plane.workflows.generic_web_deploy import (
     execute_generic_web_deploy,
     resolve_generic_web_profile_lane,
 )
+from control_plane.workflows.generic_web_preview import (
+    GenericWebPreviewDesiredStateRequest,
+    discover_generic_web_preview_desired_state,
+    resolve_generic_web_preview_profile,
+)
 from control_plane.workflows.preview_desired_state import discover_github_preview_desired_state
 from control_plane.workflows.preview_lifecycle import build_preview_lifecycle_plan
 from control_plane.workflows.preview_lifecycle_cleanup import (
@@ -236,6 +241,22 @@ class GenericWebDeployEnvelope(BaseModel):
             raise ValueError("generic web deploy requires product")
         if self.product.strip() != self.deploy.product.strip():
             raise ValueError("generic web deploy requires matching product values")
+        return self
+
+
+class GenericWebPreviewDesiredStateEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    desired_state: GenericWebPreviewDesiredStateRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "GenericWebPreviewDesiredStateEnvelope":
+        if not self.product.strip():
+            raise ValueError("generic web preview desired state requires product")
+        if self.product.strip() != self.desired_state.product.strip():
+            raise ValueError("generic web preview desired state requires matching product values")
         return self
 
 
@@ -1446,6 +1467,7 @@ def create_launchplane_service_app(
         "/v1/evidence/promotions",
         "/v1/drivers/launchplane/self-deploy",
         "/v1/drivers/generic-web/deploy",
+        "/v1/drivers/generic-web/preview-desired-state",
         "/v1/drivers/odoo/artifact-publish-inputs",
         "/v1/drivers/odoo/artifact-publish",
         "/v1/drivers/odoo/post-deploy",
@@ -2275,6 +2297,56 @@ def create_launchplane_service_app(
                     lane=lane,
                 )
                 result = {"deployment_record_id": driver_result.deployment_record_id}
+            elif path == "/v1/drivers/generic-web/preview-desired-state":
+                request = GenericWebPreviewDesiredStateEnvelope.model_validate(payload)
+                profile = resolve_generic_web_preview_profile(
+                    record_store=record_store,
+                    product=request.product,
+                )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="preview_desired_state.discover",
+                    product=profile.product,
+                    context=profile.preview.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot discover generic web preview desired state"
+                                    " for the requested product/context."
+                                ),
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                driver_result = discover_generic_web_preview_desired_state(
+                    control_plane_root=resolved_root,
+                    record_store=record_store,
+                    request=request.desired_state,
+                    discovered_at=_utc_now_timestamp(),
+                    profile=profile,
+                )
+                preview_desired_state_id = _write_preview_desired_state_if_supported(
+                    record_store=record_store,
+                    record=driver_result,
+                )
+                result = {"preview_desired_state_id": preview_desired_state_id}
             elif path == "/v1/drivers/odoo/post-deploy":
                 request = OdooPostDeployEnvelope.model_validate(payload)
                 if not authz_policy.allows(

--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.workflows.preview_desired_state import discover_github_preview_desired_state
+
+
+class GenericWebPreviewDesiredStateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    source: str = "generic-web-preview"
+    label: str = "preview"
+    max_pages: int = Field(default=10, ge=1, le=20)
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "GenericWebPreviewDesiredStateRequest":
+        if not self.product.strip():
+            raise ValueError("Generic web preview desired state requires product.")
+        if not self.source.strip():
+            raise ValueError("Generic web preview desired state requires source.")
+        if not self.label.strip():
+            raise ValueError("Generic web preview desired state requires label.")
+        return self
+
+
+def _anchor_repo(repository: str) -> str:
+    owner, separator, repo = repository.strip().partition("/")
+    if not separator or not owner.strip() or not repo.strip() or "/" in repo.strip():
+        raise click.ClickException("GitHub repository must use owner/repo format.")
+    return repo.strip()
+
+
+def _preview_slug_prefix(slug_template: str) -> str:
+    prefix, _, _ = slug_template.partition("{number}")
+    return prefix or "pr-"
+
+
+def resolve_generic_web_preview_profile(
+    *, record_store: object, product: str
+) -> LaunchplaneProductProfileRecord:
+    profile = record_store.read_product_profile_record(product)
+    if profile.driver_id != "generic-web":
+        raise click.ClickException(
+            f"Product {profile.product!r} is configured for driver {profile.driver_id!r}, not generic-web."
+        )
+    if not profile.preview.enabled:
+        raise click.ClickException(f"Product {profile.product!r} does not have generic-web previews enabled.")
+    if not profile.preview.context.strip():
+        raise click.ClickException(f"Product {profile.product!r} does not define a preview context.")
+    return profile
+
+
+def discover_generic_web_preview_desired_state(
+    *,
+    control_plane_root: Path,
+    record_store: object,
+    request: GenericWebPreviewDesiredStateRequest,
+    discovered_at: str,
+    profile: LaunchplaneProductProfileRecord | None = None,
+) -> PreviewDesiredStateRecord:
+    resolved_profile = profile
+    if resolved_profile is None:
+        resolved_profile = resolve_generic_web_preview_profile(
+            record_store=record_store,
+            product=request.product,
+        )
+    return discover_github_preview_desired_state(
+        control_plane_root=control_plane_root,
+        product=resolved_profile.product,
+        context=resolved_profile.preview.context,
+        source=request.source,
+        discovered_at=discovered_at,
+        repository=resolved_profile.repository,
+        label=request.label,
+        anchor_repo=_anchor_repo(resolved_profile.repository),
+        preview_slug_prefix=_preview_slug_prefix(resolved_profile.preview.slug_template),
+        preview_slug_template=resolved_profile.preview.slug_template,
+        max_pages=request.max_pages,
+    )

--- a/control_plane/workflows/preview_desired_state.py
+++ b/control_plane/workflows/preview_desired_state.py
@@ -22,6 +22,19 @@ def _repository_parts(repository: str) -> tuple[str, str]:
     return owner.strip(), repo.strip()
 
 
+def render_preview_slug(
+    *,
+    anchor_pr_number: int,
+    preview_slug_prefix: str = "pr-",
+    preview_slug_template: str = "",
+) -> str:
+    if preview_slug_template.strip():
+        if "{number}" not in preview_slug_template:
+            raise click.ClickException("Preview slug template must contain {number}.")
+        return preview_slug_template.strip().replace("{number}", str(anchor_pr_number))
+    return f"{preview_slug_prefix}{anchor_pr_number}"
+
+
 def list_github_open_pull_requests_with_label(
     *,
     owner: str,
@@ -115,6 +128,7 @@ def discover_github_preview_desired_state(
     label: str,
     anchor_repo: str,
     preview_slug_prefix: str = "pr-",
+    preview_slug_template: str = "",
     max_pages: int = 10,
 ) -> PreviewDesiredStateRecord:
     try:
@@ -136,7 +150,11 @@ def discover_github_preview_desired_state(
         )
         desired_previews = tuple(
             PreviewLifecycleDesiredPreview(
-                preview_slug=f"{preview_slug_prefix}{pull_request['number']}",
+                preview_slug=render_preview_slug(
+                    anchor_pr_number=int(pull_request["number"]),
+                    preview_slug_prefix=preview_slug_prefix,
+                    preview_slug_template=preview_slug_template,
+                ),
                 anchor_repo=anchor_repo,
                 anchor_pr_number=int(pull_request["number"]),
                 anchor_pr_url=str(pull_request["html_url"]),

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -92,6 +92,12 @@ The `stable_deploy` action routes to `POST /v1/drivers/generic-web/deploy`. The
 route resolves product lane context from DB-backed product profile records and
 runtime target bindings from DB-backed Dokploy target records.
 
+The `preview_desired_state` action routes to
+`POST /v1/drivers/generic-web/preview-desired-state`. Product workflows provide
+the product key; Launchplane resolves the preview context, owning repository,
+anchor repo, and slug template from the DB-backed product profile before writing
+desired preview state records.
+
 Product drivers can declare `base_driver_id="generic-web"` when they reuse the
 generic web lifecycle and add named product-specific gates or runtime actions.
 The relationship is explicit metadata; product-specific capabilities are still

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -38,6 +38,7 @@ VeriReel product paths:
   - `POST /v1/product-profiles`
 - product driver routes:
   - `POST /v1/drivers/generic-web/deploy`
+  - `POST /v1/drivers/generic-web/preview-desired-state`
   - `POST /v1/drivers/odoo/artifact-publish-inputs`
   - `POST /v1/drivers/odoo/artifact-publish`
   - `POST /v1/drivers/odoo/post-deploy`
@@ -302,6 +303,12 @@ Generic web deploys use `POST /v1/drivers/generic-web/deploy`. The request names
 the product, target instance, immutable artifact/image reference, and source ref;
 Launchplane resolves the context from the DB-backed product profile lane and the
 runtime target from DB-backed Dokploy target records.
+
+Generic web preview desired-state discovery uses
+`POST /v1/drivers/generic-web/preview-desired-state`. The request names the
+product and optional pull-request label/page limit; Launchplane resolves the
+repository, preview context, anchor repo, and preview slug template from the
+DB-backed product profile before recording desired preview state.
 
 ### Operator read endpoints
 

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -86,6 +86,11 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         actions = {action.action_id: action for action in descriptor.actions}
         self.assertEqual(actions["stable_deploy"].route_path, "/v1/drivers/generic-web/deploy")
         self.assertEqual(actions["stable_deploy"].safety, "mutation")
+        self.assertEqual(
+            actions["preview_desired_state"].route_path,
+            "/v1/drivers/generic-web/preview-desired-state",
+        )
+        self.assertEqual(actions["preview_desired_state"].safety, "safe_write")
 
     def test_preview_read_model_is_capability_driven_not_verireel_named(self) -> None:
         descriptor = DriverDescriptor(

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -1,0 +1,109 @@
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import click
+
+from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductImageProfile,
+    ProductPreviewProfile,
+)
+from control_plane.workflows.generic_web_preview import (
+    GenericWebPreviewDesiredStateRequest,
+    discover_generic_web_preview_desired_state,
+    resolve_generic_web_preview_profile,
+)
+from control_plane.workflows.preview_desired_state import render_preview_slug
+
+
+class _GenericWebPreviewStore:
+    def __init__(self, profile: LaunchplaneProductProfileRecord) -> None:
+        self.profile = profile
+
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
+        if product != self.profile.product:
+            raise FileNotFoundError(product)
+        return self.profile
+
+
+def _profile(*, preview_enabled: bool = True) -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord(
+        product="sellyouroutboard",
+        display_name="SellYourOutboard.com",
+        repository="cbusillo/sellyouroutboard",
+        driver_id="generic-web",
+        image=ProductImageProfile(repository="ghcr.io/cbusillo/sellyouroutboard"),
+        runtime_port=3000,
+        health_path="/api/health",
+        preview=ProductPreviewProfile(
+            enabled=preview_enabled,
+            context="sellyouroutboard-testing" if preview_enabled else "",
+            slug_template="preview-{number}-site",
+        ),
+        updated_at="2026-04-30T21:00:00Z",
+        source="test",
+    )
+
+
+class GenericWebPreviewTests(unittest.TestCase):
+    def test_render_preview_slug_uses_template_when_present(self) -> None:
+        self.assertEqual(
+            render_preview_slug(
+                anchor_pr_number=123,
+                preview_slug_prefix="pr-",
+                preview_slug_template="preview-{number}-site",
+            ),
+            "preview-123-site",
+        )
+
+    def test_discover_generic_web_preview_desired_state_uses_profile_contract(self) -> None:
+        store = _GenericWebPreviewStore(_profile())
+        record = PreviewDesiredStateRecord(
+            desired_state_id="preview-desired-state-syo-testing-1",
+            product="sellyouroutboard",
+            context="sellyouroutboard-testing",
+            source="generic-web-preview",
+            discovered_at="2026-04-30T21:00:00Z",
+            repository="cbusillo/sellyouroutboard",
+            label="preview",
+            anchor_repo="sellyouroutboard",
+            preview_slug_prefix="preview-",
+            status="pass",
+            desired_count=0,
+        )
+
+        with patch(
+            "control_plane.workflows.generic_web_preview.discover_github_preview_desired_state",
+            return_value=record,
+        ) as discover:
+            result = discover_generic_web_preview_desired_state(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebPreviewDesiredStateRequest(product="sellyouroutboard"),
+                discovered_at="2026-04-30T21:00:00Z",
+            )
+
+        self.assertEqual(result, record)
+        discover.assert_called_once()
+        _, kwargs = discover.call_args
+        self.assertEqual(kwargs["product"], "sellyouroutboard")
+        self.assertEqual(kwargs["context"], "sellyouroutboard-testing")
+        self.assertEqual(kwargs["repository"], "cbusillo/sellyouroutboard")
+        self.assertEqual(kwargs["anchor_repo"], "sellyouroutboard")
+        self.assertEqual(kwargs["preview_slug_prefix"], "preview-")
+        self.assertEqual(kwargs["preview_slug_template"], "preview-{number}-site")
+
+    def test_resolve_generic_web_preview_profile_rejects_disabled_preview(self) -> None:
+        store = _GenericWebPreviewStore(_profile(preview_enabled=False))
+
+        with self.assertRaises(click.ClickException):
+            resolve_generic_web_preview_profile(
+                record_store=store,
+                product="sellyouroutboard",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1134,6 +1134,145 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
 
+    def test_generic_web_preview_desired_state_route_uses_profile_context(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["preview_desired_state.discover"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
+                            "@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            record = PreviewDesiredStateRecord(
+                desired_state_id="preview-desired-state-syo-testing-1",
+                product="sellyouroutboard",
+                context="sellyouroutboard-testing",
+                source="generic-web-preview",
+                discovered_at="2026-04-30T21:00:00Z",
+                repository="cbusillo/sellyouroutboard",
+                label="preview",
+                anchor_repo="sellyouroutboard",
+                status="pass",
+                desired_count=0,
+            )
+
+            with patch(
+                "control_plane.service.discover_generic_web_preview_desired_state",
+                return_value=record,
+            ) as discover:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/preview-desired-state",
+                    payload={
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "desired_state": {
+                            "schema_version": 1,
+                            "product": "sellyouroutboard",
+                        },
+                    },
+                    headers={"Idempotency-Key": "generic-web-preview-desired-state:syo"},
+                )
+            records = FilesystemRecordStore(state_dir=state_dir).list_preview_desired_state_records(
+                context_name="sellyouroutboard-testing"
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(
+            payload["records"]["preview_desired_state_id"],
+            "preview-desired-state-syo-testing-1",
+        )
+        discover.assert_called_once()
+        _, kwargs = discover.call_args
+        self.assertEqual(kwargs["profile"].product, "sellyouroutboard")
+        self.assertEqual(kwargs["profile"].preview.context, "sellyouroutboard-testing")
+        self.assertEqual(records[0].desired_state_id, "preview-desired-state-syo-testing-1")
+
+    def test_generic_web_preview_desired_state_route_rejects_wrong_context(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["different-context"],
+                            "actions": ["preview_desired_state.discover"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
+                            "@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/generic-web/preview-desired-state",
+                payload={
+                    "schema_version": 1,
+                    "product": "sellyouroutboard",
+                    "desired_state": {
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                    },
+                },
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
     def test_driver_context_view_endpoint_returns_lane_summary(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add a generic-web preview desired-state driver route backed by DB product profiles
- resolve preview context, repository, anchor repo, and slug template from Launchplane-owned product profile records
- support `{number}` preview slug templates while preserving the existing prefix contract

## Validation
- `uv run --extra dev ruff check .`
- `uv run python -m unittest`
- `npx pnpm@10.10.0 --dir frontend validate`
- `git diff --check`
- `docker build -t launchplane-generic-web-preview-test .`

Refs #84
