### PR TITLE
Add generic web preview cleanup

### DIFF
--- a/control_plane/contracts/product_profile_record.py
+++ b/control_plane/contracts/product_profile_record.py
@@ -36,6 +36,7 @@ class ProductPreviewProfile(BaseModel):
     enabled: bool = False
     context: str = ""
     slug_template: str = "pr-{number}"
+    app_name_prefix: str = ""
 
     @model_validator(mode="after")
     def _validate_preview(self) -> "ProductPreviewProfile":

--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -86,6 +86,7 @@ GENERIC_WEB_DRIVER = DriverDescriptor(
             capability_id="preview_inventory_managed",
             label="Preview inventory managed",
             description="Read provider inventory and reconcile current preview state through Launchplane records.",
+            actions=("preview_inventory", "preview_destroy"),
             panels=("preview_inventory", "deployment_evidence", "audit"),
         ),
         DriverCapabilityDescriptor(
@@ -113,6 +114,24 @@ GENERIC_WEB_DRIVER = DriverDescriptor(
             scope="context",
             route_path="/v1/drivers/generic-web/preview-desired-state",
             writes_records=("preview_desired_state",),
+        ),
+        _action(
+            "preview_inventory",
+            "Read preview inventory",
+            "Scan provider state for active generic-web previews and record inventory evidence.",
+            safety="safe_write",
+            scope="context",
+            route_path="/v1/drivers/generic-web/preview-inventory",
+            writes_records=("preview_inventory_scan",),
+        ),
+        _action(
+            "preview_destroy",
+            "Destroy preview",
+            "Destroy a generic-web preview application and record cleanup evidence.",
+            safety="destructive",
+            scope="preview",
+            route_path="/v1/drivers/generic-web/preview-destroy",
+            writes_records=("preview",),
         ),
     ),
 )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -93,7 +93,11 @@ from control_plane.workflows.generic_web_deploy import (
 )
 from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewDesiredStateRequest,
+    GenericWebPreviewDestroyRequest,
+    GenericWebPreviewInventoryRequest,
     discover_generic_web_preview_desired_state,
+    execute_generic_web_preview_destroy,
+    execute_generic_web_preview_inventory,
     resolve_generic_web_preview_profile,
 )
 from control_plane.workflows.preview_desired_state import discover_github_preview_desired_state
@@ -153,7 +157,6 @@ from control_plane.workflows.verireel_prod_rollback import (
 )
 from control_plane.workflows.verireel_preview_driver import (
     VeriReelPreviewDestroyRequest,
-    VeriReelPreviewInventoryResult,
     VeriReelPreviewInventoryRequest,
     VeriReelPreviewRefreshRequest,
     execute_verireel_preview_destroy,
@@ -257,6 +260,38 @@ class GenericWebPreviewDesiredStateEnvelope(BaseModel):
             raise ValueError("generic web preview desired state requires product")
         if self.product.strip() != self.desired_state.product.strip():
             raise ValueError("generic web preview desired state requires matching product values")
+        return self
+
+
+class GenericWebPreviewInventoryEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    inventory: GenericWebPreviewInventoryRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "GenericWebPreviewInventoryEnvelope":
+        if not self.product.strip():
+            raise ValueError("generic web preview inventory requires product")
+        if self.product.strip() != self.inventory.product.strip():
+            raise ValueError("generic web preview inventory requires matching product values")
+        return self
+
+
+class GenericWebPreviewDestroyEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    destroy: GenericWebPreviewDestroyRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "GenericWebPreviewDestroyEnvelope":
+        if not self.product.strip():
+            raise ValueError("generic web preview destroy requires product")
+        if self.product.strip() != self.destroy.product.strip():
+            raise ValueError("generic web preview destroy requires matching product values")
         return self
 
 
@@ -1329,22 +1364,23 @@ def _request_launchplane_self_deploy(
 def _write_preview_inventory_scan_if_supported(
     *,
     record_store: object,
-    result: VeriReelPreviewInventoryResult,
+    context: str,
+    source: str,
+    preview_slugs: tuple[str, ...],
 ) -> str:
     if not hasattr(record_store, "write_preview_inventory_scan_record"):
         return ""
     scanned_at = _utc_now_timestamp()
-    preview_slugs = tuple(item.previewSlug for item in result.previews)
     scan_id = build_preview_inventory_scan_id(
-        context_name=result.context,
+        context_name=context,
         scanned_at=scanned_at,
     )
     getattr(record_store, "write_preview_inventory_scan_record")(
         PreviewInventoryScanRecord(
             scan_id=scan_id,
-            context=result.context,
+            context=context,
             scanned_at=scanned_at,
-            source="verireel-preview-inventory",
+            source=source,
             status="pass",
             preview_count=len(preview_slugs),
             preview_slugs=preview_slugs,
@@ -1468,6 +1504,8 @@ def create_launchplane_service_app(
         "/v1/drivers/launchplane/self-deploy",
         "/v1/drivers/generic-web/deploy",
         "/v1/drivers/generic-web/preview-desired-state",
+        "/v1/drivers/generic-web/preview-inventory",
+        "/v1/drivers/generic-web/preview-destroy",
         "/v1/drivers/odoo/artifact-publish-inputs",
         "/v1/drivers/odoo/artifact-publish",
         "/v1/drivers/odoo/post-deploy",
@@ -2347,6 +2385,91 @@ def create_launchplane_service_app(
                     record=driver_result,
                 )
                 result = {"preview_desired_state_id": preview_desired_state_id}
+            elif path == "/v1/drivers/generic-web/preview-inventory":
+                request = GenericWebPreviewInventoryEnvelope.model_validate(payload)
+                profile = resolve_generic_web_preview_profile(
+                    record_store=record_store,
+                    product=request.product,
+                )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="preview_inventory.read",
+                    product=profile.product,
+                    context=profile.preview.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot read generic web preview inventory"
+                                    " for the requested product/context."
+                                ),
+                            },
+                        },
+                    )
+                driver_result = execute_generic_web_preview_inventory(
+                    control_plane_root=resolved_root,
+                    record_store=record_store,
+                    request=request.inventory,
+                    profile=profile,
+                )
+                preview_inventory_scan_id = _write_preview_inventory_scan_if_supported(
+                    record_store=record_store,
+                    context=driver_result.context,
+                    source=driver_result.source,
+                    preview_slugs=tuple(item.previewSlug for item in driver_result.previews),
+                )
+                result = {"preview_inventory_scan_id": preview_inventory_scan_id}
+            elif path == "/v1/drivers/generic-web/preview-destroy":
+                request = GenericWebPreviewDestroyEnvelope.model_validate(payload)
+                profile = resolve_generic_web_preview_profile(
+                    record_store=record_store,
+                    product=request.product,
+                )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="preview_destroy.execute",
+                    product=profile.product,
+                    context=profile.preview.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot destroy generic web preview state"
+                                    " for the requested product/context."
+                                ),
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                driver_result = execute_generic_web_preview_destroy(
+                    control_plane_root=resolved_root,
+                    record_store=record_store,
+                    request=request.destroy,
+                    profile=profile,
+                )
+                result = {}
             elif path == "/v1/drivers/odoo/post-deploy":
                 request = OdooPostDeployEnvelope.model_validate(payload)
                 if not authz_policy.allows(
@@ -2960,7 +3083,9 @@ def create_launchplane_service_app(
                 )
                 preview_inventory_scan_id = _write_preview_inventory_scan_if_supported(
                     record_store=record_store,
-                    result=driver_result,
+                    context=driver_result.context,
+                    source="verireel-preview-inventory",
+                    preview_slugs=tuple(item.previewSlug for item in driver_result.previews),
                 )
                 result = {"preview_inventory_scan_id": preview_inventory_scan_id}
             elif path == "/v1/drivers/verireel/preview-destroy":
@@ -3325,6 +3450,14 @@ def create_launchplane_service_app(
                             },
                         },
                     )
+                cleanup_driver_id = "verireel" if request.product == "verireel" else ""
+                cleanup_slug_template = "pr-{number}"
+                try:
+                    cleanup_profile = record_store.read_product_profile_record(request.product)
+                    cleanup_driver_id = cleanup_profile.driver_id
+                    cleanup_slug_template = cleanup_profile.preview.slug_template
+                except FileNotFoundError:
+                    pass
                 driver_result = build_preview_lifecycle_cleanup_record(
                     plan=plan,
                     requested_at=_utc_now_timestamp(),
@@ -3334,6 +3467,8 @@ def create_launchplane_service_app(
                     control_plane_root=resolved_root,
                     record_store=record_store,
                     timeout_seconds=request.timeout_seconds,
+                    driver_id=cleanup_driver_id,
+                    preview_slug_template=cleanup_slug_template,
                 )
                 preview_lifecycle_cleanup_id = _write_preview_lifecycle_cleanup_if_supported(
                     record_store=record_store,

--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Literal
 
 import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane import dokploy as control_plane_dokploy
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.workflows.preview_desired_state import discover_github_preview_desired_state
+from control_plane.workflows.ship import utc_now_timestamp
 
 
 class GenericWebPreviewDesiredStateRequest(BaseModel):
@@ -30,6 +33,74 @@ class GenericWebPreviewDesiredStateRequest(BaseModel):
         return self
 
 
+class GenericWebPreviewInventoryRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    source: str = "generic-web-preview-inventory"
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "GenericWebPreviewInventoryRequest":
+        if not self.product.strip():
+            raise ValueError("Generic web preview inventory requires product.")
+        if not self.source.strip():
+            raise ValueError("Generic web preview inventory requires source.")
+        return self
+
+
+class GenericWebPreviewInventoryItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    applicationId: str
+    applicationName: str
+    previewSlug: str
+
+
+class GenericWebPreviewInventoryResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    product: str
+    context: str
+    source: str
+    app_name_prefix: str
+    previews: tuple[GenericWebPreviewInventoryItem, ...]
+
+
+class GenericWebPreviewDestroyRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    preview_slug: str
+    destroy_reason: str
+    timeout_seconds: int = Field(default=300, ge=1)
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "GenericWebPreviewDestroyRequest":
+        if not self.product.strip():
+            raise ValueError("Generic web preview destroy requires product.")
+        if not self.preview_slug.strip():
+            raise ValueError("Generic web preview destroy requires preview_slug.")
+        if not self.destroy_reason.strip():
+            raise ValueError("Generic web preview destroy requires destroy_reason.")
+        return self
+
+
+class GenericWebPreviewDestroyResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    destroy_status: Literal["pass", "fail"]
+    destroy_started_at: str
+    destroy_finished_at: str
+    product: str
+    context: str
+    preview_slug: str
+    application_name: str
+    application_id: str
+    error_message: str = ""
+
+
 def _anchor_repo(repository: str) -> str:
     owner, separator, repo = repository.strip().partition("/")
     if not separator or not owner.strip() or not repo.strip() or "/" in repo.strip():
@@ -40,6 +111,94 @@ def _anchor_repo(repository: str) -> str:
 def _preview_slug_prefix(slug_template: str) -> str:
     prefix, _, _ = slug_template.partition("{number}")
     return prefix or "pr-"
+
+
+def effective_preview_app_name_prefix(*, profile: LaunchplaneProductProfileRecord) -> str:
+    return profile.preview.app_name_prefix.strip() or f"{profile.product}-preview"
+
+
+def preview_application_name(*, app_name_prefix: str, preview_slug: str) -> str:
+    return f"{app_name_prefix.strip()}-{preview_slug.strip()}"
+
+
+def preview_slug_from_application_name(*, app_name_prefix: str, application_name: str) -> str:
+    prefix = f"{app_name_prefix.strip()}-"
+    if not application_name.startswith(prefix):
+        return ""
+    return application_name[len(prefix) :]
+
+
+def preview_pr_number_from_slug(*, preview_slug: str, slug_template: str) -> int | None:
+    prefix, separator, suffix = slug_template.partition("{number}")
+    if not separator:
+        return None
+    slug = preview_slug.strip()
+    if not slug.startswith(prefix):
+        return None
+    tail = slug[len(prefix) :]
+    if suffix:
+        if not tail.endswith(suffix):
+            return None
+        tail = tail[: -len(suffix)]
+    if not tail.isdigit():
+        return None
+    number = int(tail)
+    return number if number > 0 else None
+
+
+def _iter_dokploy_applications(raw_projects: object):
+    if not isinstance(raw_projects, list):
+        raise click.ClickException("Dokploy project inventory returned an invalid response payload.")
+    for raw_project in raw_projects:
+        project = control_plane_dokploy.as_json_object(raw_project)
+        if project is None:
+            continue
+        raw_environments = project.get("environments")
+        if not isinstance(raw_environments, list):
+            continue
+        for raw_environment in raw_environments:
+            environment = control_plane_dokploy.as_json_object(raw_environment)
+            if environment is None:
+                continue
+            raw_applications = environment.get("applications")
+            if not isinstance(raw_applications, list):
+                continue
+            for raw_application in raw_applications:
+                application = control_plane_dokploy.as_json_object(raw_application)
+                if application is not None:
+                    yield application
+
+
+def _find_application_by_name(*, host: str, token: str, application_name: str):
+    raw_projects = control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/project.all",
+    )
+    for application in _iter_dokploy_applications(raw_projects):
+        if str(application.get("name") or "").strip() == application_name:
+            return application
+    return None
+
+
+def _delete_domain(*, host: str, token: str, domain_id: str) -> None:
+    control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/domain.delete",
+        method="POST",
+        payload={"domainId": domain_id},
+    )
+
+
+def _delete_application(*, host: str, token: str, application_id: str) -> None:
+    control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/application.delete",
+        method="POST",
+        payload={"applicationId": application_id},
+    )
 
 
 def resolve_generic_web_preview_profile(
@@ -83,4 +242,126 @@ def discover_generic_web_preview_desired_state(
         preview_slug_prefix=_preview_slug_prefix(resolved_profile.preview.slug_template),
         preview_slug_template=resolved_profile.preview.slug_template,
         max_pages=request.max_pages,
+    )
+
+
+def execute_generic_web_preview_inventory(
+    *,
+    control_plane_root: Path,
+    record_store: object,
+    request: GenericWebPreviewInventoryRequest,
+    profile: LaunchplaneProductProfileRecord | None = None,
+) -> GenericWebPreviewInventoryResult:
+    resolved_profile = profile
+    if resolved_profile is None:
+        resolved_profile = resolve_generic_web_preview_profile(
+            record_store=record_store,
+            product=request.product,
+        )
+    app_name_prefix = effective_preview_app_name_prefix(profile=resolved_profile)
+    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
+    raw_projects = control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/project.all",
+    )
+    preview_items: list[GenericWebPreviewInventoryItem] = []
+    for application in _iter_dokploy_applications(raw_projects):
+        application_name = str(application.get("name") or "").strip()
+        preview_slug = preview_slug_from_application_name(
+            app_name_prefix=app_name_prefix,
+            application_name=application_name,
+        )
+        if not preview_slug:
+            continue
+        application_id = str(application.get("applicationId") or application.get("id") or "").strip()
+        if not application_id:
+            continue
+        preview_items.append(
+            GenericWebPreviewInventoryItem(
+                applicationId=application_id,
+                applicationName=application_name,
+                previewSlug=preview_slug,
+            )
+        )
+    return GenericWebPreviewInventoryResult(
+        product=resolved_profile.product,
+        context=resolved_profile.preview.context,
+        source=request.source,
+        app_name_prefix=app_name_prefix,
+        previews=tuple(sorted(preview_items, key=lambda item: item.previewSlug)),
+    )
+
+
+def execute_generic_web_preview_destroy(
+    *,
+    control_plane_root: Path,
+    record_store: object,
+    request: GenericWebPreviewDestroyRequest,
+    profile: LaunchplaneProductProfileRecord | None = None,
+) -> GenericWebPreviewDestroyResult:
+    resolved_profile = profile
+    if resolved_profile is None:
+        resolved_profile = resolve_generic_web_preview_profile(
+            record_store=record_store,
+            product=request.product,
+        )
+    started_at = utc_now_timestamp()
+    app_name_prefix = effective_preview_app_name_prefix(profile=resolved_profile)
+    application_name = preview_application_name(
+        app_name_prefix=app_name_prefix,
+        preview_slug=request.preview_slug,
+    )
+    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
+    application = _find_application_by_name(
+        host=host,
+        token=token,
+        application_name=application_name,
+    )
+    application_id = str((application or {}).get("applicationId") or "").strip()
+    cleanup_errors: list[str] = []
+    if application_id:
+        try:
+            raw_domains = control_plane_dokploy.dokploy_request(
+                host=host,
+                token=token,
+                path="/api/domain.byApplicationId",
+                query={"applicationId": application_id},
+            )
+            if isinstance(raw_domains, list):
+                for raw_domain in raw_domains:
+                    domain = control_plane_dokploy.as_json_object(raw_domain)
+                    if domain is None:
+                        continue
+                    domain_id = str(domain.get("domainId") or "").strip()
+                    if domain_id:
+                        _delete_domain(host=host, token=token, domain_id=domain_id)
+        except click.ClickException as exc:
+            cleanup_errors.append(f"domain cleanup failed: {exc}")
+        try:
+            _delete_application(host=host, token=token, application_id=application_id)
+        except click.ClickException as exc:
+            cleanup_errors.append(f"application cleanup failed: {exc}")
+    finished_at = utc_now_timestamp()
+    if cleanup_errors:
+        return GenericWebPreviewDestroyResult(
+            destroy_status="fail",
+            destroy_started_at=started_at,
+            destroy_finished_at=finished_at,
+            product=resolved_profile.product,
+            context=resolved_profile.preview.context,
+            preview_slug=request.preview_slug,
+            application_name=application_name,
+            application_id=application_id,
+            error_message="; ".join(cleanup_errors),
+        )
+    return GenericWebPreviewDestroyResult(
+        destroy_status="pass",
+        destroy_started_at=started_at,
+        destroy_finished_at=finished_at,
+        product=resolved_profile.product,
+        context=resolved_profile.preview.context,
+        preview_slug=request.preview_slug,
+        application_name=application_name,
+        application_id=application_id,
     )

--- a/control_plane/workflows/preview_lifecycle_cleanup.py
+++ b/control_plane/workflows/preview_lifecycle_cleanup.py
@@ -13,6 +13,11 @@ from control_plane.contracts.preview_lifecycle_plan_record import PreviewLifecyc
 from control_plane.contracts.preview_mutation_request import PreviewDestroyMutationRequest
 from control_plane.launchplane_mutations import apply_launchplane_destroy_preview
 from control_plane.workflows.launchplane import find_preview_record
+from control_plane.workflows.generic_web_preview import (
+    GenericWebPreviewDestroyRequest,
+    execute_generic_web_preview_destroy,
+    preview_pr_number_from_slug,
+)
 from control_plane.workflows.verireel_preview_driver import (
     VeriReelPreviewDestroyRequest,
     execute_verireel_preview_destroy,
@@ -73,6 +78,137 @@ def _blocked_record(
     )
 
 
+def _build_generic_web_cleanup_record(
+    *,
+    plan: PreviewLifecyclePlanRecord,
+    requested_at: str,
+    source: str,
+    cleanup_id: str,
+    destroy_reason: str,
+    control_plane_root: Path,
+    record_store: Any,
+    timeout_seconds: int,
+    preview_slug_template: str,
+) -> PreviewLifecycleCleanupRecord:
+    parsed_previews: list[tuple[str, int]] = []
+    anchor_repo = plan.product
+    for preview_slug in plan.orphaned_slugs:
+        anchor_pr_number = preview_pr_number_from_slug(
+            preview_slug=preview_slug,
+            slug_template=preview_slug_template,
+        )
+        if anchor_pr_number is None:
+            return _blocked_record(
+                plan=plan,
+                requested_at=requested_at,
+                source=source,
+                apply=True,
+                error_message=(
+                    "Generic web preview cleanup could not derive a PR number from "
+                    f"preview slug {preview_slug!r} using template {preview_slug_template!r}."
+                ),
+            )
+        preview = find_preview_record(
+            record_store=record_store,
+            context_name=plan.context,
+            anchor_repo=anchor_repo,
+            anchor_pr_number=anchor_pr_number,
+        )
+        if preview is None:
+            return _blocked_record(
+                plan=plan,
+                requested_at=requested_at,
+                source=source,
+                apply=True,
+                error_message=(
+                    "Launchplane will not destroy preview provider state without a matching "
+                    f"stored preview record for {plan.context}/{anchor_repo}/{preview_slug}."
+                ),
+            )
+        parsed_previews.append((preview_slug, anchor_pr_number))
+
+    results: list[PreviewLifecycleCleanupResult] = []
+    destroyed_slugs: list[str] = []
+    failed_slugs: list[str] = []
+    for preview_slug, anchor_pr_number in parsed_previews:
+        destroy_result = execute_generic_web_preview_destroy(
+            control_plane_root=control_plane_root,
+            record_store=record_store,
+            request=GenericWebPreviewDestroyRequest(
+                product=plan.product,
+                preview_slug=preview_slug,
+                destroy_reason=destroy_reason,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+        if destroy_result.destroy_status == "pass":
+            try:
+                apply_launchplane_destroy_preview(
+                    record_store=record_store,
+                    request=PreviewDestroyMutationRequest(
+                        context=plan.context,
+                        anchor_repo=anchor_repo,
+                        anchor_pr_number=anchor_pr_number,
+                        destroyed_at=destroy_result.destroy_finished_at,
+                        destroy_reason=destroy_reason,
+                    ),
+                )
+                destroyed_slugs.append(preview_slug)
+                results.append(
+                    PreviewLifecycleCleanupResult(
+                        preview_slug=preview_slug,
+                        anchor_repo=anchor_repo,
+                        anchor_pr_number=anchor_pr_number,
+                        status="destroyed",
+                        application_name=destroy_result.application_name,
+                        application_id=destroy_result.application_id,
+                    )
+                )
+            except click.ClickException as exc:
+                failed_slugs.append(preview_slug)
+                results.append(
+                    PreviewLifecycleCleanupResult(
+                        preview_slug=preview_slug,
+                        anchor_repo=anchor_repo,
+                        anchor_pr_number=anchor_pr_number,
+                        status="failed",
+                        application_name=destroy_result.application_name,
+                        application_id=destroy_result.application_id,
+                        error_message=str(exc),
+                    )
+                )
+            continue
+        failed_slugs.append(preview_slug)
+        results.append(
+            PreviewLifecycleCleanupResult(
+                preview_slug=preview_slug,
+                anchor_repo=anchor_repo,
+                anchor_pr_number=anchor_pr_number,
+                status="failed",
+                application_name=destroy_result.application_name,
+                application_id=destroy_result.application_id,
+                error_message=destroy_result.error_message,
+            )
+        )
+
+    return PreviewLifecycleCleanupRecord(
+        cleanup_id=cleanup_id,
+        product=plan.product,
+        context=plan.context,
+        plan_id=plan.plan_id,
+        inventory_scan_id=plan.inventory_scan_id,
+        requested_at=requested_at,
+        source=source,
+        apply=True,
+        status="pass" if not failed_slugs else "fail",
+        planned_slugs=plan.orphaned_slugs,
+        destroyed_slugs=tuple(destroyed_slugs),
+        failed_slugs=tuple(failed_slugs),
+        results=tuple(results),
+        error_message="" if not failed_slugs else "One or more preview cleanup actions failed.",
+    )
+
+
 def build_preview_lifecycle_cleanup_record(
     *,
     plan: PreviewLifecyclePlanRecord,
@@ -83,6 +219,8 @@ def build_preview_lifecycle_cleanup_record(
     control_plane_root: Path,
     record_store: Any,
     timeout_seconds: int,
+    driver_id: str = "",
+    preview_slug_template: str = "pr-{number}",
 ) -> PreviewLifecycleCleanupRecord:
     cleanup_id = build_preview_lifecycle_cleanup_id(
         context_name=plan.context,
@@ -110,13 +248,38 @@ def build_preview_lifecycle_cleanup_record(
             planned_slugs=plan.orphaned_slugs,
             results=_planned_results(plan),
         )
+    resolved_driver_id = driver_id.strip() or ("verireel" if plan.product == "verireel" else "")
+    if resolved_driver_id not in {"verireel", "generic-web"}:
+        return _blocked_record(
+            plan=plan,
+            requested_at=requested_at,
+            source=source,
+            apply=True,
+            error_message=(
+                "Preview lifecycle cleanup execution is currently implemented for "
+                "verireel and generic-web only."
+            ),
+        )
+    if resolved_driver_id == "generic-web":
+        return _build_generic_web_cleanup_record(
+            plan=plan,
+            requested_at=requested_at,
+            source=source,
+            cleanup_id=cleanup_id,
+            destroy_reason=destroy_reason,
+            control_plane_root=control_plane_root,
+            record_store=record_store,
+            timeout_seconds=timeout_seconds,
+            preview_slug_template=preview_slug_template,
+        )
+
     if plan.product != "verireel" or plan.context != "verireel-testing":
         return _blocked_record(
             plan=plan,
             requested_at=requested_at,
             source=source,
             apply=True,
-            error_message="Preview lifecycle cleanup execution is currently implemented for verireel-testing only.",
+            error_message="VeriReel preview lifecycle cleanup execution requires verireel-testing.",
         )
 
     parsed_previews: list[tuple[str, int]] = []

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -98,6 +98,13 @@ the product key; Launchplane resolves the preview context, owning repository,
 anchor repo, and slug template from the DB-backed product profile before writing
 desired preview state records.
 
+The `preview_inventory` and `preview_destroy` actions route to
+`POST /v1/drivers/generic-web/preview-inventory` and
+`POST /v1/drivers/generic-web/preview-destroy`. They are intentionally limited
+to stateless container previews: Launchplane scans and deletes Dokploy
+applications by the product profile's preview application-name prefix, while
+preview creation/refresh remains a separate contract.
+
 Product drivers can declare `base_driver_id="generic-web"` when they reuse the
 generic web lifecycle and add named product-specific gates or runtime actions.
 The relationship is explicit metadata; product-specific capabilities are still

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -39,6 +39,8 @@ VeriReel product paths:
 - product driver routes:
   - `POST /v1/drivers/generic-web/deploy`
   - `POST /v1/drivers/generic-web/preview-desired-state`
+  - `POST /v1/drivers/generic-web/preview-inventory`
+  - `POST /v1/drivers/generic-web/preview-destroy`
   - `POST /v1/drivers/odoo/artifact-publish-inputs`
   - `POST /v1/drivers/odoo/artifact-publish`
   - `POST /v1/drivers/odoo/post-deploy`
@@ -309,6 +311,13 @@ Generic web preview desired-state discovery uses
 product and optional pull-request label/page limit; Launchplane resolves the
 repository, preview context, anchor repo, and preview slug template from the
 DB-backed product profile before recording desired preview state.
+
+Generic web preview inventory and destroy use
+`POST /v1/drivers/generic-web/preview-inventory` and
+`POST /v1/drivers/generic-web/preview-destroy`. They scan and delete stateless
+Dokploy preview applications by the preview application-name prefix in the
+DB-backed product profile. Lifecycle cleanup can dispatch to this generic path
+only after a passing plan and a matching stored preview record are present.
 
 ### Operator read endpoints
 

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -91,6 +91,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             "/v1/drivers/generic-web/preview-desired-state",
         )
         self.assertEqual(actions["preview_desired_state"].safety, "safe_write")
+        self.assertEqual(
+            actions["preview_inventory"].route_path,
+            "/v1/drivers/generic-web/preview-inventory",
+        )
+        self.assertEqual(
+            actions["preview_destroy"].route_path,
+            "/v1/drivers/generic-web/preview-destroy",
+        )
+        self.assertEqual(actions["preview_destroy"].safety, "destructive")
 
     def test_preview_read_model_is_capability_driven_not_verireel_named(self) -> None:
         descriptor = DriverDescriptor(

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -12,7 +12,12 @@ from control_plane.contracts.product_profile_record import (
 )
 from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewDesiredStateRequest,
+    GenericWebPreviewDestroyRequest,
+    GenericWebPreviewInventoryRequest,
     discover_generic_web_preview_desired_state,
+    execute_generic_web_preview_destroy,
+    execute_generic_web_preview_inventory,
+    preview_pr_number_from_slug,
     resolve_generic_web_preview_profile,
 )
 from control_plane.workflows.preview_desired_state import render_preview_slug
@@ -41,6 +46,7 @@ def _profile(*, preview_enabled: bool = True) -> LaunchplaneProductProfileRecord
             enabled=preview_enabled,
             context="sellyouroutboard-testing" if preview_enabled else "",
             slug_template="preview-{number}-site",
+            app_name_prefix="syo-preview",
         ),
         updated_at="2026-04-30T21:00:00Z",
         source="test",
@@ -103,6 +109,118 @@ class GenericWebPreviewTests(unittest.TestCase):
                 record_store=store,
                 product="sellyouroutboard",
             )
+
+    def test_preview_pr_number_from_slug_uses_template(self) -> None:
+        self.assertEqual(
+            preview_pr_number_from_slug(
+                preview_slug="preview-42-site",
+                slug_template="preview-{number}-site",
+            ),
+            42,
+        )
+        self.assertIsNone(
+            preview_pr_number_from_slug(
+                preview_slug="not-preview-42-site",
+                slug_template="preview-{number}-site",
+            )
+        )
+
+    def test_execute_generic_web_preview_inventory_filters_by_app_prefix(self) -> None:
+        store = _GenericWebPreviewStore(_profile())
+        raw_projects = [
+            {
+                "environments": [
+                    {
+                        "applications": [
+                            {"applicationId": "app-1", "name": "syo-preview-preview-42-site"},
+                            {"applicationId": "app-2", "name": "other-preview-pr-1"},
+                        ]
+                    }
+                ]
+            }
+        ]
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.dokploy_request",
+                return_value=raw_projects,
+            ),
+        ):
+            result = execute_generic_web_preview_inventory(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebPreviewInventoryRequest(product="sellyouroutboard"),
+            )
+
+        self.assertEqual(result.context, "sellyouroutboard-testing")
+        self.assertEqual(result.app_name_prefix, "syo-preview")
+        self.assertEqual([item.previewSlug for item in result.previews], ["preview-42-site"])
+
+    def test_execute_generic_web_preview_destroy_deletes_domains_and_application(self) -> None:
+        store = _GenericWebPreviewStore(_profile())
+        requests: list[dict[str, object]] = []
+
+        def _fake_dokploy_request(**kwargs):
+            requests.append(kwargs)
+            path = kwargs["path"]
+            if path == "/api/project.all":
+                return [
+                    {
+                        "environments": [
+                            {
+                                "applications": [
+                                    {
+                                        "applicationId": "app-1",
+                                        "name": "syo-preview-preview-42-site",
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            if path == "/api/domain.byApplicationId":
+                return [{"domainId": "domain-1"}]
+            return {}
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.dokploy_request",
+                side_effect=_fake_dokploy_request,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.utc_now_timestamp",
+                side_effect=["2026-04-30T21:00:00Z", "2026-04-30T21:00:02Z"],
+            ),
+        ):
+            result = execute_generic_web_preview_destroy(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebPreviewDestroyRequest(
+                    product="sellyouroutboard",
+                    preview_slug="preview-42-site",
+                    destroy_reason="test",
+                ),
+            )
+
+        self.assertEqual(result.destroy_status, "pass")
+        self.assertEqual(result.application_id, "app-1")
+        self.assertEqual(
+            [request["path"] for request in requests],
+            [
+                "/api/project.all",
+                "/api/domain.byApplicationId",
+                "/api/domain.delete",
+                "/api/application.delete",
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_preview_lifecycle_cleanup.py
+++ b/tests/test_preview_lifecycle_cleanup.py
@@ -1,0 +1,108 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from control_plane.contracts.preview_lifecycle_plan_record import PreviewLifecyclePlanRecord
+from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.workflows.generic_web_preview import GenericWebPreviewDestroyResult
+from control_plane.workflows.preview_lifecycle_cleanup import build_preview_lifecycle_cleanup_record
+
+
+class PreviewLifecycleCleanupTests(unittest.TestCase):
+    def test_generic_web_cleanup_destroys_orphan_with_matching_preview_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_preview_record(
+                PreviewRecord(
+                    preview_id="preview-syo-testing-sellyouroutboard-pr-42",
+                    context="sellyouroutboard-testing",
+                    anchor_repo="sellyouroutboard",
+                    anchor_pr_number=42,
+                    anchor_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/42",
+                    preview_label="sellyouroutboard/pr-42",
+                    canonical_url="https://preview-42-site.example.com",
+                    state="active",
+                    created_at="2026-04-30T21:00:00Z",
+                    updated_at="2026-04-30T21:00:00Z",
+                    eligible_at="2026-04-30T21:00:00Z",
+                )
+            )
+            plan = PreviewLifecyclePlanRecord(
+                plan_id="preview-lifecycle-plan-syo-testing-1",
+                product="sellyouroutboard",
+                context="sellyouroutboard-testing",
+                planned_at="2026-04-30T21:00:00Z",
+                source="test",
+                status="pass",
+                inventory_scan_id="preview-inventory-scan-syo-testing-1",
+                orphaned_slugs=("preview-42-site",),
+            )
+
+            with patch(
+                "control_plane.workflows.preview_lifecycle_cleanup.execute_generic_web_preview_destroy",
+                return_value=GenericWebPreviewDestroyResult(
+                    destroy_status="pass",
+                    destroy_started_at="2026-04-30T21:01:00Z",
+                    destroy_finished_at="2026-04-30T21:01:02Z",
+                    product="sellyouroutboard",
+                    context="sellyouroutboard-testing",
+                    preview_slug="preview-42-site",
+                    application_name="syo-preview-preview-42-site",
+                    application_id="app-42",
+                ),
+            ) as destroy:
+                record = build_preview_lifecycle_cleanup_record(
+                    plan=plan,
+                    requested_at="2026-04-30T21:02:00Z",
+                    source="test",
+                    apply=True,
+                    destroy_reason="test_cleanup",
+                    control_plane_root=root,
+                    record_store=store,
+                    timeout_seconds=300,
+                    driver_id="generic-web",
+                    preview_slug_template="preview-{number}-site",
+                )
+
+            self.assertEqual(record.status, "pass")
+            self.assertEqual(record.destroyed_slugs, ("preview-42-site",))
+            self.assertEqual(record.results[0].anchor_pr_number, 42)
+            destroy.assert_called_once()
+            preview = store.read_preview_record("preview-syo-testing-sellyouroutboard-pr-42")
+            self.assertEqual(preview.state, "destroyed")
+            self.assertEqual(preview.destroy_reason, "test_cleanup")
+
+    def test_generic_web_cleanup_blocks_slug_that_does_not_match_template(self) -> None:
+        plan = PreviewLifecyclePlanRecord(
+            plan_id="preview-lifecycle-plan-syo-testing-1",
+            product="sellyouroutboard",
+            context="sellyouroutboard-testing",
+            planned_at="2026-04-30T21:00:00Z",
+            source="test",
+            status="pass",
+            inventory_scan_id="preview-inventory-scan-syo-testing-1",
+            orphaned_slugs=("bad-slug",),
+        )
+
+        record = build_preview_lifecycle_cleanup_record(
+            plan=plan,
+            requested_at="2026-04-30T21:02:00Z",
+            source="test",
+            apply=True,
+            destroy_reason="test_cleanup",
+            control_plane_root=Path("."),
+            record_store=object(),
+            timeout_seconds=300,
+            driver_id="generic-web",
+            preview_slug_template="preview-{number}-site",
+        )
+
+        self.assertEqual(record.status, "blocked")
+        self.assertEqual(record.blocked_slugs, ("bad-slug",))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1273,6 +1273,79 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
 
+    def test_generic_web_preview_inventory_route_writes_scan_from_driver_result(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["preview_inventory.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
+                            "@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            driver_result = SimpleNamespace(
+                context="sellyouroutboard-testing",
+                source="generic-web-preview-inventory",
+                previews=(SimpleNamespace(previewSlug="pr-42"),),
+            )
+
+            with patch(
+                "control_plane.service.execute_generic_web_preview_inventory",
+                return_value=driver_result,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/preview-inventory",
+                    payload={
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "inventory": {
+                            "schema_version": 1,
+                            "product": "sellyouroutboard",
+                        },
+                    },
+                )
+            records = FilesystemRecordStore(state_dir=state_dir).list_preview_inventory_scan_records(
+                context_name="sellyouroutboard-testing"
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(
+            payload["records"]["preview_inventory_scan_id"],
+            records[0].scan_id,
+        )
+        self.assertEqual(records[0].source, "generic-web-preview-inventory")
+        self.assertEqual(records[0].preview_slugs, ("pr-42",))
+
     def test_driver_context_view_endpoint_returns_lane_summary(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add generic-web preview inventory and destroy routes for stateless Dokploy preview apps
- dispatch lifecycle cleanup to generic-web using DB-backed product profile slug/app naming
- keep preview refresh/provisioning out of scope until the generic Dokploy template contract is explicit

## Validation
- `uv run --extra dev ruff check .`
- `uv run python -m unittest`
- `npx pnpm@10.10.0 --dir frontend validate`
- `git diff --check`
- `docker build -t launchplane-generic-web-preview-cleanup-test .`

Refs #84
