### PR TITLE
Add generic web preview readiness

### DIFF
--- a/control_plane/contracts/product_profile_record.py
+++ b/control_plane/contracts/product_profile_record.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
@@ -37,6 +39,17 @@ class ProductPreviewProfile(BaseModel):
     context: str = ""
     slug_template: str = "pr-{number}"
     app_name_prefix: str = ""
+    template_instance: str = "testing"
+    required_template_env_keys: tuple[str, ...] = ()
+    copied_env_keys: tuple[str, ...] = ()
+    omitted_env_keys: tuple[str, ...] = ()
+    override_env: dict[str, str] = Field(default_factory=dict)
+    preview_url_env_keys: tuple[str, ...] = ()
+    preview_domain_env_keys: tuple[str, ...] = ()
+    required_provider_fields: tuple[str, ...] = ()
+    data_transport_mode: Literal["none", "clone", "bootstrap", "migrate_seed", "driver"] = "none"
+    migration_command: str = ""
+    seed_command: str = ""
 
     @model_validator(mode="after")
     def _validate_preview(self) -> "ProductPreviewProfile":
@@ -44,6 +57,42 @@ class ProductPreviewProfile(BaseModel):
             raise ValueError("enabled product preview profile requires context")
         if self.enabled and "{number}" not in self.slug_template:
             raise ValueError("enabled product preview profile slug_template requires {number}")
+        if self.enabled and not self.template_instance.strip():
+            raise ValueError("enabled product preview profile requires template_instance")
+        key_fields = {
+            "required_template_env_keys": self.required_template_env_keys,
+            "copied_env_keys": self.copied_env_keys,
+            "omitted_env_keys": self.omitted_env_keys,
+            "preview_url_env_keys": self.preview_url_env_keys,
+            "preview_domain_env_keys": self.preview_domain_env_keys,
+            "required_provider_fields": self.required_provider_fields,
+        }
+        normalized: dict[str, tuple[str, ...]] = {}
+        for field_name, raw_keys in key_fields.items():
+            keys: list[str] = []
+            for raw_key in raw_keys:
+                key = raw_key.strip()
+                if not key:
+                    raise ValueError(f"product preview profile {field_name} values must be non-empty")
+                if key in keys:
+                    raise ValueError(f"product preview profile {field_name} values must be unique")
+                keys.append(key)
+            normalized[field_name] = tuple(keys)
+        copied = set(normalized["copied_env_keys"])
+        omitted = set(normalized["omitted_env_keys"])
+        overlap = sorted(copied & omitted)
+        if overlap:
+            raise ValueError("product preview profile cannot both copy and omit env keys: " + ", ".join(overlap))
+        for raw_key, raw_value in self.override_env.items():
+            key = raw_key.strip()
+            if not key:
+                raise ValueError("product preview profile override_env keys must be non-empty")
+            if raw_value is None:
+                raise ValueError("product preview profile override_env values must not be null")
+        if self.data_transport_mode == "none" and (self.migration_command or self.seed_command):
+            raise ValueError(
+                "product preview profile migration_command/seed_command require a data transport mode"
+            )
         return self
 
 

--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -125,6 +125,14 @@ GENERIC_WEB_DRIVER = DriverDescriptor(
             writes_records=("preview_inventory_scan",),
         ),
         _action(
+            "preview_readiness",
+            "Evaluate preview readiness",
+            "Validate generic-web preview template settings before provider mutation.",
+            safety="read",
+            scope="context",
+            route_path="/v1/drivers/generic-web/preview-readiness",
+        ),
+        _action(
             "preview_destroy",
             "Destroy preview",
             "Destroy a generic-web preview application and record cleanup evidence.",

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -95,7 +95,9 @@ from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewDesiredStateRequest,
     GenericWebPreviewDestroyRequest,
     GenericWebPreviewInventoryRequest,
+    GenericWebPreviewReadinessRequest,
     discover_generic_web_preview_desired_state,
+    evaluate_generic_web_preview_readiness,
     execute_generic_web_preview_destroy,
     execute_generic_web_preview_inventory,
     resolve_generic_web_preview_profile,
@@ -276,6 +278,22 @@ class GenericWebPreviewInventoryEnvelope(BaseModel):
             raise ValueError("generic web preview inventory requires product")
         if self.product.strip() != self.inventory.product.strip():
             raise ValueError("generic web preview inventory requires matching product values")
+        return self
+
+
+class GenericWebPreviewReadinessEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    readiness: GenericWebPreviewReadinessRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "GenericWebPreviewReadinessEnvelope":
+        if not self.product.strip():
+            raise ValueError("generic web preview readiness requires product")
+        if self.product.strip() != self.readiness.product.strip():
+            raise ValueError("generic web preview readiness requires matching product values")
         return self
 
 
@@ -1505,6 +1523,7 @@ def create_launchplane_service_app(
         "/v1/drivers/generic-web/deploy",
         "/v1/drivers/generic-web/preview-desired-state",
         "/v1/drivers/generic-web/preview-inventory",
+        "/v1/drivers/generic-web/preview-readiness",
         "/v1/drivers/generic-web/preview-destroy",
         "/v1/drivers/odoo/artifact-publish-inputs",
         "/v1/drivers/odoo/artifact-publish",
@@ -2425,6 +2444,41 @@ def create_launchplane_service_app(
                     preview_slugs=tuple(item.previewSlug for item in driver_result.previews),
                 )
                 result = {"preview_inventory_scan_id": preview_inventory_scan_id}
+            elif path == "/v1/drivers/generic-web/preview-readiness":
+                request = GenericWebPreviewReadinessEnvelope.model_validate(payload)
+                profile = resolve_generic_web_preview_profile(
+                    record_store=record_store,
+                    product=request.product,
+                )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="preview_readiness.evaluate",
+                    product=profile.product,
+                    context=profile.preview.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot evaluate generic web preview readiness"
+                                    " for the requested product/context."
+                                ),
+                            },
+                        },
+                    )
+                driver_result = evaluate_generic_web_preview_readiness(
+                    control_plane_root=resolved_root,
+                    record_store=record_store,
+                    request=request.readiness,
+                    checked_at=_utc_now_timestamp(),
+                    profile=profile,
+                )
+                result = {}
             elif path == "/v1/drivers/generic-web/preview-destroy":
                 request = GenericWebPreviewDestroyEnvelope.model_validate(payload)
                 profile = resolve_generic_web_preview_profile(

--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -8,7 +8,10 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
-from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductLaneProfile,
+)
 from control_plane.workflows.preview_desired_state import discover_github_preview_desired_state
 from control_plane.workflows.ship import utc_now_timestamp
 
@@ -99,6 +102,62 @@ class GenericWebPreviewDestroyResult(BaseModel):
     application_name: str
     application_id: str
     error_message: str = ""
+
+
+class GenericWebPreviewReadinessRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    source: str = "generic-web-preview-readiness"
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "GenericWebPreviewReadinessRequest":
+        if not self.product.strip():
+            raise ValueError("Generic web preview readiness requires product.")
+        if not self.source.strip():
+            raise ValueError("Generic web preview readiness requires source.")
+        return self
+
+
+class GenericWebPreviewTransportSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    data_transport_mode: Literal["none", "clone", "bootstrap", "migrate_seed", "driver"]
+    copied_env_keys: tuple[str, ...]
+    omitted_env_keys: tuple[str, ...]
+    override_env_keys: tuple[str, ...]
+    preview_url_env_keys: tuple[str, ...]
+    preview_domain_env_keys: tuple[str, ...]
+    migration_command_configured: bool
+    seed_command_configured: bool
+
+
+class GenericWebPreviewReadinessCheck(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    check_id: str
+    status: Literal["pass", "blocked"]
+    message: str
+
+
+class GenericWebPreviewReadinessResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    readiness_status: Literal["pass", "blocked"]
+    checked_at: str
+    product: str
+    context: str
+    template_context: str
+    template_instance: str
+    template_target_type: str = ""
+    template_target_id: str = ""
+    template_target_name: str = ""
+    source: str
+    missing_template_env_keys: tuple[str, ...]
+    missing_provider_fields: tuple[str, ...]
+    transport: GenericWebPreviewTransportSummary
+    checks: tuple[GenericWebPreviewReadinessCheck, ...]
 
 
 def _anchor_repo(repository: str) -> str:
@@ -214,6 +273,234 @@ def resolve_generic_web_preview_profile(
     if not profile.preview.context.strip():
         raise click.ClickException(f"Product {profile.product!r} does not define a preview context.")
     return profile
+
+
+def _template_lane(*, profile: LaunchplaneProductProfileRecord) -> ProductLaneProfile | None:
+    template_instance = profile.preview.template_instance.strip()
+    for lane in profile.lanes:
+        if lane.instance == template_instance:
+            return lane
+    return None
+
+
+def _field_value(payload: dict[str, object], field_path: str) -> object:
+    current: object = payload
+    for part in field_path.split("."):
+        if not part:
+            return None
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+    return current
+
+
+def _is_blank(value: object) -> bool:
+    return value is None or (isinstance(value, str) and not value.strip())
+
+
+def _read_template_payload(
+    *, control_plane_root: Path, template_lane: ProductLaneProfile
+) -> tuple[control_plane_dokploy.DokployTargetDefinition | None, dict[str, object] | None, str]:
+    source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
+        control_plane_root=control_plane_root,
+    )
+    target_definition = control_plane_dokploy.find_dokploy_target_definition(
+        source_of_truth,
+        context_name=template_lane.context,
+        instance_name=template_lane.instance,
+    )
+    if target_definition is None:
+        return None, None, f"No Dokploy target definition found for {template_lane.context}/{template_lane.instance}."
+    if target_definition.target_type != "application":
+        return (
+            target_definition,
+            None,
+            "Generic web preview readiness requires the template lane to be a Dokploy application.",
+        )
+    if not target_definition.target_id.strip():
+        return (
+            target_definition,
+            None,
+            "Generic web preview readiness requires the template lane to have a Dokploy target_id.",
+        )
+    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
+    payload = control_plane_dokploy.fetch_dokploy_target_payload(
+        host=host,
+        token=token,
+        target_type=target_definition.target_type,
+        target_id=target_definition.target_id,
+    )
+    return target_definition, payload, ""
+
+
+def _transport_summary(*, profile: LaunchplaneProductProfileRecord) -> GenericWebPreviewTransportSummary:
+    return GenericWebPreviewTransportSummary(
+        data_transport_mode=profile.preview.data_transport_mode,
+        copied_env_keys=profile.preview.copied_env_keys,
+        omitted_env_keys=profile.preview.omitted_env_keys,
+        override_env_keys=tuple(sorted(profile.preview.override_env)),
+        preview_url_env_keys=profile.preview.preview_url_env_keys,
+        preview_domain_env_keys=profile.preview.preview_domain_env_keys,
+        migration_command_configured=bool(profile.preview.migration_command.strip()),
+        seed_command_configured=bool(profile.preview.seed_command.strip()),
+    )
+
+
+def evaluate_generic_web_preview_readiness(
+    *,
+    control_plane_root: Path,
+    record_store: object,
+    request: GenericWebPreviewReadinessRequest,
+    checked_at: str,
+    profile: LaunchplaneProductProfileRecord | None = None,
+) -> GenericWebPreviewReadinessResult:
+    resolved_profile = profile
+    if resolved_profile is None:
+        resolved_profile = resolve_generic_web_preview_profile(
+            record_store=record_store,
+            product=request.product,
+        )
+
+    checks: list[GenericWebPreviewReadinessCheck] = []
+    template_lane = _template_lane(profile=resolved_profile)
+    if template_lane is None:
+        checks.append(
+            GenericWebPreviewReadinessCheck(
+                check_id="template_lane",
+                status="blocked",
+                message=(
+                    "Product profile has no lane matching preview.template_instance "
+                    f"{resolved_profile.preview.template_instance!r}."
+                ),
+            )
+        )
+        return GenericWebPreviewReadinessResult(
+            readiness_status="blocked",
+            checked_at=checked_at,
+            product=resolved_profile.product,
+            context=resolved_profile.preview.context,
+            template_context="",
+            template_instance=resolved_profile.preview.template_instance,
+            source=request.source,
+            missing_template_env_keys=(),
+            missing_provider_fields=(),
+            transport=_transport_summary(profile=resolved_profile),
+            checks=tuple(checks),
+        )
+
+    target_definition: control_plane_dokploy.DokployTargetDefinition | None = None
+    template_payload: dict[str, object] | None = None
+    target_error = ""
+    try:
+        target_definition, template_payload, target_error = _read_template_payload(
+            control_plane_root=control_plane_root,
+            template_lane=template_lane,
+        )
+    except click.ClickException as exc:
+        target_error = str(exc)
+    if target_error:
+        checks.append(
+            GenericWebPreviewReadinessCheck(
+                check_id="template_target",
+                status="blocked",
+                message=target_error,
+            )
+        )
+        return GenericWebPreviewReadinessResult(
+            readiness_status="blocked",
+            checked_at=checked_at,
+            product=resolved_profile.product,
+            context=resolved_profile.preview.context,
+            template_context=template_lane.context,
+            template_instance=template_lane.instance,
+            template_target_type=(target_definition.target_type if target_definition is not None else ""),
+            template_target_id=(target_definition.target_id if target_definition is not None else ""),
+            template_target_name=(target_definition.target_name if target_definition is not None else ""),
+            source=request.source,
+            missing_template_env_keys=(),
+            missing_provider_fields=(),
+            transport=_transport_summary(profile=resolved_profile),
+            checks=tuple(checks),
+        )
+
+    assert target_definition is not None
+    assert template_payload is not None
+    env_map = control_plane_dokploy.parse_dokploy_env_text(str(template_payload.get("env") or ""))
+    required_env_keys = tuple(
+        dict.fromkeys(
+            (
+                *resolved_profile.preview.required_template_env_keys,
+                *resolved_profile.preview.copied_env_keys,
+            )
+        )
+    )
+    missing_env_keys = tuple(key for key in required_env_keys if not env_map.get(key, "").strip())
+    missing_provider_fields = tuple(
+        field
+        for field in resolved_profile.preview.required_provider_fields
+        if _is_blank(_field_value(template_payload, field))
+    )
+
+    if missing_env_keys:
+        checks.append(
+            GenericWebPreviewReadinessCheck(
+                check_id="template_env",
+                status="blocked",
+                message="Template lane is missing required env keys: " + ", ".join(missing_env_keys),
+            )
+        )
+    else:
+        checks.append(
+            GenericWebPreviewReadinessCheck(
+                check_id="template_env",
+                status="pass",
+                message="Template lane includes required env keys.",
+            )
+        )
+    if missing_provider_fields:
+        checks.append(
+            GenericWebPreviewReadinessCheck(
+                check_id="template_provider_fields",
+                status="blocked",
+                message="Template lane is missing required provider fields: "
+                + ", ".join(missing_provider_fields),
+            )
+        )
+    else:
+        checks.append(
+            GenericWebPreviewReadinessCheck(
+                check_id="template_provider_fields",
+                status="pass",
+                message="Template lane includes required provider fields.",
+            )
+        )
+    checks.append(
+        GenericWebPreviewReadinessCheck(
+            check_id="transport_policy",
+            status="pass",
+            message=(
+                "Preview transport policy is configured for "
+                f"{resolved_profile.preview.data_transport_mode!r} mode."
+            ),
+        )
+    )
+    status: Literal["pass", "blocked"] = "blocked" if missing_env_keys or missing_provider_fields else "pass"
+    return GenericWebPreviewReadinessResult(
+        readiness_status=status,
+        checked_at=checked_at,
+        product=resolved_profile.product,
+        context=resolved_profile.preview.context,
+        template_context=template_lane.context,
+        template_instance=template_lane.instance,
+        template_target_type=target_definition.target_type,
+        template_target_id=target_definition.target_id,
+        template_target_name=target_definition.target_name,
+        source=request.source,
+        missing_template_env_keys=missing_env_keys,
+        missing_provider_fields=missing_provider_fields,
+        transport=_transport_summary(profile=resolved_profile),
+        checks=tuple(checks),
+    )
 
 
 def discover_generic_web_preview_desired_state(

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -98,12 +98,14 @@ the product key; Launchplane resolves the preview context, owning repository,
 anchor repo, and slug template from the DB-backed product profile before writing
 desired preview state records.
 
-The `preview_inventory` and `preview_destroy` actions route to
-`POST /v1/drivers/generic-web/preview-inventory` and
-`POST /v1/drivers/generic-web/preview-destroy`. They are intentionally limited
-to stateless container previews: Launchplane scans and deletes Dokploy
-applications by the product profile's preview application-name prefix, while
-preview creation/refresh remains a separate contract.
+The `preview_inventory`, `preview_readiness`, and `preview_destroy` actions
+route to `POST /v1/drivers/generic-web/preview-inventory`,
+`POST /v1/drivers/generic-web/preview-readiness`, and
+`POST /v1/drivers/generic-web/preview-destroy`. Inventory and destroy scan and
+delete Dokploy applications by the product profile's preview application-name
+prefix. Readiness validates the DB-backed preview template lane, provider field,
+settings, and transport policy before any provider mutation. Preview
+creation/refresh remains a separate contract built on that readiness result.
 
 Product drivers can declare `base_driver_id="generic-web"` when they reuse the
 generic web lifecycle and add named product-specific gates or runtime actions.

--- a/docs/records.md
+++ b/docs/records.md
@@ -129,7 +129,10 @@ JSONB until they graduate into normal product behavior.
 Product profile records are DB-backed Launchplane configuration for product
 identity and driver selection. They hold product key, display name, owning repo,
 driver id, image repository, runtime port, health path, stable lane bindings,
-and preview context policy.
+and preview context policy. Generic-web preview policy can also name the source
+template lane, required template env keys, copied or omitted settings, preview
+URL/domain env keys, required provider fields, and the declared data transport
+mode so readiness can fail before Launchplane mutates a provider.
 
 These records replace repo-local Launchplane lifecycle manifests. Product repos
 still own their normal app/runtime contract, such as Dockerfile, image publish,

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -40,6 +40,7 @@ VeriReel product paths:
   - `POST /v1/drivers/generic-web/deploy`
   - `POST /v1/drivers/generic-web/preview-desired-state`
   - `POST /v1/drivers/generic-web/preview-inventory`
+  - `POST /v1/drivers/generic-web/preview-readiness`
   - `POST /v1/drivers/generic-web/preview-destroy`
   - `POST /v1/drivers/odoo/artifact-publish-inputs`
   - `POST /v1/drivers/odoo/artifact-publish`

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -96,6 +96,11 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             "/v1/drivers/generic-web/preview-inventory",
         )
         self.assertEqual(
+            actions["preview_readiness"].route_path,
+            "/v1/drivers/generic-web/preview-readiness",
+        )
+        self.assertEqual(actions["preview_readiness"].safety, "read")
+        self.assertEqual(
             actions["preview_destroy"].route_path,
             "/v1/drivers/generic-web/preview-destroy",
         )

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -4,17 +4,21 @@ from unittest.mock import patch
 
 import click
 
+from control_plane.dokploy import DokploySourceOfTruth, DokployTargetDefinition
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductImageProfile,
+    ProductLaneProfile,
     ProductPreviewProfile,
 )
 from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewDesiredStateRequest,
     GenericWebPreviewDestroyRequest,
     GenericWebPreviewInventoryRequest,
+    GenericWebPreviewReadinessRequest,
     discover_generic_web_preview_desired_state,
+    evaluate_generic_web_preview_readiness,
     execute_generic_web_preview_destroy,
     execute_generic_web_preview_inventory,
     preview_pr_number_from_slug,
@@ -42,11 +46,26 @@ def _profile(*, preview_enabled: bool = True) -> LaunchplaneProductProfileRecord
         image=ProductImageProfile(repository="ghcr.io/cbusillo/sellyouroutboard"),
         runtime_port=3000,
         health_path="/api/health",
+        lanes=(
+            ProductLaneProfile(
+                instance="testing",
+                context="sellyouroutboard-testing",
+                base_url="https://testing.sellyouroutboard.com",
+                health_url="https://testing.sellyouroutboard.com/api/health",
+            ),
+        ),
         preview=ProductPreviewProfile(
             enabled=preview_enabled,
             context="sellyouroutboard-testing" if preview_enabled else "",
             slug_template="preview-{number}-site",
             app_name_prefix="syo-preview",
+            required_template_env_keys=("SMTP_HOST",),
+            copied_env_keys=("SMTP_FROM",),
+            omitted_env_keys=("PUBLIC_URL",),
+            override_env={"NODE_ENV": "production"},
+            preview_url_env_keys=("PUBLIC_URL",),
+            preview_domain_env_keys=("PUBLIC_DOMAIN",),
+            required_provider_fields=("dockerImage", "registry.username"),
         ),
         updated_at="2026-04-30T21:00:00Z",
         source="test",
@@ -110,6 +129,15 @@ class GenericWebPreviewTests(unittest.TestCase):
                 product="sellyouroutboard",
             )
 
+    def test_preview_profile_rejects_copy_omit_overlap(self) -> None:
+        with self.assertRaises(ValueError):
+            ProductPreviewProfile(
+                enabled=True,
+                context="sellyouroutboard-testing",
+                copied_env_keys=("SMTP_HOST",),
+                omitted_env_keys=("SMTP_HOST",),
+            )
+
     def test_preview_pr_number_from_slug_uses_template(self) -> None:
         self.assertEqual(
             preview_pr_number_from_slug(
@@ -159,6 +187,101 @@ class GenericWebPreviewTests(unittest.TestCase):
         self.assertEqual(result.context, "sellyouroutboard-testing")
         self.assertEqual(result.app_name_prefix, "syo-preview")
         self.assertEqual([item.previewSlug for item in result.previews], ["preview-42-site"])
+
+    def test_evaluate_generic_web_preview_readiness_passes_with_template_contract(self) -> None:
+        store = _GenericWebPreviewStore(_profile())
+        source = DokploySourceOfTruth(
+            schema_version=1,
+            targets=(
+                DokployTargetDefinition(
+                    context="sellyouroutboard-testing",
+                    instance="testing",
+                    target_type="application",
+                    target_id="app-testing",
+                    target_name="sellyouroutboard-testing",
+                ),
+            ),
+        )
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                return_value=source,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "env": "SMTP_HOST=smtp.example\nSMTP_FROM=hello@example.com\n",
+                    "dockerImage": "ghcr.io/cbusillo/sellyouroutboard:sha",
+                    "registry": {"username": "github-actions"},
+                },
+            ),
+        ):
+            result = evaluate_generic_web_preview_readiness(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebPreviewReadinessRequest(product="sellyouroutboard"),
+                checked_at="2026-04-30T21:00:00Z",
+            )
+
+        self.assertEqual(result.readiness_status, "pass")
+        self.assertEqual(result.template_instance, "testing")
+        self.assertEqual(result.template_target_id, "app-testing")
+        self.assertEqual(result.missing_template_env_keys, ())
+        self.assertEqual(result.missing_provider_fields, ())
+        self.assertEqual(result.transport.copied_env_keys, ("SMTP_FROM",))
+        self.assertEqual(result.transport.preview_url_env_keys, ("PUBLIC_URL",))
+
+    def test_evaluate_generic_web_preview_readiness_blocks_missing_template_inputs(self) -> None:
+        store = _GenericWebPreviewStore(_profile())
+        source = DokploySourceOfTruth(
+            schema_version=1,
+            targets=(
+                DokployTargetDefinition(
+                    context="sellyouroutboard-testing",
+                    instance="testing",
+                    target_type="application",
+                    target_id="app-testing",
+                ),
+            ),
+        )
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                return_value=source,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "env": "SMTP_HOST=\n",
+                    "dockerImage": "",
+                    "registry": {},
+                },
+            ),
+        ):
+            result = evaluate_generic_web_preview_readiness(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebPreviewReadinessRequest(product="sellyouroutboard"),
+                checked_at="2026-04-30T21:00:00Z",
+            )
+
+        self.assertEqual(result.readiness_status, "blocked")
+        self.assertEqual(result.missing_template_env_keys, ("SMTP_HOST", "SMTP_FROM"))
+        self.assertEqual(result.missing_provider_fields, ("dockerImage", "registry.username"))
+        self.assertEqual(
+            [check.check_id for check in result.checks],
+            ["template_env", "template_provider_fields", "transport_policy"],
+        )
 
     def test_execute_generic_web_preview_destroy_deletes_domains_and_application(self) -> None:
         store = _GenericWebPreviewStore(_profile())

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1346,6 +1346,70 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(records[0].source, "generic-web-preview-inventory")
         self.assertEqual(records[0].preview_slugs, ("pr-42",))
 
+    def test_generic_web_preview_readiness_route_returns_driver_result(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["preview_readiness.evaluate"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
+                            "@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.evaluate_generic_web_preview_readiness",
+                return_value={"readiness_status": "blocked", "missing_template_env_keys": ["SMTP_HOST"]},
+            ) as readiness:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/preview-readiness",
+                    payload={
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "readiness": {
+                            "schema_version": 1,
+                            "product": "sellyouroutboard",
+                        },
+                    },
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["readiness_status"], "blocked")
+        self.assertEqual(payload["result"]["missing_template_env_keys"], ["SMTP_HOST"])
+        readiness.assert_called_once()
+        _, kwargs = readiness.call_args
+        self.assertEqual(kwargs["profile"].product, "sellyouroutboard")
+
     def test_driver_context_view_endpoint_returns_lane_summary(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add DB-backed generic-web preview readiness and transport policy fields to product profiles
- expose `preview_readiness` through the driver descriptor and `POST /v1/drivers/generic-web/preview-readiness`
- validate template lane env/provider fields before preview provider mutation and document the contract

## Verification
- `uv run --extra dev ruff check .`
- `uv run python -m unittest`
- `npx pnpm@10.10.0 --dir frontend validate`
- `git diff --check`
- `docker build -t launchplane-generic-web-readiness-test .`