### PR TITLE
Add generic web preview refresh

### DIFF
--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -116,6 +116,14 @@ GENERIC_WEB_DRIVER = DriverDescriptor(
             writes_records=("preview_desired_state",),
         ),
         _action(
+            "preview_refresh",
+            "Refresh preview",
+            "Create or update a generic-web preview application after readiness passes.",
+            safety="mutation",
+            scope="preview",
+            route_path="/v1/drivers/generic-web/preview-refresh",
+        ),
+        _action(
             "preview_inventory",
             "Read preview inventory",
             "Scan provider state for active generic-web previews and record inventory evidence.",

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -96,10 +96,12 @@ from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewDestroyRequest,
     GenericWebPreviewInventoryRequest,
     GenericWebPreviewReadinessRequest,
+    GenericWebPreviewRefreshRequest,
     discover_generic_web_preview_desired_state,
     evaluate_generic_web_preview_readiness,
     execute_generic_web_preview_destroy,
     execute_generic_web_preview_inventory,
+    execute_generic_web_preview_refresh,
     resolve_generic_web_preview_profile,
 )
 from control_plane.workflows.preview_desired_state import discover_github_preview_desired_state
@@ -262,6 +264,22 @@ class GenericWebPreviewDesiredStateEnvelope(BaseModel):
             raise ValueError("generic web preview desired state requires product")
         if self.product.strip() != self.desired_state.product.strip():
             raise ValueError("generic web preview desired state requires matching product values")
+        return self
+
+
+class GenericWebPreviewRefreshEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    refresh: GenericWebPreviewRefreshRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "GenericWebPreviewRefreshEnvelope":
+        if not self.product.strip():
+            raise ValueError("generic web preview refresh requires product")
+        if self.product.strip() != self.refresh.product.strip():
+            raise ValueError("generic web preview refresh requires matching product values")
         return self
 
 
@@ -1522,6 +1540,7 @@ def create_launchplane_service_app(
         "/v1/drivers/launchplane/self-deploy",
         "/v1/drivers/generic-web/deploy",
         "/v1/drivers/generic-web/preview-desired-state",
+        "/v1/drivers/generic-web/preview-refresh",
         "/v1/drivers/generic-web/preview-inventory",
         "/v1/drivers/generic-web/preview-readiness",
         "/v1/drivers/generic-web/preview-destroy",
@@ -2444,6 +2463,51 @@ def create_launchplane_service_app(
                     preview_slugs=tuple(item.previewSlug for item in driver_result.previews),
                 )
                 result = {"preview_inventory_scan_id": preview_inventory_scan_id}
+            elif path == "/v1/drivers/generic-web/preview-refresh":
+                request = GenericWebPreviewRefreshEnvelope.model_validate(payload)
+                profile = resolve_generic_web_preview_profile(
+                    record_store=record_store,
+                    product=request.product,
+                )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="preview_refresh.execute",
+                    product=profile.product,
+                    context=profile.preview.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot refresh generic web preview state"
+                                    " for the requested product/context."
+                                ),
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                driver_result = execute_generic_web_preview_refresh(
+                    control_plane_root=resolved_root,
+                    record_store=record_store,
+                    request=request.refresh,
+                    profile=profile,
+                )
+                result = {}
             elif path == "/v1/drivers/generic-web/preview-readiness":
                 request = GenericWebPreviewReadinessEnvelope.model_validate(payload)
                 profile = resolve_generic_web_preview_profile(

--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import json
+import time
 from pathlib import Path
 from typing import Literal
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
 
 import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -101,6 +106,52 @@ class GenericWebPreviewDestroyResult(BaseModel):
     preview_slug: str
     application_name: str
     application_id: str
+    error_message: str = ""
+
+
+class GenericWebPreviewRefreshRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    preview_slug: str
+    preview_url: str
+    image_reference: str
+    source: str = "generic-web-preview-refresh"
+    timeout_seconds: int = Field(default=300, ge=1)
+    no_cache: bool = False
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "GenericWebPreviewRefreshRequest":
+        if not self.product.strip():
+            raise ValueError("Generic web preview refresh requires product.")
+        if not self.preview_slug.strip():
+            raise ValueError("Generic web preview refresh requires preview_slug.")
+        if not self.preview_url.strip():
+            raise ValueError("Generic web preview refresh requires preview_url.")
+        parsed = urlparse(self.preview_url.strip())
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("Generic web preview refresh preview_url must be an absolute http(s) URL.")
+        if not self.image_reference.strip():
+            raise ValueError("Generic web preview refresh requires image_reference.")
+        if not self.source.strip():
+            raise ValueError("Generic web preview refresh requires source.")
+        return self
+
+
+class GenericWebPreviewRefreshResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    refresh_status: Literal["pass", "blocked", "fail"]
+    refresh_started_at: str
+    refresh_finished_at: str
+    product: str
+    context: str
+    preview_slug: str
+    application_name: str
+    application_id: str = ""
+    preview_url: str
+    readiness: GenericWebPreviewReadinessResult | None = None
     error_message: str = ""
 
 
@@ -240,6 +291,194 @@ def _find_application_by_name(*, host: str, token: str, application_name: str):
     return None
 
 
+def _fetch_application(*, host: str, token: str, application_id: str) -> dict[str, object]:
+    return control_plane_dokploy.fetch_dokploy_target_payload(
+        host=host,
+        token=token,
+        target_type="application",
+        target_id=application_id,
+    )
+
+
+def _ensure_application(
+    *,
+    host: str,
+    token: str,
+    application_name: str,
+    app_name: str,
+    description: str,
+    template_application: dict[str, object],
+) -> tuple[dict[str, object], bool]:
+    existing = _find_application_by_name(host=host, token=token, application_name=application_name)
+    if existing is not None:
+        application_id = str(existing.get("applicationId") or "").strip()
+        if not application_id:
+            raise click.ClickException(
+                f"Dokploy application {application_name!r} exists but does not expose an applicationId."
+            )
+        return _fetch_application(host=host, token=token, application_id=application_id), False
+
+    environment_id = str(template_application.get("environmentId") or "").strip()
+    server_id = str(template_application.get("serverId") or "").strip()
+    if not environment_id:
+        raise click.ClickException("Generic web preview template application is missing environmentId.")
+    if not server_id:
+        raise click.ClickException("Generic web preview template application is missing serverId.")
+    created = control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/application.create",
+        method="POST",
+        payload={
+            "name": application_name,
+            "appName": app_name,
+            "description": description,
+            "environmentId": environment_id,
+            "serverId": server_id,
+        },
+    )
+    created_application = control_plane_dokploy.as_json_object(created)
+    created_application_id = str((created_application or {}).get("applicationId") or "").strip()
+    if not created_application_id:
+        raise click.ClickException(
+            f"Dokploy did not return an applicationId for preview app {application_name!r}."
+        )
+    return _fetch_application(host=host, token=token, application_id=created_application_id), True
+
+
+def _configure_application(
+    *,
+    host: str,
+    token: str,
+    application: dict[str, object],
+    template_application: dict[str, object],
+    image_reference: str,
+    env_text: str,
+) -> None:
+    application_id = str(application.get("applicationId") or "").strip()
+    if not application_id:
+        raise click.ClickException("Preview application payload is missing applicationId.")
+    control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/application.update",
+        method="POST",
+        payload={
+            "applicationId": application_id,
+            "description": str(application.get("description") or "").strip(),
+            "sourceType": "docker",
+            "autoDeploy": True,
+            "replicas": template_application.get("replicas"),
+            "endpointSpecSwarm": template_application.get("endpointSpecSwarm"),
+            "createEnvFile": template_application.get("createEnvFile"),
+            "triggerType": template_application.get("triggerType"),
+            "enabled": template_application.get("enabled"),
+        },
+    )
+    control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/application.saveBuildType",
+        method="POST",
+        payload={
+            "applicationId": application_id,
+            "buildType": template_application.get("buildType"),
+            "dockerfile": template_application.get("dockerfile"),
+            "dockerContextPath": template_application.get("dockerContextPath"),
+            "dockerBuildStage": template_application.get("dockerBuildStage"),
+            "herokuVersion": template_application.get("herokuVersion"),
+            "railpackVersion": template_application.get("railpackVersion"),
+            "publishDirectory": template_application.get("publishDirectory"),
+            "isStaticSpa": template_application.get("isStaticSpa"),
+        },
+    )
+    control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/application.saveDockerProvider",
+        method="POST",
+        payload={
+            "applicationId": application_id,
+            "dockerImage": image_reference,
+            "username": template_application.get("username"),
+            "password": template_application.get("password"),
+            "registryUrl": template_application.get("registryUrl"),
+        },
+    )
+    control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/application.saveEnvironment",
+        method="POST",
+        payload={
+            "applicationId": application_id,
+            "env": env_text,
+            "buildArgs": template_application.get("buildArgs"),
+            "buildSecrets": template_application.get("buildSecrets"),
+            "createEnvFile": template_application.get("createEnvFile"),
+        },
+    )
+
+
+def _ensure_domain(
+    *, host: str, token: str, application_id: str, preview_host: str, runtime_port: int
+) -> tuple[str, tuple[str, ...]]:
+    raw_domains = control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/domain.byApplicationId",
+        query={"applicationId": application_id},
+    )
+    domains = raw_domains if isinstance(raw_domains, list) else []
+    existing: dict[str, object] | None = None
+    stale_domain_ids: list[str] = []
+    for raw_domain in domains:
+        domain = control_plane_dokploy.as_json_object(raw_domain)
+        if domain is None:
+            continue
+        domain_host = str(domain.get("host") or "").strip()
+        domain_id = str(domain.get("domainId") or "").strip()
+        if domain_host == preview_host and domain_id:
+            existing = domain
+            continue
+        if domain_id:
+            stale_domain_ids.append(domain_id)
+    payload: dict[str, object] = {
+        "host": preview_host,
+        "path": "/",
+        "internalPath": "/",
+        "port": runtime_port,
+        "https": True,
+        "applicationId": application_id,
+        "certificateType": "none",
+        "customCertResolver": None,
+        "composeId": None,
+        "serviceName": None,
+        "domainType": "application",
+        "previewDeploymentId": None,
+        "stripPath": False,
+    }
+    if existing is not None:
+        existing_domain_id = str(existing.get("domainId") or "").strip()
+        control_plane_dokploy.dokploy_request(
+            host=host,
+            token=token,
+            path="/api/domain.update",
+            method="POST",
+            payload={"domainId": existing_domain_id, **payload},
+        )
+        return "", tuple(stale_domain_ids)
+    created = control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/domain.create",
+        method="POST",
+        payload=payload,
+    )
+    created_domain = control_plane_dokploy.as_json_object(created)
+    return str((created_domain or {}).get("domainId") or "").strip(), tuple(stale_domain_ids)
+
+
 def _delete_domain(*, host: str, token: str, domain_id: str) -> None:
     control_plane_dokploy.dokploy_request(
         host=host,
@@ -344,6 +583,73 @@ def _transport_summary(*, profile: LaunchplaneProductProfileRecord) -> GenericWe
         migration_command_configured=bool(profile.preview.migration_command.strip()),
         seed_command_configured=bool(profile.preview.seed_command.strip()),
     )
+
+
+def _preview_host(preview_url: str) -> str:
+    parsed = urlparse(preview_url.strip())
+    if not parsed.hostname:
+        raise click.ClickException("Generic web preview URL is missing a hostname.")
+    if parsed.port:
+        return f"{parsed.hostname}:{parsed.port}"
+    return parsed.hostname
+
+
+def _render_preview_env_text(
+    *,
+    profile: LaunchplaneProductProfileRecord,
+    template_application: dict[str, object],
+    preview_url: str,
+) -> str:
+    template_env = control_plane_dokploy.parse_dokploy_env_text(
+        str(template_application.get("env") or "")
+    )
+    preview_host = _preview_host(preview_url)
+    updates: dict[str, str] = {}
+    for key in profile.preview.copied_env_keys:
+        value = template_env.get(key, "")
+        if value:
+            updates[key] = value
+    updates.update(profile.preview.override_env)
+    for key in profile.preview.preview_url_env_keys:
+        updates[key] = preview_url
+    for key in profile.preview.preview_domain_env_keys:
+        updates[key] = preview_host
+    return control_plane_dokploy.render_dokploy_env_text_with_overrides(
+        "",
+        updates=updates,
+    )
+
+
+def _wait_for_preview_health(*, preview_url: str, health_path: str, timeout_seconds: int) -> None:
+    parsed = urlparse(preview_url.rstrip("/"))
+    health_url = parsed._replace(path=health_path, params="", query="", fragment="").geturl()
+    deadline = timeout_seconds
+    request = Request(
+        health_url,
+        headers={
+            "Accept": "application/json, text/plain, */*",
+            "Cache-Control": "no-store",
+        },
+    )
+    while deadline > 0:
+        try:
+            with urlopen(request, timeout=min(15, deadline)) as response:
+                body = response.read().decode("utf-8")
+            if 200 <= response.status < 400:
+                if not body.strip():
+                    return
+                try:
+                    payload = json.loads(body)
+                except json.JSONDecodeError:
+                    return
+                if payload.get("ok") is not False:
+                    return
+        except (HTTPError, URLError, TimeoutError, ValueError):
+            pass
+        sleep_seconds = min(5, deadline)
+        time.sleep(sleep_seconds)
+        deadline -= sleep_seconds
+    raise click.ClickException(f"Timed out waiting for {health_url} to report healthy.")
 
 
 def evaluate_generic_web_preview_readiness(
@@ -500,6 +806,166 @@ def evaluate_generic_web_preview_readiness(
         missing_provider_fields=missing_provider_fields,
         transport=_transport_summary(profile=resolved_profile),
         checks=tuple(checks),
+    )
+
+
+def execute_generic_web_preview_refresh(
+    *,
+    control_plane_root: Path,
+    record_store: object,
+    request: GenericWebPreviewRefreshRequest,
+    profile: LaunchplaneProductProfileRecord | None = None,
+) -> GenericWebPreviewRefreshResult:
+    resolved_profile = profile
+    if resolved_profile is None:
+        resolved_profile = resolve_generic_web_preview_profile(
+            record_store=record_store,
+            product=request.product,
+        )
+    started_at = utc_now_timestamp()
+    app_name_prefix = effective_preview_app_name_prefix(profile=resolved_profile)
+    application_name = preview_application_name(
+        app_name_prefix=app_name_prefix,
+        preview_slug=request.preview_slug,
+    )
+    readiness = evaluate_generic_web_preview_readiness(
+        control_plane_root=control_plane_root,
+        record_store=record_store,
+        request=GenericWebPreviewReadinessRequest(product=request.product, source=request.source),
+        checked_at=started_at,
+        profile=resolved_profile,
+    )
+    if readiness.readiness_status != "pass":
+        finished_at = utc_now_timestamp()
+        return GenericWebPreviewRefreshResult(
+            refresh_status="blocked",
+            refresh_started_at=started_at,
+            refresh_finished_at=finished_at,
+            product=resolved_profile.product,
+            context=resolved_profile.preview.context,
+            preview_slug=request.preview_slug,
+            application_name=application_name,
+            preview_url=request.preview_url,
+            readiness=readiness,
+            error_message="Generic web preview readiness blocked refresh.",
+        )
+
+    template_lane = _template_lane(profile=resolved_profile)
+    if template_lane is None:
+        raise click.ClickException("Generic web preview readiness passed without a template lane.")
+    created_application_id = ""
+    created_domain_id = ""
+    stale_domain_ids: tuple[str, ...] = ()
+    application_id = ""
+    try:
+        host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
+        target_definition, template_application, target_error = _read_template_payload(
+            control_plane_root=control_plane_root,
+            template_lane=template_lane,
+        )
+        if target_error or template_application is None or target_definition is None:
+            raise click.ClickException(target_error or "Generic web preview template payload is unavailable.")
+        env_text = _render_preview_env_text(
+            profile=resolved_profile,
+            template_application=template_application,
+            preview_url=request.preview_url,
+        )
+        application, created_application = _ensure_application(
+            host=host,
+            token=token,
+            application_name=application_name,
+            app_name=f"{resolved_profile.product}-{request.preview_slug}",
+            description=f"Preview environment for {resolved_profile.product} {request.preview_slug}",
+            template_application=template_application,
+        )
+        application_id = str(application.get("applicationId") or "").strip()
+        if created_application:
+            created_application_id = application_id
+        _configure_application(
+            host=host,
+            token=token,
+            application=application,
+            template_application=template_application,
+            image_reference=request.image_reference,
+            env_text=env_text,
+        )
+        created_domain_id, stale_domain_ids = _ensure_domain(
+            host=host,
+            token=token,
+            application_id=application_id,
+            preview_host=_preview_host(request.preview_url),
+            runtime_port=resolved_profile.runtime_port,
+        )
+        latest_before = control_plane_dokploy.latest_deployment_for_target(
+            host=host,
+            token=token,
+            target_type="application",
+            target_id=application_id,
+        )
+        control_plane_dokploy.trigger_deployment(
+            host=host,
+            token=token,
+            target_type="application",
+            target_id=application_id,
+            no_cache=request.no_cache,
+        )
+        control_plane_dokploy.wait_for_target_deployment(
+            host=host,
+            token=token,
+            target_type="application",
+            target_id=application_id,
+            before_key=control_plane_dokploy.deployment_key(latest_before),
+            timeout_seconds=request.timeout_seconds,
+        )
+        _wait_for_preview_health(
+            preview_url=request.preview_url,
+            health_path=resolved_profile.health_path,
+            timeout_seconds=request.timeout_seconds,
+        )
+        for stale_domain_id in stale_domain_ids:
+            _delete_domain(host=host, token=token, domain_id=stale_domain_id)
+    except click.ClickException as exc:
+        rollback_errors: list[str] = []
+        if created_domain_id:
+            try:
+                _delete_domain(host=host, token=token, domain_id=created_domain_id)
+            except click.ClickException as rollback_exc:
+                rollback_errors.append(f"domain rollback failed: {rollback_exc}")
+        if created_application_id:
+            try:
+                _delete_application(host=host, token=token, application_id=created_application_id)
+            except click.ClickException as rollback_exc:
+                rollback_errors.append(f"application rollback failed: {rollback_exc}")
+        finished_at = utc_now_timestamp()
+        message = str(exc)
+        if rollback_errors:
+            message = f"{message}\n" + "\n".join(rollback_errors)
+        return GenericWebPreviewRefreshResult(
+            refresh_status="fail",
+            refresh_started_at=started_at,
+            refresh_finished_at=finished_at,
+            product=resolved_profile.product,
+            context=resolved_profile.preview.context,
+            preview_slug=request.preview_slug,
+            application_name=application_name,
+            application_id=application_id,
+            preview_url=request.preview_url,
+            readiness=readiness,
+            error_message=message,
+        )
+
+    finished_at = utc_now_timestamp()
+    return GenericWebPreviewRefreshResult(
+        refresh_status="pass",
+        refresh_started_at=started_at,
+        refresh_finished_at=finished_at,
+        product=resolved_profile.product,
+        context=resolved_profile.preview.context,
+        preview_slug=request.preview_slug,
+        application_name=application_name,
+        application_id=application_id,
+        preview_url=request.preview_url,
+        readiness=readiness,
     )
 
 

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -98,14 +98,15 @@ the product key; Launchplane resolves the preview context, owning repository,
 anchor repo, and slug template from the DB-backed product profile before writing
 desired preview state records.
 
-The `preview_inventory`, `preview_readiness`, and `preview_destroy` actions
-route to `POST /v1/drivers/generic-web/preview-inventory`,
+The `preview_refresh`, `preview_inventory`, `preview_readiness`, and
+`preview_destroy` actions route to `POST /v1/drivers/generic-web/preview-refresh`,
+`POST /v1/drivers/generic-web/preview-inventory`,
 `POST /v1/drivers/generic-web/preview-readiness`, and
-`POST /v1/drivers/generic-web/preview-destroy`. Inventory and destroy scan and
-delete Dokploy applications by the product profile's preview application-name
-prefix. Readiness validates the DB-backed preview template lane, provider field,
-settings, and transport policy before any provider mutation. Preview
-creation/refresh remains a separate contract built on that readiness result.
+`POST /v1/drivers/generic-web/preview-destroy`. Refresh runs readiness first,
+then creates or updates a stateless Dokploy application from the DB-backed
+template lane, applies explicit settings transport, deploys the submitted image,
+and checks the product health path. Inventory and destroy scan and delete
+Dokploy applications by the product profile's preview application-name prefix.
 
 Product drivers can declare `base_driver_id="generic-web"` when they reuse the
 generic web lifecycle and add named product-specific gates or runtime actions.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -39,6 +39,7 @@ VeriReel product paths:
 - product driver routes:
   - `POST /v1/drivers/generic-web/deploy`
   - `POST /v1/drivers/generic-web/preview-desired-state`
+  - `POST /v1/drivers/generic-web/preview-refresh`
   - `POST /v1/drivers/generic-web/preview-inventory`
   - `POST /v1/drivers/generic-web/preview-readiness`
   - `POST /v1/drivers/generic-web/preview-destroy`

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -92,6 +92,11 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         self.assertEqual(actions["preview_desired_state"].safety, "safe_write")
         self.assertEqual(
+            actions["preview_refresh"].route_path,
+            "/v1/drivers/generic-web/preview-refresh",
+        )
+        self.assertEqual(actions["preview_refresh"].safety, "mutation")
+        self.assertEqual(
             actions["preview_inventory"].route_path,
             "/v1/drivers/generic-web/preview-inventory",
         )

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -17,10 +17,12 @@ from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewDestroyRequest,
     GenericWebPreviewInventoryRequest,
     GenericWebPreviewReadinessRequest,
+    GenericWebPreviewRefreshRequest,
     discover_generic_web_preview_desired_state,
     evaluate_generic_web_preview_readiness,
     execute_generic_web_preview_destroy,
     execute_generic_web_preview_inventory,
+    execute_generic_web_preview_refresh,
     preview_pr_number_from_slug,
     resolve_generic_web_preview_profile,
 )
@@ -65,7 +67,7 @@ def _profile(*, preview_enabled: bool = True) -> LaunchplaneProductProfileRecord
             override_env={"NODE_ENV": "production"},
             preview_url_env_keys=("PUBLIC_URL",),
             preview_domain_env_keys=("PUBLIC_DOMAIN",),
-            required_provider_fields=("dockerImage", "registry.username"),
+            required_provider_fields=("dockerImage", "username"),
         ),
         updated_at="2026-04-30T21:00:00Z",
         source="test",
@@ -217,7 +219,7 @@ class GenericWebPreviewTests(unittest.TestCase):
                 return_value={
                     "env": "SMTP_HOST=smtp.example\nSMTP_FROM=hello@example.com\n",
                     "dockerImage": "ghcr.io/cbusillo/sellyouroutboard:sha",
-                    "registry": {"username": "github-actions"},
+                    "username": "github-actions",
                 },
             ),
         ):
@@ -277,11 +279,172 @@ class GenericWebPreviewTests(unittest.TestCase):
 
         self.assertEqual(result.readiness_status, "blocked")
         self.assertEqual(result.missing_template_env_keys, ("SMTP_HOST", "SMTP_FROM"))
-        self.assertEqual(result.missing_provider_fields, ("dockerImage", "registry.username"))
+        self.assertEqual(result.missing_provider_fields, ("dockerImage", "username"))
         self.assertEqual(
             [check.check_id for check in result.checks],
             ["template_env", "template_provider_fields", "transport_policy"],
         )
+
+    def test_execute_generic_web_preview_refresh_blocks_before_provider_mutation(self) -> None:
+        store = _GenericWebPreviewStore(_profile())
+        source = DokploySourceOfTruth(
+            schema_version=1,
+            targets=(
+                DokployTargetDefinition(
+                    context="sellyouroutboard-testing",
+                    instance="testing",
+                    target_type="application",
+                    target_id="app-testing",
+                ),
+            ),
+        )
+        with (
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                return_value=source,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={"env": "", "dockerImage": "", "registry": {}},
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.dokploy_request"
+            ) as dokploy_request,
+        ):
+            result = execute_generic_web_preview_refresh(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebPreviewRefreshRequest(
+                    product="sellyouroutboard",
+                    preview_slug="preview-42-site",
+                    preview_url="https://preview-42.example.test",
+                    image_reference="ghcr.io/cbusillo/sellyouroutboard:sha",
+                ),
+            )
+
+        self.assertEqual(result.refresh_status, "blocked")
+        dokploy_request.assert_not_called()
+
+    def test_execute_generic_web_preview_refresh_creates_application_from_template(self) -> None:
+        store = _GenericWebPreviewStore(_profile())
+        source = DokploySourceOfTruth(
+            schema_version=1,
+            targets=(
+                DokployTargetDefinition(
+                    context="sellyouroutboard-testing",
+                    instance="testing",
+                    target_type="application",
+                    target_id="app-testing",
+                    target_name="sellyouroutboard-testing",
+                ),
+            ),
+        )
+        requests: list[dict[str, object]] = []
+
+        def _fake_dokploy_request(**kwargs):
+            requests.append(kwargs)
+            path = kwargs["path"]
+            if path == "/api/project.all":
+                return [{"environments": [{"applications": []}]}]
+            if path == "/api/application.create":
+                return {"applicationId": "app-preview"}
+            if path == "/api/domain.byApplicationId":
+                return []
+            if path == "/api/domain.create":
+                return {"domainId": "domain-preview"}
+            return {}
+
+        def _fake_fetch(**kwargs):
+            target_id = kwargs["target_id"]
+            if target_id == "app-testing":
+                return {
+                    "applicationId": "app-testing",
+                    "environmentId": "env-1",
+                    "serverId": "server-1",
+                    "env": "SMTP_HOST=smtp.example\nSMTP_FROM=hello@example.com\nPUBLIC_URL=https://testing.example\n",
+                    "dockerImage": "ghcr.io/cbusillo/sellyouroutboard:old",
+                    "username": "github-actions",
+                    "password": "registry-token",
+                    "registryUrl": "ghcr.io",
+                    "buildType": "dockerfile",
+                }
+            if target_id == "app-preview":
+                return {"applicationId": "app-preview", "description": ""}
+            raise AssertionError(target_id)
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                return_value=source,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.fetch_dokploy_target_payload",
+                side_effect=_fake_fetch,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.dokploy_request",
+                side_effect=_fake_dokploy_request,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.latest_deployment_for_target",
+                return_value=None,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.trigger_deployment",
+            ) as trigger_deployment,
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.wait_for_target_deployment",
+            ),
+            patch("control_plane.workflows.generic_web_preview._wait_for_preview_health") as wait_health,
+            patch(
+                "control_plane.workflows.generic_web_preview.utc_now_timestamp",
+                side_effect=["2026-04-30T21:00:00Z", "2026-04-30T21:00:05Z"],
+            ),
+        ):
+            result = execute_generic_web_preview_refresh(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebPreviewRefreshRequest(
+                    product="sellyouroutboard",
+                    preview_slug="preview-42-site",
+                    preview_url="https://preview-42.example.test",
+                    image_reference="ghcr.io/cbusillo/sellyouroutboard:sha",
+                ),
+            )
+
+        self.assertEqual(result.refresh_status, "pass")
+        self.assertEqual(result.application_id, "app-preview")
+        self.assertEqual(
+            [request["path"] for request in requests],
+            [
+                "/api/project.all",
+                "/api/application.create",
+                "/api/application.update",
+                "/api/application.saveBuildType",
+                "/api/application.saveDockerProvider",
+                "/api/application.saveEnvironment",
+                "/api/domain.byApplicationId",
+                "/api/domain.create",
+            ],
+        )
+        save_environment = [
+            request for request in requests if request["path"] == "/api/application.saveEnvironment"
+        ][0]
+        env_text = str(save_environment["payload"]["env"])
+        self.assertIn("SMTP_FROM=hello@example.com", env_text)
+        self.assertIn("PUBLIC_URL=https://preview-42.example.test", env_text)
+        self.assertIn("PUBLIC_DOMAIN=preview-42.example.test", env_text)
+        self.assertNotIn("SMTP_HOST=", env_text)
+        trigger_deployment.assert_called_once()
+        wait_health.assert_called_once()
 
     def test_execute_generic_web_preview_destroy_deletes_domains_and_application(self) -> None:
         store = _GenericWebPreviewStore(_profile())

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1346,6 +1346,74 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(records[0].source, "generic-web-preview-inventory")
         self.assertEqual(records[0].preview_slugs, ("pr-42",))
 
+    def test_generic_web_preview_refresh_route_returns_driver_result(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["preview_refresh.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
+                            "@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_generic_web_preview_refresh",
+                return_value={"refresh_status": "pass", "application_id": "app-preview"},
+            ) as refresh:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/preview-refresh",
+                    payload={
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "refresh": {
+                            "schema_version": 1,
+                            "product": "sellyouroutboard",
+                            "preview_slug": "pr-42",
+                            "preview_url": "https://pr-42.example.test",
+                            "image_reference": "ghcr.io/cbusillo/sellyouroutboard:sha",
+                        },
+                    },
+                    headers={"Idempotency-Key": "generic-web-preview-refresh:syo:pr-42"},
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["refresh_status"], "pass")
+        self.assertEqual(payload["result"]["application_id"], "app-preview")
+        refresh.assert_called_once()
+        _, kwargs = refresh.call_args
+        self.assertEqual(kwargs["profile"].product, "sellyouroutboard")
+
     def test_generic_web_preview_readiness_route_returns_driver_result(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add generic-web `preview_refresh` action and service route
- create/update stateless preview applications from the DB-backed template lane only after readiness passes
- apply explicit env transport, domain wiring, deploy wait, health checks, and rollback for newly created resources

## Verification
- `uv run --extra dev ruff check .`
- `uv run python -m unittest`
- `npx pnpm@10.10.0 --dir frontend validate`
- `git diff --check`
- `docker build -t launchplane-generic-web-refresh-test .`