### PR TITLE
Default preview apps to DNSRR endpoint mode

### DIFF
--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -346,6 +346,10 @@ def _ensure_application(
     return _fetch_application(host=host, token=token, application_id=created_application_id), True
 
 
+def _preview_endpoint_spec_swarm(template_application: dict[str, object]) -> object:
+    return template_application.get("endpointSpecSwarm") or {"Mode": "dnsrr"}
+
+
 def _configure_application(
     *,
     host: str,
@@ -369,7 +373,7 @@ def _configure_application(
             "sourceType": "docker",
             "autoDeploy": True,
             "replicas": template_application.get("replicas"),
-            "endpointSpecSwarm": template_application.get("endpointSpecSwarm"),
+            "endpointSpecSwarm": _preview_endpoint_spec_swarm(template_application),
             "createEnvFile": template_application.get("createEnvFile"),
             "triggerType": template_application.get("triggerType"),
             "enabled": template_application.get("enabled"),

--- a/control_plane/workflows/verireel_preview_driver.py
+++ b/control_plane/workflows/verireel_preview_driver.py
@@ -493,6 +493,7 @@ def _configure_application(
     application_id = str(application.get("applicationId") or "").strip()
     if not application_id:
         raise click.ClickException("Preview application payload is missing applicationId.")
+    endpoint_spec = template_application.get("endpointSpecSwarm") or {"Mode": "dnsrr"}
     control_plane_dokploy.dokploy_request(
         host=host,
         token=token,
@@ -504,7 +505,7 @@ def _configure_application(
             "sourceType": "docker",
             "autoDeploy": True,
             "replicas": template_application.get("replicas"),
-            "endpointSpecSwarm": template_application.get("endpointSpecSwarm"),
+            "endpointSpecSwarm": endpoint_spec,
             "createEnvFile": template_application.get("createEnvFile"),
             "triggerType": template_application.get("triggerType"),
             "enabled": template_application.get("enabled"),

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -435,6 +435,10 @@ class GenericWebPreviewTests(unittest.TestCase):
                 "/api/domain.create",
             ],
         )
+        update_application = [
+            request for request in requests if request["path"] == "/api/application.update"
+        ][0]
+        self.assertEqual(update_application["payload"]["endpointSpecSwarm"], {"Mode": "dnsrr"})
         save_environment = [
             request for request in requests if request["path"] == "/api/application.saveEnvironment"
         ][0]


### PR DESCRIPTION
## Summary
- default generic web preview app updates to Dokploy DNSRR endpoint mode when the template does not specify one
- apply the same safe default to the VeriReel preview adapter path
- cover the generic web preview update payload in tests

## Validation
- uv run python -m unittest tests.test_generic_web_preview
- uv run --extra dev ruff check . && uv run python -m unittest && npx pnpm@10.10.0 --dir frontend validate && git diff --check && docker build -t launchplane-generic-web-dnsrr-test .