### PR TITLE
Allow generic preview workflows to report PR feedback

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1485,6 +1485,40 @@ def _write_preview_pr_feedback_if_supported(
     return record.feedback_id
 
 
+def _allows_preview_pr_feedback_write(
+    *,
+    authz_policy: LaunchplaneAuthzPolicy,
+    identity: LaunchplaneIdentity,
+    product: str,
+    context: str,
+    status: PreviewPrFeedbackStatus,
+) -> bool:
+    if authz_policy.allows(
+        identity=identity,
+        action="preview_pr_feedback.write",
+        product=product,
+        context=context,
+    ):
+        return True
+
+    lifecycle_actions_by_status = {
+        "ready": ("preview_refresh.execute",),
+        "failed": ("preview_refresh.execute",),
+        "destroyed": ("preview_destroy.execute",),
+        "cleanup_failed": ("preview_destroy.execute",),
+        "cleared": ("preview_refresh.execute", "preview_destroy.execute"),
+    }
+    return any(
+        authz_policy.allows(
+            identity=identity,
+            action=action,
+            product=product,
+            context=context,
+        )
+        for action in lifecycle_actions_by_status.get(status, ())
+    )
+
+
 def create_launchplane_service_app(
     *,
     state_dir: Path,
@@ -3460,11 +3494,12 @@ def create_launchplane_service_app(
                 result = {"preview_desired_state_id": preview_desired_state_id}
             elif path == "/v1/previews/pr-feedback":
                 request = PreviewPrFeedbackEnvelope.model_validate(payload)
-                if not authz_policy.allows(
+                if not _allows_preview_pr_feedback_write(
+                    authz_policy=authz_policy,
                     identity=identity,
-                    action="preview_pr_feedback.write",
                     product=request.product,
                     context=request.context,
+                    status=request.status,
                 ):
                     return _json_response(
                         start_response=start_response,

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -292,6 +292,12 @@ repos submit thin preview outcome facts to `POST /v1/previews/pr-feedback`;
 Launchplane renders the review comment, upserts the anchored GitHub PR comment
 when its runtime token is available, and stores an append-only feedback record
 with the comment body, delivery action, comment URL, and any skip/failure reason.
+Workflows can be granted explicit `preview_pr_feedback.write`, or generic-web
+preview workflows can reuse their matching lifecycle grants: refresh-capable
+workflows may report ready/failed feedback, and destroy-capable workflows may
+report destroyed/cleanup-failed feedback. Unsupported/fork notices still require
+the explicit feedback grant because they are outside the normal refresh/destroy
+flow.
 
 ### Product profile endpoints
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3612,6 +3612,179 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertIn("protected preview provisioning path", payload["result"]["comment_markdown"])
         self.assertEqual(payload["result"]["delivery_status"], "skipped")
 
+    def test_preview_pr_feedback_endpoint_accepts_generic_refresh_grant(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/pull/19/merge"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["preview_refresh.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
+                            "@refs/pull/19/merge"
+                        ),
+                        event_name="pull_request",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/pr-feedback",
+                payload={
+                    "product": "sellyouroutboard",
+                    "context": "sellyouroutboard-testing",
+                    "source": "preview-control-plane",
+                    "repository": "cbusillo/sellyouroutboard",
+                    "anchor_repo": "sellyouroutboard",
+                    "anchor_pr_number": 19,
+                    "anchor_pr_url": "https://github.com/cbusillo/sellyouroutboard/pull/19",
+                    "status": "ready",
+                    "preview_url": "https://pr-19.syo-preview.shinycomputers.com",
+                },
+            )
+
+            feedback_records = FilesystemRecordStore(
+                state_dir=root / "state"
+            ).list_preview_pr_feedback_records(context_name="sellyouroutboard-testing")
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(feedback_records[0].status, "ready")
+
+    def test_preview_pr_feedback_endpoint_accepts_generic_destroy_grant(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/preview-cleanup.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["preview_destroy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/preview-cleanup.yml"
+                            "@refs/heads/main"
+                        ),
+                        event_name="pull_request",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/pr-feedback",
+                payload={
+                    "product": "sellyouroutboard",
+                    "context": "sellyouroutboard-testing",
+                    "source": "preview-cleanup",
+                    "repository": "cbusillo/sellyouroutboard",
+                    "anchor_repo": "sellyouroutboard",
+                    "anchor_pr_number": 19,
+                    "anchor_pr_url": "https://github.com/cbusillo/sellyouroutboard/pull/19",
+                    "status": "destroyed",
+                },
+            )
+
+            feedback_records = FilesystemRecordStore(
+                state_dir=root / "state"
+            ).list_preview_pr_feedback_records(context_name="sellyouroutboard-testing")
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(feedback_records[0].status, "destroyed")
+
+    def test_preview_pr_feedback_endpoint_keeps_unsupported_explicit(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/pull/19/merge"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["preview_refresh.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
+                            "@refs/pull/19/merge"
+                        ),
+                        event_name="pull_request",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/pr-feedback",
+                payload={
+                    "product": "sellyouroutboard",
+                    "context": "sellyouroutboard-testing",
+                    "source": "preview-control-plane",
+                    "repository": "cbusillo/sellyouroutboard",
+                    "anchor_repo": "sellyouroutboard",
+                    "anchor_pr_number": 19,
+                    "anchor_pr_url": "https://github.com/cbusillo/sellyouroutboard/pull/19",
+                    "status": "unsupported",
+                },
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
     def test_preview_pr_feedback_endpoint_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- allow `/v1/previews/pr-feedback` to accept matching generic preview lifecycle grants
- map ready/failed feedback to `preview_refresh.execute` and destroyed/cleanup_failed feedback to `preview_destroy.execute`
- keep unsupported feedback behind explicit `preview_pr_feedback.write`

## Verification
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_preview_pr_feedback_endpoint_records_skipped_delivery_without_token tests.test_service.LaunchplaneServiceTests.test_preview_pr_feedback_endpoint_accepts_generic_refresh_grant tests.test_service.LaunchplaneServiceTests.test_preview_pr_feedback_endpoint_accepts_generic_destroy_grant tests.test_service.LaunchplaneServiceTests.test_preview_pr_feedback_endpoint_keeps_unsupported_explicit tests.test_service.LaunchplaneServiceTests.test_preview_pr_feedback_endpoint_rejects_unauthorized_workflow
- uv run ruff check control_plane/service.py tests/test_service.py
- git diff --check

Note: JetBrains inspections could not run against this worktree because only the main launchplane checkout is open in PyCharm.
