### PR TITLE
Document thin product repo and driver workflows

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,8 +9,14 @@ Use these docs as the source of truth for `launchplane`.
   and the fallback-removal target.
 - [service-boundary.md](service-boundary.md) — Launchplane HTTP ingress, GitHub
   OIDC trust, and first API contracts.
+- [new-product-repo.md](new-product-repo.md) — checklist for building a new
+  website or service repo operated by Launchplane.
+- [product-repo-contract.md](product-repo-contract.md) — thin product repo
+  approval gate and new website repo checklist.
 - [driver-descriptors.md](driver-descriptors.md) — provider-neutral driver
   descriptor, action safety, registry, and read-model endpoint contract.
+- [driver-development.md](driver-development.md) — when and how to add a new
+  Launchplane driver type or product driver.
 - [compatibility-retirement.md](compatibility-retirement.md) — checkpoints for
   deleting or demoting local CLI/file-backed compatibility surfaces.
 - [ui-standards.md](ui-standards.md) — tenant-first Launchplane UI direction and

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -63,6 +63,11 @@ should stabilize before Launchplane adds writable driver metadata. Product and
 lane configuration still belongs in DB-backed Launchplane records, not in
 repo-local Launchplane TOML manifests.
 
+For guidance on adding a new driver type or product-specific driver, see
+[driver-development.md](driver-development.md). For the expected shape of a
+product repo that calls a driver, see
+[product-repo-contract.md](product-repo-contract.md).
+
 ## Read Endpoints
 
 All endpoints are authenticated and use action `driver.read`.

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -1,0 +1,128 @@
+---
+title: Driver Development
+---
+
+## Purpose
+
+Launchplane drivers are the backend-owned boundary for product lifecycle
+behavior. A driver declares what a product can do, validates requests, executes
+or delegates provider work, writes durable records, and exposes read models for
+operators and future UI actions.
+
+Use `generic-web` directly when a product fits the common web-app lifecycle. Add
+a new driver type or product driver only when the product has obligations that
+should be named, authorized, tested, and operated separately from the generic
+web path.
+
+## When To Add A Driver
+
+Add a driver when the product needs one or more of these:
+
+- product-specific backup, restore, or rollback gates
+- database bootstrap, migration, seed, clone, anonymization, or cleanup
+- post-deploy maintenance commands
+- product-specific smoke checks that affect promotion readiness
+- platform-specific artifact handling
+- runtime behavior that cannot be described with the `generic-web` profile
+- a distinct authorization surface for a high-risk action
+
+Do not add a driver just to rename `generic-web` for a product. Prefer a product
+profile using `driver_id="generic-web"` until there is a real product-specific
+capability to model.
+
+## Driver Shape
+
+Each driver should have these pieces:
+
+- Descriptor metadata in `control_plane/drivers/registry.py`.
+- Typed request and result models in a workflow module.
+- Service routes under `/v1/drivers/{driver_id}/...`.
+- Authz actions that match the driver actions and safety level.
+- Storage writes through existing record contracts or a new contract when the
+  behavior needs durable query state.
+- Tests for request validation, authorization, successful execution, failure
+  records, and read-model behavior.
+- Docs that explain whether the driver extends `generic-web` or stands alone.
+
+Product drivers that reuse common web behavior should declare
+`base_driver_id="generic-web"` in the descriptor and delegate common work rather
+than copying preview/deploy logic. The product-specific behavior still needs
+named capabilities and named routes.
+
+## Capability Design
+
+Use capability names to describe operator-visible behavior, not implementation
+mechanics. Prefer names like these:
+
+- `stable_deploy`
+- `preview_refresh`
+- `preview_destroy`
+- `preview_inventory`
+- `preview_readiness`
+- `preview_pr_feedback`
+- `prod_backup_gate`
+- `prod_promotion`
+- `prod_rollback`
+- `app_maintenance`
+
+Provider details such as Dokploy application IDs, endpoint mode, registry
+credentials, or deployment job IDs belong behind adapters and evidence records.
+Expose them in read models only when operators need them to decide or repair
+state.
+
+## Route Design
+
+Driver routes should accept product intent and let Launchplane derive the rest
+from records whenever possible.
+
+Good trigger inputs:
+
+- product key
+- instance or lane when the action is stable-lane specific
+- immutable artifact or image reference
+- source ref or commit SHA
+- PR number for preview actions
+- explicit production confirmation for destructive actions
+
+Avoid requiring product repos to send:
+
+- provider target IDs
+- public preview URLs when Launchplane can derive them
+- health paths or runtime ports already stored in product profiles
+- record IDs that Launchplane can generate idempotently
+- rendered feedback markdown
+- copied environment values or secret names beyond typed profile policy
+
+If a route temporarily needs one of those fields, document why and add a cleanup
+item to move it into product profiles, runtime-environment records, managed
+secrets, or driver-owned derivation.
+
+## Implementation Steps
+
+1. Decide whether `generic-web` plus product profile fields is sufficient.
+2. Add or extend the driver descriptor in the registry.
+3. Add typed request/result models and executor functions in
+   `control_plane/workflows/`.
+4. Wire service routes and authz action checks in `control_plane/service.py`.
+5. Write records through existing storage contracts when possible.
+6. Add focused unit tests for validation, authorization, execution, and failure
+   evidence.
+7. Update docs and any product-repo trigger examples.
+8. Seed or migrate DB-backed product profile, target, runtime environment,
+   managed secret, and authz policy records outside the product repo.
+
+Keep slices small. Land read-only descriptors and profile shape before
+high-risk provider mutations. Land readiness checks before create/update/delete
+actions when a provider mutation depends on external target state.
+
+## Product Repo Boundary
+
+Driver development should make product repos thinner, not larger. When a new
+driver needs a product workflow, the workflow should only build/test/publish the
+artifact and send a minimal Launchplane trigger request. See
+[product-repo-contract.md](product-repo-contract.md) for the approval gate.
+
+Legacy product repos may still carry scripts that shape Launchplane evidence or
+call provider APIs directly. Treat those as migration candidates: classify them,
+move the durable behavior into Launchplane, then delete or shrink the product
+repo scripts.

--- a/docs/new-product-repo.md
+++ b/docs/new-product-repo.md
@@ -1,0 +1,99 @@
+---
+title: New Product Repo
+---
+
+## Purpose
+
+Use this checklist when creating a website or service repo that will be operated
+by Launchplane. The goal is a normal product repo with a thin Launchplane
+handoff, not a repo that grows its own control plane.
+
+## Build The Product First
+
+Create the repo around the product's normal development needs:
+
+- application source, tests, and local dev commands
+- package manager lockfile and dependency policy
+- Dockerfile or artifact build contract
+- local-only fixtures, seed data, and development database helpers when needed
+- product-specific smoke checks that prove real product behavior
+
+Keep Launchplane lifecycle records, lane topology, provider targets, managed
+secrets, and deployment truth out of the repo.
+
+## Runtime Contract
+
+Every Launchplane-operated web product should expose a small runtime contract:
+
+- immutable container image or artifact reference
+- known runtime port
+- health endpoint path
+- non-secret build revision or image tag in the health response
+- documented required runtime environment keys
+- product-specific smoke check command when generic health is not enough
+
+For most web products, `generic-web` can use this contract directly from the
+DB-backed product profile.
+
+## Launchplane Records
+
+Before wiring workflows, seed or verify these records in Launchplane:
+
+- product profile with product key, owning repo, driver id, image repository,
+  runtime port, health path, and preview policy
+- lane profiles for stable instances such as `testing` and `prod`
+- Dokploy or provider target records and target-id records
+- runtime-environment records for non-secret settings
+- managed secret records for secret values
+- authz policy records for GitHub Actions workflows
+
+Do not store these as product-repo Launchplane manifests. The repo may document
+the expected app runtime contract, but Launchplane records are the live source
+of lifecycle truth.
+
+## GitHub Actions Shape
+
+Start with these workflows:
+
+- CI: lint, test, build, and product-owned checks.
+- Security: dependency and static/security checks appropriate for the repo.
+- Publish image: build and publish an immutable artifact, then trigger
+  Launchplane stable deploy for `testing`.
+- Preview trigger: for PRs that request preview, build and publish an immutable
+  preview image, then trigger Launchplane preview refresh.
+- Preview cleanup trigger: on PR close or preview label removal, trigger
+  Launchplane preview destroy.
+
+The Launchplane trigger steps should use GitHub Actions OIDC and pass minimal
+facts only: product key, source ref or SHA, PR number when relevant, immutable
+artifact reference, and optional run URL.
+
+## Choose A Driver
+
+Use `generic-web` when the product is a stateless or mostly stateless web app
+whose lifecycle is image deploy, health check, preview refresh, preview cleanup,
+and PR feedback.
+
+Create a product driver when the product has named extra obligations:
+
+- database migration, clone, bootstrap, seed, or anonymization
+- backup gate, restore, rollback, or destructive repair behavior
+- product-specific promotion smoke checks
+- post-deploy maintenance commands
+- platform-specific artifact or runtime semantics
+
+See [driver-development.md](driver-development.md) for the driver workflow and
+[product-repo-contract.md](product-repo-contract.md) for the approval gate.
+
+## Before Approval
+
+Before treating the repo as Launchplane-ready:
+
+- CI and security pass.
+- The image or artifact is immutable and traceable to a source SHA.
+- Launchplane can read the product profile and target records.
+- A non-prod deploy or preview path has been exercised through Launchplane.
+- Product workflows do not mutate providers directly.
+- Product workflows do not render Launchplane evidence or PR feedback markdown.
+- Any remaining Launchplane adapter scripts are small, temporary, and listed as
+  migration candidates.

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -1,0 +1,147 @@
+---
+title: Product Repo Contract
+---
+
+## Purpose
+
+Product repos should stay product-shaped. They own application code, local
+developer ergonomics, product tests, and artifact publishing. Launchplane owns
+the durable lifecycle around those artifacts: product profiles, runtime targets,
+deployments, previews, feedback, promotion evidence, backup gates, rollbacks,
+cleanup, and provider mutations.
+
+This document is the approval gate for new website repos and the cleanup target
+for older repos that grew Launchplane-like scripts before the service boundary
+existed.
+
+## Target Shape
+
+```text
+product repo
+  - app source
+  - Dockerfile and runtime contract
+  - local dev/test commands
+  - product-specific smoke or E2E checks
+  - image build and publish workflow
+  - thin Launchplane trigger workflow
+
+Launchplane
+  - product profile and lane configuration
+  - driver descriptors and driver routes
+  - provider credentials and managed secrets
+  - preview/deploy/promotion/rollback orchestration
+  - health, readiness, inventory, cleanup, and feedback records
+  - PR feedback rendering and delivery
+```
+
+The product repo should not carry Launchplane lifecycle truth in TOML, JSON,
+checked-in fixtures, or copied ops scripts. Product and lane configuration lives
+in Launchplane DB-backed records.
+
+## What Product Repos Own
+
+- Application source code and product-owned business behavior.
+- Product dependencies, lockfiles, and package/build tooling.
+- Dockerfile or image build contract.
+- Local development helpers, including local-only databases when the product
+  needs them.
+- CI checks that validate the source artifact before Launchplane sees it: lint,
+  typecheck, unit tests, app build, container build, and product-specific smoke
+  checks.
+- Publishing an immutable image or artifact reference that Launchplane can
+  deploy.
+- A minimal GitHub Actions trigger that authenticates to Launchplane with OIDC
+  and submits the product key, source ref or SHA, PR number when relevant, and
+  immutable artifact reference.
+
+Product-specific checks may stay in the repo when they exercise product behavior
+Launchplane cannot know generically, such as a checkout flow, owner route, QR
+scan flow, or domain-specific API behavior. Generic runtime health and revision
+checks should move to Launchplane drivers once the driver has the necessary
+profile data.
+
+## What Launchplane Owns
+
+- Product profile records, lane profiles, preview policy, runtime port, health
+  path, preview slug policy, and public URL/domain policy.
+- Dokploy or other provider target records and target-id records.
+- Runtime-environment records and managed secret records.
+- Driver request validation, idempotency policy, action safety, and audit
+  evidence.
+- Provider mutations: create/update/delete preview apps, deploy stable lanes,
+  promote, rollback, capture backup gates, and cleanup stale runtime state.
+- Readiness checks before provider mutation.
+- Health checks when they are based on profile-owned health paths and expected
+  revisions or image references.
+- PR feedback records, markdown rendering, comment delivery, and stale feedback
+  cleanup.
+- Promotion, rollback, deployment, preview, inventory, and cleanup records.
+
+## Minimal Trigger Inputs
+
+A product workflow should submit only the facts Launchplane cannot derive from
+DB-backed profiles or GitHub OIDC claims:
+
+- product key
+- source ref or commit SHA
+- immutable artifact or image reference
+- PR number for preview actions
+- explicit production confirmation for destructive or high-risk actions
+- optional run URL for audit display
+
+Launchplane should derive context, lane, preview slug, preview URL, target,
+health path, feedback marker, provider credentials, managed secrets, and record
+ids unless a driver-specific route documents an explicit exception.
+
+## Approval Gate
+
+A product repo is approved when all of these are true:
+
+- Workflows build, test, and publish product artifacts, then trigger
+  Launchplane. They do not directly mutate runtime providers.
+- Scripts do not own Launchplane record or evidence shaping that Launchplane can
+  derive from profiles, driver requests, provider results, or GitHub OIDC
+  claims.
+- Preview, deploy, promotion, rollback, and cleanup triggers pass minimal inputs
+  only.
+- Product-specific checks remain in the repo only when they validate product
+  behavior rather than generic deploy plumbing.
+- Removed scripts are unused or replaced by equivalent Launchplane routes with
+  tests.
+- CI and security gates pass after cleanup.
+- At least one non-prod Launchplane path is exercised after the cleanup.
+
+## Cleanup Workflow
+
+For an existing repo, classify each workflow and script before deleting code:
+
+- `keep`: product build, test, lint, local dev, local DB, or real product smoke
+  behavior.
+- `move`: Launchplane lifecycle behavior that should become or already is a
+  driver route.
+- `delete`: stale compatibility code with no active caller or with a proven
+  Launchplane replacement.
+- `adapter`: temporary OIDC trigger glue that should shrink or move into a
+  reusable Launchplane GitHub Action/CLI.
+
+Start with low-risk deletions and documentation, then replace active workflow
+behavior in small slices. Do not remove active backup, promotion, rollback, or
+cleanup safety gates until Launchplane owns the equivalent behavior and tests.
+
+## New Repo Checklist
+
+When creating a new website repo for Launchplane:
+
+- Build the app as a normal product repo first.
+- Add a health endpoint that returns enough non-secret version data for
+  Launchplane to verify the deployed artifact.
+- Publish immutable container images or artifacts from GitHub Actions.
+- Seed the product profile, lane profiles, target records, runtime environment,
+  managed secrets, and authz policy in Launchplane.
+- Use `generic-web` directly when the product is a stateless or mostly
+  stateless web app with standard preview/deploy behavior.
+- Add a product driver only when the product has named extra obligations such as
+  database bootstrap, data migration, backup gates, restore/rollback behavior,
+  product smoke checks, or platform-specific post-deploy actions.
+- Keep Launchplane lifecycle config out of the product repo unless this document
+  or a driver-specific doc explicitly names a temporary compatibility exception.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -19,6 +19,12 @@ The current repo-local CLI and file-backed state directory are implementation
 scaffolding. This document defines the boundary those adapters should converge
 on.
 
+Product repos should build, test, and publish product artifacts, then call this
+boundary with minimal trigger facts. They should not carry Launchplane lifecycle
+truth, provider mutation logic, rendered evidence payloads, or copied driver
+behavior. See [product-repo-contract.md](product-repo-contract.md) for the
+approval gate.
+
 ## Current Implementation Status
 
 The service boundary is implemented and deployed for the current Odoo and


### PR DESCRIPTION
## Summary
- add Launchplane docs for new product repos, thin product repo approval, and driver development
- link the docs from the Launchplane docs index
- cross-link the service boundary and driver descriptor docs to the new guidance

## Verification
- git diff --check
- markdown validation ran clean during patching for the touched docs

Note: branch was pushed with the signed-in account because the shiny-code-bot token was rejected for git push earlier in this session.