### PR TITLE
Handle empty Dokploy application build fields

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -716,10 +716,8 @@ def update_dokploy_target_env(
             "env": env_text,
             "createEnvFile": bool(create_env_file) if isinstance(create_env_file, bool) else True,
         }
-        if isinstance(build_args, str):
-            payload["buildArgs"] = build_args
-        if isinstance(build_secrets, str):
-            payload["buildSecrets"] = build_secrets
+        payload["buildArgs"] = build_args if isinstance(build_args, str) else ""
+        payload["buildSecrets"] = build_secrets if isinstance(build_secrets, str) else ""
         dokploy_request(
             host=host,
             token=token,

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -76,6 +76,29 @@ def _seed_dokploy_target_records(
 
 
 class DokployConfigTests(unittest.TestCase):
+    def test_update_application_env_includes_empty_build_fields_when_missing(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        with patch(
+            "control_plane.dokploy.dokploy_request",
+            side_effect=lambda **kwargs: requests.append(kwargs) or {"ok": True},
+        ):
+            control_plane_dokploy.update_dokploy_target_env(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                target_type="application",
+                target_id="app-123",
+                target_payload={"createEnvFile": True, "buildArgs": None, "buildSecrets": None},
+                env_text="APP_URL=https://example.com",
+            )
+
+        self.assertEqual(len(requests), 1)
+        self.assertEqual(requests[0]["path"], "/api/application.saveEnvironment")
+        payload = requests[0]["payload"]
+        self.assertIsInstance(payload, dict)
+        self.assertEqual(payload["buildArgs"], "")
+        self.assertEqual(payload["buildSecrets"], "")
+
     def test_dokploy_targets_list_and_show_include_shopify_policy_metadata(self) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- Always send buildArgs/buildSecrets when updating Dokploy application environment payloads
- Preserve existing string values and use empty strings when Dokploy returns null/missing fields

## Verification
- uv run python -m unittest tests.test_dokploy.DokployConfigTests.test_update_application_env_includes_empty_build_fields_when_missing
- uv run python -m unittest tests.test_dokploy
- uv run ruff check --diff control_plane/dokploy.py tests/test_dokploy.py
- uv run ruff check control_plane/dokploy.py tests/test_dokploy.py
- JetBrains inspection: clean for changed files

Refs #99