### PR TITLE
Add VeriReel runtime verification driver

### DIFF
--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -271,7 +271,13 @@ VERIREEL_DRIVER = DriverDescriptor(
             capability_id="stable_deploy",
             label="Stable deploy",
             description="Deploy and inspect stable VeriReel environments through Launchplane evidence records.",
-            actions=("testing_deploy", "prod_deploy", "stable_environment", "app_maintenance"),
+            actions=(
+                "testing_deploy",
+                "prod_deploy",
+                "stable_environment",
+                "runtime_verification",
+                "app_maintenance",
+            ),
             panels=("lane_health", "deployment_evidence", "settings"),
         ),
         DriverCapabilityDescriptor(
@@ -306,6 +312,14 @@ VERIREEL_DRIVER = DriverDescriptor(
             safety="read",
             scope="instance",
             route_path="/v1/drivers/verireel/stable-environment",
+        ),
+        _action(
+            "runtime_verification",
+            "Verify stable runtime",
+            "Verify stable VeriReel health and public page responses through Launchplane.",
+            safety="read",
+            scope="instance",
+            route_path="/v1/drivers/verireel/runtime-verification",
         ),
         _action(
             "app_maintenance",

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -145,6 +145,10 @@ from control_plane.workflows.verireel_environment import (
     VeriReelStableEnvironmentRequest,
     resolve_verireel_stable_environment,
 )
+from control_plane.workflows.verireel_rollout import (
+    VeriReelRolloutVerificationRequest,
+    execute_verireel_rollout_verification,
+)
 from control_plane.workflows.verireel_app_maintenance import (
     VeriReelAppMaintenanceRequest,
     execute_verireel_app_maintenance,
@@ -623,6 +627,20 @@ class VeriReelStableEnvironmentEnvelope(BaseModel):
     def _validate_alignment(self) -> "VeriReelStableEnvironmentEnvelope":
         if self.product.strip() != "verireel":
             raise ValueError("VeriReel stable environment requires product 'verireel'.")
+        return self
+
+
+class VeriReelRuntimeVerificationEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    verification: VeriReelRolloutVerificationRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "VeriReelRuntimeVerificationEnvelope":
+        if self.product.strip() != "verireel":
+            raise ValueError("VeriReel runtime verification requires product 'verireel'.")
         return self
 
 
@@ -1803,6 +1821,7 @@ def create_launchplane_service_app(
         "/v1/drivers/verireel/preview-verification",
         "/v1/drivers/verireel/testing-deploy",
         "/v1/drivers/verireel/stable-environment",
+        "/v1/drivers/verireel/runtime-verification",
         "/v1/drivers/verireel/app-maintenance",
         "/v1/drivers/verireel/prod-deploy",
         "/v1/drivers/verireel/prod-backup-gate",
@@ -3170,10 +3189,38 @@ def create_launchplane_service_app(
                                 ),
                             },
                         },
-                    )
+                )
                 driver_result = resolve_verireel_stable_environment(
                     control_plane_root=resolved_root,
                     request=request.environment,
+                )
+                result = {}
+            elif path == "/v1/drivers/verireel/runtime-verification":
+                request = VeriReelRuntimeVerificationEnvelope.model_validate(payload)
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="verireel_stable_environment.read",
+                    product=request.product,
+                    context=request.verification.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot execute the VeriReel runtime verification driver"
+                                    " for the requested product/context."
+                                ),
+                            },
+                        },
+                    )
+                driver_result = execute_verireel_rollout_verification(
+                    control_plane_root=resolved_root,
+                    request=request.verification,
                 )
                 result = {}
             elif path == "/v1/drivers/verireel/app-maintenance":
@@ -3996,6 +4043,7 @@ def create_launchplane_service_app(
         should_store_idempotency = True
         if path in {
             "/v1/drivers/verireel/stable-environment",
+            "/v1/drivers/verireel/runtime-verification",
             "/v1/drivers/verireel/preview-inventory",
         }:
             should_store_idempotency = False

--- a/control_plane/workflows/verireel_prod_promotion.py
+++ b/control_plane/workflows/verireel_prod_promotion.py
@@ -1,16 +1,12 @@
 from __future__ import annotations
 
-import json
 from pathlib import Path
 import time
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
 
 import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane import dokploy as control_plane_dokploy
-from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.promotion_record import (
@@ -22,26 +18,17 @@ from control_plane.contracts.promotion_record import (
     PromotionRecord,
 )
 from control_plane.storage.filesystem import FilesystemRecordStore
-from control_plane.workflows.ship import utc_now_timestamp
 from control_plane.workflows.verireel_stable_deploy import (
     VeriReelStableDeployRequest,
     execute_verireel_stable_deploy,
 )
-
-
-DEFAULT_ROLLOUT_TIMEOUT_SECONDS = 300
-DEFAULT_ROLLOUT_INTERVAL_SECONDS = 5
-DEFAULT_ROLLOUT_PAGE_PATHS = ("/", "/sign-in")
-
-
-class VeriReelRolloutVerificationResult(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    status: str
-    base_url: str = ""
-    health_urls: tuple[str, ...] = ()
-    started_at: str = ""
-    finished_at: str = ""
+from control_plane.workflows.verireel_rollout import (
+    DEFAULT_ROLLOUT_INTERVAL_SECONDS,
+    DEFAULT_ROLLOUT_TIMEOUT_SECONDS,
+    VeriReelRolloutVerificationResult,
+    resolve_verireel_rollout_base_urls,
+    verify_verireel_rollout,
+)
 
 
 class VeriReelProdPromotionRequest(BaseModel):
@@ -325,90 +312,11 @@ def _resolve_rollout_base_urls(
     control_plane_root: Path,
     request: VeriReelProdPromotionRequest,
 ) -> tuple[str, ...]:
-    source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
+    return resolve_verireel_rollout_base_urls(
         control_plane_root=control_plane_root,
+        context=request.context,
+        instance=request.to_instance,
     )
-    target_definition = control_plane_dokploy.find_dokploy_target_definition(
-        source_of_truth,
-        context_name=request.context,
-        instance_name=request.to_instance,
-    )
-    if target_definition is None:
-        raise click.ClickException(
-            f"No Dokploy target definition found for {request.context}/{request.to_instance}."
-        )
-    environment_values = control_plane_runtime_environments.resolve_runtime_environment_values(
-        control_plane_root=control_plane_root,
-        context_name=request.context,
-        instance_name=request.to_instance,
-    )
-    base_urls = control_plane_dokploy.resolve_healthcheck_base_urls(
-        target_definition=target_definition,
-        environment_values=environment_values,
-    )
-    if not base_urls:
-        raise click.ClickException(
-            f"No rollout base URL configured for {request.context}/{request.to_instance}."
-        )
-    return base_urls
-
-
-def _fetch_url_text(url: str, *, accept: str) -> tuple[int, str]:
-    request = Request(
-        url,
-        headers={
-            "Accept": accept,
-            "Cache-Control": "no-store",
-        },
-    )
-    with urlopen(request, timeout=15) as response:
-        return response.status, response.read().decode("utf-8")
-
-
-def _validate_health_payload(
-    payload: object,
-    *,
-    health_url: str,
-    expected_build_revision: str,
-    expected_build_tag: str,
-) -> str | None:
-    if not isinstance(payload, dict) or payload.get("ok") is not True:
-        return f"health payload from {health_url} did not report ok=true"
-    if expected_build_revision and payload.get("buildRevision") != expected_build_revision:
-        return (
-            f"health payload from {health_url} reported buildRevision "
-            f"'{payload.get('buildRevision', 'unknown')}' instead of expected "
-            f"'{expected_build_revision}'"
-        )
-    if expected_build_tag and payload.get("buildTag") != expected_build_tag:
-        return (
-            f"health payload from {health_url} reported buildTag "
-            f"'{payload.get('buildTag', 'unknown')}' instead of expected "
-            f"'{expected_build_tag}'"
-        )
-    return None
-
-
-def _assert_rollout_pages(base_url: str) -> None:
-    for page_path in DEFAULT_ROLLOUT_PAGE_PATHS:
-        page_url = f"{base_url.rstrip('/')}{page_path}"
-        try:
-            status_code, response_text = _fetch_url_text(
-                page_url,
-                accept="text/html,application/json",
-            )
-        except (HTTPError, URLError, TimeoutError, ValueError) as exc:
-            raise click.ClickException(
-                f"VeriReel prod rollout page verification failed for {page_url}: {exc}"
-            ) from exc
-        if status_code < 200 or status_code >= 300:
-            raise click.ClickException(
-                f"VeriReel prod rollout page verification expected {page_url} to return 2xx, received {status_code}."
-            )
-        if "VeriReel" not in response_text:
-            raise click.ClickException(
-                f'VeriReel prod rollout page verification expected {page_url} to include "VeriReel".'
-            )
 
 
 def _verify_rollout(
@@ -416,51 +324,16 @@ def _verify_rollout(
     control_plane_root: Path,
     request: VeriReelProdPromotionRequest,
 ) -> VeriReelRolloutVerificationResult:
-    started_at = utc_now_timestamp()
-    base_urls = _resolve_rollout_base_urls(
+    return verify_verireel_rollout(
         control_plane_root=control_plane_root,
-        request=request,
+        context=request.context,
+        instance=request.to_instance,
+        expected_build_revision=request.expected_build_revision,
+        expected_build_tag=request.expected_build_tag,
+        timeout_seconds=request.rollout_timeout_seconds,
+        interval_seconds=request.rollout_interval_seconds,
+        error_prefix="VeriReel prod rollout",
     )
-    health_urls = tuple(f"{base_url.rstrip('/')}/api/health" for base_url in base_urls)
-    last_error = "health endpoint not checked yet"
-    deadline = time.monotonic() + request.rollout_timeout_seconds
-    while time.monotonic() <= deadline:
-        for base_url, health_url in zip(base_urls, health_urls, strict=False):
-            try:
-                status_code, response_text = _fetch_url_text(
-                    health_url,
-                    accept="application/json,text/html",
-                )
-                if status_code < 200 or status_code >= 300:
-                    last_error = f"received {status_code} from {health_url}"
-                    continue
-                payload = json.loads(response_text)
-                validation_error = _validate_health_payload(
-                    payload,
-                    health_url=health_url,
-                    expected_build_revision=request.expected_build_revision,
-                    expected_build_tag=request.expected_build_tag,
-                )
-                if validation_error is not None:
-                    last_error = validation_error
-                    continue
-                _assert_rollout_pages(base_url)
-                return VeriReelRolloutVerificationResult(
-                    status="pass",
-                    base_url=base_url,
-                    health_urls=(health_url,),
-                    started_at=started_at,
-                    finished_at=utc_now_timestamp(),
-                )
-            except (HTTPError, URLError, TimeoutError, json.JSONDecodeError, ValueError) as exc:
-                last_error = str(exc)
-            except click.ClickException as exc:
-                raise click.ClickException(str(exc)) from exc
-        remaining_seconds = deadline - time.monotonic()
-        if remaining_seconds <= 0:
-            break
-        time.sleep(min(request.rollout_interval_seconds, remaining_seconds))
-    raise click.ClickException(f"VeriReel prod rollout verification timed out: {last_error}")
 
 
 def _resolve_application_id(
@@ -670,6 +543,10 @@ def execute_verireel_prod_promotion(
             instance=request.to_instance,
             artifact_id=request.artifact_id,
             source_git_ref=request.source_git_ref,
+            expected_build_revision=request.expected_build_revision,
+            expected_build_tag=request.expected_build_tag,
+            rollout_timeout_seconds=request.rollout_timeout_seconds,
+            rollout_interval_seconds=request.rollout_interval_seconds,
             no_cache=request.no_cache,
         ),
     )
@@ -716,26 +593,13 @@ def execute_verireel_prod_promotion(
             error_message=deployment_result.error_message,
         )
 
-    try:
-        rollout_result = _verify_rollout(
-            control_plane_root=control_plane_root,
-            request=request,
+    if deployment_result.rollout_status != "pass":
+        error_message = deployment_result.error_message or "VeriReel prod rollout verification failed."
+        failed_rollout_result = VeriReelRolloutVerificationResult(
+            status="fail",
+            base_url=deployment_result.rollout_base_url,
+            health_urls=deployment_result.rollout_health_urls,
         )
-    except click.ClickException as exc:
-        error_message = str(exc)
-        failed_rollout_result = VeriReelRolloutVerificationResult(status="fail")
-        try:
-            base_urls = _resolve_rollout_base_urls(
-                control_plane_root=control_plane_root,
-                request=request,
-            )
-            failed_rollout_result = VeriReelRolloutVerificationResult(
-                status="fail",
-                base_url=base_urls[0],
-                health_urls=(f"{base_urls[0].rstrip('/')}/api/health",),
-            )
-        except click.ClickException:
-            pass
         _write_failed_promotion_record(
             record_store=record_store,
             request=request,
@@ -765,6 +629,13 @@ def execute_verireel_prod_promotion(
             target_id=deployment_result.target_id,
             error_message=error_message,
         )
+    rollout_result = VeriReelRolloutVerificationResult(
+        status=deployment_result.rollout_status,
+        base_url=deployment_result.rollout_base_url,
+        health_urls=deployment_result.rollout_health_urls,
+        started_at=deployment_result.rollout_started_at,
+        finished_at=deployment_result.rollout_finished_at,
+    )
 
     try:
         _run_prisma_migrations(

--- a/control_plane/workflows/verireel_prod_rollback.py
+++ b/control_plane/workflows/verireel_prod_rollback.py
@@ -24,12 +24,26 @@ from control_plane.workflows.verireel_prod_promotion import (
     DEFAULT_ROLLOUT_INTERVAL_SECONDS,
     DEFAULT_ROLLOUT_TIMEOUT_SECONDS,
     VeriReelRolloutVerificationResult,
-    _assert_rollout_pages,
-    _fetch_url_text,
     _read_backup_gate_record,
-    _resolve_rollout_base_urls,
-    _validate_health_payload,
 )
+from control_plane.workflows.verireel_rollout import (
+    assert_verireel_rollout_pages as _assert_rollout_pages,
+    fetch_url_text as _fetch_url_text,
+    resolve_verireel_rollout_base_urls,
+    validate_verireel_health_payload as _validate_health_payload,
+)
+
+
+def _resolve_rollout_base_urls(
+    *,
+    control_plane_root: Path,
+    request: "VeriReelProdRollbackRequest",
+) -> tuple[str, ...]:
+    return resolve_verireel_rollout_base_urls(
+        control_plane_root=control_plane_root,
+        context=request.context,
+        instance=request.to_instance,
+    )
 
 
 class VeriReelProdRollbackRequest(BaseModel):

--- a/control_plane/workflows/verireel_rollout.py
+++ b/control_plane/workflows/verireel_rollout.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import time
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import click
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane import dokploy as control_plane_dokploy
+from control_plane import runtime_environments as control_plane_runtime_environments
+from control_plane.contracts.promotion_record import HealthcheckEvidence
+from control_plane.workflows.ship import utc_now_timestamp
+
+
+DEFAULT_ROLLOUT_TIMEOUT_SECONDS = 300
+DEFAULT_ROLLOUT_INTERVAL_SECONDS = 5
+DEFAULT_ROLLOUT_PAGE_PATHS = ("/", "/sign-in")
+
+
+class VeriReelRolloutVerificationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    context: str = "verireel"
+    instance: str = "testing"
+    expected_build_revision: str = ""
+    expected_build_tag: str = ""
+    timeout_seconds: int = Field(default=DEFAULT_ROLLOUT_TIMEOUT_SECONDS, ge=1)
+    interval_seconds: int = Field(default=DEFAULT_ROLLOUT_INTERVAL_SECONDS, ge=1)
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "VeriReelRolloutVerificationRequest":
+        if self.context != "verireel":
+            raise ValueError("VeriReel rollout verification requires context 'verireel'.")
+        if self.instance not in {"testing", "prod"}:
+            raise ValueError("VeriReel rollout verification requires instance 'testing' or 'prod'.")
+        return self
+
+
+class VeriReelRolloutVerificationResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: str
+    base_url: str = ""
+    health_urls: tuple[str, ...] = ()
+    started_at: str = ""
+    finished_at: str = ""
+    error_message: str = ""
+
+
+def resolve_verireel_rollout_base_urls(
+    *,
+    control_plane_root: Path,
+    context: str,
+    instance: str,
+) -> tuple[str, ...]:
+    source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
+        control_plane_root=control_plane_root,
+    )
+    target_definition = control_plane_dokploy.find_dokploy_target_definition(
+        source_of_truth,
+        context_name=context,
+        instance_name=instance,
+    )
+    if target_definition is None:
+        raise click.ClickException(f"No Dokploy target definition found for {context}/{instance}.")
+
+    environment_values = control_plane_runtime_environments.resolve_runtime_environment_values(
+        control_plane_root=control_plane_root,
+        context_name=context,
+        instance_name=instance,
+    )
+    base_urls = control_plane_dokploy.resolve_healthcheck_base_urls(
+        target_definition=target_definition,
+        environment_values=environment_values,
+    )
+    if not base_urls:
+        raise click.ClickException(f"No rollout base URL configured for {context}/{instance}.")
+    return base_urls
+
+
+def fetch_url_text(url: str, *, accept: str) -> tuple[int, str]:
+    request = Request(
+        url,
+        headers={
+            "Accept": accept,
+            "Cache-Control": "no-store",
+        },
+    )
+    with urlopen(request, timeout=15) as response:
+        return response.status, response.read().decode("utf-8")
+
+
+def validate_verireel_health_payload(
+    payload: object,
+    *,
+    health_url: str,
+    expected_build_revision: str,
+    expected_build_tag: str,
+) -> str | None:
+    if not isinstance(payload, dict) or payload.get("ok") is not True:
+        return f"health payload from {health_url} did not report ok=true"
+    if expected_build_revision and payload.get("buildRevision") != expected_build_revision:
+        return (
+            f"health payload from {health_url} reported buildRevision "
+            f"'{payload.get('buildRevision', 'unknown')}' instead of expected "
+            f"'{expected_build_revision}'"
+        )
+    if expected_build_tag and payload.get("buildTag") != expected_build_tag:
+        return (
+            f"health payload from {health_url} reported buildTag "
+            f"'{payload.get('buildTag', 'unknown')}' instead of expected "
+            f"'{expected_build_tag}'"
+        )
+    return None
+
+
+def assert_verireel_rollout_pages(
+    base_url: str,
+    *,
+    error_prefix: str = "VeriReel prod rollout",
+) -> None:
+    for page_path in DEFAULT_ROLLOUT_PAGE_PATHS:
+        page_url = f"{base_url.rstrip('/')}{page_path}"
+        try:
+            status_code, response_text = fetch_url_text(
+                page_url,
+                accept="text/html,application/json",
+            )
+        except (HTTPError, URLError, TimeoutError, ValueError) as exc:
+            raise click.ClickException(f"{error_prefix} page verification failed for {page_url}: {exc}") from exc
+        if status_code < 200 or status_code >= 300:
+            raise click.ClickException(
+                f"{error_prefix} page verification expected {page_url} to return 2xx, received {status_code}."
+            )
+        if "VeriReel" not in response_text:
+            raise click.ClickException(
+                f'{error_prefix} page verification expected {page_url} to include "VeriReel".'
+            )
+
+
+def verify_verireel_rollout(
+    *,
+    control_plane_root: Path,
+    context: str,
+    instance: str,
+    expected_build_revision: str = "",
+    expected_build_tag: str = "",
+    timeout_seconds: int = DEFAULT_ROLLOUT_TIMEOUT_SECONDS,
+    interval_seconds: int = DEFAULT_ROLLOUT_INTERVAL_SECONDS,
+    error_prefix: str = "VeriReel prod rollout",
+) -> VeriReelRolloutVerificationResult:
+    started_at = utc_now_timestamp()
+    base_urls = resolve_verireel_rollout_base_urls(
+        control_plane_root=control_plane_root,
+        context=context,
+        instance=instance,
+    )
+    health_urls = tuple(f"{base_url.rstrip('/')}/api/health" for base_url in base_urls)
+    last_error = "health endpoint not checked yet"
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() <= deadline:
+        for base_url, health_url in zip(base_urls, health_urls, strict=False):
+            try:
+                status_code, response_text = fetch_url_text(
+                    health_url,
+                    accept="application/json,text/html",
+                )
+                if status_code < 200 or status_code >= 300:
+                    last_error = f"received {status_code} from {health_url}"
+                    continue
+                payload = json.loads(response_text)
+                validation_error = validate_verireel_health_payload(
+                    payload,
+                    health_url=health_url,
+                    expected_build_revision=expected_build_revision,
+                    expected_build_tag=expected_build_tag,
+                )
+                if validation_error is not None:
+                    last_error = validation_error
+                    continue
+                assert_verireel_rollout_pages(base_url, error_prefix=error_prefix)
+                return VeriReelRolloutVerificationResult(
+                    status="pass",
+                    base_url=base_url,
+                    health_urls=(health_url,),
+                    started_at=started_at,
+                    finished_at=utc_now_timestamp(),
+                )
+            except (HTTPError, URLError, TimeoutError, json.JSONDecodeError, ValueError) as exc:
+                last_error = str(exc)
+            except click.ClickException as exc:
+                raise click.ClickException(str(exc)) from exc
+        remaining_seconds = deadline - time.monotonic()
+        if remaining_seconds <= 0:
+            break
+        time.sleep(min(interval_seconds, remaining_seconds))
+    raise click.ClickException(f"{error_prefix} verification timed out: {last_error}")
+
+
+def health_evidence_from_rollout(
+    *,
+    result: VeriReelRolloutVerificationResult | None,
+    timeout_seconds: int,
+) -> HealthcheckEvidence:
+    if result is None:
+        return HealthcheckEvidence(status="skipped")
+    if not result.health_urls:
+        return HealthcheckEvidence(status=result.status)
+    return HealthcheckEvidence(
+        verified=result.status in {"pass", "fail"},
+        urls=result.health_urls,
+        timeout_seconds=timeout_seconds,
+        status=result.status,
+    )
+
+
+def failed_verireel_rollout_result(
+    *,
+    control_plane_root: Path,
+    context: str,
+    instance: str,
+    error_message: str,
+) -> VeriReelRolloutVerificationResult:
+    try:
+        base_urls = resolve_verireel_rollout_base_urls(
+            control_plane_root=control_plane_root,
+            context=context,
+            instance=instance,
+        )
+    except click.ClickException:
+        return VeriReelRolloutVerificationResult(status="fail", error_message=error_message)
+    return VeriReelRolloutVerificationResult(
+        status="fail",
+        base_url=base_urls[0],
+        health_urls=(f"{base_urls[0].rstrip('/')}/api/health",),
+        error_message=error_message,
+    )
+
+
+def execute_verireel_rollout_verification(
+    *,
+    control_plane_root: Path,
+    request: VeriReelRolloutVerificationRequest,
+) -> VeriReelRolloutVerificationResult:
+    try:
+        return verify_verireel_rollout(
+            control_plane_root=control_plane_root,
+            context=request.context,
+            instance=request.instance,
+            expected_build_revision=request.expected_build_revision,
+            expected_build_tag=request.expected_build_tag,
+            timeout_seconds=request.timeout_seconds,
+            interval_seconds=request.interval_seconds,
+            error_prefix=f"VeriReel {request.instance} rollout",
+        )
+    except click.ClickException as exc:
+        return failed_verireel_rollout_result(
+            control_plane_root=control_plane_root,
+            context=request.context,
+            instance=request.instance,
+            error_message=str(exc),
+        )

--- a/control_plane/workflows/verireel_stable_deploy.py
+++ b/control_plane/workflows/verireel_stable_deploy.py
@@ -14,6 +14,14 @@ from control_plane.contracts.ship_request import ShipRequest
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.dokploy_deploy import execute_dokploy_artifact_deploy
 from control_plane.workflows.ship import build_deployment_record, generate_deployment_record_id, utc_now_timestamp
+from control_plane.workflows.verireel_rollout import (
+    DEFAULT_ROLLOUT_INTERVAL_SECONDS,
+    DEFAULT_ROLLOUT_TIMEOUT_SECONDS,
+    VeriReelRolloutVerificationResult,
+    failed_verireel_rollout_result,
+    health_evidence_from_rollout,
+    verify_verireel_rollout,
+)
 
 
 StableInstanceName = Literal["testing", "prod"]
@@ -27,6 +35,10 @@ class VeriReelStableDeployRequest(BaseModel):
     instance: StableInstanceName = "testing"
     artifact_id: str
     source_git_ref: str
+    expected_build_revision: str = ""
+    expected_build_tag: str = ""
+    rollout_timeout_seconds: int = Field(default=DEFAULT_ROLLOUT_TIMEOUT_SECONDS, ge=1)
+    rollout_interval_seconds: int = Field(default=DEFAULT_ROLLOUT_INTERVAL_SECONDS, ge=1)
     timeout_seconds: int | None = Field(default=None, ge=1)
     no_cache: bool = False
 
@@ -53,7 +65,27 @@ class VeriReelStableDeployResult(BaseModel):
     target_name: str
     target_type: str
     target_id: str
+    rollout_status: str = "skipped"
+    rollout_base_url: str = ""
+    rollout_health_urls: tuple[str, ...] = ()
+    rollout_started_at: str = ""
+    rollout_finished_at: str = ""
     error_message: str = ""
+
+
+def _artifact_tag(artifact_id: str) -> str:
+    artifact_name = artifact_id.rsplit("/", 1)[-1]
+    if ":" not in artifact_name:
+        return ""
+    return artifact_name.rsplit(":", 1)[-1]
+
+
+def _expected_build_revision(request: VeriReelStableDeployRequest) -> str:
+    return request.expected_build_revision.strip() or request.source_git_ref.strip()
+
+
+def _expected_build_tag(request: VeriReelStableDeployRequest) -> str:
+    return request.expected_build_tag.strip() or _artifact_tag(request.artifact_id)
 
 
 def _resolve_deploy_mode(*, configured_ship_mode: str, target_type: str) -> str:
@@ -160,6 +192,23 @@ def _execute_dokploy_deploy(
     )
 
 
+def _verify_rollout(
+    *,
+    control_plane_root: Path,
+    request: VeriReelStableDeployRequest,
+) -> VeriReelRolloutVerificationResult:
+    return verify_verireel_rollout(
+        control_plane_root=control_plane_root,
+        context=request.context,
+        instance=request.instance,
+        expected_build_revision=_expected_build_revision(request),
+        expected_build_tag=_expected_build_tag(request),
+        timeout_seconds=request.rollout_timeout_seconds,
+        interval_seconds=request.rollout_interval_seconds,
+        error_prefix=f"VeriReel {request.instance} rollout",
+    )
+
+
 def execute_verireel_stable_deploy(
     *,
     control_plane_root: Path,
@@ -245,6 +294,47 @@ def execute_verireel_stable_deploy(
         )
 
     finished_at = utc_now_timestamp()
+    try:
+        rollout_result = _verify_rollout(
+            control_plane_root=control_plane_root,
+            request=request,
+        )
+    except click.ClickException as exc:
+        failed_rollout_result = failed_verireel_rollout_result(
+            control_plane_root=control_plane_root,
+            context=request.context,
+            instance=request.instance,
+            error_message=str(exc),
+        )
+        record_store.write_deployment_record(
+            build_deployment_record(
+                request=ship_request,
+                record_id=record_id,
+                deployment_id="control-plane-dokploy",
+                deployment_status="pass",
+                started_at=started_at,
+                finished_at=finished_at,
+                resolved_target=resolved_target,
+                destination_health=health_evidence_from_rollout(
+                    result=failed_rollout_result,
+                    timeout_seconds=request.rollout_timeout_seconds,
+                ),
+            )
+        )
+        return VeriReelStableDeployResult(
+            deployment_record_id=record_id,
+            deploy_status="pass",
+            deploy_started_at=started_at,
+            deploy_finished_at=finished_at,
+            target_name=resolved_target.target_name,
+            target_type=resolved_target.target_type,
+            target_id=resolved_target.target_id,
+            rollout_status="fail",
+            rollout_base_url=failed_rollout_result.base_url,
+            rollout_health_urls=failed_rollout_result.health_urls,
+            error_message=str(exc),
+        )
+
     record_store.write_deployment_record(
         build_deployment_record(
             request=ship_request,
@@ -254,6 +344,10 @@ def execute_verireel_stable_deploy(
             started_at=started_at,
             finished_at=finished_at,
             resolved_target=resolved_target,
+            destination_health=health_evidence_from_rollout(
+                result=rollout_result,
+                timeout_seconds=request.rollout_timeout_seconds,
+            ),
         )
     )
     return VeriReelStableDeployResult(
@@ -264,4 +358,9 @@ def execute_verireel_stable_deploy(
         target_name=resolved_target.target_name,
         target_type=resolved_target.target_type,
         target_id=resolved_target.target_id,
+        rollout_status=rollout_result.status,
+        rollout_base_url=rollout_result.base_url,
+        rollout_health_urls=rollout_result.health_urls,
+        rollout_started_at=rollout_result.started_at,
+        rollout_finished_at=rollout_result.finished_at,
     )

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -137,6 +137,11 @@ follow-up contract thin: the repo reports the primitive result facts, and the
 driver translates them into Launchplane records. Do not leave rendered evidence
 payload construction in the product repo.
 
+Generic runtime health, public page readiness, and build identity checks belong
+in the driver once Launchplane has the lane profile, target, health path, and
+expected artifact identity. Product repos should call the driver route, not keep
+their own URL derivation or health polling scripts.
+
 For example, VeriReel preview refresh writes the initial preview generation from
 the provider result, then the product repo reports only the product smoke result
 to `/v1/drivers/verireel/preview-verification`. Launchplane updates the latest

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -30,7 +30,8 @@ Launchplane
   - driver descriptors and driver routes
   - provider credentials and managed secrets
   - preview/deploy/promotion/rollback orchestration
-  - health, readiness, inventory, cleanup, and feedback records
+- health, readiness, inventory, cleanup, and feedback records or driver
+  responses
   - PR feedback rendering and delivery
 ```
 
@@ -71,8 +72,9 @@ profile data.
 - Provider mutations: create/update/delete preview apps, deploy stable lanes,
   promote, rollback, capture backup gates, and cleanup stale runtime state.
 - Readiness checks before provider mutation.
-- Health checks when they are based on profile-owned health paths and expected
-  revisions or image references.
+- Health checks, public page readiness, and deployed build identity checks when
+  they are based on profile-owned health paths and expected revisions or image
+  references.
 - PR feedback records, markdown rendering, comment delivery, and stale feedback
   cleanup.
 - Promotion, rollback, deployment, preview, inventory, and cleanup records.
@@ -128,8 +130,9 @@ For an existing repo, classify each workflow and script before deleting code:
   reusable Launchplane GitHub Action/CLI.
 
 Start with low-risk deletions and documentation, then replace active workflow
-behavior in small slices. Do not remove active backup, promotion, rollback, or
-cleanup safety gates until Launchplane owns the equivalent behavior and tests.
+behavior in small slices. Do not remove active backup, promotion, rollback,
+runtime health, or cleanup safety gates until Launchplane owns the equivalent
+behavior and tests.
 
 ## New Repo Checklist
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -216,6 +216,7 @@ allowed product: verireel
 allowed contexts: verireel
 allowed actions:
   - verireel_testing_deploy.execute
+  - verireel_stable_environment.read
   - deployment.write
 ```
 
@@ -226,6 +227,7 @@ event_name: workflow_dispatch
 allowed product: verireel
 allowed contexts: verireel
 allowed actions:
+  - verireel_stable_environment.read
   - backup_gate.write
   - verireel_prod_deploy.execute
   - verireel_prod_promotion.execute

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -66,6 +66,7 @@ from control_plane.workflows.verireel_prod_promotion import VeriReelProdPromotio
 from control_plane.workflows.verireel_prod_rollback import VeriReelProdRollbackResult
 from control_plane.workflows.verireel_stable_deploy import VeriReelStableDeployResult
 from control_plane.workflows.verireel_environment import VeriReelStableEnvironmentResult
+from control_plane.workflows.verireel_rollout import VeriReelRolloutVerificationResult
 from control_plane.workflows.odoo_artifact_publish import OdooArtifactPublishResult
 from control_plane.workflows.odoo_post_deploy import OdooPostDeployResult
 from control_plane.workflows.odoo_prod_backup_gate import OdooProdBackupGateResult
@@ -2911,6 +2912,67 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 payload["result"]["primary_base_url"], "https://ver-testing.shinycomputers.com"
             )
             resolve_mock.assert_called_once()
+
+    def test_verireel_runtime_verification_driver_executes_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/publish-image.yml@refs/heads/main"
+                            ],
+                            "event_names": ["push", "workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel"],
+                            "actions": ["verireel_stable_environment.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/publish-image.yml@refs/heads/main"
+                        ),
+                        event_name="push",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_verireel_rollout_verification",
+                return_value=VeriReelRolloutVerificationResult(
+                    status="pass",
+                    base_url="https://ver-testing.shinycomputers.com",
+                    health_urls=("https://ver-testing.shinycomputers.com/api/health",),
+                    started_at="2026-05-01T12:00:00Z",
+                    finished_at="2026-05-01T12:00:05Z",
+                ),
+            ) as verify_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/runtime-verification",
+                    payload={
+                        "product": "verireel",
+                        "verification": {"context": "verireel", "instance": "testing"},
+                    },
+                )
+
+            self.assertEqual(status_code, 202)
+            self.assertEqual(payload["status"], "accepted")
+            self.assertEqual(payload["result"]["status"], "pass")
+            self.assertEqual(
+                payload["result"]["base_url"], "https://ver-testing.shinycomputers.com"
+            )
+            verify_mock.assert_called_once()
 
     def test_verireel_app_maintenance_driver_executes_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_verireel_prod_promotion.py
+++ b/tests/test_verireel_prod_promotion.py
@@ -79,6 +79,11 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                     target_name="ver-prod-app",
                     target_type="application",
                     target_id="prod-app-123",
+                    rollout_status="pass",
+                    rollout_base_url="https://ver-prod.shinycomputers.com",
+                    rollout_health_urls=("https://ver-prod.shinycomputers.com/api/health",),
+                    rollout_started_at="2026-04-21T18:21:16Z",
+                    rollout_finished_at="2026-04-21T18:21:45Z",
                 ),
             ), patch(
                 "control_plane.workflows.verireel_prod_promotion._run_prisma_migrations",
@@ -86,13 +91,6 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
             ), patch(
                 "control_plane.workflows.verireel_prod_promotion._verify_rollout",
                 side_effect=[
-                    VeriReelRolloutVerificationResult(
-                        status="pass",
-                        base_url="https://ver-prod.shinycomputers.com",
-                        health_urls=("https://ver-prod.shinycomputers.com/api/health",),
-                        started_at="2026-04-21T18:21:16Z",
-                        finished_at="2026-04-21T18:21:45Z",
-                    ),
                     VeriReelRolloutVerificationResult(
                         status="pass",
                         base_url="https://ver-prod.shinycomputers.com",
@@ -170,6 +168,11 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                     target_name="ver-prod-app",
                     target_type="application",
                     target_id="prod-app-123",
+                    rollout_status="pass",
+                    rollout_base_url="https://ver-prod.shinycomputers.com",
+                    rollout_health_urls=("https://ver-prod.shinycomputers.com/api/health",),
+                    rollout_started_at="2026-04-21T18:21:16Z",
+                    rollout_finished_at="2026-04-21T18:21:45Z",
                 ),
             ), patch(
                 "control_plane.workflows.verireel_prod_promotion._verify_rollout",
@@ -238,6 +241,11 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                     target_name="ver-prod-app",
                     target_type="application",
                     target_id="prod-app-123",
+                    rollout_status="pass",
+                    rollout_base_url="https://ver-prod.shinycomputers.com",
+                    rollout_health_urls=("https://ver-prod.shinycomputers.com/api/health",),
+                    rollout_started_at="2026-04-21T18:21:16Z",
+                    rollout_finished_at="2026-04-21T18:21:45Z",
                 ),
             ), patch(
                 "control_plane.workflows.verireel_prod_promotion._run_prisma_migrations",
@@ -245,13 +253,6 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
             ), patch(
                 "control_plane.workflows.verireel_prod_promotion._verify_rollout",
                 side_effect=[
-                    VeriReelRolloutVerificationResult(
-                        status="pass",
-                        base_url="https://ver-prod.shinycomputers.com",
-                        health_urls=("https://ver-prod.shinycomputers.com/api/health",),
-                        started_at="2026-04-21T18:21:16Z",
-                        finished_at="2026-04-21T18:21:45Z",
-                    ),
                     click.ClickException("VeriReel prod rollout verification timed out: health payload mismatch."),
                 ],
             ), patch(
@@ -309,10 +310,14 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                     target_name="ver-prod-app",
                     target_type="application",
                     target_id="prod-app-123",
+                    rollout_status="fail",
+                    rollout_base_url="https://ver-prod.shinycomputers.com",
+                    rollout_health_urls=("https://ver-prod.shinycomputers.com/api/health",),
+                    error_message=(
+                        "VeriReel prod rollout page verification expected "
+                        "https://ver-prod.shinycomputers.com/ to include \"VeriReel\"."
+                    ),
                 ),
-            ), patch(
-                "control_plane.workflows.verireel_prod_promotion._verify_rollout",
-                side_effect=click.ClickException("VeriReel prod rollout page verification expected https://ver-prod.shinycomputers.com/ to include \"VeriReel\"."),
             ), patch(
                 "control_plane.workflows.verireel_prod_promotion._resolve_rollout_base_urls",
                 return_value=("https://ver-prod.shinycomputers.com",),

--- a/tests/test_verireel_prod_rollback.py
+++ b/tests/test_verireel_prod_rollback.py
@@ -177,19 +177,19 @@ class VeriReelProdRollbackWorkflowTests(unittest.TestCase):
 
         with (
             patch(
-                "control_plane.workflows.verireel_prod_promotion.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                "control_plane.workflows.verireel_rollout.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
                 return_value=source_of_truth,
             ),
             patch(
-                "control_plane.workflows.verireel_prod_promotion.control_plane_dokploy.find_dokploy_target_definition",
+                "control_plane.workflows.verireel_rollout.control_plane_dokploy.find_dokploy_target_definition",
                 return_value=target_definition,
             ) as find_target,
             patch(
-                "control_plane.workflows.verireel_prod_promotion.control_plane_runtime_environments.resolve_runtime_environment_values",
+                "control_plane.workflows.verireel_rollout.control_plane_runtime_environments.resolve_runtime_environment_values",
                 return_value={"VERIREEL_PROD_OPERATOR_BASE_URL": "https://ver-prod.shinycomputers.com"},
             ) as resolve_environment,
             patch(
-                "control_plane.workflows.verireel_prod_promotion.control_plane_dokploy.resolve_healthcheck_base_urls",
+                "control_plane.workflows.verireel_rollout.control_plane_dokploy.resolve_healthcheck_base_urls",
                 return_value=("https://ver-prod.shinycomputers.com",),
             ),
         ):

--- a/tests/test_verireel_testing_deploy.py
+++ b/tests/test_verireel_testing_deploy.py
@@ -14,6 +14,7 @@ from control_plane.workflows.verireel_stable_deploy import (
     _execute_dokploy_deploy,
     execute_verireel_stable_deploy,
 )
+from control_plane.workflows.verireel_rollout import VeriReelRolloutVerificationResult
 
 
 class VeriReelTestingDeployWorkflowTests(unittest.TestCase):
@@ -61,6 +62,15 @@ class VeriReelTestingDeployWorkflowTests(unittest.TestCase):
                 ),
             ), patch(
                 "control_plane.workflows.verireel_stable_deploy._execute_dokploy_deploy"
+            ), patch(
+                "control_plane.workflows.verireel_stable_deploy._verify_rollout",
+                return_value=VeriReelRolloutVerificationResult(
+                    status="pass",
+                    base_url="https://ver-testing.shinycomputers.com",
+                    health_urls=("https://ver-testing.shinycomputers.com/api/health",),
+                    started_at="2026-04-20T18:21:16Z",
+                    finished_at="2026-04-20T18:21:45Z",
+                ),
             ):
                 result = execute_verireel_stable_deploy(
                     control_plane_root=root,
@@ -75,7 +85,8 @@ class VeriReelTestingDeployWorkflowTests(unittest.TestCase):
             self.assertEqual(deployment.deploy.status, "pass")
             self.assertEqual(deployment.deploy.started_at, "2026-04-20T18:20:00Z")
             self.assertEqual(deployment.deploy.finished_at, "2026-04-20T18:21:15Z")
-            self.assertEqual(deployment.destination_health.status, "skipped")
+            self.assertEqual(deployment.destination_health.status, "pass")
+            self.assertEqual(result.rollout_status, "pass")
 
     def test_execute_writes_failed_deployment_record(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add shared VeriReel rollout verification in Launchplane and expose /v1/drivers/verireel/runtime-verification
- make stable deploys verify destination health/build identity and include rollout fields in driver responses
- reuse the shared verifier in prod promotion/rollback and document the product-repo boundary for generic runtime health

## Verification
- uv run --extra dev ruff check --diff control_plane/workflows/verireel_rollout.py control_plane/workflows/verireel_stable_deploy.py control_plane/workflows/verireel_prod_promotion.py control_plane/workflows/verireel_prod_rollback.py control_plane/service.py control_plane/drivers/registry.py tests/test_verireel_testing_deploy.py tests/test_verireel_prod_promotion.py tests/test_verireel_prod_rollback.py tests/test_service.py
- uv run --extra dev ruff check control_plane/workflows/verireel_rollout.py control_plane/workflows/verireel_stable_deploy.py control_plane/workflows/verireel_prod_promotion.py control_plane/workflows/verireel_prod_rollback.py control_plane/service.py control_plane/drivers/registry.py tests/test_verireel_testing_deploy.py tests/test_verireel_prod_promotion.py tests/test_verireel_prod_rollback.py tests/test_service.py
- uv run python -m unittest tests.test_verireel_testing_deploy tests.test_verireel_prod_promotion tests.test_verireel_prod_rollback tests.test_service
- uv run python -m unittest

## Follow-up
- Merge and deploy this before the VeriReel thin-trigger workflow PR, because that PR calls the new runtime-verification route.