### PR TITLE
Let VeriReel promotion driver record source health

### DIFF
--- a/control_plane/workflows/verireel_prod_promotion.py
+++ b/control_plane/workflows/verireel_prod_promotion.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import time
 
 import click
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane.contracts.backup_gate_record import BackupGateRecord
@@ -16,6 +16,7 @@ from control_plane.contracts.promotion_record import (
     HealthcheckEvidence,
     PostDeployUpdateEvidence,
     PromotionRecord,
+    ReleaseStatus,
 )
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.verireel_stable_deploy import (
@@ -42,11 +43,17 @@ class VeriReelProdPromotionRequest(BaseModel):
     source_git_ref: str
     backup_record_id: str
     promotion_record_id: str
+    source_health_status: ReleaseStatus = "skipped"
     expected_build_revision: str = ""
     expected_build_tag: str = ""
     rollout_timeout_seconds: int = Field(default=DEFAULT_ROLLOUT_TIMEOUT_SECONDS, ge=1)
     rollout_interval_seconds: int = Field(default=DEFAULT_ROLLOUT_INTERVAL_SECONDS, ge=1)
     no_cache: bool = False
+
+    @field_validator("source_health_status", mode="before")
+    @classmethod
+    def _normalize_source_health_status(cls, value: object) -> ReleaseStatus:
+        return _normalize_release_status(str(value or ""), label="Source health status")
 
     @model_validator(mode="after")
     def _validate_request(self) -> "VeriReelProdPromotionRequest":
@@ -65,6 +72,19 @@ class VeriReelProdPromotionRequest(BaseModel):
         if not self.promotion_record_id.strip():
             raise ValueError("VeriReel prod promotion requires promotion_record_id.")
         return self
+
+
+def _normalize_release_status(value: str, *, label: str) -> ReleaseStatus:
+    normalized = value.strip().lower()
+    if normalized in {"success", "passed", "pass"}:
+        return "pass"
+    if normalized in {"failure", "failed", "fail", "cancelled", "canceled", "timed_out"}:
+        return "fail"
+    if normalized in {"skipped", "not-run", "not_run", ""}:
+        return "skipped"
+    if normalized in {"pending", "in_progress", "in-progress"}:
+        return "pending"
+    raise ValueError(f"{label} must be pass, fail, skipped, or pending.")
 
 
 class VeriReelProdPromotionResult(BaseModel):
@@ -184,7 +204,7 @@ def _build_promotion_record(
         context=request.context,
         from_instance=request.from_instance,
         to_instance=request.to_instance,
-        source_health=HealthcheckEvidence(status="skipped"),
+        source_health=HealthcheckEvidence(status=request.source_health_status),
         backup_gate=BackupGateEvidence(
             required=backup_gate_record.required,
             status=backup_gate_record.status,
@@ -278,7 +298,7 @@ def _write_failed_promotion_record(
             context=request.context,
             from_instance=request.from_instance,
             to_instance=request.to_instance,
-            source_health=HealthcheckEvidence(status="skipped"),
+            source_health=HealthcheckEvidence(status=request.source_health_status),
             backup_gate=BackupGateEvidence(
                 required=(backup_gate_record.required if backup_gate_record is not None else True),
                 status=(backup_gate_record.status if backup_gate_record is not None else "fail"),

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -241,7 +241,10 @@ Current derived-state behavior:
   `POST /v1/drivers/verireel/prod-deploy` trigger the shared testing and prod
   deploys, `POST /v1/drivers/verireel/prod-backup-gate` captures the prod
   backup gate and writes the backup-gate record, and the promotion / rollback
-  drivers own the remaining stable-lane execution path. VeriReel maintenance
+  drivers own the remaining stable-lane execution path. The prod-promotion
+  driver writes the promotion record from the backup gate, deploy result,
+  migration result, destination health check, and primitive testing-lane health
+  status sent by the product workflow. VeriReel maintenance
   operations that need Dokploy authority, such as testing migrations, preview
   owner-admin verification helpers, reset-testing, and preview inventory, also
   flow through Launchplane driver routes instead of product-repo workflow

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -482,6 +482,11 @@ retries do not collide. The regular cleanup workflow uses
 - VeriReel prod promotion driver:
   `verireel-prod-promotion:<product>:<context>:<from_instance>:<to_instance>:<artifact_id>:<source_git_ref>:<backup_record_id>:<promotion_record_id>:<expected_build_revision>:<expected_build_tag>`
 
+The VeriReel prod-promotion request may include the primitive testing-lane
+source health status. Launchplane normalizes that status and writes it into the
+driver-owned promotion record; product workflows should not post a second
+rendered promotion evidence payload for fields the driver can derive.
+
 Recommended first success shape:
 
 ```json

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -4300,6 +4300,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                             "source_git_ref": "abcdef1234567890",
                             "backup_record_id": "backup-gate-verireel-prod-run-12345-attempt-1",
                             "promotion_record_id": "promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                            "source_health_status": "success",
                         },
                     },
                 )
@@ -4319,6 +4320,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 "promotion-verireel-testing-to-prod-run-12345-attempt-1",
             )
             execute_mock.assert_called_once()
+            request = execute_mock.call_args.kwargs["request"]
+            self.assertEqual(request.source_health_status, "pass")
 
     def test_odoo_post_deploy_driver_executes_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_verireel_prod_promotion.py
+++ b/tests/test_verireel_prod_promotion.py
@@ -65,6 +65,7 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                 source_git_ref="abcdef1234567890",
                 backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
                 promotion_record_id="promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                source_health_status="success",
                 expected_build_revision="abcdef1234567890",
                 expected_build_tag="sha-abcdef1234567890",
             )
@@ -122,6 +123,7 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                 "promotion-verireel-testing-to-prod-run-12345-attempt-1"
             )
             self.assertEqual(promotion.backup_record_id, "backup-gate-verireel-prod-run-12345-attempt-1")
+            self.assertEqual(promotion.source_health.status, "pass")
             self.assertEqual(promotion.deploy.status, "pass")
             self.assertEqual(promotion.deploy.deployment_id, "prod-app-123")
             self.assertEqual(promotion.deploy.started_at, "2026-04-21T18:20:00Z")


### PR DESCRIPTION
## Summary
- accept a primitive `source_health_status` on the VeriReel prod-promotion driver request
- normalize GitHub-style workflow results into promotion-record status values
- write source health into both success and failure promotion records
- document that the driver owns the promotion record while product workflows pass only primitive source-health facts

## Validation
- `uv run --extra dev ruff check --diff .`
- `uv run --extra dev ruff check .`
- `uv run python -m unittest tests.test_verireel_prod_promotion tests.test_verireel_prod_rollback tests.test_service.LaunchplaneServiceTests`
- `uv run python -m unittest`

Dependency for the VeriReel cleanup that removes repo-owned prod-promotion evidence payload construction.