### PR TITLE
Add VeriReel testing verification driver

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -17,7 +17,7 @@ from urllib.parse import parse_qs, unquote
 from wsgiref.simple_server import WSGIServer, make_server
 
 import click
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 from jwt import InvalidTokenError
 
 from control_plane import dokploy as control_plane_dokploy
@@ -51,7 +51,12 @@ from control_plane.contracts.preview_pr_feedback_record import (
     PreviewPrFeedbackStatus,
 )
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
-from control_plane.contracts.promotion_record import PromotionRecord
+from control_plane.contracts.promotion_record import (
+    HealthcheckEvidence,
+    PostDeployUpdateEvidence,
+    PromotionRecord,
+    ReleaseStatus,
+)
 from control_plane.drivers.registry import (
     build_driver_context_view,
     list_driver_descriptors,
@@ -583,6 +588,60 @@ class VeriReelTestingDeployEnvelope(BaseModel):
             raise ValueError("VeriReel testing deploy requires product 'verireel'.")
         if self.deploy.instance != "testing":
             raise ValueError("VeriReel testing deploy requires instance 'testing'.")
+        return self
+
+
+def _normalize_release_status(value: object, *, label: str) -> ReleaseStatus:
+    normalized = str(value or "").strip().lower()
+    if normalized in {"success", "passed", "pass"}:
+        return "pass"
+    if normalized in {"failure", "failed", "fail", "cancelled", "canceled", "timed_out"}:
+        return "fail"
+    if normalized in {"skipped", "not-run", "not_run", ""}:
+        return "skipped"
+    if normalized in {"pending", "in_progress", "in-progress"}:
+        return "pending"
+    raise ValueError(f"{label} must be pass, fail, skipped, or pending.")
+
+
+class VeriReelTestingVerificationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    context: str = "verireel"
+    instance: str = "testing"
+    deployment_record_id: str
+    migration_status: ReleaseStatus
+    verification_status: ReleaseStatus
+    owner_routes_status: ReleaseStatus
+
+    @field_validator("migration_status", "verification_status", "owner_routes_status", mode="before")
+    @classmethod
+    def _normalize_status(cls, value: object) -> ReleaseStatus:
+        return _normalize_release_status(value, label="Testing verification status")
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "VeriReelTestingVerificationRequest":
+        if self.context != "verireel":
+            raise ValueError("VeriReel testing verification requires context 'verireel'.")
+        if self.instance != "testing":
+            raise ValueError("VeriReel testing verification requires instance 'testing'.")
+        if not self.deployment_record_id.strip():
+            raise ValueError("VeriReel testing verification requires deployment_record_id.")
+        return self
+
+
+class VeriReelTestingVerificationEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    verification: VeriReelTestingVerificationRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "VeriReelTestingVerificationEnvelope":
+        if self.product.strip() != "verireel":
+            raise ValueError("VeriReel testing verification requires product 'verireel'.")
         return self
 
 
@@ -1716,6 +1775,92 @@ def _apply_verireel_preview_verification_records(
     )
 
 
+def _testing_post_deploy_detail(status: ReleaseStatus) -> str:
+    if status == "pass":
+        return "Prisma migrations completed on testing."
+    if status == "fail":
+        return "Prisma migrations failed on testing."
+    return ""
+
+
+def _testing_destination_health_status(
+    *,
+    deployment_record: DeploymentRecord,
+    request: VeriReelTestingVerificationRequest,
+) -> ReleaseStatus:
+    statuses = (
+        deployment_record.destination_health.status,
+        request.verification_status,
+        request.owner_routes_status,
+    )
+    if any(status == "fail" for status in statuses):
+        return "fail"
+    if all(status == "pass" for status in statuses):
+        return "pass"
+    if any(status == "pending" for status in statuses):
+        return "pending"
+    return "skipped"
+
+
+def _updated_testing_destination_health(
+    *,
+    deployment_record: DeploymentRecord,
+    status: ReleaseStatus,
+) -> HealthcheckEvidence:
+    if status in {"pass", "fail"} and deployment_record.destination_health.urls:
+        return deployment_record.destination_health.model_copy(update={"status": status})
+    return HealthcheckEvidence(status=status)
+
+
+def _apply_verireel_testing_verification_records(
+    *,
+    record_store: object,
+    request: VeriReelTestingVerificationRequest,
+) -> dict[str, str]:
+    typed_record_store = cast(FilesystemRecordStore, record_store)
+    try:
+        deployment_record = typed_record_store.read_deployment_record(
+            request.deployment_record_id
+        )
+    except FileNotFoundError as exc:
+        raise click.ClickException(
+            f"No Launchplane deployment record found for {request.deployment_record_id}."
+        ) from exc
+    if deployment_record.context != request.context:
+        raise click.ClickException(
+            "Testing verification context does not match deployment record context."
+        )
+    if deployment_record.instance != request.instance:
+        raise click.ClickException(
+            "Testing verification instance does not match deployment record instance."
+        )
+
+    destination_health_status = _testing_destination_health_status(
+        deployment_record=deployment_record,
+        request=request,
+    )
+    updated_record = deployment_record.model_copy(
+        update={
+            "post_deploy_update": PostDeployUpdateEvidence(
+                attempted=request.migration_status != "skipped",
+                status=request.migration_status,
+                detail=_testing_post_deploy_detail(request.migration_status),
+            ),
+            "destination_health": _updated_testing_destination_health(
+                deployment_record=deployment_record,
+                status=destination_health_status,
+            ),
+        }
+    )
+    result = apply_deployment_evidence(
+        record_store=typed_record_store,
+        deployment_record=updated_record,
+    )
+    result["deployment_health_status"] = destination_health_status
+    result["post_deploy_status"] = request.migration_status
+    return result
+
+
 def _allows_preview_pr_feedback_write(
     *,
     authz_policy: LaunchplaneAuthzPolicy,
@@ -1820,6 +1965,7 @@ def create_launchplane_service_app(
         "/v1/drivers/verireel/preview-destroy",
         "/v1/drivers/verireel/preview-verification",
         "/v1/drivers/verireel/testing-deploy",
+        "/v1/drivers/verireel/testing-verification",
         "/v1/drivers/verireel/stable-environment",
         "/v1/drivers/verireel/runtime-verification",
         "/v1/drivers/verireel/app-maintenance",
@@ -3167,6 +3313,44 @@ def create_launchplane_service_app(
                     request=request.deploy,
                 )
                 result = {"deployment_record_id": driver_result.deployment_record_id}
+            elif path == "/v1/drivers/verireel/testing-verification":
+                request = VeriReelTestingVerificationEnvelope.model_validate(payload)
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="deployment.write",
+                    product=request.product,
+                    context=request.verification.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot write VeriReel testing verification"
+                                    " for the requested product/context."
+                                ),
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                result = _apply_verireel_testing_verification_records(
+                    record_store=record_store,
+                    request=request.verification,
+                )
             elif path == "/v1/drivers/verireel/stable-environment":
                 request = VeriReelStableEnvironmentEnvelope.model_validate(payload)
                 if not authz_policy.allows(

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -87,6 +87,7 @@ Current implementation scope:
 - `POST /v1/drivers/verireel/preview-refresh`
 - `POST /v1/drivers/verireel/preview-destroy`
 - `POST /v1/drivers/verireel/testing-deploy`
+- `POST /v1/drivers/verireel/testing-verification`
 - `POST /v1/drivers/verireel/prod-deploy`
 - `POST /v1/drivers/verireel/prod-backup-gate`
 - `POST /v1/drivers/verireel/prod-promotion`
@@ -244,15 +245,17 @@ Current derived-state behavior:
   drivers own the remaining stable-lane execution path. The prod-promotion
   driver writes the promotion record from the backup gate, deploy result,
   migration result, destination health check, and primitive testing-lane health
-  status sent by the product workflow. VeriReel maintenance
-  operations that need Dokploy authority, such as testing migrations, preview
-  owner-admin verification helpers, reset-testing, and preview inventory, also
-  flow through Launchplane driver routes instead of product-repo workflow
-  secrets. Stable testing/prod base URLs and target identity are resolved from
-  Launchplane's DB-backed target/runtime records through the stable-environment
-  route. Those routes return durable record identifiers, topology metadata, or
-  timing/status for the caller to thread into later verification or promotion
-  evidence.
+  status sent by the product workflow. The testing-verification route accepts
+  primitive migration, browser verification, and owner-route statuses and
+  updates the existing testing deployment record plus current inventory.
+  VeriReel maintenance operations that need Dokploy authority, such as testing
+  migrations, preview owner-admin verification helpers, reset-testing, and
+  preview inventory, also flow through Launchplane driver routes instead of
+  product-repo workflow secrets. Stable testing/prod base URLs and target
+  identity are resolved from Launchplane's DB-backed target/runtime records
+  through the stable-environment route. Those routes return durable record
+  identifiers, topology metadata, or timing/status for the caller to thread into
+  later verification or promotion evidence.
 - Launchplane can also execute the Odoo stable-lane driver path directly:
   `POST /v1/drivers/odoo/prod-backup-gate` captures DB and filestore backup
   evidence, `POST /v1/drivers/odoo/prod-promotion` validates the stored

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -56,6 +56,7 @@ VeriReel product paths:
   - `POST /v1/drivers/odoo/prod-promotion`
   - `POST /v1/drivers/odoo/prod-rollback`
   - `POST /v1/drivers/verireel/testing-deploy`
+  - `POST /v1/drivers/verireel/testing-verification`
   - `POST /v1/drivers/verireel/stable-environment`
   - `POST /v1/drivers/verireel/app-maintenance`
   - `POST /v1/drivers/verireel/prod-deploy`
@@ -374,6 +375,7 @@ The first explicit driver routes now in service are:
 - `POST /v1/drivers/odoo/prod-promotion`
 - `POST /v1/drivers/odoo/prod-rollback`
 - `POST /v1/drivers/verireel/testing-deploy`
+- `POST /v1/drivers/verireel/testing-verification`
 - `POST /v1/drivers/verireel/stable-environment`
 - `POST /v1/drivers/verireel/app-maintenance`
 - `POST /v1/drivers/verireel/prod-deploy`
@@ -475,6 +477,8 @@ retries do not collide. The regular cleanup workflow uses
 - prod promotion evidence: `prod-promotion:<product>:<context>:<from_instance>:<to_instance>:<record_id>`
 - VeriReel testing deploy driver:
   `verireel-testing-deploy:<product>:<context>:<instance>:<artifact_id>:<source_git_ref>`
+- VeriReel testing verification driver:
+  `verireel-testing-verification:<product>:<context>:<instance>:<deployment_record_id>`
 - VeriReel prod deploy driver:
   `verireel-prod-deploy:<product>:<context>:<instance>:<artifact_id>:<source_git_ref>`
 - VeriReel prod backup gate driver:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2799,6 +2799,188 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(payload["result"]["target_id"], "testing-app-123")
             execute_mock.assert_called_once()
 
+    def test_verireel_testing_verification_driver_updates_deployment_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_deployment_record(
+                DeploymentRecord(
+                    record_id="deployment-verireel-testing-run-12345-attempt-1",
+                    artifact_identity=ArtifactIdentityReference(
+                        artifact_id="ghcr.io/every/verireel-app:sha-abcdef1234567890"
+                    ),
+                    context="verireel",
+                    instance="testing",
+                    source_git_ref="abcdef1234567890",
+                    resolved_target=ResolvedTargetEvidence(
+                        target_type="application",
+                        target_id="testing-app-123",
+                        target_name="ver-testing-app",
+                    ),
+                    deploy=DeploymentEvidence(
+                        target_name="ver-testing-app",
+                        target_type="application",
+                        deploy_mode="dokploy-application-api",
+                        deployment_id="testing-app-123",
+                        status="pass",
+                        started_at="2026-04-20T18:20:00Z",
+                        finished_at="2026-04-20T18:21:15Z",
+                    ),
+                    destination_health={
+                        "verified": True,
+                        "urls": ["https://ver-testing.shinycomputers.com/api/health"],
+                        "timeout_seconds": 45,
+                        "status": "pass",
+                    },
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/publish-image.yml@refs/heads/main"
+                            ],
+                            "event_names": ["push", "workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel"],
+                            "actions": ["deployment.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/publish-image.yml@refs/heads/main"
+                        ),
+                        event_name="push",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/verireel/testing-verification",
+                payload={
+                    "product": "verireel",
+                    "verification": {
+                        "deployment_record_id": "deployment-verireel-testing-run-12345-attempt-1",
+                        "migration_status": "success",
+                        "verification_status": "success",
+                        "owner_routes_status": "success",
+                    },
+                },
+            )
+
+            self.assertEqual(status_code, 202)
+            self.assertEqual(payload["status"], "accepted")
+            self.assertEqual(
+                payload["records"],
+                {
+                    "deployment_record_id": "deployment-verireel-testing-run-12345-attempt-1",
+                    "inventory_record_id": "verireel-testing",
+                },
+            )
+            deployment = store.read_deployment_record(
+                "deployment-verireel-testing-run-12345-attempt-1"
+            )
+            inventory = store.read_environment_inventory(
+                context_name="verireel",
+                instance_name="testing",
+            )
+            self.assertEqual(deployment.post_deploy_update.status, "pass")
+            self.assertEqual(deployment.destination_health.status, "pass")
+            self.assertEqual(inventory.deployment_record_id, deployment.record_id)
+
+    def test_verireel_testing_verification_driver_marks_product_check_failure(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_deployment_record(
+                DeploymentRecord(
+                    record_id="deployment-verireel-testing-run-12345-attempt-1",
+                    artifact_identity=ArtifactIdentityReference(
+                        artifact_id="ghcr.io/every/verireel-app:sha-abcdef1234567890"
+                    ),
+                    context="verireel",
+                    instance="testing",
+                    source_git_ref="abcdef1234567890",
+                    deploy=DeploymentEvidence(
+                        target_name="ver-testing-app",
+                        target_type="application",
+                        deploy_mode="dokploy-application-api",
+                        deployment_id="testing-app-123",
+                        status="pass",
+                    ),
+                    destination_health={
+                        "verified": True,
+                        "urls": ["https://ver-testing.shinycomputers.com/api/health"],
+                        "timeout_seconds": 45,
+                        "status": "pass",
+                    },
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/publish-image.yml@refs/heads/main"
+                            ],
+                            "event_names": ["push", "workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel"],
+                            "actions": ["deployment.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/publish-image.yml@refs/heads/main"
+                        ),
+                        event_name="push",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, _payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/verireel/testing-verification",
+                payload={
+                    "product": "verireel",
+                    "verification": {
+                        "deployment_record_id": "deployment-verireel-testing-run-12345-attempt-1",
+                        "migration_status": "success",
+                        "verification_status": "failure",
+                        "owner_routes_status": "success",
+                    },
+                },
+            )
+
+            self.assertEqual(status_code, 202)
+            deployment = store.read_deployment_record(
+                "deployment-verireel-testing-run-12345-attempt-1"
+            )
+            self.assertEqual(deployment.post_deploy_update.status, "pass")
+            self.assertEqual(deployment.destination_health.status, "fail")
+
     def test_verireel_testing_deploy_driver_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add a Launchplane driver route for VeriReel testing verification updates
- update existing testing deployment records with migration and product verification status
- document the new route and idempotency scope

## Validation
- uv run --extra dev ruff check --diff .
- uv run --extra dev ruff check .
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests tests.test_verireel_testing_deploy
- uv run python -m unittest

Refs #84