### PR TITLE
Add trusted product config apply command

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -8490,6 +8490,266 @@ def _build_runtime_environment_record_for_relabel(
     )
 
 
+def _load_product_config_apply_payload(input_file: Path) -> dict[str, object]:
+    try:
+        payload = json.loads(input_file.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise click.ClickException(f"Product config input file {input_file} was not found.") from error
+    except JSONDecodeError as error:
+        raise click.ClickException(
+            f"Product config input file {input_file} is not valid JSON: {error}"
+        ) from error
+    if not isinstance(payload, dict):
+        raise click.ClickException("Product config input file must contain a JSON object.")
+    schema_version = payload.get("schema_version", 1)
+    if schema_version != 1:
+        raise click.ClickException("Product config input schema_version must be 1.")
+    return payload
+
+
+def _product_config_required_text(
+    payload: dict[str, object], key: str, *, default: str = ""
+) -> str:
+    value = str(payload.get(key, default) or "").strip()
+    if not value:
+        raise click.ClickException(f"Product config input requires {key!r}.")
+    return value
+
+
+def _product_config_optional_text(payload: dict[str, object], key: str) -> str:
+    return str(payload.get(key, "") or "").strip()
+
+
+def _default_runtime_scope(*, context_name: str, instance_name: str) -> str:
+    if instance_name:
+        return "instance"
+    if context_name:
+        return "context"
+    return "global"
+
+
+def _default_secret_scope(*, context_name: str, instance_name: str) -> str:
+    if instance_name:
+        return "context_instance"
+    if context_name:
+        return "context"
+    return "global"
+
+
+def _product_config_runtime_input(
+    payload: dict[str, object], *, context_name: str, instance_name: str
+) -> dict[str, object]:
+    runtime_payload = payload.get("runtime_env", payload.get("runtime_environment", {}))
+    if runtime_payload is None:
+        return {"scope": _default_runtime_scope(context_name=context_name, instance_name=instance_name), "env": {}}
+    if not isinstance(runtime_payload, dict):
+        raise click.ClickException("Product config runtime_env must be a JSON object.")
+    if "env" in runtime_payload:
+        raw_env = runtime_payload.get("env")
+        if raw_env is None:
+            raw_env = {}
+        if not isinstance(raw_env, dict):
+            raise click.ClickException("Product config runtime_env.env must be a JSON object.")
+    else:
+        raw_env = {
+            key: value
+            for key, value in runtime_payload.items()
+            if key not in {"scope", "context", "instance"}
+        }
+    scope = str(
+        runtime_payload.get(
+            "scope", _default_runtime_scope(context_name=context_name, instance_name=instance_name)
+        )
+        or ""
+    ).strip()
+    return {
+        "scope": scope,
+        "context": str(runtime_payload.get("context", context_name) or "").strip(),
+        "instance": str(runtime_payload.get("instance", instance_name) or "").strip(),
+        "env": raw_env,
+    }
+
+
+def _normalize_product_config_runtime_env(raw_env: dict[object, object]) -> dict[str, object]:
+    env: dict[str, object] = {}
+    for raw_key, raw_value in raw_env.items():
+        if not isinstance(raw_key, str):
+            raise click.ClickException("Product config runtime env keys must be strings.")
+        key_name = _normalize_runtime_environment_key(raw_key)
+        if _runtime_environment_key_requires_secret_store(key_name):
+            raise click.ClickException(
+                f"Runtime environment key {key_name!r} must be written as a managed secret."
+            )
+        if not isinstance(raw_value, (str, int, float, bool)):
+            raise click.ClickException(
+                f"Product config runtime env value for {key_name!r} must be a scalar."
+            )
+        env[key_name] = raw_value
+    return env
+
+
+def _product_config_secret_inputs(
+    payload: dict[str, object], *, context_name: str, instance_name: str
+) -> tuple[dict[str, object], ...]:
+    raw_secrets = payload.get("secrets", ())
+    if raw_secrets is None:
+        return ()
+    if not isinstance(raw_secrets, list):
+        raise click.ClickException("Product config secrets must be a JSON array.")
+    normalized: list[dict[str, object]] = []
+    for index, raw_secret in enumerate(raw_secrets, start=1):
+        if not isinstance(raw_secret, dict):
+            raise click.ClickException(f"Product config secret #{index} must be a JSON object.")
+        binding_key = str(raw_secret.get("binding_key", raw_secret.get("name", "")) or "").strip()
+        name = str(raw_secret.get("name", binding_key) or "").strip()
+        plaintext_value = raw_secret.get("value")
+        if not binding_key:
+            raise click.ClickException(f"Product config secret #{index} requires binding_key.")
+        if not name:
+            raise click.ClickException(f"Product config secret #{index} requires name.")
+        if not isinstance(plaintext_value, str) or not plaintext_value.strip():
+            raise click.ClickException(f"Product config secret #{index} requires a non-empty value.")
+        normalized.append(
+            {
+                "scope": str(
+                    raw_secret.get(
+                        "scope",
+                        _default_secret_scope(context_name=context_name, instance_name=instance_name),
+                    )
+                    or ""
+                ).strip(),
+                "integration": str(
+                    raw_secret.get(
+                        "integration",
+                        control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+                    )
+                    or ""
+                ).strip(),
+                "name": name,
+                "binding_key": binding_key,
+                "value": plaintext_value,
+                "context": str(raw_secret.get("context", context_name) or "").strip(),
+                "instance": str(raw_secret.get("instance", instance_name) or "").strip(),
+                "description": str(raw_secret.get("description", "") or "").strip(),
+            }
+        )
+    return tuple(normalized)
+
+
+def _require_product_config_master_key_if_needed(secrets: tuple[dict[str, object], ...]) -> None:
+    if not secrets:
+        return
+    if not any(os.environ.get(key, "").strip() for key in _MASTER_ENCRYPTION_KEY_ENV_KEYS):
+        expected_keys = " or ".join(_MASTER_ENCRYPTION_KEY_ENV_KEYS)
+        raise click.ClickException(
+            f"Product config secrets require {expected_keys} in the trusted Launchplane context."
+        )
+
+
+def _product_config_secret_current_action(
+    *, record_store: PostgresRecordStore, secret: dict[str, object]
+) -> tuple[str, str]:
+    existing_record = record_store.find_secret_record(
+        scope=str(secret["scope"]),
+        integration=str(secret["integration"]),
+        name=str(secret["name"]),
+        context=str(secret["context"]),
+        instance=str(secret["instance"]),
+    )
+    if existing_record is None:
+        return "created", ""
+    current_version = record_store.read_secret_version(existing_record.current_version_id)
+    if control_plane_secrets._decrypt_secret_value(current_version.ciphertext) == str(secret["value"]):
+        return "unchanged", existing_record.secret_id
+    return "rotated", existing_record.secret_id
+
+
+def _summarize_product_config_secret_input(
+    *, action: str, secret: dict[str, object], secret_id: str = ""
+) -> dict[str, object]:
+    summary = {
+        "action": action,
+        "scope": secret["scope"],
+        "integration": secret["integration"],
+        "name": secret["name"],
+        "binding_key": secret["binding_key"],
+        "context": secret["context"],
+        "instance": secret["instance"],
+    }
+    if secret_id:
+        summary["secret_id"] = secret_id
+    return summary
+
+
+def _plan_product_config_runtime_environment(
+    *,
+    existing_records: tuple[RuntimeEnvironmentRecord, ...],
+    scope: str,
+    context_name: str,
+    instance_name: str,
+    env: dict[str, object],
+    source_label: str,
+) -> tuple[RuntimeEnvironmentRecord | None, dict[str, object]]:
+    _validate_runtime_environment_scope_route(
+        scope=scope,
+        context_name=context_name,
+        instance_name=instance_name,
+    )
+    target_record = _find_runtime_environment_record(
+        existing_records=existing_records,
+        scope=scope,
+        context_name=context_name,
+        instance_name=instance_name,
+    )
+    if not env:
+        return (
+            None,
+            {
+                "action": "skipped",
+                "scope": scope,
+                "context": context_name,
+                "instance": instance_name,
+                "keys": [],
+                "changed_keys": [],
+                "unchanged_keys": [],
+                "env_value_count_after": len(target_record.env) if target_record is not None else 0,
+            },
+        )
+    current_values = dict(target_record.env) if target_record is not None else {}
+    changed_keys = sorted(
+        key_name
+        for key_name, value in env.items()
+        if key_name not in current_values or str(current_values[key_name]) != str(value)
+    )
+    unchanged_keys = sorted(key_name for key_name in env if key_name not in changed_keys)
+    action = "created" if target_record is None else "updated"
+    if not changed_keys:
+        action = "unchanged"
+    planned_values = dict(current_values)
+    planned_values.update(env)
+    planned_record = RuntimeEnvironmentRecord(
+        scope=scope,
+        context=context_name,
+        instance=instance_name,
+        env=planned_values,
+        updated_at=utc_now_timestamp(),
+        source_label=source_label.strip() or "product-config-apply",
+    )
+    return (
+        planned_record,
+        {
+            "action": action,
+            "scope": scope,
+            "context": context_name,
+            "instance": instance_name,
+            "keys": sorted(env),
+            "changed_keys": changed_keys,
+            "unchanged_keys": unchanged_keys,
+            "env_value_count_after": len(planned_values),
+        },
+    )
+
+
 def _summarize_odoo_instance_override_record(
     record: OdooInstanceOverrideRecord,
 ) -> dict[str, object]:
@@ -9051,6 +9311,132 @@ def storage() -> None:
 @main.group()
 def secrets() -> None:
     """Launchplane managed secret commands."""
+
+
+@main.group("product-config")
+def product_config() -> None:
+    """Trusted product runtime config apply commands."""
+
+
+@product_config.command("apply")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string from a trusted Launchplane context.",
+)
+@click.option(
+    "--input-file",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False),
+    required=True,
+    help="Operator-approved JSON bundle containing runtime_env and secrets.",
+)
+@click.option("--actor", default="cli", show_default=True)
+@click.option("--source-label", default="product-config-apply", show_default=True)
+@click.option("--dry-run", "dry_run", is_flag=True, default=False)
+@click.option("--apply", "apply_changes", is_flag=True, default=False)
+def product_config_apply(
+    database_url: str,
+    input_file: Path,
+    actor: str,
+    source_label: str,
+    dry_run: bool,
+    apply_changes: bool,
+) -> None:
+    if dry_run == apply_changes:
+        raise click.ClickException("Choose exactly one of --dry-run or --apply.")
+
+    payload = _load_product_config_apply_payload(input_file)
+    product = _product_config_required_text(payload, "product")
+    context_name = _product_config_optional_text(payload, "context")
+    instance_name = _product_config_optional_text(payload, "instance")
+    runtime_input = _product_config_runtime_input(
+        payload,
+        context_name=context_name,
+        instance_name=instance_name,
+    )
+    runtime_env = _normalize_product_config_runtime_env(runtime_input["env"])  # type: ignore[arg-type]
+    secrets = _product_config_secret_inputs(
+        payload,
+        context_name=context_name,
+        instance_name=instance_name,
+    )
+    _require_product_config_master_key_if_needed(secrets)
+
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    postgres_store.ensure_schema()
+    try:
+        runtime_record, runtime_summary = _plan_product_config_runtime_environment(
+            existing_records=postgres_store.list_runtime_environment_records(),
+            scope=str(runtime_input["scope"]),
+            context_name=str(runtime_input["context"]),
+            instance_name=str(runtime_input["instance"]),
+            env=runtime_env,
+            source_label=source_label,
+        )
+        secret_summaries: list[dict[str, object]] = []
+        for secret in secrets:
+            planned_action, existing_secret_id = _product_config_secret_current_action(
+                record_store=postgres_store,
+                secret=secret,
+            )
+            if apply_changes:
+                result = control_plane_secrets.write_secret_value(
+                    record_store=postgres_store,
+                    scope=str(secret["scope"]),
+                    integration=str(secret["integration"]),
+                    name=str(secret["name"]),
+                    plaintext_value=str(secret["value"]),
+                    binding_key=str(secret["binding_key"]),
+                    context_name=str(secret["context"]),
+                    instance_name=str(secret["instance"]),
+                    description=str(secret["description"]),
+                    actor=actor,
+                    source_label=source_label,
+                )
+                secret_summaries.append(
+                    _summarize_product_config_secret_input(
+                        action=str(result["action"]),
+                        secret=secret,
+                        secret_id=str(result["secret_id"]),
+                    )
+                )
+                continue
+            secret_summaries.append(
+                _summarize_product_config_secret_input(
+                    action=planned_action,
+                    secret=secret,
+                    secret_id=existing_secret_id,
+                )
+            )
+        if apply_changes and runtime_record is not None and runtime_summary["action"] != "unchanged":
+            postgres_store.write_runtime_environment_record(runtime_record)
+            runtime_summary = {
+                **runtime_summary,
+                "record": _summarize_runtime_environment_record(runtime_record),
+            }
+    finally:
+        postgres_store.close()
+
+    changed_secret_count = sum(
+        1 for item in secret_summaries if item["action"] in {"created", "rotated"}
+    )
+    payload = {
+        "status": "ok",
+        "mode": "apply" if apply_changes else "dry-run",
+        "product": product,
+        "context": context_name,
+        "instance": instance_name,
+        "actor": actor,
+        "source_label": source_label,
+        "runtime_environment": runtime_summary,
+        "secrets": secret_summaries,
+        "summary": {
+            "runtime_changed_key_count": len(runtime_summary.get("changed_keys", [])),
+            "secret_change_count": changed_secret_count,
+        },
+    }
+    click.echo(json.dumps(payload, indent=2, sort_keys=True))
 
 
 @storage.command("import-core-records")

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -22,6 +22,8 @@ be treated as the final cross-product ingress boundary for Launchplane.
 - `inventory`: inspect current environment inventory.
 - `promote`: record, resolve, and execute artifact-backed promotions.
 - `promotions`: write and inspect promotion records.
+- `product-config`: dry-run and apply trusted product runtime/secret config
+  bundles from a live Launchplane context.
 - `release-tuples`: inspect state-backed tuple records and explicitly export a
   TOML catalog from minted state.
 - `service`: run the first local Launchplane HTTP ingress slice.
@@ -332,6 +334,13 @@ Current derived-state behavior:
   directly into DB-backed runtime-environment records for `global`, `context`,
   or `instance` scope. It rejects secret-shaped keys and returns key metadata
   only, not plaintext values.
+- `product-config apply --dry-run|--apply --input-file <json>` is the supported
+  trusted-context bundle path for product runtime config changes. It writes
+  non-secret values to runtime-environment records and secret-shaped values to
+  managed secret records while returning only key names, actions, counts, actor,
+  and source metadata. Use it from a live Launchplane context that already has
+  current `LAUNCHPLANE_DATABASE_URL`; bundles with secrets also require
+  `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`.
 - `environments unset` removes named keys from a DB-backed runtime-environment
   record without reading or printing plaintext values.
 - `environments relabel` updates runtime-environment record source metadata
@@ -342,6 +351,37 @@ Current derived-state behavior:
   contract for a context and instance.
 - TOML/env files are not runtime import surfaces; use DB-native
   runtime-environment records and managed secrets instead.
+- Product repos and GitHub issues must not contain product secret values. Put
+  the JSON bundle on an operator-controlled machine or inside the hosted
+  Launchplane execution context, run `--dry-run` first, then run `--apply` only
+  after the key/action summary matches the approved change.
+
+Example product config bundle shape:
+
+```json
+{
+  "schema_version": 1,
+  "product": "sellyouroutboard",
+  "context": "sellyouroutboard",
+  "instance": "prod",
+  "runtime_env": {
+    "CONTACT_EMAIL_MODE": "smtp",
+    "CONTACT_FROM_EMAIL": "owner@example.com"
+  },
+  "secrets": [
+    {
+      "name": "smtp-password",
+      "binding_key": "SMTP_PASSWORD",
+      "value": "operator-supplied-secret"
+    }
+  ]
+}
+```
+
+`runtime_env` values are non-secret scalar values. `secrets` default to the
+`runtime_environment` integration and the current context/instance, which makes
+them available as managed runtime environment overlays.
+
 - `environments show-live-target` reads the live Dokploy target payload for a
   tracked route and reports whether the target is ready for artifact-backed
   split-repo execution.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -88,6 +88,12 @@ title: Secrets
   non-secret runtime values directly to DB-backed runtime-environment records
   and redacts values from command output. Secret-shaped keys are rejected and
   should be written with `secrets put`.
+- `uv run launchplane product-config apply --input-file bundle.json --dry-run`
+  previews an approved product runtime/secret bundle without printing plaintext
+  values or writing records. `--apply` writes non-secret runtime keys and
+  managed secret values through the same DB-backed stores. Run this command only
+  from a trusted Launchplane context with current `LAUNCHPLANE_DATABASE_URL` and,
+  when secrets are present, `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`.
 - `uv run launchplane environments unset --scope <scope> --key KEY` removes
   stale keys from DB-backed runtime-environment records without reading or
   printing plaintext values.

--- a/tests/test_runtime_environments.py
+++ b/tests/test_runtime_environments.py
@@ -675,6 +675,222 @@ ODOO_DB_PASSWORD = "file-secret"
         self.assertEqual(payload["environment"]["ODOO_MASTER_PASSWORD"], "shared-master")
         self.assertEqual(payload["environment"]["ODOO_DB_PASSWORD"], "local-secret")
 
+    def test_product_config_apply_dry_run_redacts_and_does_not_write(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            input_file = control_plane_root / "product-config.json"
+            input_file.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "context": "sellyouroutboard",
+                        "instance": "prod",
+                        "runtime_env": {
+                            "CONTACT_EMAIL_MODE": "smtp",
+                            "SELLYOUROUTBOARD_SITE_URL": "https://www.sellyouroutboard.com",
+                        },
+                        "secrets": [
+                            {
+                                "name": "smtp-password",
+                                "binding_key": "SMTP_PASSWORD",
+                                "value": "smtp-secret-value",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_MASTER_ENCRYPTION_KEY": "test-master-key"},
+                clear=True,
+            ):
+                result = CliRunner().invoke(
+                    main,
+                    [
+                        "product-config",
+                        "apply",
+                        "--database-url",
+                        database_url,
+                        "--input-file",
+                        str(input_file),
+                        "--actor",
+                        "operator@example.com",
+                        "--dry-run",
+                    ],
+                )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertNotIn("smtp-secret-value", result.output)
+            self.assertNotIn("https://www.sellyouroutboard.com", result.output)
+            payload = json.loads(result.output)
+            self.assertEqual(payload["mode"], "dry-run")
+            self.assertEqual(payload["runtime_environment"]["action"], "created")
+            self.assertEqual(payload["secrets"][0]["action"], "created")
+
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                self.assertEqual(store.list_runtime_environment_records(), ())
+                self.assertEqual(store.list_secret_records(), ())
+            finally:
+                store.close()
+
+    def test_product_config_apply_writes_runtime_env_and_secret_without_echoing_values(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            input_file = control_plane_root / "product-config.json"
+            input_file.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "context": "sellyouroutboard",
+                        "instance": "prod",
+                        "runtime_env": {"CONTACT_EMAIL_MODE": "smtp"},
+                        "secrets": [
+                            {
+                                "name": "smtp-password",
+                                "binding_key": "SMTP_PASSWORD",
+                                "value": "smtp-secret-value",
+                                "description": "SMTP password for owner contact mail.",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_DATABASE_URL": database_url,
+                    "LAUNCHPLANE_MASTER_ENCRYPTION_KEY": "test-master-key",
+                },
+                clear=True,
+            ):
+                result = CliRunner().invoke(
+                    main,
+                    [
+                        "product-config",
+                        "apply",
+                        "--input-file",
+                        str(input_file),
+                        "--actor",
+                        "operator@example.com",
+                        "--source-label",
+                        "issue-110-test",
+                        "--apply",
+                    ],
+                )
+                resolved_values = control_plane_runtime_environments.resolve_runtime_environment_values(
+                    control_plane_root=control_plane_root,
+                    context_name="sellyouroutboard",
+                    instance_name="prod",
+                )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertNotIn("smtp-secret-value", result.output)
+            self.assertNotIn("smtp\"", result.output)
+            payload = json.loads(result.output)
+            self.assertEqual(payload["mode"], "apply")
+            self.assertEqual(payload["runtime_environment"]["record"]["source_label"], "issue-110-test")
+            self.assertEqual(payload["secrets"][0]["action"], "created")
+            self.assertEqual(resolved_values["CONTACT_EMAIL_MODE"], "smtp")
+            self.assertEqual(resolved_values["SMTP_PASSWORD"], "smtp-secret-value")
+
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                secret_records = store.list_secret_records()
+                self.assertEqual(len(secret_records), 1)
+                audit_events = store.list_secret_audit_events(
+                    secret_id=secret_records[0].secret_id
+                )
+                self.assertEqual(audit_events[0].actor, "operator@example.com")
+                self.assertEqual(audit_events[0].metadata["source"], "issue-110-test")
+            finally:
+                store.close()
+
+    def test_product_config_apply_requires_master_key_for_secrets(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            input_file = control_plane_root / "product-config.json"
+            input_file.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "context": "sellyouroutboard",
+                        "instance": "prod",
+                        "secrets": [
+                            {
+                                "name": "smtp-password",
+                                "binding_key": "SMTP_PASSWORD",
+                                "value": "smtp-secret-value",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch.dict(os.environ, {}, clear=True):
+                result = CliRunner().invoke(
+                    main,
+                    [
+                        "product-config",
+                        "apply",
+                        "--database-url",
+                        database_url,
+                        "--input-file",
+                        str(input_file),
+                        "--dry-run",
+                    ],
+                )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Product config secrets require LAUNCHPLANE_MASTER_ENCRYPTION_KEY", result.output)
+        self.assertNotIn("smtp-secret-value", result.output)
+
+    def test_product_config_apply_rejects_secret_shaped_runtime_env(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            input_file = control_plane_root / "product-config.json"
+            input_file.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "context": "sellyouroutboard",
+                        "instance": "prod",
+                        "runtime_env": {"SMTP_PASSWORD": "smtp-secret-value"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "product-config",
+                    "apply",
+                    "--database-url",
+                    database_url,
+                    "--input-file",
+                    str(input_file),
+                    "--dry-run",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("must be written as a managed secret", result.output)
+        self.assertNotIn("smtp-secret-value", result.output)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `launchplane product-config apply` as a trusted-context dry-run/apply workflow for product runtime config bundles
- write non-secret runtime values through DB-backed runtime-environment records and secret values through managed secret records
- redact plaintext values from command output and require `LAUNCHPLANE_MASTER_ENCRYPTION_KEY` when bundles contain secrets
- document the operator bundle shape in operations/secrets docs

## Validation
- uv run --extra dev ruff check --diff .
- uv run --extra dev ruff check .
- uv run python -m unittest tests.test_runtime_environments.RuntimeEnvironmentTests tests.test_secrets.LaunchplaneSecretsTests
- uv run python -m unittest
- uv run launchplane product-config apply --help

Closes #110