### PR TITLE
Add product config service API

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -17,6 +17,7 @@ from pydantic import ValidationError
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import odoo_instance_overrides as control_plane_odoo_instance_overrides
+from control_plane import product_config as control_plane_product_config
 from control_plane import release_tuples as control_plane_release_tuples
 from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane import secrets as control_plane_secrets
@@ -6446,7 +6447,9 @@ def _launchplane_managed_store_status(*, database_url: str) -> dict[str, object]
             "runtime_environment_record_count": len(runtime_environment_records),
             "dokploy_target_id_record_count": len(dokploy_target_id_records),
             "release_tuple_record_count": len(record_store.list_release_tuple_records()),
-            "authz_policy_record_count": len(record_store.list_authz_policy_records(status="active")),
+            "authz_policy_record_count": len(
+                record_store.list_authz_policy_records(status="active")
+            ),
         }
     except Exception as error:
         return {
@@ -6523,8 +6526,12 @@ def _build_launchplane_service_target_preflight(
             env_map=env_map,
             env_keys=_LAUNCHPLANE_SERVICE_POLICY_ENV_KEYS,
         ),
-        "authz_policy_record_count": int(managed_store_status.get("authz_policy_record_count") or 0),
-        "authz_policy_db_configured": int(managed_store_status.get("authz_policy_record_count") or 0)
+        "authz_policy_record_count": int(
+            managed_store_status.get("authz_policy_record_count") or 0
+        ),
+        "authz_policy_db_configured": int(
+            managed_store_status.get("authz_policy_record_count") or 0
+        )
         > 0,
         "target_ids_env_configured": False,
         "target_ids_record_count": int(
@@ -8490,266 +8497,6 @@ def _build_runtime_environment_record_for_relabel(
     )
 
 
-def _load_product_config_apply_payload(input_file: Path) -> dict[str, object]:
-    try:
-        payload = json.loads(input_file.read_text(encoding="utf-8"))
-    except FileNotFoundError as error:
-        raise click.ClickException(f"Product config input file {input_file} was not found.") from error
-    except JSONDecodeError as error:
-        raise click.ClickException(
-            f"Product config input file {input_file} is not valid JSON: {error}"
-        ) from error
-    if not isinstance(payload, dict):
-        raise click.ClickException("Product config input file must contain a JSON object.")
-    schema_version = payload.get("schema_version", 1)
-    if schema_version != 1:
-        raise click.ClickException("Product config input schema_version must be 1.")
-    return payload
-
-
-def _product_config_required_text(
-    payload: dict[str, object], key: str, *, default: str = ""
-) -> str:
-    value = str(payload.get(key, default) or "").strip()
-    if not value:
-        raise click.ClickException(f"Product config input requires {key!r}.")
-    return value
-
-
-def _product_config_optional_text(payload: dict[str, object], key: str) -> str:
-    return str(payload.get(key, "") or "").strip()
-
-
-def _default_runtime_scope(*, context_name: str, instance_name: str) -> str:
-    if instance_name:
-        return "instance"
-    if context_name:
-        return "context"
-    return "global"
-
-
-def _default_secret_scope(*, context_name: str, instance_name: str) -> str:
-    if instance_name:
-        return "context_instance"
-    if context_name:
-        return "context"
-    return "global"
-
-
-def _product_config_runtime_input(
-    payload: dict[str, object], *, context_name: str, instance_name: str
-) -> dict[str, object]:
-    runtime_payload = payload.get("runtime_env", payload.get("runtime_environment", {}))
-    if runtime_payload is None:
-        return {"scope": _default_runtime_scope(context_name=context_name, instance_name=instance_name), "env": {}}
-    if not isinstance(runtime_payload, dict):
-        raise click.ClickException("Product config runtime_env must be a JSON object.")
-    if "env" in runtime_payload:
-        raw_env = runtime_payload.get("env")
-        if raw_env is None:
-            raw_env = {}
-        if not isinstance(raw_env, dict):
-            raise click.ClickException("Product config runtime_env.env must be a JSON object.")
-    else:
-        raw_env = {
-            key: value
-            for key, value in runtime_payload.items()
-            if key not in {"scope", "context", "instance"}
-        }
-    scope = str(
-        runtime_payload.get(
-            "scope", _default_runtime_scope(context_name=context_name, instance_name=instance_name)
-        )
-        or ""
-    ).strip()
-    return {
-        "scope": scope,
-        "context": str(runtime_payload.get("context", context_name) or "").strip(),
-        "instance": str(runtime_payload.get("instance", instance_name) or "").strip(),
-        "env": raw_env,
-    }
-
-
-def _normalize_product_config_runtime_env(raw_env: dict[object, object]) -> dict[str, object]:
-    env: dict[str, object] = {}
-    for raw_key, raw_value in raw_env.items():
-        if not isinstance(raw_key, str):
-            raise click.ClickException("Product config runtime env keys must be strings.")
-        key_name = _normalize_runtime_environment_key(raw_key)
-        if _runtime_environment_key_requires_secret_store(key_name):
-            raise click.ClickException(
-                f"Runtime environment key {key_name!r} must be written as a managed secret."
-            )
-        if not isinstance(raw_value, (str, int, float, bool)):
-            raise click.ClickException(
-                f"Product config runtime env value for {key_name!r} must be a scalar."
-            )
-        env[key_name] = raw_value
-    return env
-
-
-def _product_config_secret_inputs(
-    payload: dict[str, object], *, context_name: str, instance_name: str
-) -> tuple[dict[str, object], ...]:
-    raw_secrets = payload.get("secrets", ())
-    if raw_secrets is None:
-        return ()
-    if not isinstance(raw_secrets, list):
-        raise click.ClickException("Product config secrets must be a JSON array.")
-    normalized: list[dict[str, object]] = []
-    for index, raw_secret in enumerate(raw_secrets, start=1):
-        if not isinstance(raw_secret, dict):
-            raise click.ClickException(f"Product config secret #{index} must be a JSON object.")
-        binding_key = str(raw_secret.get("binding_key", raw_secret.get("name", "")) or "").strip()
-        name = str(raw_secret.get("name", binding_key) or "").strip()
-        plaintext_value = raw_secret.get("value")
-        if not binding_key:
-            raise click.ClickException(f"Product config secret #{index} requires binding_key.")
-        if not name:
-            raise click.ClickException(f"Product config secret #{index} requires name.")
-        if not isinstance(plaintext_value, str) or not plaintext_value.strip():
-            raise click.ClickException(f"Product config secret #{index} requires a non-empty value.")
-        normalized.append(
-            {
-                "scope": str(
-                    raw_secret.get(
-                        "scope",
-                        _default_secret_scope(context_name=context_name, instance_name=instance_name),
-                    )
-                    or ""
-                ).strip(),
-                "integration": str(
-                    raw_secret.get(
-                        "integration",
-                        control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
-                    )
-                    or ""
-                ).strip(),
-                "name": name,
-                "binding_key": binding_key,
-                "value": plaintext_value,
-                "context": str(raw_secret.get("context", context_name) or "").strip(),
-                "instance": str(raw_secret.get("instance", instance_name) or "").strip(),
-                "description": str(raw_secret.get("description", "") or "").strip(),
-            }
-        )
-    return tuple(normalized)
-
-
-def _require_product_config_master_key_if_needed(secrets: tuple[dict[str, object], ...]) -> None:
-    if not secrets:
-        return
-    if not any(os.environ.get(key, "").strip() for key in _MASTER_ENCRYPTION_KEY_ENV_KEYS):
-        expected_keys = " or ".join(_MASTER_ENCRYPTION_KEY_ENV_KEYS)
-        raise click.ClickException(
-            f"Product config secrets require {expected_keys} in the trusted Launchplane context."
-        )
-
-
-def _product_config_secret_current_action(
-    *, record_store: PostgresRecordStore, secret: dict[str, object]
-) -> tuple[str, str]:
-    existing_record = record_store.find_secret_record(
-        scope=str(secret["scope"]),
-        integration=str(secret["integration"]),
-        name=str(secret["name"]),
-        context=str(secret["context"]),
-        instance=str(secret["instance"]),
-    )
-    if existing_record is None:
-        return "created", ""
-    current_version = record_store.read_secret_version(existing_record.current_version_id)
-    if control_plane_secrets._decrypt_secret_value(current_version.ciphertext) == str(secret["value"]):
-        return "unchanged", existing_record.secret_id
-    return "rotated", existing_record.secret_id
-
-
-def _summarize_product_config_secret_input(
-    *, action: str, secret: dict[str, object], secret_id: str = ""
-) -> dict[str, object]:
-    summary = {
-        "action": action,
-        "scope": secret["scope"],
-        "integration": secret["integration"],
-        "name": secret["name"],
-        "binding_key": secret["binding_key"],
-        "context": secret["context"],
-        "instance": secret["instance"],
-    }
-    if secret_id:
-        summary["secret_id"] = secret_id
-    return summary
-
-
-def _plan_product_config_runtime_environment(
-    *,
-    existing_records: tuple[RuntimeEnvironmentRecord, ...],
-    scope: str,
-    context_name: str,
-    instance_name: str,
-    env: dict[str, object],
-    source_label: str,
-) -> tuple[RuntimeEnvironmentRecord | None, dict[str, object]]:
-    _validate_runtime_environment_scope_route(
-        scope=scope,
-        context_name=context_name,
-        instance_name=instance_name,
-    )
-    target_record = _find_runtime_environment_record(
-        existing_records=existing_records,
-        scope=scope,
-        context_name=context_name,
-        instance_name=instance_name,
-    )
-    if not env:
-        return (
-            None,
-            {
-                "action": "skipped",
-                "scope": scope,
-                "context": context_name,
-                "instance": instance_name,
-                "keys": [],
-                "changed_keys": [],
-                "unchanged_keys": [],
-                "env_value_count_after": len(target_record.env) if target_record is not None else 0,
-            },
-        )
-    current_values = dict(target_record.env) if target_record is not None else {}
-    changed_keys = sorted(
-        key_name
-        for key_name, value in env.items()
-        if key_name not in current_values or str(current_values[key_name]) != str(value)
-    )
-    unchanged_keys = sorted(key_name for key_name in env if key_name not in changed_keys)
-    action = "created" if target_record is None else "updated"
-    if not changed_keys:
-        action = "unchanged"
-    planned_values = dict(current_values)
-    planned_values.update(env)
-    planned_record = RuntimeEnvironmentRecord(
-        scope=scope,
-        context=context_name,
-        instance=instance_name,
-        env=planned_values,
-        updated_at=utc_now_timestamp(),
-        source_label=source_label.strip() or "product-config-apply",
-    )
-    return (
-        planned_record,
-        {
-            "action": action,
-            "scope": scope,
-            "context": context_name,
-            "instance": instance_name,
-            "keys": sorted(env),
-            "changed_keys": changed_keys,
-            "unchanged_keys": unchanged_keys,
-            "env_value_count_after": len(planned_values),
-        },
-    )
-
-
 def _summarize_odoo_instance_override_record(
     record: OdooInstanceOverrideRecord,
 ) -> dict[str, object]:
@@ -9346,96 +9093,20 @@ def product_config_apply(
     if dry_run == apply_changes:
         raise click.ClickException("Choose exactly one of --dry-run or --apply.")
 
-    payload = _load_product_config_apply_payload(input_file)
-    product = _product_config_required_text(payload, "product")
-    context_name = _product_config_optional_text(payload, "context")
-    instance_name = _product_config_optional_text(payload, "instance")
-    runtime_input = _product_config_runtime_input(
-        payload,
-        context_name=context_name,
-        instance_name=instance_name,
-    )
-    runtime_env = _normalize_product_config_runtime_env(runtime_input["env"])  # type: ignore[arg-type]
-    secrets = _product_config_secret_inputs(
-        payload,
-        context_name=context_name,
-        instance_name=instance_name,
-    )
-    _require_product_config_master_key_if_needed(secrets)
-
     postgres_store = PostgresRecordStore(database_url=database_url)
     postgres_store.ensure_schema()
     try:
-        runtime_record, runtime_summary = _plan_product_config_runtime_environment(
-            existing_records=postgres_store.list_runtime_environment_records(),
-            scope=str(runtime_input["scope"]),
-            context_name=str(runtime_input["context"]),
-            instance_name=str(runtime_input["instance"]),
-            env=runtime_env,
+        payload = control_plane_product_config.apply_product_config_bundle(
+            record_store=postgres_store,
+            payload=control_plane_product_config.load_product_config_apply_payload(input_file),
+            mode="apply" if apply_changes else "dry-run",
+            actor=actor,
             source_label=source_label,
         )
-        secret_summaries: list[dict[str, object]] = []
-        for secret in secrets:
-            planned_action, existing_secret_id = _product_config_secret_current_action(
-                record_store=postgres_store,
-                secret=secret,
-            )
-            if apply_changes:
-                result = control_plane_secrets.write_secret_value(
-                    record_store=postgres_store,
-                    scope=str(secret["scope"]),
-                    integration=str(secret["integration"]),
-                    name=str(secret["name"]),
-                    plaintext_value=str(secret["value"]),
-                    binding_key=str(secret["binding_key"]),
-                    context_name=str(secret["context"]),
-                    instance_name=str(secret["instance"]),
-                    description=str(secret["description"]),
-                    actor=actor,
-                    source_label=source_label,
-                )
-                secret_summaries.append(
-                    _summarize_product_config_secret_input(
-                        action=str(result["action"]),
-                        secret=secret,
-                        secret_id=str(result["secret_id"]),
-                    )
-                )
-                continue
-            secret_summaries.append(
-                _summarize_product_config_secret_input(
-                    action=planned_action,
-                    secret=secret,
-                    secret_id=existing_secret_id,
-                )
-            )
-        if apply_changes and runtime_record is not None and runtime_summary["action"] != "unchanged":
-            postgres_store.write_runtime_environment_record(runtime_record)
-            runtime_summary = {
-                **runtime_summary,
-                "record": _summarize_runtime_environment_record(runtime_record),
-            }
+    except control_plane_product_config.ProductConfigError as error:
+        raise click.ClickException(str(error)) from error
     finally:
         postgres_store.close()
-
-    changed_secret_count = sum(
-        1 for item in secret_summaries if item["action"] in {"created", "rotated"}
-    )
-    payload = {
-        "status": "ok",
-        "mode": "apply" if apply_changes else "dry-run",
-        "product": product,
-        "context": context_name,
-        "instance": instance_name,
-        "actor": actor,
-        "source_label": source_label,
-        "runtime_environment": runtime_summary,
-        "secrets": secret_summaries,
-        "summary": {
-            "runtime_changed_key_count": len(runtime_summary.get("changed_keys", [])),
-            "secret_change_count": changed_secret_count,
-        },
-    }
     click.echo(json.dumps(payload, indent=2, sort_keys=True))
 
 

--- a/control_plane/product_config.py
+++ b/control_plane/product_config.py
@@ -1,0 +1,488 @@
+from __future__ import annotations
+
+import json
+import os
+from json import JSONDecodeError
+from pathlib import Path
+from typing import Literal, cast
+
+from control_plane import secrets as control_plane_secrets
+from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
+from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentScope
+from control_plane.contracts.runtime_environment_record import ScalarValue
+from control_plane.contracts.secret_record import SecretScope
+from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.workflows.ship import utc_now_timestamp
+
+
+MASTER_ENCRYPTION_KEY_ENV_KEYS = ("LAUNCHPLANE_MASTER_ENCRYPTION_KEY",)
+SECRET_SHAPED_RUNTIME_ENV_KEY_PARTS = {"PASSWORD", "TOKEN", "SECRET", "KEY"}
+ProductConfigMode = Literal["dry-run", "apply"]
+
+
+class ProductConfigError(ValueError):
+    """Operator-facing product config validation or planning failure."""
+
+
+def load_product_config_apply_payload(input_file: Path) -> dict[str, object]:
+    try:
+        payload = json.loads(input_file.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise ProductConfigError(
+            f"Product config input file {input_file} was not found."
+        ) from error
+    except JSONDecodeError as error:
+        raise ProductConfigError(
+            f"Product config input file {input_file} is not valid JSON: {error}"
+        ) from error
+    if not isinstance(payload, dict):
+        raise ProductConfigError("Product config input file must contain a JSON object.")
+    validate_product_config_schema_version(payload)
+    return payload
+
+
+def validate_product_config_schema_version(payload: dict[str, object]) -> None:
+    schema_version = payload.get("schema_version", 1)
+    if schema_version != 1:
+        raise ProductConfigError("Product config input schema_version must be 1.")
+
+
+def required_text(payload: dict[str, object], key: str, *, default: str = "") -> str:
+    value = str(payload.get(key, default) or "").strip()
+    if not value:
+        raise ProductConfigError(f"Product config input requires {key!r}.")
+    return value
+
+
+def optional_text(payload: dict[str, object], key: str) -> str:
+    return str(payload.get(key, "") or "").strip()
+
+
+def product_context(payload: dict[str, object]) -> tuple[str, str, str]:
+    validate_product_config_schema_version(payload)
+    return (
+        required_text(payload, "product"),
+        optional_text(payload, "context"),
+        optional_text(payload, "instance"),
+    )
+
+
+def summarize_runtime_environment_record(record: RuntimeEnvironmentRecord) -> dict[str, object]:
+    return {
+        "scope": record.scope,
+        "context": record.context,
+        "instance": record.instance,
+        "updated_at": record.updated_at,
+        "source_label": record.source_label,
+        "env_keys": sorted(record.env.keys()),
+        "env_value_count": len(record.env),
+    }
+
+
+def apply_product_config_bundle(
+    *,
+    record_store: PostgresRecordStore,
+    payload: dict[str, object],
+    mode: ProductConfigMode,
+    actor: str,
+    source_label: str,
+) -> dict[str, object]:
+    if mode not in {"dry-run", "apply"}:
+        raise ProductConfigError("Product config mode must be 'dry-run' or 'apply'.")
+    product, context_name, instance_name = product_context(payload)
+    runtime_input = _product_config_runtime_input(
+        payload,
+        context_name=context_name,
+        instance_name=instance_name,
+    )
+    runtime_env = _normalize_product_config_runtime_env(runtime_input["env"])
+    secrets = _product_config_secret_inputs(
+        payload,
+        context_name=context_name,
+        instance_name=instance_name,
+    )
+    _require_product_config_master_key_if_needed(secrets)
+
+    runtime_record, runtime_summary = _plan_product_config_runtime_environment(
+        existing_records=record_store.list_runtime_environment_records(),
+        scope=str(runtime_input["scope"]),
+        context_name=str(runtime_input["context"]),
+        instance_name=str(runtime_input["instance"]),
+        env=runtime_env,
+        source_label=source_label,
+    )
+    secret_summaries: list[dict[str, object]] = []
+    apply_changes = mode == "apply"
+    for secret in secrets:
+        planned_action, existing_secret_id = _product_config_secret_current_action(
+            record_store=record_store,
+            secret=secret,
+        )
+        if apply_changes:
+            result = control_plane_secrets.write_secret_value(
+                record_store=record_store,
+                scope=cast(SecretScope, str(secret["scope"])),
+                integration=str(secret["integration"]),
+                name=str(secret["name"]),
+                plaintext_value=str(secret["value"]),
+                binding_key=str(secret["binding_key"]),
+                context_name=str(secret["context"]),
+                instance_name=str(secret["instance"]),
+                description=str(secret["description"]),
+                actor=actor,
+                source_label=source_label,
+            )
+            secret_summaries.append(
+                _summarize_product_config_secret_input(
+                    action=str(result["action"]),
+                    secret=secret,
+                    secret_id=str(result["secret_id"]),
+                )
+            )
+            continue
+        secret_summaries.append(
+            _summarize_product_config_secret_input(
+                action=planned_action,
+                secret=secret,
+                secret_id=existing_secret_id,
+            )
+        )
+    if apply_changes and runtime_record is not None and runtime_summary["action"] != "unchanged":
+        record_store.write_runtime_environment_record(runtime_record)
+        runtime_summary = {
+            **runtime_summary,
+            "record": summarize_runtime_environment_record(runtime_record),
+        }
+
+    changed_secret_count = sum(
+        1 for item in secret_summaries if item["action"] in {"created", "rotated"}
+    )
+    return {
+        "status": "ok",
+        "mode": mode,
+        "product": product,
+        "context": context_name,
+        "instance": instance_name,
+        "actor": actor,
+        "source_label": source_label,
+        "runtime_environment": runtime_summary,
+        "secrets": secret_summaries,
+        "summary": {
+            "runtime_changed_key_count": len(
+                cast(list[object], runtime_summary.get("changed_keys", []))
+            ),
+            "secret_change_count": changed_secret_count,
+        },
+    }
+
+
+def _default_runtime_scope(*, context_name: str, instance_name: str) -> str:
+    if instance_name:
+        return "instance"
+    if context_name:
+        return "context"
+    return "global"
+
+
+def _default_secret_scope(*, context_name: str, instance_name: str) -> str:
+    if instance_name:
+        return "context_instance"
+    if context_name:
+        return "context"
+    return "global"
+
+
+def _product_config_runtime_input(
+    payload: dict[str, object], *, context_name: str, instance_name: str
+) -> dict[str, object]:
+    runtime_payload = payload.get("runtime_env", payload.get("runtime_environment", {}))
+    if runtime_payload is None:
+        return {
+            "scope": _default_runtime_scope(context_name=context_name, instance_name=instance_name),
+            "env": {},
+        }
+    if not isinstance(runtime_payload, dict):
+        raise ProductConfigError("Product config runtime_env must be a JSON object.")
+    if "env" in runtime_payload:
+        raw_env = runtime_payload.get("env")
+        if raw_env is None:
+            raw_env = {}
+        if not isinstance(raw_env, dict):
+            raise ProductConfigError("Product config runtime_env.env must be a JSON object.")
+    else:
+        raw_env = {
+            key: value
+            for key, value in runtime_payload.items()
+            if key not in {"scope", "context", "instance"}
+        }
+    scope = str(
+        runtime_payload.get(
+            "scope", _default_runtime_scope(context_name=context_name, instance_name=instance_name)
+        )
+        or ""
+    ).strip()
+    return {
+        "scope": scope,
+        "context": str(runtime_payload.get("context", context_name) or "").strip(),
+        "instance": str(runtime_payload.get("instance", instance_name) or "").strip(),
+        "env": raw_env,
+    }
+
+
+def _normalize_product_config_runtime_env(raw_env: object) -> dict[str, ScalarValue]:
+    if not isinstance(raw_env, dict):
+        raise ProductConfigError("Product config runtime_env.env must be a JSON object.")
+    env: dict[str, ScalarValue] = {}
+    for raw_key, raw_value in raw_env.items():
+        if not isinstance(raw_key, str):
+            raise ProductConfigError("Product config runtime env keys must be strings.")
+        key_name = _normalize_runtime_environment_key(raw_key)
+        if _runtime_environment_key_requires_secret_store(key_name):
+            raise ProductConfigError(
+                f"Runtime environment key {key_name!r} must be written as a managed secret."
+            )
+        if not isinstance(raw_value, (str, int, float, bool)):
+            raise ProductConfigError(
+                f"Product config runtime env value for {key_name!r} must be a scalar."
+            )
+        env[key_name] = raw_value
+    return env
+
+
+def _product_config_secret_inputs(
+    payload: dict[str, object], *, context_name: str, instance_name: str
+) -> tuple[dict[str, object], ...]:
+    raw_secrets = payload.get("secrets", ())
+    if raw_secrets is None:
+        return ()
+    if not isinstance(raw_secrets, list):
+        raise ProductConfigError("Product config secrets must be a JSON array.")
+    normalized: list[dict[str, object]] = []
+    for index, raw_secret in enumerate(raw_secrets, start=1):
+        if not isinstance(raw_secret, dict):
+            raise ProductConfigError(f"Product config secret #{index} must be a JSON object.")
+        binding_key = str(raw_secret.get("binding_key", raw_secret.get("name", "")) or "").strip()
+        name = str(raw_secret.get("name", binding_key) or "").strip()
+        plaintext_value = raw_secret.get("value")
+        if not binding_key:
+            raise ProductConfigError(f"Product config secret #{index} requires binding_key.")
+        if not name:
+            raise ProductConfigError(f"Product config secret #{index} requires name.")
+        if not isinstance(plaintext_value, str) or not plaintext_value.strip():
+            raise ProductConfigError(f"Product config secret #{index} requires a non-empty value.")
+        normalized.append(
+            {
+                "scope": str(
+                    raw_secret.get(
+                        "scope",
+                        _default_secret_scope(
+                            context_name=context_name, instance_name=instance_name
+                        ),
+                    )
+                    or ""
+                ).strip(),
+                "integration": str(
+                    raw_secret.get(
+                        "integration",
+                        control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+                    )
+                    or ""
+                ).strip(),
+                "name": name,
+                "binding_key": binding_key,
+                "value": plaintext_value,
+                "context": str(raw_secret.get("context", context_name) or "").strip(),
+                "instance": str(raw_secret.get("instance", instance_name) or "").strip(),
+                "description": str(raw_secret.get("description", "") or "").strip(),
+            }
+        )
+    return tuple(normalized)
+
+
+def _require_product_config_master_key_if_needed(secrets: tuple[dict[str, object], ...]) -> None:
+    if not secrets:
+        return
+    if not any(os.environ.get(key, "").strip() for key in MASTER_ENCRYPTION_KEY_ENV_KEYS):
+        expected_keys = " or ".join(MASTER_ENCRYPTION_KEY_ENV_KEYS)
+        raise ProductConfigError(
+            f"Product config secrets require {expected_keys} in the trusted Launchplane context."
+        )
+
+
+def _product_config_secret_current_action(
+    *, record_store: PostgresRecordStore, secret: dict[str, object]
+) -> tuple[str, str]:
+    existing_record = record_store.find_secret_record(
+        scope=str(secret["scope"]),
+        integration=str(secret["integration"]),
+        name=str(secret["name"]),
+        context=str(secret["context"]),
+        instance=str(secret["instance"]),
+    )
+    if existing_record is None:
+        return "created", ""
+    current_version = record_store.read_secret_version(existing_record.current_version_id)
+    if control_plane_secrets._decrypt_secret_value(current_version.ciphertext) == str(
+        secret["value"]
+    ):
+        return "unchanged", existing_record.secret_id
+    return "rotated", existing_record.secret_id
+
+
+def _summarize_product_config_secret_input(
+    *, action: str, secret: dict[str, object], secret_id: str = ""
+) -> dict[str, object]:
+    summary = {
+        "action": action,
+        "scope": secret["scope"],
+        "integration": secret["integration"],
+        "name": secret["name"],
+        "binding_key": secret["binding_key"],
+        "context": secret["context"],
+        "instance": secret["instance"],
+    }
+    if secret_id:
+        summary["secret_id"] = secret_id
+    return summary
+
+
+def _plan_product_config_runtime_environment(
+    *,
+    existing_records: tuple[RuntimeEnvironmentRecord, ...],
+    scope: str,
+    context_name: str,
+    instance_name: str,
+    env: dict[str, ScalarValue],
+    source_label: str,
+) -> tuple[RuntimeEnvironmentRecord | None, dict[str, object]]:
+    _validate_runtime_environment_scope_route(
+        scope=scope,
+        context_name=context_name,
+        instance_name=instance_name,
+    )
+    target_record = _find_runtime_environment_record(
+        existing_records=existing_records,
+        scope=scope,
+        context_name=context_name,
+        instance_name=instance_name,
+    )
+    if not env:
+        return (
+            None,
+            {
+                "action": "skipped",
+                "scope": scope,
+                "context": context_name,
+                "instance": instance_name,
+                "keys": [],
+                "changed_keys": [],
+                "unchanged_keys": [],
+                "env_value_count_after": len(target_record.env) if target_record is not None else 0,
+            },
+        )
+    current_values = dict(target_record.env) if target_record is not None else {}
+    changed_keys = sorted(
+        key_name
+        for key_name, value in env.items()
+        if key_name not in current_values or str(current_values[key_name]) != str(value)
+    )
+    unchanged_keys = sorted(key_name for key_name in env if key_name not in changed_keys)
+    action = "created" if target_record is None else "updated"
+    if not changed_keys:
+        action = "unchanged"
+    planned_values: dict[str, ScalarValue] = dict(current_values)
+    planned_values.update(env)
+    planned_record = RuntimeEnvironmentRecord(
+        scope=cast(RuntimeEnvironmentScope, scope),
+        context=context_name,
+        instance=instance_name,
+        env=planned_values,
+        updated_at=utc_now_timestamp(),
+        source_label=source_label.strip() or "product-config-apply",
+    )
+    return (
+        planned_record,
+        {
+            "action": action,
+            "scope": scope,
+            "context": context_name,
+            "instance": instance_name,
+            "keys": sorted(env),
+            "changed_keys": changed_keys,
+            "unchanged_keys": unchanged_keys,
+            "env_value_count_after": len(planned_values),
+        },
+    )
+
+
+def _normalize_runtime_environment_key(raw_key: str) -> str:
+    normalized_key = raw_key.strip()
+    if not normalized_key:
+        raise ProductConfigError("Runtime environment keys must be non-empty.")
+    return normalized_key
+
+
+def _runtime_environment_key_requires_secret_store(key_name: str) -> bool:
+    return any(
+        key_part in SECRET_SHAPED_RUNTIME_ENV_KEY_PARTS
+        for key_part in key_name.strip().upper().split("_")
+    )
+
+
+def _validate_runtime_environment_scope_route(
+    *,
+    scope: str,
+    context_name: str,
+    instance_name: str,
+) -> None:
+    if scope == "global":
+        if context_name or instance_name:
+            raise ProductConfigError(
+                "Global runtime environment records do not accept --context or --instance."
+            )
+        return
+    if scope == "context":
+        if not context_name or instance_name:
+            raise ProductConfigError(
+                "Context runtime environment records require --context and do not accept --instance."
+            )
+        return
+    if scope == "instance":
+        if not context_name or not instance_name:
+            raise ProductConfigError(
+                "Instance runtime environment records require --context and --instance."
+            )
+        return
+    raise ProductConfigError(f"Unsupported runtime environment scope: {scope}")
+
+
+def _runtime_environment_record_matches(
+    record: RuntimeEnvironmentRecord,
+    *,
+    scope: str,
+    context_name: str,
+    instance_name: str,
+) -> bool:
+    return (
+        record.scope == scope
+        and record.context == context_name
+        and record.instance == instance_name
+    )
+
+
+def _find_runtime_environment_record(
+    *,
+    existing_records: tuple[RuntimeEnvironmentRecord, ...],
+    scope: str,
+    context_name: str,
+    instance_name: str,
+) -> RuntimeEnvironmentRecord | None:
+    for record in existing_records:
+        if _runtime_environment_record_matches(
+            record,
+            scope=scope,
+            context_name=context_name,
+            instance_name=instance_name,
+        ):
+            return record
+    return None

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_valida
 from jwt import InvalidTokenError
 
 from control_plane import dokploy as control_plane_dokploy
+from control_plane import product_config as control_plane_product_config
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.authz_policy_record import (
     LaunchplaneAuthzPolicyRecord,
@@ -88,6 +89,7 @@ from control_plane.service_human_auth import (
 )
 from control_plane.storage.factory import build_record_store, storage_backend_name
 from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.evidence_ingestion import (
     apply_deployment_evidence,
     apply_promotion_evidence,
@@ -615,7 +617,9 @@ class VeriReelTestingVerificationRequest(BaseModel):
     verification_status: ReleaseStatus
     owner_routes_status: ReleaseStatus
 
-    @field_validator("migration_status", "verification_status", "owner_routes_status", mode="before")
+    @field_validator(
+        "migration_status", "verification_status", "owner_routes_status", mode="before"
+    )
     @classmethod
     def _normalize_status(cls, value: object) -> ReleaseStatus:
         return _normalize_release_status(value, label="Testing verification status")
@@ -895,6 +899,52 @@ class LaunchplaneSelfDeployEnvelope(BaseModel):
         return self
 
 
+class ProductConfigApplyEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    mode: str
+    product: str
+    context: str = ""
+    instance: str = ""
+    source_label: str = "product-config-api"
+    runtime_env: dict[str, object] | None = None
+    runtime_environment: dict[str, object] | None = None
+    secrets: list[dict[str, object]] = Field(default_factory=list)
+
+    @field_validator("mode")
+    @classmethod
+    def _validate_mode(cls, value: str) -> str:
+        normalized_value = value.strip().lower()
+        if normalized_value not in {"dry-run", "apply"}:
+            raise ValueError("Product config mode must be 'dry-run' or 'apply'.")
+        return normalized_value
+
+    @model_validator(mode="after")
+    def _validate_product(self) -> "ProductConfigApplyEnvelope":
+        self.product = self.product.strip()
+        self.context = self.context.strip()
+        self.instance = self.instance.strip()
+        self.source_label = self.source_label.strip() or "product-config-api"
+        if not self.product:
+            raise ValueError("Product config apply requires product.")
+        return self
+
+    def product_config_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "schema_version": self.schema_version,
+            "product": self.product,
+            "context": self.context,
+            "instance": self.instance,
+            "secrets": self.secrets,
+        }
+        if self.runtime_env is not None:
+            payload["runtime_env"] = self.runtime_env
+        if self.runtime_environment is not None:
+            payload["runtime_environment"] = self.runtime_environment
+        return payload
+
+
 def _json_response(
     *,
     start_response: Callable[[str, list[tuple[str, str]]], None],
@@ -1124,7 +1174,17 @@ def _idempotency_key(environ: dict[str, object]) -> str:
     return str(environ.get("HTTP_IDEMPOTENCY_KEY", "")).strip()
 
 
-def _idempotency_scope(identity) -> str:
+def _identity_actor(identity: LaunchplaneIdentity) -> str:
+    if isinstance(identity, GitHubHumanIdentity):
+        return f"github:{identity.login}"
+    return (
+        f"github-actions:{identity.repository}:{identity.workflow_ref or identity.job_workflow_ref}"
+    )
+
+
+def _idempotency_scope(identity: LaunchplaneIdentity) -> str:
+    if isinstance(identity, GitHubHumanIdentity):
+        return "|".join(("github-human", identity.login, str(identity.github_id)))
     workflow_ref = identity.workflow_ref or identity.job_workflow_ref or ""
     return "|".join(
         (
@@ -1631,7 +1691,9 @@ def _apply_verireel_preview_refresh_records(
     request: VeriReelPreviewRefreshRequest,
     driver_result: VeriReelPreviewRefreshResult,
 ) -> dict[str, object]:
-    requested_at = driver_result.refresh_started_at.strip() or driver_result.refresh_finished_at.strip()
+    requested_at = (
+        driver_result.refresh_started_at.strip() or driver_result.refresh_finished_at.strip()
+    )
     finished_at = driver_result.refresh_finished_at.strip() or requested_at
     preview_url = driver_result.preview_url.strip() or request.preview_url.strip()
     refresh_passed = driver_result.refresh_status == "pass"
@@ -1819,9 +1881,7 @@ def _apply_verireel_testing_verification_records(
 ) -> dict[str, str]:
     typed_record_store = cast(FilesystemRecordStore, record_store)
     try:
-        deployment_record = typed_record_store.read_deployment_record(
-            request.deployment_record_id
-        )
+        deployment_record = typed_record_store.read_deployment_record(request.deployment_record_id)
     except FileNotFoundError as exc:
         raise click.ClickException(
             f"No Launchplane deployment record found for {request.deployment_record_id}."
@@ -1941,6 +2001,7 @@ def create_launchplane_service_app(
         "/v1/evidence/backup-gates",
         "/v1/evidence/previews/generations",
         "/v1/evidence/previews/destroyed",
+        "/v1/product-config/apply",
         "/v1/previews/desired-state",
         "/v1/previews/pr-feedback",
         "/v1/previews/lifecycle-cleanup",
@@ -2062,7 +2123,9 @@ def create_launchplane_service_app(
                     },
                 )
             except Exception:  # noqa: BLE001
-                _LOGGER.exception("GitHub OAuth callback failed", extra={"trace_id": request_trace_id})
+                _LOGGER.exception(
+                    "GitHub OAuth callback failed", extra={"trace_id": request_trace_id}
+                )
                 return _json_response(
                     start_response=start_response,
                     status_code=400,
@@ -2706,6 +2769,82 @@ def create_launchplane_service_app(
                     return idempotent_response
                 record_store.write_backup_gate_record(request.backup_gate)
                 result = {"backup_gate_record_id": request.backup_gate.record_id}
+            elif path == "/v1/product-config/apply":
+                request = ProductConfigApplyEnvelope.model_validate(payload)
+                action = (
+                    "product_config.apply" if request.mode == "apply" else "product_config.plan"
+                )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action=action,
+                    product=request.product,
+                    context=request.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot plan or apply product config for the"
+                                    " requested product/context."
+                                ),
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                if not isinstance(record_store, PostgresRecordStore):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "database_required",
+                                "message": "Product config apply requires DB-backed Launchplane storage.",
+                            },
+                        },
+                    )
+                try:
+                    driver_result = control_plane_product_config.apply_product_config_bundle(
+                        record_store=record_store,
+                        payload=request.product_config_payload(),
+                        mode=cast(control_plane_product_config.ProductConfigMode, request.mode),
+                        actor=_identity_actor(identity),
+                        source_label=request.source_label,
+                    )
+                except control_plane_product_config.ProductConfigError as error:
+                    status_code = 400
+                    error_code = "invalid_request"
+                    if "LAUNCHPLANE_MASTER_ENCRYPTION_KEY" in str(error):
+                        status_code = 503
+                        error_code = "secret_configuration_required"
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=status_code,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": error_code,
+                                "message": str(error),
+                            },
+                        },
+                    )
             elif path == "/v1/drivers/launchplane/self-deploy":
                 request = LaunchplaneSelfDeployEnvelope.model_validate(payload)
                 if not authz_policy.allows(
@@ -3373,7 +3512,7 @@ def create_launchplane_service_app(
                                 ),
                             },
                         },
-                )
+                    )
                 driver_result = resolve_verireel_stable_environment(
                     control_plane_root=resolved_root,
                     request=request.environment,
@@ -4206,7 +4345,9 @@ def create_launchplane_service_app(
                 },
             )
         except Exception:  # noqa: BLE001
-            _LOGGER.exception("Unexpected Launchplane service error", extra={"trace_id": request_trace_id})
+            _LOGGER.exception(
+                "Unexpected Launchplane service error", extra={"trace_id": request_trace_id}
+            )
             return _json_response(
                 start_response=start_response,
                 status_code=500,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -17,8 +17,8 @@ be treated as the final cross-product ingress boundary for Launchplane.
 - `deployments`: write and inspect deployment records.
 - `environments`: write, list, and resolve DB-backed runtime environment
   contracts.
-- `launchplane-previews`: inspect, mutate, render, ingest, and replay Launchplane preview
-  state.
+- `launchplane-previews`: inspect, mutate, render, ingest, and replay
+  Launchplane preview state.
 - `inventory`: inspect current environment inventory.
 - `promote`: record, resolve, and execute artifact-backed promotions.
 - `promotions`: write and inspect promotion records.
@@ -113,7 +113,9 @@ records with:
 
 ```bash
 uv run launchplane service render-authz-policy --policy-file ./bootstrap-policy.toml
-uv run launchplane service render-authz-policy --policy-file ./bootstrap-policy.toml --format b64
+uv run launchplane service render-authz-policy \
+  --policy-file ./bootstrap-policy.toml \
+  --format b64
 uv run launchplane authz-policies import-toml --policy-file ./bootstrap-policy.toml
 ```
 
@@ -139,8 +141,9 @@ ref suffix such as `.../preview-control-plane.yml@*`, because pull-request runs
 execute from branch-specific workflow refs rather than a fixed `main` ref.
 
 The Launchplane container entrypoint now fails closed unless one of
-`LAUNCHPLANE_POLICY_TOML`, `LAUNCHPLANE_POLICY_B64`, or `LAUNCHPLANE_POLICY_FILE` is supplied.
-It also refuses to start from the checked-in `.example` policy path.
+`LAUNCHPLANE_POLICY_TOML`, `LAUNCHPLANE_POLICY_B64`, or
+`LAUNCHPLANE_POLICY_FILE` is supplied. It also refuses to start from the
+checked-in `.example` policy path.
 
 ## Launchplane Service Deploy Posture
 
@@ -192,8 +195,8 @@ The Dokploy-hosted Launchplane target should consume `DOCKER_IMAGE_REFERENCE` fr
 its env so deploy automation can switch the service by immutable digest and
 roll back to the prior digest when verification fails.
 
-Before a real Launchplane deploy, run the sanitized preflight check against the live
-Dokploy target:
+Before a real Launchplane deploy, run the sanitized preflight check against the
+live Dokploy target:
 
 ```bash
 uv run launchplane service inspect-dokploy-target \
@@ -341,6 +344,12 @@ Current derived-state behavior:
   and source metadata. Use it from a live Launchplane context that already has
   current `LAUNCHPLANE_DATABASE_URL`; bundles with secrets also require
   `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`.
+- `POST /v1/product-config/apply` exposes the same planner/writer through the
+  authenticated service API for operator UI use. Submit `mode: "dry-run"` to
+  preview with `product_config.plan`, then `mode: "apply"` with
+  `product_config.apply` after review. The service response is redacted and the
+  route fails closed when secret writes are requested without the Launchplane
+  master encryption key in the service runtime.
 - `environments unset` removes named keys from a DB-backed runtime-environment
   record without reading or printing plaintext values.
 - `environments relabel` updates runtime-environment record source metadata
@@ -392,9 +401,9 @@ them available as managed runtime environment overlays.
   for the compose post-deploy update path.
 - The post-deploy overlay supports only `ODOO_DB_NAME`, `ODOO_FILESTORE_PATH`,
   and `ODOO_DATA_WORKFLOW_LOCK_FILE`.
-- When multiple healthcheck URLs are resolved for a lane, Launchplane treats them as
-  alternate verification surfaces and accepts the first `2xx` response instead
-  of requiring every URL to succeed.
+- When multiple healthcheck URLs are resolved for a lane, Launchplane treats
+  them as alternate verification surfaces and accepts the first `2xx` response
+  instead of requiring every URL to succeed.
 
 ## Odoo Instance Override Contracts
 
@@ -619,10 +628,10 @@ Use `release-tuples export-catalog --state-dir <state>` to render those minted
 state records as catalog TOML when an operator is ready to review and
 materialize a new tracked baseline.
 
-GitHub PR feedback uses one Launchplane-owned marker comment per PR. The comment is
-a review surface over durable Launchplane records: preview URL/state, manifest and
-baseline tuple, source inputs, artifact identity when present, health status,
-next action, and apply outcome.
+GitHub PR feedback uses one Launchplane-owned marker comment per PR. The
+comment is a review surface over durable Launchplane records: preview URL/state,
+manifest and baseline tuple, source inputs, artifact identity when present,
+health status, next action, and apply outcome.
 
 Launchplane treats product PRs as preview anchors. Companion, infra, and tooling
 repos should remain source inputs only unless a product explicitly maps them to

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -42,6 +42,8 @@ VeriReel product paths:
   - `GET /v1/product-profiles`
   - `GET /v1/product-profiles/{product}`
   - `POST /v1/product-profiles`
+- product config write route:
+  - `POST /v1/product-config/apply`
 - product driver routes:
   - `POST /v1/drivers/generic-web/deploy`
   - `POST /v1/drivers/generic-web/preview-desired-state`
@@ -317,6 +319,17 @@ flow.
 Product profiles are Launchplane-owned product/driver bindings. They are written
 through authenticated service ingress and stored in Launchplane records; product
 repos do not carry repo-local Launchplane lifecycle manifests.
+
+Product config writes use `POST /v1/product-config/apply`. The request carries
+`mode: "dry-run"` or `mode: "apply"`, product/context/instance, non-secret
+runtime values, and write-only managed secret values. Dry-run requires the
+`product_config.plan` action; apply requires `product_config.apply`. The route
+reuses the same planner/writer as `launchplane product-config apply`, returns
+only actions, keys, counts, actor/source metadata, and secret IDs, and fails
+closed when a secret bundle is submitted without
+`LAUNCHPLANE_MASTER_ENCRYPTION_KEY` in the trusted Launchplane runtime. Request
+bodies for this route must not be copied into logs, issues, docs, or workflow
+artifacts because they can contain plaintext secret values.
 
 Generic web deploys use `POST /v1/drivers/generic-web/deploy`. The request names
 the product, target instance, immutable artifact/image reference, and source ref;

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -16,7 +16,10 @@ from click.testing import CliRunner
 from control_plane.cli import main
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.backup_gate_record import BackupGateRecord
-from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRecord, authz_policy_sha256
+from control_plane.contracts.authz_policy_record import (
+    LaunchplaneAuthzPolicyRecord,
+    authz_policy_sha256,
+)
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
@@ -36,6 +39,7 @@ from control_plane.contracts.promotion_record import (
     DeploymentEvidence,
     PromotionRecord,
 )
+from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.service import create_launchplane_service_app
 from control_plane.service_auth import (
     GitHubActionsIdentity,
@@ -201,6 +205,37 @@ def _product_profile_payload(product: str = "sellyouroutboard") -> dict[str, obj
         },
         "updated_at": "2026-04-30T21:30:00Z",
         "source": "test",
+    }
+
+
+def _sqlite_database_url(database_path: Path) -> str:
+    return f"sqlite+pysqlite:///{database_path}"
+
+
+def _product_config_payload() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "mode": "dry-run",
+        "product": "sellyouroutboard",
+        "context": "sellyouroutboard-prod",
+        "instance": "prod",
+        "source_label": "product-config-api-test",
+        "runtime_env": {
+            "scope": "instance",
+            "env": {
+                "CONTACT_EMAIL_MODE": "smtp",
+                "SELLYOUROUTBOARD_SITE_URL": "https://www.sellyouroutboard.com",
+            },
+        },
+        "secrets": [
+            {
+                "name": "SMTP_PASSWORD",
+                "binding_key": "SMTP_PASSWORD",
+                "value": "smtp-secret-value",
+                "scope": "context_instance",
+                "description": "SMTP password",
+            }
+        ],
     }
 
 
@@ -702,7 +737,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
     def test_service_uses_db_backed_authz_policy_when_present(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
-            database_url = f"sqlite+pysqlite:///{Path(temporary_directory_name) / 'launchplane.sqlite3'}"
+            database_url = (
+                f"sqlite+pysqlite:///{Path(temporary_directory_name) / 'launchplane.sqlite3'}"
+            )
             db_policy = LaunchplaneAuthzPolicy.model_validate(
                 {
                     "github_actions": [
@@ -772,9 +809,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 control_plane_root_path=root,
             )
 
-            shell_status, shell_headers, shell_body = _invoke_raw_app(
-                app, method="GET", path="/ui"
-            )
+            shell_status, shell_headers, shell_body = _invoke_raw_app(app, method="GET", path="/ui")
             asset_status, asset_headers, asset_body = _invoke_raw_app(
                 app, method="GET", path="/ui/assets/app.js"
             )
@@ -1020,6 +1055,302 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 method="POST",
                 path="/v1/product-profiles",
                 payload=_product_profile_payload(),
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_product_config_api_dry_run_returns_redacted_plan_without_writes(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-prod"],
+                            "actions": ["product_config.plan"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            with patch.dict(
+                os.environ,
+                {control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"},
+                clear=True,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/product-config/apply",
+                    payload=_product_config_payload(),
+                    headers={"Idempotency-Key": "product-config-dry-run"},
+                )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                runtime_records = store.list_runtime_environment_records()
+                secret_records = store.list_secret_records()
+            finally:
+                store.close()
+
+        response_text = json.dumps(payload, sort_keys=True)
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "dry-run")
+        self.assertEqual(payload["result"]["runtime_environment"]["action"], "created")
+        self.assertEqual(payload["result"]["secrets"][0]["action"], "created")
+        self.assertNotIn("smtp-secret-value", response_text)
+        self.assertNotIn("https://www.sellyouroutboard.com", response_text)
+        self.assertEqual(runtime_records, ())
+        self.assertEqual(secret_records, ())
+
+    def test_product_config_api_apply_writes_runtime_and_managed_secret(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-prod"],
+                            "actions": ["product_config.apply"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            request_payload = {**_product_config_payload(), "mode": "apply"}
+
+            with patch.dict(
+                os.environ,
+                {control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"},
+                clear=True,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/product-config/apply",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "product-config-apply"},
+                )
+                store = PostgresRecordStore(database_url=database_url)
+                store.ensure_schema()
+                try:
+                    runtime_records = store.list_runtime_environment_records()
+                    secret_records = store.list_secret_records()
+                    secret_binding = store.list_secret_bindings(limit=None)[0]
+                finally:
+                    store.close()
+
+        response_text = json.dumps(payload, sort_keys=True)
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "apply")
+        self.assertEqual(payload["result"]["runtime_environment"]["action"], "created")
+        self.assertEqual(payload["result"]["secrets"][0]["action"], "created")
+        self.assertNotIn("smtp-secret-value", response_text)
+        self.assertNotIn("https://www.sellyouroutboard.com", response_text)
+        self.assertEqual(len(runtime_records), 1)
+        self.assertEqual(
+            runtime_records[0],
+            RuntimeEnvironmentRecord(
+                scope="instance",
+                context="sellyouroutboard-prod",
+                instance="prod",
+                env={
+                    "CONTACT_EMAIL_MODE": "smtp",
+                    "SELLYOUROUTBOARD_SITE_URL": "https://www.sellyouroutboard.com",
+                },
+                updated_at=runtime_records[0].updated_at,
+                source_label="product-config-api-test",
+            ),
+        )
+        self.assertEqual(len(secret_records), 1)
+        self.assertEqual(secret_records[0].name, "SMTP_PASSWORD")
+        self.assertEqual(secret_binding.binding_key, "SMTP_PASSWORD")
+
+    def test_product_config_api_rejects_missing_master_key_for_secret_bundle(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-prod"],
+                            "actions": ["product_config.plan"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            with patch.dict(os.environ, {}, clear=True):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/product-config/apply",
+                    payload=_product_config_payload(),
+                )
+
+        self.assertEqual(status_code, 503)
+        self.assertEqual(payload["error"]["code"], "secret_configuration_required")
+
+    def test_product_config_api_rejects_secret_shaped_runtime_key(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-prod"],
+                            "actions": ["product_config.plan"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            request_payload = _product_config_payload()
+            request_payload["secrets"] = []
+            request_payload["runtime_env"] = {"scope": "instance", "env": {"API_TOKEN": "nope"}}
+
+            with patch.dict(
+                os.environ,
+                {control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"},
+                clear=True,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/product-config/apply",
+                    payload=request_payload,
+                )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+
+    def test_product_config_api_apply_requires_apply_authorization(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-prod"],
+                            "actions": ["product_config.plan"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            request_payload = {**_product_config_payload(), "mode": "apply"}
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/product-config/apply",
+                payload=request_payload,
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_product_config_api_rejects_unauthorized_context(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["product_config.plan"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/product-config/apply",
+                payload=_product_config_payload(),
             )
 
         self.assertEqual(status_code, 403)
@@ -1335,9 +1666,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         },
                     },
                 )
-            records = FilesystemRecordStore(state_dir=state_dir).list_preview_inventory_scan_records(
-                context_name="sellyouroutboard-testing"
-            )
+            records = FilesystemRecordStore(
+                state_dir=state_dir
+            ).list_preview_inventory_scan_records(context_name="sellyouroutboard-testing")
 
         self.assertEqual(status_code, 202)
         self.assertEqual(
@@ -1456,7 +1787,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
             with patch(
                 "control_plane.service.evaluate_generic_web_preview_readiness",
-                return_value={"readiness_status": "blocked", "missing_template_env_keys": ["SMTP_HOST"]},
+                return_value={
+                    "readiness_status": "blocked",
+                    "missing_template_env_keys": ["SMTP_HOST"],
+                },
             ) as readiness:
                 status_code, payload = _invoke_app(
                     app,
@@ -1913,9 +2247,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                             "oauth_env": {
                                 "LAUNCHPLANE_GITHUB_CLIENT_ID": "client-id",
                                 "LAUNCHPLANE_PUBLIC_URL": "https://launchplane.example",
-                                "LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS": (
-                                    "info@shinycomputers.com"
-                                ),
+                                "LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS": ("info@shinycomputers.com"),
                             },
                         },
                     },
@@ -3470,8 +3802,16 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     "source": "preview-janitor",
                     "desired_state_id": "preview-desired-state-verireel-testing-20260429T192314Z",
                     "desired_previews": [
-                        {"preview_slug": "pr-42", "anchor_repo": "verireel", "anchor_pr_number": 42},
-                        {"preview_slug": "pr-43", "anchor_repo": "verireel", "anchor_pr_number": 43},
+                        {
+                            "preview_slug": "pr-42",
+                            "anchor_repo": "verireel",
+                            "anchor_pr_number": 42,
+                        },
+                        {
+                            "preview_slug": "pr-43",
+                            "anchor_repo": "verireel",
+                            "anchor_pr_number": 43,
+                        },
                     ],
                 },
             )
@@ -3788,7 +4128,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 202)
         self.assertEqual(payload["status"], "accepted")
-        self.assertEqual(payload["records"]["preview_pr_feedback_id"], feedback_records[0].feedback_id)
+        self.assertEqual(
+            payload["records"]["preview_pr_feedback_id"], feedback_records[0].feedback_id
+        )
         self.assertEqual(payload["result"]["delivery_status"], "skipped")
         self.assertIn("Launchplane preview is ready", payload["result"]["comment_markdown"])
         self.assertIn("GITHUB_TOKEN", feedback_records[0].error_message)
@@ -4145,11 +4487,15 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ).list_preview_lifecycle_cleanup_records(context_name="verireel-testing")
 
         self.assertEqual(status_code, 202)
-        self.assertEqual(payload["records"]["preview_lifecycle_cleanup_id"], cleanup_records[0].cleanup_id)
+        self.assertEqual(
+            payload["records"]["preview_lifecycle_cleanup_id"], cleanup_records[0].cleanup_id
+        )
         self.assertEqual(payload["result"]["status"], "report_only")
         self.assertEqual(payload["result"]["planned_slugs"], ["pr-41"])
         self.assertEqual(cleanup_records[0].apply, False)
-        self.assertEqual(cleanup_records[0].plan_id, "preview-lifecycle-plan-verireel-testing-20260429T195838Z")
+        self.assertEqual(
+            cleanup_records[0].plan_id, "preview-lifecycle-plan-verireel-testing-20260429T195838Z"
+        )
 
     def test_preview_lifecycle_cleanup_endpoint_executes_and_records_destroyed_preview(
         self,
@@ -5676,7 +6022,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
             self.assertEqual(status_code, 202)
             self.assertEqual(payload["status"], "accepted")
-            self.assertEqual(payload["records"]["preview_id"], "preview-verireel-testing-verireel-pr-123")
+            self.assertEqual(
+                payload["records"]["preview_id"], "preview-verireel-testing-verireel-pr-123"
+            )
             self.assertEqual(
                 payload["records"]["generation_id"],
                 "preview-verireel-testing-verireel-pr-123-generation-0001",
@@ -5991,7 +6339,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
             self.assertEqual(status_code, 202)
             self.assertEqual(payload["status"], "accepted")
-            self.assertEqual(payload["records"]["preview_id"], "preview-verireel-testing-verireel-pr-123")
+            self.assertEqual(
+                payload["records"]["preview_id"], "preview-verireel-testing-verireel-pr-123"
+            )
             self.assertEqual(payload["records"]["transition"], "destroyed")
             self.assertEqual(payload["result"]["destroy_status"], "pass")
             self.assertEqual(payload["result"]["application_id"], "preview-app-123")


### PR DESCRIPTION
## Summary
- factor trusted product-config planning/apply logic into a shared module used by the CLI and service
- add authenticated POST /v1/product-config/apply with dry-run/apply modes, product_config.plan/apply authz, DB-backed storage guard, redacted results, and master-key fail-closed behavior
- document the API boundary and add service tests for dry-run, apply, redaction, missing master key, validation failure, and authorization separation

Refs #113

## Validation
- uv run python -m unittest tests.test_service tests.test_runtime_environments
- uv run python -m unittest
- uv run --extra dev ruff check .
- uv run --extra dev ruff check control_plane/product_config.py control_plane/cli.py control_plane/service.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/product_config.py control_plane/cli.py control_plane/service.py tests/test_service.py
- uv run --extra dev mypy control_plane/product_config.py
- npx --yes markdownlint-cli2 docs/operations.md docs/service-boundary.md

## Known existing baselines
- uv run --extra dev mypy control_plane tests still reports pre-existing broad typecheck failures outside this slice, but control_plane/product_config.py is clean.
- uv run --extra dev ruff format --check . still reports pre-existing formatting drift outside touched files; touched Python files are formatted.