### PR TITLE
Redact product config API errors

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2830,9 +2830,13 @@ def create_launchplane_service_app(
                 except control_plane_product_config.ProductConfigError as error:
                     status_code = 400
                     error_code = "invalid_request"
+                    error_message = "Product config request failed validation."
                     if "LAUNCHPLANE_MASTER_ENCRYPTION_KEY" in str(error):
                         status_code = 503
                         error_code = "secret_configuration_required"
+                        error_message = (
+                            "Launchplane service is missing required secret write configuration."
+                        )
                     return _json_response(
                         start_response=start_response,
                         status_code=status_code,
@@ -2841,7 +2845,7 @@ def create_launchplane_service_app(
                             "trace_id": request_trace_id,
                             "error": {
                                 "code": error_code,
-                                "message": str(error),
+                                "message": error_message,
                             },
                         },
                     )


### PR DESCRIPTION
## Summary
- replace product-config validation exception text in service responses with fixed operator-safe messages
- keep the secret master-key failure distinct without echoing exception details

Follow-up to #115 / Refs #113.

## Validation
- uv run --extra dev ruff check control_plane/service.py
- uv run --extra dev ruff format --check control_plane/service.py
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_product_config_api_rejects_missing_master_key_for_secret_bundle tests.test_service.LaunchplaneServiceTests.test_product_config_api_rejects_secret_shaped_runtime_key