### PR TITLE
Add pending preview PR feedback

### DIFF
--- a/control_plane/contracts/preview_pr_feedback_record.py
+++ b/control_plane/contracts/preview_pr_feedback_record.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 PreviewPrFeedbackStatus = Literal[
+    "pending",
     "ready",
     "destroyed",
     "failed",

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1878,6 +1878,7 @@ def _allows_preview_pr_feedback_write(
         return True
 
     lifecycle_actions_by_status = {
+        "pending": ("preview_refresh.execute",),
         "ready": ("preview_refresh.execute",),
         "failed": ("preview_refresh.execute",),
         "destroyed": ("preview_destroy.execute",),

--- a/control_plane/workflows/preview_pr_feedback.py
+++ b/control_plane/workflows/preview_pr_feedback.py
@@ -37,7 +37,14 @@ def _render_preview_pr_feedback_markdown(
     failure_summary: str,
 ) -> str:
     lines = [marker]
-    if status == "ready":
+    if status == "pending":
+        lines.extend(
+            [
+                f"Launchplane preview is waiting for PR #{anchor_pr_number}.",
+                "",
+            ]
+        )
+    elif status == "ready":
         lines.extend(
             [
                 f"Launchplane preview is ready for PR #{anchor_pr_number}.",
@@ -92,7 +99,15 @@ def _render_preview_pr_feedback_markdown(
     if failure_summary:
         lines.append(f"- Failure summary: {failure_summary}")
 
-    if status == "ready":
+    if status == "pending":
+        lines.extend(
+            [
+                "",
+                "Preview prerequisites are still in flight. Launchplane will replace this note "
+                "once the preview is ready or an actual preview failure is known.",
+            ]
+        )
+    elif status == "ready":
         lines.extend(
             [
                 "",

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -529,8 +529,11 @@ report-only and destructive provider cleanup still requires explicit
 `apply=true` from an authorized GitHub Actions workflow. PR feedback goes
 through `POST /v1/previews/pr-feedback`; Launchplane renders and upserts the
 anchored PR comment when runtime GitHub credentials are available, then records
-delivery status. Product repos remain thin adapters for labels, artifact build
-facts, and product-specific health/config hints.
+delivery status. Refresh-capable workflows can publish neutral pending feedback
+before preview publish/provision/verify outcomes are known, then replace it with
+ready or failed feedback after the actual result. Product repos remain thin
+adapters for labels, artifact build facts, and product-specific health/config
+hints.
 
 ### VeriReel Preview Evidence Handoff
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -303,10 +303,10 @@ when its runtime token is available, and stores an append-only feedback record
 with the comment body, delivery action, comment URL, and any skip/failure reason.
 Workflows can be granted explicit `preview_pr_feedback.write`, or generic-web
 preview workflows can reuse their matching lifecycle grants: refresh-capable
-workflows may report ready/failed feedback, and destroy-capable workflows may
-report destroyed/cleanup-failed feedback. Unsupported/fork notices still require
-the explicit feedback grant because they are outside the normal refresh/destroy
-flow.
+workflows may report pending/ready/failed feedback, and destroy-capable workflows
+may report destroyed/cleanup-failed feedback. Unsupported/fork notices still
+require the explicit feedback grant because they are outside the normal
+refresh/destroy flow.
 
 ### Product profile endpoints
 

--- a/tests/test_preview_pr_feedback.py
+++ b/tests/test_preview_pr_feedback.py
@@ -6,6 +6,56 @@ from control_plane.workflows.preview_pr_feedback import build_preview_pr_feedbac
 
 
 class PreviewPrFeedbackWorkflowTests(unittest.TestCase):
+    def test_pending_feedback_renders_neutral_waiting_comment(self) -> None:
+        with (
+            patch(
+                "control_plane.workflows.preview_pr_feedback.resolve_launchplane_github_token",
+                return_value="github-token",
+            ),
+            patch(
+                "control_plane.workflows.preview_pr_feedback.find_github_issue_comment_by_marker",
+                return_value=None,
+            ),
+            patch(
+                "control_plane.workflows.preview_pr_feedback.create_github_issue_comment",
+                return_value={
+                    "id": 123,
+                    "html_url": "https://github.com/every/verireel/pull/43#issuecomment-123",
+                },
+            ) as create_comment,
+            patch(
+                "control_plane.workflows.preview_pr_feedback.update_github_issue_comment"
+            ) as update_comment,
+        ):
+            record = build_preview_pr_feedback_record(
+                control_plane_root=Path("."),
+                product="verireel",
+                context="verireel-testing",
+                source="preview-fork-notice",
+                requested_at="2026-04-30T00:00:00Z",
+                repository="every/verireel",
+                anchor_repo="verireel",
+                anchor_pr_number=43,
+                anchor_pr_url="https://github.com/every/verireel/pull/43",
+                status="pending",
+                run_url="https://github.com/every/verireel/actions/runs/123",
+            )
+
+        self.assertEqual(record.status, "pending")
+        self.assertEqual(record.delivery_status, "delivered")
+        self.assertEqual(record.delivery_action, "created_comment")
+        self.assertIn(
+            "Launchplane preview is waiting for PR #43.",
+            record.comment_markdown,
+        )
+        self.assertIn(
+            "Preview prerequisites are still in flight.",
+            record.comment_markdown,
+        )
+        self.assertNotIn("failed", record.comment_markdown.lower())
+        create_comment.assert_called_once()
+        update_comment.assert_not_called()
+
     def test_cleared_feedback_deletes_existing_comment(self) -> None:
         with (
             patch(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3916,6 +3916,68 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["status"], "accepted")
         self.assertEqual(feedback_records[0].status, "ready")
 
+    def test_preview_pr_feedback_endpoint_accepts_pending_refresh_grant(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/preview-fork-notice.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request_target"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["preview_refresh.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/preview-fork-notice.yml"
+                            "@refs/heads/main"
+                        ),
+                        event_name="pull_request_target",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/pr-feedback",
+                payload={
+                    "product": "sellyouroutboard",
+                    "context": "sellyouroutboard-testing",
+                    "source": "preview-fork-notice",
+                    "repository": "cbusillo/sellyouroutboard",
+                    "anchor_repo": "sellyouroutboard",
+                    "anchor_pr_number": 19,
+                    "anchor_pr_url": "https://github.com/cbusillo/sellyouroutboard/pull/19",
+                    "status": "pending",
+                    "run_url": "https://github.com/cbusillo/sellyouroutboard/actions/runs/123",
+                },
+            )
+
+            feedback_records = FilesystemRecordStore(
+                state_dir=root / "state"
+            ).list_preview_pr_feedback_records(context_name="sellyouroutboard-testing")
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(feedback_records[0].status, "pending")
+        self.assertIn("preview is waiting", payload["result"]["comment_markdown"])
+        self.assertIn("prerequisites are still in flight", payload["result"]["comment_markdown"])
+
     def test_preview_pr_feedback_endpoint_accepts_generic_destroy_grant(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add a neutral `pending` preview PR feedback status to the Launchplane contract
- render pending feedback as a waiting comment instead of failure copy
- allow refresh-capable workflows to send pending feedback and document the contract

## Testing
- `uv run python -m unittest tests.test_preview_pr_feedback tests.test_service.LaunchplaneServiceTests.test_preview_pr_feedback_endpoint_accepts_generic_refresh_grant tests.test_service.LaunchplaneServiceTests.test_preview_pr_feedback_endpoint_accepts_pending_refresh_grant tests.test_service.LaunchplaneServiceTests.test_preview_pr_feedback_endpoint_keeps_unsupported_explicit`
- JetBrains inspection: changed Launchplane files clean

## Dependency
- Required before VeriReel can safely send `pending` preview PR feedback.