### PR TITLE
Harden product config service writes

### DIFF
--- a/control_plane/product_config.py
+++ b/control_plane/product_config.py
@@ -23,6 +23,10 @@ ProductConfigMode = Literal["dry-run", "apply"]
 class ProductConfigError(ValueError):
     """Operator-facing product config validation or planning failure."""
 
+    def __init__(self, message: str, *, code: str = "invalid_request") -> None:
+        super().__init__(message)
+        self.code = code
+
 
 def load_product_config_apply_payload(input_file: Path) -> dict[str, object]:
     try:
@@ -199,6 +203,8 @@ def _product_config_runtime_input(
     if runtime_payload is None:
         return {
             "scope": _default_runtime_scope(context_name=context_name, instance_name=instance_name),
+            "context": context_name,
+            "instance": instance_name,
             "env": {},
         }
     if not isinstance(runtime_payload, dict):
@@ -215,16 +221,31 @@ def _product_config_runtime_input(
             for key, value in runtime_payload.items()
             if key not in {"scope", "context", "instance"}
         }
+    expected_scope = _default_runtime_scope(context_name=context_name, instance_name=instance_name)
     scope = str(
         runtime_payload.get(
-            "scope", _default_runtime_scope(context_name=context_name, instance_name=instance_name)
+            "scope",
+            expected_scope,
         )
         or ""
     ).strip()
+    if scope != expected_scope:
+        raise ProductConfigError(
+            "Product config runtime_env scope must match the top-level target."
+        )
+    runtime_context = str(runtime_payload.get("context", context_name) or "").strip()
+    runtime_instance = str(runtime_payload.get("instance", instance_name) or "").strip()
+    _validate_product_config_target_alignment(
+        target_kind="runtime_env",
+        context_name=runtime_context,
+        instance_name=runtime_instance,
+        expected_context=context_name,
+        expected_instance=instance_name,
+    )
     return {
         "scope": scope,
-        "context": str(runtime_payload.get("context", context_name) or "").strip(),
-        "instance": str(runtime_payload.get("instance", instance_name) or "").strip(),
+        "context": runtime_context,
+        "instance": runtime_instance,
         "env": raw_env,
     }
 
@@ -270,17 +291,26 @@ def _product_config_secret_inputs(
             raise ProductConfigError(f"Product config secret #{index} requires name.")
         if not isinstance(plaintext_value, str) or not plaintext_value.strip():
             raise ProductConfigError(f"Product config secret #{index} requires a non-empty value.")
+        expected_scope = _default_secret_scope(
+            context_name=context_name, instance_name=instance_name
+        )
+        scope = str(raw_secret.get("scope", expected_scope) or "").strip()
+        if scope != expected_scope:
+            raise ProductConfigError(
+                f"Product config secret #{index} scope must match the top-level target."
+            )
+        secret_context = str(raw_secret.get("context", context_name) or "").strip()
+        secret_instance = str(raw_secret.get("instance", instance_name) or "").strip()
+        _validate_product_config_target_alignment(
+            target_kind=f"secret #{index}",
+            context_name=secret_context,
+            instance_name=secret_instance,
+            expected_context=context_name,
+            expected_instance=instance_name,
+        )
         normalized.append(
             {
-                "scope": str(
-                    raw_secret.get(
-                        "scope",
-                        _default_secret_scope(
-                            context_name=context_name, instance_name=instance_name
-                        ),
-                    )
-                    or ""
-                ).strip(),
+                "scope": scope,
                 "integration": str(
                     raw_secret.get(
                         "integration",
@@ -291,12 +321,26 @@ def _product_config_secret_inputs(
                 "name": name,
                 "binding_key": binding_key,
                 "value": plaintext_value,
-                "context": str(raw_secret.get("context", context_name) or "").strip(),
-                "instance": str(raw_secret.get("instance", instance_name) or "").strip(),
+                "context": secret_context,
+                "instance": secret_instance,
                 "description": str(raw_secret.get("description", "") or "").strip(),
             }
         )
     return tuple(normalized)
+
+
+def _validate_product_config_target_alignment(
+    *,
+    target_kind: str,
+    context_name: str,
+    instance_name: str,
+    expected_context: str,
+    expected_instance: str,
+) -> None:
+    if context_name != expected_context or instance_name != expected_instance:
+        raise ProductConfigError(
+            f"Product config {target_kind} target must match the top-level target."
+        )
 
 
 def _require_product_config_master_key_if_needed(secrets: tuple[dict[str, object], ...]) -> None:
@@ -305,7 +349,8 @@ def _require_product_config_master_key_if_needed(secrets: tuple[dict[str, object
     if not any(os.environ.get(key, "").strip() for key in MASTER_ENCRYPTION_KEY_ENV_KEYS):
         expected_keys = " or ".join(MASTER_ENCRYPTION_KEY_ENV_KEYS)
         raise ProductConfigError(
-            f"Product config secrets require {expected_keys} in the trusted Launchplane context."
+            f"Product config secrets require {expected_keys} in the trusted Launchplane context.",
+            code="secret_configuration_required",
         )
 
 

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2828,11 +2828,14 @@ def create_launchplane_service_app(
                         source_label=request.source_label,
                     )
                 except control_plane_product_config.ProductConfigError as error:
+                    error_code = error.code
+                    error_message = "Product config request failed validation."
                     status_code = 400
-                    error_code = "invalid_request"
-                    if "LAUNCHPLANE_MASTER_ENCRYPTION_KEY" in str(error):
+                    if error_code == "secret_configuration_required":
                         status_code = 503
-                        error_code = "secret_configuration_required"
+                        error_message = (
+                            "Launchplane service is missing required secret write configuration."
+                        )
                     return _json_response(
                         start_response=start_response,
                         status_code=status_code,
@@ -2841,7 +2844,7 @@ def create_launchplane_service_app(
                             "trace_id": request_trace_id,
                             "error": {
                                 "code": error_code,
-                                "message": str(error),
+                                "message": error_message,
                             },
                         },
                     )

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -348,8 +348,9 @@ Current derived-state behavior:
   authenticated service API for operator UI use. Submit `mode: "dry-run"` to
   preview with `product_config.plan`, then `mode: "apply"` with
   `product_config.apply` after review. The service response is redacted and the
-  route fails closed when secret writes are requested without the Launchplane
-  master encryption key in the service runtime.
+  route rejects nested runtime or secret targets that differ from the authorized
+  top-level context/instance. It fails closed when secret writes are requested
+  without the Launchplane master encryption key in the service runtime.
 - `environments unset` removes named keys from a DB-backed runtime-environment
   record without reading or printing plaintext values.
 - `environments relabel` updates runtime-environment record source metadata

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -324,12 +324,15 @@ Product config writes use `POST /v1/product-config/apply`. The request carries
 `mode: "dry-run"` or `mode: "apply"`, product/context/instance, non-secret
 runtime values, and write-only managed secret values. Dry-run requires the
 `product_config.plan` action; apply requires `product_config.apply`. The route
-reuses the same planner/writer as `launchplane product-config apply`, returns
-only actions, keys, counts, actor/source metadata, and secret IDs, and fails
-closed when a secret bundle is submitted without
-`LAUNCHPLANE_MASTER_ENCRYPTION_KEY` in the trusted Launchplane runtime. Request
-bodies for this route must not be copied into logs, issues, docs, or workflow
-artifacts because they can contain plaintext secret values.
+authorizes the top-level product/context/instance target and rejects nested
+runtime or secret targets that try to broaden or change that authorized target.
+It reuses the same planner/writer as `launchplane product-config apply`, returns
+only actions, keys, counts, actor/source metadata, and secret IDs, uses generic
+validation messages for rejected requests, and fails closed when a secret bundle
+is submitted without `LAUNCHPLANE_MASTER_ENCRYPTION_KEY` in the trusted
+Launchplane runtime. Request bodies for this route must not be copied into logs,
+issues, docs, or workflow artifacts because they can contain plaintext secret
+values.
 
 Generic web deploys use `POST /v1/drivers/generic-web/deploy`. The request names
 the product, target instance, immutable artifact/image reference, and source ref;

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1232,6 +1232,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 503)
         self.assertEqual(payload["error"]["code"], "secret_configuration_required")
+        self.assertEqual(
+            payload["error"]["message"],
+            "Launchplane service is missing required secret write configuration.",
+        )
+        self.assertNotIn("LAUNCHPLANE_MASTER_ENCRYPTION_KEY", json.dumps(payload))
 
     def test_product_config_api_rejects_secret_shaped_runtime_key(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -1278,6 +1283,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 400)
         self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(payload["error"]["message"], "Product config request failed validation.")
+        self.assertNotIn("API_TOKEN", json.dumps(payload))
 
     def test_product_config_api_apply_requires_apply_authorization(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -1355,6 +1362,140 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_product_config_api_rejects_runtime_env_target_override(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-prod"],
+                            "actions": ["product_config.plan"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            request_payload = _product_config_payload()
+            runtime_env = dict(request_payload["runtime_env"])
+            runtime_env["context"] = "sellyouroutboard-testing"
+            request_payload["runtime_env"] = runtime_env
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/product-config/apply",
+                payload=request_payload,
+            )
+
+        response_text = json.dumps(payload, sort_keys=True)
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(payload["error"]["message"], "Product config request failed validation.")
+        self.assertNotIn("sellyouroutboard-testing", response_text)
+
+    def test_product_config_api_rejects_secret_scope_override(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-prod"],
+                            "actions": ["product_config.plan"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            request_payload = _product_config_payload()
+            request_payload["secrets"] = [{**request_payload["secrets"][0], "scope": "global"}]
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/product-config/apply",
+                payload=request_payload,
+            )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(payload["error"]["message"], "Product config request failed validation.")
+
+    def test_product_config_api_rejects_secret_target_override(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-prod"],
+                            "actions": ["product_config.plan"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            request_payload = _product_config_payload()
+            request_payload["secrets"] = [
+                {
+                    **request_payload["secrets"][0],
+                    "context": "sellyouroutboard-testing",
+                }
+            ]
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/product-config/apply",
+                payload=request_payload,
+            )
+
+        response_text = json.dumps(payload, sort_keys=True)
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(payload["error"]["message"], "Product config request failed validation.")
+        self.assertNotIn("sellyouroutboard-testing", response_text)
 
     def test_generic_web_deploy_route_uses_profile_lane_for_authorization(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- reject nested product-config runtime and secret targets that differ from the top-level authorized context/instance
- replace product-config API exception-string classification with typed error codes and generic public error messages
- document the tightened service boundary and add regression tests for target override and error redaction

Follow-up to PR #115 and PR #116.

## Security review
- The GitHub Advanced Security review on PR #115 was correct when filed, but PR #116 already handled the direct raw-error response on `main`.
- The context/scope override feedback remained valid: the service authorized the top-level request context while the shared planner accepted nested runtime/secret targets.

## Validation
- `uv run python -m unittest tests.test_service tests.test_runtime_environments`
- `uv run --extra dev ruff check --diff control_plane/product_config.py control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/product_config.py control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/product_config.py control_plane/service.py tests/test_service.py`
- `uv run --extra dev mypy control_plane/product_config.py`
- `npx --yes markdownlint-cli2 docs/operations.md docs/service-boundary.md`
- `uv run python -m unittest`
