### PR TITLE
Validate product config scopes before apply

### DIFF
--- a/control_plane/product_config.py
+++ b/control_plane/product_config.py
@@ -18,6 +18,7 @@ from control_plane.workflows.ship import utc_now_timestamp
 MASTER_ENCRYPTION_KEY_ENV_KEYS = ("LAUNCHPLANE_MASTER_ENCRYPTION_KEY",)
 SECRET_SHAPED_RUNTIME_ENV_KEY_PARTS = {"PASSWORD", "TOKEN", "SECRET", "KEY"}
 ProductConfigMode = Literal["dry-run", "apply"]
+_VALID_SECRET_SCOPES: tuple[SecretScope, ...] = ("global", "context", "context_instance")
 
 
 class ProductConfigError(ValueError):
@@ -199,6 +200,8 @@ def _product_config_runtime_input(
     if runtime_payload is None:
         return {
             "scope": _default_runtime_scope(context_name=context_name, instance_name=instance_name),
+            "context": context_name,
+            "instance": instance_name,
             "env": {},
         }
     if not isinstance(runtime_payload, dict):
@@ -215,16 +218,19 @@ def _product_config_runtime_input(
             for key, value in runtime_payload.items()
             if key not in {"scope", "context", "instance"}
         }
+    runtime_context = str(runtime_payload.get("context", context_name) or "").strip()
+    runtime_instance = str(runtime_payload.get("instance", instance_name) or "").strip()
     scope = str(
         runtime_payload.get(
-            "scope", _default_runtime_scope(context_name=context_name, instance_name=instance_name)
+            "scope",
+            _default_runtime_scope(context_name=runtime_context, instance_name=runtime_instance),
         )
         or ""
     ).strip()
     return {
         "scope": scope,
-        "context": str(runtime_payload.get("context", context_name) or "").strip(),
-        "instance": str(runtime_payload.get("instance", instance_name) or "").strip(),
+        "context": runtime_context,
+        "instance": runtime_instance,
         "env": raw_env,
     }
 
@@ -252,7 +258,7 @@ def _normalize_product_config_runtime_env(raw_env: object) -> dict[str, ScalarVa
 def _product_config_secret_inputs(
     payload: dict[str, object], *, context_name: str, instance_name: str
 ) -> tuple[dict[str, object], ...]:
-    raw_secrets = payload.get("secrets", ())
+    raw_secrets = payload.get("secrets", [])
     if raw_secrets is None:
         return ()
     if not isinstance(raw_secrets, list):
@@ -270,33 +276,74 @@ def _product_config_secret_inputs(
             raise ProductConfigError(f"Product config secret #{index} requires name.")
         if not isinstance(plaintext_value, str) or not plaintext_value.strip():
             raise ProductConfigError(f"Product config secret #{index} requires a non-empty value.")
+        secret_context = str(raw_secret.get("context", context_name) or "").strip()
+        secret_instance = str(raw_secret.get("instance", instance_name) or "").strip()
+        scope = str(
+            raw_secret.get(
+                "scope",
+                _default_secret_scope(context_name=secret_context, instance_name=secret_instance),
+            )
+            or ""
+        ).strip()
+        validated_scope = _validate_product_config_secret_scope_route(
+            scope=scope,
+            context_name=secret_context,
+            instance_name=secret_instance,
+            index=index,
+        )
+        integration = str(
+            raw_secret.get(
+                "integration",
+                control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+            )
+            or ""
+        ).strip()
+        if not integration:
+            raise ProductConfigError(f"Product config secret #{index} requires integration.")
         normalized.append(
             {
-                "scope": str(
-                    raw_secret.get(
-                        "scope",
-                        _default_secret_scope(
-                            context_name=context_name, instance_name=instance_name
-                        ),
-                    )
-                    or ""
-                ).strip(),
-                "integration": str(
-                    raw_secret.get(
-                        "integration",
-                        control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
-                    )
-                    or ""
-                ).strip(),
+                "scope": validated_scope,
+                "integration": integration,
                 "name": name,
                 "binding_key": binding_key,
                 "value": plaintext_value,
-                "context": str(raw_secret.get("context", context_name) or "").strip(),
-                "instance": str(raw_secret.get("instance", instance_name) or "").strip(),
+                "context": secret_context,
+                "instance": secret_instance,
                 "description": str(raw_secret.get("description", "") or "").strip(),
             }
         )
     return tuple(normalized)
+
+
+def _validate_product_config_secret_scope_route(
+    *, scope: str, context_name: str, instance_name: str, index: int
+) -> SecretScope:
+    if scope not in _VALID_SECRET_SCOPES:
+        expected_scopes = ", ".join(_VALID_SECRET_SCOPES)
+        raise ProductConfigError(
+            f"Product config secret #{index} has unsupported scope {scope!r}; "
+            f"expected one of {expected_scopes}."
+        )
+    if scope == "global":
+        if context_name or instance_name:
+            raise ProductConfigError(
+                f"Product config secret #{index} uses global scope and must not set "
+                "context or instance."
+            )
+        return "global"
+    if scope == "context":
+        if not context_name or instance_name:
+            raise ProductConfigError(
+                f"Product config secret #{index} uses context scope and must set context "
+                "without instance."
+            )
+        return "context"
+    if not context_name or not instance_name:
+        raise ProductConfigError(
+            f"Product config secret #{index} uses context_instance scope and must set "
+            "context and instance."
+        )
+    return "context_instance"
 
 
 def _require_product_config_master_key_if_needed(secrets: tuple[dict[str, object], ...]) -> None:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -343,7 +343,11 @@ Current derived-state behavior:
   managed secret records while returning only key names, actions, counts, actor,
   and source metadata. Use it from a live Launchplane context that already has
   current `LAUNCHPLANE_DATABASE_URL`; bundles with secrets also require
-  `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`.
+  `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`. Runtime and secret scopes default from
+  the effective route they will write: top-level `context`/`instance` unless the
+  nested `runtime_env` object or an individual secret supplies its own route.
+  Dry-run validates secret scope/route compatibility before reporting a plan, so
+  apply does not discover invalid secret scopes after writing earlier secrets.
 - `POST /v1/product-config/apply` exposes the same planner/writer through the
   authenticated service API for operator UI use. Submit `mode: "dry-run"` to
   preview with `product_config.plan`, then `mode: "apply"` with
@@ -388,8 +392,11 @@ Example product config bundle shape:
 ```
 
 `runtime_env` values are non-secret scalar values. `secrets` default to the
-`runtime_environment` integration and the current context/instance, which makes
-them available as managed runtime environment overlays.
+`runtime_environment` integration and the current or per-secret
+context/instance, which makes them available as managed runtime environment
+overlays. Secret scope routes must be compatible: `global` has no context or
+instance, `context` has context only, and `context_instance` has both context and
+instance.
 
 - `environments show-live-target` reads the live Dokploy target payload for a
   tracked route and reports whether the target is ready for artifact-backed

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -93,7 +93,9 @@ title: Secrets
   values or writing records. `--apply` writes non-secret runtime keys and
   managed secret values through the same DB-backed stores. Run this command only
   from a trusted Launchplane context with current `LAUNCHPLANE_DATABASE_URL` and,
-  when secrets are present, `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`.
+  when secrets are present, `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`. Dry-run and
+  apply both reject invalid secret scopes or scope/context/instance mismatches
+  before any managed secret write starts.
 - `uv run launchplane environments unset --scope <scope> --key KEY` removes
   stale keys from DB-backed runtime-environment records without reading or
   printing plaintext values.

--- a/tests/test_runtime_environments.py
+++ b/tests/test_runtime_environments.py
@@ -814,6 +814,164 @@ ODOO_DB_PASSWORD = "file-secret"
             finally:
                 store.close()
 
+    def test_product_config_apply_defaults_runtime_scope_from_nested_route(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            input_file = control_plane_root / "product-config.json"
+            input_file.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "runtime_env": {
+                            "context": "sellyouroutboard",
+                            "instance": "prod",
+                            "env": {"CONTACT_EMAIL_MODE": "smtp"},
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "product-config",
+                    "apply",
+                    "--database-url",
+                    database_url,
+                    "--input-file",
+                    str(input_file),
+                    "--apply",
+                ],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            payload = json.loads(result.output)
+            self.assertEqual(payload["runtime_environment"]["scope"], "instance")
+            self.assertEqual(payload["runtime_environment"]["context"], "sellyouroutboard")
+            self.assertEqual(payload["runtime_environment"]["instance"], "prod")
+
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                runtime_records = store.list_runtime_environment_records()
+                self.assertEqual(len(runtime_records), 1)
+                self.assertEqual(runtime_records[0].scope, "instance")
+                self.assertEqual(runtime_records[0].context, "sellyouroutboard")
+                self.assertEqual(runtime_records[0].instance, "prod")
+            finally:
+                store.close()
+
+    def test_product_config_apply_defaults_secret_scope_from_per_secret_route(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            input_file = control_plane_root / "product-config.json"
+            input_file.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "runtime_env": {},
+                        "secrets": [
+                            {
+                                "name": "smtp-password",
+                                "binding_key": "SMTP_PASSWORD",
+                                "value": "smtp-secret-value",
+                                "context": "sellyouroutboard",
+                                "instance": "prod",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_MASTER_ENCRYPTION_KEY": "test-master-key"},
+                clear=True,
+            ):
+                result = CliRunner().invoke(
+                    main,
+                    [
+                        "product-config",
+                        "apply",
+                        "--database-url",
+                        database_url,
+                        "--input-file",
+                        str(input_file),
+                        "--dry-run",
+                    ],
+                )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            payload = json.loads(result.output)
+            self.assertEqual(payload["secrets"][0]["scope"], "context_instance")
+            self.assertEqual(payload["secrets"][0]["context"], "sellyouroutboard")
+            self.assertEqual(payload["secrets"][0]["instance"], "prod")
+
+    def test_product_config_apply_rejects_invalid_secret_scope_before_writes(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            input_file = control_plane_root / "product-config.json"
+            input_file.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "runtime_env": {},
+                        "secrets": [
+                            {
+                                "scope": "global",
+                                "name": "valid-secret",
+                                "binding_key": "VALID_SECRET",
+                                "value": "first-secret-value",
+                            },
+                            {
+                                "scope": "not-a-scope",
+                                "name": "invalid-secret",
+                                "binding_key": "INVALID_SECRET",
+                                "value": "second-secret-value",
+                            },
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_MASTER_ENCRYPTION_KEY": "test-master-key"},
+                clear=True,
+            ):
+                result = CliRunner().invoke(
+                    main,
+                    [
+                        "product-config",
+                        "apply",
+                        "--database-url",
+                        database_url,
+                        "--input-file",
+                        str(input_file),
+                        "--apply",
+                    ],
+                )
+
+            self.assertNotEqual(result.exit_code, 0)
+            self.assertIn("unsupported scope 'not-a-scope'", result.output)
+            self.assertNotIn("first-secret-value", result.output)
+            self.assertNotIn("second-secret-value", result.output)
+
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                self.assertEqual(store.list_secret_records(), ())
+                self.assertEqual(store.list_secret_bindings(limit=None), ())
+            finally:
+                store.close()
+
     def test_product_config_apply_requires_master_key_for_secrets(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary

- Preserve the current product-config rule that nested `runtime_env` and secret routes must match the top-level target, while validating those routes/scopes before planning or applying.
- Validate per-secret scope/context/instance compatibility up front so invalid secret scopes cannot be discovered after earlier secrets are written.
- Treat omitted/null `secrets` as an empty list and document dry-run/apply parity for secret route validation.

## Validation

- `uv run python -m unittest tests.test_runtime_environments`
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_product_config_api_dry_run_returns_redacted_plan_without_writes tests.test_service.LaunchplaneServiceTests.test_product_config_api_apply_writes_runtime_and_managed_secret tests.test_service.LaunchplaneServiceTests.test_product_config_api_rejects_missing_master_key_for_secret_bundle tests.test_service.LaunchplaneServiceTests.test_product_config_api_rejects_secret_shaped_runtime_key tests.test_service.LaunchplaneServiceTests.test_product_config_api_apply_requires_apply_authorization tests.test_service.LaunchplaneServiceTests.test_product_config_api_rejects_unauthorized_context`
- `uv run --extra dev ruff check --fix --diff control_plane/product_config.py tests/test_runtime_environments.py`
- `uv run --extra dev ruff check control_plane/product_config.py tests/test_runtime_environments.py`
- `uv run --extra dev mypy control_plane/product_config.py tests/test_runtime_environments.py`
- `uv run python -m unittest`

## Notes

A broader `uv run --extra dev mypy control_plane tests/test_runtime_environments.py` still reports existing unrelated baseline errors across the project, so the typed validation here is scoped to touched Python files.