### PR TITLE
Add runtime env live target apply

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -7825,6 +7825,166 @@ def _sync_live_target_from_tracked_contract(
     return payload
 
 
+def _runtime_env_live_target_delta(
+    *,
+    desired_env_map: dict[str, str],
+    live_env_map: dict[str, str],
+) -> dict[str, object]:
+    desired_keys = sorted(desired_env_map)
+    missing_keys = [env_key for env_key in desired_keys if env_key not in live_env_map]
+    different_keys = [
+        env_key
+        for env_key in desired_keys
+        if env_key in live_env_map and live_env_map[env_key] != desired_env_map[env_key]
+    ]
+    unchanged_keys = [
+        env_key
+        for env_key in desired_keys
+        if env_key in live_env_map and live_env_map[env_key] == desired_env_map[env_key]
+    ]
+    return {
+        "desired_key_count": len(desired_keys),
+        "live_key_count": len(live_env_map),
+        "missing_keys": missing_keys,
+        "different_keys": different_keys,
+        "changed_keys": sorted({*missing_keys, *different_keys}),
+        "unchanged_key_count": len(unchanged_keys),
+    }
+
+
+def _apply_live_target_runtime_environment(
+    *,
+    context_name: str,
+    instance_name: str,
+    apply_changes: bool,
+    deploy: bool,
+    no_cache: bool,
+    deploy_timeout_seconds: int | None,
+) -> dict[str, object]:
+    control_plane_root = _control_plane_root()
+    source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
+        control_plane_root=control_plane_root,
+    )
+    target_definition = _require_dokploy_target_definition(
+        source_of_truth=source_of_truth,
+        context_name=context_name,
+        instance_name=instance_name,
+        operation_name="Runtime environment live target apply",
+    )
+    desired_env_map = control_plane_runtime_environments.resolve_runtime_environment_values(
+        control_plane_root=control_plane_root,
+        context_name=context_name,
+        instance_name=instance_name,
+    )
+    if not desired_env_map:
+        raise click.ClickException(
+            f"No Launchplane runtime environment values resolved for {context_name}/{instance_name}."
+        )
+
+    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
+    target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
+        host=host,
+        token=token,
+        target_type=target_definition.target_type,
+        target_id=target_definition.target_id,
+    )
+    live_env_map = control_plane_dokploy.parse_dokploy_env_text(
+        str(target_payload.get("env") or "")
+    )
+    initial_delta = _runtime_env_live_target_delta(
+        desired_env_map=desired_env_map,
+        live_env_map=live_env_map,
+    )
+    changed_keys = initial_delta["changed_keys"]
+    changed_key_count = len(changed_keys) if isinstance(changed_keys, list) else 0
+    deploy_result: dict[str, str] | None = None
+    verification = {
+        "status": "skipped",
+        "reason": "dry_run" if not apply_changes else "no_runtime_env_changes",
+    }
+
+    if apply_changes and changed_key_count:
+        refreshed_payload = control_plane_dokploy.fetch_dokploy_target_payload(
+            host=host,
+            token=token,
+            target_type=target_definition.target_type,
+            target_id=target_definition.target_id,
+        )
+        refreshed_env_map = control_plane_dokploy.parse_dokploy_env_text(
+            str(refreshed_payload.get("env") or "")
+        )
+        updated_env_map = dict(refreshed_env_map)
+        updated_env_map.update(desired_env_map)
+        control_plane_dokploy.update_dokploy_target_env(
+            host=host,
+            token=token,
+            target_type=target_definition.target_type,
+            target_id=target_definition.target_id,
+            target_payload=refreshed_payload,
+            env_text=control_plane_dokploy.serialize_dokploy_env_text(updated_env_map),
+        )
+        persisted_payload = control_plane_dokploy.fetch_dokploy_target_payload(
+            host=host,
+            token=token,
+            target_type=target_definition.target_type,
+            target_id=target_definition.target_id,
+        )
+        persisted_env_map = control_plane_dokploy.parse_dokploy_env_text(
+            str(persisted_payload.get("env") or "")
+        )
+        verification_delta = _runtime_env_live_target_delta(
+            desired_env_map=desired_env_map,
+            live_env_map=persisted_env_map,
+        )
+        verification_changed_keys = verification_delta["changed_keys"]
+        verification = {
+            "status": "pass" if verification_changed_keys == [] else "fail",
+            "missing_keys": verification_delta["missing_keys"],
+            "different_keys": verification_delta["different_keys"],
+            "verified_key_count": verification_delta["unchanged_key_count"],
+        }
+        if verification["status"] != "pass":
+            raise click.ClickException(
+                "Dokploy target env did not persist all Launchplane runtime environment keys."
+            )
+
+    if apply_changes and deploy:
+        deploy_result = _trigger_and_wait_for_dokploy_target_deploy(
+            host=host,
+            token=token,
+            target_type=target_definition.target_type,
+            target_id=target_definition.target_id,
+            deploy_timeout_seconds=control_plane_dokploy.resolve_ship_timeout_seconds(
+                timeout_override_seconds=deploy_timeout_seconds,
+                target_definition=target_definition,
+            ),
+            no_cache=no_cache,
+        )
+
+    return {
+        "status": "ok",
+        "mode": "apply" if apply_changes else "dry-run",
+        "context": context_name,
+        "instance": instance_name,
+        "tracked_target": {
+            "target_id": target_definition.target_id,
+            "target_type": target_definition.target_type,
+            "target_name": target_definition.target_name,
+        },
+        "runtime_environment": initial_delta,
+        "apply": {
+            "applied": apply_changes,
+            "env_updated": bool(apply_changes and changed_key_count),
+            "verification": verification,
+        },
+        "deploy": {
+            "requested": deploy,
+            "triggered": deploy_result is not None,
+            **({"result": deploy_result} if deploy_result is not None else {}),
+        },
+    }
+
+
 def _sync_artifact_image_reference_for_target(
     *,
     context_name: str,
@@ -12391,6 +12551,38 @@ def environments_sync_live_target(
         context_name=context_name,
         instance_name=instance_name,
         apply_changes=apply_changes,
+    )
+    click.echo(json.dumps(payload, indent=2, sort_keys=True))
+
+
+@environments.command("apply-live-target")
+@click.option("--context", "context_name", required=True)
+@click.option("--instance", "instance_name", required=True)
+@click.option("--dry-run", "dry_run", is_flag=True, default=False)
+@click.option("--apply", "apply_changes", is_flag=True, default=False)
+@click.option("--deploy", is_flag=True, default=False)
+@click.option("--no-cache", is_flag=True, default=False)
+@click.option("--deploy-timeout-seconds", type=int, default=None, show_default=False)
+def environments_apply_live_target(
+    context_name: str,
+    instance_name: str,
+    dry_run: bool,
+    apply_changes: bool,
+    deploy: bool,
+    no_cache: bool,
+    deploy_timeout_seconds: int | None,
+) -> None:
+    if dry_run == apply_changes:
+        raise click.ClickException("Choose exactly one of --dry-run or --apply.")
+    if dry_run and (deploy or no_cache or deploy_timeout_seconds is not None):
+        raise click.ClickException("Deploy options require --apply.")
+    payload = _apply_live_target_runtime_environment(
+        context_name=context_name,
+        instance_name=instance_name,
+        apply_changes=apply_changes,
+        deploy=deploy,
+        no_cache=no_cache,
+        deploy_timeout_seconds=deploy_timeout_seconds,
     )
     click.echo(json.dumps(payload, indent=2, sort_keys=True))
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -359,6 +359,13 @@ Current derived-state behavior:
   keys without echoing plaintext values.
 - `environments resolve` reads the control-plane-owned runtime environment
   contract for a context and instance.
+- `environments apply-live-target --dry-run|--apply` resolves the DB-backed
+  runtime environment and managed secret overlay for a tracked Dokploy target,
+  compares it against the live target env by key, and can apply those keys
+  without requiring an artifact manifest. It preserves unrelated live env keys,
+  verifies persistence by key/count metadata only, and never prints plaintext
+  env or secret values. Add `--deploy` with `--apply` when the app should be
+  explicitly redeployed/reloaded after the config update.
 - TOML/env files are not runtime import surfaces; use DB-native
   runtime-environment records and managed secrets instead.
 - Product repos and GitHub issues must not contain product secret values. Put
@@ -395,6 +402,8 @@ them available as managed runtime environment overlays.
 - `environments show-live-target` reads the live Dokploy target payload for a
   tracked route and reports whether the target is ready for artifact-backed
   split-repo execution.
+- `environments apply-live-target` applies Launchplane DB-backed runtime env and
+  managed secret overlays to a tracked live target without shipping an artifact.
 - `environments sync-live-target --apply` pushes the tracked Dokploy source and
   tracked env overlay for a route into the live target before re-reading the
   artifact-readiness summary.

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -668,6 +668,306 @@ protected_store_keys = ["yps-your-part-supplier", "spare-store"]
             "git@github.com:cbusillo/odoo-devkit.git",
         )
 
+    def test_apply_live_target_dry_run_reports_runtime_key_delta_without_values(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                store.write_runtime_environment_record(
+                    RuntimeEnvironmentRecord(
+                        scope="instance",
+                        context="sellyouroutboard-testing",
+                        instance="prod",
+                        env={"CONTACT_EMAIL_MODE": "runtime-private-value"},
+                        updated_at="2026-05-01T00:00:00Z",
+                        source_label="test",
+                    )
+                )
+                _seed_dokploy_target_records(
+                    store=store,
+                    payload="""
+schema_version = 2
+
+[[targets]]
+context = "sellyouroutboard-testing"
+instance = "prod"
+target_id = "application-syo-prod"
+target_type = "application"
+target_name = "syo-prod-app"
+
+[targets.env]
+TRACKED_ONLY = "tracked-private-value"
+""",
+                )
+                with patch.dict(
+                    os.environ,
+                    {
+                        "LAUNCHPLANE_DATABASE_URL": database_url,
+                        control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                    },
+                    clear=True,
+                ):
+                    control_plane_secrets.write_secret_value(
+                        record_store=store,
+                        scope="context_instance",
+                        integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+                        name="smtp-password",
+                        plaintext_value="smtp-secret-value",
+                        binding_key="SMTP_PASSWORD",
+                        context_name="sellyouroutboard-testing",
+                        instance_name="prod",
+                        actor="test",
+                    )
+            finally:
+                store.close()
+
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "LAUNCHPLANE_DATABASE_URL": database_url,
+                        control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                    },
+                    clear=True,
+                ),
+                patch(
+                    "control_plane.dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "token-123"),
+                ),
+                patch(
+                    "control_plane.dokploy.fetch_dokploy_target_payload",
+                    return_value={
+                        "applicationId": "application-syo-prod",
+                        "name": "syo-prod-app",
+                        "env": "CONTACT_EMAIL_MODE=old-value\nEXISTING=value\n",
+                    },
+                ),
+                patch("control_plane.dokploy.update_dokploy_target_env") as update_env,
+            ):
+                result = runner.invoke(
+                    main,
+                    [
+                        "environments",
+                        "apply-live-target",
+                        "--context",
+                        "sellyouroutboard-testing",
+                        "--instance",
+                        "prod",
+                        "--dry-run",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        update_env.assert_not_called()
+        self.assertNotIn("runtime-private-value", result.output)
+        self.assertNotIn("tracked-private-value", result.output)
+        self.assertNotIn("smtp-secret-value", result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["mode"], "dry-run")
+        self.assertEqual(payload["tracked_target"]["target_type"], "application")
+        self.assertEqual(payload["runtime_environment"]["desired_key_count"], 3)
+        self.assertEqual(payload["runtime_environment"]["different_keys"], ["CONTACT_EMAIL_MODE"])
+        self.assertEqual(
+            payload["runtime_environment"]["missing_keys"], ["SMTP_PASSWORD", "TRACKED_ONLY"]
+        )
+        self.assertFalse(payload["apply"]["env_updated"])
+        self.assertFalse(payload["deploy"]["triggered"])
+
+    def test_apply_live_target_updates_runtime_env_and_verifies_without_values(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                store.write_runtime_environment_record(
+                    RuntimeEnvironmentRecord(
+                        scope="instance",
+                        context="sellyouroutboard-testing",
+                        instance="prod",
+                        env={"CONTACT_EMAIL_MODE": "smtp"},
+                        updated_at="2026-05-01T00:00:00Z",
+                        source_label="test",
+                    )
+                )
+                _seed_dokploy_target_records(
+                    store=store,
+                    payload="""
+schema_version = 2
+
+[[targets]]
+context = "sellyouroutboard-testing"
+instance = "prod"
+target_id = "application-syo-prod"
+target_type = "application"
+target_name = "syo-prod-app"
+deploy_timeout_seconds = 77
+""",
+                )
+            finally:
+                store.close()
+
+            captured_env_updates: list[dict[str, object]] = []
+
+            def fetch_target_payload(**_kwargs: object) -> dict[str, object]:
+                env_text = "CONTACT_EMAIL_MODE=old\nEXISTING=value\n"
+                if captured_env_updates:
+                    env_text = str(captured_env_updates[-1]["env_text"])
+                return {
+                    "applicationId": "application-syo-prod",
+                    "name": "syo-prod-app",
+                    "env": env_text,
+                }
+
+            with (
+                patch.dict(os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True),
+                patch(
+                    "control_plane.dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "token-123"),
+                ),
+                patch(
+                    "control_plane.dokploy.fetch_dokploy_target_payload",
+                    side_effect=fetch_target_payload,
+                ),
+                patch(
+                    "control_plane.dokploy.update_dokploy_target_env",
+                    side_effect=lambda **kwargs: captured_env_updates.append(kwargs),
+                ),
+            ):
+                result = runner.invoke(
+                    main,
+                    [
+                        "environments",
+                        "apply-live-target",
+                        "--context",
+                        "sellyouroutboard-testing",
+                        "--instance",
+                        "prod",
+                        "--apply",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertEqual(len(captured_env_updates), 1)
+        env_text = str(captured_env_updates[0]["env_text"])
+        self.assertIn("CONTACT_EMAIL_MODE=smtp", env_text)
+        self.assertIn("EXISTING=value", env_text)
+        self.assertNotIn("CONTACT_EMAIL_MODE=old", result.output)
+        self.assertNotIn("CONTACT_EMAIL_MODE=smtp", result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["mode"], "apply")
+        self.assertTrue(payload["apply"]["env_updated"])
+        self.assertEqual(payload["apply"]["verification"]["status"], "pass")
+        self.assertFalse(payload["deploy"]["triggered"])
+
+    def test_apply_live_target_deploy_is_explicit(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                store.write_runtime_environment_record(
+                    RuntimeEnvironmentRecord(
+                        scope="instance",
+                        context="sellyouroutboard-testing",
+                        instance="prod",
+                        env={"CONTACT_EMAIL_MODE": "smtp"},
+                        updated_at="2026-05-01T00:00:00Z",
+                        source_label="test",
+                    )
+                )
+                _seed_dokploy_target_records(
+                    store=store,
+                    payload="""
+schema_version = 2
+
+[[targets]]
+context = "sellyouroutboard-testing"
+instance = "prod"
+target_id = "application-syo-prod"
+target_type = "application"
+target_name = "syo-prod-app"
+deploy_timeout_seconds = 77
+""",
+                )
+            finally:
+                store.close()
+
+            with (
+                patch.dict(os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True),
+                patch(
+                    "control_plane.dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "token-123"),
+                ),
+                patch(
+                    "control_plane.dokploy.fetch_dokploy_target_payload",
+                    return_value={
+                        "applicationId": "application-syo-prod",
+                        "name": "syo-prod-app",
+                        "env": "CONTACT_EMAIL_MODE=smtp\n",
+                    },
+                ),
+                patch(
+                    "control_plane.dokploy.latest_deployment_for_target",
+                    return_value={"deploymentId": "before"},
+                ),
+                patch("control_plane.dokploy.trigger_deployment") as trigger_deployment,
+                patch(
+                    "control_plane.dokploy.wait_for_target_deployment",
+                    return_value="deployment=after status=done",
+                ) as wait_for_target_deployment,
+            ):
+                result = runner.invoke(
+                    main,
+                    [
+                        "environments",
+                        "apply-live-target",
+                        "--context",
+                        "sellyouroutboard-testing",
+                        "--instance",
+                        "prod",
+                        "--apply",
+                        "--deploy",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        trigger_deployment.assert_called_once()
+        self.assertEqual(trigger_deployment.call_args.kwargs["target_type"], "application")
+        wait_for_target_deployment.assert_called_once()
+        self.assertEqual(wait_for_target_deployment.call_args.kwargs["timeout_seconds"], 77)
+        payload = json.loads(result.output)
+        self.assertFalse(payload["apply"]["env_updated"])
+        self.assertTrue(payload["deploy"]["triggered"])
+        self.assertEqual(
+            payload["deploy"]["result"]["deployment_result"], "deployment=after status=done"
+        )
+
+    def test_apply_live_target_rejects_deploy_options_for_dry_run(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "environments",
+                "apply-live-target",
+                "--context",
+                "sellyouroutboard-testing",
+                "--instance",
+                "prod",
+                "--dry-run",
+                "--deploy",
+            ],
+        )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Deploy options require --apply", result.output)
+
     def test_read_control_plane_dokploy_source_of_truth_prefers_postgres_target_ids_without_file_fallback(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- add `launchplane environments apply-live-target --dry-run|--apply` for applying resolved DB-backed runtime env and managed secret overlays to tracked Dokploy targets without an artifact manifest
- preserve unrelated live target env keys, verify persisted runtime keys by redacted key/count metadata, and keep deploy/reload behind explicit `--deploy`
- document the runtime-env-only apply path and add focused CLI tests for dry-run redaction, apply verification, explicit deploy, and deploy option validation

Closes #114

## Validation
- `uv run python -m unittest tests.test_dokploy.DokployConfigTests.test_apply_live_target_dry_run_reports_runtime_key_delta_without_values tests.test_dokploy.DokployConfigTests.test_apply_live_target_updates_runtime_env_and_verifies_without_values tests.test_dokploy.DokployConfigTests.test_apply_live_target_deploy_is_explicit tests.test_dokploy.DokployConfigTests.test_apply_live_target_rejects_deploy_options_for_dry_run`
- `uv run python -m unittest tests.test_dokploy tests.test_runtime_environments`
- `uv run python -m unittest`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check control_plane/cli.py tests/test_dokploy.py`
- `npx --yes markdownlint-cli2 docs/operations.md`

## Notes
- This is the CLI/trusted-context slice only. A service API/UI wrapper can follow once this behavior is proven.