### PR TITLE
Harden product config submit safety

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "pnpm@10.10.0",
   "engines": {
-    "node": ">=22 <23"
+    "node": ">=22.12.0"
   },
   "scripts": {
     "build": "pnpm typecheck && vite build && node scripts/assert-production-fixtures.mjs",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,7 +23,7 @@ import {
   Trash2,
   XCircle
 } from "lucide-react";
-import { ReactNode, useEffect, useMemo, useState } from "react";
+import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { LaunchplaneApiError, applyProductConfig, listDrivers, logout, readAuthSession, readDriverView } from "./api";
 import type {
   AuthIdentity,
@@ -554,6 +554,7 @@ function ProductConfigPanel({
   const [submitting, setSubmitting] = useState<ProductConfigApplyRequest["mode"] | null>(null);
   const [panelError, setPanelError] = useState("");
   const [traceId, setTraceId] = useState("");
+  const requestSequence = useRef(0);
 
   useEffect(() => {
     setProduct(productDefault);
@@ -570,17 +571,23 @@ function ProductConfigPanel({
     const filledFields = [row.name, row.bindingKey, row.value].filter((value) => value.trim()).length;
     return filledFields > 0 && filledFields < 3;
   });
-  const showPartialSecretWarning = partialSecretRows.length > 0 && !result;
+  const showPartialSecretWarning = partialSecretRows.length > 0 && !result && !panelError && !submitting;
   const hasConfigInput = runtimeInputCount > 0 || completeSecretRows.length > 0;
   const canDryRun = Boolean(product.trim() && hasConfigInput && partialSecretRows.length === 0 && !disabled && !submitting);
   const canApply = Boolean(pendingApplyPayload && reviewed && !disabled && !submitting);
 
   function clearReviewState() {
+    requestSequence.current += 1;
     setResult(null);
     setPendingApplyPayload(null);
     setReviewed(false);
+    setSubmitting(null);
     setPanelError("");
     setTraceId("");
+  }
+
+  function clearRenderedSecretValues() {
+    setSecretRows((rows) => rows.map((row) => ({ ...row, value: "" })));
   }
 
   function updateRuntimeRow(rowId: string, patch: Partial<RuntimeConfigRow>) {
@@ -654,17 +661,25 @@ function ProductConfigPanel({
 
   function runDryRun() {
     const payload = buildPayload("dry-run");
+    requestSequence.current += 1;
+    const requestId = requestSequence.current;
     setSubmitting("dry-run");
     setPanelError("");
     setTraceId("");
+    clearRenderedSecretValues();
     applyConfig(payload)
       .then((payloadResult) => {
+        if (requestSequence.current !== requestId) {
+          return;
+        }
         setResult(payloadResult);
         setPendingApplyPayload({ ...payload, mode: "apply" });
         setReviewed(false);
-        setSecretRows((rows) => rows.map((row) => ({ ...row, value: "" })));
       })
       .catch((apiError: unknown) => {
+        if (requestSequence.current !== requestId) {
+          return;
+        }
         if (apiError instanceof LaunchplaneApiError) {
           setPanelError(apiError.message);
           setTraceId(apiError.traceId);
@@ -674,24 +689,37 @@ function ProductConfigPanel({
           setPanelError("Product config request failed.");
         }
       })
-      .finally(() => setSubmitting(null));
+      .finally(() => {
+        if (requestSequence.current === requestId) {
+          setSubmitting(null);
+        }
+      });
   }
 
   function runApply() {
     if (!pendingApplyPayload) {
       return;
     }
+    const payload = pendingApplyPayload;
+    requestSequence.current += 1;
+    const requestId = requestSequence.current;
     setSubmitting("apply");
     setPanelError("");
     setTraceId("");
-    applyConfig(pendingApplyPayload)
+    setPendingApplyPayload(null);
+    setReviewed(false);
+    clearRenderedSecretValues();
+    applyConfig(payload)
       .then((payloadResult) => {
+        if (requestSequence.current !== requestId) {
+          return;
+        }
         setResult(payloadResult);
-        setPendingApplyPayload(null);
-        setReviewed(false);
-        setSecretRows((rows) => rows.map((row) => ({ ...row, value: "" })));
       })
       .catch((apiError: unknown) => {
+        if (requestSequence.current !== requestId) {
+          return;
+        }
         if (apiError instanceof LaunchplaneApiError) {
           setPanelError(apiError.message);
           setTraceId(apiError.traceId);
@@ -701,7 +729,11 @@ function ProductConfigPanel({
           setPanelError("Product config apply failed.");
         }
       })
-      .finally(() => setSubmitting(null));
+      .finally(() => {
+        if (requestSequence.current === requestId) {
+          setSubmitting(null);
+        }
+      });
   }
 
   return (


### PR DESCRIPTION
## Summary
- ignore stale product-config dry-run/apply callbacks after the form changes or a newer request starts
- clear rendered secret values immediately on submit, including failed dry-run/apply attempts
- clear the pending apply payload before apply returns so plaintext is not retained after failed apply
- relax the frontend Node engine to the toolchain-supported floor (`>=22.12.0`) so local Node 25 no longer emits the unsupported-engine warning

Refs #113
Addresses Codex review comments on #122: https://github.com/cbusillo/launchplane/pull/122#discussion_r3174195317 and https://github.com/cbusillo/launchplane/pull/122#discussion_r3174195322

## Validation
- pnpm --dir frontend validate
- uv run --with pytest python -m pytest tests/test_service.py -k product_config
- uv run --with pytest python -m pytest tests/test_runtime_environments.py -k product_config
- ui-browser fixture flow: dry-run -> reviewed apply, secret field empty after dry-run/apply, no fixture plaintext secret in visible text
- git diff --check