### PR TITLE
Add runtime environment delete-record command

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -70,7 +70,10 @@ from control_plane.contracts.promotion_record import (
     ReleaseStatus,
 )
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
-from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
+from control_plane.contracts.runtime_environment_record import (
+    RuntimeEnvironmentDeleteEvent,
+    RuntimeEnvironmentRecord,
+)
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.drivers.registry import build_driver_context_view
 from control_plane.launchplane_mutations import (
@@ -8657,6 +8660,114 @@ def _build_runtime_environment_record_for_relabel(
     )
 
 
+def _runtime_environment_delete_actor(actor: str) -> str:
+    return (
+        actor.strip()
+        or os.environ.get("GITHUB_ACTOR", "").strip()
+        or os.environ.get("USER", "").strip()
+        or os.environ.get("LOGNAME", "").strip()
+        or "unknown"
+    )
+
+
+def _runtime_environment_delete_event_id(
+    *,
+    record: RuntimeEnvironmentRecord,
+    actor: str,
+    recorded_at: str,
+    nonce: str,
+) -> str:
+    key_digest_input = "\n".join(
+        (
+            record.scope,
+            record.context,
+            record.instance,
+            record.updated_at,
+            record.source_label,
+            actor,
+            recorded_at,
+            nonce,
+            *sorted(record.env.keys()),
+        )
+    )
+    digest = hashlib.sha256(key_digest_input.encode("utf-8")).hexdigest()[:16]
+    return f"runtime-env-delete-{digest}"
+
+
+def _build_runtime_environment_delete_event(
+    *,
+    record: RuntimeEnvironmentRecord,
+    actor: str,
+) -> RuntimeEnvironmentDeleteEvent:
+    recorded_at = utc_now_timestamp()
+    normalized_actor = _runtime_environment_delete_actor(actor)
+    env_keys = tuple(sorted(record.env.keys()))
+    return RuntimeEnvironmentDeleteEvent(
+        event_id=_runtime_environment_delete_event_id(
+            record=record,
+            actor=normalized_actor,
+            recorded_at=recorded_at,
+            nonce=str(time.time_ns()),
+        ),
+        recorded_at=recorded_at,
+        actor=normalized_actor,
+        scope=record.scope,
+        context=record.context,
+        instance=record.instance,
+        source_label=record.source_label,
+        env_keys=env_keys,
+        env_value_count=len(env_keys),
+        detail="deleted by launchplane environments delete-record",
+    )
+
+
+def _summarize_runtime_environment_delete_event(
+    event: RuntimeEnvironmentDeleteEvent,
+) -> dict[str, object]:
+    return {
+        "event_id": event.event_id,
+        "event_type": event.event_type,
+        "recorded_at": event.recorded_at,
+        "actor": event.actor,
+        "scope": event.scope,
+        "context": event.context,
+        "instance": event.instance,
+        "source_label": event.source_label,
+        "env_keys": list(event.env_keys),
+        "env_value_count": event.env_value_count,
+        "detail": event.detail,
+    }
+
+
+def _protected_runtime_environment_delete_targets(
+    *,
+    scope: str,
+    context_name: str,
+    instance_name: str,
+    target_records: tuple[DokployTargetRecord, ...],
+) -> tuple[dict[str, object], ...]:
+    protected_targets: list[dict[str, object]] = []
+    for target_record in target_records:
+        if scope == "context" and target_record.context != context_name:
+            continue
+        if scope == "instance" and (
+            target_record.context != context_name or target_record.instance != instance_name
+        ):
+            continue
+        protected_targets.append(
+            {
+                "context": target_record.context,
+                "instance": target_record.instance,
+                "target_name": target_record.target_name,
+                "target_type": target_record.target_type,
+                "source_label": target_record.source_label,
+            }
+        )
+    return tuple(
+        sorted(protected_targets, key=lambda item: (str(item["context"]), str(item["instance"])))
+    )
+
+
 def _summarize_odoo_instance_override_record(
     record: OdooInstanceOverrideRecord,
 ) -> dict[str, object]:
@@ -11705,6 +11816,97 @@ def environments_unset(
                 "record": _summarize_runtime_environment_record(record),
                 "removed_keys": removed_keys,
                 "missing_keys": missing_keys,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+@environments.command("delete-record")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane runtime-environment records.",
+)
+@click.option("--scope", type=click.Choice(["global", "context", "instance"]), required=True)
+@click.option("--context", "context_name", default="")
+@click.option("--instance", "instance_name", default="")
+@click.option("--actor", default="", show_default=False)
+@click.option("--allow-tracked-target", is_flag=True, default=False)
+@click.option("--dry-run", "dry_run", is_flag=True, default=False)
+@click.option("--apply", "apply_changes", is_flag=True, default=False)
+def environments_delete_record(
+    database_url: str,
+    scope: str,
+    context_name: str,
+    instance_name: str,
+    actor: str,
+    allow_tracked_target: bool,
+    dry_run: bool,
+    apply_changes: bool,
+) -> None:
+    if dry_run == apply_changes:
+        raise click.ClickException("Choose exactly one of --dry-run or --apply.")
+    normalized_context = context_name.strip()
+    normalized_instance = instance_name.strip()
+    _validate_runtime_environment_scope_route(
+        scope=scope,
+        context_name=normalized_context,
+        instance_name=normalized_instance,
+    )
+
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    postgres_store.ensure_schema()
+    try:
+        target_record = _find_runtime_environment_record(
+            existing_records=postgres_store.list_runtime_environment_records(),
+            scope=scope,
+            context_name=normalized_context,
+            instance_name=normalized_instance,
+        )
+        if target_record is None:
+            raise click.ClickException(
+                "Missing DB-backed runtime environment record for the requested scope."
+            )
+        protected_targets = _protected_runtime_environment_delete_targets(
+            scope=scope,
+            context_name=normalized_context,
+            instance_name=normalized_instance,
+            target_records=postgres_store.list_dokploy_target_records(),
+        )
+        if apply_changes and protected_targets and not allow_tracked_target:
+            routes = ", ".join(
+                f"{target['context']}/{target['instance']}" for target in protected_targets
+            )
+            raise click.ClickException(
+                "Refusing to delete a runtime environment record that can affect tracked "
+                f"Dokploy target(s): {routes}. Re-run with --allow-tracked-target only "
+                "after confirming the tracked live target should lose this record."
+            )
+        event = _build_runtime_environment_delete_event(record=target_record, actor=actor)
+        if apply_changes:
+            deleted_count = postgres_store.delete_runtime_environment_record_with_event(event=event)
+            if deleted_count != 1:
+                raise click.ClickException(
+                    "Runtime environment record disappeared before delete could complete."
+                )
+    finally:
+        postgres_store.close()
+
+    click.echo(
+        json.dumps(
+            {
+                "status": "ok" if apply_changes else "dry_run",
+                "action": "delete_runtime_environment_record",
+                "record": _summarize_runtime_environment_record(target_record),
+                "event": _summarize_runtime_environment_delete_event(event),
+                "protected_tracked_targets": protected_targets,
+                "requires_allow_tracked_target": bool(
+                    protected_targets and not allow_tracked_target
+                ),
+                "deleted": apply_changes,
             },
             indent=2,
             sort_keys=True,

--- a/control_plane/contracts/runtime_environment_record.py
+++ b/control_plane/contracts/runtime_environment_record.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 ScalarValue = str | int | float | bool
 RuntimeEnvironmentScope = Literal["global", "context", "instance"]
@@ -37,3 +37,37 @@ class RuntimeEnvironmentRecord(BaseModel):
             raise ValueError("runtime environment record requires at least one env value")
         return normalized
 
+
+class RuntimeEnvironmentDeleteEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    event_id: str
+    event_type: Literal["deleted"] = "deleted"
+    recorded_at: str
+    actor: str = ""
+    scope: RuntimeEnvironmentScope
+    context: str = ""
+    instance: str = ""
+    source_label: str = ""
+    env_keys: tuple[str, ...]
+    env_value_count: int = Field(ge=0)
+    detail: str = ""
+
+    @model_validator(mode="after")
+    def _validate_event(self) -> "RuntimeEnvironmentDeleteEvent":
+        if not self.event_id.strip():
+            raise ValueError("runtime environment delete event requires event_id")
+        if not self.recorded_at.strip():
+            raise ValueError("runtime environment delete event requires recorded_at")
+        if self.scope == "global" and (self.context.strip() or self.instance.strip()):
+            raise ValueError("global runtime environment delete event cannot set context/instance")
+        if self.scope == "context" and (not self.context.strip() or self.instance.strip()):
+            raise ValueError("context runtime environment delete event requires context only")
+        if self.scope == "instance" and (not self.context.strip() or not self.instance.strip()):
+            raise ValueError(
+                "instance runtime environment delete event requires context and instance"
+            )
+        if self.env_value_count != len(self.env_keys):
+            raise ValueError("runtime environment delete event key count must match env_keys")
+        return self

--- a/control_plane/storage/migrations/versions/c0d2e4f6a8b1_add_runtime_environment_delete_events.py
+++ b/control_plane/storage/migrations/versions/c0d2e4f6a8b1_add_runtime_environment_delete_events.py
@@ -1,0 +1,49 @@
+"""add runtime environment delete events
+
+Revision ID: c0d2e4f6a8b1
+Revises: b9c1d3e5f7a9
+Create Date: 2026-05-01 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "c0d2e4f6a8b1"
+down_revision: str | None = "b9c1d3e5f7a9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "launchplane_runtime_environment_delete_events",
+        sa.Column("event_id", sa.String(), nullable=False),
+        sa.Column("scope", sa.String(), nullable=False),
+        sa.Column("context", sa.String(), nullable=False),
+        sa.Column("instance", sa.String(), nullable=False),
+        sa.Column("recorded_at", sa.String(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("event_id"),
+    )
+    op.create_index(
+        "launchplane_runtime_environment_delete_events_route_idx",
+        "launchplane_runtime_environment_delete_events",
+        ["scope", "context", "instance", sa.text("recorded_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "launchplane_runtime_environment_delete_events_route_idx",
+        table_name="launchplane_runtime_environment_delete_events",
+    )
+    op.drop_table("launchplane_runtime_environment_delete_events")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -30,7 +30,10 @@ from control_plane.contracts.preview_summary import LaunchplanePreviewSummary
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
-from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
+from control_plane.contracts.runtime_environment_record import (
+    RuntimeEnvironmentDeleteEvent,
+    RuntimeEnvironmentRecord,
+)
 from control_plane.contracts.secret_record import (
     SecretAuditEvent,
     SecretBinding,
@@ -361,6 +364,26 @@ class LaunchplaneRuntimeEnvironmentRow(Base):
     context: Mapped[str] = mapped_column(String, primary_key=True)
     instance: Mapped[str] = mapped_column(String, primary_key=True)
     updated_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneRuntimeEnvironmentDeleteEventRow(Base):
+    __tablename__ = "launchplane_runtime_environment_delete_events"
+    __table_args__ = (
+        Index(
+            "launchplane_runtime_environment_delete_events_route_idx",
+            "scope",
+            "context",
+            "instance",
+            desc("recorded_at"),
+        ),
+    )
+
+    event_id: Mapped[str] = mapped_column(String, primary_key=True)
+    scope: Mapped[str] = mapped_column(String, nullable=False)
+    context: Mapped[str] = mapped_column(String, nullable=False)
+    instance: Mapped[str] = mapped_column(String, nullable=False)
+    recorded_at: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -1102,9 +1125,7 @@ class PostgresRecordStore(HumanSessionStore):
             limit=limit,
         )
 
-    def write_preview_lifecycle_cleanup_record(
-        self, record: PreviewLifecycleCleanupRecord
-    ) -> None:
+    def write_preview_lifecycle_cleanup_record(self, record: PreviewLifecycleCleanupRecord) -> None:
         self._write_row(
             LaunchplanePreviewLifecycleCleanupRow(
                 cleanup_id=record.cleanup_id,
@@ -1389,6 +1410,74 @@ class PostgresRecordStore(HumanSessionStore):
                 updated_at=record.updated_at,
                 payload=self._payload_dict(record),
             )
+        )
+
+    def delete_runtime_environment_record_with_event(
+        self,
+        *,
+        event: RuntimeEnvironmentDeleteEvent,
+    ) -> int:
+        statement = (
+            select(LaunchplaneRuntimeEnvironmentRow)
+            .where(
+                LaunchplaneRuntimeEnvironmentRow.scope == event.scope,
+                LaunchplaneRuntimeEnvironmentRow.context == event.context,
+                LaunchplaneRuntimeEnvironmentRow.instance == event.instance,
+            )
+            .limit(1)
+        )
+        with self._session_factory() as session:
+            row = session.scalar(statement)
+            if row is None:
+                return 0
+            session.delete(row)
+            session.add(
+                LaunchplaneRuntimeEnvironmentDeleteEventRow(
+                    event_id=event.event_id,
+                    scope=event.scope,
+                    context=event.context,
+                    instance=event.instance,
+                    recorded_at=event.recorded_at,
+                    payload=self._payload_dict(event),
+                )
+            )
+            session.commit()
+            return 1
+
+    def write_runtime_environment_delete_event(self, event: RuntimeEnvironmentDeleteEvent) -> None:
+        self._write_row(
+            LaunchplaneRuntimeEnvironmentDeleteEventRow(
+                event_id=event.event_id,
+                scope=event.scope,
+                context=event.context,
+                instance=event.instance,
+                recorded_at=event.recorded_at,
+                payload=self._payload_dict(event),
+            )
+        )
+
+    def list_runtime_environment_delete_events(
+        self,
+        *,
+        scope: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+    ) -> tuple[RuntimeEnvironmentDeleteEvent, ...]:
+        filters: list[object] = []
+        if scope:
+            filters.append(LaunchplaneRuntimeEnvironmentDeleteEventRow.scope == scope)
+        if context_name:
+            filters.append(LaunchplaneRuntimeEnvironmentDeleteEventRow.context == context_name)
+        if instance_name:
+            filters.append(LaunchplaneRuntimeEnvironmentDeleteEventRow.instance == instance_name)
+        return self._list_models(
+            model_type=RuntimeEnvironmentDeleteEvent,
+            orm_model=LaunchplaneRuntimeEnvironmentDeleteEventRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneRuntimeEnvironmentDeleteEventRow.recorded_at.desc(),
+                LaunchplaneRuntimeEnvironmentDeleteEventRow.event_id.desc(),
+            ),
         )
 
     def list_runtime_environment_records(

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -360,6 +360,12 @@ Current derived-state behavior:
   submit, and shows only key/action/count metadata from Launchplane responses.
 - `environments unset` removes named keys from a DB-backed runtime-environment
   record without reading or printing plaintext values.
+- `environments delete-record --dry-run|--apply` deletes a whole mistaken
+  runtime-environment record for `global`, `context`, or `instance` scope. The
+  dry-run and apply responses include record identity, source label, update
+  timestamp, key names, key count, actor, and delete-event metadata only. Apply
+  refuses records that can affect a tracked Dokploy target unless
+  `--allow-tracked-target` is provided.
 - `environments relabel` updates runtime-environment record source metadata
   without reading or printing plaintext values.
 - `environments list` shows DB-backed runtime-environment record metadata and

--- a/tests/test_runtime_environments.py
+++ b/tests/test_runtime_environments.py
@@ -31,7 +31,9 @@ def _seed_runtime_environment_records(
     store = PostgresRecordStore(database_url=database_url)
     store.ensure_schema()
     try:
-        for record in control_plane_runtime_environments.build_runtime_environment_records_from_definition(
+        for (
+            record
+        ) in control_plane_runtime_environments.build_runtime_environment_records_from_definition(
             definition,
             updated_at=updated_at,
             source_label=source_label,
@@ -115,10 +117,12 @@ class RuntimeEnvironmentTests(unittest.TestCase):
             )
 
             with patch.dict(os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True):
-                resolved_values = control_plane_runtime_environments.resolve_runtime_environment_values(
-                    control_plane_root=control_plane_root,
-                    context_name="verireel",
-                    instance_name="prod",
+                resolved_values = (
+                    control_plane_runtime_environments.resolve_runtime_environment_values(
+                        control_plane_root=control_plane_root,
+                        context_name="verireel",
+                        instance_name="prod",
+                    )
                 )
 
         self.assertEqual(resolved_values["VERIREEL_PROD_PROXMOX_HOST"], "proxmox.example.com")
@@ -173,10 +177,12 @@ class RuntimeEnvironmentTests(unittest.TestCase):
             )
 
             with patch.dict(os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True):
-                resolved_values = control_plane_runtime_environments.resolve_runtime_environment_values(
-                    control_plane_root=control_plane_root,
-                    context_name="verireel",
-                    instance_name="prod",
+                resolved_values = (
+                    control_plane_runtime_environments.resolve_runtime_environment_values(
+                        control_plane_root=control_plane_root,
+                        context_name="verireel",
+                        instance_name="prod",
+                    )
                 )
 
         self.assertEqual(resolved_values["VERIREEL_PROD_PROXMOX_HOST"], "proxmox.example.com")
@@ -184,7 +190,9 @@ class RuntimeEnvironmentTests(unittest.TestCase):
 
     def test_environments_put_rejects_instance_scope_without_instance(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
-            database_url = _sqlite_database_url(Path(temporary_directory_name) / "launchplane.sqlite3")
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
             result = CliRunner().invoke(
                 main,
                 [
@@ -206,7 +214,9 @@ class RuntimeEnvironmentTests(unittest.TestCase):
 
     def test_environments_put_rejects_secret_shaped_keys(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
-            database_url = _sqlite_database_url(Path(temporary_directory_name) / "launchplane.sqlite3")
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
             result = CliRunner().invoke(
                 main,
                 [
@@ -284,10 +294,12 @@ class RuntimeEnvironmentTests(unittest.TestCase):
             self.assertEqual(payload["missing_keys"], ["MISSING_KEY"])
 
             with patch.dict(os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True):
-                resolved_values = control_plane_runtime_environments.resolve_runtime_environment_values(
-                    control_plane_root=control_plane_root,
-                    context_name="verireel",
-                    instance_name="prod",
+                resolved_values = (
+                    control_plane_runtime_environments.resolve_runtime_environment_values(
+                        control_plane_root=control_plane_root,
+                        context_name="verireel",
+                        instance_name="prod",
+                    )
                 )
 
         self.assertNotIn("VERIREEL_PROD_CT_ID", resolved_values)
@@ -295,7 +307,9 @@ class RuntimeEnvironmentTests(unittest.TestCase):
 
     def test_environments_unset_rejects_empty_result_record(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
-            database_url = _sqlite_database_url(Path(temporary_directory_name) / "launchplane.sqlite3")
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
             _seed_runtime_environment_records(
                 database_url=database_url,
                 definition=control_plane_runtime_environments.RuntimeEnvironmentDefinition(
@@ -323,9 +337,388 @@ class RuntimeEnvironmentTests(unittest.TestCase):
         self.assertIn("Refusing to leave an empty runtime environment record", result.output)
         self.assertNotIn("only-value", result.output)
 
+    def test_environments_delete_record_dry_run_reports_key_only_metadata(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            _seed_runtime_environment_records(
+                database_url=database_url,
+                definition=control_plane_runtime_environments.RuntimeEnvironmentDefinition(
+                    schema_version=1,
+                    shared_env={},
+                    contexts={
+                        "sellyouroutboard": control_plane_runtime_environments.RuntimeEnvironmentContextDefinition(
+                            shared_env={},
+                            instances={
+                                "prod": control_plane_runtime_environments.RuntimeEnvironmentInstanceDefinition(
+                                    env={"TAWK_WIDGET_ID": "widget-123"}
+                                )
+                            },
+                        )
+                    },
+                ),
+                source_label="operator:mistake",
+            )
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "environments",
+                    "delete-record",
+                    "--database-url",
+                    database_url,
+                    "--scope",
+                    "instance",
+                    "--context",
+                    "sellyouroutboard",
+                    "--instance",
+                    "prod",
+                    "--actor",
+                    "operator@example.com",
+                    "--dry-run",
+                ],
+            )
+
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                remaining_records = store.list_runtime_environment_records(
+                    scope="instance",
+                    context_name="sellyouroutboard",
+                    instance_name="prod",
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn("widget-123", result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["status"], "dry_run")
+        self.assertFalse(payload["deleted"])
+        self.assertEqual(payload["record"]["source_label"], "operator:mistake")
+        self.assertEqual(payload["record"]["env_keys"], ["TAWK_WIDGET_ID"])
+        self.assertEqual(payload["event"]["actor"], "operator@example.com")
+        self.assertEqual(payload["event"]["env_value_count"], 1)
+        self.assertEqual(len(remaining_records), 1)
+
+    def test_environments_delete_record_apply_deletes_whole_record_and_audits(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            _seed_runtime_environment_records(
+                database_url=database_url,
+                definition=control_plane_runtime_environments.RuntimeEnvironmentDefinition(
+                    schema_version=1,
+                    shared_env={},
+                    contexts={
+                        "sellyouroutboard": control_plane_runtime_environments.RuntimeEnvironmentContextDefinition(
+                            shared_env={},
+                            instances={
+                                "prod": control_plane_runtime_environments.RuntimeEnvironmentInstanceDefinition(
+                                    env={
+                                        "TAWK_PROPERTY_ID": "property-123",
+                                        "TAWK_WIDGET_ID": "widget-123",
+                                    }
+                                )
+                            },
+                        )
+                    },
+                ),
+                source_label="operator:mistake",
+            )
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "environments",
+                    "delete-record",
+                    "--database-url",
+                    database_url,
+                    "--scope",
+                    "instance",
+                    "--context",
+                    "sellyouroutboard",
+                    "--instance",
+                    "prod",
+                    "--actor",
+                    "operator@example.com",
+                    "--apply",
+                ],
+            )
+
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                remaining_records = store.list_runtime_environment_records(
+                    scope="instance",
+                    context_name="sellyouroutboard",
+                    instance_name="prod",
+                )
+                delete_events = store.list_runtime_environment_delete_events(
+                    scope="instance",
+                    context_name="sellyouroutboard",
+                    instance_name="prod",
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn("widget-123", result.output)
+        self.assertNotIn("property-123", result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["status"], "ok")
+        self.assertTrue(payload["deleted"])
+        self.assertEqual(payload["record"]["env_keys"], ["TAWK_PROPERTY_ID", "TAWK_WIDGET_ID"])
+        self.assertEqual(remaining_records, ())
+        self.assertEqual(len(delete_events), 1)
+        self.assertEqual(delete_events[0].actor, "operator@example.com")
+        self.assertEqual(delete_events[0].env_keys, ("TAWK_PROPERTY_ID", "TAWK_WIDGET_ID"))
+
+    def test_environments_delete_record_appends_audit_events_for_repeated_delete_shape(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            definition = control_plane_runtime_environments.RuntimeEnvironmentDefinition(
+                schema_version=1,
+                shared_env={},
+                contexts={
+                    "sellyouroutboard": control_plane_runtime_environments.RuntimeEnvironmentContextDefinition(
+                        shared_env={},
+                        instances={
+                            "prod": control_plane_runtime_environments.RuntimeEnvironmentInstanceDefinition(
+                                env={"TAWK_WIDGET_ID": "widget-123"}
+                            )
+                        },
+                    )
+                },
+            )
+            for _ in range(2):
+                _seed_runtime_environment_records(
+                    database_url=database_url,
+                    definition=definition,
+                    updated_at="2026-04-22T00:00:00Z",
+                    source_label="operator:mistake",
+                )
+                result = CliRunner().invoke(
+                    main,
+                    [
+                        "environments",
+                        "delete-record",
+                        "--database-url",
+                        database_url,
+                        "--scope",
+                        "instance",
+                        "--context",
+                        "sellyouroutboard",
+                        "--instance",
+                        "prod",
+                        "--actor",
+                        "operator@example.com",
+                        "--apply",
+                    ],
+                )
+                self.assertEqual(result.exit_code, 0, result.output)
+
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                delete_events = store.list_runtime_environment_delete_events(
+                    scope="instance",
+                    context_name="sellyouroutboard",
+                    instance_name="prod",
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(len(delete_events), 2)
+        self.assertNotEqual(delete_events[0].event_id, delete_events[1].event_id)
+
+    def test_environments_delete_record_refuses_tracked_target_without_allow_flag(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            _seed_runtime_environment_records(
+                database_url=database_url,
+                definition=control_plane_runtime_environments.RuntimeEnvironmentDefinition(
+                    schema_version=1,
+                    shared_env={},
+                    contexts={
+                        "sellyouroutboard-testing": control_plane_runtime_environments.RuntimeEnvironmentContextDefinition(
+                            shared_env={},
+                            instances={
+                                "prod": control_plane_runtime_environments.RuntimeEnvironmentInstanceDefinition(
+                                    env={"TAWK_WIDGET_ID": "widget-123"}
+                                )
+                            },
+                        )
+                    },
+                ),
+            )
+            _seed_dokploy_target_records(
+                database_url=database_url,
+                payload=(
+                    "schema_version = 2\n\n"
+                    "[[targets]]\n"
+                    'context = "sellyouroutboard-testing"\n'
+                    'instance = "prod"\n'
+                    'target_id = "target-syo-prod"\n'
+                    'target_name = "syo-prod-app"\n'
+                ),
+            )
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "environments",
+                    "delete-record",
+                    "--database-url",
+                    database_url,
+                    "--scope",
+                    "instance",
+                    "--context",
+                    "sellyouroutboard-testing",
+                    "--instance",
+                    "prod",
+                    "--apply",
+                ],
+            )
+
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                remaining_records = store.list_runtime_environment_records(
+                    scope="instance",
+                    context_name="sellyouroutboard-testing",
+                    instance_name="prod",
+                )
+                delete_events = store.list_runtime_environment_delete_events()
+            finally:
+                store.close()
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Refusing to delete", result.output)
+        self.assertIn("sellyouroutboard-testing/prod", result.output)
+        self.assertNotIn("widget-123", result.output)
+        self.assertEqual(len(remaining_records), 1)
+        self.assertEqual(delete_events, ())
+
+    def test_environments_delete_record_allow_flag_deletes_tracked_target_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            _seed_runtime_environment_records(
+                database_url=database_url,
+                definition=control_plane_runtime_environments.RuntimeEnvironmentDefinition(
+                    schema_version=1,
+                    shared_env={},
+                    contexts={
+                        "sellyouroutboard-testing": control_plane_runtime_environments.RuntimeEnvironmentContextDefinition(
+                            shared_env={},
+                            instances={
+                                "prod": control_plane_runtime_environments.RuntimeEnvironmentInstanceDefinition(
+                                    env={"TAWK_WIDGET_ID": "widget-123"}
+                                )
+                            },
+                        )
+                    },
+                ),
+            )
+            _seed_dokploy_target_records(
+                database_url=database_url,
+                payload=(
+                    "schema_version = 2\n\n"
+                    "[[targets]]\n"
+                    'context = "sellyouroutboard-testing"\n'
+                    'instance = "prod"\n'
+                    'target_id = "target-syo-prod"\n'
+                    'target_name = "syo-prod-app"\n'
+                ),
+            )
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "environments",
+                    "delete-record",
+                    "--database-url",
+                    database_url,
+                    "--scope",
+                    "instance",
+                    "--context",
+                    "sellyouroutboard-testing",
+                    "--instance",
+                    "prod",
+                    "--allow-tracked-target",
+                    "--apply",
+                ],
+            )
+
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                remaining_records = store.list_runtime_environment_records(
+                    scope="instance",
+                    context_name="sellyouroutboard-testing",
+                    instance_name="prod",
+                )
+                delete_events = store.list_runtime_environment_delete_events()
+            finally:
+                store.close()
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn("widget-123", result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["protected_tracked_targets"][0]["target_name"], "syo-prod-app")
+        self.assertFalse(payload["requires_allow_tracked_target"])
+        self.assertEqual(remaining_records, ())
+        self.assertEqual(len(delete_events), 1)
+
+    def test_environments_delete_record_distinguishes_missing_and_invalid_routes(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            missing_result = CliRunner().invoke(
+                main,
+                [
+                    "environments",
+                    "delete-record",
+                    "--database-url",
+                    database_url,
+                    "--scope",
+                    "global",
+                    "--dry-run",
+                ],
+            )
+            invalid_result = CliRunner().invoke(
+                main,
+                [
+                    "environments",
+                    "delete-record",
+                    "--database-url",
+                    database_url,
+                    "--scope",
+                    "context",
+                    "--context",
+                    "sellyouroutboard",
+                    "--instance",
+                    "prod",
+                    "--dry-run",
+                ],
+            )
+
+        self.assertNotEqual(missing_result.exit_code, 0)
+        self.assertIn("Missing DB-backed runtime environment record", missing_result.output)
+        self.assertNotEqual(invalid_result.exit_code, 0)
+        self.assertIn("require --context and do not accept --instance", invalid_result.output)
+
     def test_environments_relabel_updates_metadata_without_echoing_values(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
-            database_url = _sqlite_database_url(Path(temporary_directory_name) / "launchplane.sqlite3")
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
             _seed_runtime_environment_records(
                 database_url=database_url,
                 definition=control_plane_runtime_environments.RuntimeEnvironmentDefinition(
@@ -417,10 +810,12 @@ class RuntimeEnvironmentTests(unittest.TestCase):
             )
 
             with patch.dict(os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True):
-                resolved_values = control_plane_runtime_environments.resolve_runtime_environment_values(
-                    control_plane_root=control_plane_root,
-                    context_name="opw",
-                    instance_name="local",
+                resolved_values = (
+                    control_plane_runtime_environments.resolve_runtime_environment_values(
+                        control_plane_root=control_plane_root,
+                        context_name="opw",
+                        instance_name="local",
+                    )
                 )
 
         self.assertEqual(resolved_values["ODOO_MASTER_PASSWORD"], "shared-master")
@@ -488,22 +883,24 @@ class RuntimeEnvironmentTests(unittest.TestCase):
             _seed_dokploy_target_records(
                 database_url=database_url,
                 payload=(
-                    'schema_version = 2\n\n'
-                    '[[targets]]\n'
+                    "schema_version = 2\n\n"
+                    "[[targets]]\n"
                     'context = "cm"\n'
                     'instance = "testing"\n'
                     'target_id = "target-cm-testing"\n\n'
-                    '[targets.env]\n'
+                    "[targets.env]\n"
                     'ODOO_ADDON_REPOSITORIES = "cbusillo/disable_odoo_online@411f6b8e85cac72dc7aa2e2dc5540001043c327d"\n'
                     'ENV_OVERRIDE_CONFIG_PARAM__WEB__BASE__URL = "https://cm-testing.example.com"\n'
                 ),
             )
 
             with patch.dict(os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True):
-                resolved_values = control_plane_runtime_environments.resolve_runtime_environment_values(
-                    control_plane_root=control_plane_root,
-                    context_name="cm",
-                    instance_name="testing",
+                resolved_values = (
+                    control_plane_runtime_environments.resolve_runtime_environment_values(
+                        control_plane_root=control_plane_root,
+                        context_name="cm",
+                        instance_name="testing",
+                    )
                 )
 
         self.assertEqual(resolved_values["ODOO_MASTER_PASSWORD"], "shared-master")
@@ -544,11 +941,15 @@ class RuntimeEnvironmentTests(unittest.TestCase):
                     context_name="opw",
                 )
 
-        self.assertEqual(resolved_values["LAUNCHPLANE_PREVIEW_BASE_URL"], "https://launchplane.example")
+        self.assertEqual(
+            resolved_values["LAUNCHPLANE_PREVIEW_BASE_URL"], "https://launchplane.example"
+        )
         self.assertEqual(resolved_values["ODOO_MASTER_PASSWORD"], "shared-master")
         self.assertEqual(resolved_values["ENV_OVERRIDE_DISABLE_CRON"], "True")
 
-    def test_load_runtime_environment_definition_prefers_postgres_records_without_file_fallback(self) -> None:
+    def test_load_runtime_environment_definition_prefers_postgres_records_without_file_fallback(
+        self,
+    ) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
             database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
@@ -594,20 +995,26 @@ ODOO_DB_PASSWORD = "cm-file-secret"
             store.close()
 
             with patch.dict(os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True):
-                resolved_values = control_plane_runtime_environments.resolve_runtime_environment_values(
-                    control_plane_root=control_plane_root,
-                    context_name="opw",
-                    instance_name="local",
+                resolved_values = (
+                    control_plane_runtime_environments.resolve_runtime_environment_values(
+                        control_plane_root=control_plane_root,
+                        context_name="opw",
+                        instance_name="local",
+                    )
                 )
-                loaded_definition = control_plane_runtime_environments.load_runtime_environment_definition(
-                    control_plane_root=control_plane_root,
+                loaded_definition = (
+                    control_plane_runtime_environments.load_runtime_environment_definition(
+                        control_plane_root=control_plane_root,
+                    )
                 )
 
         self.assertEqual(resolved_values["ODOO_MASTER_PASSWORD"], "db-master")
         self.assertEqual(resolved_values["ODOO_DB_PASSWORD"], "db-secret")
         self.assertNotIn("cm", loaded_definition.contexts)
 
-    def test_load_runtime_environment_definition_requires_database_records_without_file_fallback(self) -> None:
+    def test_load_runtime_environment_definition_requires_database_records_without_file_fallback(
+        self,
+    ) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
             environments_file = control_plane_root / "config" / "runtime-environments.toml"
@@ -624,7 +1031,9 @@ ODOO_DB_PASSWORD = "file-secret"
             )
 
             with patch.dict(os.environ, {}, clear=True):
-                with self.assertRaisesRegex(Exception, "Missing Launchplane runtime environment authority"):
+                with self.assertRaisesRegex(
+                    Exception, "Missing Launchplane runtime environment authority"
+                ):
                     control_plane_runtime_environments.load_runtime_environment_definition(
                         control_plane_root=control_plane_root,
                     )
@@ -738,7 +1147,9 @@ ODOO_DB_PASSWORD = "file-secret"
             finally:
                 store.close()
 
-    def test_product_config_apply_writes_runtime_env_and_secret_without_echoing_values(self) -> None:
+    def test_product_config_apply_writes_runtime_env_and_secret_without_echoing_values(
+        self,
+    ) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
             database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
@@ -786,18 +1197,22 @@ ODOO_DB_PASSWORD = "file-secret"
                         "--apply",
                     ],
                 )
-                resolved_values = control_plane_runtime_environments.resolve_runtime_environment_values(
-                    control_plane_root=control_plane_root,
-                    context_name="sellyouroutboard",
-                    instance_name="prod",
+                resolved_values = (
+                    control_plane_runtime_environments.resolve_runtime_environment_values(
+                        control_plane_root=control_plane_root,
+                        context_name="sellyouroutboard",
+                        instance_name="prod",
+                    )
                 )
 
             self.assertEqual(result.exit_code, 0, result.output)
             self.assertNotIn("smtp-secret-value", result.output)
-            self.assertNotIn("smtp\"", result.output)
+            self.assertNotIn('smtp"', result.output)
             payload = json.loads(result.output)
             self.assertEqual(payload["mode"], "apply")
-            self.assertEqual(payload["runtime_environment"]["record"]["source_label"], "issue-110-test")
+            self.assertEqual(
+                payload["runtime_environment"]["record"]["source_label"], "issue-110-test"
+            )
             self.assertEqual(payload["secrets"][0]["action"], "created")
             self.assertEqual(resolved_values["CONTACT_EMAIL_MODE"], "smtp")
             self.assertEqual(resolved_values["SMTP_PASSWORD"], "smtp-secret-value")
@@ -806,9 +1221,7 @@ ODOO_DB_PASSWORD = "file-secret"
             try:
                 secret_records = store.list_secret_records()
                 self.assertEqual(len(secret_records), 1)
-                audit_events = store.list_secret_audit_events(
-                    secret_id=secret_records[0].secret_id
-                )
+                audit_events = store.list_secret_audit_events(secret_id=secret_records[0].secret_id)
                 self.assertEqual(audit_events[0].actor, "operator@example.com")
                 self.assertEqual(audit_events[0].metadata["source"], "issue-110-test")
             finally:
@@ -1013,7 +1426,9 @@ ODOO_DB_PASSWORD = "file-secret"
                 )
 
         self.assertNotEqual(result.exit_code, 0)
-        self.assertIn("Product config secrets require LAUNCHPLANE_MASTER_ENCRYPTION_KEY", result.output)
+        self.assertIn(
+            "Product config secrets require LAUNCHPLANE_MASTER_ENCRYPTION_KEY", result.output
+        )
         self.assertNotIn("smtp-secret-value", result.output)
 
     def test_product_config_apply_rejects_secret_shaped_runtime_env(self) -> None:


### PR DESCRIPTION
Closes #121.

Summary:
- Adds environments delete-record with dry-run/apply modes for global, context, and instance runtime environment records.
- Keeps output redacted to route/source/timestamps/key names/counts and delete-event metadata.
- Refuses apply for records that can affect tracked Dokploy targets unless --allow-tracked-target is explicitly provided.
- Adds append-only runtime environment delete audit events with migration support.

Validation:
- uv run --extra dev ruff format --check control_plane/cli.py control_plane/contracts/runtime_environment_record.py control_plane/storage/postgres.py tests/test_runtime_environments.py control_plane/storage/migrations/versions/c0d2e4f6a8b1_add_runtime_environment_delete_events.py
- uv run --extra dev ruff check control_plane/cli.py control_plane/contracts/runtime_environment_record.py control_plane/storage/postgres.py tests/test_runtime_environments.py control_plane/storage/migrations/versions/c0d2e4f6a8b1_add_runtime_environment_delete_events.py
- uv run python -m unittest tests.test_runtime_environments
- uv run python -m unittest tests.test_dokploy tests.test_runtime_environments
- uv run python -m unittest
- npx --yes markdownlint-cli2 docs/operations.md
- git diff --check