### PR TITLE
Add tracked target runtime logs

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -87,6 +87,7 @@ from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.factory import build_record_store, resolve_database_url
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.service_auth import load_authz_policy
+from control_plane.tracked_target_logs import build_tracked_target_logs_payload
 from control_plane.workflows.launchplane import (
     adapt_github_webhook_pull_request_event,
     apply_generation_failed_transition,
@@ -11887,10 +11888,18 @@ def environments_delete_record(
             )
         event = _build_runtime_environment_delete_event(record=target_record, actor=actor)
         if apply_changes:
-            deleted_count = postgres_store.delete_runtime_environment_record_with_event(event=event)
-            if deleted_count != 1:
+            delete_status = postgres_store.delete_runtime_environment_record_with_event(
+                event=event,
+                expected_record=target_record,
+            )
+            if delete_status == "missing":
                 raise click.ClickException(
                     "Runtime environment record disappeared before delete could complete."
+                )
+            if delete_status == "changed":
+                raise click.ClickException(
+                    "Runtime environment record changed before delete could complete; "
+                    "re-run delete-record after reviewing the current record."
                 )
     finally:
         postgres_store.close()
@@ -12020,6 +12029,58 @@ def environments_show_live_target(context_name: str, instance_name: str) -> None
         instance_name=instance_name,
     )
     click.echo(json.dumps(payload, indent=2, sort_keys=True))
+
+
+@environments.command("logs")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane tracked target records.",
+)
+@click.option("--context", "context_name", required=True)
+@click.option("--instance", "instance_name", required=True)
+@click.option(
+    "--lines",
+    "line_count",
+    type=int,
+    default=control_plane_dokploy.DEFAULT_DOKPLOY_LOG_LINE_COUNT,
+    show_default=True,
+)
+@click.option("--since", default="all", show_default=True)
+@click.option("--search", default="", show_default=False)
+@click.option(
+    "--control-plane-root",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Optional Launchplane repo root used to resolve Dokploy credentials.",
+)
+def environments_logs(
+    database_url: str,
+    context_name: str,
+    instance_name: str,
+    line_count: int,
+    since: str,
+    search: str,
+    control_plane_root: Path | None,
+) -> None:
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    try:
+        try:
+            payload = build_tracked_target_logs_payload(
+                record_store=postgres_store,
+                control_plane_root=control_plane_root or _control_plane_root(),
+                context_name=context_name.strip(),
+                instance_name=instance_name.strip(),
+                line_count=line_count,
+                since=since,
+                search=search,
+            )
+        except ValueError as error:
+            raise click.ClickException(str(error)) from error
+    finally:
+        postgres_store.close()
+    click.echo(json.dumps({"status": "ok", **payload}, indent=2, sort_keys=True))
 
 
 @main.group("dokploy-targets")

--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -57,6 +57,9 @@ ODOO_RAW_COMPOSE_REQUIRED_SERVICES = ("web", "database", "script-runner")
 _LIKELY_SECRET_LOG_VALUE_PATTERN = re.compile(
     r"(?i)(\b[A-Z0-9_]*(?:PASSWORD|PASS|TOKEN|SECRET|API_KEY|ACCESS_KEY|PRIVATE_KEY)[A-Z0-9_]*\s*[=:]\s*)([^\s,;]+)"
 )
+_QUOTED_SECRET_LOG_VALUE_PATTERN = re.compile(
+    r"(?i)([\"']?\b[A-Z0-9_]*(?:PASSWORD|PASS|TOKEN|SECRET|API_KEY|ACCESS_KEY|PRIVATE_KEY)[A-Z0-9_]*[\"']?\s*[=:]\s*)([\"'])(?:\\.|(?!\2).)*\2"
+)
 _BEARER_LOG_VALUE_PATTERN = re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+")
 _DOKPLOY_LOG_SINCE_PATTERN = re.compile(r"^(all|\d+[smhd])$")
 _DOKPLOY_LOG_SEARCH_PATTERN = re.compile(r"^[a-zA-Z0-9 ._-]{0,500}$")
@@ -689,7 +692,8 @@ def normalize_dokploy_log_search(raw_search: str) -> str:
 
 
 def redact_dokploy_log_line(raw_line: str) -> str:
-    redacted_line = _LIKELY_SECRET_LOG_VALUE_PATTERN.sub(r"\1[redacted]", raw_line)
+    redacted_line = _QUOTED_SECRET_LOG_VALUE_PATTERN.sub(r"\1\2[redacted]\2", raw_line)
+    redacted_line = _LIKELY_SECRET_LOG_VALUE_PATTERN.sub(r"\1[redacted]", redacted_line)
     return _BEARER_LOG_VALUE_PATTERN.sub(r"\1[redacted]", redacted_line)
 
 

--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -57,8 +57,11 @@ ODOO_RAW_COMPOSE_REQUIRED_SERVICES = ("web", "database", "script-runner")
 _LIKELY_SECRET_LOG_VALUE_PATTERN = re.compile(
     r"(?i)(\b[A-Z0-9_]*(?:PASSWORD|PASS|TOKEN|SECRET|API_KEY|ACCESS_KEY|PRIVATE_KEY)[A-Z0-9_]*\s*[=:]\s*)([^\s,;]+)"
 )
-_QUOTED_SECRET_LOG_VALUE_PATTERN = re.compile(
-    r"(?i)([\"']?\b[A-Z0-9_]*(?:PASSWORD|PASS|TOKEN|SECRET|API_KEY|ACCESS_KEY|PRIVATE_KEY)[A-Z0-9_]*[\"']?\s*[=:]\s*)([\"'])(?:\\.|(?!\2).)*\2"
+_DOUBLE_QUOTED_SECRET_LOG_VALUE_PATTERN = re.compile(
+    r'(?i)("?\b[A-Z0-9_]*(?:PASSWORD|PASS|TOKEN|SECRET|API_KEY|ACCESS_KEY|PRIVATE_KEY)[A-Z0-9_]*"?\s*[=:]\s*)"[^"\r\n]*"'
+)
+_SINGLE_QUOTED_SECRET_LOG_VALUE_PATTERN = re.compile(
+    r"(?i)('?\b[A-Z0-9_]*(?:PASSWORD|PASS|TOKEN|SECRET|API_KEY|ACCESS_KEY|PRIVATE_KEY)[A-Z0-9_]*'?\s*[=:]\s*)'[^'\r\n]*'"
 )
 _BEARER_LOG_VALUE_PATTERN = re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+")
 _DOKPLOY_LOG_SINCE_PATTERN = re.compile(r"^(all|\d+[smhd])$")
@@ -692,7 +695,8 @@ def normalize_dokploy_log_search(raw_search: str) -> str:
 
 
 def redact_dokploy_log_line(raw_line: str) -> str:
-    redacted_line = _QUOTED_SECRET_LOG_VALUE_PATTERN.sub(r"\1\2[redacted]\2", raw_line)
+    redacted_line = _DOUBLE_QUOTED_SECRET_LOG_VALUE_PATTERN.sub(r'\1"[redacted]"', raw_line)
+    redacted_line = _SINGLE_QUOTED_SECRET_LOG_VALUE_PATTERN.sub(r"\1'[redacted]'", redacted_line)
     redacted_line = _LIKELY_SECRET_LOG_VALUE_PATTERN.sub(r"\1[redacted]", redacted_line)
     return _BEARER_LOG_VALUE_PATTERN.sub(r"\1[redacted]", redacted_line)
 

--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import re
 import shlex
 import time
 from collections.abc import Callable, Mapping
@@ -23,6 +24,8 @@ from control_plane.storage.postgres import PostgresRecordStore
 DEFAULT_DOKPLOY_DEPLOY_TIMEOUT_SECONDS = 600
 DEFAULT_DOKPLOY_HEALTH_TIMEOUT_SECONDS = 180
 DEFAULT_DOKPLOY_HEALTHCHECK_PATH = "/web/health"
+DEFAULT_DOKPLOY_LOG_LINE_COUNT = 200
+MAX_DOKPLOY_LOG_LINE_COUNT = 1000
 DEFAULT_CONTROL_PLANE_DOKPLOY_SOURCE_FILE = Path("config/dokploy.toml")
 DEFAULT_CONTROL_PLANE_DOKPLOY_TARGET_IDS_FILE = Path("config/dokploy-targets.toml")
 DEFAULT_STABLE_REMOTE_INSTANCES = {"testing", "prod"}
@@ -51,6 +54,12 @@ POST_DEPLOY_UPDATE_ALLOWED_ENV_KEYS = {
 DEFAULT_DATA_WORKFLOW_LOCK_PATH = "/volumes/data/.data_workflow_in_progress"
 DEFAULT_ODOO_BACKUP_ROOT = "/volumes/data/backups/launchplane"
 ODOO_RAW_COMPOSE_REQUIRED_SERVICES = ("web", "database", "script-runner")
+_LIKELY_SECRET_LOG_VALUE_PATTERN = re.compile(
+    r"(?i)(\b[A-Z0-9_]*(?:PASSWORD|PASS|TOKEN|SECRET|API_KEY|ACCESS_KEY|PRIVATE_KEY)[A-Z0-9_]*\s*[=:]\s*)([^\s,;]+)"
+)
+_BEARER_LOG_VALUE_PATTERN = re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+")
+_DOKPLOY_LOG_SINCE_PATTERN = re.compile(r"^(all|\d+[smhd])$")
+_DOKPLOY_LOG_SEARCH_PATTERN = re.compile(r"^[a-zA-Z0-9 ._-]{0,500}$")
 
 
 type JsonPrimitive = str | int | float | bool | None
@@ -649,6 +658,97 @@ def fetch_dokploy_target_payload(
             f"Dokploy {target_type}.one returned an invalid response payload."
         )
     return payload_as_object
+
+
+def normalize_dokploy_log_line_count(line_count: int) -> int:
+    if line_count < 1:
+        raise click.ClickException("Dokploy log line count must be at least 1.")
+    if line_count > MAX_DOKPLOY_LOG_LINE_COUNT:
+        raise click.ClickException(
+            f"Dokploy log line count cannot exceed {MAX_DOKPLOY_LOG_LINE_COUNT}."
+        )
+    return line_count
+
+
+def normalize_dokploy_log_since(raw_since: str) -> str:
+    since = raw_since.strip() or "all"
+    if not _DOKPLOY_LOG_SINCE_PATTERN.fullmatch(since):
+        raise click.ClickException(
+            "Dokploy log --since must be 'all' or a duration like 5m, 2h, or 1d."
+        )
+    return since
+
+
+def normalize_dokploy_log_search(raw_search: str) -> str:
+    search = raw_search.strip()
+    if not _DOKPLOY_LOG_SEARCH_PATTERN.fullmatch(search):
+        raise click.ClickException(
+            "Dokploy log --search may contain only letters, numbers, spaces, dots, underscores, and dashes."
+        )
+    return search
+
+
+def redact_dokploy_log_line(raw_line: str) -> str:
+    redacted_line = _LIKELY_SECRET_LOG_VALUE_PATTERN.sub(r"\1[redacted]", raw_line)
+    return _BEARER_LOG_VALUE_PATTERN.sub(r"\1[redacted]", redacted_line)
+
+
+def normalize_dokploy_log_payload(payload: JsonValue) -> tuple[str, ...]:
+    raw_lines: list[str] = []
+    if isinstance(payload, str):
+        raw_lines.extend(payload.splitlines())
+    elif isinstance(payload, list):
+        for item in payload:
+            if isinstance(item, str):
+                raw_lines.extend(item.splitlines())
+            elif isinstance(item, dict):
+                message = item.get("message") or item.get("log") or item.get("line")
+                if message is not None:
+                    raw_lines.extend(str(message).splitlines())
+    elif isinstance(payload, dict):
+        for key_name in ("logs", "log", "lines", "output", "raw"):
+            value = payload.get(key_name)
+            if isinstance(value, str):
+                raw_lines.extend(value.splitlines())
+                break
+            if isinstance(value, list):
+                raw_lines.extend(
+                    line for item in value for line in normalize_dokploy_log_payload(item)
+                )
+                break
+    return tuple(redact_dokploy_log_line(line) for line in raw_lines)
+
+
+def fetch_dokploy_application_logs(
+    *,
+    host: str,
+    token: str,
+    application_id: str,
+    line_count: int = DEFAULT_DOKPLOY_LOG_LINE_COUNT,
+    since: str = "all",
+    search: str = "",
+) -> tuple[str, ...]:
+    normalized_application_id = application_id.strip()
+    if not normalized_application_id:
+        raise click.ClickException("Dokploy application logs require an application id.")
+    normalized_line_count = normalize_dokploy_log_line_count(line_count)
+    normalized_since = normalize_dokploy_log_since(since)
+    normalized_search = normalize_dokploy_log_search(search)
+    query: dict[str, str | int] = {
+        "applicationId": normalized_application_id,
+        "tail": normalized_line_count,
+        "since": normalized_since,
+    }
+    if normalized_search:
+        query["search"] = normalized_search
+    payload = dokploy_request(
+        host=host,
+        token=token,
+        path="/api/application.readLogs",
+        query=query,
+    )
+    lines = normalize_dokploy_log_payload(payload)
+    return lines[-normalized_line_count:]
 
 
 def parse_dokploy_env_text(raw_env_text: str) -> dict[str, str]:

--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -714,6 +714,11 @@ def normalize_dokploy_log_payload(payload: JsonValue) -> tuple[str, ...]:
                 if message is not None:
                     raw_lines.extend(str(message).splitlines())
     elif isinstance(payload, dict):
+        for key_name in ("message", "line"):
+            value = payload.get(key_name)
+            if value is not None:
+                raw_lines.extend(str(value).splitlines())
+                break
         for key_name in ("logs", "log", "lines", "output", "raw"):
             value = payload.get(key_name)
             if isinstance(value, str):

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2601,15 +2601,29 @@ def create_launchplane_service_app(
                                 },
                             },
                         )
-                    log_payload = build_tracked_target_logs_payload(
-                        record_store=record_store,
-                        control_plane_root=resolved_root,
-                        context_name=context_name,
-                        instance_name=instance_name,
-                        line_count=line_count,
-                        since=since,
-                        search=search,
-                    )
+                    try:
+                        log_payload = build_tracked_target_logs_payload(
+                            record_store=record_store,
+                            control_plane_root=resolved_root,
+                            context_name=context_name,
+                            instance_name=instance_name,
+                            line_count=line_count,
+                            since=since,
+                            search=search,
+                        )
+                    except ValueError as error:
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=400,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "invalid_request",
+                                    "message": str(error),
+                                },
+                            },
+                        )
                     return _json_response(
                         start_response=start_response,
                         status_code=200,

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2588,6 +2588,19 @@ def create_launchplane_service_app(
                     )
                     since = str((query.get("since") or ["all"])[0])
                     search = str((query.get("search") or [""])[0])
+                    if not isinstance(record_store, PostgresRecordStore):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=503,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "database_required",
+                                    "message": "Tracked target logs require DB-backed Launchplane storage.",
+                                },
+                            },
+                        )
                     log_payload = build_tracked_target_logs_payload(
                         record_store=record_store,
                         control_plane_root=resolved_root,

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2611,7 +2611,7 @@ def create_launchplane_service_app(
                             since=since,
                             search=search,
                         )
-                    except ValueError as error:
+                    except ValueError:
                         return _json_response(
                             start_response=start_response,
                             status_code=400,
@@ -2620,7 +2620,7 @@ def create_launchplane_service_app(
                                 "trace_id": request_trace_id,
                                 "error": {
                                     "code": "invalid_request",
-                                    "message": str(error),
+                                    "message": "Tracked target logs request failed validation.",
                                 },
                             },
                         )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -90,6 +90,7 @@ from control_plane.service_human_auth import (
 from control_plane.storage.factory import build_record_store, storage_backend_name
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.tracked_target_logs import build_tracked_target_logs_payload
 from control_plane.workflows.evidence_ingestion import (
     apply_deployment_evidence,
     apply_promotion_evidence,
@@ -1132,6 +1133,13 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         and segments[5] == "secrets"
     ):
         return "secret.list", {"context": segments[2], "instance": segments[4]}
+    if (
+        len(segments) == 6
+        and segments[:2] == ["v1", "contexts"]
+        and segments[3] == "instances"
+        and segments[5] == "logs"
+    ):
+        return "target_logs.read", {"context": segments[2], "instance": segments[4]}
     if (
         len(segments) == 5
         and segments[:2] == ["v1", "contexts"]
@@ -2547,6 +2555,55 @@ def create_launchplane_service_app(
                             "context": context_name,
                             "instance": params.get("instance", ""),
                             "secrets": statuses,
+                        },
+                    )
+                if action == "target_logs.read":
+                    context_name = params["context"]
+                    instance_name = params["instance"]
+                    if not authz_policy.allows(
+                        identity=identity,
+                        action=action,
+                        product="launchplane",
+                        context=context_name,
+                    ):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=403,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "authorization_denied",
+                                    "message": "Workflow cannot read tracked target logs for the requested context.",
+                                },
+                            },
+                        )
+                    line_count = int(
+                        str(
+                            (
+                                query.get("lines")
+                                or [control_plane_dokploy.DEFAULT_DOKPLOY_LOG_LINE_COUNT]
+                            )[0]
+                        )
+                    )
+                    since = str((query.get("since") or ["all"])[0])
+                    search = str((query.get("search") or [""])[0])
+                    log_payload = build_tracked_target_logs_payload(
+                        record_store=record_store,
+                        control_plane_root=resolved_root,
+                        context_name=context_name,
+                        instance_name=instance_name,
+                        line_count=line_count,
+                        since=since,
+                        search=search,
+                    )
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=200,
+                        payload={
+                            "status": "ok",
+                            "trace_id": request_trace_id,
+                            **log_payload,
                         },
                     )
                 if action == "launchplane_service.read":

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2601,29 +2601,15 @@ def create_launchplane_service_app(
                                 },
                             },
                         )
-                    try:
-                        log_payload = build_tracked_target_logs_payload(
-                            record_store=record_store,
-                            control_plane_root=resolved_root,
-                            context_name=context_name,
-                            instance_name=instance_name,
-                            line_count=line_count,
-                            since=since,
-                            search=search,
-                        )
-                    except ValueError:
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=400,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "invalid_request",
-                                    "message": "Tracked target logs request failed validation.",
-                                },
-                            },
-                        )
+                    log_payload = build_tracked_target_logs_payload(
+                        record_store=record_store,
+                        control_plane_root=resolved_root,
+                        context_name=context_name,
+                        instance_name=instance_name,
+                        line_count=line_count,
+                        since=since,
+                        search=search,
+                    )
                     return _json_response(
                         start_response=start_response,
                         status_code=200,

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from datetime import datetime, timezone
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
 from pydantic import BaseModel
 from sqlalchemy import JSON, Index, Integer, String, create_engine, delete, desc, select
@@ -48,6 +48,7 @@ RecordModel = TypeVar("RecordModel", bound=BaseModel)
 ConnectionFactory = Callable[[], Any]
 PayloadDict = dict[str, Any]
 PayloadJsonType = JSON().with_variant(JSONB(), "postgresql")
+RuntimeEnvironmentDeleteStatus = Literal["deleted", "missing", "changed"]
 
 
 class Base(DeclarativeBase):
@@ -1416,7 +1417,8 @@ class PostgresRecordStore(HumanSessionStore):
         self,
         *,
         event: RuntimeEnvironmentDeleteEvent,
-    ) -> int:
+        expected_record: RuntimeEnvironmentRecord,
+    ) -> RuntimeEnvironmentDeleteStatus:
         statement = (
             select(LaunchplaneRuntimeEnvironmentRow)
             .where(
@@ -1425,11 +1427,18 @@ class PostgresRecordStore(HumanSessionStore):
                 LaunchplaneRuntimeEnvironmentRow.instance == event.instance,
             )
             .limit(1)
+            .with_for_update()
         )
         with self._session_factory() as session:
             row = session.scalar(statement)
             if row is None:
-                return 0
+                return "missing"
+            current_record = self._read_payload(
+                model_type=RuntimeEnvironmentRecord,
+                payload=row.payload,
+            )
+            if self._payload_dict(current_record) != self._payload_dict(expected_record):
+                return "changed"
             session.delete(row)
             session.add(
                 LaunchplaneRuntimeEnvironmentDeleteEventRow(
@@ -1442,7 +1451,7 @@ class PostgresRecordStore(HumanSessionStore):
                 )
             )
             session.commit()
-            return 1
+            return "deleted"
 
     def write_runtime_environment_delete_event(self, event: RuntimeEnvironmentDeleteEvent) -> None:
         self._write_row(

--- a/control_plane/tracked_target_logs.py
+++ b/control_plane/tracked_target_logs.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+from control_plane import dokploy as control_plane_dokploy
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+
+
+class TrackedTargetLogsStore(Protocol):
+    def read_dokploy_target_record(
+        self, *, context_name: str, instance_name: str
+    ) -> DokployTargetRecord: ...
+
+    def read_dokploy_target_id_record(
+        self, *, context_name: str, instance_name: str
+    ) -> DokployTargetIdRecord: ...
+
+
+def build_tracked_target_logs_payload(
+    *,
+    record_store: TrackedTargetLogsStore,
+    control_plane_root: Path,
+    context_name: str,
+    instance_name: str,
+    line_count: int,
+    since: str = "all",
+    search: str = "",
+) -> dict[str, object]:
+    target_record = record_store.read_dokploy_target_record(
+        context_name=context_name,
+        instance_name=instance_name,
+    )
+    target_id_record = record_store.read_dokploy_target_id_record(
+        context_name=context_name,
+        instance_name=instance_name,
+    )
+    if target_record.target_type != "application":
+        raise ValueError(
+            "Tracked target logs currently support Dokploy application targets only. "
+            f"Configured target_type={target_record.target_type}."
+        )
+
+    normalized_line_count = control_plane_dokploy.normalize_dokploy_log_line_count(line_count)
+    normalized_since = control_plane_dokploy.normalize_dokploy_log_since(since)
+    normalized_search = control_plane_dokploy.normalize_dokploy_log_search(search)
+    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
+    target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
+        host=host,
+        token=token,
+        target_type=target_record.target_type,
+        target_id=target_id_record.target_id,
+    )
+    logs = control_plane_dokploy.fetch_dokploy_application_logs(
+        host=host,
+        token=token,
+        application_id=target_id_record.target_id,
+        line_count=normalized_line_count,
+        since=normalized_since,
+        search=normalized_search,
+    )
+    app_name = str(target_payload.get("appName") or "").strip()
+    server_id = str(target_payload.get("serverId") or "").strip()
+    return {
+        "context": context_name,
+        "instance": instance_name,
+        "target": {
+            "target_id": target_id_record.target_id,
+            "target_type": target_record.target_type,
+            "target_name": target_record.target_name,
+            "app_name": app_name,
+            "server_id": server_id,
+            "source_label": target_record.source_label,
+        },
+        "request": {
+            "line_count": normalized_line_count,
+            "since": normalized_since,
+            "search": normalized_search,
+        },
+        "logs": {
+            "line_count": len(logs),
+            "lines": list(logs),
+            "redacted": True,
+        },
+    }

--- a/control_plane/tracked_target_logs.py
+++ b/control_plane/tracked_target_logs.py
@@ -28,14 +28,23 @@ def build_tracked_target_logs_payload(
     since: str = "all",
     search: str = "",
 ) -> dict[str, object]:
-    target_record = record_store.read_dokploy_target_record(
-        context_name=context_name,
-        instance_name=instance_name,
-    )
-    target_id_record = record_store.read_dokploy_target_id_record(
-        context_name=context_name,
-        instance_name=instance_name,
-    )
+    normalized_context = context_name.strip().lower()
+    normalized_instance = instance_name.strip().lower()
+    if not normalized_context or not normalized_instance:
+        raise ValueError("Tracked target logs require non-empty context and instance.")
+    try:
+        target_record = record_store.read_dokploy_target_record(
+            context_name=normalized_context,
+            instance_name=normalized_instance,
+        )
+        target_id_record = record_store.read_dokploy_target_id_record(
+            context_name=normalized_context,
+            instance_name=normalized_instance,
+        )
+    except FileNotFoundError as error:
+        raise ValueError(
+            "Missing DB-backed tracked Dokploy target records for requested context/instance."
+        ) from error
     if target_record.target_type != "application":
         raise ValueError(
             "Tracked target logs currently support Dokploy application targets only. "
@@ -63,8 +72,8 @@ def build_tracked_target_logs_payload(
     app_name = str(target_payload.get("appName") or "").strip()
     server_id = str(target_payload.get("serverId") or "").strip()
     return {
-        "context": context_name,
-        "instance": instance_name,
+        "context": normalized_context,
+        "instance": normalized_instance,
         "target": {
             "target_id": target_id_record.target_id,
             "target_type": target_record.target_type,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -330,6 +330,15 @@ Current derived-state behavior:
   target-id records in steady state.
 - Dokploy source loading fails closed when target ids are missing, duplicate
   routes are present, or the tracked target records omit a required target id.
+- `environments logs --context <context> --instance <instance> --lines <n>`
+  resolves the DB-backed tracked Dokploy target and target id before fetching
+  bounded application logs. The first cut supports Dokploy `application`
+  targets, includes route/target/app/server metadata, accepts optional
+  `--since` and `--search`, and redacts likely secret values from returned log
+  lines.
+- `GET /v1/contexts/{context}/instances/{instance}/logs?lines=200` exposes the
+  same tracked-target log reader through the authenticated service API using
+  action `target_logs.read`.
 
 ## Runtime Environment Contracts
 
@@ -365,7 +374,9 @@ Current derived-state behavior:
   dry-run and apply responses include record identity, source label, update
   timestamp, key names, key count, actor, and delete-event metadata only. Apply
   refuses records that can affect a tracked Dokploy target unless
-  `--allow-tracked-target` is provided.
+  `--allow-tracked-target` is provided. Apply also fails closed if the target
+  record changes after the command reads it; re-run the command after reviewing
+  the current record.
 - `environments relabel` updates runtime-environment record source metadata
   without reading or printing plaintext values.
 - `environments list` shows DB-backed runtime-environment record metadata and

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -416,11 +416,17 @@ read-model contract documented in [driver-descriptors.md](driver-descriptors.md)
 - `GET /v1/drivers/{driver_id}`
 - `GET /v1/contexts/{context}/driver-view`
 - `GET /v1/contexts/{context}/instances/{instance}/driver-view`
+- `GET /v1/contexts/{context}/instances/{instance}/logs?lines=200`
 
 They use action `driver.read`. Discovery authorizes against context
 `launchplane`; context and instance views authorize against the requested
 context. These routes expose Launchplane capabilities and repository-backed read
 state, not runtime-provider primitives.
+
+The logs route is the exception to the `driver.read` action because it reads live
+provider output. It uses action `target_logs.read`, resolves DB-backed tracked
+target records by context/instance, supports bounded Dokploy `application` logs,
+and redacts likely secret values before returning lines.
 
 The preview driver cut stays intentionally narrow but keeps topology in
 Launchplane: Launchplane owns preview URL derivation from the

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -76,6 +76,147 @@ def _seed_dokploy_target_records(
 
 
 class DokployConfigTests(unittest.TestCase):
+    def test_application_log_payload_normalization_redacts_likely_secrets(self) -> None:
+        lines = control_plane_dokploy.normalize_dokploy_log_payload(
+            {
+                "logs": [
+                    "started",
+                    "RESEND_API_KEY=re_123 Bearer abc.def SMTP_PASSWORD=smtp-secret",
+                ]
+            }
+        )
+
+        self.assertEqual(lines[0], "started")
+        self.assertIn("RESEND_API_KEY=[redacted]", lines[1])
+        self.assertIn("Bearer [redacted]", lines[1])
+        self.assertIn("SMTP_PASSWORD=[redacted]", lines[1])
+        self.assertNotIn("re_123", lines[1])
+        self.assertNotIn("smtp-secret", lines[1])
+
+    def test_fetch_application_logs_calls_dokploy_read_logs_endpoint(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        with patch(
+            "control_plane.dokploy.dokploy_request",
+            side_effect=lambda **kwargs: (
+                requests.append(kwargs) or {"logs": "one\ntwo\nTHREE_TOKEN=secret"}
+            ),
+        ):
+            lines = control_plane_dokploy.fetch_dokploy_application_logs(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                application_id="app-123",
+                line_count=2,
+            )
+
+        self.assertEqual(len(requests), 1)
+        self.assertEqual(requests[0]["path"], "/api/application.readLogs")
+        self.assertEqual(
+            requests[0]["query"], {"applicationId": "app-123", "tail": 2, "since": "all"}
+        )
+        self.assertEqual(lines, ("two", "THREE_TOKEN=[redacted]"))
+
+    def test_environments_logs_resolves_tracked_application_and_redacts_output(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            _seed_dokploy_target_records(
+                store=store,
+                payload="""
+schema_version = 2
+
+[[targets]]
+context = "sellyouroutboard-testing"
+instance = "testing"
+target_id = "app-123"
+target_type = "application"
+target_name = "syo-testing-app"
+""",
+            )
+            store.close()
+
+            with (
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "secret-token"),
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_target_payload",
+                    return_value={"appName": "syo-testing-gfbiqh", "serverId": "server-1"},
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_application_logs",
+                    return_value=("started", "SMTP_PASSWORD=[redacted]"),
+                ),
+            ):
+                result = runner.invoke(
+                    main,
+                    [
+                        "environments",
+                        "logs",
+                        "--database-url",
+                        database_url,
+                        "--context",
+                        "sellyouroutboard-testing",
+                        "--instance",
+                        "testing",
+                        "--lines",
+                        "2",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["target"]["target_id"], "app-123")
+        self.assertEqual(payload["target"]["target_name"], "syo-testing-app")
+        self.assertEqual(payload["target"]["app_name"], "syo-testing-gfbiqh")
+        self.assertEqual(payload["logs"]["lines"], ["started", "SMTP_PASSWORD=[redacted]"])
+        self.assertNotIn("secret-token", result.output)
+
+    def test_environments_logs_rejects_compose_targets(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            _seed_dokploy_target_records(
+                store=store,
+                payload="""
+schema_version = 2
+
+[[targets]]
+context = "opw"
+instance = "testing"
+target_id = "compose-123"
+target_type = "compose"
+target_name = "opw-testing"
+""",
+            )
+            store.close()
+
+            result = runner.invoke(
+                main,
+                [
+                    "environments",
+                    "logs",
+                    "--database-url",
+                    database_url,
+                    "--context",
+                    "opw",
+                    "--instance",
+                    "testing",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("application targets only", result.output)
+
     def test_update_application_env_includes_empty_build_fields_when_missing(self) -> None:
         requests: list[dict[str, object]] = []
 

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -103,6 +103,18 @@ class DokployConfigTests(unittest.TestCase):
             '{"API_KEY":"[redacted]","nested":{"SERVICE_TOKEN":"[redacted]"},"note":"safe"}',
         )
 
+    def test_normalize_dokploy_log_payload_reads_message_objects_in_dict_lists(self) -> None:
+        lines = control_plane_dokploy.normalize_dokploy_log_payload(
+            {
+                "logs": [
+                    {"message": "started"},
+                    {"line": "SERVICE_TOKEN=inner-secret"},
+                ]
+            }
+        )
+
+        self.assertEqual(lines, ("started", "SERVICE_TOKEN=[redacted]"))
+
     def test_fetch_application_logs_calls_dokploy_read_logs_endpoint(self) -> None:
         requests: list[dict[str, object]] = []
 

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -93,6 +93,16 @@ class DokployConfigTests(unittest.TestCase):
         self.assertNotIn("re_123", lines[1])
         self.assertNotIn("smtp-secret", lines[1])
 
+    def test_redact_dokploy_log_line_redacts_quoted_secret_fields(self) -> None:
+        redacted_line = control_plane_dokploy.redact_dokploy_log_line(
+            '{"API_KEY":"super-secret","nested":{"SERVICE_TOKEN":"inner-secret"},"note":"safe"}'
+        )
+
+        self.assertEqual(
+            redacted_line,
+            '{"API_KEY":"[redacted]","nested":{"SERVICE_TOKEN":"[redacted]"},"note":"safe"}',
+        )
+
     def test_fetch_application_logs_calls_dokploy_read_logs_endpoint(self) -> None:
         requests: list[dict[str, object]] = []
 

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -183,9 +183,9 @@ target_name = "syo-testing-app"
                         "--database-url",
                         database_url,
                         "--context",
-                        "sellyouroutboard-testing",
+                        " SellyourOutboard-Testing ",
                         "--instance",
-                        "testing",
+                        " Testing ",
                         "--lines",
                         "2",
                     ],
@@ -193,11 +193,41 @@ target_name = "syo-testing-app"
 
         self.assertEqual(result.exit_code, 0, result.output)
         payload = json.loads(result.output)
+        self.assertEqual(payload["context"], "sellyouroutboard-testing")
+        self.assertEqual(payload["instance"], "testing")
         self.assertEqual(payload["target"]["target_id"], "app-123")
         self.assertEqual(payload["target"]["target_name"], "syo-testing-app")
         self.assertEqual(payload["target"]["app_name"], "syo-testing-gfbiqh")
         self.assertEqual(payload["logs"]["lines"], ["started", "SMTP_PASSWORD=[redacted]"])
         self.assertNotIn("secret-token", result.output)
+
+    def test_environments_logs_reports_missing_records_without_traceback(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.close()
+
+            result = runner.invoke(
+                main,
+                [
+                    "environments",
+                    "logs",
+                    "--database-url",
+                    database_url,
+                    "--context",
+                    "missing",
+                    "--instance",
+                    "testing",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Missing DB-backed tracked Dokploy target records", result.output)
+        self.assertNotIn("Traceback", result.output)
 
     def test_environments_logs_rejects_compose_targets(self) -> None:
         runner = CliRunner()

--- a/tests/test_runtime_environments.py
+++ b/tests/test_runtime_environments.py
@@ -14,6 +14,10 @@ from control_plane import dokploy as control_plane_dokploy
 from control_plane.cli import main
 from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.runtime_environment_record import (
+    RuntimeEnvironmentDeleteEvent,
+    RuntimeEnvironmentRecord,
+)
 from control_plane.storage.postgres import PostgresRecordStore
 
 
@@ -474,6 +478,55 @@ class RuntimeEnvironmentTests(unittest.TestCase):
         self.assertEqual(delete_events[0].actor, "operator@example.com")
         self.assertEqual(delete_events[0].env_keys, ("TAWK_PROPERTY_ID", "TAWK_WIDGET_ID"))
 
+    def test_environments_delete_record_apply_refuses_changed_snapshot(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            _seed_runtime_environment_records(
+                database_url=database_url,
+                definition=control_plane_runtime_environments.RuntimeEnvironmentDefinition(
+                    schema_version=1,
+                    shared_env={},
+                    contexts={
+                        "sellyouroutboard": control_plane_runtime_environments.RuntimeEnvironmentContextDefinition(
+                            shared_env={},
+                            instances={
+                                "prod": control_plane_runtime_environments.RuntimeEnvironmentInstanceDefinition(
+                                    env={"TAWK_WIDGET_ID": "widget-123"}
+                                )
+                            },
+                        )
+                    },
+                ),
+                source_label="operator:mistake",
+            )
+
+            with patch.object(
+                PostgresRecordStore,
+                "delete_runtime_environment_record_with_event",
+                return_value="changed",
+            ):
+                result = CliRunner().invoke(
+                    main,
+                    [
+                        "environments",
+                        "delete-record",
+                        "--database-url",
+                        database_url,
+                        "--scope",
+                        "instance",
+                        "--context",
+                        "sellyouroutboard",
+                        "--instance",
+                        "prod",
+                        "--apply",
+                    ],
+                )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("changed before delete could complete", result.output)
+
     def test_environments_delete_record_appends_audit_events_for_repeated_delete_shape(
         self,
     ) -> None:
@@ -534,6 +587,63 @@ class RuntimeEnvironmentTests(unittest.TestCase):
 
         self.assertEqual(len(delete_events), 2)
         self.assertNotEqual(delete_events[0].event_id, delete_events[1].event_id)
+
+    def test_delete_runtime_environment_record_refuses_changed_snapshot(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            expected_record = RuntimeEnvironmentRecord(
+                scope="instance",
+                context="sellyouroutboard",
+                instance="prod",
+                env={"TAWK_WIDGET_ID": "widget-123"},
+                updated_at="2026-04-22T00:00:00Z",
+                source_label="operator:mistake",
+            )
+            changed_record = RuntimeEnvironmentRecord(
+                scope="instance",
+                context="sellyouroutboard",
+                instance="prod",
+                env={"TAWK_PROPERTY_ID": "property-123"},
+                updated_at="2026-04-22T00:01:00Z",
+                source_label="operator:replacement",
+            )
+            stale_delete_event = RuntimeEnvironmentDeleteEvent(
+                event_id="runtime-env-delete-test",
+                recorded_at="2026-04-22T00:02:00Z",
+                actor="operator@example.com",
+                scope=expected_record.scope,
+                context=expected_record.context,
+                instance=expected_record.instance,
+                source_label=expected_record.source_label,
+                env_keys=tuple(sorted(expected_record.env.keys())),
+                env_value_count=len(expected_record.env),
+                detail="deleted by launchplane environments delete-record",
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                store.write_runtime_environment_record(expected_record)
+                store.write_runtime_environment_record(changed_record)
+
+                delete_status = store.delete_runtime_environment_record_with_event(
+                    event=stale_delete_event,
+                    expected_record=expected_record,
+                )
+
+                remaining_records = store.list_runtime_environment_records(
+                    scope="instance",
+                    context_name="sellyouroutboard",
+                    instance_name="prod",
+                )
+                delete_events = store.list_runtime_environment_delete_events()
+            finally:
+                store.close()
+
+        self.assertEqual(delete_status, "changed")
+        self.assertEqual(remaining_records, (changed_record,))
+        self.assertEqual(delete_events, ())
 
     def test_environments_delete_record_refuses_tracked_target_without_allow_flag(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1120,6 +1120,40 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
 
+    def test_tracked_target_logs_endpoint_requires_db_backed_storage(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["launchplane"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["target_logs.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/contexts/sellyouroutboard-testing/instances/testing/logs",
+            )
+
+        self.assertEqual(status_code, 503)
+        self.assertEqual(payload["error"]["code"], "database_required")
+
     def test_product_profile_endpoints_round_trip_authorized_record(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -22,6 +22,8 @@ from control_plane.contracts.authz_policy_record import (
 )
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
 from control_plane.contracts.preview_generation_record import (
     PreviewGenerationRecord,
@@ -212,6 +214,41 @@ def _sqlite_database_url(database_path: Path) -> str:
     return f"sqlite+pysqlite:///{database_path}"
 
 
+def _seed_tracked_target_records(
+    *,
+    database_url: str,
+    context: str,
+    instance: str,
+    target_id: str,
+    target_type: Literal["compose", "application"],
+    target_name: str,
+) -> None:
+    store = PostgresRecordStore(database_url=database_url)
+    store.ensure_schema()
+    try:
+        store.write_dokploy_target_record(
+            DokployTargetRecord(
+                context=context,
+                instance=instance,
+                target_type=target_type,
+                target_name=target_name,
+                updated_at="2026-05-01T00:00:00Z",
+                source_label="test",
+            )
+        )
+        store.write_dokploy_target_id_record(
+            DokployTargetIdRecord(
+                context=context,
+                instance=instance,
+                target_id=target_id,
+                updated_at="2026-05-01T00:00:00Z",
+                source_label="test",
+            )
+        )
+    finally:
+        store.close()
+
+
 def _product_config_payload() -> dict[str, object]:
     return {
         "schema_version": 1,
@@ -244,6 +281,7 @@ def _invoke_app(
     *,
     method: str,
     path: str,
+    query_string: str = "",
     payload: dict[str, object] | None = None,
     authorization: str = "Bearer valid-token",
     headers: dict[str, str] | None = None,
@@ -252,6 +290,7 @@ def _invoke_app(
     environ = {
         "REQUEST_METHOD": method,
         "PATH_INFO": path,
+        "QUERY_STRING": query_string,
         "CONTENT_LENGTH": str(len(body_bytes)),
         "wsgi.input": io.BytesIO(body_bytes),
         "HTTP_AUTHORIZATION": authorization,
@@ -964,6 +1003,122 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 404)
         self.assertEqual(payload["error"]["code"], "not_found")
+
+    def test_tracked_target_logs_endpoint_returns_redacted_application_logs(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_id="app-123",
+                target_type="application",
+                target_name="syo-testing-app",
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["launchplane"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["target_logs.read"],
+                        }
+                    ]
+                }
+            )
+            with (
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "secret-token"),
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_target_payload",
+                    return_value={"appName": "syo-testing-gfbiqh", "serverId": "server-1"},
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_application_logs",
+                    return_value=("ok", "RESEND_API_KEY=[redacted]"),
+                ) as logs_mock,
+            ):
+                app = create_launchplane_service_app(
+                    state_dir=root / "state",
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=policy,
+                    control_plane_root_path=root,
+                    database_url=database_url,
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/contexts/sellyouroutboard-testing/instances/testing/logs",
+                    query_string="lines=2&since=5m&search=contact",
+                )
+
+        self.assertEqual(status_code, 200)
+        logs_mock.assert_called_once_with(
+            host="https://dokploy.example.com",
+            token="secret-token",
+            application_id="app-123",
+            line_count=2,
+            since="5m",
+            search="contact",
+        )
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["target"]["target_name"], "syo-testing-app")
+        self.assertEqual(payload["target"]["app_name"], "syo-testing-gfbiqh")
+        self.assertEqual(payload["request"], {"line_count": 2, "since": "5m", "search": "contact"})
+        self.assertEqual(payload["logs"]["lines"], ["ok", "RESEND_API_KEY=[redacted]"])
+        self.assertNotIn("secret-token", json.dumps(payload))
+
+    def test_tracked_target_logs_endpoint_requires_authz_action(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_id="app-123",
+                target_type="application",
+                target_name="syo-testing-app",
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["launchplane"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["driver.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/contexts/sellyouroutboard-testing/instances/testing/logs",
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
 
     def test_product_profile_endpoints_round_trip_authorized_record(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
Closes #124.

Summary:
- Adds a tracked-target logs reader that resolves DB-backed Dokploy target records and target-id records by context/instance.
- Adds `launchplane environments logs` with bounded `--lines`, optional `--since`, and optional `--search` for Dokploy application targets.
- Adds `GET /v1/contexts/{context}/instances/{instance}/logs?lines=200` using action `target_logs.read`.
- Normalizes Dokploy log payload shapes and redacts likely secret values before returning lines.
- Fails clearly for unsupported compose targets until multi-service compose log selection is modeled.
- Also hardens `environments delete-record` so apply refuses to delete if the runtime-env record changed after the command snapshot.

Validation:
- uv run --extra dev ruff format --check control_plane/cli.py control_plane/dokploy.py control_plane/service.py control_plane/storage/postgres.py control_plane/tracked_target_logs.py tests/test_dokploy.py tests/test_runtime_environments.py tests/test_service.py
- uv run --extra dev ruff check control_plane/cli.py control_plane/dokploy.py control_plane/service.py control_plane/storage/postgres.py control_plane/tracked_target_logs.py tests/test_dokploy.py tests/test_runtime_environments.py tests/test_service.py
- uv run python -m unittest tests.test_dokploy tests.test_service
- uv run python -m unittest
- npx --yes markdownlint-cli2 docs/operations.md docs/service-boundary.md
- git diff --check
