### PR TITLE
Add generic-web prod promotion driver

### DIFF
--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -66,8 +66,8 @@ GENERIC_WEB_DRIVER = DriverDescriptor(
             capability_id="image_deployable",
             label="Image deployable",
             description="Deploy immutable container images and record stable-lane deployment evidence.",
-            actions=("stable_deploy",),
-            panels=("lane_health", "deployment_evidence"),
+            actions=("stable_deploy", "prod_promotion"),
+            panels=("lane_health", "deployment_evidence", "promotion_evidence"),
         ),
         DriverCapabilityDescriptor(
             capability_id="health_checked",
@@ -105,6 +105,15 @@ GENERIC_WEB_DRIVER = DriverDescriptor(
             scope="instance",
             route_path="/v1/drivers/generic-web/deploy",
             writes_records=("deployment",),
+        ),
+        _action(
+            "prod_promotion",
+            "Promote testing to prod",
+            "Promote a generic-web testing image to prod and record promotion health evidence.",
+            safety="mutation",
+            scope="instance",
+            route_path="/v1/drivers/generic-web/prod-promotion",
+            writes_records=("deployment", "promotion", "inventory"),
         ),
         _action(
             "preview_desired_state",

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -100,6 +100,11 @@ from control_plane.workflows.generic_web_deploy import (
     execute_generic_web_deploy,
     resolve_generic_web_profile_lane,
 )
+from control_plane.workflows.generic_web_promotion import (
+    GenericWebProdPromotionRequest,
+    execute_generic_web_prod_promotion,
+    resolve_generic_web_promotion_lanes,
+)
 from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewDesiredStateRequest,
     GenericWebPreviewDestroyRequest,
@@ -264,6 +269,22 @@ class GenericWebDeployEnvelope(BaseModel):
             raise ValueError("generic web deploy requires product")
         if self.product.strip() != self.deploy.product.strip():
             raise ValueError("generic web deploy requires matching product values")
+        return self
+
+
+class GenericWebProdPromotionEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    promotion: GenericWebProdPromotionRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "GenericWebProdPromotionEnvelope":
+        if not self.product.strip():
+            raise ValueError("generic web prod promotion requires product")
+        if self.product.strip() != self.promotion.product.strip():
+            raise ValueError("generic web prod promotion requires matching product values")
         return self
 
 
@@ -2019,6 +2040,7 @@ def create_launchplane_service_app(
         "/v1/evidence/promotions",
         "/v1/drivers/launchplane/self-deploy",
         "/v1/drivers/generic-web/deploy",
+        "/v1/drivers/generic-web/prod-promotion",
         "/v1/drivers/generic-web/preview-desired-state",
         "/v1/drivers/generic-web/preview-refresh",
         "/v1/drivers/generic-web/preview-inventory",
@@ -3000,6 +3022,59 @@ def create_launchplane_service_app(
                     lane=lane,
                 )
                 result = {"deployment_record_id": driver_result.deployment_record_id}
+            elif path == "/v1/drivers/generic-web/prod-promotion":
+                request = GenericWebProdPromotionEnvelope.model_validate(payload)
+                _profile, _source_lane, destination_lane = resolve_generic_web_promotion_lanes(
+                    record_store=record_store,
+                    request=request.promotion,
+                )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="generic_web_prod_promotion.execute",
+                    product=request.product,
+                    context=destination_lane.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot execute the generic web prod promotion driver"
+                                    " for the requested product/context."
+                                ),
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                driver_result = execute_generic_web_prod_promotion(
+                    control_plane_root=resolved_root,
+                    record_store=record_store,
+                    request=request.promotion,
+                )
+                result = {
+                    "promotion_record_id": driver_result.promotion_record_id,
+                    "deployment_record_id": driver_result.deployment_record_id,
+                    "backup_record_id": driver_result.backup_record_id,
+                    "inventory_record_id": driver_result.inventory_record_id,
+                    "promotion_status": driver_result.promotion_status,
+                    "deployment_status": driver_result.deployment_status,
+                    "source_health_status": driver_result.source_health_status,
+                    "destination_health_status": driver_result.destination_health_status,
+                }
             elif path == "/v1/drivers/generic-web/preview-desired-state":
                 request = GenericWebPreviewDesiredStateEnvelope.model_validate(payload)
                 profile = resolve_generic_web_preview_profile(

--- a/control_plane/workflows/generic_web_promotion.py
+++ b/control_plane/workflows/generic_web_promotion.py
@@ -1,0 +1,553 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Literal
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import click
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.backup_gate_record import BackupGateRecord
+from control_plane.contracts.deployment_record import DeploymentRecord
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductLaneProfile,
+)
+from control_plane.contracts.promotion_record import (
+    ArtifactIdentityReference,
+    BackupGateEvidence,
+    DeploymentEvidence,
+    HealthcheckEvidence,
+    PromotionRecord,
+    ReleaseStatus,
+)
+from control_plane.workflows.generic_web_deploy import (
+    GenericWebDeployRequest,
+    execute_generic_web_deploy,
+    resolve_generic_web_profile_lane,
+)
+from control_plane.workflows.inventory import build_environment_inventory
+from control_plane.workflows.promote import generate_promotion_record_id
+from control_plane.workflows.ship import utc_now_timestamp
+
+DEFAULT_GENERIC_WEB_HEALTH_TIMEOUT_SECONDS = 60
+
+
+class GenericWebProdPromotionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    artifact_id: str
+    source_git_ref: str
+    from_instance: str = "testing"
+    to_instance: str = "prod"
+    backup_record_id: str = ""
+    backup_required: bool = False
+    wait: bool = True
+    timeout_seconds: int | None = Field(default=None, ge=1)
+    verify_health: bool = True
+    health_timeout_seconds: int = Field(default=DEFAULT_GENERIC_WEB_HEALTH_TIMEOUT_SECONDS, ge=1)
+    dry_run: bool = False
+    no_cache: bool = False
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "GenericWebProdPromotionRequest":
+        self.product = self.product.strip()
+        self.artifact_id = self.artifact_id.strip()
+        self.source_git_ref = self.source_git_ref.strip()
+        self.from_instance = self.from_instance.strip().lower()
+        self.to_instance = self.to_instance.strip().lower()
+        self.backup_record_id = self.backup_record_id.strip()
+        if not self.product:
+            raise ValueError("generic web prod promotion requires product")
+        if not self.artifact_id:
+            raise ValueError("generic web prod promotion requires artifact_id")
+        if not self.source_git_ref:
+            raise ValueError("generic web prod promotion requires source_git_ref")
+        if self.from_instance == self.to_instance:
+            raise ValueError("generic web prod promotion source and destination must differ")
+        if self.from_instance != "testing" or self.to_instance != "prod":
+            raise ValueError("generic web prod promotion requires testing -> prod")
+        if self.backup_required and not self.backup_record_id:
+            raise ValueError(
+                "generic web prod promotion requires backup_record_id when backup_required=true"
+            )
+        if not self.wait:
+            raise ValueError("generic web prod promotion requires wait=true")
+        return self
+
+
+class GenericWebProdPromotionResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    product: str
+    context: str
+    from_instance: str
+    to_instance: str
+    artifact_id: str
+    backup_record_id: str = ""
+    promotion_record_id: str
+    deployment_record_id: str = ""
+    inventory_record_id: str = ""
+    promotion_status: Literal["pending", "pass", "fail"]
+    deployment_status: ReleaseStatus = "skipped"
+    backup_status: ReleaseStatus = "skipped"
+    source_health_status: ReleaseStatus = "skipped"
+    destination_health_status: ReleaseStatus = "skipped"
+    target_name: str = ""
+    target_type: str = ""
+    target_id: str = ""
+    dry_run: bool = False
+    error_message: str = ""
+
+
+def resolve_generic_web_promotion_lanes(
+    *, record_store: object, request: GenericWebProdPromotionRequest
+) -> tuple[LaunchplaneProductProfileRecord, ProductLaneProfile, ProductLaneProfile]:
+    source_profile, source_lane = resolve_generic_web_profile_lane(
+        record_store=record_store,
+        request=GenericWebDeployRequest(
+            product=request.product,
+            instance=request.from_instance,
+            artifact_id=request.artifact_id,
+            source_git_ref=request.source_git_ref,
+        ),
+    )
+    destination_profile, destination_lane = resolve_generic_web_profile_lane(
+        record_store=record_store,
+        request=GenericWebDeployRequest(
+            product=request.product,
+            instance=request.to_instance,
+            artifact_id=request.artifact_id,
+            source_git_ref=request.source_git_ref,
+        ),
+    )
+    if source_profile.product != destination_profile.product:
+        raise click.ClickException("Generic web promotion resolved inconsistent product profiles.")
+    if source_lane.context != destination_lane.context:
+        raise click.ClickException(
+            "Generic web promotion currently requires source and destination lanes to share a context. "
+            f"Resolved source={source_lane.context} destination={destination_lane.context}."
+        )
+    return source_profile, source_lane, destination_lane
+
+
+def execute_generic_web_prod_promotion(
+    *,
+    control_plane_root: Path,
+    record_store: object,
+    request: GenericWebProdPromotionRequest,
+) -> GenericWebProdPromotionResult:
+    profile, source_lane, destination_lane = resolve_generic_web_promotion_lanes(
+        record_store=record_store,
+        request=request,
+    )
+    promotion_record_id = generate_promotion_record_id(
+        context_name=destination_lane.context,
+        from_instance_name=source_lane.instance,
+        to_instance_name=destination_lane.instance,
+    )
+    source_health = _health_evidence_for_lane(
+        lane=source_lane,
+        request=request,
+        health_path=profile.health_path,
+        status="pending" if request.verify_health else "skipped",
+    )
+    destination_health = _health_evidence_for_lane(
+        lane=destination_lane,
+        request=request,
+        health_path=profile.health_path,
+        status="pending" if request.verify_health else "skipped",
+    )
+    backup_gate = _resolve_backup_gate(
+        record_store=record_store,
+        request=request,
+        context=destination_lane.context,
+    )
+
+    if request.dry_run:
+        return GenericWebProdPromotionResult(
+            product=request.product,
+            context=destination_lane.context,
+            from_instance=source_lane.instance,
+            to_instance=destination_lane.instance,
+            artifact_id=request.artifact_id,
+            backup_record_id=request.backup_record_id,
+            promotion_record_id=promotion_record_id,
+            promotion_status="pending",
+            backup_status=backup_gate.status,
+            source_health_status=source_health.status,
+            destination_health_status=destination_health.status,
+            dry_run=True,
+        )
+
+    try:
+        source_health = _verify_health_evidence(source_health)
+    except click.ClickException as error:
+        failed_record = _build_promotion_record(
+            request=request,
+            promotion_record_id=promotion_record_id,
+            context=destination_lane.context,
+            source_health=_mark_health_failed(source_health),
+            backup_gate=backup_gate,
+            destination_health=_mark_health_skipped(destination_health),
+            deployment_record=None,
+            deployment_status="fail",
+            target_name=_fallback_target_name(request=request, lane=destination_lane),
+            target_type="application",
+            deployment_record_id="",
+        )
+        record_store.write_promotion_record(failed_record)
+        return _result_from_record(
+            request=request,
+            record=failed_record,
+            deployment_record=None,
+            inventory_record_id="",
+            target_id="",
+            dry_run=False,
+            error_message=str(error),
+        )
+
+    deploy_result = execute_generic_web_deploy(
+        control_plane_root=control_plane_root,
+        record_store=record_store,
+        request=GenericWebDeployRequest(
+            product=request.product,
+            instance=destination_lane.instance,
+            artifact_id=request.artifact_id,
+            source_git_ref=request.source_git_ref,
+            timeout_seconds=request.timeout_seconds,
+            no_cache=request.no_cache,
+        ),
+        lane=destination_lane,
+    )
+    deployment_record = _read_deployment_record(
+        record_store=record_store,
+        deployment_record_id=deploy_result.deployment_record_id,
+    )
+    if deploy_result.deploy_status == "pass":
+        try:
+            destination_health = _verify_health_evidence(destination_health)
+        except click.ClickException as error:
+            destination_health = _mark_health_failed(destination_health)
+            _write_deployment_health(
+                record_store=record_store,
+                deployment_record=deployment_record,
+                destination_health=destination_health,
+            )
+            final_record = _build_promotion_record(
+                request=request,
+                promotion_record_id=promotion_record_id,
+                context=destination_lane.context,
+                source_health=source_health,
+                backup_gate=backup_gate,
+                destination_health=destination_health,
+                deployment_record=deployment_record,
+                deployment_status="fail",
+                target_name=deploy_result.target_name,
+                target_type=deploy_result.target_type or "application",
+                deployment_record_id=deploy_result.deployment_record_id,
+            )
+            record_store.write_promotion_record(final_record)
+            return _result_from_record(
+                request=request,
+                record=final_record,
+                deployment_record=deployment_record,
+                inventory_record_id="",
+                target_id=deploy_result.target_id,
+                dry_run=False,
+                error_message=str(error),
+            )
+    else:
+        destination_health = _mark_health_skipped(destination_health)
+
+    deployment_record = _write_deployment_health(
+        record_store=record_store,
+        deployment_record=deployment_record,
+        destination_health=destination_health,
+    )
+    final_record = _build_promotion_record(
+        request=request,
+        promotion_record_id=promotion_record_id,
+        context=destination_lane.context,
+        source_health=source_health,
+        backup_gate=backup_gate,
+        destination_health=destination_health,
+        deployment_record=deployment_record,
+        deployment_status=deploy_result.deploy_status,
+        target_name=deploy_result.target_name,
+        target_type=deploy_result.target_type or "application",
+        deployment_record_id=deploy_result.deployment_record_id,
+    )
+    record_store.write_promotion_record(final_record)
+    inventory_record_id = ""
+    if deployment_record.deploy.status == "pass" and destination_health.status in {
+        "pass",
+        "skipped",
+    }:
+        inventory = build_environment_inventory(
+            deployment_record=deployment_record,
+            updated_at=utc_now_timestamp(),
+            promotion_record_id=final_record.record_id,
+            promoted_from_instance=final_record.from_instance,
+        )
+        record_store.write_environment_inventory(inventory)
+        inventory_record_id = f"{inventory.context}-{inventory.instance}"
+    return _result_from_record(
+        request=request,
+        record=final_record,
+        deployment_record=deployment_record,
+        inventory_record_id=inventory_record_id,
+        target_id=deploy_result.target_id,
+        dry_run=False,
+        error_message=deploy_result.error_message,
+    )
+
+
+def _resolve_backup_gate(
+    *, record_store: object, request: GenericWebProdPromotionRequest, context: str
+) -> BackupGateEvidence:
+    if not request.backup_record_id:
+        return BackupGateEvidence(required=request.backup_required, status="skipped", evidence={})
+    try:
+        backup_record: BackupGateRecord = record_store.read_backup_gate_record(
+            request.backup_record_id
+        )
+    except FileNotFoundError as exc:
+        raise click.ClickException(
+            f"Generic web prod promotion requires stored backup gate record '{request.backup_record_id}'."
+        ) from exc
+    if backup_record.instance != request.to_instance:
+        raise click.ClickException(
+            "Backup gate record instance does not match generic web prod promotion destination. "
+            f"Record={backup_record.instance} request={request.to_instance}."
+        )
+    if backup_record.context != context:
+        raise click.ClickException(
+            "Backup gate record context does not match generic web prod promotion context. "
+            f"Record={backup_record.context} request={context}."
+        )
+    if backup_record.required and backup_record.status != "pass":
+        raise click.ClickException(
+            f"Backup gate record '{backup_record.record_id}' must have status=pass before prod promotion."
+        )
+    if request.backup_required and not backup_record.required:
+        raise click.ClickException(
+            f"Backup gate record '{backup_record.record_id}' is marked required=false."
+        )
+    return BackupGateEvidence(
+        required=backup_record.required or request.backup_required,
+        status=backup_record.status,
+        evidence=dict(backup_record.evidence),
+    )
+
+
+def _health_url_for_lane(*, lane: ProductLaneProfile, health_path: str) -> str:
+    health_url = lane.health_url.strip()
+    if health_url:
+        return health_url
+    base_url = lane.base_url.strip().rstrip("/")
+    if base_url:
+        normalized_health_path = health_path.strip() or "/api/health"
+        if not normalized_health_path.startswith("/"):
+            normalized_health_path = f"/{normalized_health_path}"
+        return f"{base_url}{normalized_health_path}"
+    return ""
+
+
+def _health_evidence_for_lane(
+    *,
+    lane: ProductLaneProfile,
+    request: GenericWebProdPromotionRequest,
+    health_path: str,
+    status: ReleaseStatus,
+) -> HealthcheckEvidence:
+    if not request.verify_health:
+        return HealthcheckEvidence(status="skipped")
+    health_url = _health_url_for_lane(lane=lane, health_path=health_path)
+    if not health_url:
+        return HealthcheckEvidence(status="skipped")
+    return HealthcheckEvidence(
+        urls=(health_url,),
+        timeout_seconds=request.health_timeout_seconds,
+        status=status,
+    )
+
+
+def _wait_for_healthcheck(*, url: str, timeout_seconds: int) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    last_error = ""
+    while time.monotonic() < deadline:
+        try:
+            request = Request(url, method="GET")
+            with urlopen(request, timeout=min(5, timeout_seconds)) as response:
+                if 200 <= response.status < 300:
+                    return
+                last_error = f"http {response.status}"
+        except HTTPError as error:
+            last_error = f"http {error.code}"
+        except URLError as error:
+            last_error = str(error.reason)
+        time.sleep(1)
+    raise click.ClickException(f"Healthcheck failed for {url}: {last_error or 'timeout'}")
+
+
+def _verify_health_evidence(evidence: HealthcheckEvidence) -> HealthcheckEvidence:
+    if evidence.status == "skipped" or not evidence.urls:
+        return evidence
+    timeout_seconds = evidence.timeout_seconds or DEFAULT_GENERIC_WEB_HEALTH_TIMEOUT_SECONDS
+    healthcheck_errors: list[str] = []
+    for health_url in evidence.urls:
+        try:
+            _wait_for_healthcheck(url=health_url, timeout_seconds=timeout_seconds)
+            return HealthcheckEvidence(
+                verified=True,
+                urls=evidence.urls,
+                timeout_seconds=timeout_seconds,
+                status="pass",
+            )
+        except click.ClickException as error:
+            healthcheck_errors.append(str(error))
+    raise click.ClickException(
+        "Healthcheck verification failed for all generic web URLs:\n"
+        + "\n".join(healthcheck_errors)
+    )
+
+
+def _mark_health_failed(evidence: HealthcheckEvidence) -> HealthcheckEvidence:
+    if evidence.status == "skipped":
+        return evidence
+    return HealthcheckEvidence(
+        verified=bool(evidence.urls),
+        urls=evidence.urls,
+        timeout_seconds=evidence.timeout_seconds,
+        status="fail",
+    )
+
+
+def _mark_health_skipped(evidence: HealthcheckEvidence) -> HealthcheckEvidence:
+    return HealthcheckEvidence(
+        urls=evidence.urls,
+        timeout_seconds=evidence.timeout_seconds,
+        status="skipped",
+    )
+
+
+def _read_deployment_record(*, record_store: object, deployment_record_id: str) -> DeploymentRecord:
+    try:
+        return record_store.read_deployment_record(deployment_record_id)
+    except FileNotFoundError as exc:
+        raise click.ClickException(
+            f"Generic web prod promotion could not read deployment record '{deployment_record_id}'."
+        ) from exc
+
+
+def _write_deployment_health(
+    *,
+    record_store: object,
+    deployment_record: DeploymentRecord,
+    destination_health: HealthcheckEvidence,
+) -> DeploymentRecord:
+    updated_record = deployment_record.model_copy(
+        update={
+            "verify_destination_health": destination_health.status != "skipped",
+            "destination_health": destination_health,
+        }
+    )
+    record_store.write_deployment_record(updated_record)
+    return updated_record
+
+
+def _build_promotion_record(
+    *,
+    request: GenericWebProdPromotionRequest,
+    promotion_record_id: str,
+    context: str,
+    source_health: HealthcheckEvidence,
+    backup_gate: BackupGateEvidence,
+    destination_health: HealthcheckEvidence,
+    deployment_record: DeploymentRecord | None,
+    deployment_status: ReleaseStatus,
+    target_name: str,
+    target_type: str,
+    deployment_record_id: str,
+) -> PromotionRecord:
+    target_deploy_mode = "dokploy-application-api"
+    target_deployment_id = "control-plane-dokploy"
+    resolved_target_name = target_name or _fallback_target_name(
+        request=request,
+        lane=ProductLaneProfile(instance=request.to_instance, context=context),
+    )
+    if deployment_record is not None:
+        target_deploy_mode = deployment_record.deploy.deploy_mode
+        target_deployment_id = deployment_record.deploy.deployment_id
+        resolved_target_name = deployment_record.deploy.target_name
+        target_type = deployment_record.deploy.target_type
+    return PromotionRecord(
+        record_id=promotion_record_id,
+        artifact_identity=ArtifactIdentityReference(artifact_id=request.artifact_id),
+        deployment_record_id=deployment_record_id,
+        backup_record_id=request.backup_record_id,
+        context=context,
+        from_instance=request.from_instance,
+        to_instance=request.to_instance,
+        source_health=source_health,
+        backup_gate=backup_gate,
+        deploy=DeploymentEvidence(
+            target_name=resolved_target_name,
+            target_type=target_type,
+            deploy_mode=target_deploy_mode,
+            deployment_id=target_deployment_id,
+            status=deployment_status,
+            started_at=deployment_record.deploy.started_at if deployment_record is not None else "",
+            finished_at=deployment_record.deploy.finished_at
+            if deployment_record is not None
+            else "",
+        ),
+        destination_health=destination_health,
+    )
+
+
+def _fallback_target_name(
+    *, request: GenericWebProdPromotionRequest, lane: ProductLaneProfile
+) -> str:
+    return f"{request.product}-{lane.instance}"
+
+
+def _result_from_record(
+    *,
+    request: GenericWebProdPromotionRequest,
+    record: PromotionRecord,
+    deployment_record: DeploymentRecord | None,
+    inventory_record_id: str,
+    target_id: str,
+    dry_run: bool,
+    error_message: str,
+) -> GenericWebProdPromotionResult:
+    return GenericWebProdPromotionResult(
+        product=request.product,
+        context=record.context,
+        from_instance=record.from_instance,
+        to_instance=record.to_instance,
+        artifact_id=record.artifact_identity.artifact_id,
+        backup_record_id=record.backup_record_id,
+        promotion_record_id=record.record_id,
+        deployment_record_id=deployment_record.record_id if deployment_record is not None else "",
+        inventory_record_id=inventory_record_id,
+        promotion_status="pass"
+        if record.deploy.status == "pass"
+        and record.destination_health.status in {"pass", "skipped"}
+        else "fail",
+        deployment_status=record.deploy.status,
+        backup_status=record.backup_gate.status,
+        source_health_status=record.source_health.status,
+        destination_health_status=record.destination_health.status,
+        target_name=record.deploy.target_name,
+        target_type=record.deploy.target_type,
+        target_id=target_id,
+        dry_run=dry_run,
+        error_message=error_message,
+    )

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -86,16 +86,25 @@ inspect JSONB payloads directly.
 
 ## Initial Drivers
 
-Generic web exposes base capabilities and the first common deploy action:
+Generic web exposes base capabilities and common stable-lane actions:
 
 - image deployment evidence
 - HTTP health checking
+- testing-to-prod promotion evidence
 - preview lifecycle and inventory read models
 - PR feedback ownership
 
 The `stable_deploy` action routes to `POST /v1/drivers/generic-web/deploy`. The
 route resolves product lane context from DB-backed product profile records and
 runtime target bindings from DB-backed Dokploy target records.
+
+The `prod_promotion` action routes to
+`POST /v1/drivers/generic-web/prod-promotion`. It promotes a generic-web
+testing image to prod using DB-backed product profile lanes, records source and
+destination health evidence, writes promotion/deployment linkage, and refreshes
+prod inventory after successful verified deploys. Product-specific drivers such
+as VeriReel or Odoo can wrap this common action when they need additional gates
+such as backups, migrations, rollout checks, or tenant-specific validation.
 
 The `preview_desired_state` action routes to
 `POST /v1/drivers/generic-web/preview-desired-state`. Product workflows provide

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -270,6 +270,14 @@ Current derived-state behavior:
   values, override inputs, and managed secrets from DB-backed Launchplane
   records; tenant workflows should only send thin OIDC-authenticated requests
   and record returned IDs.
+- Generic web products can use the common
+  `POST /v1/drivers/generic-web/prod-promotion` route for testing-to-prod image
+  promotion when product-specific gates are not needed. The route resolves
+  product profile lanes, deploys the submitted image to the prod lane, records
+  source and destination health evidence, writes promotion/deployment linkage,
+  and refreshes prod inventory after a verified deploy. Product-specific
+  drivers can wrap this base path with stricter backup, migration, rollout, or
+  tenant checks instead of reimplementing the shared promotion record flow.
 
 ## Core Rules
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -380,6 +380,7 @@ These use the same authn/authz boundary as evidence ingress:
 - `POST /v1/drivers/odoo/prod-backup-gate`
 - `POST /v1/drivers/odoo/prod-promotion`
 - `POST /v1/drivers/odoo/prod-rollback`
+- `POST /v1/drivers/generic-web/prod-promotion`
 - `POST /v1/drivers/verireel/...`
 
 The first explicit driver routes now in service are:
@@ -390,6 +391,7 @@ The first explicit driver routes now in service are:
 - `POST /v1/drivers/odoo/prod-backup-gate`
 - `POST /v1/drivers/odoo/prod-promotion`
 - `POST /v1/drivers/odoo/prod-rollback`
+- `POST /v1/drivers/generic-web/prod-promotion`
 - `POST /v1/drivers/verireel/testing-deploy`
 - `POST /v1/drivers/verireel/testing-verification`
 - `POST /v1/drivers/verireel/stable-environment`
@@ -497,6 +499,8 @@ retries do not collide. The regular cleanup workflow uses
 - testing deployment evidence: `testing-deployment:<product>:<context>:<instance>:<record_id>`
 - prod deployment evidence: `prod-deployment:<product>:<context>:<instance>:<record_id>`
 - prod promotion evidence: `prod-promotion:<product>:<context>:<from_instance>:<to_instance>:<record_id>`
+- generic-web prod promotion driver:
+  `generic-web-prod-promotion:<product>:<context>:<from_instance>:<to_instance>:<artifact_id>:<source_git_ref>`
 - VeriReel testing deploy driver:
   `verireel-testing-deploy:<product>:<context>:<instance>:<artifact_id>:<source_git_ref>`
 - VeriReel testing verification driver:

--- a/tests/test_generic_web_promotion.py
+++ b/tests/test_generic_web_promotion.py
@@ -1,0 +1,349 @@
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import click
+from pydantic import ValidationError
+
+from control_plane.contracts.deployment_record import ResolvedTargetEvidence
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductImageProfile,
+    ProductLaneProfile,
+    ProductPreviewProfile,
+)
+from control_plane.contracts.promotion_record import HealthcheckEvidence
+from control_plane.contracts.ship_request import ShipRequest
+from control_plane.workflows.generic_web_promotion import (
+    GenericWebProdPromotionRequest,
+    execute_generic_web_prod_promotion,
+)
+from control_plane.workflows.ship import build_deployment_record
+
+
+class _GenericWebPromotionStore:
+    def __init__(self, profile: LaunchplaneProductProfileRecord) -> None:
+        self.profile = profile
+        self.deployments = {}
+        self.promotions = {}
+        self.inventories = {}
+
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
+        if product != self.profile.product:
+            raise FileNotFoundError(product)
+        return self.profile
+
+    def write_deployment_record(self, record) -> None:
+        self.deployments[record.record_id] = record
+
+    def read_deployment_record(self, record_id: str):
+        try:
+            return self.deployments[record_id]
+        except KeyError as exc:
+            raise FileNotFoundError(record_id) from exc
+
+    def write_promotion_record(self, record) -> None:
+        self.promotions[record.record_id] = record
+
+    def write_environment_inventory(self, record) -> None:
+        self.inventories[(record.context, record.instance)] = record
+
+
+def _profile(
+    *,
+    health_path: str = "/api/health",
+    explicit_health_urls: bool = True,
+) -> LaunchplaneProductProfileRecord:
+    testing_health_url = ""
+    prod_health_url = ""
+    if explicit_health_urls:
+        testing_health_url = "https://testing.sellyouroutboard.com/api/health"
+        prod_health_url = "https://www.sellyouroutboard.com/api/health"
+    return LaunchplaneProductProfileRecord(
+        product="sellyouroutboard",
+        display_name="SellYourOutboard.com",
+        repository="cbusillo/sellyouroutboard",
+        driver_id="generic-web",
+        image=ProductImageProfile(repository="ghcr.io/cbusillo/sellyouroutboard"),
+        runtime_port=3000,
+        health_path=health_path,
+        lanes=(
+            ProductLaneProfile(
+                instance="testing",
+                context="sellyouroutboard-testing",
+                base_url="https://testing.sellyouroutboard.com",
+                health_url=testing_health_url,
+            ),
+            ProductLaneProfile(
+                instance="prod",
+                context="sellyouroutboard-testing",
+                base_url="https://www.sellyouroutboard.com",
+                health_url=prod_health_url,
+            ),
+        ),
+        preview=ProductPreviewProfile(
+            enabled=True,
+            context="sellyouroutboard-testing",
+            slug_template="pr-{number}",
+        ),
+        updated_at="2026-05-01T21:00:00Z",
+        source="test",
+    )
+
+
+def _request(**overrides) -> GenericWebProdPromotionRequest:
+    payload = {
+        "product": "sellyouroutboard",
+        "artifact_id": "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+        "source_git_ref": "abc123",
+    }
+    payload.update(overrides)
+    return GenericWebProdPromotionRequest(**payload)
+
+
+def _deployment_record():
+    ship_request = ShipRequest(
+        artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+        context="sellyouroutboard-testing",
+        instance="prod",
+        source_git_ref="abc123",
+        target_name="syo-prod-app",
+        target_type="application",
+        deploy_mode="dokploy-application-api",
+        verify_health=False,
+        destination_health=HealthcheckEvidence(status="skipped"),
+    )
+    return build_deployment_record(
+        request=ship_request,
+        record_id="deployment-syo-prod",
+        deployment_id="control-plane-dokploy",
+        deployment_status="pass",
+        started_at="2026-05-01T21:00:00Z",
+        finished_at="2026-05-01T21:01:00Z",
+        resolved_target=ResolvedTargetEvidence(
+            target_type="application",
+            target_id="app-123",
+            target_name="syo-prod-app",
+        ),
+    )
+
+
+class GenericWebProdPromotionTests(unittest.TestCase):
+    def test_execute_records_source_destination_health_promotion_and_inventory(self) -> None:
+        store = _GenericWebPromotionStore(_profile())
+
+        def fake_deploy(**kwargs):
+            store.write_deployment_record(_deployment_record())
+            return type(
+                "DeployResult",
+                (),
+                {
+                    "deployment_record_id": "deployment-syo-prod",
+                    "deploy_status": "pass",
+                    "target_name": "syo-prod-app",
+                    "target_type": "application",
+                    "target_id": "app-123",
+                    "error_message": "",
+                },
+            )()
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_promotion.execute_generic_web_deploy",
+                side_effect=fake_deploy,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_promotion._wait_for_healthcheck",
+                return_value=None,
+            ) as healthcheck,
+        ):
+            result = execute_generic_web_prod_promotion(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=_request(),
+            )
+
+        self.assertEqual(result.promotion_status, "pass")
+        self.assertEqual(result.source_health_status, "pass")
+        self.assertEqual(result.destination_health_status, "pass")
+        self.assertEqual(result.inventory_record_id, "sellyouroutboard-testing-prod")
+        self.assertEqual(len(store.promotions), 1)
+        promotion = next(iter(store.promotions.values()))
+        self.assertEqual(promotion.backup_gate.status, "skipped")
+        self.assertEqual(promotion.source_health.status, "pass")
+        self.assertEqual(promotion.destination_health.status, "pass")
+        deployment = store.deployments["deployment-syo-prod"]
+        self.assertEqual(deployment.destination_health.status, "pass")
+        self.assertIn(("sellyouroutboard-testing", "prod"), store.inventories)
+        self.assertEqual(healthcheck.call_count, 2)
+
+    def test_dry_run_returns_pending_evidence_without_mutation(self) -> None:
+        store = _GenericWebPromotionStore(_profile())
+
+        result = execute_generic_web_prod_promotion(
+            control_plane_root=Path("."),
+            record_store=store,
+            request=_request(dry_run=True),
+        )
+
+        self.assertTrue(result.dry_run)
+        self.assertEqual(result.promotion_status, "pending")
+        self.assertEqual(result.source_health_status, "pending")
+        self.assertEqual(result.destination_health_status, "pending")
+        self.assertEqual(store.deployments, {})
+        self.assertEqual(store.promotions, {})
+
+    def test_request_requires_testing_to_prod(self) -> None:
+        with self.assertRaises(ValidationError):
+            _request(from_instance="staging", to_instance="prod")
+
+    def test_execute_refreshes_inventory_when_health_is_skipped(self) -> None:
+        store = _GenericWebPromotionStore(_profile())
+
+        def fake_deploy(**kwargs):
+            store.write_deployment_record(_deployment_record())
+            return type(
+                "DeployResult",
+                (),
+                {
+                    "deployment_record_id": "deployment-syo-prod",
+                    "deploy_status": "pass",
+                    "target_name": "syo-prod-app",
+                    "target_type": "application",
+                    "target_id": "app-123",
+                    "error_message": "",
+                },
+            )()
+
+        with patch(
+            "control_plane.workflows.generic_web_promotion.execute_generic_web_deploy",
+            side_effect=fake_deploy,
+        ):
+            result = execute_generic_web_prod_promotion(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=_request(verify_health=False),
+            )
+
+        self.assertEqual(result.promotion_status, "pass")
+        self.assertEqual(result.destination_health_status, "skipped")
+        self.assertEqual(result.inventory_record_id, "sellyouroutboard-testing-prod")
+        self.assertIn(("sellyouroutboard-testing", "prod"), store.inventories)
+
+    def test_health_fallback_uses_product_health_path(self) -> None:
+        store = _GenericWebPromotionStore(
+            _profile(health_path="/healthz", explicit_health_urls=False)
+        )
+
+        def fake_deploy(**kwargs):
+            store.write_deployment_record(_deployment_record())
+            return type(
+                "DeployResult",
+                (),
+                {
+                    "deployment_record_id": "deployment-syo-prod",
+                    "deploy_status": "pass",
+                    "target_name": "syo-prod-app",
+                    "target_type": "application",
+                    "target_id": "app-123",
+                    "error_message": "",
+                },
+            )()
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_promotion.execute_generic_web_deploy",
+                side_effect=fake_deploy,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_promotion._wait_for_healthcheck",
+                return_value=None,
+            ) as healthcheck,
+        ):
+            result = execute_generic_web_prod_promotion(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=_request(),
+            )
+
+        self.assertEqual(result.promotion_status, "pass")
+        health_urls = [call.kwargs["url"] for call in healthcheck.call_args_list]
+        self.assertEqual(
+            health_urls,
+            [
+                "https://testing.sellyouroutboard.com/healthz",
+                "https://www.sellyouroutboard.com/healthz",
+            ],
+        )
+
+    def test_source_health_failure_records_failed_promotion_without_deploy(self) -> None:
+        store = _GenericWebPromotionStore(_profile())
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_promotion.execute_generic_web_deploy"
+            ) as deploy,
+            patch(
+                "control_plane.workflows.generic_web_promotion._wait_for_healthcheck",
+                side_effect=click.ClickException("source unhealthy"),
+            ),
+        ):
+            result = execute_generic_web_prod_promotion(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=_request(),
+            )
+
+        self.assertEqual(result.promotion_status, "fail")
+        self.assertEqual(result.source_health_status, "fail")
+        self.assertEqual(result.destination_health_status, "skipped")
+        self.assertIn("source unhealthy", result.error_message)
+        self.assertEqual(store.deployments, {})
+        self.assertEqual(len(store.promotions), 1)
+        deploy.assert_not_called()
+
+    def test_deploy_failure_marks_destination_health_skipped(self) -> None:
+        store = _GenericWebPromotionStore(_profile())
+
+        def fake_deploy(**kwargs):
+            deployment_record = _deployment_record().model_copy(
+                update={"deploy": _deployment_record().deploy.model_copy(update={"status": "fail"})}
+            )
+            store.write_deployment_record(deployment_record)
+            return type(
+                "DeployResult",
+                (),
+                {
+                    "deployment_record_id": "deployment-syo-prod",
+                    "deploy_status": "fail",
+                    "target_name": "syo-prod-app",
+                    "target_type": "application",
+                    "target_id": "app-123",
+                    "error_message": "provider failed",
+                },
+            )()
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_promotion.execute_generic_web_deploy",
+                side_effect=fake_deploy,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_promotion._wait_for_healthcheck",
+                return_value=None,
+            ) as healthcheck,
+        ):
+            result = execute_generic_web_prod_promotion(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=_request(),
+            )
+
+        self.assertEqual(result.promotion_status, "fail")
+        self.assertEqual(result.source_health_status, "pass")
+        self.assertEqual(result.destination_health_status, "skipped")
+        self.assertEqual(healthcheck.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -78,6 +78,7 @@ from control_plane.workflows.odoo_post_deploy import OdooPostDeployResult
 from control_plane.workflows.odoo_prod_backup_gate import OdooProdBackupGateResult
 from control_plane.workflows.odoo_prod_promotion import OdooProdPromotionResult
 from control_plane.workflows.odoo_prod_rollback import OdooProdRollbackResult
+from control_plane.workflows.generic_web_promotion import GenericWebProdPromotionResult
 
 
 class _StubVerifier:
@@ -208,6 +209,21 @@ def _product_profile_payload(product: str = "sellyouroutboard") -> dict[str, obj
         "updated_at": "2026-04-30T21:30:00Z",
         "source": "test",
     }
+
+
+def _product_profile_payload_with_prod(product: str = "sellyouroutboard") -> dict[str, object]:
+    payload = _product_profile_payload(product)
+    lanes = list(payload["lanes"])
+    lanes.append(
+        {
+            "instance": "prod",
+            "context": f"{product}-testing",
+            "base_url": "https://www.sellyouroutboard.com",
+            "health_url": "https://www.sellyouroutboard.com/api/health",
+        }
+    )
+    payload["lanes"] = tuple(lanes)
+    return payload
 
 
 def _sqlite_database_url(database_path: Path) -> str:
@@ -1787,6 +1803,152 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "schema_version": 1,
                         "product": "sellyouroutboard",
                         "instance": "testing",
+                        "artifact_id": "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+                        "source_git_ref": "abc123",
+                    },
+                },
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_generic_web_prod_promotion_route_executes_for_authorized_product_context(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload_with_prod())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/promote-prod.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["generic_web_prod_promotion.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/promote-prod.yml"
+                            "@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_generic_web_prod_promotion",
+                return_value=GenericWebProdPromotionResult(
+                    product="sellyouroutboard",
+                    context="sellyouroutboard-testing",
+                    from_instance="testing",
+                    to_instance="prod",
+                    artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+                    promotion_record_id="promotion-syo-testing-to-prod",
+                    deployment_record_id="deployment-syo-prod",
+                    inventory_record_id="sellyouroutboard-testing-prod",
+                    promotion_status="pass",
+                    deployment_status="pass",
+                    backup_status="skipped",
+                    source_health_status="pass",
+                    destination_health_status="pass",
+                    target_name="syo-prod-app",
+                    target_type="application",
+                    target_id="app-123",
+                ),
+            ) as execute_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/prod-promotion",
+                    payload={
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "promotion": {
+                            "schema_version": 1,
+                            "product": "sellyouroutboard",
+                            "artifact_id": "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+                            "source_git_ref": "abc123",
+                        },
+                    },
+                    headers={"Idempotency-Key": "generic-web-prod-promotion-syo"},
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(payload["records"]["promotion_record_id"], "promotion-syo-testing-to-prod")
+        self.assertEqual(payload["records"]["deployment_record_id"], "deployment-syo-prod")
+        self.assertEqual(payload["records"]["inventory_record_id"], "sellyouroutboard-testing-prod")
+        self.assertEqual(payload["result"]["source_health_status"], "pass")
+        self.assertEqual(payload["result"]["destination_health_status"], "pass")
+        execute_mock.assert_called_once()
+
+    def test_generic_web_prod_promotion_route_rejects_wrong_product_context(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload_with_prod())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/promote-prod.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["different-context"],
+                            "actions": ["generic_web_prod_promotion.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/promote-prod.yml"
+                            "@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/generic-web/prod-promotion",
+                payload={
+                    "schema_version": 1,
+                    "product": "sellyouroutboard",
+                    "promotion": {
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
                         "artifact_id": "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
                         "source_git_ref": "abc123",
                     },


### PR DESCRIPTION
## Summary

- add a product-neutral generic-web testing-to-prod promotion workflow and service route
- record source health, destination health, promotion/deployment linkage, and destination inventory
- expose the new action in driver descriptors and document the reusable path for product-specific wrappers

## Notes

This is intended as the common generic-web promotion spine. Products such as SYO can call it directly; VeriReel/Odoo-style drivers can wrap the same pattern when they need stricter product gates like backups, migrations, rollout checks, or tenant validation.

Closes #107

## Validation

- `uv run python -m unittest tests.test_generic_web_deploy tests.test_generic_web_promotion tests.test_service`
- `uv run --extra dev ruff format --check control_plane/drivers/registry.py control_plane/service.py control_plane/workflows/generic_web_promotion.py tests/test_service.py tests/test_generic_web_promotion.py`
- `uv run --extra dev ruff check control_plane/drivers/registry.py control_plane/service.py control_plane/workflows/generic_web_promotion.py tests/test_service.py tests/test_generic_web_promotion.py`
- `npx markdownlint-cli2 docs/driver-descriptors.md docs/operations.md docs/service-boundary.md`
- `git diff --check`
- `uv run python -m unittest` (545 tests)