### PR TITLE
Add generic-web promotion workflow bridge

### DIFF
--- a/control_plane/contracts/product_profile_record.py
+++ b/control_plane/contracts/product_profile_record.py
@@ -96,6 +96,30 @@ class ProductPreviewProfile(BaseModel):
         return self
 
 
+class ProductPromotionWorkflowProfile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workflow_id: str = "promote-prod.yml"
+    ref: str = "main"
+    dry_run_input: str = "dry_run"
+    bump_input: str = "bump"
+    default_bump: str = "patch"
+
+    @model_validator(mode="after")
+    def _validate_workflow(self) -> "ProductPromotionWorkflowProfile":
+        if not self.workflow_id.strip():
+            raise ValueError("product promotion workflow requires workflow_id")
+        if not self.ref.strip():
+            raise ValueError("product promotion workflow requires ref")
+        if not self.dry_run_input.strip():
+            raise ValueError("product promotion workflow requires dry_run_input")
+        if not self.bump_input.strip():
+            raise ValueError("product promotion workflow requires bump_input")
+        if self.default_bump.strip() not in {"patch", "minor", "major"}:
+            raise ValueError("product promotion workflow default_bump must be patch, minor, or major")
+        return self
+
+
 class LaunchplaneProductProfileRecord(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -109,6 +133,9 @@ class LaunchplaneProductProfileRecord(BaseModel):
     health_path: str
     lanes: tuple[ProductLaneProfile, ...] = ()
     preview: ProductPreviewProfile = Field(default_factory=ProductPreviewProfile)
+    promotion_workflow: ProductPromotionWorkflowProfile = Field(
+        default_factory=ProductPromotionWorkflowProfile
+    )
     updated_at: str
     source: str
 

--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -117,6 +117,15 @@ GENERIC_WEB_DRIVER = DriverDescriptor(
             writes_records=("deployment", "promotion", "inventory"),
         ),
         _action(
+            "prod_promotion_workflow",
+            "Dispatch promote workflow",
+            "Dispatch the product-owned GitHub workflow that promotes testing to prod.",
+            safety="mutation",
+            scope="instance",
+            route_path="/v1/drivers/generic-web/prod-promotion-workflow",
+            writes_records=(),
+        ),
+        _action(
             "preview_desired_state",
             "Discover desired previews",
             "Discover labeled pull requests for a generic-web product profile and record desired preview state.",

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -105,6 +105,10 @@ from control_plane.workflows.generic_web_promotion import (
     execute_generic_web_prod_promotion,
     resolve_generic_web_promotion_lanes,
 )
+from control_plane.workflows.generic_web_promotion_workflow import (
+    GenericWebPromotionWorkflowRequest,
+    dispatch_generic_web_promotion_workflow,
+)
 from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewDesiredStateRequest,
     GenericWebPreviewDestroyRequest,
@@ -285,6 +289,22 @@ class GenericWebProdPromotionEnvelope(BaseModel):
             raise ValueError("generic web prod promotion requires product")
         if self.product.strip() != self.promotion.product.strip():
             raise ValueError("generic web prod promotion requires matching product values")
+        return self
+
+
+class GenericWebPromotionWorkflowEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    workflow: GenericWebPromotionWorkflowRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "GenericWebPromotionWorkflowEnvelope":
+        if not self.product.strip():
+            raise ValueError("generic web promotion workflow requires product")
+        if self.product.strip() != self.workflow.product.strip():
+            raise ValueError("generic web promotion workflow requires matching product values")
         return self
 
 
@@ -2041,6 +2061,7 @@ def create_launchplane_service_app(
         "/v1/drivers/launchplane/self-deploy",
         "/v1/drivers/generic-web/deploy",
         "/v1/drivers/generic-web/prod-promotion",
+        "/v1/drivers/generic-web/prod-promotion-workflow",
         "/v1/drivers/generic-web/preview-desired-state",
         "/v1/drivers/generic-web/preview-refresh",
         "/v1/drivers/generic-web/preview-inventory",
@@ -2283,7 +2304,10 @@ def create_launchplane_service_app(
                     session_manager=session_manager,
                 )
             else:
-                if path == "/v1/drivers/generic-web/prod-promotion":
+                if path in {
+                    "/v1/drivers/generic-web/prod-promotion",
+                    "/v1/drivers/generic-web/prod-promotion-workflow",
+                }:
                     identity = _read_identity(
                         environ=environ,
                         verifier=verifier,
@@ -3097,6 +3121,47 @@ def create_launchplane_service_app(
                     "backup_status": driver_result.backup_status,
                     "dry_run": driver_result.dry_run,
                 }
+            elif path == "/v1/drivers/generic-web/prod-promotion-workflow":
+                request = GenericWebPromotionWorkflowEnvelope.model_validate(payload)
+                profile = record_store.read_product_profile_record(request.product)
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="generic_web_prod_promotion.dispatch",
+                    product=profile.product,
+                    context=request.workflow.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Caller cannot dispatch the generic web prod promotion workflow"
+                                    " for the requested product/context."
+                                ),
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                driver_result = dispatch_generic_web_promotion_workflow(
+                    control_plane_root=resolved_root,
+                    profile=profile,
+                    request=request.workflow,
+                )
+                result = driver_result.model_dump(mode="json")
             elif path == "/v1/drivers/generic-web/preview-desired-state":
                 request = GenericWebPreviewDesiredStateEnvelope.model_validate(payload)
                 profile = resolve_generic_web_preview_profile(

--- a/control_plane/workflows/generic_web_promotion_workflow.py
+++ b/control_plane/workflows/generic_web_promotion_workflow.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from pathlib import Path
+import time
+from typing import Literal
+from urllib.parse import quote, urlencode
+
+import click
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.workflows.launchplane import github_api_request, resolve_launchplane_github_token
+
+
+class GenericWebPromotionWorkflowRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    context: str
+    dry_run: bool = True
+    bump: Literal["patch", "minor", "major"] | None = None
+    observe_timeout_seconds: int = Field(default=12, ge=0, le=60)
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "GenericWebPromotionWorkflowRequest":
+        self.product = self.product.strip()
+        self.context = self.context.strip()
+        if not self.product:
+            raise ValueError("generic web promotion workflow requires product")
+        if not self.context:
+            raise ValueError("generic web promotion workflow requires context")
+        return self
+
+
+class GenericWebPromotionWorkflowResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    product: str
+    context: str
+    repository: str
+    workflow_id: str
+    ref: str
+    dry_run: bool
+    bump: Literal["patch", "minor", "major"]
+    dispatch_status: Literal["dispatched"] = "dispatched"
+    run_id: int = 0
+    run_url: str = ""
+    run_status: str = "pending"
+    run_conclusion: str = ""
+
+
+def dispatch_generic_web_promotion_workflow(
+    *,
+    control_plane_root: Path,
+    profile: LaunchplaneProductProfileRecord,
+    request: GenericWebPromotionWorkflowRequest,
+) -> GenericWebPromotionWorkflowResult:
+    if profile.product.strip() != request.product:
+        raise click.ClickException("Generic-web promotion workflow product does not match profile.")
+    contexts = {lane.context.strip() for lane in profile.lanes if lane.context.strip()}
+    if request.context not in contexts:
+        raise click.ClickException("Generic-web promotion workflow context is not in the product profile.")
+    owner, repo = _repository_parts(profile.repository)
+    token = resolve_launchplane_github_token(
+        control_plane_root=control_plane_root,
+        context_name=request.context,
+    )
+    if not token:
+        raise click.ClickException(
+            "Launchplane runtime records do not expose GITHUB_TOKEN for this context"
+        )
+    workflow = profile.promotion_workflow
+    workflow_id = workflow.workflow_id.strip()
+    ref = workflow.ref.strip()
+    bump = request.bump or workflow.default_bump.strip()
+    previous_run_ids = _workflow_dispatch_run_ids(
+        owner=owner,
+        repo=repo,
+        workflow_id=workflow_id,
+        ref=ref,
+        token=token,
+    )
+    github_api_request(
+        path=f"/repos/{owner}/{repo}/actions/workflows/{quote(workflow_id, safe='')}/dispatches",
+        token=token,
+        method="POST",
+        body={
+            "ref": ref,
+            "inputs": {
+                workflow.dry_run_input.strip(): str(request.dry_run).lower(),
+                workflow.bump_input.strip(): bump,
+            },
+        },
+    )
+    run = _wait_for_workflow_run(
+        owner=owner,
+        repo=repo,
+        workflow_id=workflow_id,
+        ref=ref,
+        token=token,
+        previous_run_ids=previous_run_ids,
+        timeout_seconds=request.observe_timeout_seconds,
+    )
+    return GenericWebPromotionWorkflowResult(
+        product=profile.product,
+        context=request.context,
+        repository=profile.repository,
+        workflow_id=workflow_id,
+        ref=ref,
+        dry_run=request.dry_run,
+        bump=bump,
+        run_id=_int_value(run.get("id")) if run else 0,
+        run_url=_string_value(run.get("html_url")) if run else "",
+        run_status=_string_value(run.get("status")) if run else "pending",
+        run_conclusion=_string_value(run.get("conclusion")) if run else "",
+    )
+
+
+def _wait_for_workflow_run(
+    *,
+    owner: str,
+    repo: str,
+    workflow_id: str,
+    ref: str,
+    token: str,
+    previous_run_ids: set[int],
+    timeout_seconds: int,
+) -> dict[str, object]:
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        run = _latest_workflow_dispatch_run(
+            owner=owner,
+            repo=repo,
+            workflow_id=workflow_id,
+            ref=ref,
+            token=token,
+            previous_run_ids=previous_run_ids,
+        )
+        if run:
+            return run
+        if time.monotonic() >= deadline:
+            return {}
+        time.sleep(1)
+
+
+def _latest_workflow_dispatch_run(
+    *,
+    owner: str,
+    repo: str,
+    workflow_id: str,
+    ref: str,
+    token: str,
+    previous_run_ids: set[int],
+) -> dict[str, object]:
+    workflow_runs = _workflow_dispatch_runs(
+        owner=owner,
+        repo=repo,
+        workflow_id=workflow_id,
+        ref=ref,
+        token=token,
+    )
+    new_runs: list[dict[str, object]] = []
+    for raw_run in workflow_runs:
+        run_id = _int_value(raw_run.get("id"))
+        if not run_id or run_id in previous_run_ids:
+            continue
+        new_runs.append(raw_run)
+    if len(new_runs) == 1:
+        return new_runs[0]
+    return {}
+
+
+def _workflow_dispatch_run_ids(
+    *, owner: str, repo: str, workflow_id: str, ref: str, token: str
+) -> set[int]:
+    return {
+        run_id
+        for run_id in (
+            _int_value(run.get("id"))
+            for run in _workflow_dispatch_runs(
+                owner=owner,
+                repo=repo,
+                workflow_id=workflow_id,
+                ref=ref,
+                token=token,
+            )
+        )
+        if run_id
+    }
+
+
+def _workflow_dispatch_runs(
+    *, owner: str, repo: str, workflow_id: str, ref: str, token: str
+) -> list[dict[str, object]]:
+    query = urlencode({"event": "workflow_dispatch", "branch": ref, "per_page": 10})
+    payload = github_api_request(
+        path=f"/repos/{owner}/{repo}/actions/workflows/{quote(workflow_id, safe='')}/runs?{query}",
+        token=token,
+    )
+    if not isinstance(payload, dict):
+        raise click.ClickException(
+            f"GitHub workflow runs response for {owner}/{repo}/{workflow_id} must be an object."
+        )
+    workflow_runs = payload.get("workflow_runs")
+    if not isinstance(workflow_runs, list):
+        raise click.ClickException(
+            f"GitHub workflow runs response for {owner}/{repo}/{workflow_id} is missing workflow_runs."
+        )
+    return [run for run in workflow_runs if isinstance(run, dict)]
+
+
+def _repository_parts(repository: str) -> tuple[str, str]:
+    owner, separator, repo = repository.strip().partition("/")
+    if not separator or not owner.strip() or not repo.strip() or "/" in repo.strip():
+        raise click.ClickException("GitHub repository must use owner/repo format.")
+    return owner.strip(), repo.strip()
+
+
+def _string_value(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _int_value(value: object) -> int:
+    return value if isinstance(value, int) else 0

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -278,6 +278,13 @@ Current derived-state behavior:
   and refreshes prod inventory after a verified deploy. Product-specific
   drivers can wrap this base path with stricter backup, migration, rollout, or
   tenant checks instead of reimplementing the shared promotion record flow.
+- Operators should promote generic web products through the product-owned GitHub
+  workflow bridge. The UI first calls the generic-web prod-promotion route with
+  `dry_run=true`, then dispatches
+  `POST /v1/drivers/generic-web/prod-promotion-workflow`. Launchplane resolves
+  the product repository/workflow from the DB-backed product profile and the
+  managed `GITHUB_TOKEN` from runtime records; the product workflow still owns
+  release/tag creation and any product-specific safeguards.
 
 ## Core Rules
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -46,6 +46,8 @@ VeriReel product paths:
   - `POST /v1/product-config/apply`
 - product driver routes:
   - `POST /v1/drivers/generic-web/deploy`
+  - `POST /v1/drivers/generic-web/prod-promotion`
+  - `POST /v1/drivers/generic-web/prod-promotion-workflow`
   - `POST /v1/drivers/generic-web/preview-desired-state`
   - `POST /v1/drivers/generic-web/preview-refresh`
   - `POST /v1/drivers/generic-web/preview-inventory`
@@ -338,6 +340,15 @@ Generic web deploys use `POST /v1/drivers/generic-web/deploy`. The request names
 the product, target instance, immutable artifact/image reference, and source ref;
 Launchplane resolves the context from the DB-backed product profile lane and the
 runtime target from DB-backed Dokploy target records.
+
+Generic web prod promotion can be exercised directly with
+`POST /v1/drivers/generic-web/prod-promotion`; browser sessions may only use this
+route with `dry_run=true`. The operator UI then uses
+`POST /v1/drivers/generic-web/prod-promotion-workflow` to dispatch the
+product-owned GitHub workflow configured by the DB-backed product profile. That
+workflow remains responsible for product release/tag behavior while Launchplane
+supplies authz, managed `GITHUB_TOKEN` lookup, dispatch inputs, and workflow-run
+observation.
 
 Generic web preview desired-state discovery uses
 `POST /v1/drivers/generic-web/preview-desired-state`. The request names the

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import {
   LaunchplaneApiError,
   applyProductConfig,
+  dispatchGenericWebPromotionWorkflow,
   dryRunGenericWebProdPromotion,
   listDrivers,
   listProductProfiles,
@@ -44,6 +45,8 @@ import type {
   DriverView,
   GenericWebProdPromotionPayload,
   GenericWebProdPromotionRequest,
+  GenericWebPromotionWorkflowPayload,
+  GenericWebPromotionWorkflowRequest,
   LaneSummary,
   ProductConfigApplyPayload,
   ProductConfigApplyRequest,
@@ -152,6 +155,16 @@ const FIXTURE_GENERIC_WEB_ACTIONS: DriverActionDescriptor[] = [
     method: "POST",
     route_path: "/v1/drivers/generic-web/prod-promotion",
     writes_records: ["deployment", "promotion", "inventory"],
+  },
+  {
+    action_id: "prod_promotion_workflow",
+    label: "Dispatch promote workflow",
+    description: "Dispatch the product-owned GitHub promote workflow.",
+    safety: "mutation",
+    scope: "instance",
+    method: "POST",
+    route_path: "/v1/drivers/generic-web/prod-promotion-workflow",
+    writes_records: [],
   },
 ];
 const FIXTURE_VERIREEL_DRIVER: DriverDescriptor = {
@@ -1385,6 +1398,7 @@ function PromotionBridge({
   loading,
   onAction,
   dryRunPromotion = dryRunGenericWebProdPromotion,
+  dispatchWorkflow = dispatchGenericWebPromotionWorkflow,
 }: {
   prod: LaneSummary | null;
   testing: LaneSummary | null;
@@ -1397,13 +1411,27 @@ function PromotionBridge({
   dryRunPromotion?: (
     payload: GenericWebProdPromotionRequest,
   ) => Promise<GenericWebProdPromotionPayload>;
+  dispatchWorkflow?: (
+    payload: GenericWebPromotionWorkflowRequest,
+  ) => Promise<GenericWebPromotionWorkflowPayload>;
 }) {
   const primaryAction = pickNextAction(actions, decision.verdict);
+  const workflowAction = actions.find(
+    (action) =>
+      action.route_path === "/v1/drivers/generic-web/prod-promotion-workflow",
+  );
   const [dryRunResult, setDryRunResult] =
     useState<GenericWebProdPromotionPayload | null>(null);
+  const [workflowResult, setWorkflowResult] =
+    useState<GenericWebPromotionWorkflowPayload | null>(null);
   const [dryRunError, setDryRunError] = useState("");
   const [dryRunTraceId, setDryRunTraceId] = useState("");
   const [submittingDryRun, setSubmittingDryRun] = useState(false);
+  const [workflowError, setWorkflowError] = useState("");
+  const [workflowTraceId, setWorkflowTraceId] = useState("");
+  const [submittingWorkflowMode, setSubmittingWorkflowMode] = useState<
+    "dry-run" | "promote" | ""
+  >("");
   const testingArtifact = artifactFromLane(testing);
   const testingSourceRef = sourceRefFromLane(testing);
   const supportsGenericWebPromotion =
@@ -1418,6 +1446,15 @@ function PromotionBridge({
     !loading &&
     !submittingDryRun,
   );
+  const canDispatchWorkflow = Boolean(
+    supportsGenericWebPromotion &&
+    workflowAction &&
+    dryRunResult &&
+    product.trim() &&
+    context.trim() &&
+    !loading &&
+    !submittingWorkflowMode,
+  );
   const verdictLabel =
     decision.verdict === "ready"
       ? "Ready to promote"
@@ -1427,8 +1464,11 @@ function PromotionBridge({
 
   useEffect(() => {
     setDryRunResult(null);
+    setWorkflowResult(null);
     setDryRunError("");
     setDryRunTraceId("");
+    setWorkflowError("");
+    setWorkflowTraceId("");
   }, [product, context, testingArtifact, testingSourceRef]);
 
   function runPromotionDryRun() {
@@ -1466,6 +1506,39 @@ function PromotionBridge({
         }
       })
       .finally(() => setSubmittingDryRun(false));
+  }
+
+  function dispatchPromotionWorkflow(dryRun: boolean) {
+    if (!canDispatchWorkflow) {
+      return;
+    }
+    setSubmittingWorkflowMode(dryRun ? "dry-run" : "promote");
+    setWorkflowError("");
+    setWorkflowTraceId("");
+    const request: GenericWebPromotionWorkflowRequest = {
+      schema_version: 1,
+      product: product.trim(),
+      workflow: {
+        schema_version: 1,
+        product: product.trim(),
+        context: context.trim(),
+        dry_run: dryRun,
+        observe_timeout_seconds: 12,
+      },
+    };
+    dispatchWorkflow(request)
+      .then((payload) => setWorkflowResult(payload))
+      .catch((apiError: unknown) => {
+        if (apiError instanceof LaunchplaneApiError) {
+          setWorkflowError(apiError.message);
+          setWorkflowTraceId(apiError.traceId);
+        } else if (apiError instanceof Error) {
+          setWorkflowError(apiError.message);
+        } else {
+          setWorkflowError("Promotion workflow dispatch failed.");
+        }
+      })
+      .finally(() => setSubmittingWorkflowMode(""));
   }
 
   return (
@@ -1514,21 +1587,55 @@ function PromotionBridge({
           {primaryAction ? (
             <div className="bridge-action-stack">
               {supportsGenericWebPromotion ? (
-                <button
-                  className="button button-primary bridge-action"
-                  type="button"
-                  data-safety="safe_write"
-                  aria-label="Dry run generic-web prod promotion"
-                  disabled={!canDryRun}
-                  onClick={runPromotionDryRun}
-                >
-                  {submittingDryRun ? (
-                    <Loader2 className="spin" size={16} />
-                  ) : (
-                    <Send size={16} />
-                  )}
-                  <span>Dry run promotion</span>
-                </button>
+                <>
+                  <button
+                    className="button button-primary bridge-action"
+                    type="button"
+                    data-safety="safe_write"
+                    aria-label="Dry run generic-web prod promotion"
+                    disabled={!canDryRun}
+                    onClick={runPromotionDryRun}
+                  >
+                    {submittingDryRun ? (
+                      <Loader2 className="spin" size={16} />
+                    ) : (
+                      <Send size={16} />
+                    )}
+                    <span>Dry run promotion</span>
+                  </button>
+                  {dryRunResult ? (
+                    <div className="workflow-action-row">
+                      <button
+                        className="button button-secondary bridge-action"
+                        type="button"
+                        data-safety="safe_write"
+                        disabled={!canDispatchWorkflow}
+                        onClick={() => dispatchPromotionWorkflow(true)}
+                      >
+                        {submittingWorkflowMode === "dry-run" ? (
+                          <Loader2 className="spin" size={16} />
+                        ) : (
+                          <Play size={16} />
+                        )}
+                        <span>Run workflow dry run</span>
+                      </button>
+                      <button
+                        className="button button-primary bridge-action"
+                        type="button"
+                        data-safety="mutation"
+                        disabled={!canDispatchWorkflow}
+                        onClick={() => dispatchPromotionWorkflow(false)}
+                      >
+                        {submittingWorkflowMode === "promote" ? (
+                          <Loader2 className="spin" size={16} />
+                        ) : (
+                          <Send size={16} />
+                        )}
+                        <span>Promote through workflow</span>
+                      </button>
+                    </div>
+                  ) : null}
+                </>
               ) : (
                 <button
                   className="button button-primary bridge-action"
@@ -1553,6 +1660,15 @@ function PromotionBridge({
               ) : null}
               {dryRunResult ? (
                 <PromotionDryRunResult payload={dryRunResult} />
+              ) : null}
+              {workflowError ? (
+                <InlinePanelError
+                  message={workflowError}
+                  traceId={workflowTraceId}
+                />
+              ) : null}
+              {workflowResult ? (
+                <PromotionWorkflowResult payload={workflowResult} />
               ) : null}
             </div>
           ) : null}
@@ -1620,6 +1736,64 @@ function PromotionDryRunResult({
               ? "unexpected write candidate"
               : "none"}
           </code>
+        </div>
+        <div className="config-result-row">
+          <strong>Trace</strong>
+          <code>{payload.trace_id}</code>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PromotionWorkflowResult({
+  payload,
+}: {
+  payload: GenericWebPromotionWorkflowPayload;
+}) {
+  const result = payload.result;
+  return (
+    <div className="config-result bridge-workflow-result" aria-live="polite">
+      <div className="config-result-summary">
+        <KeyValue
+          label="Workflow"
+          value={result.dry_run ? "dry-run" : "promote"}
+          status={result.dry_run ? "pending" : "pass"}
+        />
+        <KeyValue
+          label="Dispatch"
+          value={result.dispatch_status}
+          status="pass"
+        />
+        <KeyValue
+          label="Run"
+          value={result.run_status || "pending"}
+          status={result.run_status}
+        />
+        <KeyValue
+          label="Conclusion"
+          value={result.run_conclusion || "pending"}
+          status={result.run_conclusion || "pending"}
+        />
+      </div>
+      <div className="config-result-list">
+        <div className="config-result-row">
+          <strong>Repository</strong>
+          <code>{result.repository}</code>
+        </div>
+        <div className="config-result-row">
+          <strong>Workflow</strong>
+          <code>{`${result.workflow_id}@${result.ref}`}</code>
+        </div>
+        <div className="config-result-row">
+          <strong>Run</strong>
+          {result.run_url ? (
+            <a href={result.run_url} target="_blank" rel="noreferrer">
+              {result.run_id || result.run_url}
+            </a>
+          ) : (
+            <code>not observed yet</code>
+          )}
         </div>
         <div className="config-result-row">
           <strong>Trace</strong>
@@ -2183,6 +2357,7 @@ function StateFixtureGallery({
             loading={false}
             onAction={() => undefined}
             dryRunPromotion={fixtureGenericWebPromotionDryRun}
+            dispatchWorkflow={fixtureGenericWebPromotionWorkflow}
           />
         </div>
         <div className="fixture-card">
@@ -2239,6 +2414,31 @@ function fixtureGenericWebPromotionDryRun(): Promise<GenericWebProdPromotionPayl
       destination_health_status: "skipped",
       backup_status: "skipped",
       dry_run: true,
+    },
+  });
+}
+
+function fixtureGenericWebPromotionWorkflow(
+  payload: GenericWebPromotionWorkflowRequest,
+): Promise<GenericWebPromotionWorkflowPayload> {
+  return Promise.resolve({
+    status: "accepted",
+    trace_id: "fixture-trace-generic-web-workflow",
+    records: {},
+    result: {
+      product: payload.product,
+      context: payload.workflow.context,
+      repository: "cbusillo/sellyouroutboard",
+      workflow_id: "promote-prod.yml",
+      ref: "main",
+      dry_run: payload.workflow.dry_run,
+      bump: payload.workflow.bump ?? "patch",
+      dispatch_status: "dispatched",
+      run_id: 25237186636,
+      run_url:
+        "https://github.com/cbusillo/sellyouroutboard/actions/runs/25237186636",
+      run_status: "queued",
+      run_conclusion: "",
     },
   });
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -5,6 +5,8 @@ import type {
   DriverViewPayload,
   GenericWebProdPromotionPayload,
   GenericWebProdPromotionRequest,
+  GenericWebPromotionWorkflowPayload,
+  GenericWebPromotionWorkflowRequest,
   LogoutPayload,
   ProductConfigApplyPayload,
   ProductConfigApplyRequest,
@@ -102,6 +104,16 @@ export function dryRunGenericWebProdPromotion(
 ): Promise<GenericWebProdPromotionPayload> {
   return requestJson<GenericWebProdPromotionPayload>(
     "/v1/drivers/generic-web/prod-promotion",
+    "POST",
+    payload,
+  );
+}
+
+export function dispatchGenericWebPromotionWorkflow(
+  payload: GenericWebPromotionWorkflowRequest,
+): Promise<GenericWebPromotionWorkflowPayload> {
+  return requestJson<GenericWebPromotionWorkflowPayload>(
+    "/v1/drivers/generic-web/prod-promotion-workflow",
     "POST",
     payload,
   );

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -709,8 +709,15 @@ p {
   width: 100%;
 }
 
+.workflow-action-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
 .bridge-inline-alert,
-.bridge-dry-run-result {
+.bridge-dry-run-result,
+.bridge-workflow-result {
   border: 1px solid var(--hair-soft);
 }
 
@@ -805,10 +812,9 @@ p {
 }
 
 .config-row-secret {
-  grid-template-columns: minmax(130px, 0.85fr) minmax(130px, 0.85fr) minmax(
-      130px,
-      1fr
-    ) minmax(120px, 0.9fr) auto;
+  grid-template-columns:
+    minmax(130px, 0.85fr) minmax(130px, 0.85fr) minmax(130px, 1fr)
+    minmax(120px, 0.9fr) auto;
 }
 
 .config-inline-alert {
@@ -1393,6 +1399,10 @@ p {
   .bridge-direction {
     grid-template-columns: minmax(0, 1fr);
     align-items: stretch;
+  }
+
+  .workflow-action-row {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .preview-row .status-pill,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -372,6 +372,13 @@ export interface ProductProfileRecord {
     base_url: string;
     health_url: string;
   }>;
+  promotion_workflow: {
+    workflow_id: string;
+    ref: string;
+    dry_run_input: string;
+    bump_input: string;
+    default_bump: "patch" | "minor" | "major";
+  };
 }
 
 export interface ProductProfileListPayload {
@@ -417,5 +424,38 @@ export interface GenericWebProdPromotionPayload {
     destination_health_status: Status;
     backup_status: Status;
     dry_run: boolean;
+  };
+}
+
+export interface GenericWebPromotionWorkflowRequest {
+  schema_version: 1;
+  product: string;
+  workflow: {
+    schema_version: 1;
+    product: string;
+    context: string;
+    dry_run: boolean;
+    bump?: "patch" | "minor" | "major";
+    observe_timeout_seconds: number;
+  };
+}
+
+export interface GenericWebPromotionWorkflowPayload {
+  status: "accepted";
+  trace_id: string;
+  records: Record<string, string>;
+  result: {
+    product: string;
+    context: string;
+    repository: string;
+    workflow_id: string;
+    ref: string;
+    dry_run: boolean;
+    bump: "patch" | "minor" | "major";
+    dispatch_status: "dispatched";
+    run_id: number;
+    run_url: string;
+    run_status: string;
+    run_conclusion: string;
   };
 }

--- a/tests/test_generic_web_promotion.py
+++ b/tests/test_generic_web_promotion.py
@@ -10,6 +10,7 @@ from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductImageProfile,
     ProductLaneProfile,
+    ProductPromotionWorkflowProfile,
     ProductPreviewProfile,
 )
 from control_plane.contracts.promotion_record import HealthcheckEvidence
@@ -17,6 +18,10 @@ from control_plane.contracts.ship_request import ShipRequest
 from control_plane.workflows.generic_web_promotion import (
     GenericWebProdPromotionRequest,
     execute_generic_web_prod_promotion,
+)
+from control_plane.workflows.generic_web_promotion_workflow import (
+    GenericWebPromotionWorkflowRequest,
+    dispatch_generic_web_promotion_workflow,
 )
 from control_plane.workflows.ship import build_deployment_record
 
@@ -343,6 +348,149 @@ class GenericWebProdPromotionTests(unittest.TestCase):
         self.assertEqual(result.source_health_status, "pass")
         self.assertEqual(result.destination_health_status, "skipped")
         self.assertEqual(healthcheck.call_count, 1)
+
+
+class GenericWebPromotionWorkflowTests(unittest.TestCase):
+    def test_dispatches_product_workflow_and_observes_run(self) -> None:
+        requests: list[tuple[str, str, dict[str, object] | None]] = []
+        listed_once = False
+
+        def fake_github_api_request(
+            *, path: str, token: str, method: str = "GET", body: dict[str, object] | None = None
+        ):
+            nonlocal listed_once
+            requests.append((method, path, body))
+            if method == "POST":
+                self.assertEqual(token, "github-token")
+                return None
+            if not listed_once:
+                listed_once = True
+                return {
+                    "workflow_runs": [
+                        {
+                            "id": 100,
+                            "html_url": "https://github.com/cbusillo/sellyouroutboard/actions/runs/100",
+                            "status": "completed",
+                            "conclusion": "success",
+                        }
+                    ]
+                }
+            return {
+                "workflow_runs": [
+                    {
+                        "id": 25237186636,
+                        "html_url": "https://github.com/cbusillo/sellyouroutboard/actions/runs/25237186636",
+                        "status": "queued",
+                        "conclusion": None,
+                        "created_at": "2099-01-01T00:00:00Z",
+                    }
+                ]
+            }
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_promotion_workflow.resolve_launchplane_github_token",
+                return_value="github-token",
+            ),
+            patch(
+                "control_plane.workflows.generic_web_promotion_workflow.github_api_request",
+                side_effect=fake_github_api_request,
+            ),
+        ):
+            profile = _profile().model_copy(
+                update={
+                    "promotion_workflow": ProductPromotionWorkflowProfile(
+                        default_bump="minor"
+                    )
+                }
+            )
+            result = dispatch_generic_web_promotion_workflow(
+                control_plane_root=Path("."),
+                profile=profile,
+                request=GenericWebPromotionWorkflowRequest(
+                    product="sellyouroutboard",
+                    context="sellyouroutboard-testing",
+                    dry_run=False,
+                    observe_timeout_seconds=0,
+                ),
+            )
+
+        self.assertEqual(result.repository, "cbusillo/sellyouroutboard")
+        self.assertEqual(result.workflow_id, "promote-prod.yml")
+        self.assertEqual(result.ref, "main")
+        self.assertFalse(result.dry_run)
+        self.assertEqual(result.bump, "minor")
+        self.assertEqual(result.run_id, 25237186636)
+        self.assertEqual(result.run_status, "queued")
+        self.assertEqual(requests[1][0], "POST")
+        self.assertEqual(
+            requests[1][1],
+            "/repos/cbusillo/sellyouroutboard/actions/workflows/promote-prod.yml/dispatches",
+        )
+        self.assertEqual(
+            requests[1][2],
+            {"ref": "main", "inputs": {"dry_run": "false", "bump": "minor"}},
+        )
+
+    def test_observation_declines_ambiguous_new_runs(self) -> None:
+        list_count = 0
+
+        def fake_github_api_request(
+            *, path: str, token: str, method: str = "GET", body: dict[str, object] | None = None
+        ):
+            nonlocal list_count
+            if method == "POST":
+                return None
+            list_count += 1
+            if list_count == 1:
+                return {"workflow_runs": []}
+            return {
+                "workflow_runs": [
+                    {"id": 101, "html_url": "https://github.example/runs/101", "status": "queued"},
+                    {"id": 102, "html_url": "https://github.example/runs/102", "status": "queued"},
+                ]
+            }
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_promotion_workflow.resolve_launchplane_github_token",
+                return_value="github-token",
+            ),
+            patch(
+                "control_plane.workflows.generic_web_promotion_workflow.github_api_request",
+                side_effect=fake_github_api_request,
+            ),
+        ):
+            result = dispatch_generic_web_promotion_workflow(
+                control_plane_root=Path("."),
+                profile=_profile(),
+                request=GenericWebPromotionWorkflowRequest(
+                    product="sellyouroutboard",
+                    context="sellyouroutboard-testing",
+                    observe_timeout_seconds=0,
+                ),
+            )
+
+        self.assertEqual(result.run_id, 0)
+        self.assertEqual(result.run_url, "")
+        self.assertEqual(result.run_status, "pending")
+
+    def test_dispatch_requires_managed_github_token(self) -> None:
+        with patch(
+            "control_plane.workflows.generic_web_promotion_workflow.resolve_launchplane_github_token",
+            return_value="",
+        ):
+            with self.assertRaises(click.ClickException) as raised:
+                dispatch_generic_web_promotion_workflow(
+                    control_plane_root=Path("."),
+                    profile=_profile(),
+                    request=GenericWebPromotionWorkflowRequest(
+                        product="sellyouroutboard",
+                        context="sellyouroutboard-testing",
+                    ),
+                )
+
+        self.assertIn("GITHUB_TOKEN", str(raised.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -79,6 +79,7 @@ from control_plane.workflows.odoo_prod_backup_gate import OdooProdBackupGateResu
 from control_plane.workflows.odoo_prod_promotion import OdooProdPromotionResult
 from control_plane.workflows.odoo_prod_rollback import OdooProdRollbackResult
 from control_plane.workflows.generic_web_promotion import GenericWebProdPromotionResult
+from control_plane.workflows.generic_web_promotion_workflow import GenericWebPromotionWorkflowResult
 
 
 class _StubVerifier:
@@ -2089,6 +2090,119 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "product": "sellyouroutboard",
                         "artifact_id": "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
                         "source_git_ref": "abc123",
+                        "dry_run": False,
+                    },
+                },
+                authorization="",
+                headers={"Cookie": cookie},
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_human_session_can_dispatch_generic_web_promotion_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload_with_prod())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_humans": [
+                        {
+                            "logins": ["alice"],
+                            "roles": ["admin"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["generic_web_prod_promotion.dispatch"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=_StubGitHubOAuthClient(_human_identity(role="admin")),  # type: ignore[arg-type]
+            )
+            cookie = _signed_in_cookie(app)
+
+            with patch(
+                "control_plane.service.dispatch_generic_web_promotion_workflow",
+                return_value=GenericWebPromotionWorkflowResult(
+                    product="sellyouroutboard",
+                    context="sellyouroutboard-testing",
+                    repository="cbusillo/sellyouroutboard",
+                    workflow_id="promote-prod.yml",
+                    ref="main",
+                    dry_run=False,
+                    bump="patch",
+                    run_id=25237186636,
+                    run_url="https://github.com/cbusillo/sellyouroutboard/actions/runs/25237186636",
+                    run_status="queued",
+                ),
+            ) as dispatch_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/prod-promotion-workflow",
+                    payload={
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "workflow": {
+                            "schema_version": 1,
+                            "product": "sellyouroutboard",
+                            "context": "sellyouroutboard-testing",
+                            "dry_run": False,
+                            "bump": "patch",
+                            "observe_timeout_seconds": 0,
+                        },
+                    },
+                    authorization="",
+                    headers={"Cookie": cookie},
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["repository"], "cbusillo/sellyouroutboard")
+        self.assertEqual(payload["result"]["workflow_id"], "promote-prod.yml")
+        self.assertFalse(payload["result"]["dry_run"])
+        self.assertEqual(payload["result"]["run_id"], 25237186636)
+        self.assertEqual(payload["records"], {})
+        dispatch_mock.assert_called_once()
+
+    def test_generic_web_promotion_workflow_rejects_unauthorized_human(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload_with_prod())
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_humans": []}),
+                control_plane_root_path=root,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=_StubGitHubOAuthClient(_human_identity(role="admin")),  # type: ignore[arg-type]
+            )
+            cookie = _signed_in_cookie(app)
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/generic-web/prod-promotion-workflow",
+                payload={
+                    "schema_version": 1,
+                    "product": "sellyouroutboard",
+                    "workflow": {
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "context": "sellyouroutboard-testing",
                         "dry_run": False,
                     },
                 },


### PR DESCRIPTION
## Summary

Refs #130.

This is PR 2 for generic-web prod promotion UI:
- adds a product-profile promotion workflow profile with defaults for `promote-prod.yml`, `main`, `dry_run`, and `bump`
- adds `POST /v1/drivers/generic-web/prod-promotion-workflow` for dispatching the product-owned GitHub workflow
- resolves the dispatch token through Launchplane-managed runtime `GITHUB_TOKEN` for the requested product context
- observes the workflow run without attributing older runs, and leaves run evidence pending when concurrent dispatches make attribution ambiguous
- updates the operator UI so workflow dispatch buttons appear only after the Launchplane dry-run succeeds
- supports workflow dry-run dispatch and live product-workflow promotion dispatch while keeping release/tag creation product-owned

## Validation

- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests tests.test_generic_web_promotion`
- `uv run --extra dev ruff check --no-fix control_plane/contracts/product_profile_record.py control_plane/drivers/registry.py control_plane/service.py control_plane/workflows/generic_web_promotion_workflow.py tests/test_service.py tests/test_generic_web_promotion.py`
- `uv run --extra dev ruff check control_plane/contracts/product_profile_record.py control_plane/drivers/registry.py control_plane/service.py control_plane/workflows/generic_web_promotion_workflow.py tests/test_service.py tests/test_generic_web_promotion.py`
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend build`
- `uv run python -m unittest` passed: 553 tests
- `npx --yes markdownlint-cli2 docs/service-boundary.md docs/operations.md`
- Browser fixture review at `/ui/?fixtures=1`: dry-run first, then workflow dry-run dispatch result with run link/status and `Record writes none`

## Notes

This does not create releases directly in Launchplane. The live promote button dispatches the product workflow with `dry_run=false`; the product workflow remains responsible for release/tag safeguards.