### PR TITLE
Polish generic-web promotion evidence

### DIFF
--- a/control_plane/workflows/generic_web_promotion_workflow.py
+++ b/control_plane/workflows/generic_web_promotion_workflow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 import time
 from typing import Literal
@@ -60,7 +61,9 @@ def dispatch_generic_web_promotion_workflow(
         raise click.ClickException("Generic-web promotion workflow product does not match profile.")
     contexts = {lane.context.strip() for lane in profile.lanes if lane.context.strip()}
     if request.context not in contexts:
-        raise click.ClickException("Generic-web promotion workflow context is not in the product profile.")
+        raise click.ClickException(
+            "Generic-web promotion workflow context is not in the product profile."
+        )
     owner, repo = _repository_parts(profile.repository)
     token = resolve_launchplane_github_token(
         control_plane_root=control_plane_root,
@@ -81,6 +84,7 @@ def dispatch_generic_web_promotion_workflow(
         ref=ref,
         token=token,
     )
+    dispatch_started_at = datetime.now(UTC)
     github_api_request(
         path=f"/repos/{owner}/{repo}/actions/workflows/{quote(workflow_id, safe='')}/dispatches",
         token=token,
@@ -100,6 +104,7 @@ def dispatch_generic_web_promotion_workflow(
         ref=ref,
         token=token,
         previous_run_ids=previous_run_ids,
+        min_created_at=dispatch_started_at,
         timeout_seconds=request.observe_timeout_seconds,
     )
     return GenericWebPromotionWorkflowResult(
@@ -125,6 +130,7 @@ def _wait_for_workflow_run(
     ref: str,
     token: str,
     previous_run_ids: set[int],
+    min_created_at: datetime,
     timeout_seconds: int,
 ) -> dict[str, object]:
     deadline = time.monotonic() + timeout_seconds
@@ -136,6 +142,7 @@ def _wait_for_workflow_run(
             ref=ref,
             token=token,
             previous_run_ids=previous_run_ids,
+            min_created_at=min_created_at,
         )
         if run:
             return run
@@ -152,6 +159,7 @@ def _latest_workflow_dispatch_run(
     ref: str,
     token: str,
     previous_run_ids: set[int],
+    min_created_at: datetime,
 ) -> dict[str, object]:
     workflow_runs = _workflow_dispatch_runs(
         owner=owner,
@@ -164,6 +172,9 @@ def _latest_workflow_dispatch_run(
     for raw_run in workflow_runs:
         run_id = _int_value(raw_run.get("id"))
         if not run_id or run_id in previous_run_ids:
+            continue
+        created_at = _datetime_value(raw_run.get("created_at"))
+        if created_at is None or created_at < min_created_at:
             continue
         new_runs.append(raw_run)
     if len(new_runs) == 1:
@@ -223,3 +234,14 @@ def _string_value(value: object) -> str:
 
 def _int_value(value: object) -> int:
     return value if isinstance(value, int) else 0
+
+
+def _datetime_value(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    normalized = value.strip().removesuffix("Z") + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    return parsed.astimezone(UTC)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2287,6 +2287,9 @@ function StateFixtureGallery({
 }: {
   actions: DriverActionDescriptor[];
 }) {
+  const [selectedEvidence, setSelectedEvidence] = useState<EvidenceRow | null>(
+    null,
+  );
   const readyProd = fixtureLane({
     instance: "prod",
     artifact: "ghcr.io/every/verireel@sha256:11112222",
@@ -2386,6 +2389,14 @@ function StateFixtureGallery({
         </div>
       </div>
       <div className="fixture-wide">
+        <EvidenceTimeline
+          prod={readyProd}
+          testing={readyTesting}
+          previews={[]}
+          onSelect={setSelectedEvidence}
+        />
+      </div>
+      <div className="fixture-wide">
         <ProductConfigPanel
           productDefault="sellyouroutboard"
           contextDefault="sellyouroutboard-testing"
@@ -2394,6 +2405,10 @@ function StateFixtureGallery({
           applyConfig={fixtureProductConfigApply}
         />
       </div>
+      <EvidenceDetailDrawer
+        evidence={selectedEvidence}
+        onClose={() => setSelectedEvidence(null)}
+      />
     </section>
   );
 }
@@ -2866,6 +2881,113 @@ function buildEvidenceRows(
     { lane: prod, laneName: "prod" },
     { lane: testing, laneName: "testing" },
   ].forEach(({ lane, laneName }) => {
+    if (lane?.inventory) {
+      const inventory = lane.inventory;
+      rows.push({
+        id: `${inventory.context}:${inventory.instance}:inventory`,
+        title: `${lane.instance} inventory`,
+        detail:
+          inventory.deploy.target_name ||
+          artifactFromLane(lane) ||
+          "recorded inventory",
+        status: worstStatus([
+          inventory.deploy.status,
+          inventory.destination_health.status,
+        ]),
+        time: inventory.updated_at,
+        lane: laneName,
+        kind: "inventory",
+        facts: [
+          { label: "Context", value: inventory.context },
+          { label: "Instance", value: inventory.instance },
+          {
+            label: "Artifact",
+            value: inventory.artifact_identity?.artifact_id ?? "unknown",
+            mono: true,
+          },
+          { label: "Source ref", value: inventory.source_git_ref, mono: true },
+          {
+            label: "Deployment record",
+            value: inventory.deployment_record_id,
+            mono: true,
+          },
+          {
+            label: "Promotion record",
+            value: inventory.promotion_record_id ?? "none",
+            mono: true,
+          },
+          {
+            label: "Promoted from",
+            value: inventory.promoted_from_instance ?? "none",
+          },
+          {
+            label: "Deploy status",
+            value: labelForStatus(inventory.deploy.status),
+            status: inventory.deploy.status,
+          },
+          {
+            label: "Health status",
+            value: labelForStatus(inventory.destination_health.status),
+            status: inventory.destination_health.status,
+          },
+          {
+            label: "Health URLs",
+            value: inventory.destination_health.urls.join(", ") || "none",
+            mono: true,
+          },
+          { label: "Updated", value: formatTime(inventory.updated_at) },
+        ],
+      });
+    }
+    if (lane?.release_tuple) {
+      const release = lane.release_tuple;
+      rows.push({
+        id: release.tuple_id,
+        title: `${release.channel} release tuple`,
+        detail: release.artifact_id,
+        status: "pass",
+        time: release.minted_at,
+        lane: laneName,
+        kind: "release",
+        facts: [
+          { label: "Tuple", value: release.tuple_id, mono: true },
+          { label: "Context", value: release.context },
+          { label: "Channel", value: release.channel },
+          { label: "Provenance", value: release.provenance },
+          { label: "Artifact", value: release.artifact_id, mono: true },
+          {
+            label: "Image repository",
+            value: release.image_repository ?? "unknown",
+            mono: true,
+          },
+          {
+            label: "Image digest",
+            value: release.image_digest ?? "unknown",
+            mono: true,
+          },
+          {
+            label: "Deployment record",
+            value: release.deployment_record_id ?? "unknown",
+            mono: true,
+          },
+          {
+            label: "Promotion record",
+            value: release.promotion_record_id ?? "unknown",
+            mono: true,
+          },
+          {
+            label: "Promoted from",
+            value: release.promoted_from_channel ?? "none",
+          },
+          ...Object.entries(release.repo_shas).map(([repo, sha]) => ({
+            label: repo,
+            value: sha,
+            mono: true,
+          })),
+          { label: "Minted", value: formatTime(release.minted_at) },
+        ],
+      });
+    }
     if (lane?.latest_deployment) {
       const deployment = lane.latest_deployment;
       rows.push({
@@ -2913,6 +3035,10 @@ function buildEvidenceRows(
             label: "Health URLs",
             value: deployment.destination_health.urls.join(", ") || "none",
             mono: true,
+          },
+          {
+            label: "Health verified",
+            value: deployment.destination_health.verified ? "yes" : "no",
           },
           {
             label: "Started",
@@ -3000,6 +3126,25 @@ function buildEvidenceRows(
             label: "Health status",
             value: labelForStatus(promotion.destination_health.status),
             status: promotion.destination_health.status,
+          },
+          {
+            label: "Source health",
+            value: labelForStatus(promotion.source_health?.status ?? "unknown"),
+            status: promotion.source_health?.status ?? "unknown",
+          },
+          {
+            label: "Source health URLs",
+            value: promotion.source_health?.urls.join(", ") || "none",
+            mono: true,
+          },
+          {
+            label: "Health URLs",
+            value: promotion.destination_health.urls.join(", ") || "none",
+            mono: true,
+          },
+          {
+            label: "Health verified",
+            value: promotion.destination_health.verified ? "yes" : "no",
           },
           {
             label: "Finished",
@@ -3175,6 +3320,26 @@ function fixtureLane({
       destination_health: destinationHealth,
       updated_at: deploy.finished_at,
       deployment_record_id: `fixture-deployment-${instance}`,
+      promotion_record_id:
+        instance === "prod" ? "fixture-promotion-prod" : undefined,
+      promoted_from_instance: instance === "prod" ? "testing" : undefined,
+    },
+    release_tuple: {
+      tuple_id: `verireel-${instance}-20260428`,
+      context: "verireel",
+      channel: instance,
+      artifact_id: artifact,
+      repo_shas: {
+        verireel: "6b3c9d7e8f901234567890abcdef1234567890ab",
+      },
+      image_repository: "ghcr.io/every/verireel",
+      image_digest: `sha256:${instance === "prod" ? "prod" : "test"}fixture`,
+      deployment_record_id: `fixture-deployment-${instance}`,
+      promotion_record_id:
+        instance === "prod" ? "fixture-promotion-prod" : undefined,
+      promoted_from_channel: instance === "prod" ? "testing" : undefined,
+      provenance: instance === "prod" ? "promotion" : "ship",
+      minted_at: deploy.finished_at,
     },
     latest_deployment: {
       record_id: `fixture-deployment-${instance}`,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -144,6 +144,7 @@ export interface PromotionRecord {
   context: string;
   from_instance: string;
   to_instance: string;
+  source_health?: HealthcheckEvidence;
   backup_gate: {
     required: boolean;
     status: Status;

--- a/tests/test_generic_web_promotion.py
+++ b/tests/test_generic_web_promotion.py
@@ -398,11 +398,7 @@ class GenericWebPromotionWorkflowTests(unittest.TestCase):
             ),
         ):
             profile = _profile().model_copy(
-                update={
-                    "promotion_workflow": ProductPromotionWorkflowProfile(
-                        default_bump="minor"
-                    )
-                }
+                update={"promotion_workflow": ProductPromotionWorkflowProfile(default_bump="minor")}
             )
             result = dispatch_generic_web_promotion_workflow(
                 control_plane_root=Path("."),
@@ -448,6 +444,53 @@ class GenericWebPromotionWorkflowTests(unittest.TestCase):
                 "workflow_runs": [
                     {"id": 101, "html_url": "https://github.example/runs/101", "status": "queued"},
                     {"id": 102, "html_url": "https://github.example/runs/102", "status": "queued"},
+                ]
+            }
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_promotion_workflow.resolve_launchplane_github_token",
+                return_value="github-token",
+            ),
+            patch(
+                "control_plane.workflows.generic_web_promotion_workflow.github_api_request",
+                side_effect=fake_github_api_request,
+            ),
+        ):
+            result = dispatch_generic_web_promotion_workflow(
+                control_plane_root=Path("."),
+                profile=_profile(),
+                request=GenericWebPromotionWorkflowRequest(
+                    product="sellyouroutboard",
+                    context="sellyouroutboard-testing",
+                    observe_timeout_seconds=0,
+                ),
+            )
+
+        self.assertEqual(result.run_id, 0)
+        self.assertEqual(result.run_url, "")
+        self.assertEqual(result.run_status, "pending")
+
+    def test_observation_ignores_new_run_created_before_dispatch(self) -> None:
+        list_count = 0
+
+        def fake_github_api_request(
+            *, path: str, token: str, method: str = "GET", body: dict[str, object] | None = None
+        ):
+            nonlocal list_count
+            if method == "POST":
+                return None
+            list_count += 1
+            if list_count == 1:
+                return {"workflow_runs": []}
+            return {
+                "workflow_runs": [
+                    {
+                        "id": 101,
+                        "html_url": "https://github.example/runs/101",
+                        "status": "queued",
+                        "created_at": "2000-01-01T00:00:00Z",
+                    }
                 ]
             }
 


### PR DESCRIPTION
## Summary

Completes the final #130 UI polish slice for generic-web promotion evidence and folds in the Codex review hardening from #132.

- surface inventory records and release tuples in the operator evidence timeline
- show promotion/deployment record IDs, promoted-from linkage, repo SHAs, image identity, and health URLs/verified flags in evidence detail
- add fixture coverage for clickable evidence timeline rows and release tuple details
- harden workflow run observation so Launchplane only attaches a GitHub Actions run when it is both new and created after the current dispatch began; otherwise the dispatch remains accepted with pending run evidence instead of risking a wrong run link

Fixes the remaining checkbox in #130.
Addresses the Codex review comment on #132: https://github.com/cbusillo/launchplane/pull/132#discussion_r3175671275

## Validation

- `uv run python -m unittest tests.test_generic_web_promotion`
- `uv run python -m unittest`
- `uv run --extra dev ruff format --check control_plane/workflows/generic_web_promotion_workflow.py tests/test_generic_web_promotion.py`
- `uv run --extra dev ruff check control_plane/workflows/generic_web_promotion_workflow.py tests/test_generic_web_promotion.py`
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend build`
- `git diff --check`
- browser fixture review at `http://127.0.0.1:5178/ui/?fixtures=1`: verified release tuple/inventory rows appear in the timeline, clicked `Inspect prod release tuple evidence`, confirmed tuple/image/promotion record facts, and confirmed no horizontal overflow

## Notes

The repo-wide mypy gate still reports pre-existing unrelated typing noise when invoked by tooling around apply-patch; this PR did not introduce or rely on those paths.
