### PR TITLE
Fix operator context state drift

### DIFF
--- a/control_plane/workflows/generic_web_promotion_workflow.py
+++ b/control_plane/workflows/generic_web_promotion_workflow.py
@@ -84,7 +84,7 @@ def dispatch_generic_web_promotion_workflow(
         ref=ref,
         token=token,
     )
-    dispatch_started_at = datetime.now(UTC)
+    dispatch_started_at = _github_timestamp_precision(datetime.now(UTC))
     github_api_request(
         path=f"/repos/{owner}/{repo}/actions/workflows/{quote(workflow_id, safe='')}/dispatches",
         token=token,
@@ -161,6 +161,7 @@ def _latest_workflow_dispatch_run(
     previous_run_ids: set[int],
     min_created_at: datetime,
 ) -> dict[str, object]:
+    min_created_at = _github_timestamp_precision(min_created_at)
     workflow_runs = _workflow_dispatch_runs(
         owner=owner,
         repo=repo,
@@ -239,9 +240,15 @@ def _int_value(value: object) -> int:
 def _datetime_value(value: object) -> datetime | None:
     if not isinstance(value, str) or not value.strip():
         return None
-    normalized = value.strip().removesuffix("Z") + "+00:00"
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = normalized.removesuffix("Z") + "+00:00"
     try:
         parsed = datetime.fromisoformat(normalized)
     except ValueError:
         return None
     return parsed.astimezone(UTC)
+
+
+def _github_timestamp_precision(value: datetime) -> datetime:
+    return value.astimezone(UTC).replace(microsecond=0)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -336,10 +336,7 @@ export function App() {
   }, [authStatus, selected, refreshKey]);
 
   const choices = useMemo(() => {
-    if (!drivers.length) {
-      return DEFAULT_CHOICES;
-    }
-    return drivers.flatMap((driver) => {
+    const driverChoices = drivers.flatMap((driver) => {
       const stableContexts = driver.context_patterns.filter((context) => {
         return context !== "verireel-testing" && !context.includes("*");
       });
@@ -359,7 +356,7 @@ export function App() {
         label: profile.display_name || profile.product,
       }));
     });
-    const merged = [...profileChoices, ...DEFAULT_CHOICES];
+    const merged = [...profileChoices, ...driverChoices, ...DEFAULT_CHOICES];
     const seen = new Set<string>();
     return merged.filter((choice) => {
       const key = `${choice.driverId}:${choice.context}`;
@@ -370,6 +367,21 @@ export function App() {
       return true;
     });
   }, [drivers, productProfiles]);
+
+  useEffect(() => {
+    if (!choices.length) {
+      return;
+    }
+    const selectedKey = `${selected.driverId}:${selected.context}`;
+    if (
+      choices.some(
+        (choice) => `${choice.driverId}:${choice.context}` === selectedKey,
+      )
+    ) {
+      return;
+    }
+    setSelected(choices[0]);
+  }, [choices, selected]);
 
   const currentDriver = drivers.find(
     (driver) => driver.driver_id === selected.driverId,
@@ -489,7 +501,7 @@ export function App() {
               />
             </section>
             <section className="work-grid work-grid-evidence">
-              <SecretBindingList
+              <RuntimeAuthorityList
                 driver={selectedDriver ?? null}
                 lane={prodDriverView?.lane_summary ?? null}
               />
@@ -2097,7 +2109,7 @@ function ActionList({
   );
 }
 
-function SecretBindingList({
+function RuntimeAuthorityList({
   driver,
   lane,
 }: {
@@ -2109,14 +2121,35 @@ function SecretBindingList({
       return group.secret_bindings.map((binding) => ({ group, binding }));
     }) ?? [];
   const actualBindings = lane?.secret_bindings ?? [];
+  const runtimeRecords = lane?.runtime_environment_records ?? [];
 
   return (
     <section className="panel">
       <PanelHead
-        eyebrow="managed secrets"
-        title="Bindings"
+        eyebrow="runtime authority"
+        title="Keys and bindings"
         right={<KeyRound size={17} aria-hidden="true" />}
       />
+      <div className="secret-list">
+        {runtimeRecords.map((record) => {
+          const envKeys = Object.keys(record.env).sort();
+          return (
+            <div
+              className="secret-row"
+              key={`${record.scope}:${record.context}:${record.instance}:${record.updated_at}`}
+            >
+              <span className="lane-chip lane-chip-prod">
+                {record.scope === "global"
+                  ? "global"
+                  : record.instance || record.context}
+              </span>
+              <strong>{envKeys.join(", ") || "no keys"}</strong>
+              <span>{record.source_label || "runtime environment"}</span>
+              <StatusPill status={envKeys.length ? "pass" : "unknown"} />
+            </div>
+          );
+        })}
+      </div>
       {actualBindings.length ? (
         <div className="secret-list">
           {actualBindings.map((binding) => (
@@ -2145,7 +2178,11 @@ function SecretBindingList({
           {!bindingHints.length ? (
             <StateBlock
               icon={<KeyRound size={18} />}
-              title="No binding metadata"
+              title={
+                runtimeRecords.length
+                  ? "No secret binding metadata"
+                  : "No runtime metadata"
+              }
             />
           ) : null}
         </div>
@@ -2387,6 +2424,12 @@ function StateFixtureGallery({
             loading={false}
           />
         </div>
+      </div>
+      <div className="fixture-wide">
+        <RuntimeAuthorityList
+          driver={FIXTURE_VERIREEL_DRIVER}
+          lane={readyProd}
+        />
       </div>
       <div className="fixture-wide">
         <EvidenceTimeline
@@ -3341,6 +3384,29 @@ function fixtureLane({
       provenance: instance === "prod" ? "promotion" : "ship",
       minted_at: deploy.finished_at,
     },
+    runtime_environment_records: [
+      {
+        scope: "context",
+        context: "verireel",
+        instance: "",
+        env: {
+          LAUNCHPLANE_PREVIEW_BASE_URL: "https://preview.verireel.example",
+        },
+        updated_at: deploy.finished_at,
+        source_label: "fixture-context-env",
+      },
+      {
+        scope: "instance",
+        context: "verireel",
+        instance,
+        env: {
+          CONTACT_EMAIL_MODE: "smtp",
+          PUBLIC_TAWK_WIDGET_ID: "redacted-fixture",
+        },
+        updated_at: deploy.finished_at,
+        source_label: "fixture-instance-env",
+      },
+    ],
     latest_deployment: {
       record_id: `fixture-deployment-${instance}`,
       artifact_identity: { artifact_id: artifact },
@@ -3362,7 +3428,20 @@ function fixtureLane({
           evidence: backupStatus === "pass" ? { snapshot: "fixture-prod" } : {},
         }
       : null,
-    secret_bindings: [],
+    secret_bindings: [
+      {
+        binding_id: `fixture-secret-binding-${instance}`,
+        secret_id: `fixture-secret-${instance}`,
+        integration: "runtime_environment",
+        binding_type: "env",
+        binding_key: "SMTP_PASSWORD",
+        context: "verireel",
+        instance,
+        status: "configured",
+        created_at: deploy.finished_at,
+        updated_at: deploy.finished_at,
+      },
+    ],
     provenance: {
       source_kind: "record",
       source_record_id: `fixture-deployment-${instance}`,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -167,6 +167,15 @@ export interface SecretBinding {
   updated_at: string;
 }
 
+export interface RuntimeEnvironmentRecord {
+  scope: "global" | "context" | "instance";
+  context: string;
+  instance: string;
+  env: Record<string, string | number | boolean>;
+  updated_at: string;
+  source_label: string;
+}
+
 export interface LaneSummary {
   context: string;
   instance: string;
@@ -176,6 +185,7 @@ export interface LaneSummary {
   latest_promotion?: PromotionRecord | null;
   latest_backup_gate?: BackupGateRecord | null;
   odoo_instance_override?: unknown | null;
+  runtime_environment_records?: RuntimeEnvironmentRecord[];
   secret_bindings: SecretBinding[];
   provenance: DataProvenance;
 }

--- a/tests/test_generic_web_promotion.py
+++ b/tests/test_generic_web_promotion.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import patch
 
@@ -21,6 +22,7 @@ from control_plane.workflows.generic_web_promotion import (
 )
 from control_plane.workflows.generic_web_promotion_workflow import (
     GenericWebPromotionWorkflowRequest,
+    _latest_workflow_dispatch_run,
     dispatch_generic_web_promotion_workflow,
 )
 from control_plane.workflows.ship import build_deployment_record
@@ -517,6 +519,38 @@ class GenericWebPromotionWorkflowTests(unittest.TestCase):
         self.assertEqual(result.run_id, 0)
         self.assertEqual(result.run_url, "")
         self.assertEqual(result.run_status, "pending")
+
+    def test_observation_accepts_run_created_in_same_second_as_dispatch(self) -> None:
+        def fake_github_api_request(
+            *, path: str, token: str, method: str = "GET", body: dict[str, object] | None = None
+        ):
+            self.assertEqual(method, "GET")
+            return {
+                "workflow_runs": [
+                    {
+                        "id": 101,
+                        "html_url": "https://github.example/runs/101",
+                        "status": "queued",
+                        "created_at": "2099-01-01T00:00:00Z",
+                    }
+                ]
+            }
+
+        with patch(
+            "control_plane.workflows.generic_web_promotion_workflow.github_api_request",
+            side_effect=fake_github_api_request,
+        ):
+            run = _latest_workflow_dispatch_run(
+                owner="cbusillo",
+                repo="sellyouroutboard",
+                workflow_id="promote-prod.yml",
+                ref="main",
+                token="github-token",
+                previous_run_ids=set(),
+                min_created_at=datetime(2099, 1, 1, 0, 0, 0, 999999, UTC),
+            )
+
+        self.assertEqual(run.get("id"), 101)
 
     def test_dispatch_requires_managed_github_token(self) -> None:
         with patch(


### PR DESCRIPTION
## Summary

Fixes the Launchplane operator UI state drift spotted after #133 and addresses the Codex review on #133.

- include product-profile-backed generic-web products in the context picker after the signed-in driver list loads, instead of returning early with only durable driver contexts
- force selected driver/context state back onto a valid picker choice if loaded options no longer contain the previous selection, preventing the header/body from disagreeing with the visible select value
- show redacted runtime authority metadata from lane summaries: runtime env key names/count context only, plus managed secret binding keys/status; values remain hidden
- normalize GitHub workflow dispatch timestamp comparisons to second precision so a legitimate run created in the same second as dispatch is not discarded as too old

Addresses the Codex review on #133: https://github.com/cbusillo/launchplane/pull/133#discussion_r3175701696

## Validation

- `uv run --extra dev ruff format --check control_plane/workflows/generic_web_promotion_workflow.py tests/test_generic_web_promotion.py`
- `uv run --extra dev ruff check control_plane/workflows/generic_web_promotion_workflow.py tests/test_generic_web_promotion.py`
- `uv run python -m unittest tests.test_generic_web_promotion`
- `uv run python -m unittest`
- `pnpm --dir frontend build`
- `git diff --check`
- browser fixture review verified `Keys and bindings`, runtime key names (`CONTACT_EMAIL_MODE`, `PUBLIC_TAWK_WIDGET_ID`), managed secret binding key (`SMTP_PASSWORD`), and no horizontal overflow
