### PR TITLE
Make operator UI product-workspace first

### DIFF
--- a/docs/records.md
+++ b/docs/records.md
@@ -134,6 +134,23 @@ template lane, required template env keys, copied or omitted settings, preview
 URL/domain env keys, required provider fields, and the declared data transport
 mode so readiness can fail before Launchplane mutates a provider.
 
+The product key is the durable workspace identity. For example,
+`sellyouroutboard` is the SellYourOutboard product workspace; `testing`, `prod`,
+and the preview inventory all appear under that workspace in the operator UI.
+The `context` fields on lane and preview profile entries are technical routing
+and record lookup identifiers, not user-facing product names. Stable
+generic-web lanes should converge on the product context, such as
+`sellyouroutboard` for both `testing` and `prod`, so promotion and runtime reads
+resolve one product stack. A separate preview context may remain while preview
+apps are isolated from stable lane records.
+
+When cleaning up a legacy context such as `sellyouroutboard-testing`, migrate or
+reseed only the mutable current-authority records needed by live resolution,
+such as runtime environments, secret bindings, tracked targets, inventories, and
+release tuples. Do not rewrite append-only deployments, promotions, backup
+gates, or preview history; those records are historical evidence and should
+continue to describe the route that produced them.
+
 These records replace repo-local Launchplane lifecycle manifests. Product repos
 still own their normal app/runtime contract, such as Dockerfile, image publish,
 health endpoint, tests, and source/build inputs. Launchplane owns the product
@@ -147,8 +164,8 @@ Launchplane service context; reads use `product_profile.read`.
 
 For initial seed or repair work, operators can write the same DB-backed record
 directly with `uv run launchplane product-profiles upsert --database-url ...`.
-That command is an operator tool for creating the Launchplane record; it is not a
-repo-local manifest and should not become product repo authority.
+That command is an operator tool for creating the Launchplane record; it is not
+a repo-local manifest and should not become product repo authority.
 
 This file layout describes today's local Launchplane implementation, not the
 final cross-product communication boundary. The stable long-term contract should

--- a/docs/ui-standards.md
+++ b/docs/ui-standards.md
@@ -15,6 +15,7 @@ but fail this rubric are not complete.
 
 Every UI slice declares one primary object before implementation:
 
+- product workspace
 - tenant
 - environment lane
 - preview
@@ -25,10 +26,27 @@ Do not blur these into a generic set of status cards. If a slice needs multiple
 objects, make the primary object visually dominant and place supporting objects
 as evidence around it.
 
+The top-level picker chooses a product workspace, not a raw Launchplane context.
+Use display names such as `SellYourOutboard`, `VeriReel`, `Odoo CM`, and
+`Odoo OPW`. Context strings such as `sellyouroutboard`,
+`sellyouroutboard-testing`, `verireel-testing`, `cm`, or `opw` are routing and
+record identifiers. They may appear in evidence, route metadata, or scoped write
+forms, but they should not be the primary picker label.
+
+Stable lanes (`testing` and `prod`) belong visually under one product workspace.
+If a generic-web product still has a legacy testing-shaped context, the UI may
+read that route as transition metadata, but the operator model remains one
+product with stable lanes and preview inventory under it. Preview routing can
+use a separate technical context while previews are isolated from stable lane
+state.
+
 ## Visual Direction
 
 - Tenant-first: prefer a direct tenant environment page over a fleet queue when
   Launchplane is scoped to one tenant.
+- Product-first: for generic-web and reusable drivers, make the product
+  workspace the first visible identity and demote driver/context details to
+  metadata.
 - Operational density: prioritize scan speed, evidence, timestamps, and status
   clarity over decorative layout.
 - Distinct lanes: `prod`, `testing`, and `preview` must have different visual
@@ -60,6 +78,7 @@ Before committing a meaningful UI slice, check it against this rubric:
 
 - Can a new operator tell what product/tenant they are looking at within a few
   seconds?
+- Does the picker show product names instead of raw context strings?
 - Can they tell what is in `prod`, what is in `testing`, and whether previews
   exist?
 - Are primary actions visibly safer and more important than secondary actions?

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -63,8 +63,12 @@ type Theme = "dark" | "light";
 type AuthStatus = "checking" | "signed_out" | "signed_in";
 type DriverChoice = {
   driverId: string;
-  context: string;
+  testingContext: string;
+  prodContext: string;
+  previewContext: string;
   label: string;
+  driverLabel: string;
+  repository?: string;
 };
 type PromotionVerdict = "ready" | "pending" | "blocked";
 type PromotionGate = {
@@ -114,11 +118,36 @@ const THEME_STORAGE_KEY = "launchplane.theme";
 const DEFAULT_CHOICES: DriverChoice[] = [
   {
     driverId: "sellyouroutboard",
-    context: "sellyouroutboard-testing",
-    label: "Sell Your Outboard",
+    testingContext: "sellyouroutboard-testing",
+    prodContext: "sellyouroutboard-testing",
+    previewContext: "sellyouroutboard-testing",
+    label: "SellYourOutboard",
+    driverLabel: "generic-web",
   },
-  { driverId: "verireel", context: "verireel", label: "VeriReel" },
-  { driverId: "odoo", context: "opw", label: "Odoo" },
+  {
+    driverId: "verireel",
+    testingContext: "verireel",
+    prodContext: "verireel",
+    previewContext: "verireel-testing",
+    label: "VeriReel",
+    driverLabel: "verireel",
+  },
+  {
+    driverId: "odoo",
+    testingContext: "cm",
+    prodContext: "cm",
+    previewContext: "",
+    label: "Odoo CM",
+    driverLabel: "odoo",
+  },
+  {
+    driverId: "odoo",
+    testingContext: "opw",
+    prodContext: "opw",
+    previewContext: "",
+    label: "Odoo OPW",
+    driverLabel: "odoo",
+  },
 ];
 const FIXTURE_ACTIONS: DriverActionDescriptor[] = [
   {
@@ -197,6 +226,62 @@ const FIXTURE_ODOO_DRIVER: DriverDescriptor = {
   capabilities: [],
   actions: [],
 };
+
+function choiceKey(choice: DriverChoice): string {
+  return `${choice.driverId}:${choice.testingContext}:${choice.prodContext}:${choice.previewContext}`;
+}
+
+function labelForDriverContext(
+  driver: DriverDescriptor,
+  context: string,
+): string {
+  if (driver.driver_id === "odoo") {
+    if (context === "cm") {
+      return "Odoo CM";
+    }
+    if (context === "opw") {
+      return "Odoo OPW";
+    }
+  }
+  return driver.label;
+}
+
+function displayNameForProduct(profile: ProductProfileRecord): string {
+  if (profile.product === "sellyouroutboard") {
+    return "SellYourOutboard";
+  }
+  return profile.display_name || profile.product;
+}
+
+function contextForProductLane(
+  profile: ProductProfileRecord,
+  instance: "testing" | "prod",
+): string {
+  const lane = profile.lanes.find(
+    (candidate) => candidate.instance === instance,
+  );
+  if (lane?.context.trim()) {
+    return lane.context.trim();
+  }
+  const fallbackLane = profile.lanes.find((candidate) =>
+    candidate.context.trim(),
+  );
+  return fallbackLane?.context.trim() || "";
+}
+
+function choiceFromProductProfile(profile: ProductProfileRecord): DriverChoice {
+  return {
+    driverId: profile.product,
+    testingContext: contextForProductLane(profile, "testing"),
+    prodContext: contextForProductLane(profile, "prod"),
+    previewContext: profile.preview?.enabled
+      ? profile.preview.context.trim()
+      : "",
+    label: displayNameForProduct(profile),
+    driverLabel: profile.driver_id,
+    repository: profile.repository,
+  };
+}
 
 export function App() {
   const showFixtureGallery =
@@ -283,10 +368,10 @@ export function App() {
     setTraceId("");
     Promise.all([
       listDrivers(),
-      readDriverView(selected.context, "prod"),
-      readDriverView(selected.context, "testing"),
-      selected.driverId === "verireel"
-        ? readDriverView("verireel-testing", "")
+      readDriverView(selected.prodContext, "prod"),
+      readDriverView(selected.testingContext, "testing"),
+      selected.previewContext
+        ? readDriverView(selected.previewContext, "")
         : Promise.resolve(null),
       listProductProfiles("generic-web").catch(() => ({
         status: "ok" as const,
@@ -342,24 +427,23 @@ export function App() {
       });
       return stableContexts.map((context) => ({
         driverId: driver.driver_id,
-        context,
-        label: driver.label,
+        testingContext: context,
+        prodContext: context,
+        previewContext:
+          driver.driver_id === "verireel" && context === "verireel"
+            ? "verireel-testing"
+            : "",
+        label: labelForDriverContext(driver, context),
+        driverLabel: driver.driver_id,
       }));
     });
-    const profileChoices = productProfiles.flatMap((profile) => {
-      const contexts = new Set(
-        profile.lanes.map((lane) => lane.context).filter(Boolean),
-      );
-      return [...contexts].map((context) => ({
-        driverId: profile.product,
-        context,
-        label: profile.display_name || profile.product,
-      }));
-    });
+    const profileChoices = productProfiles.map((profile) =>
+      choiceFromProductProfile(profile),
+    );
     const merged = [...profileChoices, ...driverChoices, ...DEFAULT_CHOICES];
     const seen = new Set<string>();
     return merged.filter((choice) => {
-      const key = `${choice.driverId}:${choice.context}`;
+      const key = choiceKey(choice);
       if (seen.has(key)) {
         return false;
       }
@@ -372,12 +456,8 @@ export function App() {
     if (!choices.length) {
       return;
     }
-    const selectedKey = `${selected.driverId}:${selected.context}`;
-    if (
-      choices.some(
-        (choice) => `${choice.driverId}:${choice.context}` === selectedKey,
-      )
-    ) {
+    const selectedKey = choiceKey(selected);
+    if (choices.some((choice) => choiceKey(choice) === selectedKey)) {
       return;
     }
     setSelected(choices[0]);
@@ -466,7 +546,7 @@ export function App() {
                 testing={testingDriverView?.lane_summary ?? null}
                 actions={actions}
                 product={selectedDriver?.product ?? selected.driverId}
-                context={selected.context}
+                context={selected.prodContext}
                 decision={promotionDecision}
                 loading={loading}
                 onAction={setReviewAction}
@@ -480,7 +560,7 @@ export function App() {
             </section>
             <ProductConfigPanel
               productDefault={selectedDriver?.product ?? selected.driverId}
-              contextDefault={selected.context}
+              contextDefault={selected.prodContext}
               instanceDefault="prod"
               disabled={loading}
             />
@@ -548,8 +628,8 @@ function Header({
   onLogout: () => void;
   onRefresh: () => void;
 }) {
-  const selectedValue = `${selected.driverId}:${selected.context}`;
-  const selectId = "launchplane-context-select";
+  const selectedValue = choiceKey(selected);
+  const selectId = "launchplane-product-select";
 
   return (
     <header className="topbar">
@@ -558,10 +638,10 @@ function Header({
           LP
         </div>
         <div>
-          <div className="brand-title">Launchplane</div>
+          <div className="brand-title">{selected.label}</div>
           <div className="brand-meta">
-            <span>{selected.context}</span>
-            <span>{selected.driverId}</span>
+            <span>{selected.driverLabel}</span>
+            <span>{selected.repository ?? "stable lanes"}</span>
           </div>
         </div>
       </div>
@@ -573,15 +653,14 @@ function Header({
           </div>
         ) : null}
         <label className="select-label">
-          <span>Context</span>
+          <span>Product</span>
           <select
             id={selectId}
-            aria-label="Launchplane context"
+            aria-label="Launchplane product"
             value={selectedValue}
             onChange={(event) => {
               const choice = choices.find(
-                (item) =>
-                  `${item.driverId}:${item.context}` === event.target.value,
+                (item) => choiceKey(item) === event.target.value,
               );
               if (choice) {
                 onSelect(choice);
@@ -589,11 +668,8 @@ function Header({
             }}
           >
             {choices.map((choice) => (
-              <option
-                key={`${choice.driverId}:${choice.context}`}
-                value={`${choice.driverId}:${choice.context}`}
-              >
-                {choice.label} / {choice.context}
+              <option key={choiceKey(choice)} value={choiceKey(choice)}>
+                {choice.label}
               </option>
             ))}
           </select>
@@ -944,8 +1020,8 @@ function ProductConfigPanel({
   return (
     <section className="panel product-config-panel">
       <PanelHead
-        eyebrow="runtime authority"
-        title="Product config"
+        eyebrow="write config"
+        title="Apply runtime config change"
         right={
           <StatusPill
             status={
@@ -960,7 +1036,7 @@ function ProductConfigPanel({
       />
       <div className="config-target-grid">
         <label className="config-label">
-          <span>Product</span>
+          <span>Product ID</span>
           <input
             value={product}
             onChange={(event) => {
@@ -971,7 +1047,7 @@ function ProductConfigPanel({
           />
         </label>
         <label className="config-label">
-          <span>Context</span>
+          <span>Stable context</span>
           <input
             value={contextName}
             onChange={(event) => {
@@ -2126,8 +2202,8 @@ function RuntimeAuthorityList({
   return (
     <section className="panel">
       <PanelHead
-        eyebrow="runtime authority"
-        title="Keys and bindings"
+        eyebrow="current state"
+        title="Current runtime authority"
         right={<KeyRound size={17} aria-hidden="true" />}
       />
       <div className="secret-list">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -383,6 +383,11 @@ export interface ProductProfileRecord {
     base_url: string;
     health_url: string;
   }>;
+  preview?: {
+    enabled: boolean;
+    context: string;
+    slug_template: string;
+  };
   promotion_workflow: {
     workflow_id: string;
     ref: string;


### PR DESCRIPTION
## Summary

- make the operator topbar and picker product-workspace first instead of context-first
- show `SellYourOutboard` as the workspace label and demote raw context strings to scoped write/evidence metadata
- carry explicit testing/prod/preview contexts internally so lane reads remain honest during the SYO DB cutover
- document the product/context/lane model and the guardrail against rewriting append-only evidence records

## Validation

- `pnpm --dir frontend build`
- `npx --yes markdownlint-cli2 docs/ui-standards.md docs/records.md`
- `uv run python -m unittest`
- browser fixture review at `/ui/?fixtures=1`: topbar shows `SellYourOutboard`; picker options are `SellYourOutboard`, `VeriReel`, `Odoo CM`, `Odoo OPW`; no `SellYourOutboard.com`; no legacy context in picker labels; no horizontal overflow at desktop viewport

## Tracking

First slice of #135. This PR intentionally does not mutate live DB records or delete the stray runtime environment record from #126.
