### PR TITLE
Tolerate preview read failures

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -371,7 +371,7 @@ export function App() {
       readDriverView(selected.prodContext, "prod"),
       readDriverView(selected.testingContext, "testing"),
       selected.previewContext
-        ? readDriverView(selected.previewContext, "")
+        ? readDriverView(selected.previewContext, "").catch(() => null)
         : Promise.resolve(null),
       listProductProfiles("generic-web").catch(() => ({
         status: "ok" as const,


### PR DESCRIPTION
## Summary

- make the preview-context driver-view fetch best-effort
- keep prod/testing lane reads strict so real stable-lane failures still surface
- prevents a 403/404 preview context response from blanking the product workspace dashboard

## Validation

- `pnpm --dir frontend build`

## Follow-up

Addresses the Codex review on #136: https://github.com/cbusillo/launchplane/pull/136#discussion_r3175825659
