### PR TITLE
Add product context cutover audit

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -74,6 +74,7 @@ from control_plane.contracts.runtime_environment_record import (
     RuntimeEnvironmentDeleteEvent,
     RuntimeEnvironmentRecord,
 )
+from control_plane.contracts.secret_record import SecretRecord
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.drivers.registry import build_driver_context_view
 from control_plane.launchplane_mutations import (
@@ -258,6 +259,168 @@ def _summarize_product_profile_record(record: LaunchplaneProductProfileRecord) -
         "updated_at": record.updated_at,
         "source": record.source,
     }
+
+
+def _summarize_product_profile_lane(record: ProductLaneProfile) -> dict[str, object]:
+    return {
+        "instance": record.instance,
+        "context": record.context,
+        "base_url": record.base_url,
+        "health_url": record.health_url,
+    }
+
+
+def _route_key(context_name: str, instance_name: str) -> tuple[str, str]:
+    return (context_name, instance_name)
+
+
+def _summarize_secret_record_for_context_audit(
+    *,
+    record_store: PostgresRecordStore,
+    record: SecretRecord,
+) -> dict[str, object]:
+    binding = control_plane_secrets.build_secret_status(
+        record_store,
+        secret_id=record.secret_id,
+    ).get("binding")
+    return {
+        "secret_id": record.secret_id,
+        "scope": record.scope,
+        "integration": record.integration,
+        "name": record.name,
+        "context": record.context,
+        "instance": record.instance,
+        "status": record.status,
+        "binding_key": str(binding.get("binding_key", "")) if isinstance(binding, dict) else "",
+        "binding_status": str(binding.get("status", "")) if isinstance(binding, dict) else "",
+        "updated_at": record.updated_at,
+    }
+
+
+def _context_cutover_route_payload(
+    *,
+    record_store: PostgresRecordStore,
+    context_name: str,
+) -> dict[str, object]:
+    runtime_records = record_store.list_runtime_environment_records(context_name=context_name)
+    secret_records = record_store.list_secret_records(context_name=context_name, limit=None)
+    target_records = tuple(
+        record
+        for record in record_store.list_dokploy_target_records()
+        if record.context == context_name
+    )
+    target_ids_by_route = _target_id_map(
+        tuple(
+            record
+            for record in record_store.list_dokploy_target_id_records()
+            if record.context == context_name
+        )
+    )
+    inventory_records = tuple(
+        record
+        for record in record_store.list_environment_inventory()
+        if record.context == context_name
+    )
+    release_tuple_records = tuple(
+        record
+        for record in record_store.list_release_tuple_records()
+        if record.context == context_name
+    )
+    return {
+        "context": context_name,
+        "runtime_environment_records": [
+            _summarize_runtime_environment_record(record) for record in runtime_records
+        ],
+        "managed_secret_records": [
+            _summarize_secret_record_for_context_audit(
+                record_store=record_store,
+                record=record,
+            )
+            for record in secret_records
+        ],
+        "dokploy_targets": [
+            _summarize_dokploy_target_record(
+                record,
+                target_id=target_ids_by_route.get(_route_key(record.context, record.instance), ""),
+            )
+            for record in target_records
+        ],
+        "inventory_records": [
+            _summarize_environment_inventory(record) for record in inventory_records
+        ],
+        "release_tuple_records": [
+            {
+                "tuple_id": record.tuple_id,
+                "context": record.context,
+                "channel": record.channel,
+                "artifact_id": record.artifact_id,
+                "image_repository": record.image_repository,
+                "image_digest": record.image_digest,
+                "deployment_record_id": record.deployment_record_id,
+                "promotion_record_id": record.promotion_record_id,
+                "promoted_from_channel": record.promoted_from_channel,
+                "provenance": record.provenance,
+                "minted_at": record.minted_at,
+            }
+            for record in release_tuple_records
+        ],
+        "append_only_evidence_counts": {
+            "backup_gates": len(
+                record_store.list_backup_gate_records(context_name=context_name, limit=None)
+            ),
+            "deployments": len(
+                record_store.list_deployment_records(context_name=context_name, limit=None)
+            ),
+            "promotions": len(
+                record_store.list_promotion_records(context_name=context_name, limit=None)
+            ),
+        },
+    }
+
+
+def _build_context_cutover_warnings(
+    *,
+    profile: LaunchplaneProductProfileRecord,
+    source_context: str,
+    target_context: str,
+    preview_context: str,
+    source_payload: dict[str, object],
+    target_payload: dict[str, object],
+) -> list[str]:
+    warnings: list[str] = []
+    stable_lane_contexts = {
+        lane.instance: lane.context
+        for lane in profile.lanes
+        if lane.instance in {"testing", "prod"}
+    }
+    if source_context in stable_lane_contexts.values():
+        warnings.append(
+            f"Stable product profile lanes still reference legacy context {source_context!r}."
+        )
+    if target_context not in stable_lane_contexts.values():
+        warnings.append(
+            f"No stable product profile lane currently references target context {target_context!r}."
+        )
+    if profile.preview.enabled and profile.preview.context not in {preview_context, target_context}:
+        warnings.append(
+            f"Preview profile context {profile.preview.context!r} differs from requested preview context."
+        )
+    if source_payload["append_only_evidence_counts"] != {
+        "backup_gates": 0,
+        "deployments": 0,
+        "promotions": 0,
+    }:
+        warnings.append(
+            "Legacy context has append-only evidence; do not rewrite those records during cutover."
+        )
+    if (
+        target_payload["runtime_environment_records"]
+        and source_payload["runtime_environment_records"]
+    ):
+        warnings.append(
+            "Both source and target contexts have runtime environment records; compare key sets before deleting either side."
+        )
+    return warnings
 
 
 def _parse_product_profile_lanes(lanes_json: str) -> tuple[ProductLaneProfile, ...]:
@@ -12201,6 +12364,107 @@ def product_profiles_show(database_url: str, product: str) -> None:
     click.echo(
         json.dumps(
             {"status": "ok", "profile": record.model_dump(mode="json")},
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+@product_profiles.command("audit-context-cutover")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane product and runtime records.",
+)
+@click.option("--product", required=True, help="Product key to audit.")
+@click.option("--source-context", required=True, help="Legacy context to inspect.")
+@click.option("--target-context", required=True, help="Canonical context to inspect.")
+@click.option(
+    "--preview-context",
+    default="",
+    help="Preview context to inspect; defaults to the product profile preview context.",
+)
+def product_profiles_audit_context_cutover(
+    database_url: str,
+    product: str,
+    source_context: str,
+    target_context: str,
+    preview_context: str,
+) -> None:
+    normalized_source_context = source_context.strip()
+    normalized_target_context = target_context.strip()
+    if not normalized_source_context or not normalized_target_context:
+        raise click.ClickException("Provide non-empty --source-context and --target-context.")
+    if normalized_source_context == normalized_target_context:
+        raise click.ClickException("Source and target contexts must differ.")
+
+    record_store = _product_profile_store(database_url)
+    try:
+        profile = record_store.read_product_profile_record(product.strip())
+        normalized_preview_context = preview_context.strip() or profile.preview.context.strip()
+        source_payload = _context_cutover_route_payload(
+            record_store=record_store,
+            context_name=normalized_source_context,
+        )
+        target_payload = _context_cutover_route_payload(
+            record_store=record_store,
+            context_name=normalized_target_context,
+        )
+        preview_payload = (
+            _context_cutover_route_payload(
+                record_store=record_store,
+                context_name=normalized_preview_context,
+            )
+            if normalized_preview_context
+            and normalized_preview_context
+            not in {normalized_source_context, normalized_target_context}
+            else None
+        )
+        warnings = _build_context_cutover_warnings(
+            profile=profile,
+            source_context=normalized_source_context,
+            target_context=normalized_target_context,
+            preview_context=normalized_preview_context,
+            source_payload=source_payload,
+            target_payload=target_payload,
+        )
+    finally:
+        record_store.close()
+
+    stable_lanes = [lane for lane in profile.lanes if lane.instance in {"testing", "prod"}]
+    click.echo(
+        json.dumps(
+            {
+                "status": "ok",
+                "product": profile.product,
+                "source_context": normalized_source_context,
+                "target_context": normalized_target_context,
+                "preview_context": normalized_preview_context,
+                "profile": {
+                    "summary": _summarize_product_profile_record(profile),
+                    "stable_lanes": [
+                        _summarize_product_profile_lane(lane) for lane in stable_lanes
+                    ],
+                    "preview": {
+                        "enabled": profile.preview.enabled,
+                        "context": profile.preview.context,
+                        "slug_template": profile.preview.slug_template,
+                        "template_instance": profile.preview.template_instance,
+                    },
+                },
+                "contexts": {
+                    "source": source_payload,
+                    "target": target_payload,
+                    "preview": preview_payload,
+                },
+                "warnings": warnings,
+                "guardrails": [
+                    "Do not rewrite append-only deployments, promotions, backup gates, or preview history.",
+                    "Compare runtime key sets before deleting source or target runtime records.",
+                    "Apply product profile lane changes only after target current-authority records exist.",
+                ],
+            },
             indent=2,
             sort_keys=True,
         )

--- a/docs/records.md
+++ b/docs/records.md
@@ -151,6 +151,20 @@ release tuples. Do not rewrite append-only deployments, promotions, backup
 gates, or preview history; those records are historical evidence and should
 continue to describe the route that produced them.
 
+Before changing a product profile or deleting legacy rows, audit both route
+families with:
+
+```bash
+uv run launchplane product-profiles audit-context-cutover \
+  --product sellyouroutboard \
+  --source-context sellyouroutboard-testing \
+  --target-context sellyouroutboard
+```
+
+The audit reports key names, record ids, counts, target names, and binding
+metadata only. It does not print runtime values, managed secret plaintext,
+secret ciphertext, or full provider env text.
+
 These records replace repo-local Launchplane lifecycle manifests. Product repos
 still own their normal app/runtime contract, such as Dockerfile, image publish,
 health endpoint, tests, and source/build inputs. Launchplane owns the product

--- a/tests/test_product_profile_context_audit.py
+++ b/tests/test_product_profile_context_audit.py
@@ -1,0 +1,261 @@
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from click.testing import CliRunner
+
+from control_plane.cli import main
+from control_plane.contracts.deployment_record import DeploymentRecord
+from control_plane.contracts.deployment_record import ResolvedTargetEvidence
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.product_profile_record import ProductImageProfile
+from control_plane.contracts.product_profile_record import ProductLaneProfile
+from control_plane.contracts.product_profile_record import ProductPreviewProfile
+from control_plane.contracts.promotion_record import ArtifactIdentityReference
+from control_plane.contracts.promotion_record import DeploymentEvidence
+from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
+from control_plane.contracts.secret_record import SecretBinding
+from control_plane.contracts.secret_record import SecretRecord
+from control_plane.contracts.secret_record import SecretVersion
+from control_plane.storage.postgres import PostgresRecordStore
+
+
+def _sqlite_database_url(database_path: Path) -> str:
+    return f"sqlite+pysqlite:///{database_path}"
+
+
+def _product_profile() -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord(
+        product="sellyouroutboard",
+        display_name="SellYourOutboard",
+        repository="cbusillo/sellyouroutboard",
+        driver_id="generic-web",
+        image=ProductImageProfile(repository="ghcr.io/cbusillo/sellyouroutboard"),
+        runtime_port=3000,
+        health_path="/api/health",
+        lanes=(
+            ProductLaneProfile(
+                instance="testing",
+                context="sellyouroutboard-testing",
+                base_url="https://testing.sellyouroutboard.com",
+                health_url="https://testing.sellyouroutboard.com/api/health",
+            ),
+            ProductLaneProfile(
+                instance="prod",
+                context="sellyouroutboard-testing",
+                base_url="https://www.sellyouroutboard.com",
+                health_url="https://www.sellyouroutboard.com/api/health",
+            ),
+        ),
+        preview=ProductPreviewProfile(
+            enabled=True,
+            context="sellyouroutboard-testing",
+            slug_template="pr-{number}",
+        ),
+        updated_at="2026-05-01T00:00:00Z",
+        source="test",
+    )
+
+
+def _deployment_record() -> DeploymentRecord:
+    return DeploymentRecord(
+        record_id="deployment-syo-testing-1",
+        artifact_identity=ArtifactIdentityReference(artifact_id="artifact-syo-1"),
+        context="sellyouroutboard-testing",
+        instance="testing",
+        source_git_ref="abcdef1",
+        resolved_target=ResolvedTargetEvidence(
+            target_type="application",
+            target_id="app-syo-testing",
+            target_name="syo-testing-app",
+        ),
+        deploy=DeploymentEvidence(
+            target_name="syo-testing-app",
+            target_type="application",
+            deploy_mode="dokploy-application-api",
+            deployment_id="dokploy-deployment-1",
+            status="pass",
+            started_at="2026-05-01T00:01:00Z",
+            finished_at="2026-05-01T00:02:00Z",
+        ),
+    )
+
+
+def _seed_records(database_url: str) -> None:
+    store = PostgresRecordStore(database_url=database_url)
+    store.ensure_schema()
+    try:
+        store.write_product_profile_record(_product_profile())
+        store.write_runtime_environment_record(
+            RuntimeEnvironmentRecord(
+                scope="instance",
+                context="sellyouroutboard-testing",
+                instance="prod",
+                env={"TAWK_PROPERTY_ID": "property-legacy"},
+                updated_at="2026-05-01T00:03:00Z",
+                source_label="legacy",
+            )
+        )
+        store.write_runtime_environment_record(
+            RuntimeEnvironmentRecord(
+                scope="instance",
+                context="sellyouroutboard",
+                instance="prod",
+                env={"TAWK_WIDGET_ID": "widget-canonical"},
+                updated_at="2026-05-01T00:04:00Z",
+                source_label="operator:mistake",
+            )
+        )
+        store.write_dokploy_target_record(
+            DokployTargetRecord(
+                context="sellyouroutboard-testing",
+                instance="prod",
+                target_type="application",
+                target_name="syo-prod-app",
+                domains=("sellyouroutboard.com",),
+                updated_at="2026-05-01T00:05:00Z",
+                source_label="test",
+            )
+        )
+        store.write_dokploy_target_id_record(
+            DokployTargetIdRecord(
+                context="sellyouroutboard-testing",
+                instance="prod",
+                target_id="target-syo-prod",
+                updated_at="2026-05-01T00:05:00Z",
+                source_label="test",
+            )
+        )
+        store.write_secret_record(
+            SecretRecord(
+                secret_id="secret-syo-smtp-password",
+                scope="context_instance",
+                integration="runtime_environment",
+                name="smtp-password",
+                context="sellyouroutboard-testing",
+                instance="prod",
+                current_version_id="secret-version-syo-smtp-password",
+                created_at="2026-05-01T00:06:00Z",
+                updated_at="2026-05-01T00:06:00Z",
+                updated_by="test",
+            )
+        )
+        store.write_secret_version(
+            SecretVersion(
+                version_id="secret-version-syo-smtp-password",
+                secret_id="secret-syo-smtp-password",
+                created_at="2026-05-01T00:06:00Z",
+                ciphertext="encrypted-smtp-password",
+            )
+        )
+        store.write_secret_binding(
+            SecretBinding(
+                binding_id="secret-binding-syo-smtp-password",
+                secret_id="secret-syo-smtp-password",
+                integration="runtime_environment",
+                binding_key="SMTP_PASSWORD",
+                context="sellyouroutboard-testing",
+                instance="prod",
+                created_at="2026-05-01T00:06:00Z",
+                updated_at="2026-05-01T00:06:00Z",
+            )
+        )
+        store.write_deployment_record(_deployment_record())
+    finally:
+        store.close()
+
+
+class ProductProfileContextAuditTests(unittest.TestCase):
+    def test_audit_context_cutover_reports_redacted_current_authority(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            _seed_records(database_url)
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "product-profiles",
+                    "audit-context-cutover",
+                    "--database-url",
+                    database_url,
+                    "--product",
+                    "sellyouroutboard",
+                    "--source-context",
+                    "sellyouroutboard-testing",
+                    "--target-context",
+                    "sellyouroutboard",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn("property-legacy", result.output)
+        self.assertNotIn("widget-canonical", result.output)
+        self.assertNotIn("encrypted-smtp-password", result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["profile"]["summary"]["display_name"], "SellYourOutboard")
+        self.assertEqual(
+            payload["contexts"]["source"]["runtime_environment_records"][0]["env_keys"],
+            ["TAWK_PROPERTY_ID"],
+        )
+        self.assertEqual(
+            payload["contexts"]["target"]["runtime_environment_records"][0]["env_keys"],
+            ["TAWK_WIDGET_ID"],
+        )
+        self.assertEqual(
+            payload["contexts"]["source"]["managed_secret_records"][0]["binding_key"],
+            "SMTP_PASSWORD",
+        )
+        self.assertEqual(
+            payload["contexts"]["source"]["dokploy_targets"][0]["target_id"],
+            "target-syo-prod",
+        )
+        self.assertEqual(
+            payload["contexts"]["source"]["append_only_evidence_counts"]["deployments"],
+            1,
+        )
+        self.assertIn(
+            "Stable product profile lanes still reference legacy context",
+            "\n".join(payload["warnings"]),
+        )
+        self.assertIn(
+            "do not rewrite those records",
+            "\n".join(payload["warnings"]),
+        )
+
+    def test_audit_context_cutover_rejects_same_source_and_target(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.close()
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "product-profiles",
+                    "audit-context-cutover",
+                    "--database-url",
+                    database_url,
+                    "--product",
+                    "sellyouroutboard",
+                    "--source-context",
+                    "sellyouroutboard",
+                    "--target-context",
+                    "sellyouroutboard",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Source and target contexts must differ", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `product-profiles audit-context-cutover` for redacted SYO/product context cleanup planning
- report product profile lanes, preview context, runtime env key metadata, managed secret binding metadata, tracked Dokploy targets, inventory, release tuples, and append-only evidence counts for source/target contexts
- document the audit command and guardrail that legacy append-only evidence should not be rewritten

## Validation

- `uv run ruff check --diff control_plane/cli.py tests/test_product_profile_context_audit.py`
- `uv run ruff check control_plane/cli.py tests/test_product_profile_context_audit.py`
- `npx --yes markdownlint-cli2 docs/records.md`
- `uv run python -m unittest tests.test_product_profile_context_audit tests.test_runtime_environments`
- `uv run python -m unittest`

## Tracking

Continues #135. This is audit-only and does not mutate live DB records or delete the stray runtime environment record from #126.
