### PR TITLE
Expose product context cutover audit via service

### DIFF
--- a/.github/workflows/product-context-cutover-audit.yml
+++ b/.github/workflows/product-context-cutover-audit.yml
@@ -1,0 +1,183 @@
+---
+name: Product Context Cutover Audit
+
+"on":
+  workflow_dispatch:
+    inputs:
+      product:
+        description: Product profile key to audit.
+        required: true
+        default: sellyouroutboard
+        type: string
+      source_context:
+        description: Legacy context to inspect.
+        required: true
+        default: sellyouroutboard-testing
+        type: string
+      target_context:
+        description: Canonical context to inspect.
+        required: true
+        default: sellyouroutboard
+        type: string
+      preview_context:
+        description: Optional preview context override.
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: launchplane-product-context-cutover-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    env:
+      LAUNCHPLANE_URL: >-
+        ${{ vars.LAUNCHPLANE_PUBLIC_URL ||
+        'https://launchplane.shinycomputers.com' }}
+      PRODUCT: ${{ inputs.product }}
+      SOURCE_CONTEXT: ${{ inputs.source_context }}
+      TARGET_CONTEXT: ${{ inputs.target_context }}
+      PREVIEW_CONTEXT: ${{ inputs.preview_context }}
+    steps:
+      - name: Validate audit inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${LAUNCHPLANE_URL:?Missing LAUNCHPLANE_PUBLIC_URL variable}"
+          : "${PRODUCT:?Missing product input}"
+          : "${SOURCE_CONTEXT:?Missing source_context input}"
+          : "${TARGET_CONTEXT:?Missing target_context input}"
+          if [ "$SOURCE_CONTEXT" = "$TARGET_CONTEXT" ]; then
+            echo 'source_context and target_context must differ.' >&2
+            exit 1
+          fi
+
+      - name: Request redacted cutover audit
+        id: audit
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          service_origin="$({
+            python3 - <<'PY'
+          import os
+          from urllib.parse import urlsplit
+
+          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"].strip())
+          if not parsed.scheme or not parsed.netloc or not parsed.hostname:
+              raise SystemExit("LAUNCHPLANE_URL must be an absolute URL.")
+          print(f"{parsed.scheme}://{parsed.netloc}")
+          PY
+          })"
+          service_audience="$({
+            python3 - <<'PY'
+          import os
+          from urllib.parse import urlsplit
+
+          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"].strip())
+          if not parsed.hostname:
+              raise SystemExit("LAUNCHPLANE_URL must include a hostname.")
+          print(parsed.hostname)
+          PY
+          })"
+
+          oidc_response="$(curl -fsS \
+            -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${service_audience}")"
+          oidc_token="$(jq -r '.value // empty' <<< "$oidc_response")"
+          if [ -z "$oidc_token" ]; then
+            echo 'GitHub OIDC token response did not include a token value.' >&2
+            exit 1
+          fi
+
+          audit_url="$({
+            SERVICE_ORIGIN="$service_origin" python3 - <<'PY'
+          import os
+          from urllib.parse import urlencode
+
+          origin = os.environ["SERVICE_ORIGIN"].rstrip("/")
+          product = os.environ["PRODUCT"].strip()
+          query = {
+              "source_context": os.environ["SOURCE_CONTEXT"].strip(),
+              "target_context": os.environ["TARGET_CONTEXT"].strip(),
+          }
+          preview_context = os.environ["PREVIEW_CONTEXT"].strip()
+          if preview_context:
+              query["preview_context"] = preview_context
+          print(
+              f"{origin}/v1/product-profiles/{product}"
+              f"/context-cutover-audit?{urlencode(query)}"
+          )
+          PY
+          })"
+
+          response_file="launchplane-context-cutover-audit.json"
+          status_code="$(curl -sS \
+            -o "$response_file" \
+            -w '%{http_code}' \
+            -H "Authorization: Bearer ${oidc_token}" \
+            -H 'Accept: application/json' \
+            "$audit_url")"
+          if [ "$status_code" != '200' ]; then
+            cat "$response_file" >&2
+            echo 'Launchplane context cutover audit failed' \
+              "with HTTP ${status_code}." >&2
+            exit 1
+          fi
+
+          jq . "$response_file"
+          warnings_count="$(jq '.audit.warnings | length' "$response_file")"
+          echo "warnings_count=${warnings_count}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload redacted audit artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: launchplane-context-cutover-audit-${{ inputs.product }}
+          path: launchplane-context-cutover-audit.json
+          if-no-files-found: error
+
+      - name: Summarize audit
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo '## Launchplane product context cutover audit'
+            echo
+            preview_context="$({
+              jq -r '.audit.preview_context // empty' \
+                launchplane-context-cutover-audit.json
+            })"
+            source_runtime_count="$({
+              jq '.audit.contexts.source.runtime_environment_records | length' \
+                launchplane-context-cutover-audit.json
+            })"
+            target_runtime_count="$({
+              jq '.audit.contexts.target.runtime_environment_records | length' \
+                launchplane-context-cutover-audit.json
+            })"
+            source_secret_count="$({
+              jq '.audit.contexts.source.managed_secret_records | length' \
+                launchplane-context-cutover-audit.json
+            })"
+            target_secret_count="$({
+              jq '.audit.contexts.target.managed_secret_records | length' \
+                launchplane-context-cutover-audit.json
+            })"
+            echo "- Product: ${PRODUCT}"
+            echo "- Source context: ${SOURCE_CONTEXT}"
+            echo "- Target context: ${TARGET_CONTEXT}"
+            echo "- Preview context: ${preview_context}"
+            echo "- Source runtime records: ${source_runtime_count}"
+            echo "- Target runtime records: ${target_runtime_count}"
+            echo "- Source managed secrets: ${source_secret_count}"
+            echo "- Target managed secrets: ${target_secret_count}"
+            echo "- Warnings: ${{ steps.audit.outputs.warnings_count }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -18,6 +18,7 @@ from pydantic import ValidationError
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import odoo_instance_overrides as control_plane_odoo_instance_overrides
 from control_plane import product_config as control_plane_product_config
+from control_plane import product_context_audit as control_plane_product_context_audit
 from control_plane import release_tuples as control_plane_release_tuples
 from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane import secrets as control_plane_secrets
@@ -74,7 +75,6 @@ from control_plane.contracts.runtime_environment_record import (
     RuntimeEnvironmentDeleteEvent,
     RuntimeEnvironmentRecord,
 )
-from control_plane.contracts.secret_record import SecretRecord
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.drivers.registry import build_driver_context_view
 from control_plane.launchplane_mutations import (
@@ -259,168 +259,6 @@ def _summarize_product_profile_record(record: LaunchplaneProductProfileRecord) -
         "updated_at": record.updated_at,
         "source": record.source,
     }
-
-
-def _summarize_product_profile_lane(record: ProductLaneProfile) -> dict[str, object]:
-    return {
-        "instance": record.instance,
-        "context": record.context,
-        "base_url": record.base_url,
-        "health_url": record.health_url,
-    }
-
-
-def _route_key(context_name: str, instance_name: str) -> tuple[str, str]:
-    return (context_name, instance_name)
-
-
-def _summarize_secret_record_for_context_audit(
-    *,
-    record_store: PostgresRecordStore,
-    record: SecretRecord,
-) -> dict[str, object]:
-    binding = control_plane_secrets.build_secret_status(
-        record_store,
-        secret_id=record.secret_id,
-    ).get("binding")
-    return {
-        "secret_id": record.secret_id,
-        "scope": record.scope,
-        "integration": record.integration,
-        "name": record.name,
-        "context": record.context,
-        "instance": record.instance,
-        "status": record.status,
-        "binding_key": str(binding.get("binding_key", "")) if isinstance(binding, dict) else "",
-        "binding_status": str(binding.get("status", "")) if isinstance(binding, dict) else "",
-        "updated_at": record.updated_at,
-    }
-
-
-def _context_cutover_route_payload(
-    *,
-    record_store: PostgresRecordStore,
-    context_name: str,
-) -> dict[str, object]:
-    runtime_records = record_store.list_runtime_environment_records(context_name=context_name)
-    secret_records = record_store.list_secret_records(context_name=context_name, limit=None)
-    target_records = tuple(
-        record
-        for record in record_store.list_dokploy_target_records()
-        if record.context == context_name
-    )
-    target_ids_by_route = _target_id_map(
-        tuple(
-            record
-            for record in record_store.list_dokploy_target_id_records()
-            if record.context == context_name
-        )
-    )
-    inventory_records = tuple(
-        record
-        for record in record_store.list_environment_inventory()
-        if record.context == context_name
-    )
-    release_tuple_records = tuple(
-        record
-        for record in record_store.list_release_tuple_records()
-        if record.context == context_name
-    )
-    return {
-        "context": context_name,
-        "runtime_environment_records": [
-            _summarize_runtime_environment_record(record) for record in runtime_records
-        ],
-        "managed_secret_records": [
-            _summarize_secret_record_for_context_audit(
-                record_store=record_store,
-                record=record,
-            )
-            for record in secret_records
-        ],
-        "dokploy_targets": [
-            _summarize_dokploy_target_record(
-                record,
-                target_id=target_ids_by_route.get(_route_key(record.context, record.instance), ""),
-            )
-            for record in target_records
-        ],
-        "inventory_records": [
-            _summarize_environment_inventory(record) for record in inventory_records
-        ],
-        "release_tuple_records": [
-            {
-                "tuple_id": record.tuple_id,
-                "context": record.context,
-                "channel": record.channel,
-                "artifact_id": record.artifact_id,
-                "image_repository": record.image_repository,
-                "image_digest": record.image_digest,
-                "deployment_record_id": record.deployment_record_id,
-                "promotion_record_id": record.promotion_record_id,
-                "promoted_from_channel": record.promoted_from_channel,
-                "provenance": record.provenance,
-                "minted_at": record.minted_at,
-            }
-            for record in release_tuple_records
-        ],
-        "append_only_evidence_counts": {
-            "backup_gates": len(
-                record_store.list_backup_gate_records(context_name=context_name, limit=None)
-            ),
-            "deployments": len(
-                record_store.list_deployment_records(context_name=context_name, limit=None)
-            ),
-            "promotions": len(
-                record_store.list_promotion_records(context_name=context_name, limit=None)
-            ),
-        },
-    }
-
-
-def _build_context_cutover_warnings(
-    *,
-    profile: LaunchplaneProductProfileRecord,
-    source_context: str,
-    target_context: str,
-    preview_context: str,
-    source_payload: dict[str, object],
-    target_payload: dict[str, object],
-) -> list[str]:
-    warnings: list[str] = []
-    stable_lane_contexts = {
-        lane.instance: lane.context
-        for lane in profile.lanes
-        if lane.instance in {"testing", "prod"}
-    }
-    if source_context in stable_lane_contexts.values():
-        warnings.append(
-            f"Stable product profile lanes still reference legacy context {source_context!r}."
-        )
-    if target_context not in stable_lane_contexts.values():
-        warnings.append(
-            f"No stable product profile lane currently references target context {target_context!r}."
-        )
-    if profile.preview.enabled and profile.preview.context not in {preview_context, target_context}:
-        warnings.append(
-            f"Preview profile context {profile.preview.context!r} differs from requested preview context."
-        )
-    if source_payload["append_only_evidence_counts"] != {
-        "backup_gates": 0,
-        "deployments": 0,
-        "promotions": 0,
-    }:
-        warnings.append(
-            "Legacy context has append-only evidence; do not rewrite those records during cutover."
-        )
-    if (
-        target_payload["runtime_environment_records"]
-        and source_payload["runtime_environment_records"]
-    ):
-        warnings.append(
-            "Both source and target contexts have runtime environment records; compare key sets before deleting either side."
-        )
-    return warnings
 
 
 def _parse_product_profile_lanes(lanes_json: str) -> tuple[ProductLaneProfile, ...]:
@@ -12392,79 +12230,23 @@ def product_profiles_audit_context_cutover(
     target_context: str,
     preview_context: str,
 ) -> None:
-    normalized_source_context = source_context.strip()
-    normalized_target_context = target_context.strip()
-    if not normalized_source_context or not normalized_target_context:
-        raise click.ClickException("Provide non-empty --source-context and --target-context.")
-    if normalized_source_context == normalized_target_context:
-        raise click.ClickException("Source and target contexts must differ.")
-
     record_store = _product_profile_store(database_url)
     try:
-        profile = record_store.read_product_profile_record(product.strip())
-        normalized_preview_context = preview_context.strip() or profile.preview.context.strip()
-        source_payload = _context_cutover_route_payload(
+        payload = control_plane_product_context_audit.build_product_context_cutover_audit(
             record_store=record_store,
-            context_name=normalized_source_context,
+            product=product,
+            source_context=source_context,
+            target_context=target_context,
+            preview_context=preview_context,
         )
-        target_payload = _context_cutover_route_payload(
-            record_store=record_store,
-            context_name=normalized_target_context,
-        )
-        preview_payload = (
-            _context_cutover_route_payload(
-                record_store=record_store,
-                context_name=normalized_preview_context,
-            )
-            if normalized_preview_context
-            and normalized_preview_context
-            not in {normalized_source_context, normalized_target_context}
-            else None
-        )
-        warnings = _build_context_cutover_warnings(
-            profile=profile,
-            source_context=normalized_source_context,
-            target_context=normalized_target_context,
-            preview_context=normalized_preview_context,
-            source_payload=source_payload,
-            target_payload=target_payload,
-        )
+    except ValueError as error:
+        raise click.ClickException(str(error)) from error
     finally:
         record_store.close()
 
-    stable_lanes = [lane for lane in profile.lanes if lane.instance in {"testing", "prod"}]
     click.echo(
         json.dumps(
-            {
-                "status": "ok",
-                "product": profile.product,
-                "source_context": normalized_source_context,
-                "target_context": normalized_target_context,
-                "preview_context": normalized_preview_context,
-                "profile": {
-                    "summary": _summarize_product_profile_record(profile),
-                    "stable_lanes": [
-                        _summarize_product_profile_lane(lane) for lane in stable_lanes
-                    ],
-                    "preview": {
-                        "enabled": profile.preview.enabled,
-                        "context": profile.preview.context,
-                        "slug_template": profile.preview.slug_template,
-                        "template_instance": profile.preview.template_instance,
-                    },
-                },
-                "contexts": {
-                    "source": source_payload,
-                    "target": target_payload,
-                    "preview": preview_payload,
-                },
-                "warnings": warnings,
-                "guardrails": [
-                    "Do not rewrite append-only deployments, promotions, backup gates, or preview history.",
-                    "Compare runtime key sets before deleting source or target runtime records.",
-                    "Apply product profile lane changes only after target current-authority records exist.",
-                ],
-            },
+            payload,
             indent=2,
             sort_keys=True,
         )

--- a/control_plane/product_context_audit.py
+++ b/control_plane/product_context_audit.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+from control_plane import secrets as control_plane_secrets
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductLaneProfile,
+)
+from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
+from control_plane.contracts.secret_record import SecretRecord
+from control_plane.storage.postgres import PostgresRecordStore
+
+
+def _artifact_id_or_empty(artifact_identity: object) -> str:
+    if artifact_identity is None:
+        return ""
+    return str(getattr(artifact_identity, "artifact_id", "") or "")
+
+
+def summarize_product_profile_record(
+    record: LaunchplaneProductProfileRecord,
+) -> dict[str, object]:
+    return {
+        "product": record.product,
+        "display_name": record.display_name,
+        "repository": record.repository,
+        "driver_id": record.driver_id,
+        "image_repository": record.image.repository,
+        "runtime_port": record.runtime_port,
+        "health_path": record.health_path,
+        "lane_count": len(record.lanes),
+        "preview_enabled": record.preview.enabled,
+        "preview_context": record.preview.context,
+        "updated_at": record.updated_at,
+        "source": record.source,
+    }
+
+
+def _summarize_product_profile_lane(record: ProductLaneProfile) -> dict[str, object]:
+    return {
+        "instance": record.instance,
+        "context": record.context,
+        "base_url": record.base_url,
+        "health_url": record.health_url,
+    }
+
+
+def _summarize_runtime_environment_record(
+    record: RuntimeEnvironmentRecord,
+) -> dict[str, object]:
+    return {
+        "scope": record.scope,
+        "context": record.context,
+        "instance": record.instance,
+        "updated_at": record.updated_at,
+        "source_label": record.source_label,
+        "env_keys": sorted(record.env.keys()),
+        "env_value_count": len(record.env),
+    }
+
+
+def _summarize_environment_inventory(record: EnvironmentInventory) -> dict[str, object]:
+    return {
+        "context": record.context,
+        "instance": record.instance,
+        "artifact_id": _artifact_id_or_empty(record.artifact_identity),
+        "source_git_ref": record.source_git_ref,
+        "updated_at": record.updated_at,
+        "deployment_record_id": record.deployment_record_id,
+        "promotion_record_id": record.promotion_record_id,
+        "promoted_from_instance": record.promoted_from_instance,
+        "deploy_status": record.deploy.status,
+        "post_deploy_update_status": record.post_deploy_update.status,
+        "destination_health_status": record.destination_health.status,
+    }
+
+
+def _dokploy_target_route(record: DokployTargetRecord | DokployTargetIdRecord) -> tuple[str, str]:
+    return (record.context.strip().lower(), record.instance.strip().lower())
+
+
+def _target_id_map(
+    target_id_records: tuple[DokployTargetIdRecord, ...],
+) -> dict[tuple[str, str], str]:
+    return {_dokploy_target_route(record): record.target_id for record in target_id_records}
+
+
+def _summarize_dokploy_target_record(
+    record: DokployTargetRecord,
+    *,
+    target_id: str = "",
+) -> dict[str, object]:
+    return {
+        "context": record.context,
+        "instance": record.instance,
+        "target_id": target_id,
+        "target_type": record.target_type,
+        "project_name": record.project_name,
+        "target_name": record.target_name,
+        "source_git_ref": record.source_git_ref,
+        "compose_path": record.compose_path,
+        "watch_paths": list(record.watch_paths),
+        "domains": list(record.domains),
+        "require_test_gate": record.require_test_gate,
+        "require_prod_gate": record.require_prod_gate,
+        "healthcheck_enabled": record.healthcheck_enabled,
+        "healthcheck_path": record.healthcheck_path,
+        "env_keys": sorted(record.env.keys()),
+        "env_value_count": len(record.env),
+        "shopify_protected_store_keys": sorted(record.policies.shopify.protected_store_keys),
+        "updated_at": record.updated_at,
+        "source_label": record.source_label,
+    }
+
+
+def _summarize_secret_record_for_context_audit(
+    *,
+    record_store: PostgresRecordStore,
+    record: SecretRecord,
+) -> dict[str, object]:
+    binding = control_plane_secrets.build_secret_status(
+        record_store,
+        secret_id=record.secret_id,
+    ).get("binding")
+    return {
+        "secret_id": record.secret_id,
+        "scope": record.scope,
+        "integration": record.integration,
+        "name": record.name,
+        "context": record.context,
+        "instance": record.instance,
+        "status": record.status,
+        "binding_key": str(binding.get("binding_key", "")) if isinstance(binding, dict) else "",
+        "binding_status": str(binding.get("status", "")) if isinstance(binding, dict) else "",
+        "updated_at": record.updated_at,
+    }
+
+
+def _context_cutover_route_payload(
+    *,
+    record_store: PostgresRecordStore,
+    context_name: str,
+) -> dict[str, object]:
+    runtime_records = record_store.list_runtime_environment_records(context_name=context_name)
+    secret_records = record_store.list_secret_records(context_name=context_name, limit=None)
+    target_records = tuple(
+        record
+        for record in record_store.list_dokploy_target_records()
+        if record.context == context_name
+    )
+    target_ids_by_route = _target_id_map(
+        tuple(
+            record
+            for record in record_store.list_dokploy_target_id_records()
+            if record.context == context_name
+        )
+    )
+    inventory_records = tuple(
+        record
+        for record in record_store.list_environment_inventory()
+        if record.context == context_name
+    )
+    release_tuple_records = tuple(
+        record
+        for record in record_store.list_release_tuple_records()
+        if record.context == context_name
+    )
+    return {
+        "context": context_name,
+        "runtime_environment_records": [
+            _summarize_runtime_environment_record(record) for record in runtime_records
+        ],
+        "managed_secret_records": [
+            _summarize_secret_record_for_context_audit(
+                record_store=record_store,
+                record=record,
+            )
+            for record in secret_records
+        ],
+        "dokploy_targets": [
+            _summarize_dokploy_target_record(
+                record,
+                target_id=target_ids_by_route.get(_dokploy_target_route(record), ""),
+            )
+            for record in target_records
+        ],
+        "inventory_records": [
+            _summarize_environment_inventory(record) for record in inventory_records
+        ],
+        "release_tuple_records": [
+            {
+                "tuple_id": record.tuple_id,
+                "context": record.context,
+                "channel": record.channel,
+                "artifact_id": record.artifact_id,
+                "image_repository": record.image_repository,
+                "image_digest": record.image_digest,
+                "deployment_record_id": record.deployment_record_id,
+                "promotion_record_id": record.promotion_record_id,
+                "promoted_from_channel": record.promoted_from_channel,
+                "provenance": record.provenance,
+                "minted_at": record.minted_at,
+            }
+            for record in release_tuple_records
+        ],
+        "append_only_evidence_counts": {
+            "backup_gates": len(
+                record_store.list_backup_gate_records(context_name=context_name, limit=None)
+            ),
+            "deployments": len(
+                record_store.list_deployment_records(context_name=context_name, limit=None)
+            ),
+            "promotions": len(
+                record_store.list_promotion_records(context_name=context_name, limit=None)
+            ),
+        },
+    }
+
+
+def _build_context_cutover_warnings(
+    *,
+    profile: LaunchplaneProductProfileRecord,
+    source_context: str,
+    target_context: str,
+    preview_context: str,
+    source_payload: dict[str, object],
+    target_payload: dict[str, object],
+) -> list[str]:
+    warnings: list[str] = []
+    stable_lane_contexts = {
+        lane.instance: lane.context
+        for lane in profile.lanes
+        if lane.instance in {"testing", "prod"}
+    }
+    if source_context in stable_lane_contexts.values():
+        warnings.append(
+            f"Stable product profile lanes still reference legacy context {source_context!r}."
+        )
+    if target_context not in stable_lane_contexts.values():
+        warnings.append(
+            f"No stable product profile lane currently references target context {target_context!r}."
+        )
+    if profile.preview.enabled and profile.preview.context not in {preview_context, target_context}:
+        warnings.append(
+            f"Preview profile context {profile.preview.context!r} differs from requested preview context."
+        )
+    if source_payload["append_only_evidence_counts"] != {
+        "backup_gates": 0,
+        "deployments": 0,
+        "promotions": 0,
+    }:
+        warnings.append(
+            "Legacy context has append-only evidence; do not rewrite those records during cutover."
+        )
+    if (
+        target_payload["runtime_environment_records"]
+        and source_payload["runtime_environment_records"]
+    ):
+        warnings.append(
+            "Both source and target contexts have runtime environment records; compare key sets before deleting either side."
+        )
+    return warnings
+
+
+def build_product_context_cutover_audit(
+    *,
+    record_store: PostgresRecordStore,
+    product: str,
+    source_context: str,
+    target_context: str,
+    preview_context: str = "",
+) -> dict[str, object]:
+    normalized_product = product.strip()
+    normalized_source_context = source_context.strip()
+    normalized_target_context = target_context.strip()
+    if not normalized_product:
+        raise ValueError("Provide a non-empty product.")
+    if not normalized_source_context or not normalized_target_context:
+        raise ValueError("Provide non-empty source_context and target_context.")
+    if normalized_source_context == normalized_target_context:
+        raise ValueError("Source and target contexts must differ.")
+
+    profile = record_store.read_product_profile_record(normalized_product)
+    normalized_preview_context = preview_context.strip() or profile.preview.context.strip()
+    source_payload = _context_cutover_route_payload(
+        record_store=record_store,
+        context_name=normalized_source_context,
+    )
+    target_payload = _context_cutover_route_payload(
+        record_store=record_store,
+        context_name=normalized_target_context,
+    )
+    preview_payload = (
+        _context_cutover_route_payload(
+            record_store=record_store,
+            context_name=normalized_preview_context,
+        )
+        if normalized_preview_context
+        and normalized_preview_context not in {normalized_source_context, normalized_target_context}
+        else None
+    )
+    warnings = _build_context_cutover_warnings(
+        profile=profile,
+        source_context=normalized_source_context,
+        target_context=normalized_target_context,
+        preview_context=normalized_preview_context,
+        source_payload=source_payload,
+        target_payload=target_payload,
+    )
+    stable_lanes = [lane for lane in profile.lanes if lane.instance in {"testing", "prod"}]
+    return {
+        "status": "ok",
+        "product": profile.product,
+        "source_context": normalized_source_context,
+        "target_context": normalized_target_context,
+        "preview_context": normalized_preview_context,
+        "profile": {
+            "summary": summarize_product_profile_record(profile),
+            "stable_lanes": [_summarize_product_profile_lane(lane) for lane in stable_lanes],
+            "preview": {
+                "enabled": profile.preview.enabled,
+                "context": profile.preview.context,
+                "slug_template": profile.preview.slug_template,
+                "template_instance": profile.preview.template_instance,
+            },
+        },
+        "contexts": {
+            "source": source_payload,
+            "target": target_payload,
+            "preview": preview_payload,
+        },
+        "warnings": warnings,
+        "guardrails": [
+            "Do not rewrite append-only deployments, promotions, backup gates, or preview history.",
+            "Compare runtime key sets before deleting source or target runtime records.",
+            "Apply product profile lane changes only after target current-authority records exist.",
+        ],
+    }

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -22,6 +22,7 @@ from jwt import InvalidTokenError
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import product_config as control_plane_product_config
+from control_plane import product_context_audit as control_plane_product_context_audit
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.authz_policy_record import (
     LaunchplaneAuthzPolicyRecord,
@@ -1191,6 +1192,12 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "launchplane_service.read", {}
     if len(segments) == 2 and segments == ["v1", "product-profiles"]:
         return "product_profile.read", {}
+    if (
+        len(segments) == 4
+        and segments[:2] == ["v1", "product-profiles"]
+        and segments[3] == "context-cutover-audit"
+    ):
+        return "product_profile.read", {"product": segments[2], "context_cutover_audit": "true"}
     if len(segments) == 3 and segments[:2] == ["v1", "product-profiles"]:
         return "product_profile.read", {"product": segments[2]}
     return None
@@ -2723,6 +2730,59 @@ def create_launchplane_service_app(
                                         "code": "authorization_denied",
                                         "message": "Workflow cannot read the requested product profile.",
                                     },
+                                },
+                            )
+                        if params.get("context_cutover_audit") == "true":
+                            if not isinstance(record_store, PostgresRecordStore):
+                                return _json_response(
+                                    start_response=start_response,
+                                    status_code=503,
+                                    payload={
+                                        "status": "rejected",
+                                        "trace_id": request_trace_id,
+                                        "error": {
+                                            "code": "database_required",
+                                            "message": "Context cutover audit requires Launchplane database storage.",
+                                        },
+                                    },
+                                )
+                            source_context = str(
+                                (query.get("source_context") or [""])[0] or ""
+                            ).strip()
+                            target_context = str(
+                                (query.get("target_context") or [""])[0] or ""
+                            ).strip()
+                            preview_context = str(
+                                (query.get("preview_context") or [""])[0] or ""
+                            ).strip()
+                            try:
+                                audit_payload = control_plane_product_context_audit.build_product_context_cutover_audit(
+                                    record_store=record_store,
+                                    product=profile.product,
+                                    source_context=source_context,
+                                    target_context=target_context,
+                                    preview_context=preview_context,
+                                )
+                            except ValueError as error:
+                                return _json_response(
+                                    start_response=start_response,
+                                    status_code=400,
+                                    payload={
+                                        "status": "rejected",
+                                        "trace_id": request_trace_id,
+                                        "error": {
+                                            "code": "invalid_context_cutover_audit_request",
+                                            "message": str(error),
+                                        },
+                                    },
+                                )
+                            return _json_response(
+                                start_response=start_response,
+                                status_code=200,
+                                payload={
+                                    "status": "ok",
+                                    "trace_id": request_trace_id,
+                                    "audit": audit_payload,
                                 },
                             )
                         return _json_response(

--- a/docs/records.md
+++ b/docs/records.md
@@ -165,6 +165,12 @@ The audit reports key names, record ids, counts, target names, and binding
 metadata only. It does not print runtime values, managed secret plaintext,
 secret ciphertext, or full provider env text.
 
+The same redacted audit is exposed through the Launchplane service at
+`GET /v1/product-profiles/{product}/context-cutover-audit` with
+`source_context`, `target_context`, and optional `preview_context` query
+parameters. The manual `Product Context Cutover Audit` GitHub workflow calls
+that service route through GitHub OIDC and uploads the redacted JSON artifact.
+
 These records replace repo-local Launchplane lifecycle manifests. Product repos
 still own their normal app/runtime contract, such as Dockerfile, image publish,
 health endpoint, tests, and source/build inputs. Launchplane owns the product

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -374,6 +374,7 @@ only after a passing plan and a matching stored preview record are present.
 - `GET /v1/contexts/{context}/instances/{instance}/secrets`
 - `GET /v1/secrets/{secret_id}`
 - `GET /v1/contexts/{context}/operations/recent`
+- `GET /v1/product-profiles/{product}/context-cutover-audit`
 
 These operator reads use the same Launchplane authn/authz boundary as evidence
 ingress. The intent is to give operators a minimal typed read surface for the
@@ -381,6 +382,14 @@ current Launchplane record nouns without forcing them to infer state from
 workflow logs or host-local files. Secret status reads return metadata only:
 Launchplane does not expose plaintext secret retrieval through the service
 boundary.
+
+Product context cutover audit is read-only and uses `product_profile.read` for
+the requested product in the Launchplane service context. It returns redacted
+current-authority metadata for source, target, and optional preview contexts:
+runtime key names, managed secret IDs/binding keys, Dokploy target metadata,
+inventory and release tuple pointers, and append-only evidence counts. It does
+not return runtime values, secret plaintext, secret ciphertext, or full provider
+environment text.
 
 ### Driver execution endpoints
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1242,6 +1242,137 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ["sellyouroutboard"],
         )
 
+    def test_product_profile_context_cutover_audit_returns_redacted_metadata(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                store.write_product_profile_record(
+                    LaunchplaneProductProfileRecord.model_validate(
+                        _product_profile_payload_with_prod()
+                    )
+                )
+                store.write_runtime_environment_record(
+                    RuntimeEnvironmentRecord(
+                        scope="instance",
+                        context="sellyouroutboard-testing",
+                        instance="prod",
+                        env={"TAWK_PROPERTY_ID": "property-legacy"},
+                        updated_at="2026-05-01T00:03:00Z",
+                        source_label="legacy",
+                    )
+                )
+                store.write_runtime_environment_record(
+                    RuntimeEnvironmentRecord(
+                        scope="instance",
+                        context="sellyouroutboard",
+                        instance="prod",
+                        env={"TAWK_WIDGET_ID": "widget-canonical"},
+                        updated_at="2026-05-01T00:04:00Z",
+                        source_label="operator:mistake",
+                    )
+                )
+            finally:
+                store.close()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["launchplane"],
+                            "actions": ["product_profile.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/product-profiles/sellyouroutboard/context-cutover-audit",
+                query_string=(
+                    "source_context=sellyouroutboard-testing&target_context=sellyouroutboard"
+                ),
+            )
+
+        payload_text = json.dumps(payload, sort_keys=True)
+        self.assertEqual(status_code, 200)
+        self.assertEqual(payload["audit"]["status"], "ok")
+        self.assertNotIn("property-legacy", payload_text)
+        self.assertNotIn("widget-canonical", payload_text)
+        self.assertEqual(
+            payload["audit"]["contexts"]["source"]["runtime_environment_records"][0]["env_keys"],
+            ["TAWK_PROPERTY_ID"],
+        )
+        self.assertEqual(
+            payload["audit"]["contexts"]["target"]["runtime_environment_records"][0]["env_keys"],
+            ["TAWK_WIDGET_ID"],
+        )
+
+    def test_product_profile_context_cutover_audit_rejects_unauthorized_product(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                store.write_product_profile_record(
+                    LaunchplaneProductProfileRecord.model_validate(
+                        _product_profile_payload_with_prod()
+                    )
+                )
+            finally:
+                store.close()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["verireel"],
+                            "contexts": ["launchplane"],
+                            "actions": ["product_profile.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/product-profiles/sellyouroutboard/context-cutover-audit",
+                query_string=(
+                    "source_context=sellyouroutboard-testing&target_context=sellyouroutboard"
+                ),
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
     def test_product_profile_write_rejects_unauthorized_product(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -2255,7 +2386,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(driver["driver_id"], "sellyouroutboard")
         self.assertEqual(driver["descriptor"]["base_driver_id"], "generic-web")
         self.assertEqual(driver["descriptor"]["product"], "sellyouroutboard")
-        self.assertEqual(driver["available_actions"][1]["route_path"], "/v1/drivers/generic-web/prod-promotion")
+        self.assertEqual(
+            driver["available_actions"][1]["route_path"], "/v1/drivers/generic-web/prod-promotion"
+        )
 
     def test_generic_web_preview_desired_state_route_uses_profile_context(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- move product context cutover audit construction into a reusable module
- expose GET /v1/product-profiles/{product}/context-cutover-audit through the Launchplane service using product_profile.read
- add a manual Product Context Cutover Audit workflow that calls the service with GitHub OIDC and uploads redacted JSON

## Validation
- uv run python -m unittest tests.test_product_profile_context_audit tests.test_service
- uv run --extra dev ruff check control_plane/product_context_audit.py control_plane/cli.py control_plane/service.py tests/test_service.py tests/test_product_profile_context_audit.py
- uv run --extra dev ruff format --check control_plane/product_context_audit.py control_plane/cli.py control_plane/service.py tests/test_service.py tests/test_product_profile_context_audit.py
- markdownlint docs/service-boundary.md docs/records.md
- actionlint .github/workflows/product-context-cutover-audit.yml
- ruby YAML parse for .github/workflows/product-context-cutover-audit.yml
- git diff --check
- uv run python -m unittest