### PR TITLE
Include product profile authz denial diagnostics

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1479,6 +1479,37 @@ def _human_identity_payload(identity: GitHubHumanIdentity) -> dict[str, object]:
     }
 
 
+def _authz_diagnostic_payload(
+    *,
+    identity: LaunchplaneIdentity,
+    authz_policy_sha256_value: str,
+    authz_policy_source: str,
+) -> dict[str, object]:
+    if isinstance(identity, GitHubHumanIdentity):
+        identity_payload: dict[str, object] = {
+            "type": "github_human",
+            "login": identity.login,
+            "role": identity.role,
+        }
+    else:
+        identity_payload = {
+            "type": "github_actions",
+            "repository": identity.repository,
+            "workflow_ref": identity.workflow_ref,
+            "job_workflow_ref": identity.job_workflow_ref,
+            "event_name": identity.event_name,
+            "ref": identity.ref,
+            "ref_type": identity.ref_type,
+            "environment": identity.environment,
+            "subject": identity.subject,
+        }
+    return {
+        "identity": identity_payload,
+        "policy_source": authz_policy_source,
+        "policy_sha256": authz_policy_sha256_value,
+    }
+
+
 def _safe_return_to(value: str) -> str:
     normalized = value.strip() or "/"
     if not normalized.startswith("/") or normalized.startswith("//"):
@@ -2730,6 +2761,11 @@ def create_launchplane_service_app(
                                         "code": "authorization_denied",
                                         "message": "Workflow cannot read the requested product profile.",
                                     },
+                                    "authz": _authz_diagnostic_payload(
+                                        identity=identity,
+                                        authz_policy_sha256_value=resolved_authz_policy_sha256,
+                                        authz_policy_source=resolved_authz_policy_source,
+                                    ),
                                 },
                             )
                         if params.get("context_cutover_audit") == "true":

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1372,6 +1372,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertEqual(payload["authz"]["identity"]["repository"], "every/verireel")
+        self.assertEqual(payload["authz"]["policy_source"], "bootstrap_seeded_store")
 
     def test_product_profile_write_rejects_unauthorized_product(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- include sanitized identity and policy source/hash metadata on product-profile read authz denials
- avoid logging tokens, policy bodies, or secret values

## Validation
- uv run --extra dev ruff check control_plane/service.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_service.py
- uv run python -m unittest tests.test_service
- git diff --check