### PR TITLE
Constrain product context audit route

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1510,6 +1510,31 @@ def _authz_diagnostic_payload(
     }
 
 
+def _product_profile_context_cutover_allowed_contexts(
+    profile: LaunchplaneProductProfileRecord,
+) -> frozenset[str]:
+    contexts = {profile.product.strip()}
+    contexts.update(lane.context.strip() for lane in profile.lanes if lane.context.strip())
+    if profile.preview.enabled and profile.preview.context.strip():
+        contexts.add(profile.preview.context.strip())
+    return frozenset(context for context in contexts if context)
+
+
+def _product_profile_context_cutover_contexts_allowed(
+    *,
+    profile: LaunchplaneProductProfileRecord,
+    source_context: str,
+    target_context: str,
+    preview_context: str,
+) -> bool:
+    allowed_contexts = _product_profile_context_cutover_allowed_contexts(profile)
+    requested_contexts = {source_context.strip(), target_context.strip()}
+    if preview_context.strip():
+        requested_contexts.add(preview_context.strip())
+    requested_contexts.discard("")
+    return requested_contexts.issubset(allowed_contexts)
+
+
 def _safe_return_to(value: str) -> str:
     normalized = value.strip() or "/"
     if not normalized.startswith("/") or normalized.startswith("//"):
@@ -2791,6 +2816,24 @@ def create_launchplane_service_app(
                             preview_context = str(
                                 (query.get("preview_context") or [""])[0] or ""
                             ).strip()
+                            if not _product_profile_context_cutover_contexts_allowed(
+                                profile=profile,
+                                source_context=source_context,
+                                target_context=target_context,
+                                preview_context=preview_context,
+                            ):
+                                return _json_response(
+                                    start_response=start_response,
+                                    status_code=403,
+                                    payload={
+                                        "status": "rejected",
+                                        "trace_id": request_trace_id,
+                                        "error": {
+                                            "code": "context_not_in_product_boundary",
+                                            "message": "Requested audit contexts are not owned by the product profile.",
+                                        },
+                                    },
+                                )
                             try:
                                 audit_payload = control_plane_product_context_audit.build_product_context_cutover_audit(
                                     record_store=record_store,
@@ -2799,7 +2842,7 @@ def create_launchplane_service_app(
                                     target_context=target_context,
                                     preview_context=preview_context,
                                 )
-                            except ValueError as error:
+                            except ValueError:
                                 return _json_response(
                                     start_response=start_response,
                                     status_code=400,
@@ -2808,7 +2851,7 @@ def create_launchplane_service_app(
                                         "trace_id": request_trace_id,
                                         "error": {
                                             "code": "invalid_context_cutover_audit_request",
-                                            "message": str(error),
+                                            "message": "Context cutover audit request is invalid.",
                                         },
                                     },
                                 )
@@ -2846,6 +2889,11 @@ def create_launchplane_service_app(
                                     "code": "authorization_denied",
                                     "message": "Workflow cannot list Launchplane product profiles.",
                                 },
+                                "authz": _authz_diagnostic_payload(
+                                    identity=identity,
+                                    authz_policy_sha256_value=resolved_authz_policy_sha256,
+                                    authz_policy_source=resolved_authz_policy_source,
+                                ),
                             },
                         )
                     driver_id_filter = str((query.get("driver_id") or [""])[0] or "").strip()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1323,6 +1323,106 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ["TAWK_WIDGET_ID"],
         )
 
+    def test_product_profile_context_cutover_audit_rejects_unowned_context(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                store.write_product_profile_record(
+                    LaunchplaneProductProfileRecord.model_validate(
+                        _product_profile_payload_with_prod()
+                    )
+                )
+            finally:
+                store.close()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["launchplane"],
+                            "actions": ["product_profile.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/product-profiles/sellyouroutboard/context-cutover-audit",
+                query_string="source_context=opw&target_context=sellyouroutboard",
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "context_not_in_product_boundary")
+
+    def test_product_profile_context_cutover_audit_invalid_request_is_generic(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                store.write_product_profile_record(
+                    LaunchplaneProductProfileRecord.model_validate(
+                        _product_profile_payload_with_prod()
+                    )
+                )
+            finally:
+                store.close()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["launchplane"],
+                            "actions": ["product_profile.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/product-profiles/sellyouroutboard/context-cutover-audit",
+                query_string=("source_context=sellyouroutboard&target_context=sellyouroutboard"),
+            )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_context_cutover_audit_request")
+        self.assertEqual(
+            payload["error"]["message"],
+            "Context cutover audit request is invalid.",
+        )
+
     def test_product_profile_context_cutover_audit_rejects_unauthorized_product(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -1368,6 +1468,43 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 query_string=(
                     "source_context=sellyouroutboard-testing&target_context=sellyouroutboard"
                 ),
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertEqual(payload["authz"]["identity"]["repository"], "every/verireel")
+        self.assertEqual(payload["authz"]["policy_source"], "bootstrap_seeded_store")
+
+    def test_product_profile_list_denial_includes_authz_diagnostics(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["launchplane"],
+                            "actions": ["product_profile.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/product-profiles",
             )
 
         self.assertEqual(status_code, 403)


### PR DESCRIPTION
## Summary
- require context cutover audit source/target/preview contexts to belong to the requested product profile before returning metadata
- allow the canonical product key as an explicit product-owned target context for cutover audits
- return a generic invalid audit request message instead of reflecting validation exceptions
- include authz diagnostics on product profile list denials, matching product-specific read denials

## Addresses
- Codex P1 on #139: context ownership before returning cutover audit
- Codex P2 on #141: consistent product_profile.read denial diagnostics
- CodeQL exception-information comments on #139

## Validation
- uv run --extra dev ruff format --check control_plane/service.py tests/test_service.py
- uv run --extra dev ruff check control_plane/service.py tests/test_service.py
- uv run python -m unittest tests.test_service
- uv run python -m unittest tests.test_product_profile_context_audit tests.test_service
- uv run --extra dev ruff check control_plane/product_context_audit.py control_plane/service.py tests/test_service.py tests/test_product_profile_context_audit.py
- git diff --check