### PR TITLE
Add service authz grant route

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -286,3 +286,49 @@ jobs:
 
           echo "Timed out waiting for Launchplane image '$expected_image_reference' to become live and healthy." >&2
           exit 1
+
+      - name: Ensure product context audit authz grant
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          oidc_token="$({
+            curl -fsSL \
+              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${{ steps.service.outputs.service_audience }}" \
+            | jq -r '.value'
+          })"
+          request_payload="$({
+            jq -n \
+              --arg workflow_ref "${GITHUB_REPOSITORY}/.github/workflows/product-context-cutover-audit.yml@refs/heads/main" \
+              '{
+                schema_version: 1,
+                product: "launchplane",
+                grant: {
+                  repository: env.GITHUB_REPOSITORY,
+                  workflow_refs: [$workflow_ref],
+                  event_names: ["workflow_dispatch"],
+                  products: ["sellyouroutboard"],
+                  contexts: ["launchplane"],
+                  actions: ["product_profile.read"],
+                  source_label: "deploy:product-context-cutover-audit-grant"
+                }
+              }'
+          })"
+          response_file="$(mktemp)"
+          status_code="$(curl -sS \
+            -o "$response_file" \
+            -w '%{http_code}' \
+            -X POST \
+            -H "Authorization: Bearer ${oidc_token}" \
+            -H 'Content-Type: application/json' \
+            -H "Idempotency-Key: launchplane-authz-grant:product-context-cutover-audit:${GITHUB_SHA}" \
+            --data "$request_payload" \
+            "${{ steps.service.outputs.service_url }}/v1/authz-policies/github-actions/grants")"
+          if [ "$status_code" = "200" ] || [ "$status_code" = "202" ]; then
+            cat "$response_file"
+            exit 0
+          fi
+          cat "$response_file" >&2
+          echo "Launchplane authz grant request failed with HTTP ${status_code}." >&2
+          exit 1

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -71,6 +71,7 @@ from control_plane.launchplane_mutations import (
 )
 from control_plane.service_auth import (
     GitHubActionsIdentity,
+    GitHubActionsPolicyRule,
     GitHubHumanIdentity,
     LaunchplaneAuthzPolicy,
     LaunchplaneIdentity,
@@ -942,6 +943,71 @@ class LaunchplaneSelfDeployEnvelope(BaseModel):
         return self
 
 
+class AuthzPolicyGitHubActionsGrant(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    repository: str
+    workflow_refs: tuple[str, ...] = ()
+    job_workflow_refs: tuple[str, ...] = ()
+    event_names: tuple[str, ...] = ()
+    refs: tuple[str, ...] = ()
+    environments: tuple[str, ...] = ()
+    products: tuple[str, ...] = ()
+    contexts: tuple[str, ...] = ()
+    actions: tuple[str, ...]
+    source_label: str = "service:authz-policy-grant"
+
+    @staticmethod
+    def _normalized_tuple(values: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(value.strip() for value in values if value.strip())
+
+    @model_validator(mode="after")
+    def _validate_grant(self) -> "AuthzPolicyGitHubActionsGrant":
+        self.repository = self.repository.strip()
+        if not self.repository:
+            raise ValueError("Authz policy grant requires repository.")
+        self.workflow_refs = self._normalized_tuple(self.workflow_refs)
+        self.job_workflow_refs = self._normalized_tuple(self.job_workflow_refs)
+        self.event_names = self._normalized_tuple(self.event_names)
+        self.refs = self._normalized_tuple(self.refs)
+        self.environments = self._normalized_tuple(self.environments)
+        self.products = self._normalized_tuple(self.products)
+        self.contexts = self._normalized_tuple(self.contexts)
+        self.actions = self._normalized_tuple(self.actions)
+        if not self.actions:
+            raise ValueError("Authz policy grant requires at least one action.")
+        self.source_label = self.source_label.strip() or "service:authz-policy-grant"
+        return self
+
+    def to_policy_rule(self) -> GitHubActionsPolicyRule:
+        return GitHubActionsPolicyRule(
+            repository=self.repository,
+            workflow_refs=self.workflow_refs,
+            job_workflow_refs=self.job_workflow_refs,
+            event_names=self.event_names,
+            refs=self.refs,
+            environments=self.environments,
+            products=self.products,
+            contexts=self.contexts,
+            actions=self.actions,
+        )
+
+
+class AuthzPolicyGitHubActionsGrantEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    grant: AuthzPolicyGitHubActionsGrant
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "AuthzPolicyGitHubActionsGrantEnvelope":
+        if self.product.strip() != "launchplane":
+            raise ValueError("Authz policy grant writes require product 'launchplane'.")
+        self.product = "launchplane"
+        return self
+
+
 class ProductConfigApplyEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -1288,6 +1354,7 @@ def _accepted_payload(
                 "preview_pr_feedback_id",
                 "preview_lifecycle_cleanup_id",
                 "preview_lifecycle_plan_id",
+                "authz_policy_record_id",
                 "product_profile",
                 "generation_id",
                 "promotion_record_id",
@@ -1622,6 +1689,52 @@ def _launchplane_runtime_payload(
         "service_audience": os.environ.get("LAUNCHPLANE_SERVICE_AUDIENCE", "").strip(),
         "storage_backend": storage_backend,
     }
+
+
+def _summarize_authz_policy_record(record: LaunchplaneAuthzPolicyRecord) -> dict[str, object]:
+    return {
+        "record_id": record.record_id,
+        "status": record.status,
+        "source": record.source,
+        "updated_at": record.updated_at,
+        "policy_sha256": record.policy_sha256,
+        "github_actions_rule_count": len(record.policy.github_actions),
+        "github_humans_rule_count": len(record.policy.github_humans),
+    }
+
+
+def _write_github_actions_authz_policy_grant(
+    *,
+    record_store: PostgresRecordStore,
+    grant: AuthzPolicyGitHubActionsGrant,
+) -> tuple[LaunchplaneAuthzPolicy, LaunchplaneAuthzPolicyRecord, bool]:
+    active_records = record_store.list_authz_policy_records(status="active", limit=1)
+    if not active_records:
+        raise ValueError("No active Launchplane authz policy record found.")
+    current_policy = active_records[0].policy
+    desired_rule = grant.to_policy_rule()
+    changed = not any(rule == desired_rule for rule in current_policy.github_actions)
+    if not changed:
+        return current_policy, active_records[0], False
+
+    updated_policy = current_policy.model_copy(
+        update={"github_actions": current_policy.github_actions + (desired_rule,)}
+    )
+    updated_at = _now_timestamp()
+    policy_sha256 = authz_policy_sha256(updated_policy)
+    record = LaunchplaneAuthzPolicyRecord(
+        record_id=build_authz_policy_record_id(
+            updated_at=updated_at,
+            policy_sha256=policy_sha256,
+        ),
+        status="active",
+        source=grant.source_label,
+        updated_at=updated_at,
+        policy_sha256=policy_sha256,
+        policy=updated_policy,
+    )
+    record_store.write_authz_policy_record(record)
+    return updated_policy, record, changed
 
 
 def _request_launchplane_self_deploy(
@@ -2114,6 +2227,7 @@ def create_launchplane_service_app(
         "/v1/evidence/backup-gates",
         "/v1/evidence/previews/generations",
         "/v1/evidence/previews/destroyed",
+        "/v1/authz-policies/github-actions/grants",
         "/v1/product-config/apply",
         "/v1/previews/desired-state",
         "/v1/previews/pr-feedback",
@@ -2155,6 +2269,8 @@ def create_launchplane_service_app(
         environ: dict[str, object],
         start_response: Callable[[str, list[tuple[str, str]]], None],
     ) -> list[bytes]:
+        nonlocal authz_policy, resolved_authz_policy_sha256, resolved_authz_policy_source
+
         request_trace_id = _trace_id()
         method = str(environ.get("REQUEST_METHOD", "GET")).upper()
         path = str(environ.get("PATH_INFO", ""))
@@ -3116,6 +3232,81 @@ def create_launchplane_service_app(
                             },
                         },
                     )
+            elif path == "/v1/authz-policies/github-actions/grants":
+                request = AuthzPolicyGitHubActionsGrantEnvelope.model_validate(payload)
+                if not isinstance(record_store, PostgresRecordStore):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "database_required",
+                                "message": "Authz policy grant writes require Launchplane database storage.",
+                            },
+                        },
+                    )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="launchplane_service_deploy.execute",
+                    product=request.product,
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot write Launchplane authz policy grants.",
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                try:
+                    updated_policy, authz_policy_record, changed = (
+                        _write_github_actions_authz_policy_grant(
+                            record_store=record_store,
+                            grant=request.grant,
+                        )
+                    )
+                except ValueError:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authz_policy_unavailable",
+                                "message": "Launchplane active authz policy is unavailable.",
+                            },
+                        },
+                    )
+                authz_policy = updated_policy
+                resolved_authz_policy_sha256 = authz_policy_record.policy_sha256
+                resolved_authz_policy_source = "db"
+                result = {
+                    "authz_policy_record_id": authz_policy_record.record_id,
+                    "authz_policy_changed": str(changed).lower(),
+                }
+                driver_result = {
+                    "authz_policy": _summarize_authz_policy_record(authz_policy_record),
+                    "changed": changed,
+                }
             elif path == "/v1/drivers/launchplane/self-deploy":
                 request = LaunchplaneSelfDeployEnvelope.model_validate(payload)
                 if not authz_policy.allows(

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -85,6 +85,7 @@ Current implementation scope:
 - `POST /v1/evidence/promotions`
 - `POST /v1/evidence/previews/generations`
 - `POST /v1/evidence/previews/destroyed`
+- `POST /v1/authz-policies/github-actions/grants`
 - `POST /v1/previews/lifecycle-plan`
 - `POST /v1/drivers/verireel/preview-refresh`
 - `POST /v1/drivers/verireel/preview-destroy`
@@ -107,6 +108,11 @@ and record contracts.
 The service uses GitHub OIDC bearer tokens and DB-backed authz policy records.
 Additional evidence routes should land against the same authn/authz boundary
 rather than creating separate ad hoc ingress patterns.
+
+The deploy workflow maintains the DB-backed grant that lets the manual Product
+Context Cutover Audit workflow read the SellYourOutboard product profile. The
+grant request returns only authz policy record metadata and rule counts; it does
+not echo workflow refs or the full policy body.
 
 Render an explicit emergency bootstrap policy or import a policy into DB-backed
 records with:

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -44,6 +44,8 @@ VeriReel product paths:
   - `POST /v1/product-profiles`
 - product config write route:
   - `POST /v1/product-config/apply`
+- authz policy maintenance route:
+  - `POST /v1/authz-policies/github-actions/grants`
 - product driver routes:
   - `POST /v1/drivers/generic-web/deploy`
   - `POST /v1/drivers/generic-web/prod-promotion`
@@ -74,7 +76,10 @@ VeriReel product paths:
 Launchplane verifies GitHub OIDC, authorizes workflow identity claims, accepts
 deployment/promotion/preview lifecycle evidence over HTTP, and executes the
 current Odoo/VeriReel artifact, deploy, backup, promotion, rollback, maintenance,
-and preview mutations as authenticated Launchplane routes.
+and preview mutations as authenticated Launchplane routes. The authz policy
+grant route is reserved for Launchplane-owned deployment workflows, requires the
+`launchplane_service_deploy.execute` action, writes DB-backed GitHub Actions
+policy rules, and returns only record metadata and rule counts.
 
 The service also serves the built operator UI shell at `/`, with `/ui` retained
 as a compatibility alias. Built assets live under `/ui/assets/...`, while

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3399,6 +3399,160 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 400)
         self.assertEqual(payload["error"]["code"], "invalid_request")
 
+    def test_authz_policy_grant_endpoint_writes_db_record_and_updates_runtime(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["launchplane_service_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/authz-policies/github-actions/grants",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "grant": {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                        ],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["sellyouroutboard"],
+                        "contexts": ["launchplane"],
+                        "actions": ["product_profile.read"],
+                        "source_label": "test:audit-grant",
+                    },
+                },
+                headers={"Idempotency-Key": "authz-grant:audit"},
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                active_policy = store.list_authz_policy_records(status="active", limit=1)[0]
+                store.write_product_profile_record(
+                    LaunchplaneProductProfileRecord.model_validate(
+                        _product_profile_payload_with_prod()
+                    )
+                )
+            finally:
+                store.close()
+            profile_status_code, profile_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/product-profiles/sellyouroutboard",
+            )
+            repeat_status_code, repeat_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/authz-policies/github-actions/grants",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "grant": {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                        ],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["sellyouroutboard"],
+                        "contexts": ["launchplane"],
+                        "actions": ["product_profile.read"],
+                        "source_label": "test:audit-grant",
+                    },
+                },
+                headers={"Idempotency-Key": "authz-grant:audit-repeat"},
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["records"]["authz_policy_record_id"], active_policy.record_id)
+        self.assertEqual(payload["result"]["changed"], True)
+        self.assertNotIn("workflow_refs", json.dumps(payload, sort_keys=True))
+        self.assertEqual(profile_status_code, 200)
+        self.assertEqual(profile_payload["profile"]["product"], "sellyouroutboard")
+        self.assertEqual(repeat_status_code, 202)
+        self.assertEqual(
+            repeat_payload["records"]["authz_policy_record_id"], active_policy.record_id
+        )
+        self.assertEqual(repeat_payload["result"]["changed"], False)
+
+    def test_authz_policy_grant_endpoint_rejects_without_self_deploy_permission(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "actions": ["product_profile.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/authz-policies/github-actions/grants",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "grant": {
+                        "repository": "cbusillo/launchplane",
+                        "actions": ["product_profile.read"],
+                    },
+                },
+                headers={"Idempotency-Key": "authz-grant:unauthorized"},
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
     def test_preview_generation_endpoint_writes_records_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary

Adds a narrow Launchplane service route for DB-backed GitHub Actions authz grants and wires the deploy workflow to seed the Product Context Cutover Audit permission for SellYourOutboard.

## Details

- Adds POST /v1/authz-policies/github-actions/grants.
- Requires launchplane_service_deploy.execute on product launchplane / context launchplane.
- Writes an active DB-backed authz policy record only when the exact GitHub Actions rule is new.
- Updates the in-memory service authz policy immediately after a successful grant write.
- Returns only record metadata, policy hash, rule counts, and changed status.
- Deploy workflow calls the route after the new Launchplane image is live so the manual audit workflow can read the SellYourOutboard product profile.

## Validation

- uv run --extra dev ruff format --check control_plane/service.py tests/test_service.py
- uv run --extra dev ruff check --fix --diff control_plane/service.py tests/test_service.py
- uv run --extra dev ruff check control_plane/service.py tests/test_service.py
- actionlint .github/workflows/deploy-launchplane.yml
- markdownlint docs/service-boundary.md docs/operations.md
- uv run python -m unittest tests.test_service
- uv run python -m unittest
