### PR TITLE
Add product context cutover workflow

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -287,7 +287,7 @@ jobs:
           echo "Timed out waiting for Launchplane image '$expected_image_reference' to become live and healthy." >&2
           exit 1
 
-      - name: Ensure product context audit authz grant
+      - name: Ensure product context workflow authz grants
         shell: bash
         run: |
           set -euo pipefail
@@ -298,37 +298,59 @@ jobs:
               "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${{ steps.service.outputs.service_audience }}" \
             | jq -r '.value'
           })"
-          request_payload="$({
-            jq -n \
-              --arg workflow_ref "${GITHUB_REPOSITORY}/.github/workflows/product-context-cutover-audit.yml@refs/heads/main" \
-              '{
-                schema_version: 1,
-                product: "launchplane",
-                grant: {
-                  repository: env.GITHUB_REPOSITORY,
-                  workflow_refs: [$workflow_ref],
-                  event_names: ["workflow_dispatch"],
-                  products: ["sellyouroutboard"],
-                  contexts: ["launchplane"],
-                  actions: ["product_profile.read"],
-                  source_label: "deploy:product-context-cutover-audit-grant"
-                }
-              }'
-          })"
-          response_file="$(mktemp)"
-          status_code="$(curl -sS \
-            -o "$response_file" \
-            -w '%{http_code}' \
-            -X POST \
-            -H "Authorization: Bearer ${oidc_token}" \
-            -H 'Content-Type: application/json' \
-            -H "Idempotency-Key: launchplane-authz-grant:product-context-cutover-audit:${GITHUB_SHA}" \
-            --data "$request_payload" \
-            "${{ steps.service.outputs.service_url }}/v1/authz-policies/github-actions/grants")"
-          if [ "$status_code" = "200" ] || [ "$status_code" = "202" ]; then
-            cat "$response_file"
-            exit 0
-          fi
-          cat "$response_file" >&2
-          echo "Launchplane authz grant request failed with HTTP ${status_code}." >&2
-          exit 1
+
+          post_grant() {
+            local workflow_file="$1"
+            local action_name="$2"
+            local source_label="$3"
+            local idempotency_suffix="$4"
+            local request_payload response_file status_code
+
+            request_payload="$({
+              jq -n \
+                --arg workflow_ref "${GITHUB_REPOSITORY}/.github/workflows/${workflow_file}@refs/heads/main" \
+                --arg action_name "$action_name" \
+                --arg source_label "$source_label" \
+                '{
+                  schema_version: 1,
+                  product: "launchplane",
+                  grant: {
+                    repository: env.GITHUB_REPOSITORY,
+                    workflow_refs: [$workflow_ref],
+                    event_names: ["workflow_dispatch"],
+                    products: ["sellyouroutboard"],
+                    contexts: ["launchplane"],
+                    actions: [$action_name],
+                    source_label: $source_label
+                  }
+                }'
+            })"
+            response_file="$(mktemp)"
+            status_code="$(curl -sS \
+              -o "$response_file" \
+              -w '%{http_code}' \
+              -X POST \
+              -H "Authorization: Bearer ${oidc_token}" \
+              -H 'Content-Type: application/json' \
+              -H "Idempotency-Key: launchplane-authz-grant:${idempotency_suffix}:${GITHUB_SHA}" \
+              --data "$request_payload" \
+              "${{ steps.service.outputs.service_url }}/v1/authz-policies/github-actions/grants")"
+            if [ "$status_code" = "200" ] || [ "$status_code" = "202" ]; then
+              cat "$response_file"
+              return 0
+            fi
+            cat "$response_file" >&2
+            echo "Launchplane authz grant request failed with HTTP ${status_code}." >&2
+            return 1
+          }
+
+          post_grant \
+            product-context-cutover-audit.yml \
+            product_profile.read \
+            deploy:product-context-cutover-audit-grant \
+            product-context-cutover-audit
+          post_grant \
+            product-context-cutover.yml \
+            product_profile.write \
+            deploy:product-context-cutover-apply-grant \
+            product-context-cutover-apply

--- a/.github/workflows/product-context-cutover.yml
+++ b/.github/workflows/product-context-cutover.yml
@@ -1,0 +1,157 @@
+---
+name: Product Context Cutover
+
+"on":
+  workflow_dispatch:
+    inputs:
+      product:
+        description: Product profile key to cut over.
+        required: true
+        default: sellyouroutboard
+        type: string
+      source_context:
+        description: Legacy context to copy current-authority records from.
+        required: true
+        default: sellyouroutboard-testing
+        type: string
+      target_context:
+        description: Canonical product context to copy current-authority records to.
+        required: true
+        default: sellyouroutboard
+        type: string
+      display_name:
+        description: Product display name to write with the profile cutover.
+        required: true
+        default: SellYourOutboard
+        type: string
+      dry_run:
+        description: Plan only when true; write records and profile when false.
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: launchplane-product-context-cutover
+  cancel-in-progress: false
+
+jobs:
+  cutover:
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    env:
+      LAUNCHPLANE_URL: >-
+        ${{ vars.LAUNCHPLANE_PUBLIC_URL ||
+        'https://launchplane.shinycomputers.com' }}
+      PRODUCT: ${{ inputs.product }}
+      SOURCE_CONTEXT: ${{ inputs.source_context }}
+      TARGET_CONTEXT: ${{ inputs.target_context }}
+      DISPLAY_NAME: ${{ inputs.display_name }}
+      DRY_RUN: ${{ inputs.dry_run }}
+    steps:
+      - name: Request product context cutover
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${LAUNCHPLANE_URL:?Missing LAUNCHPLANE_PUBLIC_URL variable}"
+          : "${PRODUCT:?Missing product input}"
+          : "${SOURCE_CONTEXT:?Missing source_context input}"
+          : "${TARGET_CONTEXT:?Missing target_context input}"
+          : "${DISPLAY_NAME:?Missing display_name input}"
+
+          service_origin="$({
+            python3 - <<'PY'
+          import os
+          from urllib.parse import urlsplit
+
+          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"].strip())
+          if not parsed.scheme or not parsed.netloc or not parsed.hostname:
+              raise SystemExit("LAUNCHPLANE_URL must be an absolute URL.")
+          print(f"{parsed.scheme}://{parsed.netloc}")
+          PY
+          })"
+          service_audience="$({
+            python3 - <<'PY'
+          import os
+          from urllib.parse import urlsplit
+
+          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"].strip())
+          if not parsed.hostname:
+              raise SystemExit("LAUNCHPLANE_URL must include a hostname.")
+          print(parsed.hostname)
+          PY
+          })"
+          mode="apply"
+          if [ "$DRY_RUN" = "true" ]; then
+            mode="dry-run"
+          fi
+
+          oidc_token="$({
+            curl -fsSL \
+              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${service_audience}" \
+            | jq -r '.value'
+          })"
+          request_payload="$({
+            jq -n \
+              --arg product "$PRODUCT" \
+              --arg source_context "$SOURCE_CONTEXT" \
+              --arg target_context "$TARGET_CONTEXT" \
+              --arg display_name "$DISPLAY_NAME" \
+              --arg mode "$mode" \
+              '{
+                product: $product,
+                source_context: $source_context,
+                target_context: $target_context,
+                display_name: $display_name,
+                mode: $mode,
+                source_label: "workflow:product-context-cutover"
+              }'
+          })"
+          response_file="launchplane-product-context-cutover.json"
+          status_code="$(curl -sS \
+            -o "$response_file" \
+            -w '%{http_code}' \
+            -X POST \
+            -H "Authorization: Bearer ${oidc_token}" \
+            -H 'Content-Type: application/json' \
+            -H "Idempotency-Key: product-context-cutover:${PRODUCT}:${SOURCE_CONTEXT}:${TARGET_CONTEXT}:${mode}:${GITHUB_RUN_ID}" \
+            --data "$request_payload" \
+            "${service_origin}/v1/product-profiles/context-cutover/apply")"
+          if [ "$status_code" != "202" ]; then
+            cat "$response_file" >&2
+            echo "Launchplane product context cutover failed with HTTP ${status_code}." >&2
+            exit 1
+          fi
+          jq . "$response_file"
+
+      - name: Upload cutover artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: launchplane-product-context-cutover-${{ inputs.product }}
+          path: launchplane-product-context-cutover.json
+          if-no-files-found: error
+
+      - name: Summarize cutover
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo '## Launchplane product context cutover'
+            echo
+            echo "- Product: ${PRODUCT}"
+            echo "- Source context: ${SOURCE_CONTEXT}"
+            echo "- Target context: ${TARGET_CONTEXT}"
+            echo "- Dry run: ${DRY_RUN}"
+            echo "- Display name: ${DISPLAY_NAME}"
+            echo "- Runtime records: $(jq -c '.result.counts.runtime_environment_records' launchplane-product-context-cutover.json)"
+            echo "- Managed secrets: $(jq -c '.result.counts.managed_secret_records' launchplane-product-context-cutover.json)"
+            echo "- Dokploy targets: $(jq -c '.result.counts.dokploy_targets' launchplane-product-context-cutover.json)"
+            echo "- Dokploy target IDs: $(jq -c '.result.counts.dokploy_target_ids' launchplane-product-context-cutover.json)"
+            echo "- Inventory records: $(jq -c '.result.counts.inventory_records' launchplane-product-context-cutover.json)"
+            echo "- Release tuples: $(jq -c '.result.counts.release_tuple_records' launchplane-product-context-cutover.json)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/control_plane/product_context_cutover.py
+++ b/control_plane/product_context_cutover.py
@@ -1,0 +1,514 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.secret_record import (
+    SecretAuditEvent,
+    SecretBinding,
+    SecretRecord,
+    SecretVersion,
+)
+from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.workflows.ship import utc_now_timestamp
+
+
+ContextCutoverMode = Literal["dry-run", "apply"]
+
+
+class ProductContextCutoverRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    product: str
+    source_context: str
+    target_context: str
+    mode: ContextCutoverMode = "dry-run"
+    display_name: str = ""
+    source_label: str = "service:product-context-cutover"
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "ProductContextCutoverRequest":
+        self.product = self.product.strip()
+        self.source_context = self.source_context.strip()
+        self.target_context = self.target_context.strip()
+        self.display_name = self.display_name.strip()
+        self.source_label = self.source_label.strip() or "service:product-context-cutover"
+        if not self.product:
+            raise ValueError("Product context cutover requires product.")
+        if not self.source_context or not self.target_context:
+            raise ValueError("Product context cutover requires source_context and target_context.")
+        if self.source_context == self.target_context:
+            raise ValueError(
+                "Product context cutover source_context and target_context must differ."
+            )
+        return self
+
+
+def _slug(value: str) -> str:
+    compact = "".join(character.lower() if character.isalnum() else "-" for character in value)
+    return "-".join(part for part in compact.split("-") if part) or "value"
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
+
+
+def _target_secret_id(record: SecretRecord, *, target_context: str) -> str:
+    parts = ["secret", record.integration, record.name]
+    if target_context.strip():
+        parts.append(target_context)
+    if record.instance.strip():
+        parts.append(record.instance)
+    return "-".join(_slug(part) for part in parts)
+
+
+def _target_secret_binding_id(*, secret_id: str, binding_key: str) -> str:
+    return f"{secret_id}-binding-{_slug(binding_key)}"
+
+
+def _target_secret_version_id(*, secret_id: str, source_version_id: str) -> str:
+    return f"{secret_id}-version-copy-{_digest(source_version_id)}"
+
+
+def _target_secret_event_id(*, secret_id: str, source_secret_id: str) -> str:
+    return f"{secret_id}-event-imported-{_digest(source_secret_id)}"
+
+
+def _summarize_counts(items: list[dict[str, object]]) -> dict[str, int]:
+    counts = {"created": 0, "skipped": 0}
+    for item in items:
+        action = str(item.get("action") or "")
+        if action in counts:
+            counts[action] += 1
+    return counts
+
+
+def _profile_after_cutover(
+    profile: LaunchplaneProductProfileRecord,
+    *,
+    source_context: str,
+    target_context: str,
+    display_name: str,
+    now: str,
+    source_label: str,
+) -> LaunchplaneProductProfileRecord:
+    lanes = tuple(
+        lane.model_copy(update={"context": target_context})
+        if lane.context == source_context or lane.instance in {"testing", "prod"}
+        else lane
+        for lane in profile.lanes
+    )
+    preview = profile.preview.model_copy(
+        update={"context": target_context} if profile.preview.enabled else {}
+    )
+    return profile.model_copy(
+        update={
+            "display_name": display_name or profile.display_name,
+            "lanes": lanes,
+            "preview": preview,
+            "updated_at": now,
+            "source": source_label,
+        }
+    )
+
+
+def plan_product_context_cutover(
+    *,
+    record_store: PostgresRecordStore,
+    request: ProductContextCutoverRequest,
+) -> dict[str, object]:
+    profile = record_store.read_product_profile_record(request.product)
+    source_runtime_records = record_store.list_runtime_environment_records(
+        context_name=request.source_context
+    )
+    target_runtime_routes = {
+        (record.scope, record.instance)
+        for record in record_store.list_runtime_environment_records(
+            context_name=request.target_context
+        )
+    }
+    runtime_records = [
+        {
+            "scope": record.scope,
+            "instance": record.instance,
+            "env_keys": sorted(record.env.keys()),
+            "env_value_count": len(record.env),
+            "action": "skipped"
+            if (record.scope, record.instance) in target_runtime_routes
+            else "created",
+        }
+        for record in source_runtime_records
+    ]
+
+    source_target_records = tuple(
+        record
+        for record in record_store.list_dokploy_target_records()
+        if record.context == request.source_context
+    )
+    target_target_instances = {
+        record.instance
+        for record in record_store.list_dokploy_target_records()
+        if record.context == request.target_context
+    }
+    dokploy_targets = [
+        {
+            "instance": record.instance,
+            "target_type": record.target_type,
+            "target_name": record.target_name,
+            "domains": list(record.domains),
+            "env_keys": sorted(record.env.keys()),
+            "env_value_count": len(record.env),
+            "action": "skipped" if record.instance in target_target_instances else "created",
+        }
+        for record in source_target_records
+    ]
+
+    source_target_ids = tuple(
+        record
+        for record in record_store.list_dokploy_target_id_records()
+        if record.context == request.source_context
+    )
+    target_id_instances = {
+        record.instance
+        for record in record_store.list_dokploy_target_id_records()
+        if record.context == request.target_context
+    }
+    dokploy_target_ids = [
+        {
+            "instance": record.instance,
+            "target_id": record.target_id,
+            "action": "skipped" if record.instance in target_id_instances else "created",
+        }
+        for record in source_target_ids
+    ]
+
+    source_secret_records = record_store.list_secret_records(
+        context_name=request.source_context,
+        limit=None,
+    )
+    managed_secrets: list[dict[str, object]] = []
+    for record in source_secret_records:
+        target = record_store.find_secret_record(
+            scope=record.scope,
+            integration=record.integration,
+            name=record.name,
+            context=request.target_context,
+            instance=record.instance,
+        )
+        bindings = tuple(
+            binding
+            for binding in record_store.list_secret_bindings(
+                integration=record.integration,
+                context_name=request.source_context,
+                instance_name=record.instance,
+                limit=None,
+            )
+            if binding.secret_id == record.secret_id
+        )
+        managed_secrets.append(
+            {
+                "name": record.name,
+                "scope": record.scope,
+                "integration": record.integration,
+                "instance": record.instance,
+                "binding_keys": sorted(binding.binding_key for binding in bindings),
+                "action": "skipped" if target is not None else "created",
+            }
+        )
+
+    source_inventory_records = tuple(
+        record
+        for record in record_store.list_environment_inventory()
+        if record.context == request.source_context
+    )
+    target_inventory_instances = {
+        record.instance
+        for record in record_store.list_environment_inventory()
+        if record.context == request.target_context
+    }
+    inventory_records = [
+        {
+            "instance": record.instance,
+            "artifact_id": str(getattr(record.artifact_identity, "artifact_id", "") or ""),
+            "deployment_record_id": record.deployment_record_id,
+            "promotion_record_id": record.promotion_record_id,
+            "action": "skipped" if record.instance in target_inventory_instances else "created",
+        }
+        for record in source_inventory_records
+    ]
+
+    source_release_tuples = tuple(
+        record
+        for record in record_store.list_release_tuple_records()
+        if record.context == request.source_context
+    )
+    target_release_channels = {
+        record.channel
+        for record in record_store.list_release_tuple_records()
+        if record.context == request.target_context
+    }
+    release_tuples = [
+        {
+            "channel": record.channel,
+            "artifact_id": record.artifact_id,
+            "provenance": record.provenance,
+            "action": "skipped" if record.channel in target_release_channels else "created",
+        }
+        for record in source_release_tuples
+    ]
+
+    next_profile = _profile_after_cutover(
+        profile,
+        source_context=request.source_context,
+        target_context=request.target_context,
+        display_name=request.display_name,
+        now=utc_now_timestamp(),
+        source_label=request.source_label,
+    )
+    profile_changed = profile.model_dump(mode="json") != next_profile.model_dump(mode="json")
+    groups = {
+        "runtime_environment_records": runtime_records,
+        "managed_secret_records": managed_secrets,
+        "dokploy_targets": dokploy_targets,
+        "dokploy_target_ids": dokploy_target_ids,
+        "inventory_records": inventory_records,
+        "release_tuple_records": release_tuples,
+    }
+    return {
+        "product": request.product,
+        "source_context": request.source_context,
+        "target_context": request.target_context,
+        "mode": request.mode,
+        "profile": {
+            "action": "updated" if profile_changed else "unchanged",
+            "display_name": next_profile.display_name,
+            "lane_contexts": {
+                lane.instance: lane.context
+                for lane in next_profile.lanes
+                if lane.instance in {"testing", "prod"}
+            },
+            "preview_context": next_profile.preview.context,
+        },
+        "groups": groups,
+        "counts": {name: _summarize_counts(items) for name, items in groups.items()},
+        "guardrails": [
+            "Append-only deployments, promotions, backup gates, and preview history are not copied.",
+            "Runtime values, secret plaintext, secret ciphertext, and full provider env text are not returned.",
+        ],
+    }
+
+
+def apply_product_context_cutover(
+    *,
+    record_store: PostgresRecordStore,
+    request: ProductContextCutoverRequest,
+) -> dict[str, object]:
+    plan = plan_product_context_cutover(record_store=record_store, request=request)
+    if request.mode == "dry-run":
+        return plan
+
+    now = utc_now_timestamp()
+    for record in record_store.list_runtime_environment_records(
+        context_name=request.source_context
+    ):
+        exists = any(
+            target.scope == record.scope and target.instance == record.instance
+            for target in record_store.list_runtime_environment_records(
+                context_name=request.target_context
+            )
+        )
+        if not exists:
+            record_store.write_runtime_environment_record(
+                record.model_copy(
+                    update={
+                        "context": request.target_context,
+                        "updated_at": now,
+                        "source_label": request.source_label,
+                    }
+                )
+            )
+
+    for record in tuple(
+        item
+        for item in record_store.list_dokploy_target_records()
+        if item.context == request.source_context
+    ):
+        exists = any(
+            target.context == request.target_context and target.instance == record.instance
+            for target in record_store.list_dokploy_target_records()
+        )
+        if not exists:
+            record_store.write_dokploy_target_record(
+                record.model_copy(
+                    update={
+                        "context": request.target_context,
+                        "updated_at": now,
+                        "source_label": request.source_label,
+                    }
+                )
+            )
+
+    for record in tuple(
+        item
+        for item in record_store.list_dokploy_target_id_records()
+        if item.context == request.source_context
+    ):
+        exists = any(
+            target.context == request.target_context and target.instance == record.instance
+            for target in record_store.list_dokploy_target_id_records()
+        )
+        if not exists:
+            record_store.write_dokploy_target_id_record(
+                DokployTargetIdRecord(
+                    context=request.target_context,
+                    instance=record.instance,
+                    target_id=record.target_id,
+                    updated_at=now,
+                    source_label=request.source_label,
+                )
+            )
+
+    for record in record_store.list_secret_records(
+        context_name=request.source_context,
+        limit=None,
+    ):
+        target = record_store.find_secret_record(
+            scope=record.scope,
+            integration=record.integration,
+            name=record.name,
+            context=request.target_context,
+            instance=record.instance,
+        )
+        if target is not None:
+            continue
+        target_secret_id = _target_secret_id(record, target_context=request.target_context)
+        source_version = record_store.read_secret_version(record.current_version_id)
+        target_version_id = _target_secret_version_id(
+            secret_id=target_secret_id,
+            source_version_id=source_version.version_id,
+        )
+        record_store.write_secret_version(
+            SecretVersion(
+                version_id=target_version_id,
+                secret_id=target_secret_id,
+                created_at=now,
+                created_by=request.source_label,
+                cipher_alg=source_version.cipher_alg,
+                key_id=source_version.key_id,
+                ciphertext=source_version.ciphertext,
+            )
+        )
+        record_store.write_secret_record(
+            SecretRecord(
+                secret_id=target_secret_id,
+                scope=record.scope,
+                integration=record.integration,
+                name=record.name,
+                context=request.target_context,
+                instance=record.instance,
+                description=record.description,
+                policy=record.policy,
+                status=record.status,
+                current_version_id=target_version_id,
+                created_at=now,
+                updated_at=now,
+                last_validated_at=record.last_validated_at,
+                updated_by=request.source_label,
+            )
+        )
+        for binding in tuple(
+            item
+            for item in record_store.list_secret_bindings(
+                integration=record.integration,
+                context_name=request.source_context,
+                instance_name=record.instance,
+                limit=None,
+            )
+            if item.secret_id == record.secret_id
+        ):
+            record_store.write_secret_binding(
+                SecretBinding(
+                    binding_id=_target_secret_binding_id(
+                        secret_id=target_secret_id,
+                        binding_key=binding.binding_key,
+                    ),
+                    secret_id=target_secret_id,
+                    integration=binding.integration,
+                    binding_type=binding.binding_type,
+                    binding_key=binding.binding_key,
+                    context=request.target_context,
+                    instance=binding.instance,
+                    status=binding.status,
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+        record_store.write_secret_audit_event(
+            SecretAuditEvent(
+                event_id=_target_secret_event_id(
+                    secret_id=target_secret_id,
+                    source_secret_id=record.secret_id,
+                ),
+                secret_id=target_secret_id,
+                event_type="imported",
+                recorded_at=now,
+                actor=request.source_label,
+                detail="Launchplane imported managed secret during product context cutover.",
+                metadata={
+                    "source": request.source_label,
+                    "source_secret_id": record.secret_id,
+                    "source_context": request.source_context,
+                    "target_context": request.target_context,
+                },
+            )
+        )
+
+    for record in tuple(
+        item
+        for item in record_store.list_environment_inventory()
+        if item.context == request.source_context
+    ):
+        exists = any(
+            target.context == request.target_context and target.instance == record.instance
+            for target in record_store.list_environment_inventory()
+        )
+        if not exists:
+            record_store.write_environment_inventory(
+                record.model_copy(update={"context": request.target_context, "updated_at": now})
+            )
+
+    for record in tuple(
+        item
+        for item in record_store.list_release_tuple_records()
+        if item.context == request.source_context
+    ):
+        exists = any(
+            target.context == request.target_context and target.channel == record.channel
+            for target in record_store.list_release_tuple_records()
+        )
+        if not exists:
+            record_store.write_release_tuple_record(
+                record.model_copy(
+                    update={
+                        "context": request.target_context,
+                        "tuple_id": f"{request.target_context}-{record.channel}-{record.artifact_id}",
+                    }
+                )
+            )
+
+    profile = record_store.read_product_profile_record(request.product)
+    record_store.write_product_profile_record(
+        _profile_after_cutover(
+            profile,
+            source_context=request.source_context,
+            target_context=request.target_context,
+            display_name=request.display_name,
+            now=now,
+            source_label=request.source_label,
+        )
+    )
+    return {**plan, "applied": True}

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -23,6 +23,7 @@ from jwt import InvalidTokenError
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import product_config as control_plane_product_config
 from control_plane import product_context_audit as control_plane_product_context_audit
+from control_plane import product_context_cutover as control_plane_product_context_cutover
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.authz_policy_record import (
     LaunchplaneAuthzPolicyRecord,
@@ -2229,6 +2230,7 @@ def create_launchplane_service_app(
         "/v1/evidence/previews/destroyed",
         "/v1/authz-policies/github-actions/grants",
         "/v1/product-config/apply",
+        "/v1/product-profiles/context-cutover/apply",
         "/v1/previews/desired-state",
         "/v1/previews/pr-feedback",
         "/v1/previews/lifecycle-cleanup",
@@ -4483,6 +4485,73 @@ def create_launchplane_service_app(
                     record_store=record_store,
                     request=request.verification,
                 )
+            elif path == "/v1/product-profiles/context-cutover/apply":
+                request = control_plane_product_context_cutover.ProductContextCutoverRequest.model_validate(
+                    payload
+                )
+                if not isinstance(record_store, PostgresRecordStore):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "database_required",
+                                "message": "Product context cutover requires Launchplane database storage.",
+                            },
+                        },
+                    )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="product_profile.write",
+                    product=request.product,
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot cut over the requested product profile context.",
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                try:
+                    driver_result = (
+                        control_plane_product_context_cutover.apply_product_context_cutover(
+                            record_store=record_store,
+                            request=request,
+                        )
+                    )
+                except ValueError:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=400,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "invalid_context_cutover_request",
+                                "message": "Product context cutover request is invalid.",
+                            },
+                        },
+                    )
+                result = {"product_profile": request.product}
             elif path == "/v1/product-profiles":
                 request = LaunchplaneProductProfileRecord.model_validate(payload)
                 if not authz_policy.allows(

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -86,6 +86,7 @@ Current implementation scope:
 - `POST /v1/evidence/previews/generations`
 - `POST /v1/evidence/previews/destroyed`
 - `POST /v1/authz-policies/github-actions/grants`
+- `POST /v1/product-profiles/context-cutover/apply`
 - `POST /v1/previews/lifecycle-plan`
 - `POST /v1/drivers/verireel/preview-refresh`
 - `POST /v1/drivers/verireel/preview-destroy`
@@ -113,6 +114,14 @@ The deploy workflow maintains the DB-backed grant that lets the manual Product
 Context Cutover Audit workflow read the SellYourOutboard product profile. The
 grant request returns only authz policy record metadata and rule counts; it does
 not echo workflow refs or the full policy body.
+
+The manual Product Context Cutover workflow plans or applies the same
+current-authority record move through the Launchplane service. Run it first with
+`dry_run=true`; run with `dry_run=false` only after the artifact shows the
+expected key/count metadata for runtime records, managed secrets, Dokploy
+targets, target IDs, inventories, release tuples, and the product profile lane
+contexts. The workflow intentionally leaves append-only deployments,
+promotions, backup gates, and preview history on their original contexts.
 
 Render an explicit emergency bootstrap policy or import a policy into DB-backed
 records with:

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -44,6 +44,8 @@ VeriReel product paths:
   - `POST /v1/product-profiles`
 - product config write route:
   - `POST /v1/product-config/apply`
+- product context cutover route:
+  - `POST /v1/product-profiles/context-cutover/apply`
 - authz policy maintenance route:
   - `POST /v1/authz-policies/github-actions/grants`
 - product driver routes:
@@ -395,6 +397,13 @@ runtime key names, managed secret IDs/binding keys, Dokploy target metadata,
 inventory and release tuple pointers, and append-only evidence counts. It does
 not return runtime values, secret plaintext, secret ciphertext, or full provider
 environment text.
+
+Product context cutover apply uses `product_profile.write` for the requested
+product in the Launchplane service context. It supports `dry-run` and `apply`
+modes, copies only current-authority records into the target context, updates
+lane/preview product profile context fields, and returns key names/counts only.
+It does not copy append-only deployments, promotions, backup gates, or preview
+history.
 
 ### Driver execution endpoints
 

--- a/tests/test_product_context_cutover.py
+++ b/tests/test_product_context_cutover.py
@@ -1,0 +1,254 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductImageProfile,
+    ProductLaneProfile,
+    ProductPreviewProfile,
+)
+from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
+from control_plane.contracts.secret_record import SecretBinding, SecretRecord, SecretVersion
+from control_plane.product_context_cutover import (
+    ProductContextCutoverRequest,
+    apply_product_context_cutover,
+)
+from control_plane.storage.postgres import PostgresRecordStore
+
+
+def _sqlite_database_url(database_path: Path) -> str:
+    return f"sqlite+pysqlite:///{database_path}"
+
+
+def _seed_syo_source_records(store: PostgresRecordStore) -> None:
+    store.write_product_profile_record(
+        LaunchplaneProductProfileRecord(
+            product="sellyouroutboard",
+            display_name="SellYourOutboard.com",
+            repository="cbusillo/sellyouroutboard",
+            driver_id="generic-web",
+            image=ProductImageProfile(repository="ghcr.io/cbusillo/sellyouroutboard"),
+            runtime_port=3000,
+            health_path="/api/health",
+            lanes=(
+                ProductLaneProfile(
+                    instance="testing",
+                    context="sellyouroutboard-testing",
+                    base_url="https://syo-testing.shinycomputers.com",
+                    health_url="https://syo-testing.shinycomputers.com/api/health",
+                ),
+                ProductLaneProfile(
+                    instance="prod",
+                    context="sellyouroutboard-testing",
+                    base_url="https://www.sellyouroutboard.com",
+                    health_url="https://www.sellyouroutboard.com/api/health",
+                ),
+            ),
+            preview=ProductPreviewProfile(
+                enabled=True,
+                context="sellyouroutboard-testing",
+                slug_template="pr-{number}",
+            ),
+            updated_at="2026-05-01T04:29:07Z",
+            source="test",
+        )
+    )
+    store.write_runtime_environment_record(
+        RuntimeEnvironmentRecord(
+            scope="context",
+            context="sellyouroutboard-testing",
+            env={"LAUNCHPLANE_PREVIEW_BASE_URL": "https://preview.example"},
+            updated_at="2026-05-01T03:46:14Z",
+            source_label="test",
+        )
+    )
+    store.write_runtime_environment_record(
+        RuntimeEnvironmentRecord(
+            scope="instance",
+            context="sellyouroutboard-testing",
+            instance="prod",
+            env={"TAWK_PROPERTY_ID": "property", "CONTACT_EMAIL_MODE": "log"},
+            updated_at="2026-05-01T19:15:31Z",
+            source_label="test",
+        )
+    )
+    store.write_dokploy_target_record(
+        DokployTargetRecord(
+            context="sellyouroutboard-testing",
+            instance="prod",
+            target_type="application",
+            project_name="sellyouroutboard",
+            target_name="syo-prod-app",
+            domains=("https://www.sellyouroutboard.com", "https://sellyouroutboard.com"),
+            healthcheck_path="/api/health",
+            updated_at="2026-05-01T04:29:07Z",
+            source_label="test",
+        )
+    )
+    store.write_dokploy_target_id_record(
+        DokployTargetIdRecord(
+            context="sellyouroutboard-testing",
+            instance="prod",
+            target_id="target-prod-123",
+            updated_at="2026-05-01T04:29:07Z",
+            source_label="test",
+        )
+    )
+    store.write_secret_version(
+        SecretVersion(
+            version_id="secret-version-source",
+            secret_id="secret-runtime-environment-smtp-password-sellyouroutboard-testing-prod",
+            created_at="2026-05-01T04:00:00Z",
+            ciphertext="encrypted-value",
+        )
+    )
+    store.write_secret_record(
+        SecretRecord(
+            secret_id="secret-runtime-environment-smtp-password-sellyouroutboard-testing-prod",
+            scope="context_instance",
+            integration="runtime_environment",
+            name="SMTP_PASSWORD",
+            context="sellyouroutboard-testing",
+            instance="prod",
+            current_version_id="secret-version-source",
+            created_at="2026-05-01T04:00:00Z",
+            updated_at="2026-05-01T04:00:00Z",
+        )
+    )
+    store.write_secret_binding(
+        SecretBinding(
+            binding_id="binding-source",
+            secret_id="secret-runtime-environment-smtp-password-sellyouroutboard-testing-prod",
+            integration="runtime_environment",
+            binding_key="SMTP_PASSWORD",
+            context="sellyouroutboard-testing",
+            instance="prod",
+            created_at="2026-05-01T04:00:00Z",
+            updated_at="2026-05-01T04:00:00Z",
+        )
+    )
+
+
+class ProductContextCutoverTests(unittest.TestCase):
+    def test_dry_run_reports_redacted_plan_without_writing_target_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "test.sqlite3")
+            )
+            try:
+                store.ensure_schema()
+                _seed_syo_source_records(store)
+
+                payload = apply_product_context_cutover(
+                    record_store=store,
+                    request=ProductContextCutoverRequest(
+                        product="sellyouroutboard",
+                        source_context="sellyouroutboard-testing",
+                        target_context="sellyouroutboard",
+                        display_name="SellYourOutboard",
+                    ),
+                )
+                target_runtime_records = store.list_runtime_environment_records(
+                    context_name="sellyouroutboard"
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(payload["mode"], "dry-run")
+        self.assertEqual(payload["profile"]["display_name"], "SellYourOutboard")
+        self.assertEqual(payload["profile"]["preview_context"], "sellyouroutboard")
+        self.assertEqual(
+            payload["counts"]["runtime_environment_records"],
+            {"created": 2, "skipped": 0},
+        )
+        self.assertEqual(payload["counts"]["managed_secret_records"], {"created": 1, "skipped": 0})
+        self.assertNotIn("encrypted-value", str(payload))
+        self.assertEqual(target_runtime_records, ())
+
+    def test_apply_copies_current_authority_records_and_updates_profile(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "test.sqlite3")
+            )
+            try:
+                store.ensure_schema()
+                _seed_syo_source_records(store)
+
+                payload = apply_product_context_cutover(
+                    record_store=store,
+                    request=ProductContextCutoverRequest(
+                        product="sellyouroutboard",
+                        source_context="sellyouroutboard-testing",
+                        target_context="sellyouroutboard",
+                        mode="apply",
+                        display_name="SellYourOutboard",
+                        source_label="test:cutover",
+                    ),
+                )
+
+                profile = store.read_product_profile_record("sellyouroutboard")
+                target_runtime_records = store.list_runtime_environment_records(
+                    context_name="sellyouroutboard"
+                )
+                target = store.read_dokploy_target_record(
+                    context_name="sellyouroutboard",
+                    instance_name="prod",
+                )
+                target_id = store.read_dokploy_target_id_record(
+                    context_name="sellyouroutboard",
+                    instance_name="prod",
+                )
+                secret = store.find_secret_record(
+                    scope="context_instance",
+                    integration="runtime_environment",
+                    name="SMTP_PASSWORD",
+                    context="sellyouroutboard",
+                    instance="prod",
+                )
+                assert secret is not None
+                version = store.read_secret_version(secret.current_version_id)
+                bindings = store.list_secret_bindings(
+                    integration="runtime_environment",
+                    context_name="sellyouroutboard",
+                    instance_name="prod",
+                    limit=None,
+                )
+                repeated_payload = apply_product_context_cutover(
+                    record_store=store,
+                    request=ProductContextCutoverRequest(
+                        product="sellyouroutboard",
+                        source_context="sellyouroutboard-testing",
+                        target_context="sellyouroutboard",
+                        mode="apply",
+                        display_name="SellYourOutboard",
+                        source_label="test:cutover",
+                    ),
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(payload["mode"], "apply")
+        self.assertEqual(profile.display_name, "SellYourOutboard")
+        self.assertEqual({lane.context for lane in profile.lanes}, {"sellyouroutboard"})
+        self.assertEqual(profile.preview.context, "sellyouroutboard")
+        self.assertEqual(len(target_runtime_records), 2)
+        self.assertEqual(target.target_name, "syo-prod-app")
+        self.assertEqual(target_id.target_id, "target-prod-123")
+        self.assertEqual(secret.context, "sellyouroutboard")
+        self.assertEqual(version.ciphertext, "encrypted-value")
+        self.assertEqual([binding.binding_key for binding in bindings], ["SMTP_PASSWORD"])
+        self.assertEqual(
+            repeated_payload["counts"]["runtime_environment_records"],
+            {"created": 0, "skipped": 2},
+        )
+        self.assertEqual(
+            repeated_payload["counts"]["managed_secret_records"],
+            {"created": 0, "skipped": 1},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1242,6 +1242,74 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ["sellyouroutboard"],
         )
 
+    def test_product_context_cutover_endpoint_updates_profile_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["launchplane"],
+                            "actions": ["product_profile.write", "product_profile.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                store.write_product_profile_record(
+                    LaunchplaneProductProfileRecord.model_validate(
+                        _product_profile_payload_with_prod()
+                    )
+                )
+            finally:
+                store.close()
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/product-profiles/context-cutover/apply",
+                payload={
+                    "product": "sellyouroutboard",
+                    "source_context": "sellyouroutboard-testing",
+                    "target_context": "sellyouroutboard",
+                    "mode": "apply",
+                    "display_name": "SellYourOutboard",
+                    "source_label": "test:context-cutover",
+                },
+                headers={"Idempotency-Key": "profile-context-cutover"},
+            )
+            show_status_code, show_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/product-profiles/sellyouroutboard",
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["records"], {"product_profile": "sellyouroutboard"})
+        self.assertEqual(payload["result"]["profile"]["display_name"], "SellYourOutboard")
+        self.assertEqual(show_status_code, 200)
+        self.assertEqual(show_payload["profile"]["display_name"], "SellYourOutboard")
+        self.assertEqual(
+            {lane["context"] for lane in show_payload["profile"]["lanes"]},
+            {"sellyouroutboard"},
+        )
+        self.assertEqual(show_payload["profile"]["preview"]["context"], "sellyouroutboard")
+
     def test_product_profile_context_cutover_audit_returns_redacted_metadata(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary

Adds a Launchplane-owned product context cutover path for SellYourOutboard-style legacy context cleanup.

## Details

- Adds POST /v1/product-profiles/context-cutover/apply.
- Supports mode=dry-run and mode=apply.
- Requires product_profile.write for the requested product in the Launchplane service context.
- Plans and applies only mutable current-authority records:
  - runtime environment records
  - managed secret records, copied without plaintext and without returning ciphertext
  - managed secret bindings
  - Dokploy target records
  - Dokploy target ID records
  - environment inventory records
  - release tuple records
  - product profile lane/preview context fields and display name
- Leaves append-only deployments, promotions, backup gates, and preview history untouched.
- Adds a manual Product Context Cutover workflow with dry_run=true by default.
- Extends deploy-time authz grant seeding for both audit read and cutover write workflows.

## Validation

- uv run --extra dev ruff format --check control_plane/product_context_cutover.py control_plane/service.py tests/test_product_context_cutover.py tests/test_service.py
- uv run --extra dev ruff check --fix --diff control_plane/product_context_cutover.py control_plane/service.py tests/test_product_context_cutover.py tests/test_service.py
- uv run --extra dev ruff check control_plane/product_context_cutover.py control_plane/service.py tests/test_product_context_cutover.py tests/test_service.py
- actionlint .github/workflows/deploy-launchplane.yml .github/workflows/product-context-cutover.yml .github/workflows/product-context-cutover-audit.yml
- markdownlint docs/service-boundary.md docs/operations.md
- uv run python -m unittest tests.test_product_context_cutover tests.test_service
- uv run python -m unittest
