### PR TITLE
Constrain product context cutover apply contexts

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -4520,6 +4520,25 @@ def create_launchplane_service_app(
                             },
                         },
                     )
+                profile = record_store.read_product_profile_record(request.product)
+                if not _product_profile_context_cutover_contexts_allowed(
+                    profile=profile,
+                    source_context=request.source_context,
+                    target_context=request.target_context,
+                    preview_context="",
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "context_not_in_product_boundary",
+                                "message": "Requested cutover contexts are not owned by the product profile.",
+                            },
+                        },
+                    )
                 idempotent_response = _check_idempotent_request(
                     record_store=record_store,
                     scope=request_scope,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1310,6 +1310,62 @@ class LaunchplaneServiceTests(unittest.TestCase):
         )
         self.assertEqual(show_payload["profile"]["preview"]["context"], "sellyouroutboard")
 
+    def test_product_context_cutover_endpoint_rejects_contexts_outside_product_boundary(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["launchplane"],
+                            "actions": ["product_profile.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                store.write_product_profile_record(
+                    LaunchplaneProductProfileRecord.model_validate(
+                        _product_profile_payload_with_prod()
+                    )
+                )
+            finally:
+                store.close()
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/product-profiles/context-cutover/apply",
+                payload={
+                    "product": "sellyouroutboard",
+                    "source_context": "verireel-testing",
+                    "target_context": "sellyouroutboard",
+                    "mode": "dry-run",
+                    "display_name": "SellYourOutboard",
+                },
+                headers={"Idempotency-Key": "profile-context-cutover-cross-product"},
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "context_not_in_product_boundary")
+
     def test_product_profile_context_cutover_audit_returns_redacted_metadata(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary

Fixes Codex P1 feedback on #144 by enforcing the product context boundary before Product Context Cutover apply/dry-run executes.

## Details

- Reads the requested product profile before the cutover route performs any plan/apply work.
- Reuses the same product-owned context guard as the read-only cutover audit route.
- Rejects source/target contexts outside the product boundary with `context_not_in_product_boundary`.
- Adds service coverage for a cross-product source context rejection.

## Validation

- uv run --extra dev ruff format --check control_plane/service.py tests/test_service.py
- uv run --extra dev ruff check --fix --diff control_plane/service.py tests/test_service.py
- uv run --extra dev ruff check control_plane/service.py tests/test_service.py
- uv run python -m unittest tests.test_service
- uv run python -m unittest
