### PR TITLE
Preserve cutover idempotent replay

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -4520,6 +4520,17 @@ def create_launchplane_service_app(
                             },
                         },
                     )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
                 profile = record_store.read_product_profile_record(request.product)
                 if not _product_profile_context_cutover_contexts_allowed(
                     profile=profile,
@@ -4539,17 +4550,6 @@ def create_launchplane_service_app(
                             },
                         },
                     )
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
                 try:
                     driver_result = (
                         control_plane_product_context_cutover.apply_product_context_cutover(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1293,6 +1293,20 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
                 headers={"Idempotency-Key": "profile-context-cutover"},
             )
+            replay_status_code, replay_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/product-profiles/context-cutover/apply",
+                payload={
+                    "product": "sellyouroutboard",
+                    "source_context": "sellyouroutboard-testing",
+                    "target_context": "sellyouroutboard",
+                    "mode": "apply",
+                    "display_name": "SellYourOutboard",
+                    "source_label": "test:context-cutover",
+                },
+                headers={"Idempotency-Key": "profile-context-cutover"},
+            )
             show_status_code, show_payload = _invoke_app(
                 app,
                 method="GET",
@@ -1301,6 +1315,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 202)
         self.assertEqual(payload["records"], {"product_profile": "sellyouroutboard"})
+        self.assertEqual(replay_status_code, 202)
+        self.assertEqual(replay_payload["records"], {"product_profile": "sellyouroutboard"})
+        self.assertEqual(replay_payload["result"], payload["result"])
         self.assertEqual(payload["result"]["profile"]["display_name"], "SellYourOutboard")
         self.assertEqual(show_status_code, 200)
         self.assertEqual(show_payload["profile"]["display_name"], "SellYourOutboard")


### PR DESCRIPTION
## Summary
- replay stored idempotent responses before revalidating product cutover context ownership
- keep the ownership guard for new executions
- add a service regression test for retrying a successful context cutover after the source context has moved out of the product profile

## Validation
- `uv run --extra dev ruff format --check control_plane/service.py tests/test_service.py` (reported test file formatting needed before formatting)
- `uv run --extra dev ruff format control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/service.py tests/test_service.py`
- `uv run python -m unittest tests.test_service -k product_context_cutover`
- `uv run python -m unittest`
- `git diff --check`
