### PR TITLE
Add legacy product context cleanup

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -354,3 +354,8 @@ jobs:
             product_profile.write \
             deploy:product-context-cutover-apply-grant \
             product-context-cutover-apply
+          post_grant \
+            product-legacy-context-cleanup.yml \
+            product_profile.write \
+            deploy:product-legacy-context-cleanup-grant \
+            product-legacy-context-cleanup

--- a/.github/workflows/product-legacy-context-cleanup.yml
+++ b/.github/workflows/product-legacy-context-cleanup.yml
@@ -1,0 +1,175 @@
+---
+name: Product Legacy Context Cleanup
+
+"on":
+  workflow_dispatch:
+    inputs:
+      product:
+        description: Product profile key to clean up.
+        required: true
+        default: sellyouroutboard
+        type: string
+      source_context:
+        description: Legacy context to clean up after cutover.
+        required: true
+        default: sellyouroutboard-testing
+        type: string
+      target_context:
+        description: >-
+          Canonical product context that must already hold replacement records.
+        required: true
+        default: sellyouroutboard
+        type: string
+      dry_run:
+        description: >-
+          Plan only when true; clean mutable legacy records when false.
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: launchplane-product-legacy-context-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    env:
+      LAUNCHPLANE_URL: >-
+        ${{ vars.LAUNCHPLANE_PUBLIC_URL ||
+        'https://launchplane.shinycomputers.com' }}
+      PRODUCT: ${{ inputs.product }}
+      SOURCE_CONTEXT: ${{ inputs.source_context }}
+      TARGET_CONTEXT: ${{ inputs.target_context }}
+      DRY_RUN: ${{ inputs.dry_run }}
+    steps:
+      - name: Request legacy context cleanup
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${LAUNCHPLANE_URL:?Missing LAUNCHPLANE_PUBLIC_URL variable}"
+          : "${PRODUCT:?Missing product input}"
+          : "${SOURCE_CONTEXT:?Missing source_context input}"
+          : "${TARGET_CONTEXT:?Missing target_context input}"
+
+          service_origin="$({
+            python3 - <<'PY'
+          import os
+          from urllib.parse import urlsplit
+
+          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"].strip())
+          if not parsed.scheme or not parsed.netloc or not parsed.hostname:
+              raise SystemExit("LAUNCHPLANE_URL must be an absolute URL.")
+          print(f"{parsed.scheme}://{parsed.netloc}")
+          PY
+          })"
+          service_audience="$({
+            python3 - <<'PY'
+          import os
+          from urllib.parse import urlsplit
+
+          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"].strip())
+          if not parsed.hostname:
+              raise SystemExit("LAUNCHPLANE_URL must include a hostname.")
+          print(parsed.hostname)
+          PY
+          })"
+          mode="apply"
+          if [ "$DRY_RUN" = "true" ]; then
+            mode="dry-run"
+          fi
+
+          oidc_token="$({
+            curl -fsSL \
+              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${service_audience}" \
+            | jq -r '.value'
+          })"
+          request_payload="$({
+            actor="github-actions:${GITHUB_REPOSITORY}:${GITHUB_RUN_ID}"
+            jq -n \
+              --arg product "$PRODUCT" \
+              --arg source_context "$SOURCE_CONTEXT" \
+              --arg target_context "$TARGET_CONTEXT" \
+              --arg mode "$mode" \
+              --arg actor "$actor" \
+              '{
+                product: $product,
+                source_context: $source_context,
+                target_context: $target_context,
+                mode: $mode,
+                actor: $actor,
+                source_label: "workflow:product-legacy-context-cleanup"
+              }'
+          })"
+          response_file="launchplane-product-legacy-context-cleanup.json"
+          idempotency_key="$({
+            printf 'product-legacy-context-cleanup:%s:%s:%s:%s:%s' \
+              "$PRODUCT" \
+              "$SOURCE_CONTEXT" \
+              "$TARGET_CONTEXT" \
+              "$mode" \
+              "$GITHUB_RUN_ID"
+          })"
+          status_code="$(curl -sS \
+            -o "$response_file" \
+            -w '%{http_code}' \
+            -X POST \
+            -H "Authorization: Bearer ${oidc_token}" \
+            -H 'Content-Type: application/json' \
+            -H "Idempotency-Key: ${idempotency_key}" \
+            --data "$request_payload" \
+            "${service_origin}/v1/product-profiles/legacy-context-cleanup/apply")"
+          if [ "$status_code" != "202" ]; then
+            cat "$response_file" >&2
+            echo "Cleanup failed with HTTP ${status_code}." >&2
+            exit 1
+          fi
+          jq . "$response_file"
+
+      - name: Upload cleanup artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: launchplane-product-legacy-context-cleanup-${{ inputs.product }}
+          path: launchplane-product-legacy-context-cleanup.json
+          if-no-files-found: error
+
+      - name: Summarize cleanup
+        shell: bash
+        run: |
+          set -euo pipefail
+          result_file="launchplane-product-legacy-context-cleanup.json"
+          blocked="$(jq -r '.result.blocked' "$result_file")"
+          runtime_counts="$({
+            jq -c '.result.counts.runtime_environment_records' "$result_file"
+          })"
+          secret_counts="$({
+            jq -c '.result.counts.managed_secret_records' "$result_file"
+          })"
+          target_counts="$({
+            jq -c '.result.counts.dokploy_targets' "$result_file"
+          })"
+          target_id_counts="$({
+            jq -c '.result.counts.dokploy_target_ids' "$result_file"
+          })"
+          preserved="$(jq -c '.result.preserved_records' "$result_file")"
+          {
+            echo '## Launchplane product legacy context cleanup'
+            echo
+            echo "- Product: ${PRODUCT}"
+            echo "- Source context: ${SOURCE_CONTEXT}"
+            echo "- Target context: ${TARGET_CONTEXT}"
+            echo "- Dry run: ${DRY_RUN}"
+            echo "- Blocked: ${blocked}"
+            echo "- Runtime records: ${runtime_counts}"
+            echo "- Managed secrets: ${secret_counts}"
+            echo "- Dokploy targets: ${target_counts}"
+            echo "- Dokploy target IDs: ${target_id_counts}"
+            echo "- Preserved records: ${preserved}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/control_plane/product_context_cutover.py
+++ b/control_plane/product_context_cutover.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import hashlib
+import uuid
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.runtime_environment_record import (
+    RuntimeEnvironmentDeleteEvent,
+    RuntimeEnvironmentRecord,
+)
 from control_plane.contracts.secret_record import (
     SecretAuditEvent,
     SecretBinding,
@@ -18,6 +23,7 @@ from control_plane.workflows.ship import utc_now_timestamp
 
 
 ContextCutoverMode = Literal["dry-run", "apply"]
+LegacyContextCleanupMode = Literal["dry-run", "apply"]
 
 
 class ProductContextCutoverRequest(BaseModel):
@@ -46,6 +52,38 @@ class ProductContextCutoverRequest(BaseModel):
                 "Product context cutover source_context and target_context must differ."
             )
         return self
+
+
+class LegacyContextCleanupRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    product: str
+    source_context: str
+    target_context: str
+    mode: LegacyContextCleanupMode = "dry-run"
+    actor: str = ""
+    source_label: str = "service:legacy-context-cleanup"
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "LegacyContextCleanupRequest":
+        self.product = self.product.strip()
+        self.source_context = self.source_context.strip()
+        self.target_context = self.target_context.strip()
+        self.actor = self.actor.strip()
+        self.source_label = self.source_label.strip() or "service:legacy-context-cleanup"
+        if not self.product:
+            raise ValueError("Legacy context cleanup requires product.")
+        if not self.source_context or not self.target_context:
+            raise ValueError("Legacy context cleanup requires source_context and target_context.")
+        if self.source_context == self.target_context:
+            raise ValueError(
+                "Legacy context cleanup source_context and target_context must differ."
+            )
+        return self
+
+
+class LegacyContextCleanupBoundaryError(ValueError):
+    pass
 
 
 def _slug(value: str) -> str:
@@ -79,12 +117,134 @@ def _target_secret_event_id(*, secret_id: str, source_secret_id: str) -> str:
 
 
 def _summarize_counts(items: list[dict[str, object]]) -> dict[str, int]:
-    counts = {"created": 0, "skipped": 0}
+    return {
+        "created": sum(1 for item in items if item.get("action") == "created"),
+        "skipped": sum(1 for item in items if item.get("action") == "skipped"),
+    }
+
+
+def _summarize_actions(items: list[dict[str, object]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
     for item in items:
         action = str(item.get("action") or "")
-        if action in counts:
+        if action:
+            counts.setdefault(action, 0)
             counts[action] += 1
     return counts
+
+
+def _profile_allowed_contexts(profile: LaunchplaneProductProfileRecord) -> frozenset[str]:
+    contexts = {profile.product.strip()}
+    contexts.update(lane.context.strip() for lane in profile.lanes if lane.context.strip())
+    if profile.preview.enabled and profile.preview.context.strip():
+        contexts.add(profile.preview.context.strip())
+    return frozenset(context for context in contexts if context)
+
+
+def _runtime_delete_event(
+    *,
+    record: RuntimeEnvironmentRecord,
+    actor: str,
+    source_label: str,
+    now: str,
+) -> RuntimeEnvironmentDeleteEvent:
+    return RuntimeEnvironmentDeleteEvent(
+        event_id=f"runtime-env-delete-{uuid.uuid4().hex[:12]}",
+        recorded_at=now,
+        actor=actor,
+        scope=record.scope,
+        context=record.context,
+        instance=record.instance,
+        source_label=record.source_label,
+        env_keys=tuple(sorted(record.env.keys())),
+        env_value_count=len(record.env),
+        detail=f"deleted by {source_label}",
+    )
+
+
+def _secret_cleanup_event_id(secret_id: str) -> str:
+    return f"{secret_id}-event-disabled-{uuid.uuid4().hex[:12]}"
+
+
+def _record_target_context_exists(
+    *,
+    record_store: PostgresRecordStore,
+    source_context: str,
+    target_context: str,
+    product: str,
+) -> None:
+    profile = record_store.read_product_profile_record(product)
+    target_contexts = _profile_allowed_contexts(profile)
+    if target_context not in target_contexts:
+        raise LegacyContextCleanupBoundaryError(
+            "Legacy context cleanup target_context is not owned by the product profile."
+        )
+    if source_context in target_contexts:
+        raise LegacyContextCleanupBoundaryError(
+            "Legacy context cleanup source_context is still owned by the product profile."
+        )
+    for other_profile in record_store.list_product_profile_records():
+        if other_profile.product == product:
+            continue
+        if source_context in _profile_allowed_contexts(other_profile):
+            raise LegacyContextCleanupBoundaryError(
+                "Legacy context cleanup source_context is owned by another product profile."
+            )
+
+
+def _target_runtime_route_exists(
+    *,
+    record_store: PostgresRecordStore,
+    source_record: RuntimeEnvironmentRecord,
+    target_context: str,
+) -> bool:
+    return any(
+        target.scope == source_record.scope and target.instance == source_record.instance
+        for target in record_store.list_runtime_environment_records(context_name=target_context)
+    )
+
+
+def _target_secret_route_exists(
+    *,
+    record_store: PostgresRecordStore,
+    source_record: SecretRecord,
+    target_context: str,
+) -> bool:
+    return (
+        record_store.find_secret_record(
+            scope=source_record.scope,
+            integration=source_record.integration,
+            name=source_record.name,
+            context=target_context,
+            instance=source_record.instance,
+        )
+        is not None
+    )
+
+
+def _target_instance_exists(
+    records: tuple[object, ...], *, target_context: str, instance: str
+) -> bool:
+    return any(
+        getattr(record, "context", "") == target_context
+        and getattr(record, "instance", "") == instance
+        for record in records
+    )
+
+
+def _source_secret_bindings(
+    *, record_store: PostgresRecordStore, record: SecretRecord
+) -> tuple[SecretBinding, ...]:
+    return tuple(
+        binding
+        for binding in record_store.list_secret_bindings(
+            integration=record.integration,
+            context_name=record.context,
+            instance_name=record.instance,
+            limit=None,
+        )
+        if binding.secret_id == record.secret_id
+    )
 
 
 def _profile_after_cutover(
@@ -519,4 +679,228 @@ def apply_product_context_cutover(
     )
     if _profile_semantic_payload(profile) != _profile_semantic_payload(next_profile):
         record_store.write_product_profile_record(next_profile)
+    return {**plan, "applied": True}
+
+
+def plan_legacy_context_cleanup(
+    *,
+    record_store: PostgresRecordStore,
+    request: LegacyContextCleanupRequest,
+) -> dict[str, object]:
+    _record_target_context_exists(
+        record_store=record_store,
+        source_context=request.source_context,
+        target_context=request.target_context,
+        product=request.product,
+    )
+
+    runtime_records: list[dict[str, object]] = []
+    for record in record_store.list_runtime_environment_records(
+        context_name=request.source_context
+    ):
+        target_exists = _target_runtime_route_exists(
+            record_store=record_store,
+            source_record=record,
+            target_context=request.target_context,
+        )
+        runtime_records.append(
+            {
+                "scope": record.scope,
+                "instance": record.instance,
+                "env_keys": sorted(record.env.keys()),
+                "env_value_count": len(record.env),
+                "action": "deleted" if target_exists else "blocked_missing_target",
+            }
+        )
+
+    secret_records: list[dict[str, object]] = []
+    for record in record_store.list_secret_records(
+        context_name=request.source_context,
+        limit=None,
+    ):
+        bindings = _source_secret_bindings(record_store=record_store, record=record)
+        target_exists = _target_secret_route_exists(
+            record_store=record_store,
+            source_record=record,
+            target_context=request.target_context,
+        )
+        action = "blocked_missing_target"
+        if target_exists:
+            action = "skipped" if record.status == "disabled" else "disabled"
+        secret_records.append(
+            {
+                "secret_id": record.secret_id,
+                "scope": record.scope,
+                "integration": record.integration,
+                "name": record.name,
+                "instance": record.instance,
+                "status": record.status,
+                "binding_keys": sorted(binding.binding_key for binding in bindings),
+                "binding_statuses": {binding.binding_key: binding.status for binding in bindings},
+                "action": action,
+            }
+        )
+
+    target_records = record_store.list_dokploy_target_records()
+    dokploy_targets = [
+        {
+            "instance": record.instance,
+            "target_type": record.target_type,
+            "target_name": record.target_name,
+            "domains": list(record.domains),
+            "env_keys": sorted(record.env.keys()),
+            "env_value_count": len(record.env),
+            "action": "deleted"
+            if _target_instance_exists(
+                target_records,
+                target_context=request.target_context,
+                instance=record.instance,
+            )
+            else "blocked_missing_target",
+        }
+        for record in target_records
+        if record.context == request.source_context
+    ]
+
+    target_id_records = record_store.list_dokploy_target_id_records()
+    dokploy_target_ids = [
+        {
+            "instance": record.instance,
+            "target_id": record.target_id,
+            "action": "deleted"
+            if _target_instance_exists(
+                target_id_records,
+                target_context=request.target_context,
+                instance=record.instance,
+            )
+            else "blocked_missing_target",
+        }
+        for record in target_id_records
+        if record.context == request.source_context
+    ]
+
+    preserved_inventory = tuple(
+        record
+        for record in record_store.list_environment_inventory()
+        if record.context == request.source_context
+    )
+    preserved_release_tuples = tuple(
+        record
+        for record in record_store.list_release_tuple_records()
+        if record.context == request.source_context
+    )
+    groups = {
+        "runtime_environment_records": runtime_records,
+        "managed_secret_records": secret_records,
+        "dokploy_targets": dokploy_targets,
+        "dokploy_target_ids": dokploy_target_ids,
+    }
+    blocked = any(
+        str(item.get("action") or "").startswith("blocked")
+        for items in groups.values()
+        for item in items
+    )
+    return {
+        "product": request.product,
+        "source_context": request.source_context,
+        "target_context": request.target_context,
+        "mode": request.mode,
+        "blocked": blocked,
+        "groups": groups,
+        "counts": {name: _summarize_actions(items) for name, items in groups.items()},
+        "preserved_records": {
+            "inventory_records": len(preserved_inventory),
+            "release_tuple_records": len(preserved_release_tuples),
+            "reason": "Historical evidence is preserved; cleanup only removes mutable lookup records and disables legacy secrets.",
+        },
+        "guardrails": [
+            "Refuses cleanup while source_context is still owned by this or another product profile.",
+            "Blocks each mutable source record unless the matching target_context record already exists.",
+            "Runtime values, secret plaintext, secret ciphertext, and full provider env text are not returned.",
+            "Inventory, release tuples, deployments, promotions, backup gates, and preview history are preserved as evidence.",
+        ],
+    }
+
+
+def apply_legacy_context_cleanup(
+    *,
+    record_store: PostgresRecordStore,
+    request: LegacyContextCleanupRequest,
+) -> dict[str, object]:
+    plan = plan_legacy_context_cleanup(record_store=record_store, request=request)
+    if request.mode == "dry-run":
+        return plan
+    if plan["blocked"]:
+        raise ValueError("Legacy context cleanup plan has blocked records.")
+
+    now = utc_now_timestamp()
+    actor = request.actor or request.source_label
+    for record in record_store.list_runtime_environment_records(
+        context_name=request.source_context
+    ):
+        status = record_store.delete_runtime_environment_record_with_event(
+            event=_runtime_delete_event(
+                record=record,
+                actor=actor,
+                source_label=request.source_label,
+                now=now,
+            ),
+            expected_record=record,
+        )
+        if status == "changed":
+            raise ValueError("Runtime environment record changed during cleanup.")
+
+    for record in record_store.list_secret_records(
+        context_name=request.source_context,
+        limit=None,
+    ):
+        if record.status != "disabled":
+            record_store.write_secret_record(
+                record.model_copy(
+                    update={
+                        "status": "disabled",
+                        "updated_at": now,
+                        "updated_by": actor,
+                    }
+                )
+            )
+            record_store.write_secret_audit_event(
+                SecretAuditEvent(
+                    event_id=_secret_cleanup_event_id(record.secret_id),
+                    secret_id=record.secret_id,
+                    event_type="disabled",
+                    recorded_at=now,
+                    actor=actor,
+                    detail="Launchplane disabled managed secret during legacy context cleanup.",
+                    metadata={
+                        "source": request.source_label,
+                        "source_context": request.source_context,
+                        "target_context": request.target_context,
+                    },
+                )
+            )
+        for binding in _source_secret_bindings(record_store=record_store, record=record):
+            if binding.status != "disabled":
+                record_store.write_secret_binding(
+                    binding.model_copy(update={"status": "disabled", "updated_at": now})
+                )
+
+    for record in tuple(
+        item
+        for item in record_store.list_dokploy_target_id_records()
+        if item.context == request.source_context
+    ):
+        status = record_store.delete_dokploy_target_id_record(expected_record=record)
+        if status == "changed":
+            raise ValueError("Dokploy target ID record changed during cleanup.")
+
+    for record in tuple(
+        item
+        for item in record_store.list_dokploy_target_records()
+        if item.context == request.source_context
+    ):
+        status = record_store.delete_dokploy_target_record(expected_record=record)
+        if status == "changed":
+            raise ValueError("Dokploy target record changed during cleanup.")
+
     return {**plan, "applied": True}

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2231,6 +2231,7 @@ def create_launchplane_service_app(
         "/v1/authz-policies/github-actions/grants",
         "/v1/product-config/apply",
         "/v1/product-profiles/context-cutover/apply",
+        "/v1/product-profiles/legacy-context-cleanup/apply",
         "/v1/previews/desired-state",
         "/v1/previews/pr-feedback",
         "/v1/previews/lifecycle-cleanup",
@@ -4567,6 +4568,86 @@ def create_launchplane_service_app(
                             "error": {
                                 "code": "invalid_context_cutover_request",
                                 "message": "Product context cutover request is invalid.",
+                            },
+                        },
+                    )
+                result = {"product_profile": request.product}
+            elif path == "/v1/product-profiles/legacy-context-cleanup/apply":
+                request = control_plane_product_context_cutover.LegacyContextCleanupRequest.model_validate(
+                    payload
+                )
+                if not isinstance(record_store, PostgresRecordStore):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "database_required",
+                                "message": "Legacy context cleanup requires Launchplane database storage.",
+                            },
+                        },
+                    )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="product_profile.write",
+                    product=request.product,
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot clean up the requested legacy product context.",
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                try:
+                    driver_result = (
+                        control_plane_product_context_cutover.apply_legacy_context_cleanup(
+                            record_store=record_store,
+                            request=request,
+                        )
+                    )
+                except control_plane_product_context_cutover.LegacyContextCleanupBoundaryError:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "context_not_in_product_boundary",
+                                "message": "Requested cleanup contexts are not in the product cleanup boundary.",
+                            },
+                        },
+                    )
+                except ValueError:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=400,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "invalid_legacy_context_cleanup_request",
+                                "message": "Legacy context cleanup request is invalid.",
                             },
                         },
                     )

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -49,6 +49,7 @@ ConnectionFactory = Callable[[], Any]
 PayloadDict = dict[str, Any]
 PayloadJsonType = JSON().with_variant(JSONB(), "postgresql")
 RuntimeEnvironmentDeleteStatus = Literal["deleted", "missing", "changed"]
+CurrentAuthorityDeleteStatus = Literal["deleted", "missing", "changed"]
 
 
 class Base(DeclarativeBase):
@@ -1370,6 +1371,34 @@ class PostgresRecordStore(HumanSessionStore):
             ),
         )
 
+    def delete_dokploy_target_id_record(
+        self,
+        *,
+        expected_record: DokployTargetIdRecord,
+    ) -> CurrentAuthorityDeleteStatus:
+        statement = (
+            select(LaunchplaneDokployTargetIdRow)
+            .where(
+                LaunchplaneDokployTargetIdRow.context == expected_record.context,
+                LaunchplaneDokployTargetIdRow.instance == expected_record.instance,
+            )
+            .limit(1)
+            .with_for_update()
+        )
+        with self._session_factory() as session:
+            row = session.scalar(statement)
+            if row is None:
+                return "missing"
+            current_record = self._read_payload(
+                model_type=DokployTargetIdRecord,
+                payload=row.payload,
+            )
+            if self._payload_dict(current_record) != self._payload_dict(expected_record):
+                return "changed"
+            session.delete(row)
+            session.commit()
+            return "deleted"
+
     def write_dokploy_target_record(self, record: DokployTargetRecord) -> None:
         self._write_row(
             LaunchplaneDokployTargetRow(
@@ -1401,6 +1430,34 @@ class PostgresRecordStore(HumanSessionStore):
                 LaunchplaneDokployTargetRow.instance.asc(),
             ),
         )
+
+    def delete_dokploy_target_record(
+        self,
+        *,
+        expected_record: DokployTargetRecord,
+    ) -> CurrentAuthorityDeleteStatus:
+        statement = (
+            select(LaunchplaneDokployTargetRow)
+            .where(
+                LaunchplaneDokployTargetRow.context == expected_record.context,
+                LaunchplaneDokployTargetRow.instance == expected_record.instance,
+            )
+            .limit(1)
+            .with_for_update()
+        )
+        with self._session_factory() as session:
+            row = session.scalar(statement)
+            if row is None:
+                return "missing"
+            current_record = self._read_payload(
+                model_type=DokployTargetRecord,
+                payload=row.payload,
+            )
+            if self._payload_dict(current_record) != self._payload_dict(expected_record):
+                return "changed"
+            session.delete(row)
+            session.commit()
+            return "deleted"
 
     def write_runtime_environment_record(self, record: RuntimeEnvironmentRecord) -> None:
         self._write_row(

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -123,6 +123,15 @@ targets, target IDs, inventories, release tuples, and the product profile lane
 contexts. The workflow intentionally leaves append-only deployments,
 promotions, backup gates, and preview history on their original contexts.
 
+After a cutover has been applied and the product profile no longer references
+the legacy context, run the manual Product Legacy Context Cleanup workflow with
+`dry_run=true`. The artifact reports mutable source records that can be cleaned:
+runtime environment records and Dokploy target lookups are deleted only when the
+matching target-context record already exists, and managed secret records and
+bindings are disabled rather than deleted. Run with `dry_run=false` only when
+`blocked=false`. Inventory records, release tuples, deployments, promotions,
+backup gates, and preview history are preserved as historical evidence.
+
 Render an explicit emergency bootstrap policy or import a policy into DB-backed
 records with:
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -144,12 +144,16 @@ generic-web lanes should converge on the product context, such as
 resolve one product stack. A separate preview context may remain while preview
 apps are isolated from stable lane records.
 
-When cleaning up a legacy context such as `sellyouroutboard-testing`, migrate or
-reseed only the mutable current-authority records needed by live resolution,
-such as runtime environments, secret bindings, tracked targets, inventories, and
-release tuples. Do not rewrite append-only deployments, promotions, backup
-gates, or preview history; those records are historical evidence and should
-continue to describe the route that produced them.
+When cleaning up a legacy context such as `sellyouroutboard-testing`, first
+copy or reseed only the mutable current-authority records needed by live
+resolution: runtime environments, managed secrets and bindings, tracked targets,
+tracked target IDs, inventories, and release tuples. After the product profile
+points at the canonical context, cleanup can delete legacy runtime environment
+records and Dokploy target lookups, and can disable legacy managed secret records
+and bindings. It should not delete inventory records, release tuples,
+deployments, promotions, backup gates, or preview history; those records are
+historical evidence and should continue to describe the route that produced
+them.
 
 Before changing a product profile or deleting legacy rows, audit both route
 families with:
@@ -170,6 +174,11 @@ The same redacted audit is exposed through the Launchplane service at
 `source_context`, `target_context`, and optional `preview_context` query
 parameters. The manual `Product Context Cutover Audit` GitHub workflow calls
 that service route through GitHub OIDC and uploads the redacted JSON artifact.
+The manual `Product Legacy Context Cleanup` GitHub workflow calls the matching
+write route through GitHub OIDC. It defaults to `dry_run=true`, refuses cleanup
+while the source context is still product-owned, blocks individual mutable
+records without target-context replacements, and preserves historical evidence
+rows.
 
 These records replace repo-local Launchplane lifecycle manifests. Product repos
 still own their normal app/runtime contract, such as Dockerfile, image publish,

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -46,6 +46,8 @@ VeriReel product paths:
   - `POST /v1/product-config/apply`
 - product context cutover route:
   - `POST /v1/product-profiles/context-cutover/apply`
+- product legacy context cleanup route:
+  - `POST /v1/product-profiles/legacy-context-cleanup/apply`
 - authz policy maintenance route:
   - `POST /v1/authz-policies/github-actions/grants`
 - product driver routes:
@@ -404,6 +406,17 @@ modes, copies only current-authority records into the target context, updates
 lane/preview product profile context fields, and returns key names/counts only.
 It does not copy append-only deployments, promotions, backup gates, or preview
 history.
+
+Product legacy context cleanup uses `product_profile.write` for the requested
+product in the Launchplane service context. It supports `dry-run` and `apply`
+modes after a context cutover has moved the product profile to the target
+context. Cleanup refuses to run while the source context is still owned by this
+or another product profile. It deletes legacy runtime environment records and
+Dokploy target lookup records only when matching target-context records already
+exist, disables legacy managed secret records and bindings, and preserves
+inventory, release tuple, deployment, promotion, backup gate, and preview
+history records as evidence. Responses remain redacted to key names, counts,
+target metadata, secret IDs, and binding keys/status.
 
 ### Driver execution endpoints
 

--- a/tests/test_product_context_cutover.py
+++ b/tests/test_product_context_cutover.py
@@ -13,7 +13,10 @@ from control_plane.contracts.product_profile_record import (
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.contracts.secret_record import SecretBinding, SecretRecord, SecretVersion
 from control_plane.product_context_cutover import (
+    LegacyContextCleanupBoundaryError,
+    LegacyContextCleanupRequest,
     ProductContextCutoverRequest,
+    apply_legacy_context_cleanup,
     apply_product_context_cutover,
 )
 from control_plane.storage.postgres import PostgresRecordStore
@@ -249,6 +252,131 @@ class ProductContextCutoverTests(unittest.TestCase):
             {"created": 0, "skipped": 1},
         )
         self.assertEqual(repeated_payload["profile"]["action"], "unchanged")
+
+    def test_legacy_cleanup_deletes_lookup_records_and_disables_source_secrets(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "test.sqlite3")
+            )
+            try:
+                store.ensure_schema()
+                _seed_syo_source_records(store)
+                apply_product_context_cutover(
+                    record_store=store,
+                    request=ProductContextCutoverRequest(
+                        product="sellyouroutboard",
+                        source_context="sellyouroutboard-testing",
+                        target_context="sellyouroutboard",
+                        mode="apply",
+                        display_name="SellYourOutboard",
+                    ),
+                )
+
+                dry_run = apply_legacy_context_cleanup(
+                    record_store=store,
+                    request=LegacyContextCleanupRequest(
+                        product="sellyouroutboard",
+                        source_context="sellyouroutboard-testing",
+                        target_context="sellyouroutboard",
+                    ),
+                )
+                payload = apply_legacy_context_cleanup(
+                    record_store=store,
+                    request=LegacyContextCleanupRequest(
+                        product="sellyouroutboard",
+                        source_context="sellyouroutboard-testing",
+                        target_context="sellyouroutboard",
+                        mode="apply",
+                        actor="test-operator",
+                    ),
+                )
+
+                source_runtime_records = store.list_runtime_environment_records(
+                    context_name="sellyouroutboard-testing"
+                )
+                target_runtime_records = store.list_runtime_environment_records(
+                    context_name="sellyouroutboard"
+                )
+                source_secrets = store.list_secret_records(
+                    context_name="sellyouroutboard-testing",
+                    limit=None,
+                )
+                source_bindings = store.list_secret_bindings(
+                    integration="runtime_environment",
+                    context_name="sellyouroutboard-testing",
+                    instance_name="prod",
+                    limit=None,
+                )
+                target_secret = store.find_secret_record(
+                    scope="context_instance",
+                    integration="runtime_environment",
+                    name="SMTP_PASSWORD",
+                    context="sellyouroutboard",
+                    instance="prod",
+                )
+                source_target_records = tuple(
+                    record
+                    for record in store.list_dokploy_target_records()
+                    if record.context == "sellyouroutboard-testing"
+                )
+                source_target_ids = tuple(
+                    record
+                    for record in store.list_dokploy_target_id_records()
+                    if record.context == "sellyouroutboard-testing"
+                )
+                target = store.read_dokploy_target_record(
+                    context_name="sellyouroutboard",
+                    instance_name="prod",
+                )
+                delete_events = store.list_runtime_environment_delete_events(
+                    context_name="sellyouroutboard-testing"
+                )
+                audit_events = store.list_secret_audit_events(
+                    secret_id="secret-runtime-environment-smtp-password-sellyouroutboard-testing-prod"
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(dry_run["mode"], "dry-run")
+        self.assertFalse(dry_run["blocked"])
+        self.assertEqual(dry_run["counts"]["runtime_environment_records"], {"deleted": 2})
+        self.assertEqual(dry_run["counts"]["managed_secret_records"], {"disabled": 1})
+        self.assertEqual(payload["mode"], "apply")
+        self.assertTrue(payload["applied"])
+        self.assertEqual(source_runtime_records, ())
+        self.assertEqual(len(target_runtime_records), 2)
+        self.assertEqual([secret.status for secret in source_secrets], ["disabled"])
+        self.assertEqual([binding.status for binding in source_bindings], ["disabled"])
+        self.assertIsNotNone(target_secret)
+        assert target_secret is not None
+        self.assertEqual(target_secret.status, "configured")
+        self.assertEqual(source_target_records, ())
+        self.assertEqual(source_target_ids, ())
+        self.assertEqual(target.target_name, "syo-prod-app")
+        self.assertEqual(len(delete_events), 2)
+        self.assertEqual([event.event_type for event in audit_events], ["disabled"])
+        self.assertNotIn("encrypted-value", str(payload))
+
+    def test_legacy_cleanup_rejects_source_context_still_owned_by_product(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "test.sqlite3")
+            )
+            try:
+                store.ensure_schema()
+                _seed_syo_source_records(store)
+
+                with self.assertRaises(LegacyContextCleanupBoundaryError):
+                    apply_legacy_context_cleanup(
+                        record_store=store,
+                        request=LegacyContextCleanupRequest(
+                            product="sellyouroutboard",
+                            source_context="sellyouroutboard-testing",
+                            target_context="sellyouroutboard",
+                        ),
+                    )
+            finally:
+                store.close()
 
 
 if __name__ == "__main__":

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1383,6 +1383,67 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "context_not_in_product_boundary")
 
+    def test_legacy_context_cleanup_endpoint_returns_redacted_dry_run(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["launchplane"],
+                            "actions": ["product_profile.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            profile_payload = _product_profile_payload_with_prod()
+            profile_payload["lanes"] = tuple(
+                {**lane, "context": "sellyouroutboard"} for lane in profile_payload["lanes"]
+            )
+            profile_payload["preview"] = {
+                **profile_payload["preview"],
+                "context": "sellyouroutboard",
+            }
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                store.write_product_profile_record(
+                    LaunchplaneProductProfileRecord.model_validate(profile_payload)
+                )
+            finally:
+                store.close()
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/product-profiles/legacy-context-cleanup/apply",
+                payload={
+                    "product": "sellyouroutboard",
+                    "source_context": "sellyouroutboard-testing",
+                    "target_context": "sellyouroutboard",
+                    "mode": "dry-run",
+                },
+                headers={"Idempotency-Key": "legacy-context-cleanup-dry-run"},
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["records"], {"product_profile": "sellyouroutboard"})
+        self.assertFalse(payload["result"]["blocked"])
+        self.assertEqual(payload["result"]["groups"]["runtime_environment_records"], [])
+
     def test_product_profile_context_cutover_audit_returns_redacted_metadata(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add a DB-backed legacy context cleanup plan/apply path after product context cutover
- delete legacy runtime env and Dokploy target lookup rows only when target-context replacements exist
- disable legacy managed secret records/bindings instead of deleting them, preserving secret audit events
- add a manual Product Legacy Context Cleanup workflow and deploy-time authz grant
- document cleanup boundaries and preserved historical evidence

## Safety behavior
- cleanup refuses while the source context is still owned by this product profile
- cleanup refuses when the source context is owned by another product profile
- apply fails if any mutable source record is blocked because its target replacement is missing
- inventory, release tuples, deployments, promotions, backup gates, and preview history are preserved
- responses stay redacted to key names, counts, secret IDs, binding keys/status, and target metadata

## Validation
- `uv run --extra dev ruff format --check control_plane/product_context_cutover.py control_plane/service.py control_plane/storage/postgres.py tests/test_product_context_cutover.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/product_context_cutover.py control_plane/service.py control_plane/storage/postgres.py tests/test_product_context_cutover.py tests/test_service.py`
- `uv run python -m unittest tests.test_product_context_cutover tests.test_service`
- `uv run python -m unittest`
- `git diff --check`
- `actionlint -config-file .github/actionlint.yaml`
- `markdownlint-cli2 docs/operations.md docs/records.md docs/service-boundary.md`

Note: Dockerized actionlint could not run locally because the Docker daemon socket was unavailable, so local installed `actionlint` was used. Repo-wide `ruff format --check .` still reports unrelated pre-existing files; changed-file format check passes.
