### PR TITLE
Document operator experience reset

### DIFF
--- a/.github/github-repo-workflow.json
+++ b/.github/github-repo-workflow.json
@@ -7,6 +7,7 @@
     "configBoundary": "docs/config-boundary.md",
     "serviceBoundary": "docs/service-boundary.md",
     "driverDescriptors": "docs/driver-descriptors.md",
+    "operatorExperience": "docs/operator-experience.md",
     "operations": "docs/operations.md",
     "records": "docs/records.md",
     "secrets": "docs/secrets.md",
@@ -66,12 +67,22 @@
     "CodeQL",
     "Deploy Launchplane",
     "Preview Lifecycle",
+    "Product Context Cutover",
+    "Product Legacy Context Cleanup",
     "Dependency Graph"
   ],
   "qaLabels": [],
   "deployLabels": [],
-  "healthUrls": [],
-  "relatedRepos": [],
+  "healthUrls": [
+    "https://launchplane.shinycomputers.com/v1/health"
+  ],
+  "relatedRepos": [
+    "cbusillo/sellyouroutboard",
+    "cbusillo/verireel",
+    "cbusillo/odoo-devkit",
+    "cbusillo/odoo-tenant-cm",
+    "cbusillo/odoo-tenant-opw"
+  ],
   "validatedThrough": [],
   "githubSignals": {
     "postMerge": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,8 @@ Use these docs as the source of truth for `launchplane`.
   deleting or demoting local CLI/file-backed compatibility surfaces.
 - [ui-standards.md](ui-standards.md) — tenant-first Launchplane UI direction and
   review rubric.
+- [operator-experience.md](operator-experience.md) — API-first product,
+  environment, settings, promotion, cleanup, and UI rebuild contract.
 - [operations.md](operations.md) — operator workflows and runtime boundary rules.
 - [records.md](records.md) — persisted record formats and storage policy.
 - [public-readiness.md](public-readiness.md) — current blockers and exit criteria

--- a/docs/operator-experience.md
+++ b/docs/operator-experience.md
@@ -1,0 +1,130 @@
+---
+title: Operator Experience
+---
+
+## Direction
+
+Launchplane operator work is API-first. Finish the product/environment API
+contract before rebuilding the browser UI. The current React UI is transitional;
+do not spend time refining its context picker or product-config layout except
+for secret-safety regressions.
+
+The rebuilt UI should be a product operations surface, not a raw record browser.
+The first screen should show products, their stable environments, current
+operational state, and the next safe action.
+
+## Product Model
+
+The primary operator model is:
+
+```text
+Product
+  - testing environment
+  - prod environment
+  - previews
+  - runtime settings
+  - secret bindings
+  - promotions
+  - activity
+  - maintenance
+```
+
+Product names are display names such as `SellYourOutboard`, `VeriReel`,
+`Odoo CM`, and `Odoo OPW`. Raw context strings are routing identifiers and
+should appear only as diagnostics or evidence metadata.
+
+For SellYourOutboard, the canonical product key is `sellyouroutboard`. Stable
+environments live under that product as `testing` and `prod`. Legacy names such
+as `sellyouroutboard-testing` are transition details and must not be the primary
+picker model.
+
+## API Contract
+
+Add product/environment read models before replacing the UI:
+
+- product overview: display name, product key, owning repo, driver, stable
+  environments, preview summary, warnings, and available actions
+- environment detail: addressed by product plus environment, with target,
+  domain, deploy, promotion, runtime, and secret summaries
+- settings summary: grouped runtime variables and managed secret bindings with
+  `configured`, `missing`, `disabled`, `unvalidated`, `stale`, or `unsupported`
+  states and no plaintext values
+- action availability: dry-run, workflow dispatch, settings apply, preview
+  refresh, and cleanup actions with explicit enabled/disabled reasons
+- activity: deployments, promotions, preview events, cleanup events, and authz or
+  policy changes that matter to operators
+
+Low-level records remain useful for diagnostics, but diagnostics are secondary.
+Normal operators should not need to choose a raw context or understand provider
+lookup rows before taking safe action.
+
+## Promotion Safety
+
+Browser sessions may dry-run generic-web promotion directly. Live promotion from
+the UI should dispatch the product-owned GitHub workflow rather than mutating
+prod directly from the browser session.
+
+Before claiming UI promotion is ready, prove the signed-in browser path against
+Launchplane:
+
+- dry-run generic-web promotion from the UI
+- workflow dispatch with `dry_run=true`
+- no GitHub release created during dry-run
+- no prod deployment during dry-run
+- visible action availability and failure reasons when authz or prerequisites
+  are missing
+
+Do not run a live SellYourOutboard promotion with `dry_run=false` until the
+dry-run path and evidence are clean.
+
+## Runtime Settings And Secrets
+
+Use operator language:
+
+- Runtime settings: non-secret environment/config values Launchplane owns.
+- Secrets: managed secret records and bindings. The UI shows status, binding,
+  validation, and audit metadata; it does not reveal plaintext values.
+
+Settings writes require dry-run first, show only key names/counts/status, and
+clear submitted secret values immediately on submit and on error.
+
+## Cleanup Safety
+
+Legacy cleanup is an admin or maintenance action, not a primary product flow.
+Cleanup must refuse to delete canonical product contexts and must only remove or
+disable current-authority legacy rows after replacement coverage is proven.
+
+Preserve historical records such as deployments, promotions, backup gates,
+preview history, inventory evidence, and release tuples. Delete or disable only
+mutable current-authority rows that Launchplane can prove are legacy.
+
+## Data Trust
+
+Every operator-visible field needs a trust state:
+
+- `verified`: directly refreshed from a provider or workflow within the expected
+  freshness window
+- `recorded`: real Launchplane evidence exists, but it is not freshly provider
+  verified
+- `stale`: evidence exists but is outside its freshness window
+- `missing`: Launchplane has no evidence for the field
+- `unsupported`: the driver intentionally does not expose the capability
+
+Do not show fixture, demo, fallback, inferred, or placeholder operational data in
+production UI without a visible trust state.
+
+## UI Rebuild
+
+When the API contract is ready, rebuild the UI around:
+
+- product list and product overview
+- environment detail for `testing`, `prod`, and previews
+- runtime settings and secrets grouped by product/environment
+- promotion dry-run and workflow dispatch
+- preview state and lifecycle actions
+- activity and diagnostics
+
+Reusable pieces from the current UI may survive only if they fit the new model:
+session/auth client, API request wrapper, status formatting, evidence formatting,
+and theme basics. The current context-picker/product-config flow should be
+hidden or removed once the new settings flow covers its use cases.

--- a/docs/public-readiness.md
+++ b/docs/public-readiness.md
@@ -1,11 +1,11 @@
 ---
-title: Public Readiness
+title: Public Source Posture
 ---
 
 ## Current Verdict
 
-The repo is acceptable to make public once the public-readiness scrub PR is
-merged and the first public CodeQL run is reviewed.
+The repository is public. Keep this document as the standing public-source
+posture, not as a one-time readiness gate.
 
 Launchplane is still product-proving-ground code, not a polished standalone
 distribution. That is acceptable for public source visibility because live
@@ -28,20 +28,19 @@ GitHub settings, and private product repos.
 ## Image And Secret Posture
 
 The Launchplane container image should not contain runtime secrets. The Docker
-build copies source, scripts, and public-safe config/docs, while `.dockerignore` excludes
-runtime state and local artifacts. Secrets such as database URLs, encryption
-keys, Dokploy credentials, product tokens, passwords, and SSH private keys should
-remain runtime inputs or Launchplane-managed encrypted records.
+build copies source, scripts, and public-safe config/docs, while `.dockerignore`
+excludes runtime state and local artifacts. Secrets such as database URLs,
+encryption keys, Dokploy credentials, product tokens, passwords, and SSH private
+keys should remain runtime inputs or Launchplane-managed encrypted records.
 
-The public-readiness concern is therefore not "the image has secrets baked in."
-The remaining concern is keeping product-private operations in private product
-repos and verifying the first public code-scanning signal after visibility
-changes.
+The public-source concern is therefore not "the image has secrets baked in."
+The ongoing concern is keeping product-private operations in private product
+repos and keeping GitHub security signals reviewed.
 
-## Ready-To-Public Checklist
+## Ongoing Public Hygiene
 
-- Keep the checked-in CodeQL workflow enabled once the repo is public and verify
-  initial code-scanning alerts are clean or tracked.
+- Keep the checked-in CodeQL workflow enabled and keep code-scanning alerts clean
+  or tracked.
 - Confirm live target identifiers and product-specific authorization policy stay
   out of checked-in config and are represented by DB-backed Launchplane records.
 - Audit the built image layers before any package visibility change and confirm
@@ -53,7 +52,8 @@ changes.
 
 ## Safe Public Posture
 
-The safe public posture before Launchplane is fully generalized is:
+The safe public posture while Launchplane is still becoming a generalized
+product is:
 
 - public source code
 - private runtime secrets and operator catalogs

--- a/docs/ui-standards.md
+++ b/docs/ui-standards.md
@@ -4,9 +4,13 @@ title: UI Standards
 
 ## Purpose
 
-Launchplane UI work must read as a tenant environment control plane, not a
+Launchplane UI work must read as a product environment control plane, not a
 generic dashboard and not a preview-only queue. The first screen should make the
 operator's current product, lane state, and next safe action obvious.
+
+Use [operator-experience.md](operator-experience.md) for the API-first product
+and environment contract. Do not polish the transitional context-picker UI as if
+it were the target model.
 
 Use this document as the Launchplane UI quality gate. UI slices that pass tests
 but fail this rubric are not complete.


### PR DESCRIPTION
## Summary

- add `docs/operator-experience.md` as the durable API-first product/environment and UI rebuild contract
- update docs index, UI standards, public-source posture, and repo workflow metadata
- record current Launchplane health URL, related repos, and product cutover/cleanup workflows

## Validation

- `markdownlint docs/README.md docs/public-readiness.md docs/ui-standards.md docs/operator-experience.md`
- `jq empty .github/github-repo-workflow.json`
- `git diff --check`
