### PR TITLE
Add generic product read models

### DIFF
--- a/control_plane/contracts/product_environment_read_model.py
+++ b/control_plane/contracts/product_environment_read_model.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable
-from typing import Protocol
+from typing import Literal, Protocol
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from control_plane.contracts.data_provenance import DataProvenance, FreshnessStatus
 from control_plane.contracts.driver_descriptor import DriverActionDescriptor, DriverDescriptor
 from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
+from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.contracts.preview_summary import LaunchplanePreviewSummary
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductLaneProfile,
@@ -18,6 +20,7 @@ from control_plane.drivers.registry import build_driver_context_view, read_drive
 
 
 ActionAllowed = Callable[[str, str, str], bool]
+ProductSecretBindingTrustState = FreshnessStatus | Literal["disabled"]
 
 
 class ProductReadModelStore(Protocol):
@@ -40,15 +43,15 @@ ACTION_AUTHZ_BY_ROUTE = {
     "/v1/drivers/generic-web/preview-readiness": "preview_readiness.evaluate",
     "/v1/drivers/generic-web/preview-destroy": "preview_destroy.execute",
     "/v1/drivers/odoo/artifact-publish-inputs": "odoo_artifact_publish_inputs.read",
-    "/v1/drivers/odoo/artifact-publish": "odoo_artifact_publish.execute",
+    "/v1/drivers/odoo/artifact-publish": "odoo_artifact_publish.write",
     "/v1/drivers/odoo/post-deploy": "odoo_post_deploy.execute",
     "/v1/drivers/odoo/prod-backup-gate": "odoo_prod_backup_gate.execute",
     "/v1/drivers/odoo/prod-promotion": "odoo_prod_promotion.execute",
     "/v1/drivers/odoo/prod-rollback": "odoo_prod_rollback.execute",
     "/v1/drivers/verireel/testing-deploy": "verireel_testing_deploy.execute",
-    "/v1/drivers/verireel/testing-verification": "verireel_testing_verification.execute",
+    "/v1/drivers/verireel/testing-verification": "deployment.write",
     "/v1/drivers/verireel/stable-environment": "verireel_stable_environment.read",
-    "/v1/drivers/verireel/runtime-verification": "verireel_runtime_verification.evaluate",
+    "/v1/drivers/verireel/runtime-verification": "verireel_stable_environment.read",
     "/v1/drivers/verireel/app-maintenance": "verireel_app_maintenance.execute",
     "/v1/drivers/verireel/prod-deploy": "verireel_prod_deploy.execute",
     "/v1/drivers/verireel/prod-backup-gate": "verireel_prod_backup_gate.execute",
@@ -57,7 +60,13 @@ ACTION_AUTHZ_BY_ROUTE = {
     "/v1/drivers/verireel/preview-refresh": "verireel_preview_refresh.execute",
     "/v1/drivers/verireel/preview-inventory": "verireel_preview_inventory.read",
     "/v1/drivers/verireel/preview-destroy": "verireel_preview_destroy.execute",
-    "/v1/drivers/verireel/preview-verification": "verireel_preview_verification.write",
+    "/v1/drivers/verireel/preview-verification": "preview_generation.write",
+}
+
+PREVIEW_PROFILE_REQUIRED_ACTION_IDS = {
+    "preview_desired_state",
+    "preview_inventory",
+    "preview_readiness",
 }
 
 OPERATOR_ACTION_IDS = {
@@ -115,7 +124,7 @@ class ProductSecretBindingSummary(BaseModel):
     instance: str
     status: str
     updated_at: str
-    trust_state: FreshnessStatus
+    trust_state: ProductSecretBindingTrustState
 
 
 class ProductTargetSummary(BaseModel):
@@ -225,14 +234,14 @@ def build_product_site_overview(
         for lane in profile.lanes
     )
     preview_summary = _build_preview_summary(record_store=record_store, profile=profile)
-    action_context = profile.preview.context or _first_lane_context(profile) or "launchplane"
     available_actions = _action_availability(
         descriptor=descriptor,
+        profile=profile,
         product=profile.product,
-        context=action_context,
         previews_enabled=profile.preview.enabled,
         action_allowed=action_allowed,
         include_unsupported=True,
+        context_resolver=_product_action_context_resolver(profile=profile),
     )
     warnings = tuple(warning for warning in (descriptor_warning,) if warning)
     trust_state = _combine_trust_states(
@@ -288,11 +297,12 @@ def build_product_environment_detail(
         managed_secrets=_secret_binding_summaries(lane_summary),
         available_actions=_action_availability(
             descriptor=descriptor,
+            profile=profile,
             product=profile.product,
-            context=lane.context,
             previews_enabled=profile.preview.enabled,
             action_allowed=action_allowed,
             include_unsupported=True,
+            context_resolver=_lane_context_resolver(context=lane.context),
         ),
         warnings=warnings,
         trust_state=provenance.freshness_status,
@@ -323,6 +333,104 @@ def _profile_provenance(profile: LaunchplaneProductProfileRecord) -> DataProvena
 def _first_lane_context(profile: LaunchplaneProductProfileRecord) -> str:
     first_lane = next(iter(profile.lanes), None)
     return first_lane.context if first_lane is not None else ""
+
+
+def _profile_anchor_repo(profile: LaunchplaneProductProfileRecord) -> str:
+    _owner, separator, repo = profile.repository.strip().partition("/")
+    if separator and repo.strip() and "/" not in repo.strip():
+        return repo.strip()
+    return profile.repository.strip()
+
+
+def _lane_context_for_instance(
+    *,
+    profile: LaunchplaneProductProfileRecord,
+    preferred_instances: tuple[str, ...],
+) -> str:
+    for preferred_instance in preferred_instances:
+        for lane in profile.lanes:
+            if lane.instance == preferred_instance and lane.context.strip():
+                return lane.context
+    return ""
+
+
+def _lane_context_if_present(*, profile: LaunchplaneProductProfileRecord, instance: str) -> str:
+    for lane in profile.lanes:
+        if lane.instance == instance and lane.context.strip():
+            return lane.context
+    return ""
+
+
+def _generic_web_prod_promotion_supported(profile: LaunchplaneProductProfileRecord) -> bool:
+    testing_context = _lane_context_if_present(profile=profile, instance="testing")
+    prod_context = _lane_context_if_present(profile=profile, instance="prod")
+    return bool(testing_context and prod_context and testing_context == prod_context)
+
+
+def _prod_lane_supported(profile: LaunchplaneProductProfileRecord) -> bool:
+    return bool(_lane_context_if_present(profile=profile, instance="prod"))
+
+
+def _product_action_authorization_context(
+    *, profile: LaunchplaneProductProfileRecord, action: DriverActionDescriptor
+) -> str:
+    if action.scope == "preview" or action.action_id.startswith("preview_"):
+        preview_context = profile.preview.context.strip()
+        if preview_context:
+            return preview_context
+        return _lane_context_for_instance(profile=profile, preferred_instances=("prod", "testing"))
+    if action.action_id in {"testing_deploy", "testing_verification"}:
+        return _lane_context_for_instance(profile=profile, preferred_instances=("testing", "prod"))
+    if action.route_path == "/v1/drivers/generic-web/prod-promotion":
+        if _generic_web_prod_promotion_supported(profile):
+            return _lane_context_if_present(profile=profile, instance="prod")
+        return ""
+    if action.route_path in {
+        "/v1/drivers/odoo/prod-backup-gate",
+        "/v1/drivers/odoo/prod-promotion",
+        "/v1/drivers/odoo/prod-rollback",
+        "/v1/drivers/verireel/prod-deploy",
+        "/v1/drivers/verireel/prod-backup-gate",
+        "/v1/drivers/verireel/prod-promotion",
+        "/v1/drivers/verireel/prod-rollback",
+    }:
+        if _prod_lane_supported(profile):
+            return _lane_context_if_present(profile=profile, instance="prod")
+        return ""
+    if action.action_id == "prod_promotion_workflow":
+        return _lane_context_for_instance(profile=profile, preferred_instances=("prod", "testing"))
+    if action.action_id == "prod_promotion":
+        return _lane_context_if_present(profile=profile, instance="prod")
+    if action.action_id == "prod_backup_gate" or action.action_id == "prod_rollback":
+        return _lane_context_if_present(profile=profile, instance="prod")
+    if action.action_id in {"stable_environment", "runtime_verification", "app_maintenance"}:
+        return _lane_context_for_instance(profile=profile, preferred_instances=("prod", "testing"))
+    if action.action_id == "stable_deploy":
+        return _lane_context_for_instance(profile=profile, preferred_instances=("testing", "prod"))
+    if action.scope == "context":
+        preview_context = profile.preview.context.strip()
+        if preview_context and profile.preview.enabled:
+            return preview_context
+        return ""
+    if action.scope == "instance":
+        return _lane_context_for_instance(profile=profile, preferred_instances=("prod", "testing"))
+    return ""
+
+
+def _product_action_context_resolver(
+    *, profile: LaunchplaneProductProfileRecord
+) -> Callable[[DriverActionDescriptor], str]:
+    def resolve(action: DriverActionDescriptor) -> str:
+        return _product_action_authorization_context(profile=profile, action=action)
+
+    return resolve
+
+
+def _lane_context_resolver(*, context: str) -> Callable[[DriverActionDescriptor], str]:
+    def resolve(_action: DriverActionDescriptor) -> str:
+        return context
+
+    return resolve
 
 
 def _find_lane(*, profile: LaunchplaneProductProfileRecord, environment: str) -> ProductLaneProfile:
@@ -360,11 +468,12 @@ def _build_environment_summary(
         provenance=provenance,
         available_actions=_action_availability(
             descriptor=descriptor,
+            profile=profile,
             product=profile.product,
-            context=lane.context,
             previews_enabled=profile.preview.enabled,
             action_allowed=action_allowed,
             include_unsupported=False,
+            context_resolver=_lane_context_resolver(context=lane.context),
         ),
     )
 
@@ -399,34 +508,61 @@ def _build_preview_summary(
 ) -> ProductPreviewSummary:
     if not profile.preview.enabled:
         return ProductPreviewSummary(enabled=False)
-    summaries = ()
+    summaries: tuple[LaunchplanePreviewSummary | PreviewRecord, ...] = ()
     list_preview_summaries = getattr(record_store, "list_preview_summaries", None)
     list_preview_records = getattr(record_store, "list_preview_records", None)
+    anchor_repo = _profile_anchor_repo(profile)
     if callable(list_preview_summaries):
         summaries = list_preview_summaries(
             context_name=profile.preview.context,
+            anchor_repo=anchor_repo,
+            preview_limit=None,
             generation_limit=1,
         )
     elif callable(list_preview_records):
-        summaries = tuple(list_preview_records(context_name=profile.preview.context, limit=10))
-    latest = next(iter(summaries), None)
+        summaries = tuple(
+            list_preview_records(
+                context_name=profile.preview.context,
+                anchor_repo=anchor_repo,
+                limit=None,
+            )
+        )
+    filtered_summaries: list[LaunchplanePreviewSummary | PreviewRecord] = []
+    for summary in summaries:
+        if isinstance(summary, LaunchplanePreviewSummary):
+            preview = summary.preview
+        else:
+            preview = summary
+        if preview.context != profile.preview.context:
+            continue
+        if preview.anchor_repo != anchor_repo:
+            continue
+        if preview.state == "destroyed":
+            continue
+        filtered_summaries.append(summary)
+    summaries = tuple(filtered_summaries)
+    latest_summary = next(iter(summaries), None)
     latest_preview_id = ""
     provenance = DataProvenance(
         source_kind="record",
         freshness_status="missing",
         detail="Launchplane has not recorded previews for this product profile.",
     )
-    if latest is not None:
-        preview = getattr(latest, "preview", latest)
+    if latest_summary is not None:
+        if isinstance(latest_summary, LaunchplanePreviewSummary):
+            preview = latest_summary.preview
+            provenance = latest_summary.provenance
+        else:
+            preview = latest_summary
+            provenance = DataProvenance(
+                source_kind="record",
+                source_record_id=preview.preview_id,
+                recorded_at=preview.updated_at,
+                refreshed_at=preview.updated_at,
+                freshness_status="recorded",
+                detail="Launchplane preview identity record.",
+            )
         latest_preview_id = preview.preview_id
-        provenance = getattr(latest, "provenance", None) or DataProvenance(
-            source_kind="record",
-            source_record_id=preview.preview_id,
-            recorded_at=preview.updated_at,
-            refreshed_at=preview.updated_at,
-            freshness_status="recorded",
-            detail="Launchplane preview identity record.",
-        )
     return ProductPreviewSummary(
         enabled=True,
         context=profile.preview.context,
@@ -441,11 +577,12 @@ def _build_preview_summary(
 def _action_availability(
     *,
     descriptor: DriverDescriptor | None,
+    profile: LaunchplaneProductProfileRecord,
     product: str,
-    context: str,
     previews_enabled: bool,
     action_allowed: ActionAllowed,
     include_unsupported: bool,
+    context_resolver: Callable[[DriverActionDescriptor], str],
 ) -> tuple[ProductActionAvailability, ...]:
     descriptor_actions = {
         action.action_id: action
@@ -474,8 +611,9 @@ def _action_availability(
         availability.append(
             _availability_for_descriptor_action(
                 action=descriptor_action,
+                profile=profile,
                 product=product,
-                context=context,
+                authorization_context=context_resolver(descriptor_action),
                 previews_enabled=previews_enabled,
                 action_allowed=action_allowed,
             )
@@ -486,16 +624,22 @@ def _action_availability(
 def _availability_for_descriptor_action(
     *,
     action: DriverActionDescriptor,
+    profile: LaunchplaneProductProfileRecord,
     product: str,
-    context: str,
+    authorization_context: str,
     previews_enabled: bool,
     action_allowed: ActionAllowed,
 ) -> ProductActionAvailability:
     disabled_reasons: list[str] = []
-    if action.scope == "preview" and not previews_enabled:
+    if not previews_enabled and (
+        action.scope == "preview" or action.action_id in PREVIEW_PROFILE_REQUIRED_ACTION_IDS
+    ):
         disabled_reasons.append("Product previews are not enabled.")
+    support_reason = _action_support_reason(profile=profile, action=action)
+    if support_reason:
+        disabled_reasons.append(support_reason)
     authz_action = ACTION_AUTHZ_BY_ROUTE.get(action.route_path, action.action_id)
-    if not action_allowed(authz_action, product, context):
+    if not action_allowed(authz_action, product, authorization_context):
         disabled_reasons.append("Caller is not authorized for this action.")
     return ProductActionAvailability(
         action_id=action.action_id,
@@ -510,6 +654,27 @@ def _availability_for_descriptor_action(
         disabled_reasons=tuple(disabled_reasons),
         trust_state="recorded",
     )
+
+
+def _action_support_reason(
+    *, profile: LaunchplaneProductProfileRecord, action: DriverActionDescriptor
+) -> str:
+    if action.route_path == "/v1/drivers/generic-web/prod-promotion":
+        if not _generic_web_prod_promotion_supported(profile):
+            return "Generic web prod promotion requires testing and prod lanes to share a context."
+        return ""
+    if action.route_path in {
+        "/v1/drivers/odoo/prod-backup-gate",
+        "/v1/drivers/odoo/prod-promotion",
+        "/v1/drivers/odoo/prod-rollback",
+        "/v1/drivers/verireel/prod-deploy",
+        "/v1/drivers/verireel/prod-backup-gate",
+        "/v1/drivers/verireel/prod-promotion",
+        "/v1/drivers/verireel/prod-rollback",
+    }:
+        if not _prod_lane_supported(profile):
+            return "Product profile does not define a prod lane."
+    return ""
 
 
 def _runtime_setting_summaries(
@@ -553,7 +718,7 @@ def _secret_binding_summary(binding: SecretBinding) -> ProductSecretBindingSumma
         instance=binding.instance,
         status=binding.status,
         updated_at=binding.updated_at,
-        trust_state="recorded" if binding.status == "configured" else "missing",
+        trust_state="recorded" if binding.status == "configured" else "disabled",
     )
 
 

--- a/control_plane/contracts/product_environment_read_model.py
+++ b/control_plane/contracts/product_environment_read_model.py
@@ -1,0 +1,587 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Protocol
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from control_plane.contracts.data_provenance import DataProvenance, FreshnessStatus
+from control_plane.contracts.driver_descriptor import DriverActionDescriptor, DriverDescriptor
+from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductLaneProfile,
+)
+from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
+from control_plane.contracts.secret_record import SecretBinding
+from control_plane.drivers.registry import build_driver_context_view, read_driver_descriptor
+
+
+ActionAllowed = Callable[[str, str, str], bool]
+
+
+class ProductReadModelStore(Protocol):
+    def list_product_profile_records(
+        self,
+        *,
+        driver_id: str = "",
+    ) -> tuple[LaunchplaneProductProfileRecord, ...]: ...
+
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord: ...
+
+
+ACTION_AUTHZ_BY_ROUTE = {
+    "/v1/drivers/generic-web/deploy": "generic_web_deploy.execute",
+    "/v1/drivers/generic-web/prod-promotion": "generic_web_prod_promotion.execute",
+    "/v1/drivers/generic-web/prod-promotion-workflow": "generic_web_prod_promotion.dispatch",
+    "/v1/drivers/generic-web/preview-desired-state": "preview_desired_state.discover",
+    "/v1/drivers/generic-web/preview-inventory": "preview_inventory.read",
+    "/v1/drivers/generic-web/preview-refresh": "preview_refresh.execute",
+    "/v1/drivers/generic-web/preview-readiness": "preview_readiness.evaluate",
+    "/v1/drivers/generic-web/preview-destroy": "preview_destroy.execute",
+    "/v1/drivers/odoo/artifact-publish-inputs": "odoo_artifact_publish_inputs.read",
+    "/v1/drivers/odoo/artifact-publish": "odoo_artifact_publish.execute",
+    "/v1/drivers/odoo/post-deploy": "odoo_post_deploy.execute",
+    "/v1/drivers/odoo/prod-backup-gate": "odoo_prod_backup_gate.execute",
+    "/v1/drivers/odoo/prod-promotion": "odoo_prod_promotion.execute",
+    "/v1/drivers/odoo/prod-rollback": "odoo_prod_rollback.execute",
+    "/v1/drivers/verireel/testing-deploy": "verireel_testing_deploy.execute",
+    "/v1/drivers/verireel/testing-verification": "verireel_testing_verification.execute",
+    "/v1/drivers/verireel/stable-environment": "verireel_stable_environment.read",
+    "/v1/drivers/verireel/runtime-verification": "verireel_runtime_verification.evaluate",
+    "/v1/drivers/verireel/app-maintenance": "verireel_app_maintenance.execute",
+    "/v1/drivers/verireel/prod-deploy": "verireel_prod_deploy.execute",
+    "/v1/drivers/verireel/prod-backup-gate": "verireel_prod_backup_gate.execute",
+    "/v1/drivers/verireel/prod-promotion": "verireel_prod_promotion.execute",
+    "/v1/drivers/verireel/prod-rollback": "verireel_prod_rollback.execute",
+    "/v1/drivers/verireel/preview-refresh": "verireel_preview_refresh.execute",
+    "/v1/drivers/verireel/preview-inventory": "verireel_preview_inventory.read",
+    "/v1/drivers/verireel/preview-destroy": "verireel_preview_destroy.execute",
+    "/v1/drivers/verireel/preview-verification": "verireel_preview_verification.write",
+}
+
+OPERATOR_ACTION_IDS = {
+    "stable_deploy": ("Deploy lane", "mutation", "instance"),
+    "prod_promotion": ("Promote testing to prod", "mutation", "instance"),
+    "prod_promotion_workflow": ("Dispatch promote workflow", "mutation", "instance"),
+    "prod_backup_gate": ("Capture prod backup gate", "safe_write", "instance"),
+    "prod_rollback": ("Roll back prod", "destructive", "instance"),
+    "preview_desired_state": ("Discover desired previews", "safe_write", "context"),
+    "preview_inventory": ("Read preview inventory", "read", "context"),
+    "preview_refresh": ("Refresh preview", "mutation", "preview"),
+    "preview_readiness": ("Evaluate preview readiness", "read", "context"),
+    "preview_destroy": ("Destroy preview", "destructive", "preview"),
+}
+
+
+class ProductActionAvailability(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    action_id: str
+    label: str
+    description: str = ""
+    safety: str
+    scope: str
+    method: str = ""
+    route_path: str = ""
+    authz_action: str = ""
+    enabled: bool
+    disabled_reasons: tuple[str, ...] = ()
+    trust_state: FreshnessStatus = "recorded"
+
+
+class ProductRuntimeSettingSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    scope: str
+    context: str
+    instance: str
+    env_keys: tuple[str, ...]
+    env_value_count: int = Field(ge=0)
+    updated_at: str
+    source_label: str
+    trust_state: FreshnessStatus = "recorded"
+
+
+class ProductSecretBindingSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    binding_id: str
+    secret_id: str
+    integration: str
+    binding_type: str
+    binding_key: str
+    context: str
+    instance: str
+    status: str
+    updated_at: str
+    trust_state: FreshnessStatus
+
+
+class ProductTargetSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    provider: str = "dokploy"
+    target_type: str = ""
+    target_name: str = ""
+    target_id_recorded: bool = False
+    trust_state: FreshnessStatus = "missing"
+
+
+class ProductEnvironmentSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    environment: str
+    context: str
+    base_url: str = ""
+    health_url: str = ""
+    trust_state: FreshnessStatus
+    provenance: DataProvenance
+    warnings: tuple[str, ...] = ()
+    available_actions: tuple[ProductActionAvailability, ...] = ()
+
+
+class ProductPreviewSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool
+    context: str = ""
+    slug_template: str = ""
+    active_count: int = Field(default=0, ge=0)
+    latest_preview_id: str = ""
+    trust_state: FreshnessStatus = "unsupported"
+    provenance: DataProvenance = DataProvenance(
+        source_kind="unsupported",
+        freshness_status="unsupported",
+        detail="Product previews are not enabled for this product profile.",
+    )
+
+
+class ProductSiteOverview(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    display_name: str
+    repository: str
+    driver_id: str
+    base_driver_id: str = ""
+    environments: tuple[ProductEnvironmentSummary, ...] = ()
+    preview: ProductPreviewSummary
+    warnings: tuple[str, ...] = ()
+    trust_state: FreshnessStatus
+    provenance: DataProvenance
+    available_actions: tuple[ProductActionAvailability, ...] = ()
+
+
+class ProductEnvironmentDetail(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    display_name: str
+    repository: str
+    driver_id: str
+    base_driver_id: str = ""
+    environment: str
+    context: str
+    base_url: str = ""
+    health_url: str = ""
+    target: ProductTargetSummary
+    runtime_settings: tuple[ProductRuntimeSettingSummary, ...] = ()
+    managed_secrets: tuple[ProductSecretBindingSummary, ...] = ()
+    available_actions: tuple[ProductActionAvailability, ...] = ()
+    warnings: tuple[str, ...] = ()
+    trust_state: FreshnessStatus
+    provenance: DataProvenance
+
+
+def build_product_site_overviews(
+    *, record_store: ProductReadModelStore, action_allowed: ActionAllowed
+) -> tuple[ProductSiteOverview, ...]:
+    return tuple(
+        build_product_site_overview(
+            record_store=record_store,
+            product=profile.product,
+            action_allowed=action_allowed,
+        )
+        for profile in record_store.list_product_profile_records()
+    )
+
+
+def build_product_site_overview(
+    *, record_store: ProductReadModelStore, product: str, action_allowed: ActionAllowed
+) -> ProductSiteOverview:
+    profile = record_store.read_product_profile_record(product)
+    descriptor, descriptor_warning = _read_profile_descriptor(profile)
+    environment_summaries = tuple(
+        _build_environment_summary(
+            record_store=record_store,
+            profile=profile,
+            descriptor=descriptor,
+            lane=lane,
+            action_allowed=action_allowed,
+        )
+        for lane in profile.lanes
+    )
+    preview_summary = _build_preview_summary(record_store=record_store, profile=profile)
+    action_context = profile.preview.context or _first_lane_context(profile) or "launchplane"
+    available_actions = _action_availability(
+        descriptor=descriptor,
+        product=profile.product,
+        context=action_context,
+        previews_enabled=profile.preview.enabled,
+        action_allowed=action_allowed,
+        include_unsupported=True,
+    )
+    warnings = tuple(warning for warning in (descriptor_warning,) if warning)
+    trust_state = _combine_trust_states(
+        (summary.trust_state for summary in environment_summaries),
+        fallback="recorded",
+    )
+    return ProductSiteOverview(
+        product=profile.product,
+        display_name=profile.display_name,
+        repository=profile.repository,
+        driver_id=profile.driver_id,
+        base_driver_id=descriptor.base_driver_id if descriptor is not None else "",
+        environments=environment_summaries,
+        preview=preview_summary,
+        warnings=warnings,
+        trust_state=trust_state,
+        provenance=_profile_provenance(profile),
+        available_actions=available_actions,
+    )
+
+
+def build_product_environment_detail(
+    *,
+    record_store: ProductReadModelStore,
+    product: str,
+    environment: str,
+    action_allowed: ActionAllowed,
+) -> ProductEnvironmentDetail:
+    profile = record_store.read_product_profile_record(product)
+    lane = _find_lane(profile=profile, environment=environment)
+    descriptor, descriptor_warning = _read_profile_descriptor(profile)
+    lane_summary = _read_product_lane_summary(
+        record_store=record_store,
+        profile=profile,
+        lane=lane,
+    )
+    provenance = (
+        lane_summary.provenance if lane_summary is not None else _missing_lane_provenance(lane)
+    )
+    warnings = tuple(warning for warning in (descriptor_warning,) if warning)
+    return ProductEnvironmentDetail(
+        product=profile.product,
+        display_name=profile.display_name,
+        repository=profile.repository,
+        driver_id=profile.driver_id,
+        base_driver_id=descriptor.base_driver_id if descriptor is not None else "",
+        environment=lane.instance,
+        context=lane.context,
+        base_url=lane.base_url,
+        health_url=lane.health_url,
+        target=_target_summary(lane_summary),
+        runtime_settings=_runtime_setting_summaries(lane_summary),
+        managed_secrets=_secret_binding_summaries(lane_summary),
+        available_actions=_action_availability(
+            descriptor=descriptor,
+            product=profile.product,
+            context=lane.context,
+            previews_enabled=profile.preview.enabled,
+            action_allowed=action_allowed,
+            include_unsupported=True,
+        ),
+        warnings=warnings,
+        trust_state=provenance.freshness_status,
+        provenance=provenance,
+    )
+
+
+def _read_profile_descriptor(
+    profile: LaunchplaneProductProfileRecord,
+) -> tuple[DriverDescriptor | None, str]:
+    try:
+        return read_driver_descriptor(profile.driver_id), ""
+    except FileNotFoundError:
+        return None, f"Product driver {profile.driver_id!r} is not registered in Launchplane."
+
+
+def _profile_provenance(profile: LaunchplaneProductProfileRecord) -> DataProvenance:
+    return DataProvenance(
+        source_kind="record",
+        source_record_id=profile.product,
+        recorded_at=profile.updated_at,
+        refreshed_at=profile.updated_at,
+        freshness_status="recorded",
+        detail="Launchplane product profile record.",
+    )
+
+
+def _first_lane_context(profile: LaunchplaneProductProfileRecord) -> str:
+    first_lane = next(iter(profile.lanes), None)
+    return first_lane.context if first_lane is not None else ""
+
+
+def _find_lane(*, profile: LaunchplaneProductProfileRecord, environment: str) -> ProductLaneProfile:
+    normalized_environment = environment.strip()
+    for lane in profile.lanes:
+        if lane.instance == normalized_environment:
+            return lane
+    raise FileNotFoundError(
+        f"Product {profile.product!r} has no environment {normalized_environment!r}."
+    )
+
+
+def _build_environment_summary(
+    *,
+    record_store: ProductReadModelStore,
+    profile: LaunchplaneProductProfileRecord,
+    descriptor: DriverDescriptor | None,
+    lane: ProductLaneProfile,
+    action_allowed: ActionAllowed,
+) -> ProductEnvironmentSummary:
+    lane_summary = _read_product_lane_summary(
+        record_store=record_store,
+        profile=profile,
+        lane=lane,
+    )
+    provenance = (
+        lane_summary.provenance if lane_summary is not None else _missing_lane_provenance(lane)
+    )
+    return ProductEnvironmentSummary(
+        environment=lane.instance,
+        context=lane.context,
+        base_url=lane.base_url,
+        health_url=lane.health_url,
+        trust_state=provenance.freshness_status,
+        provenance=provenance,
+        available_actions=_action_availability(
+            descriptor=descriptor,
+            product=profile.product,
+            context=lane.context,
+            previews_enabled=profile.preview.enabled,
+            action_allowed=action_allowed,
+            include_unsupported=False,
+        ),
+    )
+
+
+def _read_product_lane_summary(
+    *,
+    record_store: object,
+    profile: LaunchplaneProductProfileRecord,
+    lane: ProductLaneProfile,
+) -> LaunchplaneLaneSummary | None:
+    view = build_driver_context_view(
+        record_store=record_store,
+        context_name=lane.context,
+        instance_name=lane.instance,
+    )
+    for driver in view.drivers:
+        if driver.descriptor.product == profile.product or driver.driver_id == profile.driver_id:
+            return driver.lane_summary
+    return None
+
+
+def _missing_lane_provenance(lane: ProductLaneProfile) -> DataProvenance:
+    return DataProvenance(
+        source_kind="record",
+        freshness_status="missing",
+        detail=f"Launchplane has not recorded lane evidence for {lane.context}/{lane.instance}.",
+    )
+
+
+def _build_preview_summary(
+    *, record_store: object, profile: LaunchplaneProductProfileRecord
+) -> ProductPreviewSummary:
+    if not profile.preview.enabled:
+        return ProductPreviewSummary(enabled=False)
+    summaries = ()
+    list_preview_summaries = getattr(record_store, "list_preview_summaries", None)
+    list_preview_records = getattr(record_store, "list_preview_records", None)
+    if callable(list_preview_summaries):
+        summaries = list_preview_summaries(
+            context_name=profile.preview.context,
+            generation_limit=1,
+        )
+    elif callable(list_preview_records):
+        summaries = tuple(list_preview_records(context_name=profile.preview.context, limit=10))
+    latest = next(iter(summaries), None)
+    latest_preview_id = ""
+    provenance = DataProvenance(
+        source_kind="record",
+        freshness_status="missing",
+        detail="Launchplane has not recorded previews for this product profile.",
+    )
+    if latest is not None:
+        preview = getattr(latest, "preview", latest)
+        latest_preview_id = preview.preview_id
+        provenance = getattr(latest, "provenance", None) or DataProvenance(
+            source_kind="record",
+            source_record_id=preview.preview_id,
+            recorded_at=preview.updated_at,
+            refreshed_at=preview.updated_at,
+            freshness_status="recorded",
+            detail="Launchplane preview identity record.",
+        )
+    return ProductPreviewSummary(
+        enabled=True,
+        context=profile.preview.context,
+        slug_template=profile.preview.slug_template,
+        active_count=len(summaries),
+        latest_preview_id=latest_preview_id,
+        trust_state=provenance.freshness_status,
+        provenance=provenance,
+    )
+
+
+def _action_availability(
+    *,
+    descriptor: DriverDescriptor | None,
+    product: str,
+    context: str,
+    previews_enabled: bool,
+    action_allowed: ActionAllowed,
+    include_unsupported: bool,
+) -> tuple[ProductActionAvailability, ...]:
+    descriptor_actions = {
+        action.action_id: action
+        for action in (descriptor.actions if descriptor is not None else ())
+    }
+    action_ids = tuple(descriptor_actions)
+    if include_unsupported:
+        action_ids = tuple(dict.fromkeys((*action_ids, *OPERATOR_ACTION_IDS)))
+    availability = []
+    for action_id in action_ids:
+        descriptor_action = descriptor_actions.get(action_id)
+        if descriptor_action is None:
+            label, safety, scope = OPERATOR_ACTION_IDS[action_id]
+            availability.append(
+                ProductActionAvailability(
+                    action_id=action_id,
+                    label=label,
+                    safety=safety,
+                    scope=scope,
+                    enabled=False,
+                    disabled_reasons=("Driver does not support this action.",),
+                    trust_state="unsupported",
+                )
+            )
+            continue
+        availability.append(
+            _availability_for_descriptor_action(
+                action=descriptor_action,
+                product=product,
+                context=context,
+                previews_enabled=previews_enabled,
+                action_allowed=action_allowed,
+            )
+        )
+    return tuple(availability)
+
+
+def _availability_for_descriptor_action(
+    *,
+    action: DriverActionDescriptor,
+    product: str,
+    context: str,
+    previews_enabled: bool,
+    action_allowed: ActionAllowed,
+) -> ProductActionAvailability:
+    disabled_reasons: list[str] = []
+    if action.scope == "preview" and not previews_enabled:
+        disabled_reasons.append("Product previews are not enabled.")
+    authz_action = ACTION_AUTHZ_BY_ROUTE.get(action.route_path, action.action_id)
+    if not action_allowed(authz_action, product, context):
+        disabled_reasons.append("Caller is not authorized for this action.")
+    return ProductActionAvailability(
+        action_id=action.action_id,
+        label=action.label,
+        description=action.description,
+        safety=action.safety,
+        scope=action.scope,
+        method=action.method,
+        route_path=action.route_path,
+        authz_action=authz_action,
+        enabled=not disabled_reasons,
+        disabled_reasons=tuple(disabled_reasons),
+        trust_state="recorded",
+    )
+
+
+def _runtime_setting_summaries(
+    lane_summary: LaunchplaneLaneSummary | None,
+) -> tuple[ProductRuntimeSettingSummary, ...]:
+    if lane_summary is None:
+        return ()
+    return tuple(
+        _runtime_setting_summary(record) for record in lane_summary.runtime_environment_records
+    )
+
+
+def _runtime_setting_summary(record: RuntimeEnvironmentRecord) -> ProductRuntimeSettingSummary:
+    return ProductRuntimeSettingSummary(
+        scope=record.scope,
+        context=record.context,
+        instance=record.instance,
+        env_keys=tuple(sorted(record.env.keys())),
+        env_value_count=len(record.env),
+        updated_at=record.updated_at,
+        source_label=record.source_label,
+    )
+
+
+def _secret_binding_summaries(
+    lane_summary: LaunchplaneLaneSummary | None,
+) -> tuple[ProductSecretBindingSummary, ...]:
+    if lane_summary is None:
+        return ()
+    return tuple(_secret_binding_summary(binding) for binding in lane_summary.secret_bindings)
+
+
+def _secret_binding_summary(binding: SecretBinding) -> ProductSecretBindingSummary:
+    return ProductSecretBindingSummary(
+        binding_id=binding.binding_id,
+        secret_id=binding.secret_id,
+        integration=binding.integration,
+        binding_type=binding.binding_type,
+        binding_key=binding.binding_key,
+        context=binding.context,
+        instance=binding.instance,
+        status=binding.status,
+        updated_at=binding.updated_at,
+        trust_state="recorded" if binding.status == "configured" else "missing",
+    )
+
+
+def _target_summary(lane_summary: LaunchplaneLaneSummary | None) -> ProductTargetSummary:
+    if lane_summary is None or lane_summary.dokploy_target is None:
+        return ProductTargetSummary()
+    return ProductTargetSummary(
+        target_type=lane_summary.dokploy_target.target_type,
+        target_name=lane_summary.dokploy_target.target_name,
+        target_id_recorded=lane_summary.dokploy_target_id is not None,
+        trust_state="recorded",
+    )
+
+
+def _combine_trust_states(
+    states: Iterable[FreshnessStatus], *, fallback: FreshnessStatus
+) -> FreshnessStatus:
+    ordered_states = tuple(state for state in states if state)
+    if not ordered_states:
+        return fallback
+    priority: tuple[FreshnessStatus, ...] = (
+        "missing",
+        "stale",
+        "recorded",
+        "verified",
+        "unsupported",
+    )
+    for status in priority:
+        if status in ordered_states:
+            return status
+    return fallback

--- a/control_plane/contracts/product_environment_read_model.py
+++ b/control_plane/contracts/product_environment_read_model.py
@@ -386,6 +386,7 @@ def _product_action_authorization_context(
             return _lane_context_if_present(profile=profile, instance="prod")
         return ""
     if action.route_path in {
+        "/v1/drivers/generic-web/prod-promotion-workflow",
         "/v1/drivers/odoo/prod-backup-gate",
         "/v1/drivers/odoo/prod-promotion",
         "/v1/drivers/odoo/prod-rollback",
@@ -664,6 +665,7 @@ def _action_support_reason(
             return "Generic web prod promotion requires testing and prod lanes to share a context."
         return ""
     if action.route_path in {
+        "/v1/drivers/generic-web/prod-promotion-workflow",
         "/v1/drivers/odoo/prod-backup-gate",
         "/v1/drivers/odoo/prod-promotion",
         "/v1/drivers/odoo/prod-rollback",

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -54,6 +54,11 @@ from control_plane.contracts.preview_pr_feedback_record import (
     PreviewPrFeedbackStatus,
 )
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.product_environment_read_model import (
+    build_product_environment_detail,
+    build_product_site_overview,
+    build_product_site_overviews,
+)
 from control_plane.contracts.promotion_record import (
     HealthcheckEvidence,
     PostDeployUpdateEvidence,
@@ -1267,6 +1272,12 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "product_profile.read", {"product": segments[2], "context_cutover_audit": "true"}
     if len(segments) == 3 and segments[:2] == ["v1", "product-profiles"]:
         return "product_profile.read", {"product": segments[2]}
+    if len(segments) == 2 and segments == ["v1", "products"]:
+        return "product_environment.read", {}
+    if len(segments) == 3 and segments[:2] == ["v1", "products"]:
+        return "product_environment.read", {"product": segments[2]}
+    if len(segments) == 5 and segments[:2] == ["v1", "products"] and segments[3] == "environments":
+        return "product_environment.read", {"product": segments[2], "environment": segments[4]}
     return None
 
 
@@ -3025,6 +3036,117 @@ def create_launchplane_service_app(
                             "trace_id": request_trace_id,
                             "driver_id": driver_id_filter,
                             "profiles": [profile.model_dump(mode="json") for profile in profiles],
+                        },
+                    )
+                if action == "product_environment.read":
+
+                    def product_action_allowed(
+                        requested_action: str, requested_product: str, requested_context: str
+                    ) -> bool:
+                        return authz_policy.allows(
+                            identity=identity,
+                            action=requested_action,
+                            product=requested_product,
+                            context=requested_context,
+                        )
+
+                    if "environment" in params:
+                        detail = build_product_environment_detail(
+                            record_store=record_store,
+                            product=params["product"],
+                            environment=params["environment"],
+                            action_allowed=product_action_allowed,
+                        )
+                        if not product_action_allowed(
+                            "product_environment.read",
+                            detail.product,
+                            detail.context,
+                        ):
+                            return _json_response(
+                                start_response=start_response,
+                                status_code=403,
+                                payload={
+                                    "status": "rejected",
+                                    "trace_id": request_trace_id,
+                                    "error": {
+                                        "code": "authorization_denied",
+                                        "message": (
+                                            "Workflow cannot read the requested product environment."
+                                        ),
+                                    },
+                                },
+                            )
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=200,
+                            payload={
+                                "status": "ok",
+                                "trace_id": request_trace_id,
+                                "environment": detail.model_dump(mode="json"),
+                            },
+                        )
+                    if "product" in params:
+                        overview = build_product_site_overview(
+                            record_store=record_store,
+                            product=params["product"],
+                            action_allowed=product_action_allowed,
+                        )
+                        if not product_action_allowed(
+                            "product_environment.read",
+                            overview.product,
+                            "launchplane",
+                        ):
+                            return _json_response(
+                                start_response=start_response,
+                                status_code=403,
+                                payload={
+                                    "status": "rejected",
+                                    "trace_id": request_trace_id,
+                                    "error": {
+                                        "code": "authorization_denied",
+                                        "message": "Workflow cannot read the requested product overview.",
+                                    },
+                                },
+                            )
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=200,
+                            payload={
+                                "status": "ok",
+                                "trace_id": request_trace_id,
+                                "product": overview.model_dump(mode="json"),
+                            },
+                        )
+                    if not product_action_allowed(
+                        "product_environment.read",
+                        "launchplane",
+                        _LAUNCHPLANE_SERVICE_CONTEXT,
+                    ):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=403,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "authorization_denied",
+                                    "message": "Workflow cannot list product overviews.",
+                                },
+                            },
+                        )
+                    overviews = build_product_site_overviews(
+                        record_store=record_store,
+                        action_allowed=product_action_allowed,
+                    )
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=200,
+                        payload={
+                            "status": "ok",
+                            "trace_id": request_trace_id,
+                            "products": [
+                                overview.model_dump(mode="json") for overview in overviews
+                            ],
                         },
                     )
                 context_name = params["context"]

--- a/docs/operator-experience.md
+++ b/docs/operator-experience.md
@@ -58,6 +58,19 @@ Low-level records remain useful for diagnostics, but diagnostics are secondary.
 Normal operators should not need to choose a raw context or understand provider
 lookup rows before taking safe action.
 
+The first product/site read endpoints are:
+
+- `GET /v1/products`
+- `GET /v1/products/{product}`
+- `GET /v1/products/{product}/environments/{environment}`
+
+These endpoints are profile and driver driven. A standard `generic-web` site
+should appear in the read model from Launchplane records alone: product profile,
+lane profiles, target records, runtime-environment records, managed secret
+bindings, authz policy, and evidence records. The shared read model must not add
+product-specific top-level fields; driver-specific data belongs behind driver
+descriptor actions, capabilities, panels, or a driver-namespaced extension.
+
 ## Promotion Safety
 
 Browser sessions may dry-run generic-web promotion directly. Live promotion from

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -403,6 +403,14 @@ target identifiers remain evidence metadata; runtime values, secret plaintext,
 secret ciphertext, and product-specific driver payloads are not exposed as
 shared top-level fields.
 
+Preview-related product actions are only shown when the product profile enables
+previews. That includes generic-web preview discovery and inventory actions,
+not just refresh and destroy operations.
+
+Prod-scoped product actions are only shown when the product profile actually
+defines a prod lane. Generic-web prod promotion is additionally hidden unless
+the testing and prod lanes share the same context.
+
 Product context cutover audit is read-only and uses `product_profile.read` for
 the requested product in the Launchplane service context. It returns redacted
 current-authority metadata for source, target, and optional preview contexts:

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -374,6 +374,9 @@ only after a passing plan and a matching stored preview record are present.
 
 ### Operator read endpoints
 
+- `GET /v1/products`
+- `GET /v1/products/{product}`
+- `GET /v1/products/{product}/environments/{environment}`
 - `GET /v1/previews/{preview_id}`
 - `GET /v1/previews/{preview_id}/history`
 - `GET /v1/inventory/{context}/{instance}`
@@ -391,6 +394,14 @@ current Launchplane record nouns without forcing them to infer state from
 workflow logs or host-local files. Secret status reads return metadata only:
 Launchplane does not expose plaintext secret retrieval through the service
 boundary.
+
+Product/site reads use action `product_environment.read`. They compose
+Launchplane-owned product profiles, driver descriptors, stable lane records,
+preview summaries, runtime-environment key summaries, managed secret binding
+metadata, action availability, and trust state. Raw context names and provider
+target identifiers remain evidence metadata; runtime values, secret plaintext,
+secret ciphertext, and product-specific driver payloads are not exposed as
+shared top-level fields.
 
 Product context cutover audit is read-only and uses `product_profile.read` for
 the requested product in the Launchplane service context. It returns redacted

--- a/tests/test_product_environment_read_model.py
+++ b/tests/test_product_environment_read_model.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import cast
 import unittest
 
 from control_plane.contracts.preview_record import PreviewRecord
@@ -281,6 +282,28 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
         actions = {action.action_id: action for action in overview.available_actions}
         self.assertFalse(actions["prod_promotion_workflow"].enabled)
         self.assertFalse(actions["prod_promotion"].enabled)
+
+    def test_product_site_overview_hides_generic_web_prod_workflow_without_prod_lane(
+        self,
+    ) -> None:
+        payload = _site_profile_payload(preview_enabled=False)
+        lanes = cast("tuple[dict[str, object], ...]", payload["lanes"])
+        payload["lanes"] = tuple(lane for lane in lanes if lane["instance"] != "prod")
+        profile = LaunchplaneProductProfileRecord.model_validate(payload)
+
+        overview = build_product_site_overview(
+            record_store=_PreviewRecordStore(profile, ()),
+            product=profile.product,
+            action_allowed=lambda *_: True,
+        )
+
+        actions = {action.action_id: action for action in overview.available_actions}
+        self.assertFalse(actions["prod_promotion_workflow"].enabled)
+        self.assertFalse(actions["prod_promotion"].enabled)
+        self.assertIn(
+            "prod lane",
+            actions["prod_promotion_workflow"].disabled_reasons[0],
+        )
 
     def test_product_site_overview_hides_prod_actions_when_no_prod_lane_exists(self) -> None:
         profile = LaunchplaneProductProfileRecord.model_validate(

--- a/tests/test_product_environment_read_model.py
+++ b/tests/test_product_environment_read_model.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.contracts.product_environment_read_model import (
+    ACTION_AUTHZ_BY_ROUTE,
+    build_product_environment_detail,
+    build_product_site_overview,
+)
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.secret_record import SecretBinding
+from control_plane.storage.postgres import PostgresRecordStore
+
+
+def _site_profile_payload(
+    *,
+    product: str = "example-site",
+    preview_enabled: bool = True,
+    preview_context: str = "shared-preview",
+    testing_context: str = "example-site-testing",
+    prod_context: str = "example-site-prod",
+) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "product": product,
+        "display_name": "Example Site",
+        "repository": f"every/{product}",
+        "driver_id": "generic-web",
+        "image": {"repository": f"ghcr.io/every/{product}"},
+        "runtime_port": 3000,
+        "health_path": "/healthz",
+        "lanes": (
+            {
+                "instance": "testing",
+                "context": testing_context,
+                "base_url": f"https://testing.{product}.example",
+                "health_url": f"https://testing.{product}.example/healthz",
+            },
+            {
+                "instance": "prod",
+                "context": prod_context,
+                "base_url": f"https://{product}.example",
+                "health_url": f"https://{product}.example/healthz",
+            },
+        ),
+        "preview": {
+            "enabled": preview_enabled,
+            "context": preview_context,
+            "slug_template": "pr-{number}",
+        },
+        "updated_at": "2026-05-02T22:30:00Z",
+        "source": "test",
+    }
+
+
+def _preview_record(
+    *,
+    preview_id: str,
+    context: str,
+    anchor_repo: str,
+    state: str,
+    updated_at: str,
+) -> PreviewRecord:
+    return PreviewRecord.model_validate(
+        {
+            "schema_version": 1,
+            "preview_id": preview_id,
+            "context": context,
+            "anchor_repo": anchor_repo,
+            "anchor_pr_number": 1,
+            "anchor_pr_url": "https://github.com/every/example-site/pull/1",
+            "preview_label": "pr-1",
+            "canonical_url": f"https://{preview_id}.example.invalid",
+            "state": state,
+            "created_at": "2026-05-02T09:00:00Z",
+            "updated_at": updated_at,
+            "eligible_at": "2026-05-02T09:00:00Z",
+        }
+    )
+
+
+class _PreviewRecordStore:
+    def __init__(
+        self, profile: LaunchplaneProductProfileRecord, previews: tuple[PreviewRecord, ...]
+    ) -> None:
+        self._profile = profile
+        self._previews = previews
+        self.preview_record_calls: list[tuple[str, str]] = []
+
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
+        if product != self._profile.product:
+            raise FileNotFoundError(product)
+        return self._profile
+
+    def list_product_profile_records(
+        self, *, driver_id: str = ""
+    ) -> tuple[LaunchplaneProductProfileRecord, ...]:
+        if driver_id and driver_id != self._profile.driver_id:
+            return ()
+        return (self._profile,)
+
+    def list_preview_records(
+        self,
+        *,
+        context_name: str = "",
+        anchor_repo: str = "",
+        anchor_pr_number: int | None = None,
+        limit: int | None = None,
+    ) -> tuple[PreviewRecord, ...]:
+        self.preview_record_calls.append((context_name, anchor_repo))
+        return self._previews
+
+
+class ProductEnvironmentReadModelTest(unittest.TestCase):
+    def test_action_authz_map_matches_live_service_handlers(self) -> None:
+        self.assertEqual(
+            ACTION_AUTHZ_BY_ROUTE["/v1/drivers/odoo/artifact-publish"],
+            "odoo_artifact_publish.write",
+        )
+        self.assertEqual(
+            ACTION_AUTHZ_BY_ROUTE["/v1/drivers/verireel/testing-verification"],
+            "deployment.write",
+        )
+        self.assertEqual(
+            ACTION_AUTHZ_BY_ROUTE["/v1/drivers/verireel/runtime-verification"],
+            "verireel_stable_environment.read",
+        )
+        self.assertEqual(
+            ACTION_AUTHZ_BY_ROUTE["/v1/drivers/verireel/preview-verification"],
+            "preview_generation.write",
+        )
+
+    def test_product_site_overview_filters_preview_summaries_by_repository_and_state(self) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(_site_profile_payload())
+        store = _PreviewRecordStore(
+            profile,
+            (
+                _preview_record(
+                    preview_id="other-site-active",
+                    context="shared-preview",
+                    anchor_repo="other-site",
+                    state="active",
+                    updated_at="2026-05-02T14:00:00Z",
+                ),
+                _preview_record(
+                    preview_id="example-site-destroyed",
+                    context="shared-preview",
+                    anchor_repo="example-site",
+                    state="destroyed",
+                    updated_at="2026-05-02T13:00:00Z",
+                ),
+                _preview_record(
+                    preview_id="example-site-active",
+                    context="shared-preview",
+                    anchor_repo="example-site",
+                    state="active",
+                    updated_at="2026-05-02T12:00:00Z",
+                ),
+            ),
+        )
+
+        overview = build_product_site_overview(
+            record_store=store,
+            product=profile.product,
+            action_allowed=lambda *_: False,
+        )
+
+        self.assertIn(("shared-preview", "example-site"), store.preview_record_calls)
+        self.assertEqual(overview.preview.active_count, 1)
+        self.assertEqual(overview.preview.latest_preview_id, "example-site-active")
+
+    def test_product_site_overview_uses_canonical_prod_context_for_prod_actions(self) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(
+            _site_profile_payload(
+                preview_enabled=False,
+                testing_context="example-site-prod",
+                prod_context="example-site-prod",
+            )
+        )
+
+        def action_allowed(action: str, product: str, context: str) -> bool:
+            return (
+                action
+                in {
+                    "generic_web_prod_promotion.dispatch",
+                    "generic_web_prod_promotion.execute",
+                }
+                and context == "example-site-prod"
+            )
+
+        overview = build_product_site_overview(
+            record_store=_PreviewRecordStore(profile, ()),
+            product=profile.product,
+            action_allowed=action_allowed,
+        )
+
+        actions = {action.action_id: action for action in overview.available_actions}
+        self.assertTrue(actions["prod_promotion_workflow"].enabled)
+        self.assertTrue(actions["prod_promotion"].enabled)
+        self.assertFalse(actions["preview_refresh"].enabled)
+
+    def test_product_site_overview_uses_testing_context_for_deploy_actions(self) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(
+            _site_profile_payload(preview_enabled=False)
+        )
+
+        def action_allowed(action: str, product: str, context: str) -> bool:
+            return action == "generic_web_deploy.execute" and context == "example-site-testing"
+
+        overview = build_product_site_overview(
+            record_store=_PreviewRecordStore(profile, ()),
+            product=profile.product,
+            action_allowed=action_allowed,
+        )
+
+        actions = {action.action_id: action for action in overview.available_actions}
+        self.assertTrue(actions["stable_deploy"].enabled)
+        self.assertFalse(actions["prod_promotion"].enabled)
+
+    def test_product_site_overview_disables_generic_web_prod_promotion_for_mixed_contexts(
+        self,
+    ) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(
+            _site_profile_payload(preview_enabled=False)
+        )
+
+        overview = build_product_site_overview(
+            record_store=_PreviewRecordStore(profile, ()),
+            product=profile.product,
+            action_allowed=lambda *_: True,
+        )
+
+        actions = {action.action_id: action for action in overview.available_actions}
+        self.assertTrue(actions["prod_promotion_workflow"].enabled)
+        self.assertFalse(actions["prod_promotion"].enabled)
+        self.assertIn(
+            "share a context",
+            actions["prod_promotion"].disabled_reasons[0],
+        )
+
+    def test_preview_disabled_hides_generic_web_preview_actions(self) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(
+            _site_profile_payload(preview_enabled=False, preview_context="")
+        )
+
+        overview = build_product_site_overview(
+            record_store=_PreviewRecordStore(profile, ()),
+            product=profile.product,
+            action_allowed=lambda *_: True,
+        )
+
+        actions = {action.action_id: action for action in overview.available_actions}
+        self.assertFalse(actions["preview_desired_state"].enabled)
+        self.assertFalse(actions["preview_inventory"].enabled)
+        self.assertFalse(actions["preview_readiness"].enabled)
+        self.assertFalse(actions["preview_refresh"].enabled)
+        self.assertFalse(actions["preview_destroy"].enabled)
+
+    def test_product_site_overview_does_not_enable_prod_actions_for_testing_only_authz(
+        self,
+    ) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(
+            _site_profile_payload(preview_enabled=False)
+        )
+
+        def action_allowed(action: str, product: str, context: str) -> bool:
+            return context == "example-site-testing" and action in {
+                "generic_web_prod_promotion.dispatch",
+                "generic_web_prod_promotion.execute",
+            }
+
+        overview = build_product_site_overview(
+            record_store=_PreviewRecordStore(profile, ()),
+            product=profile.product,
+            action_allowed=action_allowed,
+        )
+
+        actions = {action.action_id: action for action in overview.available_actions}
+        self.assertFalse(actions["prod_promotion_workflow"].enabled)
+        self.assertFalse(actions["prod_promotion"].enabled)
+
+    def test_product_site_overview_hides_prod_actions_when_no_prod_lane_exists(self) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(
+            {
+                "schema_version": 1,
+                "product": "verireel",
+                "display_name": "VeriReel",
+                "repository": "every/verireel",
+                "driver_id": "verireel",
+                "image": {"repository": "ghcr.io/every/verireel"},
+                "runtime_port": 3000,
+                "health_path": "/healthz",
+                "lanes": (
+                    {
+                        "instance": "testing",
+                        "context": "verireel-testing",
+                        "base_url": "https://testing.verireel.example",
+                        "health_url": "https://testing.verireel.example/healthz",
+                    },
+                ),
+                "preview": {
+                    "enabled": False,
+                    "context": "",
+                    "slug_template": "pr-{number}",
+                },
+                "updated_at": "2026-05-02T22:30:00Z",
+                "source": "test",
+            }
+        )
+
+        overview = build_product_site_overview(
+            record_store=_PreviewRecordStore(profile, ()),
+            product=profile.product,
+            action_allowed=lambda *_: True,
+        )
+
+        actions = {action.action_id: action for action in overview.available_actions}
+        self.assertFalse(actions["prod_deploy"].enabled)
+        self.assertFalse(actions["prod_backup_gate"].enabled)
+        self.assertFalse(actions["prod_promotion"].enabled)
+        self.assertFalse(actions["prod_rollback"].enabled)
+        self.assertIn("prod lane", actions["prod_deploy"].disabled_reasons[0])
+
+    def test_product_environment_detail_preserves_disabled_secret_bindings(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            database_url = f"sqlite+pysqlite:///{database_path}"
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            profile = LaunchplaneProductProfileRecord.model_validate(
+                _site_profile_payload(preview_enabled=False, preview_context="")
+            )
+            store.write_product_profile_record(profile)
+            store.write_secret_binding(
+                SecretBinding(
+                    binding_id="binding-1",
+                    secret_id="secret-1",
+                    integration="runtime_environment",
+                    binding_key="SMTP_PASSWORD",
+                    context="example-site-prod",
+                    instance="prod",
+                    status="disabled",
+                    created_at="2026-05-02T22:31:00Z",
+                    updated_at="2026-05-02T22:32:00Z",
+                )
+            )
+
+            detail = build_product_environment_detail(
+                record_store=store,
+                product=profile.product,
+                environment="prod",
+                action_allowed=lambda *_: False,
+            )
+
+        self.assertEqual(detail.managed_secrets[0].status, "disabled")
+        self.assertEqual(detail.managed_secrets[0].trust_state, "disabled")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -239,6 +239,40 @@ def _product_profile_payload_with_prod(product: str = "sellyouroutboard") -> dic
     return payload
 
 
+def _generic_site_profile_payload(product: str = "example-site") -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "product": product,
+        "display_name": "Example Site",
+        "repository": f"every/{product}",
+        "driver_id": "generic-web",
+        "image": {"repository": f"ghcr.io/every/{product}"},
+        "runtime_port": 3000,
+        "health_path": "/healthz",
+        "lanes": (
+            {
+                "instance": "testing",
+                "context": product,
+                "base_url": f"https://testing.{product}.example",
+                "health_url": f"https://testing.{product}.example/healthz",
+            },
+            {
+                "instance": "prod",
+                "context": product,
+                "base_url": f"https://{product}.example",
+                "health_url": f"https://{product}.example/healthz",
+            },
+        ),
+        "preview": {
+            "enabled": True,
+            "context": product,
+            "slug_template": "pr-{number}",
+        },
+        "updated_at": "2026-05-02T22:30:00Z",
+        "source": "test",
+    }
+
+
 def _sqlite_database_url(database_path: Path) -> str:
     return f"sqlite+pysqlite:///{database_path}"
 
@@ -1241,6 +1275,156 @@ class LaunchplaneServiceTests(unittest.TestCase):
             [profile["product"] for profile in list_payload["profiles"]],
             ["sellyouroutboard"],
         )
+
+    def test_product_overview_endpoint_is_generic_web_profile_driven(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["launchplane", "example-site"],
+                            "contexts": ["launchplane", "example-site"],
+                            "actions": [
+                                "product_environment.read",
+                                "generic_web_prod_promotion.dispatch",
+                            ],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/products/example-site",
+            )
+
+        self.assertEqual(status_code, 200)
+        product = payload["product"]
+        response_text = json.dumps(payload)
+        self.assertEqual(product["product"], "example-site")
+        self.assertEqual(product["driver_id"], "generic-web")
+        self.assertEqual(
+            [environment["environment"] for environment in product["environments"]],
+            ["testing", "prod"],
+        )
+        actions = {action["action_id"]: action for action in product["available_actions"]}
+        self.assertTrue(actions["prod_promotion_workflow"]["enabled"])
+        self.assertFalse(actions["prod_backup_gate"]["enabled"])
+        self.assertEqual(actions["prod_backup_gate"]["trust_state"], "unsupported")
+        self.assertNotIn("sellyouroutboard", response_text)
+
+    def test_product_environment_detail_redacts_runtime_and_secret_values(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
+            )
+            store.write_dokploy_target_record(
+                DokployTargetRecord(
+                    context="example-site",
+                    instance="prod",
+                    target_type="application",
+                    target_name="example-site-prod",
+                    updated_at="2026-05-02T22:31:00Z",
+                    source_label="test",
+                )
+            )
+            store.write_dokploy_target_id_record(
+                DokployTargetIdRecord(
+                    context="example-site",
+                    instance="prod",
+                    target_id="app-prod-123",
+                    updated_at="2026-05-02T22:31:00Z",
+                    source_label="test",
+                )
+            )
+            store.write_runtime_environment_record(
+                RuntimeEnvironmentRecord(
+                    scope="instance",
+                    context="example-site",
+                    instance="prod",
+                    env={"INTERNAL_CALLBACK_URL": "https://internal.example-site.invalid"},
+                    updated_at="2026-05-02T22:32:00Z",
+                    source_label="test",
+                )
+            )
+            with patch.dict(
+                os.environ,
+                {control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"},
+                clear=True,
+            ):
+                control_plane_secrets.write_secret_value(
+                    record_store=store,
+                    scope="context_instance",
+                    integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+                    name="SMTP_PASSWORD",
+                    plaintext_value="super-secret-password",
+                    binding_key="SMTP_PASSWORD",
+                    context_name="example-site",
+                    instance_name="prod",
+                    actor="test",
+                )
+            store.close()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["example-site"],
+                            "contexts": ["example-site"],
+                            "actions": ["product_environment.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/products/example-site/environments/prod",
+            )
+
+        response_text = json.dumps(payload)
+        self.assertEqual(status_code, 200)
+        environment = payload["environment"]
+        self.assertEqual(environment["target"]["target_name"], "example-site-prod")
+        self.assertTrue(environment["target"]["target_id_recorded"])
+        self.assertEqual(environment["runtime_settings"][0]["env_keys"], ["INTERNAL_CALLBACK_URL"])
+        self.assertEqual(environment["managed_secrets"][0]["binding_key"], "SMTP_PASSWORD")
+        self.assertNotIn("https://internal.example-site.invalid", response_text)
+        self.assertNotIn("super-secret-password", response_text)
 
     def test_product_context_cutover_endpoint_updates_profile_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary

- Adds generic product/site read-model contracts for product overview and environment detail.
- Exposes `GET /v1/products`, `GET /v1/products/{product}`, and `GET /v1/products/{product}/environments/{environment}`.
- Composes product profiles, driver descriptors, lane evidence, target metadata, runtime key summaries, managed secret binding metadata, trust state, and action availability without exposing runtime values or secret material.
- Documents the new operator read surface.

Refs #152

## Validation

- `uv run python -m unittest tests.test_service tests.test_driver_descriptors`
- `uv run python -m unittest`
- `uv run --extra dev ruff format --check control_plane/contracts/product_environment_read_model.py control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/contracts/product_environment_read_model.py control_plane/service.py tests/test_service.py`
- `uv run --extra dev mypy control_plane/contracts/product_environment_read_model.py`

## Notes

Full repo mypy remains blocked by an existing baseline: `uv run --extra dev mypy control_plane tests` reports 786 errors across 42 files, unrelated to this slice.