### PR TITLE
Add product activity read model

### DIFF
--- a/control_plane/contracts/product_environment_read_model.py
+++ b/control_plane/contracts/product_environment_read_model.py
@@ -205,6 +205,42 @@ class ProductEnvironmentDetail(BaseModel):
     provenance: DataProvenance
 
 
+class ProductActivityRecordLink(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    record_type: str
+    record_id: str
+
+
+class ProductActivityEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event_id: str
+    event_type: str
+    product: str
+    context: str
+    environment: str = ""
+    driver_id: str
+    action_id: str
+    status: str
+    occurred_at: str
+    title: str
+    summary: str = ""
+    records: tuple[ProductActivityRecordLink, ...] = ()
+    trust_state: FreshnessStatus = "recorded"
+
+
+class ProductActivityReadModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    display_name: str
+    repository: str
+    driver_id: str
+    events: tuple[ProductActivityEvent, ...] = ()
+
+
 def build_product_site_overviews(
     *, record_store: ProductReadModelStore, action_allowed: ActionAllowed
 ) -> tuple[ProductSiteOverview, ...]:
@@ -310,6 +346,35 @@ def build_product_environment_detail(
     )
 
 
+def build_product_activity_read_model(
+    *, record_store: ProductReadModelStore, product: str, limit: int = 50
+) -> ProductActivityReadModel:
+    profile = record_store.read_product_profile_record(product)
+    events: list[ProductActivityEvent] = []
+    for lane in profile.lanes:
+        events.extend(
+            _deployment_activity_events(record_store=record_store, profile=profile, lane=lane)
+        )
+        events.extend(
+            _promotion_activity_events(record_store=record_store, profile=profile, lane=lane)
+        )
+        events.extend(
+            _backup_gate_activity_events(record_store=record_store, profile=profile, lane=lane)
+        )
+    if profile.preview.enabled and profile.preview.context.strip():
+        events.extend(_preview_activity_events(record_store=record_store, profile=profile))
+        events.extend(_preview_context_activity_events(record_store=record_store, profile=profile))
+    events.extend(_authz_policy_activity_events(record_store=record_store, profile=profile))
+    events.sort(key=lambda event: (event.occurred_at, event.event_id), reverse=True)
+    return ProductActivityReadModel(
+        product=profile.product,
+        display_name=profile.display_name,
+        repository=profile.repository,
+        driver_id=profile.driver_id,
+        events=tuple(events[:limit]),
+    )
+
+
 def _read_profile_descriptor(
     profile: LaunchplaneProductProfileRecord,
 ) -> tuple[DriverDescriptor | None, str]:
@@ -317,6 +382,321 @@ def _read_profile_descriptor(
         return read_driver_descriptor(profile.driver_id), ""
     except FileNotFoundError:
         return None, f"Product driver {profile.driver_id!r} is not registered in Launchplane."
+
+
+def _optional_records(
+    record_store: object, method_name: str, **kwargs: object
+) -> tuple[object, ...]:
+    method = getattr(record_store, method_name, None)
+    if not callable(method):
+        return ()
+    return tuple(method(**kwargs))
+
+
+def _record_link(record_type: str, record_id: str) -> ProductActivityRecordLink:
+    return ProductActivityRecordLink(record_type=record_type, record_id=record_id)
+
+
+def _event_trust_state(status: str) -> FreshnessStatus:
+    if status in {"pass", "ready", "active", "configured"}:
+        return "recorded"
+    if status in {"destroyed", "skipped", "superseded"}:
+        return "recorded"
+    if status in {"pending", "failed", "fail", "blocked"}:
+        return "recorded"
+    return "recorded"
+
+
+def _activity_event(
+    *,
+    event_type: str,
+    product: str,
+    context: str,
+    environment: str,
+    driver_id: str,
+    action_id: str,
+    status: str,
+    occurred_at: str,
+    title: str,
+    summary: str = "",
+    records: tuple[ProductActivityRecordLink, ...] = (),
+) -> ProductActivityEvent:
+    record_key = records[0].record_id if records else f"{context}:{environment}:{occurred_at}"
+    return ProductActivityEvent(
+        event_id=f"{event_type}:{record_key}",
+        event_type=event_type,
+        product=product,
+        context=context,
+        environment=environment,
+        driver_id=driver_id,
+        action_id=action_id,
+        status=status,
+        occurred_at=occurred_at,
+        title=title,
+        summary=summary,
+        records=records,
+        trust_state=_event_trust_state(status),
+    )
+
+
+def _lane_action_id(*, profile: LaunchplaneProductProfileRecord, lane: ProductLaneProfile) -> str:
+    if profile.driver_id == "verireel" and lane.instance == "testing":
+        return "testing_deploy"
+    if profile.driver_id == "verireel" and lane.instance == "prod":
+        return "prod_deploy"
+    return "stable_deploy"
+
+
+def _deployment_activity_events(
+    *, record_store: object, profile: LaunchplaneProductProfileRecord, lane: ProductLaneProfile
+) -> tuple[ProductActivityEvent, ...]:
+    events: list[ProductActivityEvent] = []
+    for record in _optional_records(
+        record_store,
+        "list_deployment_records",
+        context_name=lane.context,
+        instance_name=lane.instance,
+        limit=10,
+    ):
+        deploy = getattr(record, "deploy")
+        occurred_at = deploy.finished_at or deploy.started_at
+        events.append(
+            _activity_event(
+                event_type="deployment",
+                product=profile.product,
+                context=lane.context,
+                environment=lane.instance,
+                driver_id=profile.driver_id,
+                action_id=_lane_action_id(profile=profile, lane=lane),
+                status=str(deploy.status),
+                occurred_at=occurred_at,
+                title=f"{profile.display_name} {lane.instance} deployment",
+                summary=f"Deployment {deploy.status} for {lane.context}/{lane.instance}.",
+                records=(_record_link("deployment", str(getattr(record, "record_id"))),),
+            )
+        )
+    return tuple(events)
+
+
+def _promotion_activity_events(
+    *, record_store: object, profile: LaunchplaneProductProfileRecord, lane: ProductLaneProfile
+) -> tuple[ProductActivityEvent, ...]:
+    events: list[ProductActivityEvent] = []
+    for record in _optional_records(
+        record_store,
+        "list_promotion_records",
+        context_name=lane.context,
+        to_instance_name=lane.instance,
+        limit=10,
+    ):
+        deploy = getattr(record, "deploy")
+        rollback = getattr(record, "rollback")
+        rollback_attempted = bool(getattr(rollback, "attempted", False))
+        occurred_at = (
+            rollback.finished_at or rollback.started_at
+            if rollback_attempted
+            else deploy.finished_at or deploy.started_at
+        )
+        action_id = "prod_rollback" if rollback_attempted else "prod_promotion"
+        status = str(rollback.status if rollback_attempted else deploy.status)
+        record_links = [_record_link("promotion", str(getattr(record, "record_id")))]
+        deployment_record_id = str(getattr(record, "deployment_record_id", "") or "")
+        backup_record_id = str(getattr(record, "backup_record_id", "") or "")
+        if deployment_record_id:
+            record_links.append(_record_link("deployment", deployment_record_id))
+        if backup_record_id:
+            record_links.append(_record_link("backup_gate", backup_record_id))
+        events.append(
+            _activity_event(
+                event_type="rollback" if rollback_attempted else "promotion",
+                product=profile.product,
+                context=lane.context,
+                environment=lane.instance,
+                driver_id=profile.driver_id,
+                action_id=action_id,
+                status=status,
+                occurred_at=occurred_at,
+                title=f"{profile.display_name} {lane.instance} {action_id.replace('_', ' ')}",
+                summary=(
+                    f"{getattr(record, 'from_instance')} to "
+                    f"{getattr(record, 'to_instance')} {status}."
+                ),
+                records=tuple(record_links),
+            )
+        )
+    return tuple(events)
+
+
+def _backup_gate_activity_events(
+    *, record_store: object, profile: LaunchplaneProductProfileRecord, lane: ProductLaneProfile
+) -> tuple[ProductActivityEvent, ...]:
+    events: list[ProductActivityEvent] = []
+    for record in _optional_records(
+        record_store,
+        "list_backup_gate_records",
+        context_name=lane.context,
+        instance_name=lane.instance,
+        limit=10,
+    ):
+        events.append(
+            _activity_event(
+                event_type="backup_gate",
+                product=profile.product,
+                context=lane.context,
+                environment=lane.instance,
+                driver_id=profile.driver_id,
+                action_id="prod_backup_gate",
+                status=str(getattr(record, "status")),
+                occurred_at=str(getattr(record, "created_at")),
+                title=f"{profile.display_name} {lane.instance} backup gate",
+                summary=f"Backup gate {getattr(record, 'status')} for {lane.context}/{lane.instance}.",
+                records=(_record_link("backup_gate", str(getattr(record, "record_id"))),),
+            )
+        )
+    return tuple(events)
+
+
+def _preview_activity_events(
+    *, record_store: object, profile: LaunchplaneProductProfileRecord
+) -> tuple[ProductActivityEvent, ...]:
+    events: list[ProductActivityEvent] = []
+    for record in _optional_records(
+        record_store,
+        "list_preview_records",
+        context_name=profile.preview.context,
+        anchor_repo=_profile_anchor_repo(profile),
+        limit=10,
+    ):
+        state = str(getattr(record, "state"))
+        action_id = "preview_destroy" if state == "destroyed" else "preview_refresh"
+        events.append(
+            _activity_event(
+                event_type="preview",
+                product=profile.product,
+                context=profile.preview.context,
+                environment="preview",
+                driver_id=profile.driver_id,
+                action_id=action_id,
+                status=state,
+                occurred_at=str(getattr(record, "updated_at")),
+                title=f"{profile.display_name} preview {state}",
+                summary=str(getattr(record, "preview_label")),
+                records=(_record_link("preview", str(getattr(record, "preview_id"))),),
+            )
+        )
+    return tuple(events)
+
+
+def _preview_context_activity_events(
+    *, record_store: object, profile: LaunchplaneProductProfileRecord
+) -> tuple[ProductActivityEvent, ...]:
+    events: list[ProductActivityEvent] = []
+    preview_context = profile.preview.context
+    for record in _optional_records(
+        record_store,
+        "list_preview_desired_state_records",
+        context_name=preview_context,
+        limit=5,
+    ):
+        if getattr(record, "product", "") != profile.product:
+            continue
+        events.append(
+            _activity_event(
+                event_type="preview_desired_state",
+                product=profile.product,
+                context=preview_context,
+                environment="preview",
+                driver_id=profile.driver_id,
+                action_id="preview_desired_state",
+                status=str(getattr(record, "status")),
+                occurred_at=str(getattr(record, "discovered_at")),
+                title=f"{profile.display_name} desired previews discovered",
+                summary=f"{getattr(record, 'desired_count')} desired preview(s).",
+                records=(
+                    _record_link("preview_desired_state", str(getattr(record, "desired_state_id"))),
+                ),
+            )
+        )
+    for record in _optional_records(
+        record_store,
+        "list_preview_lifecycle_cleanup_records",
+        context_name=preview_context,
+        limit=5,
+    ):
+        if getattr(record, "product", "") != profile.product:
+            continue
+        events.append(
+            _activity_event(
+                event_type="preview_cleanup",
+                product=profile.product,
+                context=preview_context,
+                environment="preview",
+                driver_id=profile.driver_id,
+                action_id="preview_destroy",
+                status=str(getattr(record, "status")),
+                occurred_at=str(getattr(record, "requested_at")),
+                title=f"{profile.display_name} preview cleanup",
+                records=(
+                    _record_link("preview_lifecycle_cleanup", str(getattr(record, "cleanup_id"))),
+                ),
+            )
+        )
+    for record in _optional_records(
+        record_store,
+        "list_preview_pr_feedback_records",
+        context_name=preview_context,
+        limit=5,
+    ):
+        if getattr(record, "product", "") != profile.product:
+            continue
+        events.append(
+            _activity_event(
+                event_type="preview_pr_feedback",
+                product=profile.product,
+                context=preview_context,
+                environment="preview",
+                driver_id=profile.driver_id,
+                action_id="preview_pr_feedback",
+                status=str(getattr(record, "status")),
+                occurred_at=str(getattr(record, "requested_at")),
+                title=f"{profile.display_name} preview PR feedback",
+                records=(_record_link("preview_pr_feedback", str(getattr(record, "feedback_id"))),),
+            )
+        )
+    return tuple(events)
+
+
+def _authz_policy_mentions_product(record: object, product: str) -> bool:
+    policy = getattr(record, "policy", None)
+    if policy is None:
+        return False
+    rules = (*getattr(policy, "github_actions", ()), *getattr(policy, "github_humans", ()))
+    return any(product in getattr(rule, "products", ()) for rule in rules)
+
+
+def _authz_policy_activity_events(
+    *, record_store: object, profile: LaunchplaneProductProfileRecord
+) -> tuple[ProductActivityEvent, ...]:
+    events: list[ProductActivityEvent] = []
+    for record in _optional_records(record_store, "list_authz_policy_records", limit=5):
+        if not _authz_policy_mentions_product(record, profile.product):
+            continue
+        events.append(
+            _activity_event(
+                event_type="authz_policy",
+                product=profile.product,
+                context="launchplane",
+                environment="",
+                driver_id="launchplane",
+                action_id="authz_policy.update",
+                status=str(getattr(record, "status")),
+                occurred_at=str(getattr(record, "updated_at")),
+                title=f"{profile.display_name} authorization policy updated",
+                summary=str(getattr(record, "source")),
+                records=(_record_link("authz_policy", str(getattr(record, "record_id"))),),
+            )
+        )
+    return tuple(events)
 
 
 def _profile_provenance(profile: LaunchplaneProductProfileRecord) -> DataProvenance:

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -55,6 +55,7 @@ from control_plane.contracts.preview_pr_feedback_record import (
 )
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.product_environment_read_model import (
+    build_product_activity_read_model,
     build_product_environment_detail,
     build_product_site_overview,
     build_product_site_overviews,
@@ -1274,6 +1275,8 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "product_profile.read", {"product": segments[2]}
     if len(segments) == 2 and segments == ["v1", "products"]:
         return "product_environment.read", {}
+    if len(segments) == 4 and segments[:2] == ["v1", "products"] and segments[3] == "activity":
+        return "product_environment.read", {"product": segments[2], "activity": "true"}
     if len(segments) == 3 and segments[:2] == ["v1", "products"]:
         return "product_environment.read", {"product": segments[2]}
     if len(segments) == 5 and segments[:2] == ["v1", "products"] and segments[3] == "environments":
@@ -3050,6 +3053,37 @@ def create_launchplane_service_app(
                             context=requested_context,
                         )
 
+                    if params.get("activity") == "true":
+                        activity = build_product_activity_read_model(
+                            record_store=record_store,
+                            product=params["product"],
+                        )
+                        if not product_action_allowed(
+                            "product_environment.read",
+                            activity.product,
+                            "launchplane",
+                        ):
+                            return _json_response(
+                                start_response=start_response,
+                                status_code=403,
+                                payload={
+                                    "status": "rejected",
+                                    "trace_id": request_trace_id,
+                                    "error": {
+                                        "code": "authorization_denied",
+                                        "message": "Workflow cannot read the requested product activity.",
+                                    },
+                                },
+                            )
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=200,
+                            payload={
+                                "status": "ok",
+                                "trace_id": request_trace_id,
+                                "activity": activity.model_dump(mode="json"),
+                            },
+                        )
                     if "environment" in params:
                         detail = build_product_environment_detail(
                             record_store=record_store,

--- a/docs/operator-experience.md
+++ b/docs/operator-experience.md
@@ -62,6 +62,7 @@ The first product/site read endpoints are:
 
 - `GET /v1/products`
 - `GET /v1/products/{product}`
+- `GET /v1/products/{product}/activity`
 - `GET /v1/products/{product}/environments/{environment}`
 
 These endpoints are profile and driver driven. A standard `generic-web` site
@@ -70,6 +71,12 @@ lane profiles, target records, runtime-environment records, managed secret
 bindings, authz policy, and evidence records. The shared read model must not add
 product-specific top-level fields; driver-specific data belongs behind driver
 descriptor actions, capabilities, panels, or a driver-namespaced extension.
+
+Product activity is an operator timeline composed from existing Launchplane
+records. Events carry product, context, environment, driver id, action id,
+status, timestamp, and record links so the UI can render deployments,
+promotions, rollbacks, backup gates, previews, cleanup, feedback, and relevant
+authz changes without loading raw record payloads.
 
 ## Promotion Safety
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -376,6 +376,7 @@ only after a passing plan and a matching stored preview record are present.
 
 - `GET /v1/products`
 - `GET /v1/products/{product}`
+- `GET /v1/products/{product}/activity`
 - `GET /v1/products/{product}/environments/{environment}`
 - `GET /v1/previews/{preview_id}`
 - `GET /v1/previews/{preview_id}/history`
@@ -402,6 +403,11 @@ metadata, action availability, and trust state. Raw context names and provider
 target identifiers remain evidence metadata; runtime values, secret plaintext,
 secret ciphertext, and product-specific driver payloads are not exposed as
 shared top-level fields.
+
+Product activity reads are intentionally record-link oriented. They summarize
+deployments, promotions, rollbacks, backup gates, preview identity/lifecycle,
+preview feedback, and matching authz-policy changes with driver/action IDs and
+record references rather than embedding raw record payloads.
 
 Preview-related product actions are only shown when the product profile enables
 previews. That includes generic-web preview discovery and inventory actions,

--- a/tests/test_product_environment_read_model.py
+++ b/tests/test_product_environment_read_model.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from types import SimpleNamespace
 from typing import cast
 import unittest
 
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.product_environment_read_model import (
     ACTION_AUTHZ_BY_ROUTE,
+    build_product_activity_read_model,
     build_product_environment_detail,
     build_product_site_overview,
 )
@@ -113,6 +115,115 @@ class _PreviewRecordStore:
     ) -> tuple[PreviewRecord, ...]:
         self.preview_record_calls.append((context_name, anchor_repo))
         return self._previews
+
+
+class _ActivityRecordStore(_PreviewRecordStore):
+    def list_deployment_records(
+        self, *, context_name: str = "", instance_name: str = "", limit: int | None = None
+    ) -> tuple[object, ...]:
+        if context_name != "example-site-prod" or instance_name != "prod":
+            return ()
+        return (
+            SimpleNamespace(
+                record_id="deployment-prod-1",
+                deploy=SimpleNamespace(
+                    status="pass",
+                    started_at="2026-05-02T10:00:00Z",
+                    finished_at="2026-05-02T10:05:00Z",
+                ),
+            ),
+        )
+
+    def list_promotion_records(
+        self,
+        *,
+        context_name: str = "",
+        from_instance_name: str = "",
+        to_instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[object, ...]:
+        if context_name != "example-site-prod" or to_instance_name != "prod":
+            return ()
+        return (
+            SimpleNamespace(
+                record_id="promotion-prod-1",
+                deployment_record_id="deployment-prod-1",
+                backup_record_id="backup-prod-1",
+                from_instance="testing",
+                to_instance="prod",
+                deploy=SimpleNamespace(
+                    status="pass",
+                    started_at="2026-05-02T11:00:00Z",
+                    finished_at="2026-05-02T11:07:00Z",
+                ),
+                rollback=SimpleNamespace(
+                    attempted=False, status="skipped", started_at="", finished_at=""
+                ),
+            ),
+        )
+
+    def list_backup_gate_records(
+        self, *, context_name: str = "", instance_name: str = "", limit: int | None = None
+    ) -> tuple[object, ...]:
+        if context_name != "example-site-prod" or instance_name != "prod":
+            return ()
+        return (
+            SimpleNamespace(
+                record_id="backup-prod-1",
+                status="pass",
+                created_at="2026-05-02T10:50:00Z",
+            ),
+        )
+
+    def list_preview_desired_state_records(
+        self, *, context_name: str = "", limit: int | None = None
+    ) -> tuple[object, ...]:
+        if context_name != "shared-preview":
+            return ()
+        return (
+            SimpleNamespace(
+                desired_state_id="desired-example-1",
+                product="example-site",
+                context="shared-preview",
+                status="pass",
+                discovered_at="2026-05-02T12:00:00Z",
+                desired_count=1,
+            ),
+            SimpleNamespace(
+                desired_state_id="desired-other-1",
+                product="other-site",
+                context="shared-preview",
+                status="pass",
+                discovered_at="2026-05-02T12:30:00Z",
+                desired_count=1,
+            ),
+        )
+
+    def list_preview_lifecycle_cleanup_records(
+        self, *, context_name: str = "", limit: int | None = None
+    ) -> tuple[object, ...]:
+        return ()
+
+    def list_preview_pr_feedback_records(
+        self, *, context_name: str = "", limit: int | None = None
+    ) -> tuple[object, ...]:
+        return ()
+
+    def list_authz_policy_records(
+        self, *, status: str = "", limit: int | None = None
+    ) -> tuple[object, ...]:
+        return (
+            SimpleNamespace(
+                record_id="authz-policy-1",
+                status="active",
+                source="test-policy",
+                updated_at="2026-05-02T13:00:00Z",
+                policy=SimpleNamespace(
+                    github_actions=(SimpleNamespace(products=("example-site",)),),
+                    github_humans=(),
+                ),
+            ),
+        )
 
 
 class ProductEnvironmentReadModelTest(unittest.TestCase):
@@ -380,3 +491,42 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
 
         self.assertEqual(detail.managed_secrets[0].status, "disabled")
         self.assertEqual(detail.managed_secrets[0].trust_state, "disabled")
+
+    def test_product_activity_read_model_aggregates_product_records(self) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(
+            _site_profile_payload(
+                preview_context="shared-preview",
+                testing_context="example-site-prod",
+                prod_context="example-site-prod",
+            )
+        )
+        store = _ActivityRecordStore(
+            profile,
+            (
+                _preview_record(
+                    preview_id="example-preview-1",
+                    context="shared-preview",
+                    anchor_repo="example-site",
+                    state="active",
+                    updated_at="2026-05-02T12:10:00Z",
+                ),
+            ),
+        )
+
+        activity = build_product_activity_read_model(
+            record_store=store,
+            product="example-site",
+        )
+
+        event_types = {event.event_type for event in activity.events}
+        self.assertIn("deployment", event_types)
+        self.assertIn("promotion", event_types)
+        self.assertIn("backup_gate", event_types)
+        self.assertIn("preview", event_types)
+        self.assertIn("preview_desired_state", event_types)
+        self.assertIn("authz_policy", event_types)
+        self.assertNotIn(
+            "desired-other-1",
+            {link.record_id for event in activity.events for link in event.records},
+        )
+        self.assertEqual(activity.events[0].event_type, "authz_policy")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1331,6 +1331,48 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(actions["prod_backup_gate"]["trust_state"], "unsupported")
         self.assertNotIn("sellyouroutboard", response_text)
 
+    def test_product_activity_endpoint_returns_product_timeline(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["example-site"],
+                            "contexts": ["launchplane"],
+                            "actions": ["product_environment.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/products/example-site/activity",
+            )
+
+        self.assertEqual(status_code, 200)
+        self.assertEqual(payload["activity"]["product"], "example-site")
+        self.assertEqual(payload["activity"]["events"][0]["event_type"], "authz_policy")
+        self.assertEqual(payload["activity"]["events"][0]["action_id"], "authz_policy.update")
+
     def test_product_environment_detail_redacts_runtime_and_secret_values(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary

- Adds `GET /v1/products/{product}/activity` as a product-level operator timeline.
- Aggregates existing Launchplane records into redacted activity events: deployments, promotions, rollbacks, backup gates, previews, preview desired state, cleanup, PR feedback, and matching authz policy updates.
- Keeps events driver/action oriented with record links instead of embedding raw record payloads.
- Documents the product activity read surface.

Stacked on #157. Refs #152.

## Validation

- `uv run python -m unittest tests.test_product_environment_read_model tests.test_service.LaunchplaneServiceTests.test_product_activity_endpoint_returns_product_timeline tests.test_service.LaunchplaneServiceTests.test_product_overview_endpoint_is_generic_web_profile_driven tests.test_service.LaunchplaneServiceTests.test_product_environment_detail_redacts_runtime_and_secret_values`
- `uv run python -m unittest tests.test_service tests.test_driver_descriptors tests.test_product_environment_read_model`
- `uv run --extra dev ruff format --check control_plane/contracts/product_environment_read_model.py control_plane/service.py tests/test_product_environment_read_model.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/contracts/product_environment_read_model.py control_plane/service.py tests/test_product_environment_read_model.py tests/test_service.py`
- `uv run --extra dev mypy control_plane/contracts/product_environment_read_model.py tests/test_product_environment_read_model.py`
- `uv run python -m unittest`

## Notes

Full repo mypy remains blocked by the existing repo-wide baseline described in #157/#152.