### PR TITLE
Preserve product activity history

### DIFF
--- a/control_plane/contracts/product_environment_read_model.py
+++ b/control_plane/contracts/product_environment_read_model.py
@@ -361,7 +361,7 @@ def build_product_activity_read_model(
         events.extend(
             _backup_gate_activity_events(record_store=record_store, profile=profile, lane=lane)
         )
-    if profile.preview.enabled and profile.preview.context.strip():
+    if profile.preview.context.strip():
         events.extend(_preview_activity_events(record_store=record_store, profile=profile))
         events.extend(_preview_context_activity_events(record_store=record_store, profile=profile))
     events.extend(_authz_policy_activity_events(record_store=record_store, profile=profile))
@@ -456,7 +456,6 @@ def _deployment_activity_events(
         "list_deployment_records",
         context_name=lane.context,
         instance_name=lane.instance,
-        limit=10,
     ):
         deploy = getattr(record, "deploy")
         occurred_at = deploy.finished_at or deploy.started_at
@@ -487,7 +486,6 @@ def _promotion_activity_events(
         "list_promotion_records",
         context_name=lane.context,
         to_instance_name=lane.instance,
-        limit=10,
     ):
         deploy = getattr(record, "deploy")
         rollback = getattr(record, "rollback")
@@ -536,7 +534,6 @@ def _backup_gate_activity_events(
         "list_backup_gate_records",
         context_name=lane.context,
         instance_name=lane.instance,
-        limit=10,
     ):
         events.append(
             _activity_event(
@@ -565,7 +562,6 @@ def _preview_activity_events(
         "list_preview_records",
         context_name=profile.preview.context,
         anchor_repo=_profile_anchor_repo(profile),
-        limit=10,
     ):
         state = str(getattr(record, "state"))
         action_id = "preview_destroy" if state == "destroyed" else "preview_refresh"
@@ -596,7 +592,6 @@ def _preview_context_activity_events(
         record_store,
         "list_preview_desired_state_records",
         context_name=preview_context,
-        limit=5,
     ):
         if getattr(record, "product", "") != profile.product:
             continue
@@ -621,7 +616,6 @@ def _preview_context_activity_events(
         record_store,
         "list_preview_lifecycle_cleanup_records",
         context_name=preview_context,
-        limit=5,
     ):
         if getattr(record, "product", "") != profile.product:
             continue
@@ -645,7 +639,6 @@ def _preview_context_activity_events(
         record_store,
         "list_preview_pr_feedback_records",
         context_name=preview_context,
-        limit=5,
     ):
         if getattr(record, "product", "") != profile.product:
             continue
@@ -678,7 +671,7 @@ def _authz_policy_activity_events(
     *, record_store: object, profile: LaunchplaneProductProfileRecord
 ) -> tuple[ProductActivityEvent, ...]:
     events: list[ProductActivityEvent] = []
-    for record in _optional_records(record_store, "list_authz_policy_records", limit=5):
+    for record in _optional_records(record_store, "list_authz_policy_records"):
         if not _authz_policy_mentions_product(record, profile.product):
             continue
         events.append(

--- a/tests/test_product_environment_read_model.py
+++ b/tests/test_product_environment_read_model.py
@@ -226,6 +226,28 @@ class _ActivityRecordStore(_PreviewRecordStore):
         )
 
 
+class _ManyDeploymentActivityRecordStore(_PreviewRecordStore):
+    def list_deployment_records(
+        self, *, context_name: str = "", instance_name: str = "", limit: int | None = None
+    ) -> tuple[object, ...]:
+        if context_name != "example-site-prod" or instance_name != "prod":
+            return ()
+        records = tuple(
+            SimpleNamespace(
+                record_id=f"deployment-prod-{index}",
+                deploy=SimpleNamespace(
+                    status="pass",
+                    started_at=f"2026-05-02T10:{index:02d}:00Z",
+                    finished_at=f"2026-05-02T10:{index:02d}:30Z",
+                ),
+            )
+            for index in range(12, 0, -1)
+        )
+        if limit is not None:
+            return records[:limit]
+        return records
+
+
 class ProductEnvironmentReadModelTest(unittest.TestCase):
     def test_action_authz_map_matches_live_service_handlers(self) -> None:
         self.assertEqual(
@@ -530,3 +552,62 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
             {link.record_id for event in activity.events for link in event.records},
         )
         self.assertEqual(activity.events[0].event_type, "authz_policy")
+
+    def test_product_activity_read_model_keeps_preview_history_when_previews_disabled(
+        self,
+    ) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(
+            _site_profile_payload(
+                preview_enabled=False,
+                preview_context="shared-preview",
+                testing_context="example-site-prod",
+                prod_context="example-site-prod",
+            )
+        )
+        store = _ActivityRecordStore(
+            profile,
+            (
+                _preview_record(
+                    preview_id="example-preview-1",
+                    context="shared-preview",
+                    anchor_repo="example-site",
+                    state="destroyed",
+                    updated_at="2026-05-02T12:10:00Z",
+                ),
+            ),
+        )
+
+        activity = build_product_activity_read_model(
+            record_store=store,
+            product="example-site",
+        )
+
+        event_types = {event.event_type for event in activity.events}
+        self.assertIn("preview", event_types)
+        self.assertIn("preview_desired_state", event_types)
+
+    def test_product_activity_read_model_limits_after_merging_all_sources(self) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(
+            _site_profile_payload(
+                preview_enabled=False,
+                preview_context="",
+                testing_context="example-site-prod",
+                prod_context="example-site-prod",
+            )
+        )
+        store = _ManyDeploymentActivityRecordStore(profile, ())
+
+        activity = build_product_activity_read_model(
+            record_store=store,
+            product="example-site",
+            limit=12,
+        )
+
+        deployment_record_ids = {
+            link.record_id
+            for event in activity.events
+            for link in event.records
+            if link.record_type == "deployment"
+        }
+        self.assertEqual(len(activity.events), 12)
+        self.assertIn("deployment-prod-1", deployment_record_ids)


### PR DESCRIPTION
## Summary

- keep historical preview activity visible when previews are currently disabled but a preview context remains recorded
- remove per-source activity fetch caps so the endpoint sorts all available source events before applying the final response limit
- add regression coverage for disabled-preview history and busy deployment histories

## Validation

- `uv run python -m unittest tests.test_product_environment_read_model`
- `uv run python -m unittest tests.test_service tests.test_driver_descriptors tests.test_product_environment_read_model`
- `uv run --extra dev ruff format --check control_plane/contracts/product_environment_read_model.py tests/test_product_environment_read_model.py`
- `uv run --extra dev ruff check control_plane/contracts/product_environment_read_model.py tests/test_product_environment_read_model.py`
- `uv run --extra dev mypy control_plane/contracts/product_environment_read_model.py tests/test_product_environment_read_model.py`
