### PR TITLE
Add product onboarding records workflow

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -62,6 +62,7 @@ from control_plane.contracts.product_profile_record import LaunchplaneProductPro
 from control_plane.contracts.product_profile_record import ProductImageProfile
 from control_plane.contracts.product_profile_record import ProductLaneProfile
 from control_plane.contracts.product_profile_record import ProductPreviewProfile
+from control_plane.contracts.product_onboarding_manifest import ProductOnboardingManifest
 from control_plane.contracts.promotion_record import (
     BackupGateEvidence,
     HealthcheckEvidence,
@@ -75,6 +76,7 @@ from control_plane.contracts.runtime_environment_record import (
     RuntimeEnvironmentDeleteEvent,
     RuntimeEnvironmentRecord,
 )
+from control_plane.contracts.secret_record import SecretBinding
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.drivers.registry import build_driver_context_view
 from control_plane.launchplane_mutations import (
@@ -113,6 +115,7 @@ from control_plane.workflows.launchplane import (
     verify_github_webhook_signature,
 )
 from control_plane.workflows.inventory import build_environment_inventory
+from control_plane.workflows.product_onboarding import apply_product_onboarding_manifest
 from control_plane.workflows.odoo_artifact_publish import (
     OdooArtifactPublishRequest,
     execute_odoo_artifact_publish,
@@ -8453,6 +8456,20 @@ def _summarize_runtime_environment_record(
     }
 
 
+def _summarize_secret_binding_record(binding: SecretBinding) -> dict[str, object]:
+    return {
+        "binding_id": binding.binding_id,
+        "integration": binding.integration,
+        "binding_type": binding.binding_type,
+        "binding_key": binding.binding_key,
+        "context": binding.context,
+        "instance": binding.instance,
+        "status": binding.status,
+        "created_at": binding.created_at,
+        "updated_at": binding.updated_at,
+    }
+
+
 def _parse_runtime_environment_assignment(raw_assignment: str) -> tuple[str, str]:
     key_name, separator, value = raw_assignment.partition("=")
     normalized_key = key_name.strip()
@@ -9336,6 +9353,11 @@ def secrets() -> None:
 @main.group("product-config")
 def product_config() -> None:
     """Trusted product runtime config apply commands."""
+
+
+@main.group("product-onboarding")
+def product_onboarding() -> None:
+    """Idempotent product onboarding record commands."""
 
 
 @product_config.command("apply")
@@ -12151,6 +12173,74 @@ def authz_policies_import_toml(database_url: str, policy_file: Path, source_labe
     click.echo(
         json.dumps(
             {"status": "ok", "record": _summarize_authz_policy_record(record)},
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+@product_onboarding.command("apply")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane product onboarding records.",
+)
+@click.option(
+    "--manifest-file",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False),
+    required=True,
+    help="Operator-approved JSON product onboarding manifest.",
+)
+@click.option("--updated-at", default="", help="Override manifest updated_at timestamp.")
+def product_onboarding_apply(database_url: str, manifest_file: Path, updated_at: str) -> None:
+    try:
+        manifest_payload = json.loads(manifest_file.read_text())
+    except JSONDecodeError as exc:
+        raise click.ClickException(
+            f"Product onboarding manifest must be valid JSON: {exc}"
+        ) from exc
+    try:
+        manifest = ProductOnboardingManifest.model_validate(manifest_payload)
+    except ValidationError as exc:
+        raise click.ClickException(f"Product onboarding manifest failed validation: {exc}") from exc
+
+    store = PostgresRecordStore(database_url=database_url)
+    store.ensure_schema()
+    try:
+        result = apply_product_onboarding_manifest(
+            record_store=store,
+            manifest=manifest,
+            updated_at=updated_at,
+        )
+    finally:
+        store.close()
+
+    target_id_map = _target_id_map(result.dokploy_target_ids)
+    click.echo(
+        json.dumps(
+            {
+                "status": "ok",
+                "product": result.product,
+                "product_profile": _summarize_product_profile_record(result.product_profile),
+                "dokploy_target_count": len(result.dokploy_targets),
+                "dokploy_targets": [
+                    _summarize_dokploy_target_record(
+                        record,
+                        target_id=target_id_map.get(_dokploy_target_route(record), ""),
+                    )
+                    for record in result.dokploy_targets
+                ],
+                "runtime_environment_record_count": len(result.runtime_environments),
+                "runtime_environment_records": [
+                    _summarize_runtime_environment_record(record)
+                    for record in result.runtime_environments
+                ],
+                "secret_binding_count": len(result.secret_bindings),
+                "secret_bindings": [
+                    _summarize_secret_binding_record(binding) for binding in result.secret_bindings
+                ],
+            },
             indent=2,
             sort_keys=True,
         )

--- a/control_plane/contracts/product_onboarding_manifest.py
+++ b/control_plane/contracts/product_onboarding_manifest.py
@@ -1,0 +1,214 @@
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.dokploy_target_record import DokployTargetType
+from control_plane.contracts.product_profile_record import (
+    ProductPreviewProfile,
+    ProductPromotionWorkflowProfile,
+)
+from control_plane.contracts.runtime_environment_record import ScalarValue
+from control_plane.contracts.secret_record import SecretStatus
+
+
+class ProductOnboardingLaneManifest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    instance: str
+    context: str
+    base_url: str = ""
+    health_url: str = ""
+
+    @model_validator(mode="after")
+    def _validate_lane(self) -> "ProductOnboardingLaneManifest":
+        if not self.instance.strip():
+            raise ValueError("product onboarding lane requires instance")
+        if not self.context.strip():
+            raise ValueError("product onboarding lane requires context")
+        return self
+
+
+class ProductOnboardingPreviewManifest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    context: str = ""
+    slug_template: str = "pr-{number}"
+    app_name_prefix: str = ""
+    template_instance: str = "testing"
+    required_template_env_keys: tuple[str, ...] = ()
+    copied_env_keys: tuple[str, ...] = ()
+    omitted_env_keys: tuple[str, ...] = ()
+    override_env: dict[str, str] = Field(default_factory=dict)
+    preview_url_env_keys: tuple[str, ...] = ()
+    preview_domain_env_keys: tuple[str, ...] = ()
+    required_provider_fields: tuple[str, ...] = ()
+    data_transport_mode: Literal["none", "clone", "bootstrap", "migrate_seed", "driver"] = "none"
+    migration_command: str = ""
+    seed_command: str = ""
+
+
+class ProductOnboardingTargetManifest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    context: str
+    instance: str
+    target_id: str = ""
+    project_name: str = ""
+    target_type: DokployTargetType = "application"
+    target_name: str = ""
+    source_git_ref: str = "origin/main"
+    source_type: str = ""
+    custom_git_url: str = ""
+    custom_git_branch: str = ""
+    compose_path: str = ""
+    watch_paths: tuple[str, ...] = ()
+    enable_submodules: bool | None = None
+    require_test_gate: bool = False
+    require_prod_gate: bool = False
+    deploy_timeout_seconds: int | None = Field(default=None, ge=1)
+    healthcheck_enabled: bool = True
+    healthcheck_path: str = ""
+    healthcheck_timeout_seconds: int | None = Field(default=None, ge=1)
+    env: dict[str, str] = Field(default_factory=dict)
+    domains: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_target(self) -> "ProductOnboardingTargetManifest":
+        if not self.context.strip():
+            raise ValueError("product onboarding target requires context")
+        if not self.instance.strip():
+            raise ValueError("product onboarding target requires instance")
+        if self.healthcheck_path and not self.healthcheck_path.startswith("/"):
+            raise ValueError("product onboarding target healthcheck_path must start with /")
+        return self
+
+
+class ProductOnboardingRuntimeEnvironmentManifest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    scope: Literal["global", "context", "instance"]
+    context: str = ""
+    instance: str = ""
+    env: dict[str, ScalarValue]
+
+
+class ProductOnboardingSecretBindingManifest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    binding_key: str
+    context: str
+    instance: str = ""
+    integration: str = "runtime_environment"
+    secret_id: str = ""
+    binding_id: str = ""
+    status: SecretStatus = "disabled"
+
+    @model_validator(mode="after")
+    def _validate_binding(self) -> "ProductOnboardingSecretBindingManifest":
+        if not self.binding_key.strip():
+            raise ValueError("product onboarding secret binding requires binding_key")
+        if not self.context.strip():
+            raise ValueError("product onboarding secret binding requires context")
+        if not self.integration.strip():
+            raise ValueError("product onboarding secret binding requires integration")
+        return self
+
+
+class ProductOnboardingManifest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    display_name: str
+    repository: str
+    driver_id: str = "generic-web"
+    image_repository: str
+    runtime_port: int = Field(ge=1, le=65535)
+    health_path: str
+    lanes: tuple[ProductOnboardingLaneManifest, ...]
+    preview: ProductOnboardingPreviewManifest = Field(
+        default_factory=ProductOnboardingPreviewManifest
+    )
+    promotion_workflow: ProductPromotionWorkflowProfile = Field(
+        default_factory=ProductPromotionWorkflowProfile
+    )
+    dokploy_targets: tuple[ProductOnboardingTargetManifest, ...] = ()
+    runtime_environments: tuple[ProductOnboardingRuntimeEnvironmentManifest, ...] = ()
+    secret_bindings: tuple[ProductOnboardingSecretBindingManifest, ...] = ()
+    updated_at: str = ""
+    source_label: str = "product-onboarding"
+
+    @model_validator(mode="after")
+    def _validate_manifest(self) -> "ProductOnboardingManifest":
+        if not self.product.strip():
+            raise ValueError("product onboarding manifest requires product")
+        if not self.display_name.strip():
+            raise ValueError("product onboarding manifest requires display_name")
+        if not self.repository.strip():
+            raise ValueError("product onboarding manifest requires repository")
+        if not self.driver_id.strip():
+            raise ValueError("product onboarding manifest requires driver_id")
+        if not self.image_repository.strip():
+            raise ValueError("product onboarding manifest requires image_repository")
+        if not self.health_path.startswith("/"):
+            raise ValueError("product onboarding manifest health_path must start with /")
+        if not self.lanes:
+            raise ValueError("product onboarding manifest requires at least one stable lane")
+
+        lane_routes = {(lane.context.strip(), lane.instance.strip()) for lane in self.lanes}
+        if len(lane_routes) != len(self.lanes):
+            raise ValueError("product onboarding lanes must be unique by context and instance")
+        lane_instances = [lane.instance.strip() for lane in self.lanes]
+        if len(set(lane_instances)) != len(lane_instances):
+            raise ValueError("product onboarding lanes must be unique by instance")
+        ProductPreviewProfile.model_validate(self.preview.model_dump(mode="json"))
+
+        for target in self.dokploy_targets:
+            route = (target.context.strip(), target.instance.strip())
+            if route not in lane_routes:
+                raise ValueError(
+                    "product onboarding target must match a stable lane: "
+                    f"{target.context}/{target.instance}"
+                )
+
+        allowed_contexts = {lane.context.strip() for lane in self.lanes}
+        if self.preview.context.strip():
+            allowed_contexts.add(self.preview.context.strip())
+        for record in self.runtime_environments:
+            if record.scope == "global":
+                if record.context.strip() or record.instance.strip():
+                    raise ValueError(
+                        "global runtime environment records cannot set context/instance"
+                    )
+                continue
+            if record.context.strip() not in allowed_contexts:
+                raise ValueError(
+                    "runtime environment context is not owned by the product profile: "
+                    f"{record.context}"
+                )
+            if record.scope == "context" and record.instance.strip():
+                raise ValueError("context runtime environment records cannot set instance")
+            if (
+                record.scope == "instance"
+                and (record.context.strip(), record.instance.strip()) not in lane_routes
+            ):
+                raise ValueError(
+                    "instance runtime environment record must match a stable lane: "
+                    f"{record.context}/{record.instance}"
+                )
+
+        for binding in self.secret_bindings:
+            if binding.context.strip() not in allowed_contexts:
+                raise ValueError(
+                    f"secret binding context is not owned by the product profile: {binding.context}"
+                )
+            if (
+                binding.instance.strip()
+                and (binding.context.strip(), binding.instance.strip()) not in lane_routes
+            ):
+                raise ValueError(
+                    "instance secret binding must match a stable lane: "
+                    f"{binding.context}/{binding.instance}"
+                )
+        return self

--- a/control_plane/workflows/product_onboarding.py
+++ b/control_plane/workflows/product_onboarding.py
@@ -1,0 +1,224 @@
+import hashlib
+import re
+from typing import Protocol
+
+from pydantic import BaseModel, ConfigDict
+
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane.contracts.product_onboarding_manifest import (
+    ProductOnboardingManifest,
+    ProductOnboardingSecretBindingManifest,
+)
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductImageProfile,
+    ProductLaneProfile,
+    ProductPreviewProfile,
+)
+from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
+from control_plane.contracts.secret_record import SecretBinding
+from control_plane.workflows.ship import utc_now_timestamp
+
+
+class ProductOnboardingRecordStore(Protocol):
+    def write_product_profile_record(self, record: LaunchplaneProductProfileRecord) -> None: ...
+
+    def write_dokploy_target_record(self, record: DokployTargetRecord) -> None: ...
+
+    def write_dokploy_target_id_record(self, record: DokployTargetIdRecord) -> None: ...
+
+    def write_runtime_environment_record(self, record: RuntimeEnvironmentRecord) -> None: ...
+
+    def write_secret_binding(self, binding: SecretBinding) -> None: ...
+
+
+class ProductOnboardingApplyResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    product: str
+    product_profile: LaunchplaneProductProfileRecord
+    dokploy_targets: tuple[DokployTargetRecord, ...] = ()
+    dokploy_target_ids: tuple[DokployTargetIdRecord, ...] = ()
+    runtime_environments: tuple[RuntimeEnvironmentRecord, ...] = ()
+    secret_bindings: tuple[SecretBinding, ...] = ()
+
+
+def build_product_profile_record(
+    *, manifest: ProductOnboardingManifest, updated_at: str
+) -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord(
+        product=manifest.product,
+        display_name=manifest.display_name,
+        repository=manifest.repository,
+        driver_id=manifest.driver_id,
+        image=ProductImageProfile(repository=manifest.image_repository),
+        runtime_port=manifest.runtime_port,
+        health_path=manifest.health_path,
+        lanes=tuple(
+            ProductLaneProfile(
+                instance=lane.instance,
+                context=lane.context,
+                base_url=lane.base_url,
+                health_url=lane.health_url or _health_url(lane.base_url, manifest.health_path),
+            )
+            for lane in manifest.lanes
+        ),
+        preview=ProductPreviewProfile.model_validate(manifest.preview.model_dump(mode="json")),
+        promotion_workflow=manifest.promotion_workflow,
+        updated_at=updated_at,
+        source=manifest.source_label,
+    )
+
+
+def build_dokploy_target_records(
+    *, manifest: ProductOnboardingManifest, updated_at: str
+) -> tuple[DokployTargetRecord, ...]:
+    return tuple(
+        DokployTargetRecord(
+            context=target.context,
+            instance=target.instance,
+            project_name=target.project_name,
+            target_type=target.target_type,
+            target_name=target.target_name,
+            source_git_ref=target.source_git_ref,
+            source_type=target.source_type,
+            custom_git_url=target.custom_git_url,
+            custom_git_branch=target.custom_git_branch,
+            compose_path=target.compose_path,
+            watch_paths=target.watch_paths,
+            enable_submodules=target.enable_submodules,
+            require_test_gate=target.require_test_gate,
+            require_prod_gate=target.require_prod_gate,
+            deploy_timeout_seconds=target.deploy_timeout_seconds,
+            healthcheck_enabled=target.healthcheck_enabled,
+            healthcheck_path=target.healthcheck_path or manifest.health_path,
+            healthcheck_timeout_seconds=target.healthcheck_timeout_seconds,
+            env=dict(target.env),
+            domains=target.domains,
+            updated_at=updated_at,
+            source_label=manifest.source_label,
+        )
+        for target in manifest.dokploy_targets
+    )
+
+
+def build_dokploy_target_id_records(
+    *, manifest: ProductOnboardingManifest, updated_at: str
+) -> tuple[DokployTargetIdRecord, ...]:
+    return tuple(
+        DokployTargetIdRecord(
+            context=target.context,
+            instance=target.instance,
+            target_id=target.target_id,
+            updated_at=updated_at,
+            source_label=manifest.source_label,
+        )
+        for target in manifest.dokploy_targets
+        if target.target_id.strip()
+    )
+
+
+def build_runtime_environment_records(
+    *, manifest: ProductOnboardingManifest, updated_at: str
+) -> tuple[RuntimeEnvironmentRecord, ...]:
+    return tuple(
+        RuntimeEnvironmentRecord(
+            scope=record.scope,
+            context=record.context,
+            instance=record.instance,
+            env=dict(record.env),
+            updated_at=updated_at,
+            source_label=manifest.source_label,
+        )
+        for record in manifest.runtime_environments
+    )
+
+
+def build_secret_bindings(
+    *, manifest: ProductOnboardingManifest, updated_at: str
+) -> tuple[SecretBinding, ...]:
+    return tuple(
+        SecretBinding(
+            binding_id=_secret_binding_id(product=manifest.product, binding=binding),
+            secret_id=_secret_id(product=manifest.product, binding=binding),
+            integration=binding.integration,
+            binding_key=binding.binding_key,
+            context=binding.context,
+            instance=binding.instance,
+            status=binding.status,
+            created_at=updated_at,
+            updated_at=updated_at,
+        )
+        for binding in manifest.secret_bindings
+    )
+
+
+def apply_product_onboarding_manifest(
+    *,
+    record_store: ProductOnboardingRecordStore,
+    manifest: ProductOnboardingManifest,
+    updated_at: str = "",
+) -> ProductOnboardingApplyResult:
+    recorded_at = updated_at.strip() or manifest.updated_at.strip() or utc_now_timestamp()
+    product_profile = build_product_profile_record(manifest=manifest, updated_at=recorded_at)
+    dokploy_targets = build_dokploy_target_records(manifest=manifest, updated_at=recorded_at)
+    dokploy_target_ids = build_dokploy_target_id_records(manifest=manifest, updated_at=recorded_at)
+    runtime_environments = build_runtime_environment_records(
+        manifest=manifest, updated_at=recorded_at
+    )
+    secret_bindings = build_secret_bindings(manifest=manifest, updated_at=recorded_at)
+
+    record_store.write_product_profile_record(product_profile)
+    for target_record in dokploy_targets:
+        record_store.write_dokploy_target_record(target_record)
+    for target_id_record in dokploy_target_ids:
+        record_store.write_dokploy_target_id_record(target_id_record)
+    for runtime_record in runtime_environments:
+        record_store.write_runtime_environment_record(runtime_record)
+    for binding in secret_bindings:
+        record_store.write_secret_binding(binding)
+
+    return ProductOnboardingApplyResult(
+        product=manifest.product,
+        product_profile=product_profile,
+        dokploy_targets=dokploy_targets,
+        dokploy_target_ids=dokploy_target_ids,
+        runtime_environments=runtime_environments,
+        secret_bindings=secret_bindings,
+    )
+
+
+def _health_url(base_url: str, health_path: str) -> str:
+    normalized_base_url = base_url.rstrip("/")
+    if not normalized_base_url:
+        return ""
+    return f"{normalized_base_url}{health_path}"
+
+
+def _secret_id(*, product: str, binding: ProductOnboardingSecretBindingManifest) -> str:
+    if binding.secret_id.strip():
+        return binding.secret_id.strip()
+    parts = [product, binding.context, binding.instance, binding.binding_key]
+    return "secret-" + _stable_slug("-".join(part for part in parts if part.strip()))
+
+
+def _secret_binding_id(*, product: str, binding: ProductOnboardingSecretBindingManifest) -> str:
+    if binding.binding_id.strip():
+        return binding.binding_id.strip()
+    digest_source = ":".join(
+        (
+            product.strip(),
+            binding.integration.strip(),
+            binding.context.strip(),
+            binding.instance.strip(),
+            binding.binding_key.strip(),
+        )
+    )
+    digest = hashlib.sha256(digest_source.encode("utf-8")).hexdigest()[:12]
+    return f"binding-{_stable_slug(product)}-{digest}"
+
+
+def _stable_slug(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip()).strip("-").lower()
+    return slug or "unnamed"

--- a/docs/new-product-repo.md
+++ b/docs/new-product-repo.md
@@ -37,19 +37,34 @@ DB-backed product profile.
 
 ## Launchplane Records
 
-Before wiring workflows, seed or verify these records in Launchplane:
+Before wiring workflows, seed or verify these records in Launchplane with an
+operator-owned onboarding manifest:
+
+```sh
+uv run launchplane product-onboarding apply \
+  --database-url "$LAUNCHPLANE_DATABASE_URL" \
+  --manifest-file state/product-onboarding/<product>.json
+```
+
+The manifest is applied idempotently and writes Launchplane-owned records for:
 
 - product profile with product key, owning repo, driver id, image repository,
   runtime port, health path, and preview policy
 - lane profiles for stable instances such as `testing` and `prod`
 - Dokploy or provider target records and target-id records
 - runtime-environment records for non-secret settings
-- managed secret records for secret values
-- authz policy records for GitHub Actions workflows
+- disabled managed secret binding placeholders for required secret keys
+
+Then import or update DB-backed authz policy records for the product's GitHub
+Actions workflows. Authz policy merging remains a separate operator step so a
+new product onboarding manifest cannot accidentally replace unrelated product
+access rules.
 
 Do not store these as product-repo Launchplane manifests. The repo may document
 the expected app runtime contract, but Launchplane records are the live source
-of lifecycle truth.
+of lifecycle truth. Store operator manifests under Launchplane state or another
+operator-owned state location, not in product repos and not in git-tracked
+history when they contain site-specific runtime details.
 
 ## GitHub Actions Shape
 

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -142,8 +142,10 @@ When creating a new website repo for Launchplane:
 - Add a health endpoint that returns enough non-secret version data for
   Launchplane to verify the deployed artifact.
 - Publish immutable container images or artifacts from GitHub Actions.
-- Seed the product profile, lane profiles, target records, runtime environment,
-  managed secrets, and authz policy in Launchplane.
+- Apply an operator-owned Launchplane product onboarding manifest to seed the
+  product profile, lane profiles, target records, runtime environment, disabled
+  managed secret binding placeholders, and then update DB-backed authz policy in
+  Launchplane.
 - Use `generic-web` directly when the product is a stateless or mostly
   stateless web app with standard preview/deploy behavior.
 - Add a product driver only when the product has named extra obligations such as

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1,0 +1,161 @@
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from click.testing import CliRunner
+
+from control_plane.cli import main
+from control_plane.contracts.product_onboarding_manifest import ProductOnboardingManifest
+from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.workflows.product_onboarding import apply_product_onboarding_manifest
+
+
+def _sqlite_database_url(database_path: Path) -> str:
+    return f"sqlite+pysqlite:///{database_path}"
+
+
+def _manifest_payload() -> dict[str, object]:
+    return {
+        "product": "example-site",
+        "display_name": "Example Site",
+        "repository": "cbusillo/example-site",
+        "driver_id": "generic-web",
+        "image_repository": "ghcr.io/cbusillo/example-site",
+        "runtime_port": 3000,
+        "health_path": "/api/health",
+        "lanes": [
+            {
+                "instance": "testing",
+                "context": "example-site-testing",
+                "base_url": "https://testing.example.invalid",
+            },
+            {
+                "instance": "prod",
+                "context": "example-site-prod",
+                "base_url": "https://example.invalid",
+                "health_url": "https://example.invalid/status",
+            },
+        ],
+        "preview": {
+            "enabled": True,
+            "context": "example-site-preview",
+            "slug_template": "pr-{number}",
+        },
+        "dokploy_targets": [
+            {
+                "context": "example-site-testing",
+                "instance": "testing",
+                "target_id": "app-testing-123",
+                "target_type": "application",
+                "target_name": "example-site-testing",
+                "domains": ["testing.example.invalid"],
+            },
+            {
+                "context": "example-site-prod",
+                "instance": "prod",
+                "target_type": "application",
+                "target_name": "example-site-prod",
+                "domains": ["example.invalid"],
+                "require_prod_gate": True,
+            },
+        ],
+        "runtime_environments": [
+            {
+                "scope": "instance",
+                "context": "example-site-testing",
+                "instance": "testing",
+                "env": {"PUBLIC_BASE_URL": "https://testing.example.invalid"},
+            }
+        ],
+        "secret_bindings": [
+            {
+                "binding_key": "SMTP_PASSWORD",
+                "context": "example-site-prod",
+                "instance": "prod",
+            }
+        ],
+        "updated_at": "2026-05-03T01:30:00Z",
+        "source_label": "test:onboarding",
+    }
+
+
+class ProductOnboardingTests(unittest.TestCase):
+    def test_apply_product_onboarding_manifest_writes_canonical_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
+            )
+            store.ensure_schema()
+            manifest = ProductOnboardingManifest.model_validate(_manifest_payload())
+
+            first_result = apply_product_onboarding_manifest(
+                record_store=store,
+                manifest=manifest,
+            )
+            second_result = apply_product_onboarding_manifest(
+                record_store=store,
+                manifest=manifest,
+            )
+
+            profile = store.read_product_profile_record("example-site")
+            targets = store.list_dokploy_target_records()
+            target_ids = store.list_dokploy_target_id_records()
+            runtime_records = store.list_runtime_environment_records()
+            secret_bindings = store.list_secret_bindings()
+            store.close()
+
+        self.assertEqual(first_result.product, "example-site")
+        self.assertEqual(second_result.product_profile.updated_at, "2026-05-03T01:30:00Z")
+        self.assertEqual(profile.driver_id, "generic-web")
+        self.assertEqual(profile.lanes[0].health_url, "https://testing.example.invalid/api/health")
+        self.assertEqual(profile.lanes[1].health_url, "https://example.invalid/status")
+        self.assertEqual(len(targets), 2)
+        self.assertEqual(len(target_ids), 1)
+        self.assertEqual(len(runtime_records), 1)
+        self.assertEqual(len(secret_bindings), 1)
+        self.assertEqual(secret_bindings[0].binding_key, "SMTP_PASSWORD")
+        self.assertEqual(secret_bindings[0].status, "disabled")
+
+    def test_product_onboarding_manifest_rejects_unowned_target_route(self) -> None:
+        payload = _manifest_payload()
+        payload["dokploy_targets"] = [
+            {
+                "context": "other-product-prod",
+                "instance": "prod",
+                "target_type": "application",
+            }
+        ]
+
+        with self.assertRaisesRegex(ValueError, "target must match a stable lane"):
+            ProductOnboardingManifest.model_validate(payload)
+
+    def test_product_onboarding_cli_applies_manifest_without_secret_values(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(temporary_directory / "db.sqlite3")
+            manifest_path = temporary_directory / "product-onboarding.json"
+            manifest_path.write_text(json.dumps(_manifest_payload()))
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "product-onboarding",
+                    "apply",
+                    "--database-url",
+                    database_url,
+                    "--manifest-file",
+                    str(manifest_path),
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["product"], "example-site")
+        self.assertEqual(payload["secret_binding_count"], 1)
+        self.assertNotIn("secret_id", payload["secret_bindings"][0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a typed `ProductOnboardingManifest` for Launchplane-owned product, lane, target, runtime, and secret-binding onboarding inputs
- add an idempotent product onboarding workflow plus `launchplane product-onboarding apply` CLI command
- document the operator-owned manifest path while keeping product repos thin and authz policy updates explicit/separate

## Notes

The onboarding manifest does not accept secret values. It can create disabled managed secret binding placeholders so Launchplane can show required secret keys without storing plaintext or generated ciphertext. DB-backed authz policy updates remain a separate operator step to avoid replacing unrelated product access rules from one product manifest.

## Validation

- `uv run python -m unittest tests.test_product_onboarding`
- `uv run python -m unittest tests.test_product_onboarding tests.test_product_environment_read_model tests.test_postgres_store`
- `uv run --extra dev ruff format --check control_plane/contracts/product_onboarding_manifest.py control_plane/workflows/product_onboarding.py control_plane/cli.py tests/test_product_onboarding.py`
- `uv run --extra dev ruff check control_plane/contracts/product_onboarding_manifest.py control_plane/workflows/product_onboarding.py control_plane/cli.py tests/test_product_onboarding.py`
- `uv run --extra dev mypy control_plane/contracts/product_onboarding_manifest.py control_plane/workflows/product_onboarding.py tests/test_product_onboarding.py`
- `uv run --extra dev ruff check .`
- `uv run python -m unittest`
