### PR TITLE
Preserve activity across context cutovers

### DIFF
--- a/control_plane/contracts/product_environment_read_model.py
+++ b/control_plane/contracts/product_environment_read_model.py
@@ -350,21 +350,57 @@ def build_product_activity_read_model(
     *, record_store: ProductReadModelStore, product: str, limit: int = 50
 ) -> ProductActivityReadModel:
     profile = record_store.read_product_profile_record(product)
+    source_limit = max(limit, 0)
     events: list[ProductActivityEvent] = []
-    for lane in profile.lanes:
+    for lane in _product_activity_lanes(profile):
         events.extend(
-            _deployment_activity_events(record_store=record_store, profile=profile, lane=lane)
+            _deployment_activity_events(
+                record_store=record_store,
+                profile=profile,
+                lane=lane,
+                source_limit=source_limit,
+            )
         )
         events.extend(
-            _promotion_activity_events(record_store=record_store, profile=profile, lane=lane)
+            _promotion_activity_events(
+                record_store=record_store,
+                profile=profile,
+                lane=lane,
+                source_limit=source_limit,
+            )
         )
         events.extend(
-            _backup_gate_activity_events(record_store=record_store, profile=profile, lane=lane)
+            _backup_gate_activity_events(
+                record_store=record_store,
+                profile=profile,
+                lane=lane,
+                source_limit=source_limit,
+            )
         )
-    if profile.preview.context.strip():
-        events.extend(_preview_activity_events(record_store=record_store, profile=profile))
-        events.extend(_preview_context_activity_events(record_store=record_store, profile=profile))
-    events.extend(_authz_policy_activity_events(record_store=record_store, profile=profile))
+    for preview_context in _product_activity_preview_contexts(profile):
+        events.extend(
+            _preview_activity_events(
+                record_store=record_store,
+                profile=profile,
+                preview_context=preview_context,
+                source_limit=source_limit,
+            )
+        )
+        events.extend(
+            _preview_context_activity_events(
+                record_store=record_store,
+                profile=profile,
+                preview_context=preview_context,
+                source_limit=source_limit,
+            )
+        )
+    events.extend(
+        _authz_policy_activity_events(
+            record_store=record_store,
+            profile=profile,
+            source_limit=source_limit,
+        )
+    )
     events.sort(key=lambda event: (event.occurred_at, event.event_id), reverse=True)
     return ProductActivityReadModel(
         product=profile.product,
@@ -447,8 +483,37 @@ def _lane_action_id(*, profile: LaunchplaneProductProfileRecord, lane: ProductLa
     return "stable_deploy"
 
 
+def _product_activity_lanes(
+    profile: LaunchplaneProductProfileRecord,
+) -> tuple[ProductLaneProfile, ...]:
+    lanes: list[ProductLaneProfile] = []
+    seen_routes: set[tuple[str, str]] = set()
+    for lane in profile.lanes:
+        for context in (lane.context, *profile.historical_contexts):
+            normalized_context = context.strip()
+            route = (normalized_context, lane.instance)
+            if not normalized_context or route in seen_routes:
+                continue
+            seen_routes.add(route)
+            lanes.append(lane.model_copy(update={"context": normalized_context}))
+    return tuple(lanes)
+
+
+def _product_activity_preview_contexts(profile: LaunchplaneProductProfileRecord) -> tuple[str, ...]:
+    contexts: list[str] = []
+    for context in (profile.preview.context, *profile.historical_contexts):
+        normalized_context = context.strip()
+        if normalized_context and normalized_context not in contexts:
+            contexts.append(normalized_context)
+    return tuple(contexts)
+
+
 def _deployment_activity_events(
-    *, record_store: object, profile: LaunchplaneProductProfileRecord, lane: ProductLaneProfile
+    *,
+    record_store: object,
+    profile: LaunchplaneProductProfileRecord,
+    lane: ProductLaneProfile,
+    source_limit: int,
 ) -> tuple[ProductActivityEvent, ...]:
     events: list[ProductActivityEvent] = []
     for record in _optional_records(
@@ -456,6 +521,7 @@ def _deployment_activity_events(
         "list_deployment_records",
         context_name=lane.context,
         instance_name=lane.instance,
+        limit=source_limit,
     ):
         deploy = getattr(record, "deploy")
         occurred_at = deploy.finished_at or deploy.started_at
@@ -478,7 +544,11 @@ def _deployment_activity_events(
 
 
 def _promotion_activity_events(
-    *, record_store: object, profile: LaunchplaneProductProfileRecord, lane: ProductLaneProfile
+    *,
+    record_store: object,
+    profile: LaunchplaneProductProfileRecord,
+    lane: ProductLaneProfile,
+    source_limit: int,
 ) -> tuple[ProductActivityEvent, ...]:
     events: list[ProductActivityEvent] = []
     for record in _optional_records(
@@ -486,6 +556,7 @@ def _promotion_activity_events(
         "list_promotion_records",
         context_name=lane.context,
         to_instance_name=lane.instance,
+        limit=source_limit,
     ):
         deploy = getattr(record, "deploy")
         rollback = getattr(record, "rollback")
@@ -526,7 +597,11 @@ def _promotion_activity_events(
 
 
 def _backup_gate_activity_events(
-    *, record_store: object, profile: LaunchplaneProductProfileRecord, lane: ProductLaneProfile
+    *,
+    record_store: object,
+    profile: LaunchplaneProductProfileRecord,
+    lane: ProductLaneProfile,
+    source_limit: int,
 ) -> tuple[ProductActivityEvent, ...]:
     events: list[ProductActivityEvent] = []
     for record in _optional_records(
@@ -534,6 +609,7 @@ def _backup_gate_activity_events(
         "list_backup_gate_records",
         context_name=lane.context,
         instance_name=lane.instance,
+        limit=source_limit,
     ):
         events.append(
             _activity_event(
@@ -554,14 +630,19 @@ def _backup_gate_activity_events(
 
 
 def _preview_activity_events(
-    *, record_store: object, profile: LaunchplaneProductProfileRecord
+    *,
+    record_store: object,
+    profile: LaunchplaneProductProfileRecord,
+    preview_context: str,
+    source_limit: int,
 ) -> tuple[ProductActivityEvent, ...]:
     events: list[ProductActivityEvent] = []
     for record in _optional_records(
         record_store,
         "list_preview_records",
-        context_name=profile.preview.context,
+        context_name=preview_context,
         anchor_repo=_profile_anchor_repo(profile),
+        limit=source_limit,
     ):
         state = str(getattr(record, "state"))
         action_id = "preview_destroy" if state == "destroyed" else "preview_refresh"
@@ -569,7 +650,7 @@ def _preview_activity_events(
             _activity_event(
                 event_type="preview",
                 product=profile.product,
-                context=profile.preview.context,
+                context=preview_context,
                 environment="preview",
                 driver_id=profile.driver_id,
                 action_id=action_id,
@@ -584,14 +665,18 @@ def _preview_activity_events(
 
 
 def _preview_context_activity_events(
-    *, record_store: object, profile: LaunchplaneProductProfileRecord
+    *,
+    record_store: object,
+    profile: LaunchplaneProductProfileRecord,
+    preview_context: str,
+    source_limit: int,
 ) -> tuple[ProductActivityEvent, ...]:
     events: list[ProductActivityEvent] = []
-    preview_context = profile.preview.context
     for record in _optional_records(
         record_store,
         "list_preview_desired_state_records",
         context_name=preview_context,
+        limit=source_limit,
     ):
         if getattr(record, "product", "") != profile.product:
             continue
@@ -616,6 +701,7 @@ def _preview_context_activity_events(
         record_store,
         "list_preview_lifecycle_cleanup_records",
         context_name=preview_context,
+        limit=source_limit,
     ):
         if getattr(record, "product", "") != profile.product:
             continue
@@ -639,6 +725,7 @@ def _preview_context_activity_events(
         record_store,
         "list_preview_pr_feedback_records",
         context_name=preview_context,
+        limit=source_limit,
     ):
         if getattr(record, "product", "") != profile.product:
             continue
@@ -668,10 +755,10 @@ def _authz_policy_mentions_product(record: object, product: str) -> bool:
 
 
 def _authz_policy_activity_events(
-    *, record_store: object, profile: LaunchplaneProductProfileRecord
+    *, record_store: object, profile: LaunchplaneProductProfileRecord, source_limit: int
 ) -> tuple[ProductActivityEvent, ...]:
     events: list[ProductActivityEvent] = []
-    for record in _optional_records(record_store, "list_authz_policy_records"):
+    for record in _optional_records(record_store, "list_authz_policy_records", limit=source_limit):
         if not _authz_policy_mentions_product(record, profile.product):
             continue
         events.append(

--- a/control_plane/contracts/product_profile_record.py
+++ b/control_plane/contracts/product_profile_record.py
@@ -73,7 +73,9 @@ class ProductPreviewProfile(BaseModel):
             for raw_key in raw_keys:
                 key = raw_key.strip()
                 if not key:
-                    raise ValueError(f"product preview profile {field_name} values must be non-empty")
+                    raise ValueError(
+                        f"product preview profile {field_name} values must be non-empty"
+                    )
                 if key in keys:
                     raise ValueError(f"product preview profile {field_name} values must be unique")
                 keys.append(key)
@@ -82,7 +84,9 @@ class ProductPreviewProfile(BaseModel):
         omitted = set(normalized["omitted_env_keys"])
         overlap = sorted(copied & omitted)
         if overlap:
-            raise ValueError("product preview profile cannot both copy and omit env keys: " + ", ".join(overlap))
+            raise ValueError(
+                "product preview profile cannot both copy and omit env keys: " + ", ".join(overlap)
+            )
         for raw_key, raw_value in self.override_env.items():
             key = raw_key.strip()
             if not key:
@@ -116,7 +120,9 @@ class ProductPromotionWorkflowProfile(BaseModel):
         if not self.bump_input.strip():
             raise ValueError("product promotion workflow requires bump_input")
         if self.default_bump.strip() not in {"patch", "minor", "major"}:
-            raise ValueError("product promotion workflow default_bump must be patch, minor, or major")
+            raise ValueError(
+                "product promotion workflow default_bump must be patch, minor, or major"
+            )
         return self
 
 
@@ -132,6 +138,7 @@ class LaunchplaneProductProfileRecord(BaseModel):
     runtime_port: int = Field(ge=1, le=65535)
     health_path: str
     lanes: tuple[ProductLaneProfile, ...] = ()
+    historical_contexts: tuple[str, ...] = ()
     preview: ProductPreviewProfile = Field(default_factory=ProductPreviewProfile)
     promotion_workflow: ProductPromotionWorkflowProfile = Field(
         default_factory=ProductPromotionWorkflowProfile
@@ -155,4 +162,12 @@ class LaunchplaneProductProfileRecord(BaseModel):
             raise ValueError("product profile requires updated_at")
         if not self.source.strip():
             raise ValueError("product profile requires source")
+        normalized_historical_contexts: list[str] = []
+        for raw_context in self.historical_contexts:
+            context = raw_context.strip()
+            if not context:
+                raise ValueError("product profile historical_contexts values must be non-empty")
+            if context not in normalized_historical_contexts:
+                normalized_historical_contexts.append(context)
+        self.historical_contexts = tuple(normalized_historical_contexts)
         return self

--- a/control_plane/product_context_cutover.py
+++ b/control_plane/product_context_cutover.py
@@ -265,10 +265,18 @@ def _profile_after_cutover(
     preview = profile.preview.model_copy(
         update={"context": target_context} if profile.preview.enabled else {}
     )
+    historical_contexts = tuple(
+        dict.fromkeys(
+            context.strip()
+            for context in (*profile.historical_contexts, source_context)
+            if context.strip()
+        )
+    )
     return profile.model_copy(
         update={
             "display_name": display_name or profile.display_name,
             "lanes": lanes,
+            "historical_contexts": historical_contexts,
             "preview": preview,
             "updated_at": now,
             "source": source_label,
@@ -280,6 +288,7 @@ def _profile_semantic_payload(profile: LaunchplaneProductProfileRecord) -> dict[
     return {
         "display_name": profile.display_name,
         "lanes": [lane.model_dump(mode="json") for lane in profile.lanes],
+        "historical_contexts": list(profile.historical_contexts),
         "preview": profile.preview.model_dump(mode="json"),
     }
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -131,6 +131,10 @@ matching target-context record already exists, and managed secret records and
 bindings are disabled rather than deleted. Run with `dry_run=false` only when
 `blocked=false`. Inventory records, release tuples, deployments, promotions,
 backup gates, and preview history are preserved as historical evidence.
+Launchplane keeps the legacy context in the product profile's
+`historical_contexts` metadata after cutover so product activity queries still
+show pre-cutover evidence while deploy and config authority use the current lane
+contexts.
 
 Render an explicit emergency bootstrap policy or import a policy into DB-backed
 records with:

--- a/docs/records.md
+++ b/docs/records.md
@@ -153,7 +153,9 @@ records and Dokploy target lookups, and can disable legacy managed secret record
 and bindings. It should not delete inventory records, release tuples,
 deployments, promotions, backup gates, or preview history; those records are
 historical evidence and should continue to describe the route that produced
-them.
+them. Product profiles retain legacy route names in `historical_contexts` after
+cutover so product activity read models can continue to include that preserved
+evidence without making the legacy context current authority again.
 
 Before changing a product profile or deleting legacy rows, audit both route
 families with:

--- a/tests/test_product_context_cutover.py
+++ b/tests/test_product_context_cutover.py
@@ -236,6 +236,7 @@ class ProductContextCutoverTests(unittest.TestCase):
         self.assertEqual(payload["mode"], "apply")
         self.assertEqual(profile.display_name, "SellYourOutboard")
         self.assertEqual({lane.context for lane in profile.lanes}, {"sellyouroutboard"})
+        self.assertEqual(profile.historical_contexts, ("sellyouroutboard-testing",))
         self.assertEqual(profile.preview.context, "sellyouroutboard")
         self.assertEqual(len(target_runtime_records), 2)
         self.assertEqual(target.target_name, "syo-prod-app")

--- a/tests/test_product_environment_read_model.py
+++ b/tests/test_product_environment_read_model.py
@@ -227,9 +227,16 @@ class _ActivityRecordStore(_PreviewRecordStore):
 
 
 class _ManyDeploymentActivityRecordStore(_PreviewRecordStore):
+    def __init__(
+        self, profile: LaunchplaneProductProfileRecord, previews: tuple[PreviewRecord, ...]
+    ) -> None:
+        super().__init__(profile, previews)
+        self.deployment_limits: list[int | None] = []
+
     def list_deployment_records(
         self, *, context_name: str = "", instance_name: str = "", limit: int | None = None
     ) -> tuple[object, ...]:
+        self.deployment_limits.append(limit)
         if context_name != "example-site-prod" or instance_name != "prod":
             return ()
         records = tuple(
@@ -246,6 +253,38 @@ class _ManyDeploymentActivityRecordStore(_PreviewRecordStore):
         if limit is not None:
             return records[:limit]
         return records
+
+
+class _HistoricalActivityRecordStore(_PreviewRecordStore):
+    def __init__(
+        self, profile: LaunchplaneProductProfileRecord, previews: tuple[PreviewRecord, ...]
+    ) -> None:
+        super().__init__(profile, previews)
+        self.deployment_calls: list[tuple[str, str, int | None]] = []
+
+    def list_deployment_records(
+        self, *, context_name: str = "", instance_name: str = "", limit: int | None = None
+    ) -> tuple[object, ...]:
+        self.deployment_calls.append((context_name, instance_name, limit))
+        if instance_name != "prod" or context_name not in {
+            "example-site-prod",
+            "example-site-legacy",
+        }:
+            return ()
+        return (
+            SimpleNamespace(
+                record_id=f"deployment-{context_name}",
+                deploy=SimpleNamespace(
+                    status="pass",
+                    started_at="2026-05-02T10:00:00Z",
+                    finished_at=(
+                        "2026-05-02T12:00:00Z"
+                        if context_name == "example-site-prod"
+                        else "2026-05-02T09:00:00Z"
+                    ),
+                ),
+            ),
+        )
 
 
 class ProductEnvironmentReadModelTest(unittest.TestCase):
@@ -586,6 +625,35 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
         self.assertIn("preview", event_types)
         self.assertIn("preview_desired_state", event_types)
 
+    def test_product_activity_read_model_reads_historical_contexts_after_cutover(
+        self,
+    ) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(
+            {
+                **_site_profile_payload(
+                    preview_enabled=False,
+                    preview_context="",
+                    testing_context="example-site-prod",
+                    prod_context="example-site-prod",
+                ),
+                "historical_contexts": ("example-site-legacy",),
+            }
+        )
+        store = _HistoricalActivityRecordStore(profile, ())
+
+        activity = build_product_activity_read_model(
+            record_store=store,
+            product="example-site",
+            limit=10,
+        )
+
+        deployment_contexts = {
+            event.context for event in activity.events if event.event_type == "deployment"
+        }
+        self.assertIn("example-site-prod", deployment_contexts)
+        self.assertIn("example-site-legacy", deployment_contexts)
+        self.assertIn(("example-site-legacy", "prod", 10), store.deployment_calls)
+
     def test_product_activity_read_model_limits_after_merging_all_sources(self) -> None:
         profile = LaunchplaneProductProfileRecord.model_validate(
             _site_profile_payload(
@@ -611,3 +679,4 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
         }
         self.assertEqual(len(activity.events), 12)
         self.assertIn("deployment-prod-1", deployment_record_ids)
+        self.assertIn(12, store.deployment_limits)


### PR DESCRIPTION
## Summary

- retain legacy context names in product profile `historical_contexts` when product context cutover moves current authority
- include current and historical contexts when building product activity timelines so pre-cutover evidence remains visible
- bound each activity source fetch by the requested final activity limit, avoiding full-history scans without using too-small per-source caps
- document historical contexts as evidence metadata, not current authority

## Validation

- `uv run python -m unittest tests.test_product_environment_read_model tests.test_product_context_cutover`
- `uv run --extra dev ruff format --check control_plane/contracts/product_profile_record.py control_plane/contracts/product_environment_read_model.py control_plane/product_context_cutover.py tests/test_product_environment_read_model.py tests/test_product_context_cutover.py`
- `uv run --extra dev ruff check control_plane/contracts/product_profile_record.py control_plane/contracts/product_environment_read_model.py control_plane/product_context_cutover.py tests/test_product_environment_read_model.py tests/test_product_context_cutover.py`
- `uv run --extra dev mypy control_plane/contracts/product_profile_record.py control_plane/contracts/product_environment_read_model.py tests/test_product_environment_read_model.py`
- `uv run python -m unittest`
- `uv run --extra dev ruff check .`
