### PR TITLE
Fix product read model regressions

### DIFF
--- a/control_plane/contracts/product_environment_read_model.py
+++ b/control_plane/contracts/product_environment_read_model.py
@@ -845,8 +845,9 @@ def _product_action_authorization_context(
         if _generic_web_prod_promotion_supported(profile):
             return _lane_context_if_present(profile=profile, instance="prod")
         return ""
+    if action.route_path == "/v1/drivers/generic-web/prod-promotion-workflow":
+        return _lane_context_for_instance(profile=profile, preferred_instances=("testing", "prod"))
     if action.route_path in {
-        "/v1/drivers/generic-web/prod-promotion-workflow",
         "/v1/drivers/odoo/prod-backup-gate",
         "/v1/drivers/odoo/prod-promotion",
         "/v1/drivers/odoo/prod-rollback",

--- a/control_plane/product_context_cutover.py
+++ b/control_plane/product_context_cutover.py
@@ -256,6 +256,7 @@ def _profile_after_cutover(
     now: str,
     source_label: str,
 ) -> LaunchplaneProductProfileRecord:
+    source_preview_context = profile.preview.context.strip()
     lanes = tuple(
         lane.model_copy(update={"context": target_context})
         if lane.context == source_context or lane.instance in {"testing", "prod"}
@@ -268,8 +269,8 @@ def _profile_after_cutover(
     historical_contexts = tuple(
         dict.fromkeys(
             context.strip()
-            for context in (*profile.historical_contexts, source_context)
-            if context.strip()
+            for context in (*profile.historical_contexts, source_context, source_preview_context)
+            if context.strip() and context.strip() != target_context
         )
     )
     return profile.model_copy(

--- a/tests/test_product_context_cutover.py
+++ b/tests/test_product_context_cutover.py
@@ -254,6 +254,46 @@ class ProductContextCutoverTests(unittest.TestCase):
         )
         self.assertEqual(repeated_payload["profile"]["action"], "unchanged")
 
+    def test_apply_preserves_distinct_preview_context_in_history(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "test.sqlite3")
+            )
+            try:
+                store.ensure_schema()
+                _seed_syo_source_records(store)
+                profile = store.read_product_profile_record("sellyouroutboard")
+                store.write_product_profile_record(
+                    profile.model_copy(
+                        update={
+                            "preview": profile.preview.model_copy(
+                                update={"context": "sellyouroutboard-preview"}
+                            )
+                        }
+                    )
+                )
+
+                apply_product_context_cutover(
+                    record_store=store,
+                    request=ProductContextCutoverRequest(
+                        product="sellyouroutboard",
+                        source_context="sellyouroutboard-testing",
+                        target_context="sellyouroutboard",
+                        mode="apply",
+                        display_name="SellYourOutboard",
+                        source_label="test:cutover",
+                    ),
+                )
+                updated_profile = store.read_product_profile_record("sellyouroutboard")
+            finally:
+                store.close()
+
+        self.assertEqual(
+            updated_profile.historical_contexts,
+            ("sellyouroutboard-testing", "sellyouroutboard-preview"),
+        )
+        self.assertEqual(updated_profile.preview.context, "sellyouroutboard")
+
     def test_legacy_cleanup_deletes_lookup_records_and_disables_source_secrets(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(

--- a/tests/test_product_environment_read_model.py
+++ b/tests/test_product_environment_read_model.py
@@ -414,6 +414,49 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
             actions["prod_promotion"].disabled_reasons[0],
         )
 
+    def test_product_site_overview_authorizes_generic_web_prod_workflow_with_testing_context(
+        self,
+    ) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(
+            _site_profile_payload(preview_enabled=False)
+        )
+
+        def action_allowed(action: str, product: str, context: str) -> bool:
+            return (
+                action == "generic_web_prod_promotion.dispatch"
+                and context == "example-site-testing"
+            )
+
+        overview = build_product_site_overview(
+            record_store=_PreviewRecordStore(profile, ()),
+            product=profile.product,
+            action_allowed=action_allowed,
+        )
+
+        actions = {action.action_id: action for action in overview.available_actions}
+        self.assertTrue(actions["prod_promotion_workflow"].enabled)
+
+    def test_product_site_overview_does_not_authorize_generic_web_prod_workflow_with_prod_only_context(
+        self,
+    ) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(
+            _site_profile_payload(preview_enabled=False)
+        )
+
+        def action_allowed(action: str, product: str, context: str) -> bool:
+            return (
+                action == "generic_web_prod_promotion.dispatch" and context == "example-site-prod"
+            )
+
+        overview = build_product_site_overview(
+            record_store=_PreviewRecordStore(profile, ()),
+            product=profile.product,
+            action_allowed=action_allowed,
+        )
+
+        actions = {action.action_id: action for action in overview.available_actions}
+        self.assertFalse(actions["prod_promotion_workflow"].enabled)
+
     def test_preview_disabled_hides_generic_web_preview_actions(self) -> None:
         profile = LaunchplaneProductProfileRecord.model_validate(
             _site_profile_payload(preview_enabled=False, preview_context="")
@@ -432,7 +475,7 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
         self.assertFalse(actions["preview_refresh"].enabled)
         self.assertFalse(actions["preview_destroy"].enabled)
 
-    def test_product_site_overview_does_not_enable_prod_actions_for_testing_only_authz(
+    def test_product_site_overview_uses_testing_only_authz_for_workflow_not_direct_prod(
         self,
     ) -> None:
         profile = LaunchplaneProductProfileRecord.model_validate(
@@ -452,7 +495,7 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
         )
 
         actions = {action.action_id: action for action in overview.available_actions}
-        self.assertFalse(actions["prod_promotion_workflow"].enabled)
+        self.assertTrue(actions["prod_promotion_workflow"].enabled)
         self.assertFalse(actions["prod_promotion"].enabled)
 
     def test_product_site_overview_hides_generic_web_prod_workflow_without_prod_lane(


### PR DESCRIPTION
## Summary

- align generic-web prod workflow dispatch read-model authz with the live handler by checking the source/testing lane context
- preserve a distinct old preview context in product profile `historical_contexts` during context cutover
- add regression coverage for both read-model behaviors

## Validation

- `uv run python -m unittest tests.test_product_environment_read_model tests.test_product_context_cutover`
- `uv run --extra dev ruff format --check control_plane/contracts/product_environment_read_model.py control_plane/product_context_cutover.py tests/test_product_environment_read_model.py tests/test_product_context_cutover.py`
- `uv run --extra dev ruff check control_plane/contracts/product_environment_read_model.py control_plane/product_context_cutover.py tests/test_product_environment_read_model.py tests/test_product_context_cutover.py`
- `uv run --extra dev mypy control_plane/contracts/product_environment_read_model.py tests/test_product_environment_read_model.py`
- `uv run --extra dev ruff check .`
- `uv run python -m unittest`
