### PR TITLE
Support profile-backed driver dispatch

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -544,6 +544,15 @@ class PromotionEvidenceEnvelope(BaseModel):
         return self
 
 
+def _validate_driver_envelope_product(product: str, *, label: str) -> None:
+    if not product.strip():
+        raise ValueError(f"{label} requires product.")
+
+
+class ProductDriverMismatchError(ValueError):
+    pass
+
+
 class OdooPostDeployEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -553,8 +562,7 @@ class OdooPostDeployEnvelope(BaseModel):
 
     @model_validator(mode="after")
     def _validate_alignment(self) -> "OdooPostDeployEnvelope":
-        if self.product.strip() != "odoo":
-            raise ValueError("Odoo post-deploy requires product 'odoo'.")
+        _validate_driver_envelope_product(self.product, label="Odoo post-deploy")
         return self
 
 
@@ -567,8 +575,7 @@ class OdooArtifactPublishEnvelope(BaseModel):
 
     @model_validator(mode="after")
     def _validate_alignment(self) -> "OdooArtifactPublishEnvelope":
-        if self.product.strip() != "odoo":
-            raise ValueError("Odoo artifact publish requires product 'odoo'.")
+        _validate_driver_envelope_product(self.product, label="Odoo artifact publish")
         return self
 
 
@@ -581,8 +588,7 @@ class OdooArtifactPublishInputsEnvelope(BaseModel):
 
     @model_validator(mode="after")
     def _validate_alignment(self) -> "OdooArtifactPublishInputsEnvelope":
-        if self.product.strip() != "odoo":
-            raise ValueError("Odoo artifact publish inputs require product 'odoo'.")
+        _validate_driver_envelope_product(self.product, label="Odoo artifact publish inputs")
         return self
 
 
@@ -595,8 +601,7 @@ class OdooProdRollbackEnvelope(BaseModel):
 
     @model_validator(mode="after")
     def _validate_alignment(self) -> "OdooProdRollbackEnvelope":
-        if self.product.strip() != "odoo":
-            raise ValueError("Odoo prod rollback requires product 'odoo'.")
+        _validate_driver_envelope_product(self.product, label="Odoo prod rollback")
         return self
 
 
@@ -609,8 +614,7 @@ class OdooProdBackupGateEnvelope(BaseModel):
 
     @model_validator(mode="after")
     def _validate_alignment(self) -> "OdooProdBackupGateEnvelope":
-        if self.product.strip() != "odoo":
-            raise ValueError("Odoo prod backup gate requires product 'odoo'.")
+        _validate_driver_envelope_product(self.product, label="Odoo prod backup gate")
         return self
 
 
@@ -623,8 +627,7 @@ class OdooProdPromotionEnvelope(BaseModel):
 
     @model_validator(mode="after")
     def _validate_alignment(self) -> "OdooProdPromotionEnvelope":
-        if self.product.strip() != "odoo":
-            raise ValueError("Odoo prod promotion requires product 'odoo'.")
+        _validate_driver_envelope_product(self.product, label="Odoo prod promotion")
         return self
 
 
@@ -637,8 +640,7 @@ class VeriReelTestingDeployEnvelope(BaseModel):
 
     @model_validator(mode="after")
     def _validate_alignment(self) -> "VeriReelTestingDeployEnvelope":
-        if self.product.strip() != "verireel":
-            raise ValueError("VeriReel testing deploy requires product 'verireel'.")
+        _validate_driver_envelope_product(self.product, label="VeriReel testing deploy")
         if self.deploy.instance != "testing":
             raise ValueError("VeriReel testing deploy requires instance 'testing'.")
         return self
@@ -695,8 +697,7 @@ class VeriReelTestingVerificationEnvelope(BaseModel):
 
     @model_validator(mode="after")
     def _validate_alignment(self) -> "VeriReelTestingVerificationEnvelope":
-        if self.product.strip() != "verireel":
-            raise ValueError("VeriReel testing verification requires product 'verireel'.")
+        _validate_driver_envelope_product(self.product, label="VeriReel testing verification")
         return self
 
 
@@ -709,8 +710,7 @@ class VeriReelProdDeployEnvelope(BaseModel):
 
     @model_validator(mode="after")
     def _validate_alignment(self) -> "VeriReelProdDeployEnvelope":
-        if self.product.strip() != "verireel":
-            raise ValueError("VeriReel prod deploy requires product 'verireel'.")
+        _validate_driver_envelope_product(self.product, label="VeriReel prod deploy")
         if self.deploy.instance != "prod":
             raise ValueError("VeriReel prod deploy requires instance 'prod'.")
         return self
@@ -725,8 +725,7 @@ class VeriReelAppMaintenanceEnvelope(BaseModel):
 
     @model_validator(mode="after")
     def _validate_alignment(self) -> "VeriReelAppMaintenanceEnvelope":
-        if self.product.strip() != "verireel":
-            raise ValueError("VeriReel app maintenance requires product 'verireel'.")
+        _validate_driver_envelope_product(self.product, label="VeriReel app maintenance")
         return self
 
 
@@ -739,8 +738,7 @@ class VeriReelStableEnvironmentEnvelope(BaseModel):
 
     @model_validator(mode="after")
     def _validate_alignment(self) -> "VeriReelStableEnvironmentEnvelope":
-        if self.product.strip() != "verireel":
-            raise ValueError("VeriReel stable environment requires product 'verireel'.")
+        _validate_driver_envelope_product(self.product, label="VeriReel stable environment")
         return self
 
 
@@ -753,8 +751,7 @@ class VeriReelRuntimeVerificationEnvelope(BaseModel):
 
     @model_validator(mode="after")
     def _validate_alignment(self) -> "VeriReelRuntimeVerificationEnvelope":
-        if self.product.strip() != "verireel":
-            raise ValueError("VeriReel runtime verification requires product 'verireel'.")
+        _validate_driver_envelope_product(self.product, label="VeriReel runtime verification")
         return self
 
 
@@ -767,8 +764,7 @@ class VeriReelProdPromotionEnvelope(BaseModel):
 
     @model_validator(mode="after")
     def _validate_alignment(self) -> "VeriReelProdPromotionEnvelope":
-        if self.product.strip() != "verireel":
-            raise ValueError("VeriReel prod promotion requires product 'verireel'.")
+        _validate_driver_envelope_product(self.product, label="VeriReel prod promotion")
         return self
 
 
@@ -779,14 +775,9 @@ class VeriReelProdBackupGateEnvelope(BaseModel):
     product: str
     backup_gate: VeriReelProdBackupGateRequest
 
-
-class ThreadingWSGIServer(ThreadingMixIn, WSGIServer):
-    daemon_threads = True
-
     @model_validator(mode="after")
     def _validate_alignment(self) -> "VeriReelProdBackupGateEnvelope":
-        if self.product.strip() != "verireel":
-            raise ValueError("VeriReel prod backup gate requires product 'verireel'.")
+        _validate_driver_envelope_product(self.product, label="VeriReel prod backup gate")
         return self
 
 
@@ -799,8 +790,7 @@ class VeriReelProdRollbackEnvelope(BaseModel):
 
     @model_validator(mode="after")
     def _validate_alignment(self) -> "VeriReelProdRollbackEnvelope":
-        if self.product.strip() != "verireel":
-            raise ValueError("VeriReel prod rollback requires product 'verireel'.")
+        _validate_driver_envelope_product(self.product, label="VeriReel prod rollback")
         return self
 
 
@@ -813,8 +803,7 @@ class VeriReelPreviewRefreshEnvelope(BaseModel):
 
     @model_validator(mode="after")
     def _validate_alignment(self) -> "VeriReelPreviewRefreshEnvelope":
-        if self.product.strip() != "verireel":
-            raise ValueError("VeriReel preview refresh requires product 'verireel'.")
+        _validate_driver_envelope_product(self.product, label="VeriReel preview refresh")
         return self
 
 
@@ -827,8 +816,7 @@ class VeriReelPreviewDestroyEnvelope(BaseModel):
 
     @model_validator(mode="after")
     def _validate_alignment(self) -> "VeriReelPreviewDestroyEnvelope":
-        if self.product.strip() != "verireel":
-            raise ValueError("VeriReel preview destroy requires product 'verireel'.")
+        _validate_driver_envelope_product(self.product, label="VeriReel preview destroy")
         return self
 
 
@@ -865,8 +853,7 @@ class VeriReelPreviewVerificationEnvelope(BaseModel):
 
     @model_validator(mode="after")
     def _validate_alignment(self) -> "VeriReelPreviewVerificationEnvelope":
-        if self.product.strip() != "verireel":
-            raise ValueError("VeriReel preview verification requires product 'verireel'.")
+        _validate_driver_envelope_product(self.product, label="VeriReel preview verification")
         return self
 
 
@@ -879,8 +866,7 @@ class VeriReelPreviewInventoryEnvelope(BaseModel):
 
     @model_validator(mode="after")
     def _validate_alignment(self) -> "VeriReelPreviewInventoryEnvelope":
-        if self.product.strip() != "verireel":
-            raise ValueError("VeriReel preview inventory requires product 'verireel'.")
+        _validate_driver_envelope_product(self.product, label="VeriReel preview inventory")
         return self
 
 
@@ -1059,6 +1045,10 @@ class ProductConfigApplyEnvelope(BaseModel):
         if self.runtime_environment is not None:
             payload["runtime_environment"] = self.runtime_environment
         return payload
+
+
+class ThreadingWSGIServer(ThreadingMixIn, WSGIServer):
+    daemon_threads = True
 
 
 def _json_response(
@@ -1615,6 +1605,37 @@ def _product_profile_context_cutover_contexts_allowed(
         requested_contexts.add(preview_context.strip())
     requested_contexts.discard("")
     return requested_contexts.issubset(allowed_contexts)
+
+
+def _product_driver_compatible(
+    *, profile: LaunchplaneProductProfileRecord, expected_driver_id: str
+) -> bool:
+    expected = expected_driver_id.strip()
+    if profile.driver_id == expected:
+        return True
+    descriptor = read_driver_descriptor(profile.driver_id)
+    return descriptor.base_driver_id == expected
+
+
+def _require_product_driver(
+    *,
+    record_store: object,
+    product: str,
+    expected_driver_id: str,
+) -> LaunchplaneProductProfileRecord | None:
+    normalized_product = product.strip()
+    normalized_driver_id = expected_driver_id.strip()
+    if normalized_product == normalized_driver_id:
+        return None
+    read_profile = getattr(record_store, "read_product_profile_record", None)
+    if not callable(read_profile):
+        raise ValueError("Product driver validation requires product profile storage.")
+    profile = cast(LaunchplaneProductProfileRecord, read_profile(normalized_product))
+    if not _product_driver_compatible(profile=profile, expected_driver_id=normalized_driver_id):
+        raise ProductDriverMismatchError(
+            "Product profile is not compatible with the requested driver route."
+        )
+    return profile
 
 
 def _safe_return_to(value: str) -> str:
@@ -3873,6 +3894,11 @@ def create_launchplane_service_app(
                 result = {}
             elif path == "/v1/drivers/odoo/post-deploy":
                 request = OdooPostDeployEnvelope.model_validate(payload)
+                _require_product_driver(
+                    record_store=record_store,
+                    product=request.product,
+                    expected_driver_id="odoo",
+                )
                 if not authz_policy.allows(
                     identity=identity,
                     action="odoo_post_deploy.execute",
@@ -3917,6 +3943,11 @@ def create_launchplane_service_app(
                 }
             elif path == "/v1/drivers/odoo/artifact-publish":
                 request = OdooArtifactPublishEnvelope.model_validate(payload)
+                _require_product_driver(
+                    record_store=record_store,
+                    product=request.product,
+                    expected_driver_id="odoo",
+                )
                 if not authz_policy.allows(
                     identity=identity,
                     action="odoo_artifact_publish.write",
@@ -3962,6 +3993,11 @@ def create_launchplane_service_app(
                 }
             elif path == "/v1/drivers/odoo/artifact-publish-inputs":
                 request = OdooArtifactPublishInputsEnvelope.model_validate(payload)
+                _require_product_driver(
+                    record_store=record_store,
+                    product=request.product,
+                    expected_driver_id="odoo",
+                )
                 if not authz_policy.allows(
                     identity=identity,
                     action="odoo_artifact_publish_inputs.read",
@@ -4001,6 +4037,11 @@ def create_launchplane_service_app(
                 driver_result = result
             elif path == "/v1/drivers/odoo/prod-backup-gate":
                 request = OdooProdBackupGateEnvelope.model_validate(payload)
+                _require_product_driver(
+                    record_store=record_store,
+                    product=request.product,
+                    expected_driver_id="odoo",
+                )
                 if not authz_policy.allows(
                     identity=identity,
                     action="odoo_prod_backup_gate.execute",
@@ -4048,6 +4089,11 @@ def create_launchplane_service_app(
                 }
             elif path == "/v1/drivers/odoo/prod-promotion":
                 request = OdooProdPromotionEnvelope.model_validate(payload)
+                _require_product_driver(
+                    record_store=record_store,
+                    product=request.product,
+                    expected_driver_id="odoo",
+                )
                 if not authz_policy.allows(
                     identity=identity,
                     action="odoo_prod_promotion.execute",
@@ -4099,6 +4145,11 @@ def create_launchplane_service_app(
                 }
             elif path == "/v1/drivers/odoo/prod-rollback":
                 request = OdooProdRollbackEnvelope.model_validate(payload)
+                _require_product_driver(
+                    record_store=record_store,
+                    product=request.product,
+                    expected_driver_id="odoo",
+                )
                 if not authz_policy.allows(
                     identity=identity,
                     action="odoo_prod_rollback.execute",
@@ -4144,6 +4195,11 @@ def create_launchplane_service_app(
                 }
             elif path == "/v1/drivers/verireel/testing-deploy":
                 request = VeriReelTestingDeployEnvelope.model_validate(payload)
+                _require_product_driver(
+                    record_store=record_store,
+                    product=request.product,
+                    expected_driver_id="verireel",
+                )
                 if not authz_policy.allows(
                     identity=identity,
                     action="verireel_testing_deploy.execute",
@@ -4184,6 +4240,11 @@ def create_launchplane_service_app(
                 result = {"deployment_record_id": driver_result.deployment_record_id}
             elif path == "/v1/drivers/verireel/testing-verification":
                 request = VeriReelTestingVerificationEnvelope.model_validate(payload)
+                _require_product_driver(
+                    record_store=record_store,
+                    product=request.product,
+                    expected_driver_id="verireel",
+                )
                 if not authz_policy.allows(
                     identity=identity,
                     action="deployment.write",
@@ -4222,6 +4283,11 @@ def create_launchplane_service_app(
                 )
             elif path == "/v1/drivers/verireel/stable-environment":
                 request = VeriReelStableEnvironmentEnvelope.model_validate(payload)
+                _require_product_driver(
+                    record_store=record_store,
+                    product=request.product,
+                    expected_driver_id="verireel",
+                )
                 if not authz_policy.allows(
                     identity=identity,
                     action="verireel_stable_environment.read",
@@ -4250,6 +4316,11 @@ def create_launchplane_service_app(
                 result = {}
             elif path == "/v1/drivers/verireel/runtime-verification":
                 request = VeriReelRuntimeVerificationEnvelope.model_validate(payload)
+                _require_product_driver(
+                    record_store=record_store,
+                    product=request.product,
+                    expected_driver_id="verireel",
+                )
                 if not authz_policy.allows(
                     identity=identity,
                     action="verireel_stable_environment.read",
@@ -4278,6 +4349,11 @@ def create_launchplane_service_app(
                 result = {}
             elif path == "/v1/drivers/verireel/app-maintenance":
                 request = VeriReelAppMaintenanceEnvelope.model_validate(payload)
+                _require_product_driver(
+                    record_store=record_store,
+                    product=request.product,
+                    expected_driver_id="verireel",
+                )
                 if not authz_policy.allows(
                     identity=identity,
                     action="verireel_app_maintenance.execute",
@@ -4317,6 +4393,11 @@ def create_launchplane_service_app(
                 result = driver_result.model_dump(mode="json")
             elif path == "/v1/drivers/verireel/prod-deploy":
                 request = VeriReelProdDeployEnvelope.model_validate(payload)
+                _require_product_driver(
+                    record_store=record_store,
+                    product=request.product,
+                    expected_driver_id="verireel",
+                )
                 if not authz_policy.allows(
                     identity=identity,
                     action="verireel_prod_deploy.execute",
@@ -4357,6 +4438,11 @@ def create_launchplane_service_app(
                 result = {"deployment_record_id": driver_result.deployment_record_id}
             elif path == "/v1/drivers/verireel/prod-backup-gate":
                 request = VeriReelProdBackupGateEnvelope.model_validate(payload)
+                _require_product_driver(
+                    record_store=record_store,
+                    product=request.product,
+                    expected_driver_id="verireel",
+                )
                 if not authz_policy.allows(
                     identity=identity,
                     action="verireel_prod_backup_gate.execute",
@@ -4398,6 +4484,11 @@ def create_launchplane_service_app(
                 result = {"backup_gate_record_id": driver_result.backup_record_id}
             elif path == "/v1/drivers/verireel/prod-promotion":
                 request = VeriReelProdPromotionEnvelope.model_validate(payload)
+                _require_product_driver(
+                    record_store=record_store,
+                    product=request.product,
+                    expected_driver_id="verireel",
+                )
                 if not authz_policy.allows(
                     identity=identity,
                     action="verireel_prod_promotion.execute",
@@ -4441,6 +4532,11 @@ def create_launchplane_service_app(
                 }
             elif path == "/v1/drivers/verireel/prod-rollback":
                 request = VeriReelProdRollbackEnvelope.model_validate(payload)
+                _require_product_driver(
+                    record_store=record_store,
+                    product=request.product,
+                    expected_driver_id="verireel",
+                )
                 if not authz_policy.allows(
                     identity=identity,
                     action="verireel_prod_rollback.execute",
@@ -4484,6 +4580,11 @@ def create_launchplane_service_app(
                 }
             elif path == "/v1/drivers/verireel/preview-refresh":
                 request = VeriReelPreviewRefreshEnvelope.model_validate(payload)
+                _require_product_driver(
+                    record_store=record_store,
+                    product=request.product,
+                    expected_driver_id="verireel",
+                )
                 if not authz_policy.allows(
                     identity=identity,
                     action="verireel_preview_refresh.execute",
@@ -4528,6 +4629,11 @@ def create_launchplane_service_app(
                 )
             elif path == "/v1/drivers/verireel/preview-inventory":
                 request = VeriReelPreviewInventoryEnvelope.model_validate(payload)
+                _require_product_driver(
+                    record_store=record_store,
+                    product=request.product,
+                    expected_driver_id="verireel",
+                )
                 if not authz_policy.allows(
                     identity=identity,
                     action="verireel_preview_inventory.read",
@@ -4562,6 +4668,11 @@ def create_launchplane_service_app(
                 result = {"preview_inventory_scan_id": preview_inventory_scan_id}
             elif path == "/v1/drivers/verireel/preview-destroy":
                 request = VeriReelPreviewDestroyEnvelope.model_validate(payload)
+                _require_product_driver(
+                    record_store=record_store,
+                    product=request.product,
+                    expected_driver_id="verireel",
+                )
                 if not authz_policy.allows(
                     identity=identity,
                     action="verireel_preview_destroy.execute",
@@ -4605,6 +4716,11 @@ def create_launchplane_service_app(
                 )
             elif path == "/v1/drivers/verireel/preview-verification":
                 request = VeriReelPreviewVerificationEnvelope.model_validate(payload)
+                _require_product_driver(
+                    record_store=record_store,
+                    product=request.product,
+                    expected_driver_id="verireel",
+                )
                 if not authz_policy.allows(
                     identity=identity,
                     action="preview_generation.write",
@@ -5224,6 +5340,19 @@ def create_launchplane_service_app(
                     "error": {
                         "code": "invalid_request",
                         "message": "Request payload failed validation.",
+                    },
+                },
+            )
+        except ProductDriverMismatchError:
+            return _json_response(
+                start_response=start_response,
+                status_code=403,
+                payload={
+                    "status": "rejected",
+                    "trace_id": request_trace_id,
+                    "error": {
+                        "code": "product_driver_mismatch",
+                        "message": "Product is not configured for the requested driver route.",
                     },
                 },
             )

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -127,6 +127,14 @@ generic web lifecycle and add named product-specific gates or runtime actions.
 The relationship is explicit metadata; product-specific capabilities are still
 declared directly on the product driver.
 
+Driver action routes are owned by the base driver contract. The service accepts
+any product key on Odoo and VeriReel action envelopes, then authorizes the call
+against that product and verifies the product profile's `driver_id` or driver
+descriptor `base_driver_id` matches the requested base driver before dispatching
+the workflow. This keeps product repos on stable Launchplane routes while
+allowing new Odoo- or VeriReel-shaped products to be added by product profile and
+authz records instead of code forks.
+
 Odoo exposes:
 
 - artifact publish handoff

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -6944,6 +6944,152 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             execute_mock.assert_called_once()
 
+    def test_odoo_driver_route_accepts_product_profile_driver_id(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            profile_payload = _product_profile_payload(product="tenant-cm")
+            profile_payload["display_name"] = "Tenant CM"
+            profile_payload["driver_id"] = "odoo"
+            profile_payload["lanes"] = (
+                {
+                    "instance": "prod",
+                    "context": "cm",
+                    "base_url": "https://cm.example.com",
+                    "health_url": "https://cm.example.com/web/health",
+                },
+            )
+            profile_payload["preview"] = {
+                "enabled": False,
+                "context": "",
+                "slug_template": "pr-{number}",
+            }
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/tenant-cm",
+                            "workflow_refs": [
+                                "every/tenant-cm/.github/workflows/deploy-odoo.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["odoo_prod_backup_gate.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="every/tenant-cm",
+                        workflow_ref=(
+                            "every/tenant-cm/.github/workflows/deploy-odoo.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_odoo_prod_backup_gate",
+                return_value=OdooProdBackupGateResult(
+                    context="cm",
+                    instance="prod",
+                    backup_record_id="backup-gate-cm-prod-run-1",
+                    backup_status="pass",
+                    backup_root="/volumes/data/backups/launchplane",
+                    database_dump_path="/volumes/data/backups/launchplane/cm/backup-gate-cm-prod-run-1/cm.dump",
+                    filestore_archive_path="/volumes/data/backups/launchplane/cm/backup-gate-cm-prod-run-1/cm-filestore.tar.gz",
+                    manifest_path="/volumes/data/backups/launchplane/cm/backup-gate-cm-prod-run-1/manifest.json",
+                ),
+            ) as execute_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/prod-backup-gate",
+                    payload={
+                        "product": "tenant-cm",
+                        "backup_gate": {
+                            "context": "cm",
+                            "instance": "prod",
+                            "backup_record_id": "backup-gate-cm-prod-run-1",
+                        },
+                    },
+                )
+
+            self.assertEqual(status_code, 202)
+            self.assertEqual(payload["records"]["backup_record_id"], "backup-gate-cm-prod-run-1")
+            execute_mock.assert_called_once()
+
+    def test_odoo_driver_route_rejects_generic_web_product_profile(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(
+                    _product_profile_payload(product="example-site")
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/example-site",
+                            "workflow_refs": [
+                                "every/example-site/.github/workflows/deploy.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["example-site"],
+                            "contexts": ["cm"],
+                            "actions": ["odoo_prod_backup_gate.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="every/example-site",
+                        workflow_ref=(
+                            "every/example-site/.github/workflows/deploy.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch("control_plane.service.execute_odoo_prod_backup_gate") as execute_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/prod-backup-gate",
+                    payload={
+                        "product": "example-site",
+                        "backup_gate": {
+                            "context": "cm",
+                            "instance": "prod",
+                            "backup_record_id": "backup-gate-example-prod-run-1",
+                        },
+                    },
+                )
+
+            self.assertEqual(status_code, 403)
+            self.assertEqual(payload["error"]["code"], "product_driver_mismatch")
+            execute_mock.assert_not_called()
+
     def test_odoo_prod_backup_gate_driver_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -7450,6 +7596,99 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             self.assertEqual(payload["result"]["rollback_status"], "pass")
+            execute_mock.assert_called_once()
+
+    def test_verireel_driver_route_accepts_product_profile_driver_id(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            profile_payload = _generic_site_profile_payload(product="video-site")
+            profile_payload["display_name"] = "Video Site"
+            profile_payload["driver_id"] = "verireel"
+            profile_payload["lanes"] = (
+                {
+                    "instance": "testing",
+                    "context": "video-site",
+                    "base_url": "https://testing.video.example",
+                    "health_url": "https://testing.video.example/api/health",
+                },
+                {
+                    "instance": "prod",
+                    "context": "video-site",
+                    "base_url": "https://video.example",
+                    "health_url": "https://video.example/api/health",
+                },
+            )
+            profile_payload["preview"] = {
+                "enabled": False,
+                "context": "",
+                "slug_template": "pr-{number}",
+            }
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/video-site",
+                            "workflow_refs": [
+                                "every/video-site/.github/workflows/promote-image.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["video-site"],
+                            "contexts": ["verireel"],
+                            "actions": ["verireel_prod_rollback.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="every/video-site",
+                        workflow_ref=(
+                            "every/video-site/.github/workflows/promote-image.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_verireel_prod_rollback",
+                return_value=VeriReelProdRollbackResult(
+                    promotion_record_id="promotion-video-testing-to-prod-run-12345-attempt-1",
+                    backup_record_id="backup-gate-video-prod-run-12345-attempt-1",
+                    snapshot_name="video-predeploy-20260421-180000",
+                    rollback_status="pass",
+                    rollback_health_status="pass",
+                    rollback_started_at="2026-04-21T18:20:00Z",
+                    rollback_finished_at="2026-04-21T18:21:00Z",
+                ),
+            ) as execute_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/prod-rollback",
+                    payload={
+                        "product": "video-site",
+                        "rollback": {
+                            "promotion_record_id": "promotion-video-testing-to-prod-run-12345-attempt-1",
+                            "backup_record_id": "backup-gate-video-prod-run-12345-attempt-1",
+                        },
+                    },
+                )
+
+            self.assertEqual(status_code, 202)
+            self.assertEqual(
+                payload["records"]["promotion_record_id"],
+                "promotion-video-testing-to-prod-run-12345-attempt-1",
+            )
             execute_mock.assert_called_once()
 
     def test_verireel_prod_rollback_driver_rejects_unauthorized_workflow(self) -> None:


### PR DESCRIPTION
## Summary
- relax Odoo/VeriReel driver envelopes so product ids are no longer hardcoded to canonical product names
- add service-side product profile driver compatibility checks before specialized driver dispatch
- cover non-canonical Odoo/VeriReel product profiles and generic-web isolation in service tests
- document that base-driver routes are reused while product eligibility comes from product profile driver metadata

Refs #161

## Validation
- uv run python -m unittest tests.test_service
- uv run python -m unittest
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_service.py
- uv run --extra dev ruff check control_plane/service.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_service.py
- git diff --check

## Notes
- Focused mypy on control_plane/service.py and tests/test_service.py still reports the existing service/test baseline, including the long-standing single request variable cascade in service.py. This PR does not introduce a new slice-specific mypy failure in the added tests.
