### PR TITLE
Use product profiles for VeriReel preview cleanup

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -833,10 +833,10 @@ class VeriReelPreviewVerificationRequest(BaseModel):
 
     @model_validator(mode="after")
     def _validate_request(self) -> "VeriReelPreviewVerificationRequest":
-        if self.context != "verireel-testing":
-            raise ValueError("VeriReel preview verification requires context 'verireel-testing'.")
-        if self.anchor_repo != "verireel":
-            raise ValueError("VeriReel preview verification requires anchor_repo 'verireel'.")
+        if not self.context.strip():
+            raise ValueError("VeriReel preview verification requires context.")
+        if not self.anchor_repo.strip():
+            raise ValueError("VeriReel preview verification requires anchor_repo.")
         if self.verification_status.strip() not in {"pass", "fail"}:
             raise ValueError("VeriReel preview verification status must be 'pass' or 'fail'.")
         if not self.verified_at.strip():

--- a/control_plane/workflows/preview_lifecycle_cleanup.py
+++ b/control_plane/workflows/preview_lifecycle_cleanup.py
@@ -273,15 +273,7 @@ def build_preview_lifecycle_cleanup_record(
             preview_slug_template=preview_slug_template,
         )
 
-    if plan.product != "verireel" or plan.context != "verireel-testing":
-        return _blocked_record(
-            plan=plan,
-            requested_at=requested_at,
-            source=source,
-            apply=True,
-            error_message="VeriReel preview lifecycle cleanup execution requires verireel-testing.",
-        )
-
+    anchor_repo = plan.product
     parsed_previews: list[tuple[str, int]] = []
     for preview_slug in plan.orphaned_slugs:
         try:
@@ -297,7 +289,7 @@ def build_preview_lifecycle_cleanup_record(
         preview = find_preview_record(
             record_store=record_store,
             context_name=plan.context,
-            anchor_repo="verireel",
+            anchor_repo=anchor_repo,
             anchor_pr_number=anchor_pr_number,
         )
         if preview is None:
@@ -308,7 +300,7 @@ def build_preview_lifecycle_cleanup_record(
                 apply=True,
                 error_message=(
                     "Launchplane will not destroy preview provider state without a matching "
-                    f"stored preview record for {plan.context}/verireel/{preview_slug}."
+                    f"stored preview record for {plan.context}/{anchor_repo}/{preview_slug}."
                 ),
             )
         parsed_previews.append((preview_slug, anchor_pr_number))
@@ -321,7 +313,7 @@ def build_preview_lifecycle_cleanup_record(
             control_plane_root=control_plane_root,
             request=VeriReelPreviewDestroyRequest(
                 context=plan.context,
-                anchor_repo="verireel",
+                anchor_repo=anchor_repo,
                 anchor_pr_number=anchor_pr_number,
                 preview_slug=preview_slug,
                 destroy_reason=destroy_reason,
@@ -334,7 +326,7 @@ def build_preview_lifecycle_cleanup_record(
                     record_store=record_store,
                     request=PreviewDestroyMutationRequest(
                         context=plan.context,
-                        anchor_repo="verireel",
+                        anchor_repo=anchor_repo,
                         anchor_pr_number=anchor_pr_number,
                         destroyed_at=destroy_result.destroy_finished_at,
                         destroy_reason=destroy_reason,
@@ -344,7 +336,7 @@ def build_preview_lifecycle_cleanup_record(
                 results.append(
                     PreviewLifecycleCleanupResult(
                         preview_slug=preview_slug,
-                        anchor_repo="verireel",
+                        anchor_repo=anchor_repo,
                         anchor_pr_number=anchor_pr_number,
                         status="destroyed",
                         application_name=destroy_result.application_name,
@@ -357,7 +349,7 @@ def build_preview_lifecycle_cleanup_record(
                 results.append(
                     PreviewLifecycleCleanupResult(
                         preview_slug=preview_slug,
-                        anchor_repo="verireel",
+                        anchor_repo=anchor_repo,
                         anchor_pr_number=anchor_pr_number,
                         status="failed",
                         application_name=destroy_result.application_name,
@@ -371,7 +363,7 @@ def build_preview_lifecycle_cleanup_record(
         results.append(
             PreviewLifecycleCleanupResult(
                 preview_slug=preview_slug,
-                anchor_repo="verireel",
+                anchor_repo=anchor_repo,
                 anchor_pr_number=anchor_pr_number,
                 status="failed",
                 application_name=destroy_result.application_name,

--- a/control_plane/workflows/verireel_preview_driver.py
+++ b/control_plane/workflows/verireel_preview_driver.py
@@ -46,10 +46,10 @@ class VeriReelPreviewRefreshRequest(BaseModel):
 
     @model_validator(mode="after")
     def _validate_request(self) -> "VeriReelPreviewRefreshRequest":
-        if self.context != "verireel-testing":
-            raise ValueError("VeriReel preview refresh requires context 'verireel-testing'.")
-        if self.anchor_repo != "verireel":
-            raise ValueError("VeriReel preview refresh requires anchor_repo 'verireel'.")
+        if not self.context.strip():
+            raise ValueError("VeriReel preview refresh requires context.")
+        if not self.anchor_repo.strip():
+            raise ValueError("VeriReel preview refresh requires anchor_repo.")
         if not self.anchor_pr_url.strip():
             raise ValueError("VeriReel preview refresh requires anchor_pr_url.")
         if not self.anchor_head_sha.strip():
@@ -80,10 +80,10 @@ class VeriReelPreviewDestroyRequest(BaseModel):
 
     @model_validator(mode="after")
     def _validate_request(self) -> "VeriReelPreviewDestroyRequest":
-        if self.context != "verireel-testing":
-            raise ValueError("VeriReel preview destroy requires context 'verireel-testing'.")
-        if self.anchor_repo != "verireel":
-            raise ValueError("VeriReel preview destroy requires anchor_repo 'verireel'.")
+        if not self.context.strip():
+            raise ValueError("VeriReel preview destroy requires context.")
+        if not self.anchor_repo.strip():
+            raise ValueError("VeriReel preview destroy requires anchor_repo.")
         if not self.preview_slug.strip():
             raise ValueError("VeriReel preview destroy requires preview_slug.")
         if self.preview_slug.strip() != _expected_preview_slug(self.anchor_pr_number):
@@ -127,8 +127,8 @@ class VeriReelPreviewInventoryRequest(BaseModel):
 
     @model_validator(mode="after")
     def _validate_request(self) -> "VeriReelPreviewInventoryRequest":
-        if self.context != "verireel-testing":
-            raise ValueError("VeriReel preview inventory requires context 'verireel-testing'.")
+        if not self.context.strip():
+            raise ValueError("VeriReel preview inventory requires context.")
         return self
 
 
@@ -222,7 +222,9 @@ def _resolve_preview_base_url(*, control_plane_root: Path, context_name: str) ->
     return preview_base_url
 
 
-def _resolve_preview_url(*, control_plane_root: Path, request: VeriReelPreviewRefreshRequest) -> str:
+def _resolve_preview_url(
+    *, control_plane_root: Path, request: VeriReelPreviewRefreshRequest
+) -> str:
     if request.preview_url.strip():
         return request.preview_url.strip()
     return _preview_url_from_base_url(
@@ -376,7 +378,9 @@ def execute_verireel_preview_inventory(
         path="/api/project.all",
     )
     if not isinstance(raw_projects, list):
-        raise click.ClickException("Dokploy project inventory returned an invalid response payload.")
+        raise click.ClickException(
+            "Dokploy project inventory returned an invalid response payload."
+        )
     preview_items: list[VeriReelPreviewInventoryItem] = []
     for raw_project in raw_projects:
         project = control_plane_dokploy.as_json_object(raw_project)
@@ -400,7 +404,9 @@ def execute_verireel_preview_inventory(
                 preview_slug = _preview_slug_from_application_name(application_name)
                 if not preview_slug:
                     continue
-                application_id = str(application.get("applicationId") or application.get("id") or "").strip()
+                application_id = str(
+                    application.get("applicationId") or application.get("id") or ""
+                ).strip()
                 if not application_id:
                     continue
                 preview_items.append(
@@ -1227,7 +1233,9 @@ def execute_verireel_preview_destroy(
         raise click.ClickException("VeriReel testing template application is missing DATABASE_URL.")
 
     started_at = utc_now_timestamp()
-    preview_url = _resolve_preview_url_for_destroy(control_plane_root=control_plane_root, request=request)
+    preview_url = _resolve_preview_url_for_destroy(
+        control_plane_root=control_plane_root, request=request
+    )
     application_name = _preview_application_name(request.preview_slug)
     application = _find_application_by_name(
         host=host, token=token, application_name=application_name

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -135,6 +135,12 @@ the workflow. This keeps product repos on stable Launchplane routes while
 allowing new Odoo- or VeriReel-shaped products to be added by product profile and
 authz records instead of code forks.
 
+VeriReel preview lifecycle cleanup also uses the product and context on the
+preview lifecycle plan as the cleanup boundary. A VeriReel-shaped product can
+therefore clean up previews recorded under its own product key and preview
+context instead of being pinned to the canonical `verireel`/`verireel-testing`
+pair.
+
 Odoo exposes:
 
 - artifact publish handoff

--- a/tests/test_preview_lifecycle_cleanup.py
+++ b/tests/test_preview_lifecycle_cleanup.py
@@ -8,6 +8,7 @@ from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.generic_web_preview import GenericWebPreviewDestroyResult
 from control_plane.workflows.preview_lifecycle_cleanup import build_preview_lifecycle_cleanup_record
+from control_plane.workflows.verireel_preview_driver import VeriReelPreviewDestroyResult
 
 
 class PreviewLifecycleCleanupTests(unittest.TestCase):
@@ -102,6 +103,71 @@ class PreviewLifecycleCleanupTests(unittest.TestCase):
 
         self.assertEqual(record.status, "blocked")
         self.assertEqual(record.blocked_slugs, ("bad-slug",))
+
+    def test_verireel_cleanup_uses_plan_product_as_anchor_repo(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_preview_record(
+                PreviewRecord(
+                    preview_id="preview-video-site-testing-video-site-pr-42",
+                    context="video-site-testing",
+                    anchor_repo="video-site",
+                    anchor_pr_number=42,
+                    anchor_pr_url="https://github.com/every/video-site/pull/42",
+                    preview_label="video-site/pr-42",
+                    canonical_url="https://pr-42.video-preview.example.com",
+                    state="active",
+                    created_at="2026-04-30T21:00:00Z",
+                    updated_at="2026-04-30T21:00:00Z",
+                    eligible_at="2026-04-30T21:00:00Z",
+                )
+            )
+            plan = PreviewLifecyclePlanRecord(
+                plan_id="preview-lifecycle-plan-video-site-testing-1",
+                product="video-site",
+                context="video-site-testing",
+                planned_at="2026-04-30T21:00:00Z",
+                source="test",
+                status="pass",
+                inventory_scan_id="preview-inventory-scan-video-site-testing-1",
+                orphaned_slugs=("pr-42",),
+            )
+
+            with patch(
+                "control_plane.workflows.preview_lifecycle_cleanup.execute_verireel_preview_destroy",
+                return_value=VeriReelPreviewDestroyResult(
+                    destroy_status="pass",
+                    destroy_started_at="2026-04-30T21:01:00Z",
+                    destroy_finished_at="2026-04-30T21:01:02Z",
+                    application_name="ver-preview-pr-42-app",
+                    application_id="app-42",
+                    preview_url="https://pr-42.video-preview.example.com",
+                ),
+            ) as destroy:
+                record = build_preview_lifecycle_cleanup_record(
+                    plan=plan,
+                    requested_at="2026-04-30T21:02:00Z",
+                    source="test",
+                    apply=True,
+                    destroy_reason="test_cleanup",
+                    control_plane_root=root,
+                    record_store=store,
+                    timeout_seconds=300,
+                    driver_id="verireel",
+                    preview_slug_template="pr-{number}",
+                )
+
+            self.assertEqual(record.status, "pass")
+            self.assertEqual(record.destroyed_slugs, ("pr-42",))
+            self.assertEqual(record.results[0].anchor_repo, "video-site")
+            destroy.assert_called_once()
+            destroy_request = destroy.call_args.kwargs["request"]
+            self.assertEqual(destroy_request.context, "video-site-testing")
+            self.assertEqual(destroy_request.anchor_repo, "video-site")
+            preview = store.read_preview_record("preview-video-site-testing-video-site-pr-42")
+            self.assertEqual(preview.state, "destroyed")
+            self.assertEqual(preview.destroy_reason, "test_cleanup")
 
 
 if __name__ == "__main__":

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -6308,6 +6308,119 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(updated_preview.destroyed_at, "2026-04-29T20:00:05Z")
         self.assertEqual(cleanup_records[0].status, "pass")
 
+    def test_preview_lifecycle_cleanup_endpoint_uses_verireel_product_profile(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            profile_payload = _generic_site_profile_payload(product="video-site")
+            profile_payload["display_name"] = "Video Site"
+            profile_payload["driver_id"] = "verireel"
+            profile_payload["preview"] = {
+                "enabled": True,
+                "context": "video-site-testing",
+                "slug_template": "pr-{number}",
+            }
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
+            )
+            store.write_preview_record(
+                PreviewRecord(
+                    preview_id="preview-video-site-testing-video-site-pr-41",
+                    context="video-site-testing",
+                    anchor_repo="video-site",
+                    anchor_pr_number=41,
+                    anchor_pr_url="https://github.example/every/video-site/pull/41",
+                    preview_label="video-site-testing/video-site#41",
+                    canonical_url="https://pr-41.preview.example",
+                    state="active",
+                    created_at="2026-04-20T10:00:00Z",
+                    updated_at="2026-04-20T10:00:00Z",
+                    eligible_at="2026-04-20T10:00:00Z",
+                )
+            )
+            store.write_preview_lifecycle_plan_record(
+                PreviewLifecyclePlanRecord(
+                    plan_id="preview-lifecycle-plan-video-site-testing-20260429T195838Z",
+                    product="video-site",
+                    context="video-site-testing",
+                    planned_at="2026-04-29T19:58:38Z",
+                    source="preview-janitor",
+                    status="pass",
+                    inventory_scan_id="preview-inventory-scan-video-site-testing-20260429T195837Z",
+                    actual_slugs=("pr-41",),
+                    orphaned_slugs=("pr-41",),
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/video-site",
+                            "workflow_refs": [
+                                "every/video-site/.github/workflows/preview-janitor.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["video-site"],
+                            "contexts": ["video-site-testing"],
+                            "actions": ["preview_lifecycle.cleanup"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="every/video-site",
+                        workflow_ref=(
+                            "every/video-site/.github/workflows/preview-janitor.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.workflows.preview_lifecycle_cleanup.execute_verireel_preview_destroy",
+                return_value=VeriReelPreviewDestroyResult(
+                    destroy_status="pass",
+                    destroy_started_at="2026-04-29T20:00:00Z",
+                    destroy_finished_at="2026-04-29T20:00:05Z",
+                    application_name="ver-preview-pr-41-app",
+                    application_id="app-41",
+                    preview_url="https://pr-41.preview.example",
+                ),
+            ) as execute_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/previews/lifecycle-cleanup",
+                    payload={
+                        "product": "video-site",
+                        "context": "video-site-testing",
+                        "plan_id": "preview-lifecycle-plan-video-site-testing-20260429T195838Z",
+                        "source": "preview-janitor",
+                        "apply": True,
+                        "destroy_reason": "external_preview_janitor_cleanup_completed",
+                    },
+                )
+
+            updated_preview = FilesystemRecordStore(state_dir=state_dir).read_preview_record(
+                "preview-video-site-testing-video-site-pr-41"
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["status"], "pass")
+        self.assertEqual(payload["result"]["destroyed_slugs"], ["pr-41"])
+        execute_mock.assert_called_once()
+        destroy_request = execute_mock.call_args.kwargs["request"]
+        self.assertEqual(destroy_request.context, "video-site-testing")
+        self.assertEqual(destroy_request.anchor_repo, "video-site")
+        self.assertEqual(updated_preview.state, "destroyed")
+
     def test_preview_lifecycle_cleanup_endpoint_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- relax VeriReel preview request validation so profile-owned contexts and anchor repos are accepted
- make preview lifecycle cleanup use the plan product/context as the VeriReel cleanup boundary
- cover direct workflow cleanup and service endpoint cleanup for a non-canonical VeriReel-shaped product
- document profile-owned VeriReel preview cleanup behavior

Stacked on #168. Refs #161.

## Validation
- uv run python -m unittest tests.test_preview_lifecycle_cleanup tests.test_service.LaunchplaneServiceTests.test_preview_lifecycle_cleanup_endpoint_executes_and_records_destroyed_preview tests.test_service.LaunchplaneServiceTests.test_preview_lifecycle_cleanup_endpoint_uses_verireel_product_profile
- uv run python -m unittest
- uv run --extra dev ruff check --diff control_plane/service.py control_plane/workflows/verireel_preview_driver.py control_plane/workflows/preview_lifecycle_cleanup.py tests/test_preview_lifecycle_cleanup.py tests/test_service.py
- uv run --extra dev ruff check control_plane/service.py control_plane/workflows/verireel_preview_driver.py control_plane/workflows/preview_lifecycle_cleanup.py tests/test_preview_lifecycle_cleanup.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/service.py control_plane/workflows/verireel_preview_driver.py control_plane/workflows/preview_lifecycle_cleanup.py tests/test_preview_lifecycle_cleanup.py tests/test_service.py
- git diff --check
