### PR TITLE
Use product profile lanes for VeriReel stable actions

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -679,8 +679,8 @@ class VeriReelTestingVerificationRequest(BaseModel):
 
     @model_validator(mode="after")
     def _validate_request(self) -> "VeriReelTestingVerificationRequest":
-        if self.context != "verireel":
-            raise ValueError("VeriReel testing verification requires context 'verireel'.")
+        if not self.context.strip():
+            raise ValueError("VeriReel testing verification requires context.")
         if self.instance != "testing":
             raise ValueError("VeriReel testing verification requires instance 'testing'.")
         if not self.deployment_record_id.strip():
@@ -1635,6 +1635,37 @@ def _require_product_driver(
         raise ProductDriverMismatchError(
             "Product profile is not compatible with the requested driver route."
         )
+    return profile
+
+
+def _product_profile_has_lane(
+    *, profile: LaunchplaneProductProfileRecord, context: str, instance: str
+) -> bool:
+    normalized_context = context.strip()
+    normalized_instance = instance.strip()
+    return any(
+        lane.context.strip() == normalized_context and lane.instance.strip() == normalized_instance
+        for lane in profile.lanes
+    )
+
+
+def _require_product_driver_lane(
+    *,
+    record_store: object,
+    product: str,
+    expected_driver_id: str,
+    context: str,
+    instance: str,
+) -> LaunchplaneProductProfileRecord | None:
+    profile = _require_product_driver(
+        record_store=record_store,
+        product=product,
+        expected_driver_id=expected_driver_id,
+    )
+    if profile is None:
+        return None
+    if not _product_profile_has_lane(profile=profile, context=context, instance=instance):
+        raise ProductDriverMismatchError("Product profile does not own the requested driver lane.")
     return profile
 
 
@@ -4195,10 +4226,12 @@ def create_launchplane_service_app(
                 }
             elif path == "/v1/drivers/verireel/testing-deploy":
                 request = VeriReelTestingDeployEnvelope.model_validate(payload)
-                _require_product_driver(
+                _require_product_driver_lane(
                     record_store=record_store,
                     product=request.product,
                     expected_driver_id="verireel",
+                    context=request.deploy.context,
+                    instance=request.deploy.instance,
                 )
                 if not authz_policy.allows(
                     identity=identity,
@@ -4240,10 +4273,12 @@ def create_launchplane_service_app(
                 result = {"deployment_record_id": driver_result.deployment_record_id}
             elif path == "/v1/drivers/verireel/testing-verification":
                 request = VeriReelTestingVerificationEnvelope.model_validate(payload)
-                _require_product_driver(
+                _require_product_driver_lane(
                     record_store=record_store,
                     product=request.product,
                     expected_driver_id="verireel",
+                    context=request.verification.context,
+                    instance=request.verification.instance,
                 )
                 if not authz_policy.allows(
                     identity=identity,
@@ -4283,10 +4318,12 @@ def create_launchplane_service_app(
                 )
             elif path == "/v1/drivers/verireel/stable-environment":
                 request = VeriReelStableEnvironmentEnvelope.model_validate(payload)
-                _require_product_driver(
+                _require_product_driver_lane(
                     record_store=record_store,
                     product=request.product,
                     expected_driver_id="verireel",
+                    context=request.environment.context,
+                    instance=request.environment.instance,
                 )
                 if not authz_policy.allows(
                     identity=identity,
@@ -4316,10 +4353,12 @@ def create_launchplane_service_app(
                 result = {}
             elif path == "/v1/drivers/verireel/runtime-verification":
                 request = VeriReelRuntimeVerificationEnvelope.model_validate(payload)
-                _require_product_driver(
+                _require_product_driver_lane(
                     record_store=record_store,
                     product=request.product,
                     expected_driver_id="verireel",
+                    context=request.verification.context,
+                    instance=request.verification.instance,
                 )
                 if not authz_policy.allows(
                     identity=identity,
@@ -4393,10 +4432,12 @@ def create_launchplane_service_app(
                 result = driver_result.model_dump(mode="json")
             elif path == "/v1/drivers/verireel/prod-deploy":
                 request = VeriReelProdDeployEnvelope.model_validate(payload)
-                _require_product_driver(
+                _require_product_driver_lane(
                     record_store=record_store,
                     product=request.product,
                     expected_driver_id="verireel",
+                    context=request.deploy.context,
+                    instance=request.deploy.instance,
                 )
                 if not authz_policy.allows(
                     identity=identity,
@@ -4438,10 +4479,12 @@ def create_launchplane_service_app(
                 result = {"deployment_record_id": driver_result.deployment_record_id}
             elif path == "/v1/drivers/verireel/prod-backup-gate":
                 request = VeriReelProdBackupGateEnvelope.model_validate(payload)
-                _require_product_driver(
+                _require_product_driver_lane(
                     record_store=record_store,
                     product=request.product,
                     expected_driver_id="verireel",
+                    context=request.backup_gate.context,
+                    instance=request.backup_gate.instance,
                 )
                 if not authz_policy.allows(
                     identity=identity,
@@ -4484,10 +4527,19 @@ def create_launchplane_service_app(
                 result = {"backup_gate_record_id": driver_result.backup_record_id}
             elif path == "/v1/drivers/verireel/prod-promotion":
                 request = VeriReelProdPromotionEnvelope.model_validate(payload)
-                _require_product_driver(
+                _require_product_driver_lane(
                     record_store=record_store,
                     product=request.product,
                     expected_driver_id="verireel",
+                    context=request.promotion.context,
+                    instance=request.promotion.from_instance,
+                )
+                _require_product_driver_lane(
+                    record_store=record_store,
+                    product=request.product,
+                    expected_driver_id="verireel",
+                    context=request.promotion.context,
+                    instance=request.promotion.to_instance,
                 )
                 if not authz_policy.allows(
                     identity=identity,
@@ -4532,10 +4584,12 @@ def create_launchplane_service_app(
                 }
             elif path == "/v1/drivers/verireel/prod-rollback":
                 request = VeriReelProdRollbackEnvelope.model_validate(payload)
-                _require_product_driver(
+                _require_product_driver_lane(
                     record_store=record_store,
                     product=request.product,
                     expected_driver_id="verireel",
+                    context=request.rollback.context,
+                    instance=request.rollback.instance,
                 )
                 if not authz_policy.allows(
                     identity=identity,

--- a/control_plane/workflows/verireel_environment.py
+++ b/control_plane/workflows/verireel_environment.py
@@ -14,13 +14,13 @@ class VeriReelStableEnvironmentRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     schema_version: int = Field(default=1, ge=1)
-    context: Literal["verireel"] = "verireel"
+    context: str = "verireel"
     instance: Literal["testing", "prod"]
 
     @model_validator(mode="after")
     def _validate_request(self) -> "VeriReelStableEnvironmentRequest":
-        if self.context != "verireel":
-            raise ValueError("VeriReel stable environment requires context 'verireel'.")
+        if not self.context.strip():
+            raise ValueError("VeriReel stable environment requires context.")
         return self
 
 

--- a/control_plane/workflows/verireel_prod_backup_gate.py
+++ b/control_plane/workflows/verireel_prod_backup_gate.py
@@ -50,8 +50,8 @@ class VeriReelProdBackupGateRequest(BaseModel):
 
     @model_validator(mode="after")
     def _validate_request(self) -> "VeriReelProdBackupGateRequest":
-        if self.context != "verireel":
-            raise ValueError("VeriReel prod backup gate requires context 'verireel'.")
+        if not self.context.strip():
+            raise ValueError("VeriReel prod backup gate requires context.")
         if self.instance != "prod":
             raise ValueError("VeriReel prod backup gate requires instance 'prod'.")
         if not self.backup_record_id.strip():
@@ -165,14 +165,12 @@ def _run_delegated_worker(
         )
     except subprocess.TimeoutExpired as exc:
         raise click.ClickException(
-            "VeriReel prod backup gate worker timed out after "
-            f"{timeout_seconds} seconds."
+            f"VeriReel prod backup gate worker timed out after {timeout_seconds} seconds."
         ) from exc
     stdout = completed.stdout.strip()
     if not stdout:
         detail = (
-            completed.stderr.strip()
-            or "VeriReel prod backup gate worker returned no JSON payload."
+            completed.stderr.strip() or "VeriReel prod backup gate worker returned no JSON payload."
         )
         raise click.ClickException(detail)
     try:

--- a/control_plane/workflows/verireel_prod_promotion.py
+++ b/control_plane/workflows/verireel_prod_promotion.py
@@ -57,8 +57,8 @@ class VeriReelProdPromotionRequest(BaseModel):
 
     @model_validator(mode="after")
     def _validate_request(self) -> "VeriReelProdPromotionRequest":
-        if self.context != "verireel":
-            raise ValueError("VeriReel prod promotion requires context 'verireel'.")
+        if not self.context.strip():
+            raise ValueError("VeriReel prod promotion requires context.")
         if self.from_instance != "testing":
             raise ValueError("VeriReel prod promotion requires from_instance 'testing'.")
         if self.to_instance != "prod":
@@ -373,14 +373,20 @@ def _resolve_application_id(
         context_name=request.context,
         instance_name=request.to_instance,
     )
-    if target_definition is None or target_definition.target_type != "application" or not target_definition.target_id.strip():
+    if (
+        target_definition is None
+        or target_definition.target_type != "application"
+        or not target_definition.target_id.strip()
+    ):
         raise click.ClickException(
             f"VeriReel prod promotion post-deploy update requires an application target for {request.context}/{request.to_instance}."
         )
     return target_definition.target_id.strip()
 
 
-def _find_application_schedule(*, host: str, token: str, application_id: str, schedule_name: str) -> dict[str, object] | None:
+def _find_application_schedule(
+    *, host: str, token: str, application_id: str, schedule_name: str
+) -> dict[str, object] | None:
     for schedule in control_plane_dokploy.list_dokploy_schedules(
         host=host,
         token=token,
@@ -430,7 +436,10 @@ def _upsert_application_schedule(
             token=token,
             path="/api/schedule.update",
             method="POST",
-            payload={"scheduleId": control_plane_dokploy.schedule_key(existing_schedule), **payload},
+            payload={
+                "scheduleId": control_plane_dokploy.schedule_key(existing_schedule),
+                **payload,
+            },
         )
     resolved_schedule = _find_application_schedule(
         host=host,
@@ -614,7 +623,9 @@ def execute_verireel_prod_promotion(
         )
 
     if deployment_result.rollout_status != "pass":
-        error_message = deployment_result.error_message or "VeriReel prod rollout verification failed."
+        error_message = (
+            deployment_result.error_message or "VeriReel prod rollout verification failed."
+        )
         failed_rollout_result = VeriReelRolloutVerificationResult(
             status="fail",
             base_url=deployment_result.rollout_base_url,

--- a/control_plane/workflows/verireel_prod_rollback.py
+++ b/control_plane/workflows/verireel_prod_rollback.py
@@ -67,8 +67,8 @@ class VeriReelProdRollbackRequest(BaseModel):
 
     @model_validator(mode="after")
     def _validate_request(self) -> "VeriReelProdRollbackRequest":
-        if self.context != "verireel":
-            raise ValueError("VeriReel prod rollback requires context 'verireel'.")
+        if not self.context.strip():
+            raise ValueError("VeriReel prod rollback requires context.")
         if self.instance != "prod":
             raise ValueError("VeriReel prod rollback requires instance 'prod'.")
         if not self.promotion_record_id.strip():

--- a/control_plane/workflows/verireel_rollout.py
+++ b/control_plane/workflows/verireel_rollout.py
@@ -33,8 +33,8 @@ class VeriReelRolloutVerificationRequest(BaseModel):
 
     @model_validator(mode="after")
     def _validate_request(self) -> "VeriReelRolloutVerificationRequest":
-        if self.context != "verireel":
-            raise ValueError("VeriReel rollout verification requires context 'verireel'.")
+        if not self.context.strip():
+            raise ValueError("VeriReel rollout verification requires context.")
         if self.instance not in {"testing", "prod"}:
             raise ValueError("VeriReel rollout verification requires instance 'testing' or 'prod'.")
         return self
@@ -131,7 +131,9 @@ def assert_verireel_rollout_pages(
                 accept="text/html,application/json",
             )
         except (HTTPError, URLError, TimeoutError, ValueError) as exc:
-            raise click.ClickException(f"{error_prefix} page verification failed for {page_url}: {exc}") from exc
+            raise click.ClickException(
+                f"{error_prefix} page verification failed for {page_url}: {exc}"
+            ) from exc
         if status_code < 200 or status_code >= 300:
             raise click.ClickException(
                 f"{error_prefix} page verification expected {page_url} to return 2xx, received {status_code}."

--- a/control_plane/workflows/verireel_stable_deploy.py
+++ b/control_plane/workflows/verireel_stable_deploy.py
@@ -13,7 +13,11 @@ from control_plane.contracts.promotion_record import HealthcheckEvidence
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.dokploy_deploy import execute_dokploy_artifact_deploy
-from control_plane.workflows.ship import build_deployment_record, generate_deployment_record_id, utc_now_timestamp
+from control_plane.workflows.ship import (
+    build_deployment_record,
+    generate_deployment_record_id,
+    utc_now_timestamp,
+)
 from control_plane.workflows.verireel_rollout import (
     DEFAULT_ROLLOUT_INTERVAL_SECONDS,
     DEFAULT_ROLLOUT_TIMEOUT_SECONDS,
@@ -44,8 +48,8 @@ class VeriReelStableDeployRequest(BaseModel):
 
     @model_validator(mode="after")
     def _validate_request(self) -> "VeriReelStableDeployRequest":
-        if self.context != "verireel":
-            raise ValueError("VeriReel stable deploy requires context 'verireel'.")
+        if not self.context.strip():
+            raise ValueError("VeriReel stable deploy requires context.")
         if self.instance not in {"testing", "prod"}:
             raise ValueError("VeriReel stable deploy requires instance 'testing' or 'prod'.")
         if not self.artifact_id.strip():
@@ -154,7 +158,8 @@ def _resolve_ship_request(
         context=request.context,
         instance=request.instance,
         source_git_ref=request.source_git_ref,
-        target_name=target_definition.target_name.strip() or _default_target_name_for_instance(request.instance),
+        target_name=target_definition.target_name.strip()
+        or _default_target_name_for_instance(request.instance),
         target_type=target_definition.target_type,
         deploy_mode=deploy_mode,
         wait=True,

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -141,6 +141,12 @@ therefore clean up previews recorded under its own product key and preview
 context instead of being pinned to the canonical `verireel`/`verireel-testing`
 pair.
 
+VeriReel stable-lane actions follow the same product-profile boundary. For
+non-canonical products, service dispatch verifies that the requested context and
+instance match a lane on the product profile before invoking stable deploy,
+environment, rollout verification, backup gate, promotion, or rollback
+workflows.
+
 Odoo exposes:
 
 - artifact publish handoff

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -7751,7 +7751,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                             ],
                             "event_names": ["workflow_dispatch"],
                             "products": ["video-site"],
-                            "contexts": ["verireel"],
+                            "contexts": ["video-site"],
                             "actions": ["verireel_prod_rollback.execute"],
                         }
                     ]
@@ -7791,6 +7791,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     payload={
                         "product": "video-site",
                         "rollback": {
+                            "context": "video-site",
+                            "instance": "prod",
                             "promotion_record_id": "promotion-video-testing-to-prod-run-12345-attempt-1",
                             "backup_record_id": "backup-gate-video-prod-run-12345-attempt-1",
                         },
@@ -7803,6 +7805,87 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 "promotion-video-testing-to-prod-run-12345-attempt-1",
             )
             execute_mock.assert_called_once()
+
+    def test_verireel_driver_route_rejects_unowned_profile_lane(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            profile_payload = _generic_site_profile_payload(product="video-site")
+            profile_payload["display_name"] = "Video Site"
+            profile_payload["driver_id"] = "verireel"
+            profile_payload["lanes"] = (
+                {
+                    "instance": "testing",
+                    "context": "video-site",
+                    "base_url": "https://testing.video.example",
+                    "health_url": "https://testing.video.example/api/health",
+                },
+                {
+                    "instance": "prod",
+                    "context": "video-site",
+                    "base_url": "https://video.example",
+                    "health_url": "https://video.example/api/health",
+                },
+            )
+            profile_payload["preview"] = {
+                "enabled": False,
+                "context": "",
+                "slug_template": "pr-{number}",
+            }
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/video-site",
+                            "workflow_refs": [
+                                "every/video-site/.github/workflows/promote-image.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["video-site"],
+                            "contexts": ["other-site"],
+                            "actions": ["verireel_prod_rollback.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="every/video-site",
+                        workflow_ref=(
+                            "every/video-site/.github/workflows/promote-image.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch("control_plane.service.execute_verireel_prod_rollback") as execute_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/prod-rollback",
+                    payload={
+                        "product": "video-site",
+                        "rollback": {
+                            "context": "other-site",
+                            "instance": "prod",
+                            "promotion_record_id": "promotion-video-testing-to-prod-run-12345-attempt-1",
+                            "backup_record_id": "backup-gate-video-prod-run-12345-attempt-1",
+                        },
+                    },
+                )
+
+            self.assertEqual(status_code, 403)
+            self.assertEqual(payload["error"]["code"], "product_driver_mismatch")
+            execute_mock.assert_not_called()
 
     def test_verireel_prod_rollback_driver_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- relax VeriReel stable request models so stable contexts are not pinned to canonical `verireel`
- add service-side product profile lane ownership checks before dispatching non-canonical VeriReel stable actions
- cover non-canonical VeriReel rollback with owned and unowned profile lane cases
- document that VeriReel stable actions are bounded by product profile lanes

Stacked on #169, which is stacked on #168. Refs #161.

## Validation
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_verireel_driver_route_accepts_product_profile_driver_id tests.test_service.LaunchplaneServiceTests.test_verireel_driver_route_rejects_unowned_profile_lane tests.test_service.LaunchplaneServiceTests.test_verireel_prod_rollback_driver_executes_for_authorized_workflow
- uv run python -m unittest tests.test_service
- uv run python -m unittest tests.test_verireel_testing_deploy tests.test_verireel_environment tests.test_verireel_prod_backup_gate tests.test_verireel_prod_promotion tests.test_verireel_prod_rollback
- uv run python -m unittest
- uv run --extra dev ruff check --diff control_plane/service.py control_plane/workflows/verireel_stable_deploy.py control_plane/workflows/verireel_environment.py control_plane/workflows/verireel_prod_backup_gate.py control_plane/workflows/verireel_prod_promotion.py control_plane/workflows/verireel_prod_rollback.py control_plane/workflows/verireel_rollout.py tests/test_service.py
- uv run --extra dev ruff check control_plane/service.py control_plane/workflows/verireel_stable_deploy.py control_plane/workflows/verireel_environment.py control_plane/workflows/verireel_prod_backup_gate.py control_plane/workflows/verireel_prod_promotion.py control_plane/workflows/verireel_prod_rollback.py control_plane/workflows/verireel_rollout.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/service.py control_plane/workflows/verireel_stable_deploy.py control_plane/workflows/verireel_environment.py control_plane/workflows/verireel_prod_backup_gate.py control_plane/workflows/verireel_prod_promotion.py control_plane/workflows/verireel_prod_rollback.py control_plane/workflows/verireel_rollout.py tests/test_service.py
- git diff --check
