### PR TITLE
Derive driver route authz from descriptors

### DIFF
--- a/control_plane/contracts/driver_descriptor.py
+++ b/control_plane/contracts/driver_descriptor.py
@@ -33,6 +33,8 @@ class DriverActionDescriptor(BaseModel):
     scope: DriverActionScope
     method: Literal["GET", "POST"]
     route_path: str
+    authz_action: str = ""
+    operator_visible: bool = True
     input_schema: dict[str, object] = Field(default_factory=dict)
     output_schema: dict[str, object] = Field(default_factory=dict)
     writes_records: tuple[str, ...] = ()

--- a/control_plane/contracts/product_environment_read_model.py
+++ b/control_plane/contracts/product_environment_read_model.py
@@ -16,7 +16,11 @@ from control_plane.contracts.product_profile_record import (
 )
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.contracts.secret_record import SecretBinding
-from control_plane.drivers.registry import build_driver_context_view, read_driver_descriptor
+from control_plane.drivers.registry import (
+    build_driver_context_view,
+    list_driver_descriptors,
+    read_driver_descriptor,
+)
 
 
 ActionAllowed = Callable[[str, str, str], bool]
@@ -33,35 +37,16 @@ class ProductReadModelStore(Protocol):
     def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord: ...
 
 
-ACTION_AUTHZ_BY_ROUTE = {
-    "/v1/drivers/generic-web/deploy": "generic_web_deploy.execute",
-    "/v1/drivers/generic-web/prod-promotion": "generic_web_prod_promotion.execute",
-    "/v1/drivers/generic-web/prod-promotion-workflow": "generic_web_prod_promotion.dispatch",
-    "/v1/drivers/generic-web/preview-desired-state": "preview_desired_state.discover",
-    "/v1/drivers/generic-web/preview-inventory": "preview_inventory.read",
-    "/v1/drivers/generic-web/preview-refresh": "preview_refresh.execute",
-    "/v1/drivers/generic-web/preview-readiness": "preview_readiness.evaluate",
-    "/v1/drivers/generic-web/preview-destroy": "preview_destroy.execute",
-    "/v1/drivers/odoo/artifact-publish-inputs": "odoo_artifact_publish_inputs.read",
-    "/v1/drivers/odoo/artifact-publish": "odoo_artifact_publish.write",
-    "/v1/drivers/odoo/post-deploy": "odoo_post_deploy.execute",
-    "/v1/drivers/odoo/prod-backup-gate": "odoo_prod_backup_gate.execute",
-    "/v1/drivers/odoo/prod-promotion": "odoo_prod_promotion.execute",
-    "/v1/drivers/odoo/prod-rollback": "odoo_prod_rollback.execute",
-    "/v1/drivers/verireel/testing-deploy": "verireel_testing_deploy.execute",
-    "/v1/drivers/verireel/testing-verification": "deployment.write",
-    "/v1/drivers/verireel/stable-environment": "verireel_stable_environment.read",
-    "/v1/drivers/verireel/runtime-verification": "verireel_stable_environment.read",
-    "/v1/drivers/verireel/app-maintenance": "verireel_app_maintenance.execute",
-    "/v1/drivers/verireel/prod-deploy": "verireel_prod_deploy.execute",
-    "/v1/drivers/verireel/prod-backup-gate": "verireel_prod_backup_gate.execute",
-    "/v1/drivers/verireel/prod-promotion": "verireel_prod_promotion.execute",
-    "/v1/drivers/verireel/prod-rollback": "verireel_prod_rollback.execute",
-    "/v1/drivers/verireel/preview-refresh": "verireel_preview_refresh.execute",
-    "/v1/drivers/verireel/preview-inventory": "verireel_preview_inventory.read",
-    "/v1/drivers/verireel/preview-destroy": "verireel_preview_destroy.execute",
-    "/v1/drivers/verireel/preview-verification": "preview_generation.write",
-}
+def _build_action_authz_by_route() -> dict[str, str]:
+    return {
+        action.route_path: action.authz_action
+        for descriptor in list_driver_descriptors()
+        for action in descriptor.actions
+        if action.route_path and action.authz_action
+    }
+
+
+ACTION_AUTHZ_BY_ROUTE = _build_action_authz_by_route()
 
 PREVIEW_PROFILE_REQUIRED_ACTION_IDS = {
     "preview_desired_state",
@@ -1049,6 +1034,7 @@ def _action_availability(
     descriptor_actions = {
         action.action_id: action
         for action in (descriptor.actions if descriptor is not None else ())
+        if action.operator_visible
     }
     action_ids = tuple(descriptor_actions)
     if include_unsupported:
@@ -1100,7 +1086,9 @@ def _availability_for_descriptor_action(
     support_reason = _action_support_reason(profile=profile, action=action)
     if support_reason:
         disabled_reasons.append(support_reason)
-    authz_action = ACTION_AUTHZ_BY_ROUTE.get(action.route_path, action.action_id)
+    authz_action = action.authz_action or ACTION_AUTHZ_BY_ROUTE.get(
+        action.route_path, action.action_id
+    )
     if not action_allowed(authz_action, product, authorization_context):
         disabled_reasons.append("Caller is not authorized for this action.")
     return ProductActionAvailability(

--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -38,6 +38,8 @@ def _action(
     scope: DriverActionScope,
     route_path: str,
     method: Literal["GET", "POST"] = "POST",
+    authz_action: str = "",
+    operator_visible: bool = True,
     writes_records: tuple[str, ...] = (),
 ) -> DriverActionDescriptor:
     return DriverActionDescriptor(
@@ -48,6 +50,8 @@ def _action(
         scope=scope,
         method=method,
         route_path=route_path,
+        authz_action=authz_action,
+        operator_visible=operator_visible,
         writes_records=writes_records,
     )
 
@@ -105,6 +109,7 @@ GENERIC_WEB_DRIVER = DriverDescriptor(
             safety="mutation",
             scope="instance",
             route_path="/v1/drivers/generic-web/deploy",
+            authz_action="generic_web_deploy.execute",
             writes_records=("deployment",),
         ),
         _action(
@@ -114,6 +119,7 @@ GENERIC_WEB_DRIVER = DriverDescriptor(
             safety="mutation",
             scope="instance",
             route_path="/v1/drivers/generic-web/prod-promotion",
+            authz_action="generic_web_prod_promotion.execute",
             writes_records=("deployment", "promotion", "inventory"),
         ),
         _action(
@@ -123,6 +129,7 @@ GENERIC_WEB_DRIVER = DriverDescriptor(
             safety="mutation",
             scope="instance",
             route_path="/v1/drivers/generic-web/prod-promotion-workflow",
+            authz_action="generic_web_prod_promotion.dispatch",
             writes_records=(),
         ),
         _action(
@@ -132,6 +139,7 @@ GENERIC_WEB_DRIVER = DriverDescriptor(
             safety="safe_write",
             scope="context",
             route_path="/v1/drivers/generic-web/preview-desired-state",
+            authz_action="preview_desired_state.discover",
             writes_records=("preview_desired_state",),
         ),
         _action(
@@ -141,6 +149,7 @@ GENERIC_WEB_DRIVER = DriverDescriptor(
             safety="mutation",
             scope="preview",
             route_path="/v1/drivers/generic-web/preview-refresh",
+            authz_action="preview_refresh.execute",
         ),
         _action(
             "preview_inventory",
@@ -149,6 +158,7 @@ GENERIC_WEB_DRIVER = DriverDescriptor(
             safety="safe_write",
             scope="context",
             route_path="/v1/drivers/generic-web/preview-inventory",
+            authz_action="preview_inventory.read",
             writes_records=("preview_inventory_scan",),
         ),
         _action(
@@ -158,6 +168,7 @@ GENERIC_WEB_DRIVER = DriverDescriptor(
             safety="read",
             scope="context",
             route_path="/v1/drivers/generic-web/preview-readiness",
+            authz_action="preview_readiness.evaluate",
         ),
         _action(
             "preview_destroy",
@@ -166,6 +177,7 @@ GENERIC_WEB_DRIVER = DriverDescriptor(
             safety="destructive",
             scope="preview",
             route_path="/v1/drivers/generic-web/preview-destroy",
+            authz_action="preview_destroy.execute",
             writes_records=("preview",),
         ),
     ),
@@ -210,6 +222,7 @@ ODOO_DRIVER = DriverDescriptor(
             safety="read",
             scope="instance",
             route_path="/v1/drivers/odoo/artifact-publish-inputs",
+            authz_action="odoo_artifact_publish_inputs.read",
         ),
         _action(
             "artifact_publish",
@@ -218,6 +231,7 @@ ODOO_DRIVER = DriverDescriptor(
             safety="safe_write",
             scope="instance",
             route_path="/v1/drivers/odoo/artifact-publish",
+            authz_action="odoo_artifact_publish.write",
             writes_records=("artifact_manifest",),
         ),
         _action(
@@ -227,6 +241,7 @@ ODOO_DRIVER = DriverDescriptor(
             safety="mutation",
             scope="instance",
             route_path="/v1/drivers/odoo/post-deploy",
+            authz_action="odoo_post_deploy.execute",
             writes_records=("odoo_instance_override",),
         ),
         _action(
@@ -236,6 +251,7 @@ ODOO_DRIVER = DriverDescriptor(
             safety="safe_write",
             scope="instance",
             route_path="/v1/drivers/odoo/prod-backup-gate",
+            authz_action="odoo_prod_backup_gate.execute",
             writes_records=("backup_gate",),
         ),
         _action(
@@ -245,6 +261,7 @@ ODOO_DRIVER = DriverDescriptor(
             safety="mutation",
             scope="instance",
             route_path="/v1/drivers/odoo/prod-promotion",
+            authz_action="odoo_prod_promotion.execute",
             writes_records=("deployment", "promotion", "inventory", "release_tuple"),
         ),
         _action(
@@ -254,6 +271,7 @@ ODOO_DRIVER = DriverDescriptor(
             safety="destructive",
             scope="instance",
             route_path="/v1/drivers/odoo/prod-rollback",
+            authz_action="odoo_prod_rollback.execute",
             writes_records=("deployment", "promotion", "inventory", "release_tuple"),
         ),
     ),
@@ -322,7 +340,19 @@ VERIREEL_DRIVER = DriverDescriptor(
             safety="mutation",
             scope="instance",
             route_path="/v1/drivers/verireel/testing-deploy",
+            authz_action="verireel_testing_deploy.execute",
             writes_records=("deployment", "inventory", "release_tuple"),
+        ),
+        _action(
+            "testing_verification",
+            "Record testing verification",
+            "Record VeriReel product smoke verification for a testing deployment.",
+            safety="safe_write",
+            scope="instance",
+            route_path="/v1/drivers/verireel/testing-verification",
+            authz_action="deployment.write",
+            operator_visible=False,
+            writes_records=("deployment",),
         ),
         _action(
             "stable_environment",
@@ -331,6 +361,7 @@ VERIREEL_DRIVER = DriverDescriptor(
             safety="read",
             scope="instance",
             route_path="/v1/drivers/verireel/stable-environment",
+            authz_action="verireel_stable_environment.read",
         ),
         _action(
             "runtime_verification",
@@ -339,6 +370,7 @@ VERIREEL_DRIVER = DriverDescriptor(
             safety="read",
             scope="instance",
             route_path="/v1/drivers/verireel/runtime-verification",
+            authz_action="verireel_stable_environment.read",
         ),
         _action(
             "app_maintenance",
@@ -347,6 +379,7 @@ VERIREEL_DRIVER = DriverDescriptor(
             safety="mutation",
             scope="instance",
             route_path="/v1/drivers/verireel/app-maintenance",
+            authz_action="verireel_app_maintenance.execute",
         ),
         _action(
             "prod_deploy",
@@ -355,6 +388,7 @@ VERIREEL_DRIVER = DriverDescriptor(
             safety="mutation",
             scope="instance",
             route_path="/v1/drivers/verireel/prod-deploy",
+            authz_action="verireel_prod_deploy.execute",
             writes_records=("deployment", "inventory", "release_tuple"),
         ),
         _action(
@@ -364,6 +398,7 @@ VERIREEL_DRIVER = DriverDescriptor(
             safety="safe_write",
             scope="instance",
             route_path="/v1/drivers/verireel/prod-backup-gate",
+            authz_action="verireel_prod_backup_gate.execute",
             writes_records=("backup_gate",),
         ),
         _action(
@@ -373,6 +408,7 @@ VERIREEL_DRIVER = DriverDescriptor(
             safety="mutation",
             scope="instance",
             route_path="/v1/drivers/verireel/prod-promotion",
+            authz_action="verireel_prod_promotion.execute",
             writes_records=("deployment", "promotion", "inventory", "release_tuple"),
         ),
         _action(
@@ -382,6 +418,7 @@ VERIREEL_DRIVER = DriverDescriptor(
             safety="destructive",
             scope="instance",
             route_path="/v1/drivers/verireel/prod-rollback",
+            authz_action="verireel_prod_rollback.execute",
             writes_records=("deployment", "promotion", "inventory", "release_tuple"),
         ),
         _action(
@@ -391,6 +428,7 @@ VERIREEL_DRIVER = DriverDescriptor(
             safety="mutation",
             scope="preview",
             route_path="/v1/drivers/verireel/preview-refresh",
+            authz_action="verireel_preview_refresh.execute",
             writes_records=("preview", "preview_generation"),
         ),
         _action(
@@ -400,6 +438,7 @@ VERIREEL_DRIVER = DriverDescriptor(
             safety="read",
             scope="context",
             route_path="/v1/drivers/verireel/preview-inventory",
+            authz_action="verireel_preview_inventory.read",
         ),
         _action(
             "preview_destroy",
@@ -408,6 +447,7 @@ VERIREEL_DRIVER = DriverDescriptor(
             safety="destructive",
             scope="preview",
             route_path="/v1/drivers/verireel/preview-destroy",
+            authz_action="verireel_preview_destroy.execute",
             writes_records=("preview", "preview_generation"),
         ),
         _action(
@@ -417,6 +457,8 @@ VERIREEL_DRIVER = DriverDescriptor(
             safety="safe_write",
             scope="preview",
             route_path="/v1/drivers/verireel/preview-verification",
+            authz_action="preview_generation.write",
+            operator_visible=False,
             writes_records=("preview", "preview_generation"),
         ),
     ),

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -34,7 +34,8 @@ The descriptor contracts live in
 - `DriverCapabilityDescriptor`: grouped product capability such as stable
   promotion, artifact publish, preview lifecycle, or post-deploy settings.
 - `DriverActionDescriptor`: read-only action metadata, route path, method,
-  scope, safety level, and records the action can write.
+  authorization action, operator visibility, scope, safety level, and records the
+  action can write.
 - `DriverSettingGroupDescriptor`: setting/status groups the UI can render later
   without knowing product-specific storage internals.
 - `DriverContextView`: context or context/instance read model composed from
@@ -145,6 +146,12 @@ VeriReel exposes:
 
 These descriptors intentionally reference Launchplane routes, not runtime
 provider concepts, as the future GUI-facing action surface.
+
+Descriptor actions are also the source of truth for driver route authorization
+metadata. `authz_action` must match the live service handler authorization
+string for that route. Some service callback routes, such as verification
+writeback routes, are declared with `operator_visible=false`; they remain in the
+driver route authorization map but are not surfaced as operator actions.
 
 Preview read models are capability-driven. A driver that exposes
 `previewable`, `preview_inventory_managed`, legacy `preview_lifecycle`, or the

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -111,6 +111,30 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         self.assertEqual(actions["preview_destroy"].safety, "destructive")
 
+    def test_driver_actions_declare_route_authorization_metadata(self) -> None:
+        route_actions = {
+            action.route_path: action
+            for descriptor in list_driver_descriptors()
+            for action in descriptor.actions
+            if action.route_path
+        }
+
+        self.assertTrue(all(action.authz_action for action in route_actions.values()))
+        self.assertEqual(
+            route_actions["/v1/drivers/verireel/testing-verification"].authz_action,
+            "deployment.write",
+        )
+        self.assertFalse(
+            route_actions["/v1/drivers/verireel/testing-verification"].operator_visible
+        )
+        self.assertEqual(
+            route_actions["/v1/drivers/verireel/preview-verification"].authz_action,
+            "preview_generation.write",
+        )
+        self.assertFalse(
+            route_actions["/v1/drivers/verireel/preview-verification"].operator_visible
+        )
+
     def test_preview_read_model_is_capability_driven_not_verireel_named(self) -> None:
         descriptor = DriverDescriptor(
             driver_id="custom-web",
@@ -137,9 +161,14 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             )
 
         self.assertEqual(view.drivers[0].driver_id, "custom-web")
-        self.assertEqual(view.drivers[0].preview_summaries[0].preview.preview_id, "preview-web-pr-7")
         self.assertEqual(
-            view.drivers[0].preview_inventory_provenance.detail,
+            view.drivers[0].preview_summaries[0].preview.preview_id, "preview-web-pr-7"
+        )
+        preview_inventory_provenance = view.drivers[0].preview_inventory_provenance
+        self.assertIsNotNone(preview_inventory_provenance)
+        assert preview_inventory_provenance is not None
+        self.assertEqual(
+            preview_inventory_provenance.detail,
             "Preview identity record exists, but no generation evidence is recorded.",
         )
 

--- a/tests/test_product_environment_read_model.py
+++ b/tests/test_product_environment_read_model.py
@@ -306,6 +306,51 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
             "preview_generation.write",
         )
 
+    def test_product_site_overview_hides_non_operator_driver_actions(self) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(
+            {
+                "schema_version": 1,
+                "product": "verireel",
+                "display_name": "VeriReel",
+                "repository": "every/verireel",
+                "driver_id": "verireel",
+                "image": {"repository": "ghcr.io/every/verireel"},
+                "runtime_port": 3000,
+                "health_path": "/healthz",
+                "lanes": (
+                    {
+                        "instance": "testing",
+                        "context": "verireel-testing",
+                        "base_url": "https://testing.verireel.example",
+                        "health_url": "https://testing.verireel.example/healthz",
+                    },
+                    {
+                        "instance": "prod",
+                        "context": "verireel",
+                        "base_url": "https://verireel.example",
+                        "health_url": "https://verireel.example/healthz",
+                    },
+                ),
+                "preview": {
+                    "enabled": True,
+                    "context": "verireel-testing",
+                    "slug_template": "pr-{number}",
+                },
+                "updated_at": "2026-05-02T22:30:00Z",
+                "source": "test",
+            }
+        )
+
+        overview = build_product_site_overview(
+            record_store=_PreviewRecordStore(profile, ()),
+            product=profile.product,
+            action_allowed=lambda *_: True,
+        )
+
+        actions = {action.action_id: action for action in overview.available_actions}
+        self.assertNotIn("testing_verification", actions)
+        self.assertNotIn("preview_verification", actions)
+
     def test_product_site_overview_filters_preview_summaries_by_repository_and_state(self) -> None:
         profile = LaunchplaneProductProfileRecord.model_validate(_site_profile_payload())
         store = _PreviewRecordStore(


### PR DESCRIPTION
## Summary
- add authz_action and operator_visible metadata to driver action descriptors
- derive product read-model driver route authz mapping from registered descriptors instead of a hand-maintained table
- register VeriReel verification callback routes as non-operator-visible descriptor actions
- document descriptor-owned route authorization metadata

## Validation
- uv run python -m unittest tests.test_driver_descriptors tests.test_product_environment_read_model
- uv run --extra dev mypy control_plane/contracts/driver_descriptor.py control_plane/drivers/registry.py control_plane/contracts/product_environment_read_model.py tests/test_driver_descriptors.py tests/test_product_environment_read_model.py
- uv run --extra dev ruff check --diff control_plane/contracts/driver_descriptor.py control_plane/drivers/registry.py control_plane/contracts/product_environment_read_model.py tests/test_driver_descriptors.py tests/test_product_environment_read_model.py docs/driver-descriptors.md
- uv run --extra dev ruff format --check --diff control_plane/contracts/driver_descriptor.py control_plane/drivers/registry.py control_plane/contracts/product_environment_read_model.py tests/test_driver_descriptors.py tests/test_product_environment_read_model.py
- uv run python -m unittest

Refs #161

Stacked on #171.