### PR TITLE
Allow profile-backed Odoo contexts

### DIFF
--- a/control_plane/workflows/odoo_artifact_publish.py
+++ b/control_plane/workflows/odoo_artifact_publish.py
@@ -14,7 +14,6 @@ from control_plane import runtime_environments as control_plane_runtime_environm
 from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
 from control_plane.storage.filesystem import FilesystemRecordStore
 
-SUPPORTED_ODOO_CONTEXTS = {"cm", "opw"}
 DEVKIT_RUNTIME_ENVIRONMENT_PAYLOAD_KEY = "ODOO_DEVKIT_RUNTIME_ENVIRONMENT_JSON"
 PUBLISH_RUNTIME_ENVIRONMENT_KEYS = (
     "ODOO_VERSION",
@@ -47,11 +46,8 @@ class OdooArtifactPublishRequest(BaseModel):
         self.instance = self.instance.strip().lower()
         self.image_repository = self.image_repository.strip()
         self.image_tag = self.image_tag.strip()
-        if self.context not in SUPPORTED_ODOO_CONTEXTS:
-            supported = ", ".join(sorted(SUPPORTED_ODOO_CONTEXTS))
-            raise ValueError(
-                f"Odoo artifact publish supports contexts {supported}; got {self.context!r}."
-            )
+        if not self.context:
+            raise ValueError("Odoo artifact publish requires context.")
         if self.instance not in {"testing", "prod"}:
             raise ValueError("Odoo artifact publish requires instance 'testing' or 'prod'.")
         if not self.image_repository:
@@ -88,11 +84,8 @@ class OdooArtifactPublishEvidenceRequest(BaseModel):
     def _validate_request(self) -> "OdooArtifactPublishEvidenceRequest":
         self.context = self.context.strip().lower()
         self.instance = self.instance.strip().lower()
-        if self.context not in SUPPORTED_ODOO_CONTEXTS:
-            supported = ", ".join(sorted(SUPPORTED_ODOO_CONTEXTS))
-            raise ValueError(
-                f"Odoo artifact publish supports contexts {supported}; got {self.context!r}."
-            )
+        if not self.context:
+            raise ValueError("Odoo artifact publish requires context.")
         if self.instance not in {"testing", "prod"}:
             raise ValueError("Odoo artifact publish requires instance 'testing' or 'prod'.")
         expected_prefix = f"artifact-{self.context}-"
@@ -115,11 +108,8 @@ class OdooArtifactPublishInputsRequest(BaseModel):
     def _validate_request(self) -> "OdooArtifactPublishInputsRequest":
         self.context = self.context.strip().lower()
         self.instance = self.instance.strip().lower()
-        if self.context not in SUPPORTED_ODOO_CONTEXTS:
-            supported = ", ".join(sorted(SUPPORTED_ODOO_CONTEXTS))
-            raise ValueError(
-                f"Odoo artifact publish supports contexts {supported}; got {self.context!r}."
-            )
+        if not self.context:
+            raise ValueError("Odoo artifact publish requires context.")
         if self.instance not in {"testing", "prod"}:
             raise ValueError("Odoo artifact publish requires instance 'testing' or 'prod'.")
         return self

--- a/control_plane/workflows/odoo_prod_backup_gate.py
+++ b/control_plane/workflows/odoo_prod_backup_gate.py
@@ -12,7 +12,6 @@ from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.ship import utc_now_timestamp
 
-SUPPORTED_ODOO_CONTEXTS = {"cm", "opw"}
 BACKUP_GATE_SOURCE = "launchplane-odoo-prod-backup-gate"
 
 
@@ -30,11 +29,8 @@ class OdooProdBackupGateRequest(BaseModel):
         self.context = self.context.strip().lower()
         self.instance = self.instance.strip().lower()
         self.backup_record_id = self.backup_record_id.strip()
-        if self.context not in SUPPORTED_ODOO_CONTEXTS:
-            supported = ", ".join(sorted(SUPPORTED_ODOO_CONTEXTS))
-            raise ValueError(
-                f"Odoo prod backup gate supports contexts {supported}; got {self.context!r}."
-            )
+        if not self.context:
+            raise ValueError("Odoo prod backup gate requires context.")
         if self.instance != "prod":
             raise ValueError("Odoo prod backup gate requires instance 'prod'.")
         if not self.backup_record_id:

--- a/control_plane/workflows/odoo_prod_promotion.py
+++ b/control_plane/workflows/odoo_prod_promotion.py
@@ -12,8 +12,6 @@ from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.storage.filesystem import FilesystemRecordStore
 
-SUPPORTED_ODOO_CONTEXTS = {"cm", "opw"}
-
 
 class OdooProdPromotionRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -39,11 +37,8 @@ class OdooProdPromotionRequest(BaseModel):
         self.artifact_id = self.artifact_id.strip()
         self.backup_record_id = self.backup_record_id.strip()
         self.source_git_ref = self.source_git_ref.strip()
-        if self.context not in SUPPORTED_ODOO_CONTEXTS:
-            supported = ", ".join(sorted(SUPPORTED_ODOO_CONTEXTS))
-            raise ValueError(
-                f"Odoo prod promotion supports contexts {supported}; got {self.context!r}."
-            )
+        if not self.context:
+            raise ValueError("Odoo prod promotion requires context.")
         if self.from_instance != "testing" or self.to_instance != "prod":
             raise ValueError("Odoo prod promotion requires testing -> prod.")
         if not self.artifact_id:

--- a/control_plane/workflows/odoo_prod_rollback.py
+++ b/control_plane/workflows/odoo_prod_rollback.py
@@ -35,7 +35,6 @@ from control_plane.workflows.ship import (
 )
 
 ARTIFACT_IMAGE_REFERENCE_ENV_KEY = "DOCKER_IMAGE_REFERENCE"
-SUPPORTED_ODOO_CONTEXTS = {"cm", "opw"}
 
 
 @dataclass(frozen=True)
@@ -71,11 +70,8 @@ class OdooProdRollbackRequest(BaseModel):
         self.promotion_record_id = self.promotion_record_id.strip()
         self.artifact_id = self.artifact_id.strip()
         self.reason = self.reason.strip()
-        if self.context not in SUPPORTED_ODOO_CONTEXTS:
-            supported = ", ".join(sorted(SUPPORTED_ODOO_CONTEXTS))
-            raise ValueError(
-                f"Odoo prod rollback supports contexts {supported}; got {self.context!r}."
-            )
+        if not self.context:
+            raise ValueError("Odoo prod rollback requires context.")
         if self.instance != "prod":
             raise ValueError("Odoo prod rollback requires instance 'prod'.")
         if self.verify_health and not self.wait:
@@ -331,10 +327,12 @@ def _sync_artifact_image_reference_for_target(
         target_id=target_definition.target_id,
     )
     env_map = control_plane_dokploy.parse_dokploy_env_text(str(target_payload.get("env") or ""))
-    runtime_environment_values = control_plane_runtime_environments.resolve_runtime_environment_values(
-        control_plane_root=control_plane_root,
-        context_name=target_definition.context,
-        instance_name=target_definition.instance,
+    runtime_environment_values = (
+        control_plane_runtime_environments.resolve_runtime_environment_values(
+            control_plane_root=control_plane_root,
+            context_name=target_definition.context,
+            instance_name=target_definition.instance,
+        )
     )
     desired_image_reference = _artifact_image_reference_from_manifest(artifact_manifest)
     if target_definition.target_type == "compose":

--- a/tests/test_odoo_artifact_publish.py
+++ b/tests/test_odoo_artifact_publish.py
@@ -3,6 +3,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+from pydantic import ValidationError
+
 from control_plane.workflows.odoo_artifact_publish import (
     DEVKIT_RUNTIME_ENVIRONMENT_PAYLOAD_KEY,
     OdooArtifactPublishEvidenceRequest,
@@ -27,6 +29,33 @@ def _artifact_payload() -> dict[str, object]:
 
 
 class OdooArtifactPublishWorkflowTests(unittest.TestCase):
+    def test_publish_requests_accept_new_odoo_contexts(self) -> None:
+        publish_request = OdooArtifactPublishRequest(
+            context="  New-Site  ",
+            manifest_path=Path("/work/new-site/workspace.toml"),
+            devkit_root=Path("/work/odoo-devkit"),
+            image_repository="ghcr.io/cbusillo/odoo-tenant-new-site",
+            image_tag="new-site-20260503-005c291b",
+        )
+        evidence_request = OdooArtifactPublishEvidenceRequest.model_validate(
+            {
+                "context": "new-site",
+                "manifest": {
+                    **_artifact_payload(),
+                    "artifact_id": "artifact-new-site-005c291b63b6",
+                },
+            }
+        )
+        inputs_request = OdooArtifactPublishInputsRequest(context="new-site")
+
+        self.assertEqual(publish_request.context, "new-site")
+        self.assertEqual(evidence_request.context, "new-site")
+        self.assertEqual(inputs_request.context, "new-site")
+
+    def test_publish_requests_reject_blank_contexts(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "requires context"):
+            OdooArtifactPublishInputsRequest(context="   ")
+
     def test_publish_resolves_launchplane_env_and_writes_artifact(self) -> None:
         record_store = Mock()
         captured_env = {}

--- a/tests/test_odoo_prod_backup_gate.py
+++ b/tests/test_odoo_prod_backup_gate.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import click
+from pydantic import ValidationError
 
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
@@ -46,6 +47,21 @@ def _runtime_values() -> dict[str, str]:
 
 
 class OdooProdBackupGateWorkflowTests(unittest.TestCase):
+    def test_request_accepts_new_odoo_context(self) -> None:
+        request = OdooProdBackupGateRequest(
+            context="  New-Site  ",
+            backup_record_id="backup-gate-new-site-prod-1",
+        )
+
+        self.assertEqual(request.context, "new-site")
+
+    def test_request_rejects_blank_context(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "requires context"):
+            OdooProdBackupGateRequest(
+                context="   ",
+                backup_record_id="backup-gate-new-site-prod-1",
+            )
+
     def _record_store(self) -> Mock:
         record_store = Mock()
         record_store.read_dokploy_target_record.return_value = _target_record()

--- a/tests/test_odoo_prod_promotion.py
+++ b/tests/test_odoo_prod_promotion.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import click
+from pydantic import ValidationError
 
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.promotion_record import (
@@ -97,6 +98,23 @@ def _source_tuple() -> ReleaseTupleRecord:
 
 
 class OdooProdPromotionWorkflowTests(unittest.TestCase):
+    def test_request_accepts_new_odoo_context(self) -> None:
+        request = OdooProdPromotionRequest(
+            context="  New-Site  ",
+            artifact_id="artifact-new-site-005c291b63b6",
+            backup_record_id="backup-gate-new-site-prod-1",
+        )
+
+        self.assertEqual(request.context, "new-site")
+
+    def test_request_rejects_blank_context(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "requires context"):
+            OdooProdPromotionRequest(
+                context="   ",
+                artifact_id="artifact-new-site-005c291b63b6",
+                backup_record_id="backup-gate-new-site-prod-1",
+            )
+
     def test_promotion_executes_existing_promotion_flow_and_writes_result(self) -> None:
         record_store = Mock()
         promotion_request = _promotion_request()

--- a/tests/test_odoo_prod_rollback.py
+++ b/tests/test_odoo_prod_rollback.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 
 import click
 from click.testing import CliRunner
+from pydantic import ValidationError
 
 from control_plane.cli import main
 from control_plane.contracts.artifact_identity import (
@@ -145,6 +146,15 @@ def _target_id_record() -> DokployTargetIdRecord:
 
 
 class OdooProdRollbackWorkflowTests(unittest.TestCase):
+    def test_request_accepts_new_odoo_context(self) -> None:
+        request = OdooProdRollbackRequest(context="  New-Site  ")
+
+        self.assertEqual(request.context, "new-site")
+
+    def test_request_rejects_blank_context(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "requires context"):
+            OdooProdRollbackRequest(context="   ")
+
     def _record_store(self) -> Mock:
         record_store = Mock()
         record_store.read_release_tuple_record.return_value = _release_tuple()


### PR DESCRIPTION
## Summary
- remove hardcoded cm/opw context allow-lists from Odoo artifact publish, backup gate, promotion, and rollback request models
- keep fail-closed blank-context validation and existing record-backed downstream checks
- add request-model coverage for new Odoo context names and blank context rejection

## Validation
- uv run python -m unittest tests.test_odoo_artifact_publish tests.test_odoo_prod_promotion tests.test_odoo_prod_backup_gate tests.test_odoo_prod_rollback
- uv run --extra dev ruff check --diff control_plane/workflows/odoo_artifact_publish.py control_plane/workflows/odoo_prod_promotion.py control_plane/workflows/odoo_prod_rollback.py control_plane/workflows/odoo_prod_backup_gate.py tests/test_odoo_artifact_publish.py tests/test_odoo_prod_promotion.py tests/test_odoo_prod_backup_gate.py tests/test_odoo_prod_rollback.py
- uv run --extra dev ruff format --check --diff control_plane/workflows/odoo_artifact_publish.py control_plane/workflows/odoo_prod_promotion.py control_plane/workflows/odoo_prod_rollback.py control_plane/workflows/odoo_prod_backup_gate.py tests/test_odoo_artifact_publish.py tests/test_odoo_prod_promotion.py tests/test_odoo_prod_backup_gate.py tests/test_odoo_prod_rollback.py
- git diff --check
- uv run python -m unittest

Refs #161