### PR TITLE
Sign human session cookies

### DIFF
--- a/control_plane/service_human_auth.py
+++ b/control_plane/service_human_auth.py
@@ -11,6 +11,8 @@ import secrets
 import warnings
 from typing import TYPE_CHECKING, Any, Literal, Protocol
 
+from cryptography.hazmat.primitives import hashes, hmac as cryptography_hmac
+
 if TYPE_CHECKING:
     from authlib.integrations.requests_client import (  # type: ignore[import-untyped]
         OAuth2Session as OAuth2SessionType,
@@ -337,11 +339,12 @@ class HumanSessionManager:
 
     def _sign_cookie_value(self, session_id: str) -> str:
         normalized_session_id = session_id.strip()
-        signature = hmac.new(
+        signer = cryptography_hmac.HMAC(
             self._config.session_secret.encode("utf-8"),
-            normalized_session_id.encode("utf-8"),
-            hashlib.sha256,
-        ).hexdigest()
+            hashes.SHA256(),
+        )
+        signer.update(normalized_session_id.encode("utf-8"))
+        signature = signer.finalize().hex()
         return f"{normalized_session_id}.{signature}"
 
     def _verify_cookie_value(self, cookie_session_id: str) -> str:

--- a/control_plane/service_human_auth.py
+++ b/control_plane/service_human_auth.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 import base64
 import hashlib
+import hmac
 import os
 import secrets
 import warnings
@@ -124,9 +125,7 @@ def load_github_oauth_config_from_env() -> GitHubOAuthConfig | None:
     cookie_secure = secure_env not in {"0", "false", "no"}
     bootstrap_admin_emails = frozenset(
         email.lower()
-        for email in _split_env_values(
-            os.environ.get("LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS", "")
-        )
+        for email in _split_env_values(os.environ.get("LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS", ""))
     )
     return GitHubOAuthConfig(
         client_id=client_id,
@@ -337,11 +336,23 @@ class HumanSessionManager:
         )
 
     def _sign_cookie_value(self, session_id: str) -> str:
-        return session_id
+        normalized_session_id = session_id.strip()
+        signature = hmac.new(
+            self._config.session_secret.encode("utf-8"),
+            normalized_session_id.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        return f"{normalized_session_id}.{signature}"
 
     def _verify_cookie_value(self, cookie_session_id: str) -> str:
-        session_id = cookie_session_id.strip().partition(".")[0]
+        session_id, separator, signature = cookie_session_id.strip().partition(".")
+        if not separator or not signature:
+            return ""
         if not session_id or any(character.isspace() for character in session_id):
+            return ""
+        expected_cookie_value = self._sign_cookie_value(session_id)
+        _expected_session_id, _separator, expected_signature = expected_cookie_value.partition(".")
+        if not hmac.compare_digest(signature, expected_signature):
             return ""
         return session_id
 

--- a/control_plane/service_human_auth.py
+++ b/control_plane/service_human_auth.py
@@ -9,7 +9,7 @@ import hmac
 import os
 import secrets
 import warnings
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 if TYPE_CHECKING:
     from authlib.integrations.requests_client import (  # type: ignore[import-untyped]
@@ -154,7 +154,7 @@ class GitHubOAuthClient:
     ) -> OAuth2SessionType:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            from authlib.integrations.requests_client import OAuth2Session  # type: ignore[import-untyped]
+            from authlib.integrations.requests_client import OAuth2Session
 
         return OAuth2Session(
             client_id=client_id,
@@ -212,7 +212,7 @@ class GitHubOAuthClient:
         )
         teams = frozenset(_team_names(team_payload))
         if self._config.bootstrap_admin_emails.intersection(email_candidates):
-            role: str | None = "admin"
+            role: Literal["read_only", "admin"] | None = "admin"
         else:
             role = authz_policy.human_role_for(
                 login=login,

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -113,9 +113,9 @@ Machine callers should authenticate with GitHub Actions OIDC.
 
 Human browser callers authenticate with GitHub OAuth. Launchplane owns the
 browser session after OAuth callback and sets an `HttpOnly`, `SameSite=Lax`
-session cookie. Sessions are backed by the Launchplane database when
-`LAUNCHPLANE_DATABASE_URL` is configured. GitHub access tokens stay server-side
-and are not exposed to the React operator UI.
+session cookie signed with `LAUNCHPLANE_SESSION_SECRET`. Sessions are backed by
+the Launchplane database when `LAUNCHPLANE_DATABASE_URL` is configured. GitHub
+access tokens stay server-side and are not exposed to the React operator UI.
 
 Launchplane should verify:
 

--- a/tests/test_service_human_auth.py
+++ b/tests/test_service_human_auth.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import unittest
+
+from control_plane.service_auth import GitHubHumanIdentity
+from control_plane.service_human_auth import (
+    GitHubOAuthConfig,
+    HumanSessionManager,
+    InMemoryHumanSessionStore,
+    LaunchplaneHumanSession,
+)
+
+
+def _config(*, session_secret: str = "session-secret") -> GitHubOAuthConfig:
+    return GitHubOAuthConfig(
+        client_id="client-id",
+        client_secret="client-secret",
+        public_url="https://launchplane.example",
+        session_secret=session_secret,
+        cookie_secure=False,
+    )
+
+
+def _identity() -> GitHubHumanIdentity:
+    return GitHubHumanIdentity(
+        login="alice",
+        github_id=123,
+        name="Alice Example",
+        email="alice@example.com",
+        organizations=frozenset({"cbusillo"}),
+        teams=frozenset({"cbusillo/platform"}),
+        role="read_only",
+    )
+
+
+class HumanSessionManagerTests(unittest.TestCase):
+    def test_session_cookie_is_signed_and_round_trips(self) -> None:
+        store = InMemoryHumanSessionStore()
+        manager = HumanSessionManager(config=_config(), session_store=store)
+        session = manager.issue(_identity())
+        cookie = manager.session_cookie_header(session)
+        signed_value = cookie.split("launchplane_session=", 1)[1].split(";", 1)[0]
+
+        self.assertIn(f"{session.session_id}.", signed_value)
+        self.assertNotEqual(signed_value, session.session_id)
+        self.assertIn("HttpOnly", cookie)
+        self.assertIn("SameSite=Lax", cookie)
+        self.assertNotIn("Secure", cookie)
+        loaded_session = manager.read_cookie(cookie)
+        self.assertIsNotNone(loaded_session)
+        assert loaded_session is not None
+        self.assertEqual(loaded_session.session_id, session.session_id)
+
+    def test_session_cookie_rejects_tampered_signature(self) -> None:
+        store = InMemoryHumanSessionStore()
+        manager = HumanSessionManager(config=_config(), session_store=store)
+        session = manager.issue(_identity())
+        cookie = manager.session_cookie_header(session)
+        tampered_cookie = cookie.replace(session.session_id, f"{session.session_id}-tampered")
+
+        self.assertIsNone(manager.read_cookie(tampered_cookie))
+
+    def test_session_cookie_rejects_signature_from_different_secret(self) -> None:
+        store = InMemoryHumanSessionStore()
+        manager = HumanSessionManager(
+            config=_config(session_secret="first-secret"), session_store=store
+        )
+        other_manager = HumanSessionManager(
+            config=_config(session_secret="second-secret"),
+            session_store=store,
+        )
+        session = manager.issue(_identity())
+        cookie = manager.session_cookie_header(session)
+
+        self.assertIsNone(other_manager.read_cookie(cookie))
+
+    def test_session_cookie_rejects_unsigned_or_malformed_values(self) -> None:
+        store = InMemoryHumanSessionStore()
+        manager = HumanSessionManager(config=_config(), session_store=store)
+        session = manager.issue(_identity())
+
+        self.assertIsNone(manager.read_cookie(f"launchplane_session={session.session_id}"))
+        self.assertIsNone(manager.read_cookie("launchplane_session=bad value.signature"))
+        self.assertIsNone(manager.read_cookie("other=value"))
+
+    def test_delete_cookie_session_requires_valid_signature(self) -> None:
+        store = InMemoryHumanSessionStore()
+        manager = HumanSessionManager(config=_config(), session_store=store)
+        session = manager.issue(_identity())
+
+        manager.delete_cookie_session(f"launchplane_session={session.session_id}.bad")
+
+        self.assertIsNotNone(store.read_session(session.session_id))
+
+        manager.delete_cookie_session(manager.session_cookie_header(session))
+
+        self.assertIsNone(store.read_session(session.session_id))
+
+    def test_expired_session_is_removed_after_signed_cookie_read(self) -> None:
+        store = InMemoryHumanSessionStore()
+        manager = HumanSessionManager(config=_config(), session_store=store)
+        expired_session = LaunchplaneHumanSession(
+            session_id="expired-session",
+            identity=_identity(),
+            created_at=datetime.now(timezone.utc) - timedelta(hours=2),
+            expires_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        )
+        store.write_session(expired_session)
+        cookie = manager.session_cookie_header(expired_session)
+
+        self.assertIsNone(manager.read_cookie(cookie))
+        self.assertIsNone(store.read_session(expired_session.session_id))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- sign Launchplane human session cookies with `LAUNCHPLANE_SESSION_SECRET` using HMAC-SHA256
- reject unsigned, malformed, tampered, and wrong-secret cookie values before reading or deleting sessions
- add focused human-session manager coverage and document signed browser session cookies
- tighten scoped mypy coverage for `control_plane/service_human_auth.py` and the new tests

## Validation
- `uv run python -m unittest tests.test_service_human_auth tests.test_service.GitHubHumanAuthTests`
- `uv run --extra dev ruff check --diff control_plane/service_human_auth.py tests/test_service_human_auth.py`
- `uv run --extra dev ruff format --check --diff control_plane/service_human_auth.py tests/test_service_human_auth.py`
- `uv run --extra dev mypy control_plane/service_human_auth.py tests/test_service_human_auth.py`
- `git diff --check`
- `uv run python -m unittest`

Refs #161
