### PR TITLE
Type secret store boundary

### DIFF
--- a/control_plane/secrets.py
+++ b/control_plane/secrets.py
@@ -4,7 +4,7 @@ import base64
 import hashlib
 import os
 import uuid
-from typing import Literal
+from typing import Literal, Protocol
 
 import click
 from cryptography.fernet import Fernet, InvalidToken
@@ -28,6 +28,54 @@ SECRET_STATUS_CONFIGURED = "configured"
 
 SecretWriteAction = Literal["created", "rotated", "unchanged"]
 SecretBindingRelabelAction = Literal["relabelled", "unchanged"]
+
+
+class SecretReadStore(Protocol):
+    def read_secret_record(self, secret_id: str) -> SecretRecord: ...
+
+    def list_secret_records(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[SecretRecord, ...]: ...
+
+    def read_secret_version(self, version_id: str) -> SecretVersion: ...
+
+    def list_secret_versions(self, *, secret_id: str) -> tuple[SecretVersion, ...]: ...
+
+    def list_secret_bindings(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[SecretBinding, ...]: ...
+
+    def list_secret_audit_events(self, *, secret_id: str) -> tuple[SecretAuditEvent, ...]: ...
+
+
+class SecretWriteStore(SecretReadStore, Protocol):
+    def find_secret_record(
+        self,
+        *,
+        scope: str,
+        integration: str,
+        name: str,
+        context: str = "",
+        instance: str = "",
+    ) -> SecretRecord | None: ...
+
+    def write_secret_record(self, record: SecretRecord) -> None: ...
+
+    def write_secret_version(self, version: SecretVersion) -> None: ...
+
+    def write_secret_binding(self, binding: SecretBinding) -> None: ...
+
+    def write_secret_audit_event(self, event: SecretAuditEvent) -> None: ...
 
 
 def _secret_slug(value: str) -> str:
@@ -124,9 +172,7 @@ def _scope_matches_record(
     return record.context == context_name and record.instance == instance_name
 
 
-def _binding_for_secret(
-    record_store: PostgresRecordStore, *, secret_id: str
-) -> SecretBinding | None:
+def _binding_for_secret(record_store: SecretReadStore, *, secret_id: str) -> SecretBinding | None:
     for binding in record_store.list_secret_bindings(limit=None):
         if binding.secret_id == secret_id and binding.status == SECRET_STATUS_CONFIGURED:
             return binding
@@ -205,7 +251,7 @@ def overlay_runtime_environment_secret_values(
 
 def write_secret_value(
     *,
-    record_store: PostgresRecordStore,
+    record_store: SecretWriteStore,
     scope: SecretScope,
     integration: str,
     name: str,
@@ -316,7 +362,7 @@ def expected_secret_binding_id(*, secret_id: str, binding_key: str) -> str:
 
 def relabel_secret_binding(
     *,
-    record_store: PostgresRecordStore,
+    record_store: SecretWriteStore,
     binding_id: str,
     binding_key: str,
     actor: str = "",
@@ -407,7 +453,7 @@ def relabel_secret_binding(
     }
 
 
-def build_secret_status(record_store: PostgresRecordStore, *, secret_id: str) -> dict[str, object]:
+def build_secret_status(record_store: SecretReadStore, *, secret_id: str) -> dict[str, object]:
     record = record_store.read_secret_record(secret_id)
     versions = record_store.list_secret_versions(secret_id=secret_id)
     binding = _binding_for_secret(record_store, secret_id=secret_id)
@@ -457,7 +503,7 @@ def build_secret_status(record_store: PostgresRecordStore, *, secret_id: str) ->
 
 
 def list_secret_statuses(
-    record_store: PostgresRecordStore,
+    record_store: SecretReadStore,
     *,
     integration: str = "",
     context_name: str = "",

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -4,11 +4,16 @@ import os
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import cast
 from unittest.mock import patch
 
 from control_plane import dokploy as control_plane_dokploy
-from control_plane import runtime_environments as control_plane_runtime_environments
+from control_plane import runtime_environments
 from control_plane import secrets as control_plane_secrets
+from control_plane.contracts.secret_record import SecretAuditEvent
+from control_plane.contracts.secret_record import SecretBinding
+from control_plane.contracts.secret_record import SecretRecord
+from control_plane.contracts.secret_record import SecretVersion
 from control_plane.storage.postgres import PostgresRecordStore
 
 
@@ -19,22 +24,163 @@ def _sqlite_database_url(database_path: Path) -> str:
 def _seed_runtime_environment_records(
     *,
     database_url: str,
-    definition: control_plane_runtime_environments.RuntimeEnvironmentDefinition,
+    definition: runtime_environments.RuntimeEnvironmentDefinition,
 ) -> None:
     store = PostgresRecordStore(database_url=database_url)
     store.ensure_schema()
     try:
-        for record in control_plane_runtime_environments.build_runtime_environment_records_from_definition(
+        records = runtime_environments.build_runtime_environment_records_from_definition(
             definition,
             updated_at="2026-04-22T00:00:00Z",
             source_label="test",
-        ):
+        )
+        for record in records:
             store.write_runtime_environment_record(record)
     finally:
         store.close()
 
 
+class _FakeSecretReadStore:
+    def __init__(self) -> None:
+        self.records = (
+            SecretRecord(
+                secret_id="secret-runtime-smtp-password-opw-testing",
+                scope="context_instance",
+                integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+                name="smtp-password",
+                context="opw",
+                instance="testing",
+                description="SMTP password",
+                current_version_id="secret-version-current",
+                created_at="2026-05-01T00:00:00Z",
+                updated_at="2026-05-01T00:01:00Z",
+                updated_by="operator",
+            ),
+        )
+        self.versions = (
+            SecretVersion(
+                version_id="secret-version-current",
+                secret_id="secret-runtime-smtp-password-opw-testing",
+                created_at="2026-05-01T00:01:00Z",
+                created_by="operator",
+                ciphertext="redacted-ciphertext",
+            ),
+            SecretVersion(
+                version_id="secret-version-previous",
+                secret_id="secret-runtime-smtp-password-opw-testing",
+                created_at="2026-05-01T00:00:30Z",
+                created_by="operator",
+                ciphertext="previous-redacted-ciphertext",
+            ),
+        )
+        self.bindings = (
+            SecretBinding(
+                binding_id="secret-runtime-smtp-password-opw-testing-binding-smtp-password",
+                secret_id="secret-runtime-smtp-password-opw-testing",
+                integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+                binding_key="SMTP_PASSWORD",
+                context="opw",
+                instance="testing",
+                created_at="2026-05-01T00:00:00Z",
+                updated_at="2026-05-01T00:01:00Z",
+            ),
+        )
+        self.audit_events = (
+            SecretAuditEvent(
+                event_id="secret-runtime-smtp-password-opw-testing-event-rotated",
+                secret_id="secret-runtime-smtp-password-opw-testing",
+                event_type="rotated",
+                recorded_at="2026-05-01T00:01:00Z",
+                actor="operator",
+                detail="Rotated from fake store.",
+                metadata={"source": "fake-store"},
+            ),
+        )
+
+    def read_secret_record(self, secret_id: str) -> SecretRecord:
+        for record in self.records:
+            if record.secret_id == secret_id:
+                return record
+        raise FileNotFoundError(secret_id)
+
+    def list_secret_records(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[SecretRecord, ...]:
+        records = tuple(
+            record
+            for record in self.records
+            if (not integration or record.integration == integration)
+            and (not context_name or record.context == context_name)
+            and (not instance_name or record.instance == instance_name)
+        )
+        return records[:limit] if limit is not None else records
+
+    def read_secret_version(self, version_id: str) -> SecretVersion:
+        for version in self.versions:
+            if version.version_id == version_id:
+                return version
+        raise FileNotFoundError(version_id)
+
+    def list_secret_versions(self, *, secret_id: str) -> tuple[SecretVersion, ...]:
+        return tuple(version for version in self.versions if version.secret_id == secret_id)
+
+    def list_secret_bindings(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[SecretBinding, ...]:
+        bindings = tuple(
+            binding
+            for binding in self.bindings
+            if (not integration or binding.integration == integration)
+            and (not context_name or binding.context == context_name)
+            and (not instance_name or binding.instance == instance_name)
+        )
+        return bindings[:limit] if limit is not None else bindings
+
+    def list_secret_audit_events(self, *, secret_id: str) -> tuple[SecretAuditEvent, ...]:
+        return tuple(event for event in self.audit_events if event.secret_id == secret_id)
+
+
 class LaunchplaneSecretsTests(unittest.TestCase):
+    def test_secret_statuses_use_structural_read_store_boundary(self) -> None:
+        store = _FakeSecretReadStore()
+
+        statuses = control_plane_secrets.list_secret_statuses(
+            store,
+            integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+            context_name="opw",
+            instance_name="testing",
+        )
+
+        self.assertEqual(len(statuses), 1)
+        status = statuses[0]
+        self.assertEqual(status["secret_id"], "secret-runtime-smtp-password-opw-testing")
+        self.assertEqual(status["version_count"], 2)
+        self.assertEqual(status["current_version_created_at"], "2026-05-01T00:01:00Z")
+        self.assertEqual(
+            status["binding"],
+            {
+                "binding_id": "secret-runtime-smtp-password-opw-testing-binding-smtp-password",
+                "binding_type": "env",
+                "binding_key": "SMTP_PASSWORD",
+                "status": "configured",
+                "context": "opw",
+                "instance": "testing",
+                "updated_at": "2026-05-01T00:01:00Z",
+            },
+        )
+        audit_events = cast("list[dict[str, object]]", status["recent_audit_events"])
+        self.assertEqual(audit_events[0]["event_type"], "rotated")
+
     def test_read_dokploy_config_prefers_managed_secret_overlay(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -71,7 +217,9 @@ class LaunchplaneSecretsTests(unittest.TestCase):
                     binding_key="DOKPLOY_TOKEN",
                     actor="test",
                 )
-                host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
+                host, token = control_plane_dokploy.read_dokploy_config(
+                    control_plane_root=control_plane_root
+                )
                 self.assertEqual(host, "https://dokploy.db.example")
                 self.assertEqual(token, "db-token")
             store.close()
@@ -82,14 +230,14 @@ class LaunchplaneSecretsTests(unittest.TestCase):
             database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
             _seed_runtime_environment_records(
                 database_url=database_url,
-                definition=control_plane_runtime_environments.RuntimeEnvironmentDefinition(
+                definition=runtime_environments.RuntimeEnvironmentDefinition(
                     schema_version=1,
                     shared_env={"ODOO_MASTER_PASSWORD": "file-shared-master"},
                     contexts={
-                        "opw": control_plane_runtime_environments.RuntimeEnvironmentContextDefinition(
+                        "opw": runtime_environments.RuntimeEnvironmentContextDefinition(
                             shared_env={"GITHUB_WEBHOOK_SECRET": "file-context-secret"},
                             instances={
-                                "testing": control_plane_runtime_environments.RuntimeEnvironmentInstanceDefinition(
+                                "testing": runtime_environments.RuntimeEnvironmentInstanceDefinition(
                                     env={
                                         "ODOO_DB_PASSWORD": "file-instance-secret",
                                         "LAUNCHPLANE_PREVIEW_BASE_URL": "https://preview.example.com",
@@ -140,7 +288,7 @@ class LaunchplaneSecretsTests(unittest.TestCase):
                     instance_name="testing",
                     actor="test",
                 )
-                resolved_values = control_plane_runtime_environments.resolve_runtime_environment_values(
+                resolved_values = runtime_environments.resolve_runtime_environment_values(
                     control_plane_root=control_plane_root,
                     context_name="opw",
                     instance_name="testing",
@@ -148,7 +296,9 @@ class LaunchplaneSecretsTests(unittest.TestCase):
                 self.assertEqual(resolved_values["ODOO_MASTER_PASSWORD"], "db-shared-master")
                 self.assertEqual(resolved_values["GITHUB_WEBHOOK_SECRET"], "db-context-secret")
                 self.assertEqual(resolved_values["ODOO_DB_PASSWORD"], "db-instance-secret")
-                self.assertEqual(resolved_values["LAUNCHPLANE_PREVIEW_BASE_URL"], "https://preview.example.com")
+                self.assertEqual(
+                    resolved_values["LAUNCHPLANE_PREVIEW_BASE_URL"], "https://preview.example.com"
+                )
             store.close()
 
 


### PR DESCRIPTION
## Summary

- add structural read/write store protocols for reusable managed-secret helpers
- replace concrete Postgres store annotations on secret status, listing, write, and relabel helpers
- keep the concrete Postgres factory path unchanged for runtime/CLI usage
- add a fake-store status test proving the read helpers work across the protocol boundary

Refs #161

## Validation

- `uv run python -m unittest tests.test_secrets`
- `uv run --extra dev mypy control_plane/secrets.py tests/test_secrets.py`
- `uv run --extra dev ruff check --diff control_plane/secrets.py tests/test_secrets.py`
- `uv run --extra dev ruff format --check --diff control_plane/secrets.py tests/test_secrets.py`
- `git diff --check`
- `uv run python -m unittest`
