### PR TITLE
Type runtime environment store boundary

### DIFF
--- a/control_plane/runtime_environments.py
+++ b/control_plane/runtime_environments.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Protocol
 
 import click
 
@@ -15,6 +16,12 @@ DEFAULT_RUNTIME_ENVIRONMENTS_FILE = "config/runtime-environments.toml"
 
 ScalarValue = str | int | float | bool
 ScalarMap = dict[str, ScalarValue]
+
+
+class RuntimeEnvironmentRecordStore(Protocol):
+    def list_runtime_environment_records(
+        self, *, context_name: str = "", instance_name: str = ""
+    ) -> tuple[RuntimeEnvironmentRecord, ...]: ...
 
 
 @dataclass(frozen=True)
@@ -40,12 +47,12 @@ def load_runtime_environment_definition(
 ) -> RuntimeEnvironmentDefinition:
     database_url = resolve_database_url()
     if database_url:
-        database_definition = _load_optional_runtime_environment_definition_from_database(database_url=database_url)
+        database_definition = _load_optional_runtime_environment_definition_from_database(
+            database_url=database_url
+        )
         if database_definition is not None:
             return database_definition
-        raise click.ClickException(
-            "Missing DB-backed Launchplane runtime environment records."
-        )
+        raise click.ClickException("Missing DB-backed Launchplane runtime environment records.")
 
     raise click.ClickException(
         "Missing Launchplane runtime environment authority. Configure DB-backed runtime environment records."
@@ -116,7 +123,10 @@ def resolve_tracked_target_environment_values(
             control_plane_root=control_plane_root
         )
     except click.ClickException as error:
-        if str(error).startswith("Missing Launchplane tracked Dokploy target authority") or str(error).startswith(
+        error_message = str(error)
+        if error_message.startswith(
+            "Missing Launchplane tracked Dokploy target authority"
+        ) or error_message.startswith(
             "Missing DB-backed Launchplane tracked Dokploy target records."
         ):
             return {}
@@ -184,7 +194,7 @@ def _load_optional_runtime_environment_definition_from_database(
     try:
         record_store = PostgresRecordStore(database_url=database_url)
         record_store.ensure_schema()
-        records = record_store.list_runtime_environment_records()
+        return load_optional_runtime_environment_definition_from_store(record_store=record_store)
     except Exception as error:
         raise click.ClickException(
             f"Could not load runtime environments from Launchplane Postgres storage: {error}"
@@ -195,6 +205,12 @@ def _load_optional_runtime_environment_definition_from_database(
                 record_store.close()
         except Exception:
             pass
+
+
+def load_optional_runtime_environment_definition_from_store(
+    *, record_store: RuntimeEnvironmentRecordStore
+) -> RuntimeEnvironmentDefinition | None:
+    records = record_store.list_runtime_environment_records()
     if not records:
         return None
     return build_runtime_environment_definition_from_records(records)

--- a/tests/test_runtime_environments.py
+++ b/tests/test_runtime_environments.py
@@ -75,7 +75,67 @@ def _seed_dokploy_target_records(*, database_url: str, payload: str) -> None:
         store.close()
 
 
+class _FakeRuntimeEnvironmentStore:
+    def __init__(self, records: tuple[RuntimeEnvironmentRecord, ...]) -> None:
+        self.records = records
+
+    def list_runtime_environment_records(
+        self, *, context_name: str = "", instance_name: str = ""
+    ) -> tuple[RuntimeEnvironmentRecord, ...]:
+        return tuple(
+            record
+            for record in self.records
+            if (not context_name or record.context == context_name)
+            and (not instance_name or record.instance == instance_name)
+        )
+
+
 class RuntimeEnvironmentTests(unittest.TestCase):
+    def test_load_optional_runtime_definition_uses_structural_store_boundary(self) -> None:
+        definition = control_plane_runtime_environments.load_optional_runtime_environment_definition_from_store(
+            record_store=_FakeRuntimeEnvironmentStore(
+                records=(
+                    RuntimeEnvironmentRecord(
+                        scope="global",
+                        env={"SHARED_MODE": "db"},
+                        updated_at="2026-05-01T00:00:00Z",
+                        source_label="fake-store",
+                    ),
+                    RuntimeEnvironmentRecord(
+                        scope="context",
+                        context="verireel",
+                        env={"VERIREEL_CONTEXT": "prod"},
+                        updated_at="2026-05-01T00:01:00Z",
+                        source_label="fake-store",
+                    ),
+                    RuntimeEnvironmentRecord(
+                        scope="instance",
+                        context="verireel",
+                        instance="prod",
+                        env={"VERIREEL_PROD_CT_ID": 101},
+                        updated_at="2026-05-01T00:02:00Z",
+                        source_label="fake-store",
+                    ),
+                )
+            )
+        )
+
+        self.assertIsNotNone(definition)
+        assert definition is not None
+        self.assertEqual(definition.shared_env["SHARED_MODE"], "db")
+        self.assertEqual(definition.contexts["verireel"].shared_env["VERIREEL_CONTEXT"], "prod")
+        self.assertEqual(
+            definition.contexts["verireel"].instances["prod"].env["VERIREEL_PROD_CT_ID"],
+            101,
+        )
+
+    def test_load_optional_runtime_definition_returns_none_for_empty_store(self) -> None:
+        definition = control_plane_runtime_environments.load_optional_runtime_environment_definition_from_store(
+            record_store=_FakeRuntimeEnvironmentStore(records=())
+        )
+
+        self.assertIsNone(definition)
+
     def test_environments_import_command_is_not_available(self) -> None:
         result = CliRunner().invoke(main, ["environments", "import"])
 


### PR DESCRIPTION
## Summary

- add a structural `RuntimeEnvironmentRecordStore` boundary for loading runtime environment definitions from persisted records
- delegate the concrete Postgres loader through the protocol-based helper while keeping DB setup concrete
- add fake-store coverage for runtime definition loading and empty-store handling
- keep runtime authority behavior unchanged: DB-backed records remain required when `LAUNCHPLANE_DATABASE_URL` is configured

Refs #161

## Validation

- `uv run python -m unittest tests.test_runtime_environments`
- `uv run --extra dev mypy control_plane/runtime_environments.py tests/test_runtime_environments.py`
- `uv run --extra dev ruff check --diff control_plane/runtime_environments.py tests/test_runtime_environments.py`
- `uv run --extra dev ruff format --check --diff control_plane/runtime_environments.py tests/test_runtime_environments.py`
- `git diff --check`
- `uv run python -m unittest`
