### PR TITLE
Type Dokploy target store boundary

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -5,7 +5,7 @@ import shlex
 import time
 from collections.abc import Callable, Mapping
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Protocol
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 from urllib.parse import urlencode
@@ -71,6 +71,12 @@ _DOKPLOY_LOG_SEARCH_PATTERN = re.compile(r"^[a-zA-Z0-9 ._-]{0,500}$")
 type JsonPrimitive = str | int | float | bool | None
 type JsonValue = JsonPrimitive | dict[str, "JsonValue"] | list["JsonValue"]
 type JsonObject = dict[str, JsonValue]
+
+
+class DokployTargetRecordStore(Protocol):
+    def list_dokploy_target_records(self) -> tuple[DokployTargetRecord, ...]: ...
+
+    def list_dokploy_target_id_records(self) -> tuple[DokployTargetIdRecord, ...]: ...
 
 
 def render_odoo_raw_compose_file(*, image_reference: str) -> str:
@@ -547,6 +553,16 @@ def build_dokploy_source_of_truth_from_records(
     return DokploySourceOfTruth.model_validate({"schema_version": 1, "targets": targets_payload})
 
 
+def load_optional_dokploy_source_of_truth_from_store(
+    *, record_store: DokployTargetRecordStore
+) -> DokploySourceOfTruth | None:
+    target_records = record_store.list_dokploy_target_records()
+    if not target_records:
+        return None
+    target_id_records = record_store.list_dokploy_target_id_records()
+    return build_dokploy_source_of_truth_from_records(target_records, target_id_records)
+
+
 def _load_optional_dokploy_source_of_truth_from_database(
     *, database_url: str
 ) -> DokploySourceOfTruth | None:
@@ -554,10 +570,7 @@ def _load_optional_dokploy_source_of_truth_from_database(
     try:
         record_store = PostgresRecordStore(database_url=database_url)
         record_store.ensure_schema()
-        target_records = record_store.list_dokploy_target_records()
-        if not target_records:
-            return None
-        target_id_records = record_store.list_dokploy_target_id_records()
+        return load_optional_dokploy_source_of_truth_from_store(record_store=record_store)
     except click.ClickException:
         raise
     except Exception as error:
@@ -570,7 +583,6 @@ def _load_optional_dokploy_source_of_truth_from_database(
                 record_store.close()
         except Exception:
             pass
-    return build_dokploy_source_of_truth_from_records(target_records, target_id_records)
 
 
 def read_dokploy_config(*, control_plane_root: Path) -> tuple[str, str]:
@@ -876,9 +888,9 @@ def update_dokploy_target_source(
     custom_git_ssh_key_id = str(target_payload.get("customGitSSHKeyId") or "").strip()
     trigger_type = str(target_payload.get("triggerType") or "push").strip() or "push"
     raw_watch_paths = target_payload.get("watchPaths")
-    watch_paths = list(target_definition.watch_paths) or (
-        list(raw_watch_paths) if isinstance(raw_watch_paths, list) else []
-    )
+    watch_paths = list(target_definition.watch_paths) or _string_items(raw_watch_paths)
+    watch_path_values: list[JsonValue] = []
+    watch_path_values.extend(watch_paths)
     auto_deploy = bool(target_payload.get("autoDeploy"))
     enable_submodules = (
         target_definition.enable_submodules
@@ -926,7 +938,7 @@ def update_dokploy_target_source(
         "customGitBranch": custom_git_branch,
         "enableSubmodules": enable_submodules,
         "triggerType": trigger_type,
-        "watchPaths": watch_paths,
+        "watchPaths": watch_path_values,
     }
     if custom_git_ssh_key_id:
         payload["customGitSSHKeyId"] = custom_git_ssh_key_id
@@ -1522,9 +1534,29 @@ def dokploy_request(
     if not raw_payload:
         return {}
     try:
-        return json.loads(raw_payload)
+        return _normalize_json_value(json.loads(raw_payload))
     except json.JSONDecodeError:
         return {"raw": raw_payload.decode("utf-8", errors="replace")}
+
+
+def _string_items(value: JsonValue | None) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _normalize_json_value(value: object) -> JsonValue:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, list):
+        return [_normalize_json_value(item) for item in value]
+    if isinstance(value, dict):
+        normalized: JsonObject = {}
+        for key_name, item in value.items():
+            if isinstance(key_name, str):
+                normalized[key_name] = _normalize_json_value(item)
+        return normalized
+    return str(value)
 
 
 def as_json_object(value: JsonValue) -> JsonObject | None:

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -6,6 +6,7 @@ import tomllib
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import cast
 from unittest.mock import patch
 
 import click
@@ -17,6 +18,7 @@ from control_plane.odoo_instance_overrides import ODOO_INSTANCE_OVERRIDES_PAYLOA
 from control_plane import secrets as control_plane_secrets
 from control_plane.cli import main
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.storage.postgres import PostgresRecordStore
@@ -75,7 +77,69 @@ def _seed_dokploy_target_records(
         )
 
 
+class _FakeDokployTargetStore:
+    def __init__(
+        self,
+        *,
+        target_records: tuple[DokployTargetRecord, ...],
+        target_id_records: tuple[DokployTargetIdRecord, ...],
+    ) -> None:
+        self.target_records = target_records
+        self.target_id_records = target_id_records
+
+    def list_dokploy_target_records(self) -> tuple[DokployTargetRecord, ...]:
+        return self.target_records
+
+    def list_dokploy_target_id_records(self) -> tuple[DokployTargetIdRecord, ...]:
+        return self.target_id_records
+
+
 class DokployConfigTests(unittest.TestCase):
+    def test_load_optional_source_of_truth_uses_structural_store_boundary(self) -> None:
+        target = control_plane_dokploy.DokployTargetDefinition(
+            context="verireel",
+            instance="prod",
+            target_id="placeholder",
+            target_type="application",
+            target_name="ver-prod-app",
+        )
+        source_of_truth = control_plane_dokploy.load_optional_dokploy_source_of_truth_from_store(
+            record_store=_FakeDokployTargetStore(
+                target_records=(
+                    control_plane_dokploy.build_dokploy_target_record_from_definition(
+                        target,
+                        updated_at="2026-05-01T00:00:00Z",
+                        source_label="fake-store",
+                    ),
+                ),
+                target_id_records=(
+                    DokployTargetIdRecord(
+                        context="verireel",
+                        instance="prod",
+                        target_id="target-ver-prod",
+                        updated_at="2026-05-01T00:00:00Z",
+                        source_label="fake-store",
+                    ),
+                ),
+            )
+        )
+
+        self.assertIsNotNone(source_of_truth)
+        assert source_of_truth is not None
+        self.assertEqual(len(source_of_truth.targets), 1)
+        self.assertEqual(source_of_truth.targets[0].target_id, "target-ver-prod")
+        self.assertEqual(source_of_truth.targets[0].target_name, "ver-prod-app")
+
+    def test_load_optional_source_of_truth_returns_none_for_empty_store(self) -> None:
+        source_of_truth = control_plane_dokploy.load_optional_dokploy_source_of_truth_from_store(
+            record_store=_FakeDokployTargetStore(
+                target_records=(),
+                target_id_records=(),
+            )
+        )
+
+        self.assertIsNone(source_of_truth)
+
     def test_application_log_payload_normalization_redacts_likely_secrets(self) -> None:
         lines = control_plane_dokploy.normalize_dokploy_log_payload(
             {
@@ -118,11 +182,13 @@ class DokployConfigTests(unittest.TestCase):
     def test_fetch_application_logs_calls_dokploy_read_logs_endpoint(self) -> None:
         requests: list[dict[str, object]] = []
 
+        def capture_request(**kwargs: object) -> dict[str, str]:
+            requests.append(kwargs)
+            return {"logs": "one\ntwo\nTHREE_TOKEN=secret"}
+
         with patch(
             "control_plane.dokploy.dokploy_request",
-            side_effect=lambda **kwargs: (
-                requests.append(kwargs) or {"logs": "one\ntwo\nTHREE_TOKEN=secret"}
-            ),
+            side_effect=capture_request,
         ):
             lines = control_plane_dokploy.fetch_dokploy_application_logs(
                 host="https://dokploy.example.com",
@@ -272,9 +338,13 @@ target_name = "opw-testing"
     def test_update_application_env_includes_empty_build_fields_when_missing(self) -> None:
         requests: list[dict[str, object]] = []
 
+        def capture_request(**kwargs: object) -> dict[str, bool]:
+            requests.append(kwargs)
+            return {"ok": True}
+
         with patch(
             "control_plane.dokploy.dokploy_request",
-            side_effect=lambda **kwargs: requests.append(kwargs) or {"ok": True},
+            side_effect=capture_request,
         ):
             control_plane_dokploy.update_dokploy_target_env(
                 host="https://dokploy.example.com",
@@ -287,7 +357,7 @@ target_name = "opw-testing"
 
         self.assertEqual(len(requests), 1)
         self.assertEqual(requests[0]["path"], "/api/application.saveEnvironment")
-        payload = requests[0]["payload"]
+        payload = cast("dict[str, object]", requests[0]["payload"])
         self.assertIsInstance(payload, dict)
         self.assertEqual(payload["buildArgs"], "")
         self.assertEqual(payload["buildSecrets"], "")
@@ -1620,6 +1690,14 @@ protected_store_keys = ["yps-your-part-supplier"]
             schedule_payloads: list[dict[str, object]] = []
             request_paths: list[str] = []
 
+            def capture_schedule_payload(**kwargs: object) -> dict[str, str]:
+                schedule_payloads.append(cast("dict[str, object]", kwargs["schedule_payload"]))
+                return {"scheduleId": "schedule-123"}
+
+            def capture_request_path(**kwargs: object) -> dict[str, bool]:
+                request_paths.append(str(kwargs["path"]))
+                return {"ok": True}
+
             with (
                 patch(
                     "control_plane.dokploy.fetch_dokploy_target_payload",
@@ -1649,10 +1727,7 @@ protected_store_keys = ["yps-your-part-supplier"]
                 ),
                 patch(
                     "control_plane.dokploy.upsert_dokploy_schedule",
-                    side_effect=lambda **kwargs: (
-                        schedule_payloads.append(kwargs["schedule_payload"])
-                        or {"scheduleId": "schedule-123"}
-                    ),
+                    side_effect=capture_schedule_payload,
                 ),
                 patch(
                     "control_plane.dokploy.latest_deployment_for_schedule",
@@ -1664,9 +1739,7 @@ protected_store_keys = ["yps-your-part-supplier"]
                 ),
                 patch(
                     "control_plane.dokploy.dokploy_request",
-                    side_effect=lambda **kwargs: (
-                        request_paths.append(str(kwargs["path"])) or {"ok": True}
-                    ),
+                    side_effect=capture_request_path,
                 ),
             ):
                 control_plane_dokploy.run_compose_post_deploy_update(
@@ -1717,6 +1790,14 @@ protected_store_keys = ["yps-your-part-supplier"]
         schedule_payloads: list[dict[str, object]] = []
         request_paths: list[str] = []
 
+        def capture_schedule_payload(**kwargs: object) -> dict[str, str]:
+            schedule_payloads.append(cast("dict[str, object]", kwargs["schedule_payload"]))
+            return {"scheduleId": "schedule-123"}
+
+        def capture_request_path(**kwargs: object) -> dict[str, bool]:
+            request_paths.append(str(kwargs["path"]))
+            return {"ok": True}
+
         with (
             patch(
                 "control_plane.dokploy.fetch_dokploy_target_payload",
@@ -1724,10 +1805,7 @@ protected_store_keys = ["yps-your-part-supplier"]
             ),
             patch(
                 "control_plane.dokploy.upsert_dokploy_schedule",
-                side_effect=lambda **kwargs: (
-                    schedule_payloads.append(kwargs["schedule_payload"])
-                    or {"scheduleId": "schedule-123"}
-                ),
+                side_effect=capture_schedule_payload,
             ),
             patch(
                 "control_plane.dokploy.latest_deployment_for_schedule",
@@ -1739,9 +1817,7 @@ protected_store_keys = ["yps-your-part-supplier"]
             ),
             patch(
                 "control_plane.dokploy.dokploy_request",
-                side_effect=lambda **kwargs: (
-                    request_paths.append(str(kwargs["path"])) or {"ok": True}
-                ),
+                side_effect=capture_request_path,
             ),
         ):
             control_plane_dokploy.run_compose_odoo_backup_gate(
@@ -1879,8 +1955,7 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
             )
 
         self.assertEqual(len(update_payloads), 1)
-        payload = update_payloads[0]["payload"]
-        self.assertIsInstance(payload, dict)
+        payload = cast("dict[str, object]", update_payloads[0]["payload"])
         self.assertEqual(payload["sourceType"], "raw")
         self.assertEqual(payload["composePath"], "docker-compose.yml")
         self.assertEqual(payload["composeFile"], compose_file)
@@ -1997,9 +2072,10 @@ actions = ["launchplane_service_deploy.execute"]
 
         self.assertEqual(result.exit_code, 0, msg=result.output)
         self.assertEqual(len(captured_env_updates), 1)
-        self.assertIn(f"LAUNCHPLANE_POLICY_B64={policy_b64}", captured_env_updates[0]["env_text"])
-        self.assertNotIn("LAUNCHPLANE_POLICY_TOML=", captured_env_updates[0]["env_text"])
-        self.assertNotIn("LAUNCHPLANE_POLICY_FILE=", captured_env_updates[0]["env_text"])
+        env_text = str(captured_env_updates[0]["env_text"])
+        self.assertIn(f"LAUNCHPLANE_POLICY_B64={policy_b64}", env_text)
+        self.assertNotIn("LAUNCHPLANE_POLICY_TOML=", env_text)
+        self.assertNotIn("LAUNCHPLANE_POLICY_FILE=", env_text)
         payload = json.loads(result.output)
         self.assertEqual(payload["status"], "ok")
         self.assertTrue(payload["changed"])


### PR DESCRIPTION
## Summary
- add a structural DokployTargetRecordStore protocol and source-of-truth loader helper
- delegate the Postgres Dokploy target record loader through the structural helper
- normalize decoded Dokploy JSON values and keep watch path payloads typed
- add fake-store source-of-truth coverage and clean typed Dokploy test mocks

Refs #161

## Validation
- uv run python -m unittest tests.test_dokploy
- uv run --extra dev mypy control_plane/dokploy.py tests/test_dokploy.py
- uv run --extra dev ruff check --diff control_plane/dokploy.py tests/test_dokploy.py
- uv run --extra dev ruff format --check --diff control_plane/dokploy.py tests/test_dokploy.py
- git diff --check
- uv run python -m unittest