### PR TITLE
Derive driver write routes from descriptors

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1274,6 +1274,36 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
     return None
 
 
+def _driver_write_routes_from_descriptors() -> frozenset[str]:
+    return frozenset(
+        action.route_path
+        for descriptor in list_driver_descriptors()
+        for action in descriptor.actions
+        if action.method == "POST" and action.route_path.startswith("/v1/drivers/")
+    )
+
+
+def _build_write_routes() -> frozenset[str]:
+    launchplane_write_routes = {
+        "/v1/evidence/deployments",
+        "/v1/evidence/backup-gates",
+        "/v1/evidence/previews/generations",
+        "/v1/evidence/previews/destroyed",
+        "/v1/authz-policies/github-actions/grants",
+        "/v1/product-config/apply",
+        "/v1/product-profiles/context-cutover/apply",
+        "/v1/product-profiles/legacy-context-cleanup/apply",
+        "/v1/previews/desired-state",
+        "/v1/previews/pr-feedback",
+        "/v1/previews/lifecycle-cleanup",
+        "/v1/previews/lifecycle-plan",
+        "/v1/product-profiles",
+        "/v1/evidence/promotions",
+        "/v1/drivers/launchplane/self-deploy",
+    }
+    return frozenset(launchplane_write_routes | set(_driver_write_routes_from_descriptors()))
+
+
 def _secret_capable_store(record_store: object):
     if hasattr(record_store, "read_secret_record") and hasattr(record_store, "list_secret_records"):
         return record_store
@@ -2289,50 +2319,7 @@ def create_launchplane_service_app(
             else None
         )
     )
-    write_routes = {
-        "/v1/evidence/deployments",
-        "/v1/evidence/backup-gates",
-        "/v1/evidence/previews/generations",
-        "/v1/evidence/previews/destroyed",
-        "/v1/authz-policies/github-actions/grants",
-        "/v1/product-config/apply",
-        "/v1/product-profiles/context-cutover/apply",
-        "/v1/product-profiles/legacy-context-cleanup/apply",
-        "/v1/previews/desired-state",
-        "/v1/previews/pr-feedback",
-        "/v1/previews/lifecycle-cleanup",
-        "/v1/previews/lifecycle-plan",
-        "/v1/product-profiles",
-        "/v1/evidence/promotions",
-        "/v1/drivers/launchplane/self-deploy",
-        "/v1/drivers/generic-web/deploy",
-        "/v1/drivers/generic-web/prod-promotion",
-        "/v1/drivers/generic-web/prod-promotion-workflow",
-        "/v1/drivers/generic-web/preview-desired-state",
-        "/v1/drivers/generic-web/preview-refresh",
-        "/v1/drivers/generic-web/preview-inventory",
-        "/v1/drivers/generic-web/preview-readiness",
-        "/v1/drivers/generic-web/preview-destroy",
-        "/v1/drivers/odoo/artifact-publish-inputs",
-        "/v1/drivers/odoo/artifact-publish",
-        "/v1/drivers/odoo/post-deploy",
-        "/v1/drivers/odoo/prod-backup-gate",
-        "/v1/drivers/odoo/prod-promotion",
-        "/v1/drivers/odoo/prod-rollback",
-        "/v1/drivers/verireel/preview-refresh",
-        "/v1/drivers/verireel/preview-inventory",
-        "/v1/drivers/verireel/preview-destroy",
-        "/v1/drivers/verireel/preview-verification",
-        "/v1/drivers/verireel/testing-deploy",
-        "/v1/drivers/verireel/testing-verification",
-        "/v1/drivers/verireel/stable-environment",
-        "/v1/drivers/verireel/runtime-verification",
-        "/v1/drivers/verireel/app-maintenance",
-        "/v1/drivers/verireel/prod-deploy",
-        "/v1/drivers/verireel/prod-backup-gate",
-        "/v1/drivers/verireel/prod-promotion",
-        "/v1/drivers/verireel/prod-rollback",
-    }
+    write_routes = _build_write_routes()
 
     def app(
         environ: dict[str, object],

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+from dataclasses import dataclass
 from datetime import datetime, timezone
 import hashlib
 import io
@@ -204,6 +205,17 @@ from control_plane.workflows.verireel_preview_driver import (
 
 
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
+
+
+@dataclass(frozen=True)
+class _DriverRouteMetadata:
+    driver_id: str
+    action_id: str
+    method: str
+    authz_action: str
+    operator_visible: bool
+
+
 _LAUNCHPLANE_IMAGE_REFERENCE_ENV_KEY = "DOCKER_IMAGE_REFERENCE"
 _LOGGER = logging.getLogger(__name__)
 _LAUNCHPLANE_SELF_DEPLOY_OAUTH_ENV_KEYS = frozenset(
@@ -1274,12 +1286,41 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
     return None
 
 
+def _driver_route_metadata_from_descriptors() -> dict[str, _DriverRouteMetadata]:
+    route_metadata: dict[str, _DriverRouteMetadata] = {}
+    for descriptor in list_driver_descriptors():
+        for action in descriptor.actions:
+            if not action.route_path.startswith("/v1/drivers/"):
+                continue
+            if not action.authz_action:
+                raise ValueError(
+                    f"Driver action {descriptor.driver_id}.{action.action_id} "
+                    "must declare authz_action."
+                )
+            if action.route_path in route_metadata:
+                raise ValueError(f"Duplicate driver action route path: {action.route_path}")
+            route_metadata[action.route_path] = _DriverRouteMetadata(
+                driver_id=descriptor.driver_id,
+                action_id=action.action_id,
+                method=action.method,
+                authz_action=action.authz_action,
+                operator_visible=action.operator_visible,
+            )
+    return route_metadata
+
+
+def _descriptor_driver_authz_action(route_path: str) -> str:
+    try:
+        return _driver_route_metadata_from_descriptors()[route_path].authz_action
+    except KeyError as exc:
+        raise ValueError(f"Unknown descriptor-backed driver route: {route_path}") from exc
+
+
 def _driver_write_routes_from_descriptors() -> frozenset[str]:
     return frozenset(
-        action.route_path
-        for descriptor in list_driver_descriptors()
-        for action in descriptor.actions
-        if action.method == "POST" and action.route_path.startswith("/v1/drivers/")
+        route_path
+        for route_path, route_metadata in _driver_route_metadata_from_descriptors().items()
+        if route_metadata.method == "POST"
     )
 
 
@@ -3548,7 +3589,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="generic_web_deploy.execute",
+                    action=_descriptor_driver_authz_action(path),
                     product=profile.product,
                     context=lane.context,
                 ):
@@ -3607,7 +3648,7 @@ def create_launchplane_service_app(
                     )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="generic_web_prod_promotion.execute",
+                    action=_descriptor_driver_authz_action(path),
                     product=request.product,
                     context=destination_lane.context,
                 ):
@@ -3659,7 +3700,7 @@ def create_launchplane_service_app(
                 profile = record_store.read_product_profile_record(request.product)
                 if not authz_policy.allows(
                     identity=identity,
-                    action="generic_web_prod_promotion.dispatch",
+                    action=_descriptor_driver_authz_action(path),
                     product=profile.product,
                     context=request.workflow.context,
                 ):
@@ -3703,7 +3744,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="preview_desired_state.discover",
+                    action=_descriptor_driver_authz_action(path),
                     product=profile.product,
                     context=profile.preview.context,
                 ):
@@ -3753,7 +3794,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="preview_inventory.read",
+                    action=_descriptor_driver_authz_action(path),
                     product=profile.product,
                     context=profile.preview.context,
                 ):
@@ -3793,7 +3834,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="preview_refresh.execute",
+                    action=_descriptor_driver_authz_action(path),
                     product=profile.product,
                     context=profile.preview.context,
                 ):
@@ -3838,7 +3879,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="preview_readiness.evaluate",
+                    action=_descriptor_driver_authz_action(path),
                     product=profile.product,
                     context=profile.preview.context,
                 ):
@@ -3873,7 +3914,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="preview_destroy.execute",
+                    action=_descriptor_driver_authz_action(path),
                     product=profile.product,
                     context=profile.preview.context,
                 ):
@@ -3919,7 +3960,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="odoo_post_deploy.execute",
+                    action=_descriptor_driver_authz_action(path),
                     product=request.product,
                     context=request.post_deploy.context,
                 ):
@@ -3968,7 +4009,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="odoo_artifact_publish.write",
+                    action=_descriptor_driver_authz_action(path),
                     product=request.product,
                     context=request.publish.context,
                 ):
@@ -4018,7 +4059,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="odoo_artifact_publish_inputs.read",
+                    action=_descriptor_driver_authz_action(path),
                     product=request.product,
                     context=request.inputs.context,
                 ):
@@ -4062,7 +4103,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="odoo_prod_backup_gate.execute",
+                    action=_descriptor_driver_authz_action(path),
                     product=request.product,
                     context=request.backup_gate.context,
                 ):
@@ -4114,7 +4155,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="odoo_prod_promotion.execute",
+                    action=_descriptor_driver_authz_action(path),
                     product=request.product,
                     context=request.promotion.context,
                 ):
@@ -4170,7 +4211,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="odoo_prod_rollback.execute",
+                    action=_descriptor_driver_authz_action(path),
                     product=request.product,
                     context=request.rollback.context,
                 ):
@@ -4222,7 +4263,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="verireel_testing_deploy.execute",
+                    action=_descriptor_driver_authz_action(path),
                     product=request.product,
                     context=request.deploy.context,
                 ):
@@ -4269,7 +4310,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="deployment.write",
+                    action=_descriptor_driver_authz_action(path),
                     product=request.product,
                     context=request.verification.context,
                 ):
@@ -4314,7 +4355,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="verireel_stable_environment.read",
+                    action=_descriptor_driver_authz_action(path),
                     product=request.product,
                     context=request.environment.context,
                 ):
@@ -4349,7 +4390,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="verireel_stable_environment.read",
+                    action=_descriptor_driver_authz_action(path),
                     product=request.product,
                     context=request.verification.context,
                 ):
@@ -4382,7 +4423,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="verireel_app_maintenance.execute",
+                    action=_descriptor_driver_authz_action(path),
                     product=request.product,
                     context=request.maintenance.context,
                 ):
@@ -4428,7 +4469,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="verireel_prod_deploy.execute",
+                    action=_descriptor_driver_authz_action(path),
                     product=request.product,
                     context=request.deploy.context,
                 ):
@@ -4475,7 +4516,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="verireel_prod_backup_gate.execute",
+                    action=_descriptor_driver_authz_action(path),
                     product=request.product,
                     context=request.backup_gate.context,
                 ):
@@ -4530,7 +4571,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="verireel_prod_promotion.execute",
+                    action=_descriptor_driver_authz_action(path),
                     product=request.product,
                     context=request.promotion.context,
                 ):
@@ -4580,7 +4621,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="verireel_prod_rollback.execute",
+                    action=_descriptor_driver_authz_action(path),
                     product=request.product,
                     context=request.rollback.context,
                 ):
@@ -4628,7 +4669,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="verireel_preview_refresh.execute",
+                    action=_descriptor_driver_authz_action(path),
                     product=request.product,
                     context=request.refresh.context,
                 ):
@@ -4677,7 +4718,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="verireel_preview_inventory.read",
+                    action=_descriptor_driver_authz_action(path),
                     product=request.product,
                     context=request.inventory.context,
                 ):
@@ -4716,7 +4757,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="verireel_preview_destroy.execute",
+                    action=_descriptor_driver_authz_action(path),
                     product=request.product,
                     context=request.destroy.context,
                 ):
@@ -4764,7 +4805,7 @@ def create_launchplane_service_app(
                 )
                 if not authz_policy.allows(
                     identity=identity,
-                    action="preview_generation.write",
+                    action=_descriptor_driver_authz_action(path),
                     product=request.product,
                     context=request.verification.context,
                 ):

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -173,7 +173,9 @@ string for that route. Some service callback routes, such as verification
 writeback routes, are declared with `operator_visible=false`; they remain in the
 driver route authorization map but are not surfaced as operator actions.
 The HTTP service admits product-driver POST routes from descriptor action route
-paths so new drivers do not need a second hardcoded router allowlist entry.
+paths and reads product-driver handler authorization actions from descriptor
+route metadata, so new drivers do not need a second hardcoded router allowlist
+or authz-action entry.
 
 Preview read models are capability-driven. A driver that exposes
 `previewable`, `preview_inventory_managed`, legacy `preview_lifecycle`, or the

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -172,6 +172,8 @@ metadata. `authz_action` must match the live service handler authorization
 string for that route. Some service callback routes, such as verification
 writeback routes, are declared with `operator_visible=false`; they remain in the
 driver route authorization map but are not surfaced as operator actions.
+The HTTP service admits product-driver POST routes from descriptor action route
+paths so new drivers do not need a second hardcoded router allowlist entry.
 
 Preview read models are capability-driven. A driver that exposes
 `previewable`, `preview_inventory_managed`, legacy `preview_lifecycle`, or the

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -455,7 +455,9 @@ These use the same authn/authz boundary as evidence ingress:
 - `POST /v1/drivers/generic-web/prod-promotion`
 - `POST /v1/drivers/verireel/...`
 
-The first explicit driver routes now in service are:
+The first driver route handlers now in service are admitted from descriptor
+action route paths rather than a separate product-driver router allowlist. The
+current handlers include:
 
 - `POST /v1/drivers/odoo/post-deploy`
 - `POST /v1/drivers/odoo/artifact-publish-inputs`

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -137,15 +137,28 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
 
     def test_service_accepts_descriptor_post_driver_routes(self) -> None:
-        descriptor_post_routes = {
-            action.route_path
+        descriptor_post_route_metadata = {
+            action.route_path: (descriptor.driver_id, action.action_id, action.authz_action)
             for descriptor in list_driver_descriptors()
             for action in descriptor.actions
             if action.method == "POST" and action.route_path.startswith("/v1/drivers/")
         }
+        service_route_metadata = control_plane_service._driver_route_metadata_from_descriptors()
 
-        self.assertTrue(descriptor_post_routes)
-        self.assertLessEqual(descriptor_post_routes, control_plane_service._build_write_routes())
+        self.assertTrue(descriptor_post_route_metadata)
+        self.assertLessEqual(
+            set(descriptor_post_route_metadata), control_plane_service._build_write_routes()
+        )
+        for route_path, (
+            driver_id,
+            action_id,
+            authz_action,
+        ) in descriptor_post_route_metadata.items():
+            self.assertEqual(service_route_metadata[route_path].driver_id, driver_id)
+            self.assertEqual(service_route_metadata[route_path].action_id, action_id)
+            self.assertEqual(
+                control_plane_service._descriptor_driver_authz_action(route_path), authz_action
+            )
         self.assertIn(
             "/v1/drivers/launchplane/self-deploy",
             control_plane_service._build_write_routes(),

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -2,6 +2,7 @@ import json
 import unittest
 from unittest.mock import patch
 
+from control_plane import service as control_plane_service
 from control_plane.contracts.driver_descriptor import (
     DriverCapabilityDescriptor,
     DriverDescriptor,
@@ -133,6 +134,21 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         self.assertFalse(
             route_actions["/v1/drivers/verireel/preview-verification"].operator_visible
+        )
+
+    def test_service_accepts_descriptor_post_driver_routes(self) -> None:
+        descriptor_post_routes = {
+            action.route_path
+            for descriptor in list_driver_descriptors()
+            for action in descriptor.actions
+            if action.method == "POST" and action.route_path.startswith("/v1/drivers/")
+        }
+
+        self.assertTrue(descriptor_post_routes)
+        self.assertLessEqual(descriptor_post_routes, control_plane_service._build_write_routes())
+        self.assertIn(
+            "/v1/drivers/launchplane/self-deploy",
+            control_plane_service._build_write_routes(),
         )
 
     def test_preview_read_model_is_capability_driven_not_verireel_named(self) -> None:


### PR DESCRIPTION
## Summary
- derive product-driver POST route admission from driver descriptor actions
- read product-driver handler authz action strings from descriptor route metadata
- keep Launchplane self-deploy and non-driver write routes explicit
- document descriptor-owned route admission/authz and add regression coverage

Refs #161

## Validation
- `uv run python -m unittest tests.test_driver_descriptors tests.test_service`
- `uv run --extra dev ruff check control_plane/service.py tests/test_driver_descriptors.py`

## Notes
- `uv run --extra dev mypy control_plane tests` still reports the existing broad baseline typing failures; this PR did not add service/descriptor unit failures.