### PR TITLE
Fix generic-web literal profile deploy resolution

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1751,10 +1751,11 @@ def _resolve_product_driver_context(
     driver_id: str,
     context: str = "",
     instance: str = "",
+    require_profile: bool = False,
 ) -> _ResolvedProductDriverContext:
     normalized_product = product.strip()
     normalized_driver_id = driver_id.strip()
-    if normalized_product == normalized_driver_id:
+    if normalized_product == normalized_driver_id and not require_profile:
         return _ResolvedProductDriverContext(profile=None)
     read_profile = getattr(record_store, "read_product_profile_record", None)
     if not callable(read_profile):
@@ -1779,6 +1780,7 @@ def _resolve_descriptor_product_driver_context(
     product: str,
     context: str = "",
     instance: str = "",
+    require_profile: bool = False,
 ) -> _ResolvedProductDriverContext:
     return _resolve_product_driver_context(
         record_store=record_store,
@@ -1786,6 +1788,7 @@ def _resolve_descriptor_product_driver_context(
         driver_id=_driver_route_metadata_from_descriptors()[route_path].driver_id,
         context=context,
         instance=instance,
+        require_profile=require_profile,
     )
 
 
@@ -3637,6 +3640,7 @@ def create_launchplane_service_app(
                     route_path=path,
                     product=request.deploy.product,
                     instance=request.deploy.instance,
+                    require_profile=True,
                 )
                 if resolved_driver_context.profile is None or resolved_driver_context.lane is None:
                     raise ProductDriverMismatchError(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2465,6 +2465,66 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(kwargs["profile"].driver_id, "verireel")
         self.assertEqual(kwargs["lane"].instance, "testing")
 
+    def test_generic_web_deploy_route_resolves_literal_generic_web_profile(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload("generic-web"))
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["generic-web"],
+                            "contexts": ["generic-web-testing"],
+                            "actions": ["generic_web_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            driver_result = SimpleNamespace(deployment_record_id="deployment-generic-web-testing")
+
+            with patch(
+                "control_plane.service.execute_generic_web_deploy",
+                return_value=driver_result,
+            ) as deploy:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/deploy",
+                    payload={
+                        "schema_version": 1,
+                        "product": "generic-web",
+                        "deploy": {
+                            "schema_version": 1,
+                            "product": "generic-web",
+                            "instance": "testing",
+                            "artifact_id": "ghcr.io/cbusillo/generic-web@sha256:abc123",
+                            "source_git_ref": "abc123",
+                        },
+                    },
+                    headers={"Idempotency-Key": "generic-web-deploy-literal-driver"},
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["records"]["deployment_record_id"], "deployment-generic-web-testing")
+        deploy.assert_called_once()
+        _, kwargs = deploy.call_args
+        self.assertEqual(kwargs["profile"].product, "generic-web")
+        self.assertEqual(kwargs["lane"].context, "generic-web-testing")
+
     def test_generic_web_deploy_route_rejects_wrong_product_context(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- preserve profile/lane resolution for generic-web deploy when product == driver id
- keep the legacy product-equals-driver short-circuit for routes that do not require a profile
- add regression coverage for literal `generic-web` product deploys

Refs #161

## Validation
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_generic_web_deploy_route_uses_profile_lane_for_authorization tests.test_service.LaunchplaneServiceTests.test_generic_web_deploy_route_accepts_base_driver_product tests.test_service.LaunchplaneServiceTests.test_generic_web_deploy_route_resolves_literal_generic_web_profile tests.test_service.LaunchplaneServiceTests.test_generic_web_deploy_route_rejects_wrong_product_context`
- `uv run python -m unittest tests.test_service`
- `uv run --extra dev ruff check control_plane/service.py tests/test_service.py`

## Notes
- This addresses the auto-review P1 finding from the descriptor-driven context resolution stack.