### PR TITLE
Add generic-web readiness dispatch metadata

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -219,6 +219,13 @@ class _DriverRouteMetadata:
 
 
 @dataclass(frozen=True)
+class _DriverRouteExecutionMetadata:
+    route_path: str
+    envelope_model: type[BaseModel]
+    denial_message: str
+
+
+@dataclass(frozen=True)
 class _ResolvedProductDriverContext:
     profile: LaunchplaneProductProfileRecord | None
     lane: ProductLaneProfile | None = None
@@ -399,6 +406,16 @@ class GenericWebPreviewReadinessEnvelope(BaseModel):
         if self.product.strip() != self.readiness.product.strip():
             raise ValueError("generic web preview readiness requires matching product values")
         return self
+
+
+_GENERIC_WEB_PREVIEW_READINESS_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/generic-web/preview-readiness",
+    envelope_model=GenericWebPreviewReadinessEnvelope,
+    denial_message=(
+        "Workflow cannot evaluate generic web preview readiness"
+        " for the requested product/context."
+    ),
+)
 
 
 class GenericWebPreviewDestroyEnvelope(BaseModel):
@@ -3896,8 +3913,11 @@ def create_launchplane_service_app(
                     profile=profile,
                 )
                 result = {}
-            elif path == "/v1/drivers/generic-web/preview-readiness":
-                request = GenericWebPreviewReadinessEnvelope.model_validate(payload)
+            elif path == _GENERIC_WEB_PREVIEW_READINESS_ROUTE.route_path:
+                request = cast(
+                    GenericWebPreviewReadinessEnvelope,
+                    _GENERIC_WEB_PREVIEW_READINESS_ROUTE.envelope_model.model_validate(payload),
+                )
                 profile = resolve_generic_web_preview_profile(
                     record_store=record_store,
                     product=request.product,
@@ -3908,10 +3928,7 @@ def create_launchplane_service_app(
                     route_path=path,
                     product=profile.product,
                     context=profile.preview.context,
-                    denial_message=(
-                        "Workflow cannot evaluate generic web preview readiness"
-                        " for the requested product/context."
-                    ),
+                    denial_message=_GENERIC_WEB_PREVIEW_READINESS_ROUTE.denial_message,
                     start_response=start_response,
                     trace_id=request_trace_id,
                 )

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -164,6 +164,19 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             control_plane_service._build_write_routes(),
         )
 
+    def test_generic_web_readiness_execution_metadata_matches_descriptor(self) -> None:
+        descriptor = read_driver_descriptor("generic-web")
+        actions = {action.action_id: action for action in descriptor.actions}
+        readiness_action = actions["preview_readiness"]
+        execution_metadata = control_plane_service._GENERIC_WEB_PREVIEW_READINESS_ROUTE
+
+        self.assertEqual(execution_metadata.route_path, readiness_action.route_path)
+        self.assertIs(
+            execution_metadata.envelope_model,
+            control_plane_service.GenericWebPreviewReadinessEnvelope,
+        )
+        self.assertIn("preview readiness", execution_metadata.denial_message)
+
     def test_preview_read_model_is_capability_driven_not_verireel_named(self) -> None:
         descriptor = DriverDescriptor(
             driver_id="custom-web",


### PR DESCRIPTION
## Summary
- introduce typed driver route execution metadata
- move generic-web preview-readiness route path, envelope model, and denial message into the first metadata entry
- assert the execution metadata stays aligned with the driver descriptor action

Refs #161

## Validation
- `uv run python -m unittest tests.test_driver_descriptors tests.test_service`
- `uv run --extra dev ruff check control_plane/service.py tests/test_driver_descriptors.py`

## Notes
- This is intentionally a tiny dispatch-table foothold: execution still happens in the existing handler chain while metadata begins moving out of inline route blocks.