### PR TITLE
Add generic-web preview dispatch metadata

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -392,6 +392,26 @@ class GenericWebPreviewInventoryEnvelope(BaseModel):
         return self
 
 
+_GENERIC_WEB_PREVIEW_REFRESH_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/generic-web/preview-refresh",
+    envelope_model=GenericWebPreviewRefreshEnvelope,
+    denial_message=(
+        "Workflow cannot refresh generic web preview state"
+        " for the requested product/context."
+    ),
+)
+
+
+_GENERIC_WEB_PREVIEW_INVENTORY_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/generic-web/preview-inventory",
+    envelope_model=GenericWebPreviewInventoryEnvelope,
+    denial_message=(
+        "Workflow cannot read generic web preview inventory"
+        " for the requested product/context."
+    ),
+)
+
+
 class GenericWebPreviewReadinessEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -3840,8 +3860,13 @@ def create_launchplane_service_app(
                     record=driver_result,
                 )
                 result = {"preview_desired_state_id": preview_desired_state_id}
-            elif path == "/v1/drivers/generic-web/preview-inventory":
-                request = GenericWebPreviewInventoryEnvelope.model_validate(payload)
+            elif path == _GENERIC_WEB_PREVIEW_INVENTORY_ROUTE.route_path:
+                request = cast(
+                    GenericWebPreviewInventoryEnvelope,
+                    _GENERIC_WEB_PREVIEW_INVENTORY_ROUTE.envelope_model.model_validate(
+                        payload
+                    ),
+                )
                 profile = resolve_generic_web_preview_profile(
                     record_store=record_store,
                     product=request.product,
@@ -3852,10 +3877,7 @@ def create_launchplane_service_app(
                     route_path=path,
                     product=profile.product,
                     context=profile.preview.context,
-                    denial_message=(
-                        "Workflow cannot read generic web preview inventory"
-                        " for the requested product/context."
-                    ),
+                    denial_message=_GENERIC_WEB_PREVIEW_INVENTORY_ROUTE.denial_message,
                     start_response=start_response,
                     trace_id=request_trace_id,
                 )
@@ -3874,8 +3896,11 @@ def create_launchplane_service_app(
                     preview_slugs=tuple(item.previewSlug for item in driver_result.previews),
                 )
                 result = {"preview_inventory_scan_id": preview_inventory_scan_id}
-            elif path == "/v1/drivers/generic-web/preview-refresh":
-                request = GenericWebPreviewRefreshEnvelope.model_validate(payload)
+            elif path == _GENERIC_WEB_PREVIEW_REFRESH_ROUTE.route_path:
+                request = cast(
+                    GenericWebPreviewRefreshEnvelope,
+                    _GENERIC_WEB_PREVIEW_REFRESH_ROUTE.envelope_model.model_validate(payload),
+                )
                 profile = resolve_generic_web_preview_profile(
                     record_store=record_store,
                     product=request.product,
@@ -3886,10 +3911,7 @@ def create_launchplane_service_app(
                     route_path=path,
                     product=profile.product,
                     context=profile.preview.context,
-                    denial_message=(
-                        "Workflow cannot refresh generic web preview state"
-                        " for the requested product/context."
-                    ),
+                    denial_message=_GENERIC_WEB_PREVIEW_REFRESH_ROUTE.denial_message,
                     start_response=start_response,
                     trace_id=request_trace_id,
                 )

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -164,18 +164,42 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             control_plane_service._build_write_routes(),
         )
 
-    def test_generic_web_readiness_execution_metadata_matches_descriptor(self) -> None:
+    def test_generic_web_preview_execution_metadata_matches_descriptors(self) -> None:
         descriptor = read_driver_descriptor("generic-web")
         actions = {action.action_id: action for action in descriptor.actions}
-        readiness_action = actions["preview_readiness"]
-        execution_metadata = control_plane_service._GENERIC_WEB_PREVIEW_READINESS_ROUTE
+        route_metadata_by_action = {
+            "preview_inventory": (
+                control_plane_service._GENERIC_WEB_PREVIEW_INVENTORY_ROUTE,
+                control_plane_service.GenericWebPreviewInventoryEnvelope,
+                "preview inventory",
+            ),
+            "preview_refresh": (
+                control_plane_service._GENERIC_WEB_PREVIEW_REFRESH_ROUTE,
+                control_plane_service.GenericWebPreviewRefreshEnvelope,
+                "refresh",
+            ),
+            "preview_readiness": (
+                control_plane_service._GENERIC_WEB_PREVIEW_READINESS_ROUTE,
+                control_plane_service.GenericWebPreviewReadinessEnvelope,
+                "preview readiness",
+            ),
+        }
 
-        self.assertEqual(execution_metadata.route_path, readiness_action.route_path)
-        self.assertIs(
-            execution_metadata.envelope_model,
-            control_plane_service.GenericWebPreviewReadinessEnvelope,
-        )
-        self.assertIn("preview readiness", execution_metadata.denial_message)
+        for action_id, (
+            execution_metadata,
+            envelope_model,
+            denial_message_fragment,
+        ) in route_metadata_by_action.items():
+            with self.subTest(action_id=action_id):
+                self.assertEqual(
+                    execution_metadata.route_path,
+                    actions[action_id].route_path,
+                )
+                self.assertIs(execution_metadata.envelope_model, envelope_model)
+                self.assertIn(
+                    denial_message_fragment,
+                    execution_metadata.denial_message,
+                )
 
     def test_preview_read_model_is_capability_driven_not_verireel_named(self) -> None:
         descriptor = DriverDescriptor(


### PR DESCRIPTION
## Summary
- add execution metadata for generic-web preview inventory and refresh routes
- consume the metadata for route path, envelope validation, and denial text
- expand descriptor alignment coverage for generic-web preview execution metadata

Refs #161

## Validation
- `uv run python -m unittest tests.test_driver_descriptors tests.test_service`
- `uv run --extra dev ruff check control_plane/service.py tests/test_driver_descriptors.py`

## Notes
- This continues the tiny dispatch-table extraction foothold while preserving existing handler-chain execution.