### PR TITLE
Cover generic-web preview destroy service route

### DIFF
--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -79,6 +79,7 @@ from control_plane.workflows.odoo_prod_promotion import OdooProdPromotionResult
 from control_plane.workflows.odoo_prod_rollback import OdooProdRollbackResult
 from control_plane.workflows.generic_web_promotion import GenericWebProdPromotionResult
 from control_plane.workflows.generic_web_promotion_workflow import GenericWebPromotionWorkflowResult
+from control_plane.workflows.generic_web_preview import GenericWebPreviewDestroyResult
 
 
 class _StubVerifier:
@@ -3355,6 +3356,84 @@ class LaunchplaneServiceTests(unittest.TestCase):
         readiness.assert_called_once()
         _, kwargs = readiness.call_args
         self.assertEqual(kwargs["profile"].product, "sellyouroutboard")
+
+    def test_generic_web_preview_destroy_route_returns_driver_result(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["preview_destroy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
+                            "@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_generic_web_preview_destroy",
+                return_value=GenericWebPreviewDestroyResult(
+                    destroy_status="pass",
+                    destroy_started_at="2026-05-03T16:00:00Z",
+                    destroy_finished_at="2026-05-03T16:00:02Z",
+                    product="sellyouroutboard",
+                    context="sellyouroutboard-testing",
+                    preview_slug="pr-42",
+                    application_name="sellyouroutboard-pr-42",
+                    application_id="app-preview",
+                ),
+            ) as destroy:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/preview-destroy",
+                    payload={
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "destroy": {
+                            "schema_version": 1,
+                            "product": "sellyouroutboard",
+                            "preview_slug": "pr-42",
+                            "destroy_reason": "external_preview_pull_request_closed",
+                        },
+                    },
+                    headers={"Idempotency-Key": "generic-web-preview-destroy:syo:pr-42"},
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["destroy_status"], "pass")
+        self.assertEqual(payload["result"]["application_id"], "app-preview")
+        destroy.assert_called_once()
+        _, kwargs = destroy.call_args
+        self.assertEqual(kwargs["profile"].product, "sellyouroutboard")
+        self.assertEqual(kwargs["profile"].preview.context, "sellyouroutboard-testing")
+        self.assertEqual(kwargs["request"].preview_slug, "pr-42")
 
     def test_driver_context_view_endpoint_returns_lane_summary(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add service-level coverage for the generic-web preview destroy route
- verify descriptor authz grant, driver result serialization, resolved profile context, and request handoff

Refs #161

## Validation
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_destroy_route_returns_driver_result tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_readiness_route_returns_driver_result tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_refresh_route_returns_driver_result`
- `uv run python -m unittest tests.test_service tests.test_driver_descriptors`
- `uv run --extra dev ruff check tests/test_service.py`
- `git diff --check`

## Notes
- This closes the only direct service coverage gap for the generic-web preview route helper before more backend dispatch cleanup.