### PR TITLE
Authorize generic-web promotion workflow against profile lane

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -3844,13 +3844,25 @@ def create_launchplane_service_app(
                 request = _GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.envelope_model.model_validate(
                     payload
                 )
-                profile = record_store.read_product_profile_record(request.product)
+                resolved_driver_context = _resolve_descriptor_product_driver_context(
+                    record_store=record_store,
+                    route_path=path,
+                    product=request.product,
+                    context=request.workflow.context,
+                    require_profile=True,
+                )
+                if resolved_driver_context.profile is None or resolved_driver_context.lane is None:
+                    raise ProductDriverMismatchError(
+                        "Generic web promotion workflow requires a product profile lane."
+                    )
+                profile = resolved_driver_context.profile
+                lane = resolved_driver_context.lane
                 authorization_response = _driver_route_authorization_response(
                     authz_policy=authz_policy,
                     identity=identity,
                     route_path=path,
                     product=profile.product,
-                    context=request.workflow.context,
+                    context=lane.context,
                     denial_message=_GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.denial_message,
                     start_response=start_response,
                     trace_id=request_trace_id,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2964,6 +2964,64 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
 
+    def test_generic_web_promotion_workflow_rejects_unowned_context_before_authz(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload_with_prod())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_humans": [
+                        {
+                            "logins": ["alice"],
+                            "roles": ["admin"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["unowned-context"],
+                            "actions": ["generic_web_prod_promotion.dispatch"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=_StubGitHubOAuthClient(_human_identity(role="admin")),  # type: ignore[arg-type]
+            )
+            cookie = _signed_in_cookie(app)
+
+            with patch(
+                "control_plane.service.dispatch_generic_web_promotion_workflow"
+            ) as dispatch_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/prod-promotion-workflow",
+                    payload={
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "workflow": {
+                            "schema_version": 1,
+                            "product": "sellyouroutboard",
+                            "context": "unowned-context",
+                            "dry_run": False,
+                        },
+                    },
+                    authorization="",
+                    headers={"Cookie": cookie},
+                )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "product_driver_mismatch")
+        dispatch_mock.assert_not_called()
+
     def test_generic_web_product_profile_appears_in_driver_view(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- resolve generic-web promotion workflow context against stored product profile lanes before authz
- authorize the workflow route using the resolved lane context instead of the caller-supplied string
- add a regression test proving an unowned context is rejected before dispatch even when policy grants that context

Refs #161

## Validation
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_human_session_can_dispatch_generic_web_promotion_workflow tests.test_service.LaunchplaneServiceTests.test_generic_web_promotion_workflow_rejects_unauthorized_human tests.test_service.LaunchplaneServiceTests.test_generic_web_promotion_workflow_rejects_unowned_context_before_authz`
- `uv run python -m unittest tests.test_service tests.test_driver_descriptors`
- `uv run --extra dev ruff check control_plane/service.py tests/test_service.py`
- `git diff --check`

## Notes
- This preserves the workflow request contract while moving service authorization to Launchplane-owned profile/lane context authority.