### PR TITLE
Add Odoo artifact dispatch metadata

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -645,11 +645,8 @@ class ProductDriverMismatchError(ValueError):
     pass
 
 
-class OdooPostDeployEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class OdooPostDeployEnvelope(_ProductRouteEnvelope):
     schema_version: int = Field(default=1, ge=1)
-    product: str
     post_deploy: OdooPostDeployRequest
 
     @model_validator(mode="after")
@@ -658,11 +655,8 @@ class OdooPostDeployEnvelope(BaseModel):
         return self
 
 
-class OdooArtifactPublishEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class OdooArtifactPublishEnvelope(_ProductRouteEnvelope):
     schema_version: int = Field(default=1, ge=1)
-    product: str
     publish: OdooArtifactPublishEvidenceRequest
 
     @model_validator(mode="after")
@@ -671,17 +665,44 @@ class OdooArtifactPublishEnvelope(BaseModel):
         return self
 
 
-class OdooArtifactPublishInputsEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class OdooArtifactPublishInputsEnvelope(_ProductRouteEnvelope):
     schema_version: int = Field(default=1, ge=1)
-    product: str
     inputs: OdooArtifactPublishInputsRequest
 
     @model_validator(mode="after")
     def _validate_alignment(self) -> "OdooArtifactPublishInputsEnvelope":
         _validate_driver_envelope_product(self.product, label="Odoo artifact publish inputs")
         return self
+
+
+_ODOO_POST_DEPLOY_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/odoo/post-deploy",
+    envelope_model=OdooPostDeployEnvelope,
+    denial_message=(
+        "Workflow cannot execute the Odoo post-deploy driver"
+        " for the requested product/context."
+    ),
+)
+
+
+_ODOO_ARTIFACT_PUBLISH_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/odoo/artifact-publish",
+    envelope_model=OdooArtifactPublishEnvelope,
+    denial_message=(
+        "Workflow cannot write Odoo artifact publish evidence"
+        " for the requested product/context."
+    ),
+)
+
+
+_ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/odoo/artifact-publish-inputs",
+    envelope_model=OdooArtifactPublishInputsEnvelope,
+    denial_message=(
+        "Workflow cannot read Odoo artifact publish inputs"
+        " for the requested product/context."
+    ),
+)
 
 
 class OdooProdRollbackEnvelope(BaseModel):
@@ -4030,8 +4051,8 @@ def create_launchplane_service_app(
                     profile=profile,
                 )
                 result = {}
-            elif path == "/v1/drivers/odoo/post-deploy":
-                request = OdooPostDeployEnvelope.model_validate(payload)
+            elif path == _ODOO_POST_DEPLOY_ROUTE.route_path:
+                request = _ODOO_POST_DEPLOY_ROUTE.envelope_model.model_validate(payload)
                 _resolve_descriptor_product_driver_context(
                     record_store=record_store,
                     route_path=path,
@@ -4043,10 +4064,7 @@ def create_launchplane_service_app(
                     route_path=path,
                     product=request.product,
                     context=request.post_deploy.context,
-                    denial_message=(
-                        "Workflow cannot execute the Odoo post-deploy driver"
-                        " for the requested product/context."
-                    ),
+                    denial_message=_ODOO_POST_DEPLOY_ROUTE.denial_message,
                     start_response=start_response,
                     trace_id=request_trace_id,
                 )
@@ -4073,8 +4091,8 @@ def create_launchplane_service_app(
                         f"odoo-post-deploy:{driver_result.context}:{driver_result.instance}:{driver_result.phase}"
                     )
                 }
-            elif path == "/v1/drivers/odoo/artifact-publish":
-                request = OdooArtifactPublishEnvelope.model_validate(payload)
+            elif path == _ODOO_ARTIFACT_PUBLISH_ROUTE.route_path:
+                request = _ODOO_ARTIFACT_PUBLISH_ROUTE.envelope_model.model_validate(payload)
                 _resolve_descriptor_product_driver_context(
                     record_store=record_store,
                     route_path=path,
@@ -4086,10 +4104,7 @@ def create_launchplane_service_app(
                     route_path=path,
                     product=request.product,
                     context=request.publish.context,
-                    denial_message=(
-                        "Workflow cannot write Odoo artifact publish evidence"
-                        " for the requested product/context."
-                    ),
+                    denial_message=_ODOO_ARTIFACT_PUBLISH_ROUTE.denial_message,
                     start_response=start_response,
                     trace_id=request_trace_id,
                 )
@@ -4117,8 +4132,10 @@ def create_launchplane_service_app(
                     "image_digest": driver_result.image_digest,
                     "source_commit": driver_result.source_commit,
                 }
-            elif path == "/v1/drivers/odoo/artifact-publish-inputs":
-                request = OdooArtifactPublishInputsEnvelope.model_validate(payload)
+            elif path == _ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE.route_path:
+                request = _ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE.envelope_model.model_validate(
+                    payload
+                )
                 _resolve_descriptor_product_driver_context(
                     record_store=record_store,
                     route_path=path,
@@ -4130,10 +4147,7 @@ def create_launchplane_service_app(
                     route_path=path,
                     product=request.product,
                     context=request.inputs.context,
-                    denial_message=(
-                        "Workflow cannot read Odoo artifact publish inputs"
-                        " for the requested product/context."
-                    ),
+                    denial_message=_ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE.denial_message,
                     start_response=start_response,
                     trace_id=request_trace_id,
                 )

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -234,6 +234,50 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
                     execution_metadata.denial_message,
                 )
 
+    def test_odoo_artifact_execution_metadata_matches_descriptors(self) -> None:
+        descriptor = read_driver_descriptor("odoo")
+        actions = {action.action_id: action for action in descriptor.actions}
+        route_metadata_by_action: dict[
+            str,
+            tuple[
+                control_plane_service._DriverRouteExecutionMetadata[Any],
+                type[Any],
+                str,
+            ],
+        ] = {
+            "artifact_publish_inputs": (
+                control_plane_service._ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE,
+                control_plane_service.OdooArtifactPublishInputsEnvelope,
+                "artifact publish inputs",
+            ),
+            "artifact_publish": (
+                control_plane_service._ODOO_ARTIFACT_PUBLISH_ROUTE,
+                control_plane_service.OdooArtifactPublishEnvelope,
+                "artifact publish evidence",
+            ),
+            "post_deploy": (
+                control_plane_service._ODOO_POST_DEPLOY_ROUTE,
+                control_plane_service.OdooPostDeployEnvelope,
+                "post-deploy driver",
+            ),
+        }
+
+        for action_id, (
+            execution_metadata,
+            envelope_model,
+            denial_message_fragment,
+        ) in route_metadata_by_action.items():
+            with self.subTest(action_id=action_id):
+                self.assertEqual(
+                    execution_metadata.route_path,
+                    actions[action_id].route_path,
+                )
+                self.assertIs(execution_metadata.envelope_model, envelope_model)
+                self.assertIn(
+                    denial_message_fragment,
+                    execution_metadata.denial_message,
+                )
+
     def test_preview_read_model_is_capability_driven_not_verireel_named(self) -> None:
         descriptor = DriverDescriptor(
             driver_id="custom-web",


### PR DESCRIPTION
## Summary
- add execution metadata for Odoo post-deploy and artifact publish routes
- consume metadata for route path, envelope validation, and denial text
- extend descriptor drift coverage for Odoo artifact/post-deploy execution metadata

Refs #161

## Validation
- `uv run python -m unittest tests.test_driver_descriptors tests.test_service`
- `uv run --extra dev ruff check control_plane/service.py tests/test_driver_descriptors.py`
- `git diff --check`