### PR TITLE
Use dispatch metadata for route policies

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1095,6 +1095,24 @@ _VERIREEL_PREVIEW_VERIFICATION_ROUTE = _DriverRouteExecutionMetadata(
 )
 
 
+_HUMAN_IDENTITY_MUTATION_ROUTES = frozenset(
+    {
+        _GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path,
+        _GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.route_path,
+    }
+)
+_NON_IDEMPOTENT_DRIVER_RESULT_ROUTES = frozenset(
+    {
+        _VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path,
+        _VERIREEL_RUNTIME_VERIFICATION_ROUTE.route_path,
+        _VERIREEL_PREVIEW_INVENTORY_ROUTE.route_path,
+    }
+)
+_PENDING_RESULT_IDEMPOTENCY_SKIP_ROUTES = frozenset(
+    {_VERIREEL_PROD_BACKUP_GATE_ROUTE.route_path}
+)
+
+
 class LaunchplaneSelfDeployRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -2869,10 +2887,7 @@ def create_launchplane_service_app(
                     session_manager=session_manager,
                 )
             else:
-                if path in {
-                    "/v1/drivers/generic-web/prod-promotion",
-                    "/v1/drivers/generic-web/prod-promotion-workflow",
-                }:
+                if path in _HUMAN_IDENTITY_MUTATION_ROUTES:
                     identity = _read_identity(
                         environ=environ,
                         verifier=verifier,
@@ -5528,13 +5543,9 @@ def create_launchplane_service_app(
             driver_result=driver_result,
         )
         should_store_idempotency = True
-        if path in {
-            "/v1/drivers/verireel/stable-environment",
-            "/v1/drivers/verireel/runtime-verification",
-            "/v1/drivers/verireel/preview-inventory",
-        }:
+        if path in _NON_IDEMPOTENT_DRIVER_RESULT_ROUTES:
             should_store_idempotency = False
-        if path == "/v1/drivers/verireel/prod-backup-gate":
+        if path in _PENDING_RESULT_IDEMPOTENCY_SKIP_ROUTES:
             driver_result_status = ""
             if isinstance(driver_result, dict):
                 driver_result_status = str(driver_result.get("backup_status") or "")

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -474,6 +474,43 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
                     execution_metadata.denial_message,
                 )
 
+    def test_route_policy_sets_use_execution_metadata(self) -> None:
+        self.assertEqual(
+            control_plane_service._HUMAN_IDENTITY_MUTATION_ROUTES,
+            frozenset(
+                {
+                    control_plane_service._GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path,
+                    control_plane_service._GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.route_path,
+                }
+            ),
+        )
+        self.assertIn(
+            "/v1/drivers/generic-web/prod-promotion",
+            control_plane_service._HUMAN_IDENTITY_MUTATION_ROUTES,
+        )
+        self.assertEqual(
+            control_plane_service._NON_IDEMPOTENT_DRIVER_RESULT_ROUTES,
+            frozenset(
+                {
+                    control_plane_service._VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path,
+                    control_plane_service._VERIREEL_RUNTIME_VERIFICATION_ROUTE.route_path,
+                    control_plane_service._VERIREEL_PREVIEW_INVENTORY_ROUTE.route_path,
+                }
+            ),
+        )
+        self.assertIn(
+            "/v1/drivers/verireel/preview-inventory",
+            control_plane_service._NON_IDEMPOTENT_DRIVER_RESULT_ROUTES,
+        )
+        self.assertEqual(
+            control_plane_service._PENDING_RESULT_IDEMPOTENCY_SKIP_ROUTES,
+            frozenset({control_plane_service._VERIREEL_PROD_BACKUP_GATE_ROUTE.route_path}),
+        )
+        self.assertIn(
+            "/v1/drivers/verireel/prod-backup-gate",
+            control_plane_service._PENDING_RESULT_IDEMPOTENCY_SKIP_ROUTES,
+        )
+
     def test_preview_read_model_is_capability_driven_not_verireel_named(self) -> None:
         descriptor = DriverDescriptor(
             driver_id="custom-web",


### PR DESCRIPTION
## Summary
- replace duplicated driver route strings in identity and idempotency policy checks with sets derived from execution metadata constants
- keep generic-web human identity mutation exceptions and VeriReel idempotency exclusions behavior-preserving
- add descriptor test coverage that keeps these route policy sets anchored to dispatch metadata

Refs #161

## Validation
- `uv run python -m unittest tests.test_driver_descriptors tests.test_service`
- `uv run --extra dev ruff check control_plane/service.py tests/test_driver_descriptors.py`
- `git diff --check`