### PR TITLE
Narrow workflow contract literal types

### DIFF
--- a/control_plane/contracts/ship_request.py
+++ b/control_plane/contracts/ship_request.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane.contracts.dokploy_target_record import DokployTargetType
 from control_plane.contracts.promotion_record import HealthcheckEvidence
 
 
@@ -12,7 +13,7 @@ class ShipRequest(BaseModel):
     instance: str
     source_git_ref: str
     target_name: str
-    target_type: str
+    target_type: DokployTargetType
     deploy_mode: str
     wait: bool = True
     timeout_seconds: int | None = Field(default=None, ge=1)

--- a/control_plane/workflows/promote.py
+++ b/control_plane/workflows/promote.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime
 
+from control_plane.contracts.dokploy_target_record import DokployTargetType
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
     BackupGateEvidence,
@@ -8,6 +9,7 @@ from control_plane.contracts.promotion_record import (
     PostDeployUpdateEvidence,
     PromotionRequest,
     PromotionRecord,
+    ReleaseStatus,
 )
 
 
@@ -21,7 +23,7 @@ def build_promotion_record(
     from_instance_name: str,
     to_instance_name: str,
     target_name: str,
-    target_type: str,
+    target_type: DokployTargetType,
     deploy_mode: str,
     deployment_id: str = "",
     source_health: HealthcheckEvidence | None = None,
@@ -54,7 +56,12 @@ def generate_promotion_record_id(*, context_name: str, from_instance_name: str, 
     return f"promotion-{timestamp}-{context_name}-{from_instance_name}-to-{to_instance_name}"
 
 
-def _resolve_post_deploy_update(status_target_type: str, *, wait: bool, deployment_status: str) -> PostDeployUpdateEvidence:
+def _resolve_post_deploy_update(
+    status_target_type: DokployTargetType,
+    *,
+    wait: bool,
+    deployment_status: ReleaseStatus,
+) -> PostDeployUpdateEvidence:
     if not wait or status_target_type != "compose":
         return PostDeployUpdateEvidence()
     if deployment_status == "pending":
@@ -76,7 +83,7 @@ def _resolve_destination_health(
     destination_health: HealthcheckEvidence,
     *,
     wait: bool,
-    deployment_status: str,
+    deployment_status: ReleaseStatus,
 ) -> HealthcheckEvidence:
     if destination_health.status == "skipped":
         return destination_health
@@ -99,7 +106,7 @@ def build_executed_promotion_record(
     request: PromotionRequest,
     record_id: str,
     deployment_id: str,
-    deployment_status: str,
+    deployment_status: ReleaseStatus,
     deployment_record_id: str = "",
 ) -> PromotionRecord:
     return PromotionRecord(

--- a/control_plane/workflows/ship.py
+++ b/control_plane/workflows/ship.py
@@ -7,8 +7,9 @@ from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
     DeploymentEvidence,
     HealthcheckEvidence,
+    PostDeployUpdateEvidence,
+    ReleaseStatus,
 )
-from control_plane.contracts.promotion_record import PostDeployUpdateEvidence
 from control_plane.contracts.ship_request import ShipRequest
 
 
@@ -25,7 +26,7 @@ def _resolve_destination_health(
     destination_health: HealthcheckEvidence,
     *,
     wait: bool,
-    deployment_status: str,
+    deployment_status: ReleaseStatus,
 ) -> HealthcheckEvidence:
     if destination_health.status == "skipped":
         return destination_health
@@ -52,7 +53,7 @@ def _resolve_destination_health(
 def _resolve_post_deploy_update(
     request: ShipRequest,
     *,
-    deployment_status: str,
+    deployment_status: ReleaseStatus,
 ) -> PostDeployUpdateEvidence:
     if not request.wait or request.target_type != "compose":
         return PostDeployUpdateEvidence()
@@ -84,7 +85,7 @@ def build_deployment_record(
     request: ShipRequest,
     record_id: str,
     deployment_id: str,
-    deployment_status: str,
+    deployment_status: ReleaseStatus,
     started_at: str,
     finished_at: str,
     resolved_target: ResolvedTargetEvidence | None = None,

--- a/control_plane/workflows/verireel_prod_promotion.py
+++ b/control_plane/workflows/verireel_prod_promotion.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from control_plane import dokploy as control_plane_dokploy
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetType
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
     BackupGateEvidence,
@@ -93,14 +94,14 @@ class VeriReelProdPromotionResult(BaseModel):
     promotion_record_id: str
     deployment_record_id: str = ""
     backup_record_id: str
-    deploy_status: str
-    rollout_status: str = "skipped"
-    migration_status: str = "skipped"
-    health_status: str = "skipped"
+    deploy_status: ReleaseStatus
+    rollout_status: ReleaseStatus = "skipped"
+    migration_status: ReleaseStatus = "skipped"
+    health_status: ReleaseStatus = "skipped"
     deploy_started_at: str = ""
     deploy_finished_at: str = ""
     target_name: str
-    target_type: str
+    target_type: DokployTargetType
     target_id: str
     error_message: str = ""
 
@@ -109,7 +110,7 @@ def _default_target_name() -> str:
     return "ver-prod-app"
 
 
-def _default_target_type() -> str:
+def _default_target_type() -> DokployTargetType:
     return "application"
 
 
@@ -176,11 +177,11 @@ def _build_promotion_record(
     deployment_record_id: str,
     target_id: str,
     target_name: str,
-    target_type: str,
-    deploy_status: str,
+    target_type: DokployTargetType,
+    deploy_status: ReleaseStatus,
     deploy_started_at: str,
     deploy_finished_at: str,
-    migration_status: str,
+    migration_status: ReleaseStatus,
     migration_detail: str,
     health_result: VeriReelRolloutVerificationResult | None,
 ) -> PromotionRecord:
@@ -227,7 +228,7 @@ def _build_promotion_record(
 def _build_post_deploy_update(
     *,
     instance_name: str,
-    migration_status: str,
+    migration_status: ReleaseStatus,
     migration_detail: str,
 ) -> PostDeployUpdateEvidence:
     if migration_status == "skipped":
@@ -273,13 +274,13 @@ def _write_failed_promotion_record(
     backup_gate_record: BackupGateRecord | None,
     error_message: str,
     deployment_record_id: str = "",
-    deploy_status: str = "fail",
+    deploy_status: ReleaseStatus = "fail",
     deploy_started_at: str = "",
     deploy_finished_at: str = "",
     target_name: str | None = None,
-    target_type: str | None = None,
+    target_type: DokployTargetType | None = None,
     target_id: str = "",
-    migration_status: str = "skipped",
+    migration_status: ReleaseStatus = "skipped",
     migration_detail: str = "",
     health_result: VeriReelRolloutVerificationResult | None = None,
 ) -> None:
@@ -360,7 +361,7 @@ def _resolve_application_id(
     *,
     control_plane_root: Path,
     request: VeriReelProdPromotionRequest,
-    target_type: str,
+    target_type: DokployTargetType,
     target_id: str,
 ) -> str:
     if target_type == "application" and target_id.strip():
@@ -386,7 +387,7 @@ def _resolve_application_id(
 
 def _find_application_schedule(
     *, host: str, token: str, application_id: str, schedule_name: str
-) -> dict[str, object] | None:
+) -> control_plane_dokploy.JsonObject | None:
     for schedule in control_plane_dokploy.list_dokploy_schedules(
         host=host,
         token=token,
@@ -394,7 +395,7 @@ def _find_application_schedule(
         schedule_type="application",
     ):
         if str(schedule.get("name") or "").strip() == schedule_name:
-            return dict(schedule)
+            return schedule
     return None
 
 
@@ -412,7 +413,7 @@ def _upsert_application_schedule(
         application_id=application_id,
         schedule_name=schedule_name,
     )
-    payload: dict[str, object] = {
+    payload: control_plane_dokploy.JsonObject = {
         "name": schedule_name,
         "cronExpression": control_plane_dokploy.DOKPLOY_MANUAL_ONLY_CRON_EXPRESSION,
         "scheduleType": "application",
@@ -431,15 +432,16 @@ def _upsert_application_schedule(
             payload=payload,
         )
     else:
+        update_payload: control_plane_dokploy.JsonObject = {
+            "scheduleId": control_plane_dokploy.schedule_key(existing_schedule),
+            **payload,
+        }
         control_plane_dokploy.dokploy_request(
             host=host,
             token=token,
             path="/api/schedule.update",
             method="POST",
-            payload={
-                "scheduleId": control_plane_dokploy.schedule_key(existing_schedule),
-                **payload,
-            },
+            payload=update_payload,
         )
     resolved_schedule = _find_application_schedule(
         host=host,
@@ -512,7 +514,7 @@ def _run_prisma_migrations(
     *,
     control_plane_root: Path,
     request: VeriReelProdPromotionRequest,
-    target_type: str,
+    target_type: DokployTargetType,
     target_id: str,
 ) -> None:
     host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
@@ -569,7 +571,7 @@ def execute_verireel_prod_promotion(
         record_store=record_store,
         request=VeriReelStableDeployRequest(
             context=request.context,
-            instance=request.to_instance,
+            instance="prod",
             artifact_id=request.artifact_id,
             source_git_ref=request.source_git_ref,
             expected_build_revision=request.expected_build_revision,

--- a/control_plane/workflows/verireel_rollout.py
+++ b/control_plane/workflows/verireel_rollout.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import runtime_environments as control_plane_runtime_environments
-from control_plane.contracts.promotion_record import HealthcheckEvidence
+from control_plane.contracts.promotion_record import HealthcheckEvidence, ReleaseStatus
 from control_plane.workflows.ship import utc_now_timestamp
 
 
@@ -43,7 +43,7 @@ class VeriReelRolloutVerificationRequest(BaseModel):
 class VeriReelRolloutVerificationResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    status: str
+    status: ReleaseStatus
     base_url: str = ""
     health_urls: tuple[str, ...] = ()
     started_at: str = ""

--- a/control_plane/workflows/verireel_stable_deploy.py
+++ b/control_plane/workflows/verireel_stable_deploy.py
@@ -9,7 +9,8 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane.contracts.deployment_record import ResolvedTargetEvidence
-from control_plane.contracts.promotion_record import HealthcheckEvidence
+from control_plane.contracts.dokploy_target_record import DokployTargetType
+from control_plane.contracts.promotion_record import HealthcheckEvidence, ReleaseStatus
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.dokploy_deploy import execute_dokploy_artifact_deploy
@@ -67,9 +68,9 @@ class VeriReelStableDeployResult(BaseModel):
     deploy_started_at: str
     deploy_finished_at: str
     target_name: str
-    target_type: str
+    target_type: DokployTargetType
     target_id: str
-    rollout_status: str = "skipped"
+    rollout_status: ReleaseStatus = "skipped"
     rollout_base_url: str = ""
     rollout_health_urls: tuple[str, ...] = ()
     rollout_started_at: str = ""
@@ -92,7 +93,7 @@ def _expected_build_tag(request: VeriReelStableDeployRequest) -> str:
     return request.expected_build_tag.strip() or _artifact_tag(request.artifact_id)
 
 
-def _resolve_deploy_mode(*, configured_ship_mode: str, target_type: str) -> str:
+def _resolve_deploy_mode(*, configured_ship_mode: str, target_type: DokployTargetType) -> str:
     if configured_ship_mode == "auto":
         return f"dokploy-{target_type}-api"
     return f"dokploy-{configured_ship_mode}-api"


### PR DESCRIPTION
## Summary
- narrow ship/promote workflow status and target-type fields to shared contract literals
- carry those types through VeriReel rollout, stable deploy, and prod promotion results
- type Dokploy schedule payloads as JSON objects in the prod promotion migration path

Refs #165

## Validation
- uv run --extra dev mypy control_plane/workflows/promote.py control_plane/workflows/ship.py control_plane/contracts/ship_request.py control_plane/workflows/verireel_rollout.py control_plane/workflows/verireel_stable_deploy.py control_plane/workflows/verireel_prod_promotion.py
- uv run python -m unittest tests.test_promote tests.test_verireel_prod_promotion
- uv run --extra dev ruff check control_plane/contracts/ship_request.py control_plane/workflows/promote.py control_plane/workflows/ship.py control_plane/workflows/verireel_rollout.py control_plane/workflows/verireel_stable_deploy.py control_plane/workflows/verireel_prod_promotion.py
- git diff --check

## Baseline
- full mypy still fails on the known cleanup baseline: 649 errors in 25 files after this slice
