### PR TITLE
Type generic web workflow stores

### DIFF
--- a/control_plane/workflows/generic_web_deploy.py
+++ b/control_plane/workflows/generic_web_deploy.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Protocol
 
 import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import runtime_environments as control_plane_runtime_environments
-from control_plane.contracts.deployment_record import ResolvedTargetEvidence
+from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
+from control_plane.contracts.dokploy_target_record import DokployTargetType
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductLaneProfile,
@@ -17,6 +18,12 @@ from control_plane.contracts.promotion_record import HealthcheckEvidence
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.workflows.dokploy_deploy import execute_dokploy_artifact_deploy
 from control_plane.workflows.ship import build_deployment_record, generate_deployment_record_id, utc_now_timestamp
+
+
+class GenericWebDeployStore(Protocol):
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord: ...
+
+    def write_deployment_record(self, record: DeploymentRecord) -> object: ...
 
 
 class GenericWebDeployRequest(BaseModel):
@@ -54,13 +61,13 @@ class GenericWebDeployResult(BaseModel):
     context: str
     instance: str
     target_name: str = ""
-    target_type: str = ""
+    target_type: DokployTargetType | Literal[""] = ""
     target_id: str = ""
     error_message: str = ""
 
 
 def resolve_generic_web_profile_lane(
-    *, record_store: object, request: GenericWebDeployRequest
+    *, record_store: GenericWebDeployStore, request: GenericWebDeployRequest
 ) -> tuple[LaunchplaneProductProfileRecord, ProductLaneProfile]:
     profile = record_store.read_product_profile_record(request.product)
     if profile.driver_id != "generic-web":
@@ -75,7 +82,7 @@ def resolve_generic_web_profile_lane(
     )
 
 
-def _resolve_deploy_mode(*, configured_ship_mode: str, target_type: str) -> str:
+def _resolve_deploy_mode(*, configured_ship_mode: str, target_type: DokployTargetType) -> str:
     if configured_ship_mode == "auto":
         return f"dokploy-{target_type}-api"
     return f"dokploy-{configured_ship_mode}-api"
@@ -169,7 +176,7 @@ def _resolve_ship_request(
 def execute_generic_web_deploy(
     *,
     control_plane_root: Path,
-    record_store: object,
+    record_store: GenericWebDeployStore,
     request: GenericWebDeployRequest,
     profile: LaunchplaneProductProfileRecord | None = None,
     lane: ProductLaneProfile | None = None,

--- a/control_plane/workflows/generic_web_promotion.py
+++ b/control_plane/workflows/generic_web_promotion.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Protocol
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
@@ -11,6 +11,8 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetType
+from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductLaneProfile,
@@ -24,6 +26,7 @@ from control_plane.contracts.promotion_record import (
     ReleaseStatus,
 )
 from control_plane.workflows.generic_web_deploy import (
+    GenericWebDeployStore,
     GenericWebDeployRequest,
     execute_generic_web_deploy,
     resolve_generic_web_profile_lane,
@@ -33,6 +36,16 @@ from control_plane.workflows.promote import generate_promotion_record_id
 from control_plane.workflows.ship import utc_now_timestamp
 
 DEFAULT_GENERIC_WEB_HEALTH_TIMEOUT_SECONDS = 60
+
+
+class GenericWebPromotionStore(GenericWebDeployStore, Protocol):
+    def read_backup_gate_record(self, record_id: str) -> BackupGateRecord: ...
+
+    def read_deployment_record(self, record_id: str) -> DeploymentRecord: ...
+
+    def write_promotion_record(self, record: PromotionRecord) -> object: ...
+
+    def write_environment_inventory(self, record: EnvironmentInventory) -> object: ...
 
 
 class GenericWebProdPromotionRequest(BaseModel):
@@ -98,14 +111,14 @@ class GenericWebProdPromotionResult(BaseModel):
     source_health_status: ReleaseStatus = "skipped"
     destination_health_status: ReleaseStatus = "skipped"
     target_name: str = ""
-    target_type: str = ""
+    target_type: DokployTargetType | Literal[""] = ""
     target_id: str = ""
     dry_run: bool = False
     error_message: str = ""
 
 
 def resolve_generic_web_promotion_lanes(
-    *, record_store: object, request: GenericWebProdPromotionRequest
+    *, record_store: GenericWebPromotionStore, request: GenericWebProdPromotionRequest
 ) -> tuple[LaunchplaneProductProfileRecord, ProductLaneProfile, ProductLaneProfile]:
     source_profile, source_lane = resolve_generic_web_profile_lane(
         record_store=record_store,
@@ -138,7 +151,7 @@ def resolve_generic_web_promotion_lanes(
 def execute_generic_web_prod_promotion(
     *,
     control_plane_root: Path,
-    record_store: object,
+    record_store: GenericWebPromotionStore,
     request: GenericWebProdPromotionRequest,
 ) -> GenericWebProdPromotionResult:
     profile, source_lane, destination_lane = resolve_generic_web_promotion_lanes(
@@ -308,7 +321,7 @@ def execute_generic_web_prod_promotion(
 
 
 def _resolve_backup_gate(
-    *, record_store: object, request: GenericWebProdPromotionRequest, context: str
+    *, record_store: GenericWebPromotionStore, request: GenericWebProdPromotionRequest, context: str
 ) -> BackupGateEvidence:
     if not request.backup_record_id:
         return BackupGateEvidence(required=request.backup_required, status="skipped", evidence={})
@@ -436,7 +449,9 @@ def _mark_health_skipped(evidence: HealthcheckEvidence) -> HealthcheckEvidence:
     )
 
 
-def _read_deployment_record(*, record_store: object, deployment_record_id: str) -> DeploymentRecord:
+def _read_deployment_record(
+    *, record_store: GenericWebPromotionStore, deployment_record_id: str
+) -> DeploymentRecord:
     try:
         return record_store.read_deployment_record(deployment_record_id)
     except FileNotFoundError as exc:
@@ -447,7 +462,7 @@ def _read_deployment_record(*, record_store: object, deployment_record_id: str) 
 
 def _write_deployment_health(
     *,
-    record_store: object,
+    record_store: GenericWebPromotionStore,
     deployment_record: DeploymentRecord,
     destination_health: HealthcheckEvidence,
 ) -> DeploymentRecord:
@@ -472,7 +487,7 @@ def _build_promotion_record(
     deployment_record: DeploymentRecord | None,
     deployment_status: ReleaseStatus,
     target_name: str,
-    target_type: str,
+    target_type: DokployTargetType,
     deployment_record_id: str,
 ) -> PromotionRecord:
     target_deploy_mode = "dokploy-application-api"


### PR DESCRIPTION
## Summary
- add explicit generic-web deploy and promotion store protocols instead of accepting bare object
- carry Dokploy target-type literals through generic-web deploy and promotion result models
- keep deployment/promotion store writes typed while preserving existing runtime behavior

Refs #165

## Validation
- uv run --extra dev mypy control_plane/workflows/generic_web_deploy.py control_plane/workflows/generic_web_promotion.py
- uv run python -m unittest tests.test_generic_web_deploy tests.test_generic_web_promotion
- uv run --extra dev ruff check control_plane/workflows/generic_web_deploy.py control_plane/workflows/generic_web_promotion.py
- git diff --check
