### PR TITLE
Type VeriReel rollback status contracts

### DIFF
--- a/control_plane/workflows/verireel_prod_rollback.py
+++ b/control_plane/workflows/verireel_prod_rollback.py
@@ -16,17 +16,18 @@ from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.promotion_record import (
     HealthcheckEvidence,
     PromotionRecord,
+    ReleaseStatus,
     RollbackExecutionEvidence,
 )
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.ship import utc_now_timestamp
 from control_plane.workflows.verireel_prod_promotion import (
-    DEFAULT_ROLLOUT_INTERVAL_SECONDS,
-    DEFAULT_ROLLOUT_TIMEOUT_SECONDS,
-    VeriReelRolloutVerificationResult,
     _read_backup_gate_record,
 )
 from control_plane.workflows.verireel_rollout import (
+    DEFAULT_ROLLOUT_INTERVAL_SECONDS,
+    DEFAULT_ROLLOUT_TIMEOUT_SECONDS,
+    VeriReelRolloutVerificationResult,
     assert_verireel_rollout_pages as _assert_rollout_pages,
     fetch_url_text as _fetch_url_text,
     resolve_verireel_rollout_base_urls,
@@ -95,7 +96,7 @@ class VeriReelProdRollbackWorkerResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     schema_version: int = Field(default=1, ge=1)
-    status: str
+    status: ReleaseStatus
     snapshot_name: str
     started_at: str = ""
     finished_at: str = ""
@@ -108,8 +109,8 @@ class VeriReelProdRollbackResult(BaseModel):
     promotion_record_id: str
     backup_record_id: str
     snapshot_name: str = ""
-    rollback_status: str
-    rollback_health_status: str = "skipped"
+    rollback_status: ReleaseStatus
+    rollback_health_status: ReleaseStatus = "skipped"
     rollback_started_at: str = ""
     rollback_finished_at: str = ""
     error_message: str = ""
@@ -259,8 +260,8 @@ def _write_promotion_rollback_state(
     promotion_record: PromotionRecord,
     request: VeriReelProdRollbackRequest,
     snapshot_name: str,
-    rollback_status: str,
-    rollback_health_status: str,
+    rollback_status: ReleaseStatus,
+    rollback_health_status: ReleaseStatus,
     rollback_started_at: str,
     rollback_finished_at: str,
     detail: str,

--- a/tests/test_verireel_prod_promotion.py
+++ b/tests/test_verireel_prod_promotion.py
@@ -7,13 +7,13 @@ import click
 
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
-from control_plane.contracts.promotion_record import DeploymentEvidence
+from control_plane.contracts.promotion_record import ArtifactIdentityReference, DeploymentEvidence
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.verireel_prod_promotion import (
     VeriReelProdPromotionRequest,
-    VeriReelRolloutVerificationResult,
     execute_verireel_prod_promotion,
 )
+from control_plane.workflows.verireel_rollout import VeriReelRolloutVerificationResult
 from control_plane.workflows.verireel_stable_deploy import VeriReelStableDeployResult
 
 
@@ -40,7 +40,9 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
             store.write_deployment_record(
                 DeploymentRecord(
                     record_id="deployment-verireel-prod-run-12345-attempt-1",
-                    artifact_identity={"artifact_id": "ghcr.io/every/verireel-app:sha-abcdef1234567890"},
+                    artifact_identity=ArtifactIdentityReference(
+                        artifact_id="ghcr.io/every/verireel-app:sha-abcdef1234567890"
+                    ),
                     context="verireel",
                     instance="prod",
                     source_git_ref="abcdef1234567890",
@@ -60,14 +62,16 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                     ),
                 )
             )
-            request = VeriReelProdPromotionRequest(
-                artifact_id="ghcr.io/every/verireel-app:sha-abcdef1234567890",
-                source_git_ref="abcdef1234567890",
-                backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
-                promotion_record_id="promotion-verireel-testing-to-prod-run-12345-attempt-1",
-                source_health_status="success",
-                expected_build_revision="abcdef1234567890",
-                expected_build_tag="sha-abcdef1234567890",
+            request = VeriReelProdPromotionRequest.model_validate(
+                {
+                    "artifact_id": "ghcr.io/every/verireel-app:sha-abcdef1234567890",
+                    "source_git_ref": "abcdef1234567890",
+                    "backup_record_id": "backup-gate-verireel-prod-run-12345-attempt-1",
+                    "promotion_record_id": "promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                    "source_health_status": "success",
+                    "expected_build_revision": "abcdef1234567890",
+                    "expected_build_tag": "sha-abcdef1234567890",
+                }
             )
 
             with patch(

--- a/tests/test_verireel_prod_rollback.py
+++ b/tests/test_verireel_prod_rollback.py
@@ -20,13 +20,11 @@ from control_plane.workflows.verireel_prod_rollback import (
     VeriReelProdRollbackRequest,
     VeriReelProdRollbackWorkerRequest,
     VeriReelProdRollbackWorkerResult,
+    _resolve_rollout_base_urls,
     _run_delegated_worker,
     execute_verireel_prod_rollback,
 )
-from control_plane.workflows.verireel_prod_promotion import (
-    VeriReelRolloutVerificationResult,
-    _resolve_rollout_base_urls,
-)
+from control_plane.workflows.verireel_rollout import VeriReelRolloutVerificationResult
 
 
 class VeriReelProdRollbackWorkflowTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- import rollout constants/results from the rollout module instead of through promotion
- type VeriReel rollback worker/result statuses as ReleaseStatus
- update paired tests to use explicit typed records and direct rollout imports

Refs #165

## Validation
- uv run --extra dev mypy control_plane/workflows/verireel_prod_rollback.py tests/test_verireel_prod_rollback.py tests/test_verireel_prod_promotion.py
- uv run python -m unittest tests.test_verireel_prod_rollback tests.test_verireel_prod_promotion
- uv run --extra dev ruff check --diff control_plane/workflows/verireel_prod_rollback.py tests/test_verireel_prod_rollback.py tests/test_verireel_prod_promotion.py
- uv run --extra dev ruff check control_plane/workflows/verireel_prod_rollback.py tests/test_verireel_prod_rollback.py tests/test_verireel_prod_promotion.py
- git diff --check