### PR TITLE
Enforce mypy in CI static checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Run Ruff
         run: uv run --extra dev ruff check .
 
+      - name: Run mypy
+        run: uv run --extra dev mypy control_plane tests
+
       - name: Audit Python dependencies
         run: uv run --with pip-audit pip-audit
 
@@ -48,6 +51,9 @@ jobs:
 
       - name: Run Ruff
         run: uv run --extra dev ruff check .
+
+      - name: Run mypy
+        run: uv run --extra dev mypy control_plane tests
 
       - name: Audit Python dependencies
         run: uv run --with pip-audit pip-audit


### PR DESCRIPTION
## Summary
- add the full Launchplane mypy gate to same-repo and fork static CI jobs
- keep the command aligned with .github/github-repo-workflow.json now that #165 is zero-baseline

## Verification
- uv run --extra dev mypy control_plane tests
- docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml

Refs #165