### PR TITLE
Document Dokploy service deploy contract

### DIFF
--- a/.github/github-repo-workflow.json
+++ b/.github/github-repo-workflow.json
@@ -6,6 +6,7 @@
     "architecture": "docs/architecture.md",
     "configBoundary": "docs/config-boundary.md",
     "serviceBoundary": "docs/service-boundary.md",
+    "dokployServiceDeployments": "docs/dokploy-service-deployments.md",
     "driverDescriptors": "docs/driver-descriptors.md",
     "operatorExperience": "docs/operator-experience.md",
     "operations": "docs/operations.md",

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,8 @@ Use these docs as the source of truth for `launchplane`.
   and the fallback-removal target.
 - [service-boundary.md](service-boundary.md) — Launchplane HTTP ingress, GitHub
   OIDC trust, and first API contracts.
+- [dokploy-service-deployments.md](dokploy-service-deployments.md) — contract
+  for simple image-backed services deployed through Dokploy applications.
 - [new-product-repo.md](new-product-repo.md) — checklist for building a new
   website or service repo operated by Launchplane.
 - [product-repo-contract.md](product-repo-contract.md) — thin product repo

--- a/docs/dokploy-service-deployments.md
+++ b/docs/dokploy-service-deployments.md
@@ -1,0 +1,179 @@
+---
+title: Dokploy Service Deployments
+---
+
+## Purpose
+
+Use this contract for a simple product service that Launchplane deploys to a
+Dokploy application target. The service may be a bot or worker instead of a
+public website, but it still follows the same Launchplane-owned lifecycle:
+publish an immutable image, resolve product profile and lane records, mutate the
+Dokploy target through Launchplane, and write deployment evidence here.
+
+Discord Blue is the first target product for this service-shaped contract. It
+should not keep long-term host-managed `systemd` or `uv` deployment ownership
+once this contract is live.
+
+## Supported Model
+
+Launchplane supports a simple service when all of these are true:
+
+- the product publishes one immutable container image per release candidate
+- the runtime is a single Dokploy application target per stable lane
+- required runtime settings can be represented by Launchplane runtime
+  environment records and managed secret bindings
+- persistent state is mounted by the Dokploy target and documented as part of
+  the product runtime contract
+- readiness can be represented by either a small HTTP health endpoint or an
+  explicitly skipped health check when the lane has no reachable health URL
+
+Use `driver_id="generic-web"` for this model. The driver name is historical: for
+service deployments it means reusable image deploy, health evidence, preview
+policy when enabled, promotion evidence, and Launchplane-owned Dokploy
+mutation. It does not require the product to expose a public website.
+
+Create a product-specific driver only when the service needs behavior beyond
+this contract, such as data migrations, product-specific smoke checks,
+destructive repair actions, backup gates, or custom rollback state.
+
+## Launchplane Records
+
+The Launchplane-owned product profile is the service identity and lane map. It
+must declare:
+
+- `product`: durable product key, for example `discord-blue`
+- `repository`: owning GitHub repo, for example `cbusillo/discord-blue`
+- `driver_id`: `generic-web`
+- `image.repository`: immutable image repository, for example
+  `ghcr.io/cbusillo/discord-blue`
+- `runtime_port`: the service's internal HTTP port when it exposes one
+- `health_path`: a path beginning with `/`, even when the lane uses an explicit
+  `health_url` or skips health verification
+- `lanes`: stable instances such as `testing` and `prod`, each with a
+  Launchplane context and optional `base_url` or `health_url`
+
+Each stable lane also needs DB-backed Dokploy target records:
+
+- `DokployTargetRecord` keyed by `context` plus `instance`
+- `target_type="application"`
+- `target_name` or `project_name` matching the operator-owned Dokploy route
+- `deploy_timeout_seconds` when the service needs a longer rollout window
+- `healthcheck_*` fields when Dokploy should independently monitor the service
+- `env` only for non-secret provider settings that Launchplane owns
+- sibling `DokployTargetIdRecord` carrying the live Dokploy application id
+
+Product repos may document these expected facts, but they must not store live
+Launchplane product profiles, target ids, provider credentials, or lifecycle
+records as repo-local authority.
+
+## Image Strategy
+
+Product repos own image build and publish. Launchplane owns deploy selection and
+evidence after the image exists.
+
+Publish images to the profile's `image.repository` and prefer digest deployment:
+
+```text
+ghcr.io/cbusillo/discord-blue@sha256:<digest>
+```
+
+Mutable tags such as `latest`, branch names, or environment names are display or
+debug labels only; they are not stable deploy inputs. If a product workflow also
+emits a human-readable tag, the Launchplane trigger should still send the exact
+digest image reference or an artifact id that Launchplane can resolve to that
+digest.
+
+For the current generic-web application deploy path, the submitted
+`artifact_id` is the deployable immutable image reference used to update the
+Dokploy application's Docker image. Do not submit a mutable tag for service
+deploys. If a later slice adds generic artifact-manifest resolution for this
+path, the manifest must still resolve to the same `repository@sha256:digest`
+identity before Dokploy is mutated.
+
+## Config, Secrets, And Volumes
+
+Non-secret runtime settings belong in Launchplane runtime-environment records.
+Secret settings belong in Launchplane managed secret records and bindings. A
+product workflow may pass the product key, source ref, run URL, and immutable
+image reference; it should not pass secret values or render a Dokploy env file.
+
+Dokploy-owned persistent volumes are allowed for service state, but the volume
+mapping is provider target configuration, not product-repo lifecycle state.
+Document the mount path in the product runtime contract and record the live
+target through Launchplane's Dokploy target records. For Discord Blue, the state
+volume should cover product config and bot runtime state that must survive image
+replacement; secrets still remain managed secret bindings, not files committed
+to the product repo.
+
+Volume contents are not Launchplane release artifacts. If a future service
+needs backup, restore, or data migration gates, add a product-specific driver or
+typed product policy instead of overloading the generic-web deploy request.
+
+## Ports And Health
+
+`runtime_port` is the container port the service listens on when it exposes an
+HTTP endpoint. For Discord Blue, use port `8787` for the Every Code bridge or a
+small health/control endpoint if that is the only HTTP surface.
+
+Stable lanes can verify health in two ways:
+
+- set `lane.health_url` to an explicit URL reachable by Launchplane, such as an
+  internal bridge health endpoint
+- set `lane.base_url` and rely on `profile.health_path` to derive the health URL
+
+If neither value is set, generic-web promotion records skip health verification
+for that lane. Skipping health is acceptable only for an initial migration slice
+with other evidence, such as a successful Dokploy deployment plus product-owned
+log or smoke evidence. The preferred Discord Blue target is a reachable health
+URL on port `8787` so promotion can fail closed on a bad rollout.
+
+Do not expose service ports publicly just to satisfy Launchplane. Keep public,
+private, and internal-only routing as Dokploy/provider configuration and record
+only the product-level health URL or runtime port in Launchplane records.
+
+## Deploy, Promote, And Roll Back
+
+A normal service deploy does this:
+
+1. Product CI builds, tests, and publishes an immutable image.
+2. The product workflow calls Launchplane with product key, stable lane,
+   source ref, and immutable image reference.
+3. Launchplane resolves the product profile lane and DB-backed Dokploy target.
+4. Launchplane updates the Dokploy application image and triggers deployment.
+5. Launchplane writes a deployment record with the resolved target and status.
+
+Promotion uses the same artifact identity and target records. When health URLs
+exist, Launchplane verifies the source and destination lane health around the
+deployment and writes promotion evidence.
+
+Rollback is another Launchplane-owned deployment to a previous immutable image
+reference. Operators should choose the previous good image from Launchplane
+deployment, promotion, inventory, or release-tuple evidence and redeploy that
+exact digest. Do not roll back by clicking Dokploy to a mutable tag or by
+changing product-repo workflow state. A future product-specific rollback route
+can add one-click selection and product smoke evidence, but the durable rollback
+source remains the previous immutable image identity.
+
+## Discord Blue Target
+
+Discord Blue should target this minimum contract before leaving the hardened
+host-managed deployment:
+
+- product key: `discord-blue`
+- driver: `generic-web`
+- image repository: `ghcr.io/cbusillo/discord-blue`
+- stable lanes: at least `testing`; add `prod` before production cutover
+- Dokploy target type: `application`
+- runtime port: `8787` when the bridge or health service is enabled
+- health path: a stable path such as `/health` or `/v1/health`
+- persistent volume: one Dokploy-mounted state/config path documented in the
+  product repo and represented by the operator-owned target configuration
+- secrets: Discord tokens and other credentials managed through Launchplane
+  secret bindings, never passed in workflow payloads
+- deploy input: immutable image reference, preferably
+  `ghcr.io/cbusillo/discord-blue@sha256:<digest>`
+
+The migration is unblocked when Launchplane can read the product profile and
+target records, deploy a testing image through the generic-web route, and record
+either a passed health check on port `8787` or an explicitly documented skipped
+health check with replacement evidence for the first cutover.

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -95,6 +95,12 @@ Generic web exposes base capabilities and common stable-lane actions:
 - preview lifecycle and inventory read models
 - PR feedback ownership
 
+Generic web can also operate simple service products deployed as Dokploy
+applications. In that shape, the product may be a bot or worker instead of a
+public website, but the driver still owns immutable image deployment, optional
+health evidence, and deployment records. The product-specific contract for this
+shape is [dokploy-service-deployments.md](dokploy-service-deployments.md).
+
 The `stable_deploy` action routes to `POST /v1/drivers/generic-web/deploy`. The
 route resolves product lane context from DB-backed product profile records and
 runtime target bindings from DB-backed Dokploy target records.

--- a/docs/new-product-repo.md
+++ b/docs/new-product-repo.md
@@ -35,6 +35,13 @@ Every Launchplane-operated web product should expose a small runtime contract:
 For most web products, `generic-web` can use this contract directly from the
 DB-backed product profile.
 
+Simple service products, such as bots or workers deployed as Dokploy
+applications, can also use `generic-web` when their lifecycle is image deploy,
+optional health verification, and Launchplane-owned provider mutation. See
+[dokploy-service-deployments.md](dokploy-service-deployments.md) for the
+service-specific contract, including persistent volumes and internal ports such
+as Discord Blue's Every Code bridge port `8787`.
+
 ## Launchplane Records
 
 Before wiring workflows, seed or verify these records in Launchplane with an
@@ -85,9 +92,10 @@ artifact reference, and optional run URL.
 
 ## Choose A Driver
 
-Use `generic-web` when the product is a stateless or mostly stateless web app
-whose lifecycle is image deploy, health check, preview refresh, preview cleanup,
-and PR feedback.
+Use `generic-web` when the product is a stateless or mostly stateless web app,
+or a simple service deployed as a Dokploy application, whose lifecycle is image
+deploy, health check, preview refresh when enabled, preview cleanup when
+enabled, and PR feedback.
 
 Create a product driver when the product has named extra obligations:
 

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -44,6 +44,8 @@ in Launchplane DB-backed records.
 - Application source code and product-owned business behavior.
 - Product dependencies, lockfiles, and package/build tooling.
 - Dockerfile or image build contract.
+- Documented runtime ports, health paths, and persistent state mounts for
+  service-shaped products that run as Dokploy applications.
 - Local development helpers, including local-only databases when the product
   needs them.
 - CI checks that validate the source artifact before Launchplane sees it: lint,
@@ -69,6 +71,8 @@ profile data.
 - Runtime-environment records and managed secret records.
 - Driver request validation, idempotency policy, action safety, and audit
   evidence.
+- Dokploy application deploys for simple service products that follow the
+  [Dokploy service deployment contract](dokploy-service-deployments.md).
 - Provider mutations: create/update/delete preview apps, deploy stable lanes,
   promote, rollback, capture backup gates, and cleanup stale runtime state.
 - Readiness checks before provider mutation.
@@ -148,6 +152,10 @@ When creating a new website repo for Launchplane:
   Launchplane.
 - Use `generic-web` directly when the product is a stateless or mostly
   stateless web app with standard preview/deploy behavior.
+- Use the Dokploy service deployment contract when the product is a simple bot
+  or worker service whose deployment can be represented as a single immutable
+  image, one Dokploy application per lane, Launchplane-managed runtime
+  settings/secrets, and an optional health endpoint.
 - Add a product driver only when the product has named extra obligations such as
   database bootstrap, data migration, backup gates, restore/rollback behavior,
   product smoke checks, or platform-specific post-deploy actions.

--- a/docs/records.md
+++ b/docs/records.md
@@ -188,6 +188,13 @@ health endpoint, tests, and source/build inputs. Launchplane owns the product
 profile that maps those app facts into preview, deploy, promotion, and evidence
 behavior.
 
+Simple service products deployed as Dokploy applications use the same product
+profile shape. For a bot or worker service, `runtime_port` is the internal HTTP
+port used for a bridge or health endpoint, `health_path` names the product-level
+health route, and lane `health_url` can point at an internal URL reachable by
+Launchplane. See [dokploy-service-deployments.md](dokploy-service-deployments.md)
+for the service-specific contract.
+
 The service exposes product profile records through `GET /v1/product-profiles`,
 `GET /v1/product-profiles/{product}`, and `POST /v1/product-profiles`. Writes
 require the `product_profile.write` action for the target product in the
@@ -366,6 +373,10 @@ state/
   `unset-shopify-protected-store-key`.
 - Repo-local Dokploy target TOML files are not a supported runtime authority or
   mutation surface for these records.
+- For service-shaped products, persistent volume mounts remain operator-owned
+  Dokploy target configuration. The product repo may document the expected mount
+  path, but Launchplane records own the live target identity and mutation path,
+  and managed secrets remain separate from volume contents.
 
 ## Odoo Instance Override Record
 


### PR DESCRIPTION
## Summary

- add a Dokploy service deployment contract for simple image-backed services such as Discord Blue
- document the `generic-web` service shape: product profiles, Dokploy application targets, immutable image references, secrets/runtime settings, persistent volumes, port `8787`, health checks, and rollback by previous digest
- link the contract from the docs index, product repo contract, new product checklist, driver descriptor docs, record docs, and repo workflow metadata

## Validation

- `markdownlint-cli2 docs/dokploy-service-deployments.md docs/README.md docs/new-product-repo.md docs/product-repo-contract.md docs/driver-descriptors.md docs/records.md`
- `jq empty .github/github-repo-workflow.json`
- `git diff --check`
- `uv run python -m unittest`
- `uv run --extra dev mypy control_plane tests`

Closes #218.
