### PR TITLE
Add product environment overview shell

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ import {
   dispatchGenericWebPromotionWorkflow,
   dryRunGenericWebProdPromotion,
   listDrivers,
+  listProducts,
   listProductProfiles,
   logout,
   readAuthSession,
@@ -51,6 +52,7 @@ import type {
   ProductConfigApplyPayload,
   ProductConfigApplyRequest,
   ProductProfileRecord,
+  ProductSiteOverview,
   ProductConfigRuntimeScope,
   ProductConfigSecretScope,
   PreviewSummary,
@@ -283,6 +285,36 @@ function choiceFromProductProfile(profile: ProductProfileRecord): DriverChoice {
   };
 }
 
+function contextForProductEnvironment(
+  product: ProductSiteOverview,
+  environment: "testing" | "prod",
+): string {
+  const summary = product.environments.find(
+    (candidate) => candidate.environment === environment,
+  );
+  if (summary?.context.trim()) {
+    return summary.context.trim();
+  }
+  const fallback = product.environments.find((candidate) =>
+    candidate.context.trim(),
+  );
+  return fallback?.context.trim() || "";
+}
+
+function choiceFromProductOverview(product: ProductSiteOverview): DriverChoice {
+  return {
+    driverId: product.product,
+    testingContext: contextForProductEnvironment(product, "testing"),
+    prodContext: contextForProductEnvironment(product, "prod"),
+    previewContext: product.preview.enabled
+      ? product.preview.context.trim()
+      : "",
+    label: product.display_name || product.product,
+    driverLabel: product.driver_id,
+    repository: product.repository,
+  };
+}
+
 export function App() {
   const showFixtureGallery =
     import.meta.env.DEV &&
@@ -297,6 +329,9 @@ export function App() {
   const [drivers, setDrivers] = useState<DriverDescriptor[]>([]);
   const [productProfiles, setProductProfiles] = useState<
     ProductProfileRecord[]
+  >([]);
+  const [productOverviews, setProductOverviews] = useState<
+    ProductSiteOverview[]
   >([]);
   const [selected, setSelected] = useState<DriverChoice>(DEFAULT_CHOICES[0]);
   const [prodView, setProdView] = useState<DriverContextView | null>(null);
@@ -355,6 +390,7 @@ export function App() {
     if (authStatus !== "signed_in") {
       setDrivers([]);
       setProductProfiles([]);
+      setProductOverviews([]);
       setProdView(null);
       setTestingView(null);
       setPreviewView(null);
@@ -373,6 +409,11 @@ export function App() {
       selected.previewContext
         ? readDriverView(selected.previewContext, "").catch(() => null)
         : Promise.resolve(null),
+      listProducts().catch(() => ({
+        status: "ok" as const,
+        trace_id: "",
+        products: [],
+      })),
       listProductProfiles("generic-web").catch(() => ({
         status: "ok" as const,
         trace_id: "",
@@ -386,6 +427,7 @@ export function App() {
           prodPayload,
           testingPayload,
           previewPayload,
+          productsPayload,
           profilePayload,
         ]) => {
           if (controller.signal.aborted) {
@@ -396,6 +438,7 @@ export function App() {
           setProdView(prodPayload.view);
           setTestingView(testingPayload.view);
           setPreviewView(previewPayload?.view ?? null);
+          setProductOverviews(productsPayload.products);
         },
       )
       .catch((apiError: unknown) => {
@@ -421,7 +464,7 @@ export function App() {
   }, [authStatus, selected, refreshKey]);
 
   const choices = useMemo(() => {
-    const driverChoices = drivers.flatMap((driver) => {
+    const driverChoices: DriverChoice[] = drivers.flatMap((driver) => {
       const stableContexts = driver.context_patterns.filter((context) => {
         return context !== "verireel-testing" && !context.includes("*");
       });
@@ -437,10 +480,18 @@ export function App() {
         driverLabel: driver.driver_id,
       }));
     });
-    const profileChoices = productProfiles.map((profile) =>
+    const profileChoices: DriverChoice[] = productProfiles.map((profile) =>
       choiceFromProductProfile(profile),
     );
-    const merged = [...profileChoices, ...driverChoices, ...DEFAULT_CHOICES];
+    const overviewChoices: DriverChoice[] = productOverviews.map((overview) =>
+      choiceFromProductOverview(overview),
+    );
+    const merged: DriverChoice[] = [
+      ...overviewChoices,
+      ...profileChoices,
+      ...driverChoices,
+      ...DEFAULT_CHOICES,
+    ];
     const seen = new Set<string>();
     return merged.filter((choice) => {
       const key = choiceKey(choice);
@@ -450,14 +501,28 @@ export function App() {
       seen.add(key);
       return true;
     });
-  }, [drivers, productProfiles]);
+  }, [drivers, productProfiles, productOverviews]);
 
   useEffect(() => {
     if (!choices.length) {
       return;
     }
     const selectedKey = choiceKey(selected);
-    if (choices.some((choice) => choiceKey(choice) === selectedKey)) {
+    const selectedChoice = choices.find(
+      (choice) => choiceKey(choice) === selectedKey,
+    );
+    const productBackedChoice = choices.find(
+      (choice) => choice.driverId === selected.driverId && choice.repository,
+    );
+    if (
+      productBackedChoice &&
+      choiceKey(productBackedChoice) !== selectedKey &&
+      !selectedChoice?.repository
+    ) {
+      setSelected(productBackedChoice);
+      return;
+    }
+    if (selectedChoice) {
       return;
     }
     setSelected(choices[0]);
@@ -473,6 +538,10 @@ export function App() {
     prodDriverView?.descriptor ??
     testingDriverView?.descriptor ??
     currentDriver;
+  const selectedProductOverview =
+    productOverviews.find(
+      (overview) => overview.product === selected.driverId,
+    ) ?? null;
 
   const actions = useMemo(() => {
     return (
@@ -499,6 +568,7 @@ export function App() {
       setAuthStatus("signed_out");
       setDrivers([]);
       setProductProfiles([]);
+      setProductOverviews([]);
       setProdView(null);
       setTestingView(null);
       setPreviewView(null);
@@ -534,6 +604,11 @@ export function App() {
                 onClearToken={signOut}
               />
             ) : null}
+            <ProductOverviewShell
+              product={selectedProductOverview}
+              selected={selected}
+              loading={loading}
+            />
             <section className="lane-grid" aria-busy={loading}>
               <LanePanel
                 title="Prod"
@@ -724,6 +799,116 @@ function Header({
         </button>
       </div>
     </header>
+  );
+}
+
+function ProductOverviewShell({
+  product,
+  selected,
+  loading,
+}: {
+  product: ProductSiteOverview | null;
+  selected: DriverChoice;
+  loading: boolean;
+}) {
+  const environments = product?.environments ?? [];
+  const enabledActions = product?.available_actions.filter(
+    (action) => action.enabled,
+  );
+  const blockedActions = product?.available_actions.filter(
+    (action) => !action.enabled,
+  );
+  const preview = product?.preview;
+
+  return (
+    <section className="panel product-overview-shell">
+      <PanelHead
+        eyebrow="product workspace"
+        title={product?.display_name || selected.label}
+        right={
+          <div className="panel-badges">
+            <TrustBadge provenance={product?.provenance ?? null} />
+            <StatusPill status={product?.trust_state ?? "missing"} />
+          </div>
+        }
+      />
+      {loading ? (
+        <SkeletonRows />
+      ) : (
+        <div className="product-overview-grid">
+          <div className="product-overview-identity">
+            <div>
+              <span className="overview-label">Product key</span>
+              <code>{product?.product || selected.driverId}</code>
+            </div>
+            <div>
+              <span className="overview-label">Repository</span>
+              <code>
+                {product?.repository || selected.repository || "unknown"}
+              </code>
+            </div>
+            <div>
+              <span className="overview-label">Driver</span>
+              <code>
+                {product?.driver_id || selected.driverLabel}
+                {product?.base_driver_id ? ` / ${product.base_driver_id}` : ""}
+              </code>
+            </div>
+          </div>
+          <div className="product-environment-strip">
+            {environments.length ? (
+              environments.map((environment) => (
+                <div
+                  className="product-environment-pill"
+                  key={`${environment.environment}:${environment.context}`}
+                  data-environment={environment.environment}
+                >
+                  <span>{environment.environment}</span>
+                  <strong>{freshnessLabel(environment.trust_state)}</strong>
+                  <code>{environment.context}</code>
+                </div>
+              ))
+            ) : (
+              <StateBlock
+                icon={<Database size={18} />}
+                title="No product environment read model"
+              />
+            )}
+          </div>
+          <div className="product-overview-sidecar">
+            <KeyValue
+              label="Previews"
+              value={
+                preview?.enabled
+                  ? `${preview.active_count} active / ${preview.context || "no context"}`
+                  : "not enabled"
+              }
+              status={preview?.enabled ? preview.trust_state : "unsupported"}
+            />
+            <KeyValue
+              label="Enabled actions"
+              value={`${enabledActions?.length ?? 0} enabled`}
+              status={enabledActions?.length ? "pass" : "unknown"}
+            />
+            <KeyValue
+              label="Blocked actions"
+              value={`${blockedActions?.length ?? 0} blocked`}
+              status={blockedActions?.length ? "blocked" : "pass"}
+            />
+          </div>
+        </div>
+      )}
+      {product?.warnings.length ? (
+        <div className="overview-warning-list">
+          {product.warnings.map((warning) => (
+            <span key={warning}>
+              <AlertTriangle size={14} aria-hidden="true" />
+              {warning}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </section>
   );
 }
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -10,6 +10,7 @@ import type {
   LogoutPayload,
   ProductConfigApplyPayload,
   ProductConfigApplyRequest,
+  ProductListPayload,
   ProductProfileListPayload,
 } from "./types";
 
@@ -87,6 +88,10 @@ export function listProductProfiles(
 ): Promise<ProductProfileListPayload> {
   const query = driverId ? `?driver_id=${encodeURIComponent(driverId)}` : "";
   return requestJson<ProductProfileListPayload>(`/v1/product-profiles${query}`);
+}
+
+export function listProducts(): Promise<ProductListPayload> {
+  return requestJson<ProductListPayload>("/v1/products");
 }
 
 export function applyProductConfig(

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -292,6 +292,98 @@ p {
   background: var(--hair);
 }
 
+.product-overview-shell {
+  border-top: 3px solid var(--lane-preview);
+}
+
+.product-overview-grid {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.86fr) minmax(0, 1.35fr) minmax(
+      220px,
+      0.72fr
+    );
+  gap: 14px;
+  padding: 16px;
+}
+
+.product-overview-identity,
+.product-overview-sidecar {
+  display: grid;
+  gap: 10px;
+  align-content: start;
+}
+
+.product-overview-identity > div {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.overview-label {
+  color: var(--fg-faint);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.product-overview-identity code,
+.product-environment-pill code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.product-environment-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  align-content: start;
+}
+
+.product-environment-pill {
+  display: grid;
+  min-height: 86px;
+  align-content: space-between;
+  gap: 7px;
+  border: 1px solid var(--hair);
+  border-radius: 6px;
+  background: var(--bg-2);
+  padding: 10px;
+}
+
+.product-environment-pill[data-environment="prod"] {
+  border-color: color-mix(in oklab, var(--lane-prod) 45%, var(--hair));
+}
+
+.product-environment-pill[data-environment="testing"] {
+  border-color: color-mix(in oklab, var(--lane-testing) 45%, var(--hair));
+}
+
+.product-environment-pill span {
+  color: var(--fg-strong);
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.product-environment-pill strong {
+  color: var(--fg-muted);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.overview-warning-list {
+  display: grid;
+  gap: 6px;
+  border-top: 1px solid var(--hair-soft);
+  padding: 0 16px 14px;
+}
+
+.overview-warning-list span {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--status-warn);
+}
+
 .work-grid {
   display: grid;
   grid-template-columns: minmax(0, 1.45fr) minmax(320px, 1fr);
@@ -1329,10 +1421,15 @@ p {
 
 @media (max-width: 1120px) {
   .lane-grid,
+  .product-overview-grid,
   .work-grid,
   .work-grid-evidence,
   .config-edit-grid {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .product-environment-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .config-target-grid {
@@ -1378,6 +1475,10 @@ p {
 
   .operator-main {
     padding: 12px;
+  }
+
+  .product-environment-strip {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .kv-row,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -404,6 +404,62 @@ export interface ProductProfileListPayload {
   profiles: ProductProfileRecord[];
 }
 
+export interface ProductActionAvailability {
+  action_id: string;
+  label: string;
+  description: string;
+  safety: Safety | string;
+  scope: string;
+  method: string;
+  route_path: string;
+  authz_action: string;
+  enabled: boolean;
+  disabled_reasons: string[];
+  trust_state: FreshnessStatus;
+}
+
+export interface ProductEnvironmentSummary {
+  environment: string;
+  context: string;
+  base_url: string;
+  health_url: string;
+  trust_state: FreshnessStatus;
+  provenance: DataProvenance;
+  warnings: string[];
+  available_actions: ProductActionAvailability[];
+}
+
+export interface ProductPreviewOverview {
+  enabled: boolean;
+  context: string;
+  slug_template: string;
+  active_count: number;
+  latest_preview_id: string;
+  trust_state: FreshnessStatus;
+  provenance: DataProvenance;
+}
+
+export interface ProductSiteOverview {
+  schema_version: number;
+  product: string;
+  display_name: string;
+  repository: string;
+  driver_id: string;
+  base_driver_id: string;
+  environments: ProductEnvironmentSummary[];
+  preview: ProductPreviewOverview;
+  warnings: string[];
+  trust_state: FreshnessStatus;
+  provenance: DataProvenance;
+  available_actions: ProductActionAvailability[];
+}
+
+export interface ProductListPayload {
+  status: "ok";
+  trace_id: string;
+  products: ProductSiteOverview[];
+}
+
 export interface GenericWebProdPromotionRequest {
   schema_version: 1;
   product: string;


### PR DESCRIPTION
## Summary

- add frontend types and API access for `/v1/products`
- make product overview read models the first signed-in surface above the legacy lane panels
- prefer product-backed picker choices so the header shows canonical product repository/context data instead of fallback context choices
- add responsive styling for the product/environment strip

## Validation

- `prettier --check frontend/src/App.tsx frontend/src/api.ts frontend/src/types.ts frontend/src/styles.css`
- `pnpm --dir frontend validate`
- `uv run python -m unittest`
- browser QA with a local mock API at desktop 1024x768 and mobile 390x844; mobile reported `canScrollX: false`

Refs #153.
