### PR TITLE
Persist generic-web preview provider results

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -127,6 +127,7 @@ from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewInventoryRequest,
     GenericWebPreviewReadinessRequest,
     GenericWebPreviewRefreshRequest,
+    GenericWebPreviewRefreshResult,
     GenericWebPreviewStore,
     discover_generic_web_preview_desired_state,
     evaluate_generic_web_preview_readiness,
@@ -134,6 +135,7 @@ from control_plane.workflows.generic_web_preview import (
     execute_generic_web_preview_inventory,
     execute_generic_web_preview_refresh,
     resolve_generic_web_preview_profile,
+    preview_pr_number_from_slug,
 )
 from control_plane.workflows.preview_desired_state import discover_github_preview_desired_state
 from control_plane.workflows.preview_lifecycle import build_preview_lifecycle_plan
@@ -2441,6 +2443,129 @@ def _verireel_preview_manifest_fingerprint(request: VeriReelPreviewRefreshReques
     )
 
 
+def _image_reference_tail(value: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        return ""
+    for separator in ("@", ":"):
+        if separator in normalized:
+            normalized = normalized.rsplit(separator, maxsplit=1)[1]
+    return normalized.strip()
+
+
+def _generic_web_preview_manifest_fingerprint(
+    request: GenericWebPreviewRefreshRequest,
+) -> str:
+    artifact_token = _repo_token(_image_reference_tail(request.image_reference) or "image")
+    return f"{_repo_token(request.preview_slug)}-{artifact_token}"
+
+
+def _generic_web_preview_anchor_pr_number(
+    *,
+    request: GenericWebPreviewRefreshRequest,
+    profile: LaunchplaneProductProfileRecord,
+) -> int:
+    if request.anchor_pr_number is not None:
+        return request.anchor_pr_number
+    pr_number = preview_pr_number_from_slug(
+        preview_slug=request.preview_slug,
+        slug_template=profile.preview.slug_template,
+    )
+    if pr_number is None:
+        raise click.ClickException(
+            "Generic web preview refresh requires anchor_pr_number when preview_slug does not match the profile slug_template."
+        )
+    return pr_number
+
+
+def _generic_web_preview_anchor_pr_url(
+    *,
+    request: GenericWebPreviewRefreshRequest,
+    profile: LaunchplaneProductProfileRecord,
+    anchor_pr_number: int,
+) -> str:
+    if request.anchor_pr_url.strip():
+        return request.anchor_pr_url.strip()
+    return f"https://github.com/{profile.repository.strip()}/pull/{anchor_pr_number}"
+
+
+def _generic_web_preview_anchor_repo(profile: LaunchplaneProductProfileRecord) -> str:
+    _owner, separator, repo = profile.repository.strip().partition("/")
+    if not separator or not repo.strip():
+        raise click.ClickException(
+            "Generic web preview profile repository must use owner/repo format."
+        )
+    return repo.strip()
+
+
+def _generic_web_preview_anchor_head_sha(request: GenericWebPreviewRefreshRequest) -> str:
+    if request.anchor_head_sha.strip():
+        return request.anchor_head_sha.strip()
+    return _image_reference_tail(request.image_reference) or request.image_reference.strip()
+
+
+def _apply_generic_web_preview_refresh_records(
+    *,
+    control_plane_root_path: Path,
+    record_store: object,
+    request: GenericWebPreviewRefreshRequest,
+    driver_result: GenericWebPreviewRefreshResult,
+    profile: LaunchplaneProductProfileRecord,
+) -> dict[str, object]:
+    anchor_pr_number = _generic_web_preview_anchor_pr_number(
+        request=request,
+        profile=profile,
+    )
+    requested_at = (
+        driver_result.refresh_started_at.strip() or driver_result.refresh_finished_at.strip()
+    )
+    finished_at = driver_result.refresh_finished_at.strip() or requested_at
+    refresh_passed = driver_result.refresh_status == "pass"
+    failure_summary = driver_result.error_message.strip() or "Preview provisioning failed."
+    preview_request = PreviewMutationRequest(
+        context=profile.preview.context,
+        anchor_repo=_generic_web_preview_anchor_repo(profile),
+        anchor_pr_number=anchor_pr_number,
+        anchor_pr_url=_generic_web_preview_anchor_pr_url(
+            request=request,
+            profile=profile,
+            anchor_pr_number=anchor_pr_number,
+        ),
+        canonical_url=driver_result.preview_url.strip() or request.preview_url.strip(),
+        state="pending" if refresh_passed else "failed",
+        created_at=requested_at,
+        updated_at=finished_at,
+        eligible_at=requested_at,
+    )
+    generation_request = PreviewGenerationMutationRequest(
+        context=profile.preview.context,
+        anchor_repo=preview_request.anchor_repo,
+        anchor_pr_number=anchor_pr_number,
+        anchor_pr_url=preview_request.anchor_pr_url,
+        anchor_head_sha=_generic_web_preview_anchor_head_sha(request),
+        state="verifying" if refresh_passed else "failed",
+        requested_reason="external_preview_refresh",
+        requested_at=requested_at,
+        started_at=requested_at,
+        finished_at="" if refresh_passed else finished_at,
+        failed_at="" if refresh_passed else finished_at,
+        resolved_manifest_fingerprint=_generic_web_preview_manifest_fingerprint(request),
+        artifact_id=request.image_reference,
+        deploy_status="pass" if refresh_passed else "fail",
+        verify_status="pending" if refresh_passed else "skipped",
+        overall_health_status="pending" if refresh_passed else "fail",
+        failure_stage="" if refresh_passed else "provision",
+        failure_summary="" if refresh_passed else failure_summary,
+    )
+    typed_record_store = cast(FilesystemRecordStore, record_store)
+    return apply_launchplane_generation_evidence(
+        control_plane_root_path=control_plane_root_path,
+        record_store=typed_record_store,
+        preview_request=preview_request,
+        generation_request=generation_request,
+    )
+
+
 def _apply_verireel_preview_refresh_records(
     *,
     control_plane_root_path: Path,
@@ -4230,13 +4355,24 @@ def create_launchplane_service_app(
                 )
                 if idempotent_response is not None:
                     return idempotent_response
+                _generic_web_preview_anchor_pr_number(
+                    request=generic_web_refresh_request.refresh,
+                    profile=profile,
+                )
                 driver_result = execute_generic_web_preview_refresh(
                     control_plane_root=resolved_root,
                     record_store=record_store,
                     request=generic_web_refresh_request.refresh,
                     profile=profile,
                 )
-                result = {}
+                driver_result = GenericWebPreviewRefreshResult.model_validate(driver_result)
+                result = _apply_generic_web_preview_refresh_records(
+                    control_plane_root_path=resolved_root,
+                    record_store=record_store,
+                    request=generic_web_refresh_request.refresh,
+                    driver_result=driver_result,
+                    profile=profile,
+                )
             elif path == _GENERIC_WEB_PREVIEW_READINESS_ROUTE.route_path:
                 generic_web_readiness_request, profile, authorization_response = (
                     _authorize_generic_web_preview_route(

--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -122,6 +122,9 @@ class GenericWebPreviewRefreshRequest(BaseModel):
     preview_slug: str
     preview_url: str
     image_reference: str
+    anchor_pr_number: int | None = Field(default=None, ge=1)
+    anchor_pr_url: str = ""
+    anchor_head_sha: str = ""
     source: str = "generic-web-preview-refresh"
     timeout_seconds: int = Field(default=300, ge=1)
     no_cache: bool = False
@@ -136,11 +139,19 @@ class GenericWebPreviewRefreshRequest(BaseModel):
             raise ValueError("Generic web preview refresh requires preview_url.")
         parsed = urlparse(self.preview_url.strip())
         if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-            raise ValueError("Generic web preview refresh preview_url must be an absolute http(s) URL.")
+            raise ValueError(
+                "Generic web preview refresh preview_url must be an absolute http(s) URL."
+            )
         if not self.image_reference.strip():
             raise ValueError("Generic web preview refresh requires image_reference.")
         if not self.source.strip():
             raise ValueError("Generic web preview refresh requires source.")
+        if self.anchor_pr_url.strip():
+            parsed_pr_url = urlparse(self.anchor_pr_url.strip())
+            if parsed_pr_url.scheme not in {"http", "https"} or not parsed_pr_url.netloc:
+                raise ValueError(
+                    "Generic web preview refresh anchor_pr_url must be an absolute http(s) URL."
+                )
         return self
 
 
@@ -263,7 +274,9 @@ def preview_pr_number_from_slug(*, preview_slug: str, slug_template: str) -> int
 
 def _iter_dokploy_applications(raw_projects: object) -> Iterator[JsonObject]:
     if not isinstance(raw_projects, list):
-        raise click.ClickException("Dokploy project inventory returned an invalid response payload.")
+        raise click.ClickException(
+            "Dokploy project inventory returned an invalid response payload."
+        )
     for raw_project in raw_projects:
         project = control_plane_dokploy.as_json_object(raw_project)
         if project is None:
@@ -326,7 +339,9 @@ def _ensure_application(
     environment_id = str(template_application.get("environmentId") or "").strip()
     server_id = str(template_application.get("serverId") or "").strip()
     if not environment_id:
-        raise click.ClickException("Generic web preview template application is missing environmentId.")
+        raise click.ClickException(
+            "Generic web preview template application is missing environmentId."
+        )
     if not server_id:
         raise click.ClickException("Generic web preview template application is missing serverId.")
     created = control_plane_dokploy.dokploy_request(
@@ -518,9 +533,13 @@ def resolve_generic_web_preview_profile(
             f"Product {profile.product!r} is configured for driver {profile.driver_id!r}, not generic-web."
         )
     if not profile.preview.enabled:
-        raise click.ClickException(f"Product {profile.product!r} does not have generic-web previews enabled.")
+        raise click.ClickException(
+            f"Product {profile.product!r} does not have generic-web previews enabled."
+        )
     if not profile.preview.context.strip():
-        raise click.ClickException(f"Product {profile.product!r} does not define a preview context.")
+        raise click.ClickException(
+            f"Product {profile.product!r} does not define a preview context."
+        )
     return profile
 
 
@@ -559,7 +578,11 @@ def _read_template_payload(
         instance_name=template_lane.instance,
     )
     if target_definition is None:
-        return None, None, f"No Dokploy target definition found for {template_lane.context}/{template_lane.instance}."
+        return (
+            None,
+            None,
+            f"No Dokploy target definition found for {template_lane.context}/{template_lane.instance}.",
+        )
     if target_definition.target_type != "application":
         return (
             target_definition,
@@ -582,7 +605,9 @@ def _read_template_payload(
     return target_definition, payload, ""
 
 
-def _transport_summary(*, profile: LaunchplaneProductProfileRecord) -> GenericWebPreviewTransportSummary:
+def _transport_summary(
+    *, profile: LaunchplaneProductProfileRecord
+) -> GenericWebPreviewTransportSummary:
     return GenericWebPreviewTransportSummary(
         data_transport_mode=profile.preview.data_transport_mode,
         copied_env_keys=profile.preview.copied_env_keys,
@@ -729,9 +754,15 @@ def evaluate_generic_web_preview_readiness(
             context=resolved_profile.preview.context,
             template_context=template_lane.context,
             template_instance=template_lane.instance,
-            template_target_type=(target_definition.target_type if target_definition is not None else ""),
-            template_target_id=(target_definition.target_id if target_definition is not None else ""),
-            template_target_name=(target_definition.target_name if target_definition is not None else ""),
+            template_target_type=(
+                target_definition.target_type if target_definition is not None else ""
+            ),
+            template_target_id=(
+                target_definition.target_id if target_definition is not None else ""
+            ),
+            template_target_name=(
+                target_definition.target_name if target_definition is not None else ""
+            ),
             source=request.source,
             missing_template_env_keys=(),
             missing_provider_fields=(),
@@ -762,7 +793,8 @@ def evaluate_generic_web_preview_readiness(
             GenericWebPreviewReadinessCheck(
                 check_id="template_env",
                 status="blocked",
-                message="Template lane is missing required env keys: " + ", ".join(missing_env_keys),
+                message="Template lane is missing required env keys: "
+                + ", ".join(missing_env_keys),
             )
         )
     else:
@@ -800,7 +832,9 @@ def evaluate_generic_web_preview_readiness(
             ),
         )
     )
-    status: Literal["pass", "blocked"] = "blocked" if missing_env_keys or missing_provider_fields else "pass"
+    status: Literal["pass", "blocked"] = (
+        "blocked" if missing_env_keys or missing_provider_fields else "pass"
+    )
     return GenericWebPreviewReadinessResult(
         readiness_status=status,
         checked_at=checked_at,
@@ -868,13 +902,17 @@ def execute_generic_web_preview_refresh(
     stale_domain_ids: tuple[str, ...] = ()
     application_id = ""
     try:
-        host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
+        host, token = control_plane_dokploy.read_dokploy_config(
+            control_plane_root=control_plane_root
+        )
         target_definition, template_application, target_error = _read_template_payload(
             control_plane_root=control_plane_root,
             template_lane=template_lane,
         )
         if target_error or template_application is None or target_definition is None:
-            raise click.ClickException(target_error or "Generic web preview template payload is unavailable.")
+            raise click.ClickException(
+                target_error or "Generic web preview template payload is unavailable."
+            )
         env_text = _render_preview_env_text(
             profile=resolved_profile,
             template_application=template_application,
@@ -1037,7 +1075,9 @@ def execute_generic_web_preview_inventory(
         )
         if not preview_slug:
             continue
-        application_id = str(application.get("applicationId") or application.get("id") or "").strip()
+        application_id = str(
+            application.get("applicationId") or application.get("id") or ""
+        ).strip()
         if not application_id:
             continue
         preview_items.append(

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -365,6 +365,16 @@ product and optional pull-request label/page limit; Launchplane resolves the
 repository, preview context, anchor repo, and preview slug template from the
 DB-backed product profile before recording desired preview state.
 
+Generic web preview refresh uses
+`POST /v1/drivers/generic-web/preview-refresh`. The request names the product,
+preview slug, preview URL, and immutable image reference; Launchplane resolves
+the repository and preview context from the DB-backed product profile, derives
+the anchor pull request from the preview slug when possible, and records preview
+and generation evidence for both successful and failed provider results. Product
+workflows may send `anchor_pr_number`, `anchor_pr_url`, and `anchor_head_sha`
+when the preview slug cannot be parsed from the configured slug template or when
+the workflow has more precise anchor metadata than the image reference.
+
 Generic web preview inventory and destroy use
 `POST /v1/drivers/generic-web/preview-inventory` and
 `POST /v1/drivers/generic-web/preview-destroy`. They scan and delete stateless

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3648,7 +3648,17 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
             with patch(
                 "control_plane.service.execute_generic_web_preview_refresh",
-                return_value={"refresh_status": "pass", "application_id": "app-preview"},
+                return_value={
+                    "refresh_status": "pass",
+                    "refresh_started_at": "2026-05-03T15:00:00Z",
+                    "refresh_finished_at": "2026-05-03T15:05:00Z",
+                    "product": "sellyouroutboard",
+                    "context": "sellyouroutboard-testing",
+                    "preview_slug": "pr-42",
+                    "application_name": "sellyouroutboard-pr-42",
+                    "application_id": "app-preview",
+                    "preview_url": "https://pr-42.example.test",
+                },
             ) as refresh:
                 status_code, payload = _invoke_app(
                     app,
@@ -3668,12 +3678,180 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     headers={"Idempotency-Key": "generic-web-preview-refresh:syo:pr-42"},
                 )
 
-        self.assertEqual(status_code, 202)
-        self.assertEqual(payload["result"]["refresh_status"], "pass")
-        self.assertEqual(payload["result"]["application_id"], "app-preview")
-        refresh.assert_called_once()
-        _, kwargs = refresh.call_args
-        self.assertEqual(kwargs["profile"].product, "sellyouroutboard")
+                self.assertEqual(status_code, 202)
+                self.assertEqual(payload["records"]["transition"], "verifying")
+                self.assertEqual(payload["result"]["refresh_status"], "pass")
+                self.assertEqual(payload["result"]["application_id"], "app-preview")
+                store = FilesystemRecordStore(state_dir=state_dir)
+                preview = store.read_preview_record(
+                    "preview-sellyouroutboard-testing-sellyouroutboard-pr-42"
+                )
+                generation = store.read_preview_generation_record(
+                    "preview-sellyouroutboard-testing-sellyouroutboard-pr-42-generation-0001"
+                )
+                self.assertEqual(preview.state, "pending")
+                self.assertEqual(generation.state, "verifying")
+                self.assertEqual(generation.deploy_status, "pass")
+                self.assertEqual(generation.verify_status, "pending")
+                refresh.assert_called_once()
+                _, kwargs = refresh.call_args
+                self.assertEqual(kwargs["profile"].product, "sellyouroutboard")
+
+    def test_generic_web_preview_refresh_route_persists_provider_failure_result(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["preview_refresh.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
+                            "@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_generic_web_preview_refresh",
+                return_value={
+                    "refresh_status": "fail",
+                    "refresh_started_at": "2026-05-03T15:00:00Z",
+                    "refresh_finished_at": "2026-05-03T15:05:00Z",
+                    "product": "sellyouroutboard",
+                    "context": "sellyouroutboard-testing",
+                    "preview_slug": "pr-42",
+                    "application_name": "sellyouroutboard-pr-42",
+                    "application_id": "app-preview",
+                    "preview_url": "https://pr-42.example.test",
+                    "error_message": "Dokploy API POST /api/application.update failed (500): provider exploded",
+                },
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/preview-refresh",
+                    payload={
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "refresh": {
+                            "schema_version": 1,
+                            "product": "sellyouroutboard",
+                            "preview_slug": "pr-42",
+                            "preview_url": "https://pr-42.example.test",
+                            "image_reference": "ghcr.io/cbusillo/sellyouroutboard:sha",
+                        },
+                    },
+                    headers={"Idempotency-Key": "generic-web-preview-refresh:syo:pr-42"},
+                )
+
+                self.assertEqual(status_code, 202)
+                self.assertEqual(payload["records"]["transition"], "failed")
+                self.assertEqual(payload["result"]["refresh_status"], "fail")
+                store = FilesystemRecordStore(state_dir=state_dir)
+                preview = store.read_preview_record(
+                    "preview-sellyouroutboard-testing-sellyouroutboard-pr-42"
+                )
+                generation = store.read_preview_generation_record(
+                    "preview-sellyouroutboard-testing-sellyouroutboard-pr-42-generation-0001"
+                )
+                self.assertEqual(preview.state, "failed")
+                self.assertEqual(generation.state, "failed")
+                self.assertEqual(generation.deploy_status, "fail")
+                self.assertEqual(generation.verify_status, "skipped")
+                self.assertEqual(generation.failure_stage, "provision")
+                self.assertEqual(
+                    generation.failure_summary,
+                    "Dokploy API POST /api/application.update failed (500): provider exploded",
+                )
+
+    def test_generic_web_preview_refresh_route_rejects_unparseable_slug_before_provider_mutation(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["preview_refresh.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
+                            "@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch("control_plane.service.execute_generic_web_preview_refresh") as refresh:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/preview-refresh",
+                    payload={
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "refresh": {
+                            "schema_version": 1,
+                            "product": "sellyouroutboard",
+                            "preview_slug": "custom-preview",
+                            "preview_url": "https://custom-preview.example.test",
+                            "image_reference": "ghcr.io/cbusillo/sellyouroutboard:sha",
+                        },
+                    },
+                    headers={"Idempotency-Key": "generic-web-preview-refresh:syo:custom"},
+                )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        refresh.assert_not_called()
 
     def test_generic_web_preview_refresh_retry_runs_again_after_failed_result(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -3730,10 +3908,27 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 side_effect=[
                     {
                         "refresh_status": "fail",
+                        "refresh_started_at": "2026-05-03T15:00:00Z",
+                        "refresh_finished_at": "2026-05-03T15:05:00Z",
+                        "product": "sellyouroutboard",
+                        "context": "sellyouroutboard-testing",
+                        "preview_slug": "pr-42",
+                        "application_name": "sellyouroutboard-pr-42",
                         "application_id": "app-preview",
+                        "preview_url": "https://pr-42.example.test",
                         "error_message": "provider unavailable",
                     },
-                    {"refresh_status": "pass", "application_id": "app-preview"},
+                    {
+                        "refresh_status": "pass",
+                        "refresh_started_at": "2026-05-03T15:06:00Z",
+                        "refresh_finished_at": "2026-05-03T15:10:00Z",
+                        "product": "sellyouroutboard",
+                        "context": "sellyouroutboard-testing",
+                        "preview_slug": "pr-42",
+                        "application_name": "sellyouroutboard-pr-42",
+                        "application_id": "app-preview",
+                        "preview_url": "https://pr-42.example.test",
+                    },
                 ],
             ) as refresh:
                 first_status_code, first_payload = _invoke_app(
@@ -3816,7 +4011,17 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
             with patch(
                 "control_plane.service.execute_generic_web_preview_refresh",
-                return_value={"refresh_status": "pass", "application_id": "app-preview"},
+                return_value={
+                    "refresh_status": "pass",
+                    "refresh_started_at": "2026-05-03T15:00:00Z",
+                    "refresh_finished_at": "2026-05-03T15:05:00Z",
+                    "product": "sellyouroutboard",
+                    "context": "sellyouroutboard-testing",
+                    "preview_slug": "pr-42",
+                    "application_name": "sellyouroutboard-pr-42",
+                    "application_id": "app-preview",
+                    "preview_url": "https://pr-42.example.test",
+                },
             ) as refresh:
                 first_status_code, _ = _invoke_app(
                     app,


### PR DESCRIPTION
## Summary
- persist generic-web preview refresh provider results into Launchplane preview and generation records
- surface failed provider refreshes as failed preview generations instead of leaving only the synchronous response as evidence
- accept optional anchor PR metadata for preview refresh requests and reject unparseable slugs before provider mutation
- document the generic-web preview refresh evidence contract

## Validation
- uv run python -m unittest
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check control_plane/service.py control_plane/workflows/generic_web_preview.py tests/test_service.py
- uv run --extra dev mypy control_plane tests
- pnpm --dir frontend validate
- git diff --check

Note: repo-wide `uv run --extra dev ruff format --check .` still reports pre-existing unrelated formatting drift in untouched files.

Refs #95
Refs #241