### PR TITLE
Classify generic-web preview ingress failures

### DIFF
--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -679,7 +679,14 @@ def _wait_for_preview_health(*, preview_url: str, health_path: str, timeout_seco
                     return
                 if payload.get("ok") is not False:
                     return
-        except (HTTPError, URLError, TimeoutError, ValueError):
+        except HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            if "dokploy dead host" in body.lower():
+                raise click.ClickException(
+                    f"Preview ingress for {health_url} returned Dokploy Dead Host; "
+                    "public preview DNS or ingress is not routed to the expected Dokploy target."
+                ) from exc
+        except (URLError, TimeoutError, ValueError):
             pass
         sleep_seconds = min(5, deadline)
         time.sleep(sleep_seconds)

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -373,7 +373,10 @@ the anchor pull request from the preview slug when possible, and records preview
 and generation evidence for both successful and failed provider results. Product
 workflows may send `anchor_pr_number`, `anchor_pr_url`, and `anchor_head_sha`
 when the preview slug cannot be parsed from the configured slug template or when
-the workflow has more precise anchor metadata than the image reference.
+the workflow has more precise anchor metadata than the image reference. Preview
+health failures that return Dokploy Dead Host are classified as public preview
+ingress failures so workflow output and persisted generation evidence point at
+DNS/ingress routing instead of a generic provider timeout.
 
 Generic web preview inventory and destroy use
 `POST /v1/drivers/generic-web/preview-inventory` and

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -1,7 +1,10 @@
 import unittest
+from email.message import Message
+from io import BytesIO
 from pathlib import Path
 from typing import cast
 from unittest.mock import patch
+from urllib.error import HTTPError
 
 import click
 
@@ -26,6 +29,7 @@ from control_plane.workflows.generic_web_preview import (
     execute_generic_web_preview_refresh,
     preview_pr_number_from_slug,
     resolve_generic_web_preview_profile,
+    _wait_for_preview_health,
 )
 from control_plane.workflows.preview_desired_state import render_preview_slug
 
@@ -330,6 +334,26 @@ class GenericWebPreviewTests(unittest.TestCase):
         self.assertEqual(result.refresh_status, "blocked")
         dokploy_request.assert_not_called()
 
+    def test_wait_for_preview_health_reports_dokploy_dead_host_as_ingress_failure(self) -> None:
+        dead_host = HTTPError(
+            url="https://preview-42.example.test/api/health",
+            code=404,
+            msg="Not Found",
+            hdrs=Message(),
+            fp=BytesIO(b"Dokploy Dead Host"),
+        )
+
+        with patch(
+            "control_plane.workflows.generic_web_preview.urlopen",
+            side_effect=dead_host,
+        ):
+            with self.assertRaisesRegex(click.ClickException, "Preview ingress"):
+                _wait_for_preview_health(
+                    preview_url="https://preview-42.example.test",
+                    health_path="/api/health",
+                    timeout_seconds=30,
+                )
+
     def test_execute_generic_web_preview_refresh_creates_application_from_template(self) -> None:
         store = _GenericWebPreviewStore(_profile())
         source = DokploySourceOfTruth(
@@ -404,7 +428,9 @@ class GenericWebPreviewTests(unittest.TestCase):
             patch(
                 "control_plane.workflows.generic_web_preview.control_plane_dokploy.wait_for_target_deployment",
             ),
-            patch("control_plane.workflows.generic_web_preview._wait_for_preview_health") as wait_health,
+            patch(
+                "control_plane.workflows.generic_web_preview._wait_for_preview_health"
+            ) as wait_health,
             patch(
                 "control_plane.workflows.generic_web_preview.utc_now_timestamp",
                 side_effect=["2026-04-30T21:00:00Z", "2026-04-30T21:00:05Z"],


### PR DESCRIPTION
## Summary
- classify Dokploy Dead Host responses from preview health checks as public preview ingress failures
- fail refresh quickly with an actionable DNS/ingress message instead of timing out as a generic health failure
- document the generic-web preview refresh ingress failure contract

## Validation
- uv run python -m unittest
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check control_plane/workflows/generic_web_preview.py tests/test_generic_web_preview.py
- uv run --extra dev mypy control_plane tests
- pnpm --dir frontend validate
- git diff --check

Refs #94
Refs #241