### PR TITLE
Grant SYO preview workflow authz

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -307,12 +307,15 @@ jobs:
             local action_name="$5"
             local source_label="$6"
             local idempotency_suffix="$7"
+            local event_name="${8:-workflow_dispatch}"
+            local workflow_ref_suffix="${9:-refs/heads/main}"
             local request_payload response_file status_code
 
             request_payload="$({
               jq -n \
                 --arg repository "$repository" \
-                --arg workflow_ref "${repository}/.github/workflows/${workflow_file}@refs/heads/main" \
+                --arg workflow_ref "${repository}/.github/workflows/${workflow_file}@${workflow_ref_suffix}" \
+                --arg event_name "$event_name" \
                 --arg product_name "$product_name" \
                 --arg context_name "$context_name" \
                 --arg action_name "$action_name" \
@@ -323,7 +326,7 @@ jobs:
                   grant: {
                     repository: $repository,
                     workflow_refs: [$workflow_ref],
-                    event_names: ["workflow_dispatch"],
+                    event_names: [$event_name],
                     products: [$product_name],
                     contexts: [$context_name],
                     actions: [$action_name],
@@ -366,18 +369,24 @@ jobs:
           }
 
           post_syo_grant() {
-            local product_name="$1"
-            local action_name="$2"
-            local source_label="$3"
-            local idempotency_suffix="$4"
+            local workflow_file="$1"
+            local product_name="$2"
+            local context_name="$3"
+            local action_name="$4"
+            local source_label="$5"
+            local idempotency_suffix="$6"
+            local event_name="${7:-workflow_dispatch}"
+            local workflow_ref_suffix="${8:-refs/heads/main}"
             post_grant \
               cbusillo/sellyouroutboard \
-              promote-prod.yml \
+              "$workflow_file" \
               "$product_name" \
-              sellyouroutboard \
+              "$context_name" \
               "$action_name" \
               "$source_label" \
-              "$idempotency_suffix"
+              "$idempotency_suffix" \
+              "$event_name" \
+              "$workflow_ref_suffix"
           }
 
           post_syo_product_grant() {
@@ -385,6 +394,8 @@ jobs:
             local source_label="$2"
             local idempotency_suffix="$3"
             post_syo_grant \
+              promote-prod.yml \
+              sellyouroutboard \
               sellyouroutboard \
               "$action_name" \
               "$source_label" \
@@ -407,7 +418,9 @@ jobs:
             deploy:product-legacy-context-cleanup-grant \
             product-legacy-context-cleanup
           post_syo_grant \
+            promote-prod.yml \
             launchplane \
+            sellyouroutboard \
             inventory.read \
             deploy:syo-prod-promotion-inventory-read-grant \
             syo-prod-promotion-inventory-read
@@ -415,3 +428,28 @@ jobs:
             generic_web_prod_promotion.execute \
             deploy:syo-prod-promotion-execute-grant \
             syo-prod-promotion-execute
+          post_syo_grant \
+            preview-control-plane.yml \
+            sellyouroutboard \
+            sellyouroutboard-testing \
+            preview_refresh.execute \
+            deploy:syo-preview-refresh-grant \
+            syo-preview-refresh \
+            pull_request \
+            '*'
+          post_syo_grant \
+            preview-cleanup.yml \
+            sellyouroutboard \
+            sellyouroutboard-testing \
+            preview_destroy.execute \
+            deploy:syo-preview-destroy-pr-grant \
+            syo-preview-destroy-pr \
+            pull_request \
+            '*'
+          post_syo_grant \
+            preview-cleanup.yml \
+            sellyouroutboard \
+            sellyouroutboard-testing \
+            preview_destroy.execute \
+            deploy:syo-preview-destroy-manual-grant \
+            syo-preview-destroy-manual

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -110,10 +110,11 @@ The service uses GitHub OIDC bearer tokens and DB-backed authz policy records.
 Additional evidence routes should land against the same authn/authz boundary
 rather than creating separate ad hoc ingress patterns.
 
-The deploy workflow maintains the DB-backed grant that lets the manual Product
-Context Cutover Audit workflow read the SellYourOutboard product profile. The
-grant request returns only authz policy record metadata and rule counts; it does
-not echo workflow refs or the full policy body.
+The deploy workflow maintains DB-backed grants for SellYourOutboard operational
+workflows, including product profile cutover reads/writes, production promotion,
+and generic-web preview refresh/destroy requests. The grant request returns only
+authz policy record metadata and rule counts; it does not echo workflow refs or
+the full policy body.
 
 The manual Product Context Cutover workflow plans or applies the same
 current-authority record move through the Launchplane service. Run it first with

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -263,6 +263,45 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
             )
         )
 
+    def test_syo_preview_grant_covers_pull_request_branch_refs(self) -> None:
+        rule = GitHubActionsPolicyRule(
+            repository="cbusillo/sellyouroutboard",
+            workflow_refs=(
+                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@*",
+            ),
+            event_names=("pull_request",),
+            products=("sellyouroutboard",),
+            contexts=("sellyouroutboard-testing",),
+            actions=("preview_refresh.execute",),
+        )
+        identity = _actions_identity(
+            repository="cbusillo/sellyouroutboard",
+            workflow_ref=(
+                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
+                "@refs/heads/replace-mike-photo-batch"
+            ),
+            event_name="pull_request",
+            ref="refs/pull/41/merge",
+            subject="repo:cbusillo/sellyouroutboard:pull_request",
+        )
+
+        self.assertTrue(
+            rule.allows(
+                identity=identity,
+                action="preview_refresh.execute",
+                product="sellyouroutboard",
+                context="sellyouroutboard-testing",
+            )
+        )
+        self.assertFalse(
+            rule.allows(
+                identity=identity,
+                action="preview_destroy.execute",
+                product="sellyouroutboard",
+                context="sellyouroutboard-testing",
+            )
+        )
+
     def test_parse_authz_policy_toml_preserves_human_and_actions_rules(self) -> None:
         policy = parse_authz_policy_toml(
             """


### PR DESCRIPTION
## Summary
- extend deploy-owned DB-backed authz grant maintenance to support event and workflow-ref suffix parameters
- add SellYourOutboard preview refresh and preview destroy grants for generic-web preview workflows
- document that deploy maintains SYO preview workflow authz and add coverage for PR branch workflow refs

## Validation
- actionlint .github/workflows/deploy-launchplane.yml
- uv run python -m unittest tests.test_service_auth.LaunchplaneAuthzPolicyBoundaryTests tests.test_service.LaunchplaneServiceTests.test_authz_policy_grant_endpoint_writes_db_record_and_updates_runtime tests.test_service.LaunchplaneServiceTests.test_authz_policy_grant_endpoint_rejects_without_self_deploy_permission
- uv run python -m unittest

Refs cbusillo/launchplane#164
Related to cbusillo/launchplane#83
Related to cbusillo/sellyouroutboard#42