### PR TITLE
Grant SYO canonical preview context authz

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -402,6 +402,36 @@ jobs:
               "$idempotency_suffix"
           }
 
+          post_syo_preview_grants() {
+            local context_name="$1"
+            local suffix="$2"
+            post_syo_grant \
+              preview-control-plane.yml \
+              sellyouroutboard \
+              "$context_name" \
+              preview_refresh.execute \
+              "deploy:syo-preview-refresh-${suffix}-grant" \
+              "syo-preview-refresh-${suffix}" \
+              pull_request \
+              '*'
+            post_syo_grant \
+              preview-cleanup.yml \
+              sellyouroutboard \
+              "$context_name" \
+              preview_destroy.execute \
+              "deploy:syo-preview-destroy-pr-${suffix}-grant" \
+              "syo-preview-destroy-pr-${suffix}" \
+              pull_request \
+              '*'
+            post_syo_grant \
+              preview-cleanup.yml \
+              sellyouroutboard \
+              "$context_name" \
+              preview_destroy.execute \
+              "deploy:syo-preview-destroy-manual-${suffix}-grant" \
+              "syo-preview-destroy-manual-${suffix}"
+          }
+
           post_launchplane_grant \
             product-context-cutover-audit.yml \
             product_profile.read \
@@ -428,28 +458,9 @@ jobs:
             generic_web_prod_promotion.execute \
             deploy:syo-prod-promotion-execute-grant \
             syo-prod-promotion-execute
-          post_syo_grant \
-            preview-control-plane.yml \
-            sellyouroutboard \
+          post_syo_preview_grants \
             sellyouroutboard-testing \
-            preview_refresh.execute \
-            deploy:syo-preview-refresh-grant \
-            syo-preview-refresh \
-            pull_request \
-            '*'
-          post_syo_grant \
-            preview-cleanup.yml \
+            legacy-context
+          post_syo_preview_grants \
             sellyouroutboard \
-            sellyouroutboard-testing \
-            preview_destroy.execute \
-            deploy:syo-preview-destroy-pr-grant \
-            syo-preview-destroy-pr \
-            pull_request \
-            '*'
-          post_syo_grant \
-            preview-cleanup.yml \
-            sellyouroutboard \
-            sellyouroutboard-testing \
-            preview_destroy.execute \
-            deploy:syo-preview-destroy-manual-grant \
-            syo-preview-destroy-manual
+            canonical-context

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -302,6 +302,37 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
             )
         )
 
+    def test_syo_preview_grant_covers_canonical_context(self) -> None:
+        rule = GitHubActionsPolicyRule(
+            repository="cbusillo/sellyouroutboard",
+            workflow_refs=(
+                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@*",
+            ),
+            event_names=("pull_request",),
+            products=("sellyouroutboard",),
+            contexts=("sellyouroutboard",),
+            actions=("preview_refresh.execute",),
+        )
+        identity = _actions_identity(
+            repository="cbusillo/sellyouroutboard",
+            workflow_ref=(
+                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
+                "@refs/heads/replace-mike-photo-batch"
+            ),
+            event_name="pull_request",
+            ref="refs/pull/41/merge",
+            subject="repo:cbusillo/sellyouroutboard:pull_request",
+        )
+
+        self.assertTrue(
+            rule.allows(
+                identity=identity,
+                action="preview_refresh.execute",
+                product="sellyouroutboard",
+                context="sellyouroutboard",
+            )
+        )
+
     def test_parse_authz_policy_toml_preserves_human_and_actions_rules(self) -> None:
         policy = parse_authz_policy_toml(
             """


### PR DESCRIPTION
## Summary
- grant SYO generic-web preview refresh/destroy actions for both the legacy `sellyouroutboard-testing` preview context and canonical `sellyouroutboard` context
- keep the deploy workflow as the DB-backed authz maintenance owner
- add authz coverage for the canonical context used after product-profile cutover

## Validation
- actionlint .github/workflows/deploy-launchplane.yml
- uv run python -m unittest tests.test_service_auth.LaunchplaneAuthzPolicyBoundaryTests

Follow-up to #249.
Related to cbusillo/sellyouroutboard#41.