### PR TITLE
Add product onboarding service route

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -353,6 +353,79 @@ jobs:
             return 1
           }
 
+          apply_product_onboarding() {
+            local idempotency_suffix="$1"
+            local request_payload response_file status_code
+
+            request_payload="$({
+              jq -n \
+                '{
+                  schema_version: 1,
+                  product: "launchplane",
+                  manifest: {
+                    product: "discord-blue",
+                    display_name: "Discord Blue",
+                    repository: "cbusillo/discord-blue",
+                    driver_id: "generic-web",
+                    image_repository: "ghcr.io/cbusillo/discord-blue",
+                    runtime_port: 8787,
+                    health_path: "/health",
+                    lanes: [
+                      {
+                        instance: "prod",
+                        context: "discord-blue"
+                      }
+                    ],
+                    dokploy_targets: [
+                      {
+                        context: "discord-blue",
+                        instance: "prod",
+                        target_type: "application",
+                        target_name: "discord-blue",
+                        healthcheck_enabled: false,
+                        deploy_timeout_seconds: 600
+                      }
+                    ],
+                    runtime_environments: [
+                      {
+                        scope: "instance",
+                        context: "discord-blue",
+                        instance: "prod",
+                        env: {
+                          DISCORD_BLUE_STATE_DIR: "/var/lib/discord-blue"
+                        }
+                      }
+                    ],
+                    secret_bindings: [
+                      {
+                        binding_key: "DISCORD_TOKEN",
+                        context: "discord-blue",
+                        instance: "prod"
+                      }
+                    ],
+                    source_label: "deploy:discord-blue-onboarding"
+                  }
+                }'
+            })"
+            response_file="$(mktemp)"
+            status_code="$(curl -sS \
+              -o "$response_file" \
+              -w '%{http_code}' \
+              -X POST \
+              -H "Authorization: Bearer ${oidc_token}" \
+              -H 'Content-Type: application/json' \
+              -H "Idempotency-Key: launchplane-product-onboarding:${idempotency_suffix}:${GITHUB_SHA}" \
+              --data "$request_payload" \
+              "${{ steps.service.outputs.service_url }}/v1/product-onboarding/apply")"
+            if [ "$status_code" = "200" ] || [ "$status_code" = "202" ]; then
+              cat "$response_file"
+              return 0
+            fi
+            cat "$response_file" >&2
+            echo "Launchplane product onboarding request failed with HTTP ${status_code}." >&2
+            return 1
+          }
+
           post_launchplane_grant() {
             local workflow_file="$1"
             local action_name="$2"
@@ -431,6 +504,19 @@ jobs:
               "deploy:syo-preview-destroy-manual-${suffix}-grant" \
               "syo-preview-destroy-manual-${suffix}"
           }
+
+          apply_product_onboarding \
+            discord-blue
+          post_grant \
+            cbusillo/discord-blue \
+            main.yml \
+            discord-blue \
+            discord-blue \
+            generic_web_deploy.execute \
+            deploy:discord-blue-stable-deploy-grant \
+            discord-blue-stable-deploy \
+            push \
+            refs/heads/main
 
           post_launchplane_grant \
             product-context-cutover-audit.yml \

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -58,6 +58,7 @@ from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductLaneProfile,
 )
+from control_plane.contracts.product_onboarding_manifest import ProductOnboardingManifest
 from control_plane.contracts.product_environment_read_model import (
     build_product_activity_read_model,
     build_product_environment_detail,
@@ -137,6 +138,7 @@ from control_plane.workflows.generic_web_preview import (
     resolve_generic_web_preview_profile,
     preview_pr_number_from_slug,
 )
+from control_plane.workflows.product_onboarding import apply_product_onboarding_manifest
 from control_plane.workflows.preview_desired_state import discover_github_preview_desired_state
 from control_plane.workflows.preview_lifecycle import build_preview_lifecycle_plan
 from control_plane.workflows.preview_lifecycle_cleanup import (
@@ -1246,6 +1248,21 @@ class AuthzPolicyGitHubActionsGrantEnvelope(BaseModel):
         return self
 
 
+class ProductOnboardingApplyEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    manifest: ProductOnboardingManifest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "ProductOnboardingApplyEnvelope":
+        if self.product.strip() != "launchplane":
+            raise ValueError("Product onboarding writes require product 'launchplane'.")
+        self.product = "launchplane"
+        return self
+
+
 class ProductConfigApplyEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -1663,6 +1680,7 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/evidence/previews/generations",
         "/v1/evidence/previews/destroyed",
         "/v1/authz-policies/github-actions/grants",
+        "/v1/product-onboarding/apply",
         "/v1/product-config/apply",
         "/v1/product-profiles/context-cutover/apply",
         "/v1/product-profiles/legacy-context-cleanup/apply",
@@ -1782,6 +1800,10 @@ def _accepted_payload(
                 "preview_lifecycle_plan_id",
                 "authz_policy_record_id",
                 "product_profile",
+                "dokploy_target_count",
+                "dokploy_target_id_count",
+                "runtime_environment_record_count",
+                "secret_binding_count",
                 "generation_id",
                 "promotion_record_id",
                 "target_id",
@@ -4074,6 +4096,104 @@ def create_launchplane_service_app(
                 driver_result = {
                     "authz_policy": _summarize_authz_policy_record(authz_policy_record),
                     "changed": changed,
+                }
+            elif path == "/v1/product-onboarding/apply":
+                onboarding_request = ProductOnboardingApplyEnvelope.model_validate(payload)
+                if not isinstance(record_store, PostgresRecordStore):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "database_required",
+                                "message": "Product onboarding writes require Launchplane database storage.",
+                            },
+                        },
+                    )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="launchplane_service_deploy.execute",
+                    product=onboarding_request.product,
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot apply Launchplane product onboarding manifests.",
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                onboarding_result = apply_product_onboarding_manifest(
+                    record_store=record_store,
+                    manifest=onboarding_request.manifest,
+                )
+                result = {
+                    "product_profile": onboarding_result.product_profile.product,
+                    "dokploy_target_count": len(onboarding_result.dokploy_targets),
+                    "dokploy_target_id_count": len(onboarding_result.dokploy_target_ids),
+                    "runtime_environment_record_count": len(
+                        onboarding_result.runtime_environments
+                    ),
+                    "secret_binding_count": len(onboarding_result.secret_bindings),
+                }
+                driver_result = {
+                    "product": onboarding_result.product,
+                    "product_profile": onboarding_result.product_profile.model_dump(mode="json"),
+                    "dokploy_targets": [
+                        record.model_dump(mode="json")
+                        for record in onboarding_result.dokploy_targets
+                    ],
+                    "dokploy_target_ids": [
+                        {
+                            "context": record.context,
+                            "instance": record.instance,
+                            "target_id_recorded": bool(record.target_id.strip()),
+                            "updated_at": record.updated_at,
+                            "source_label": record.source_label,
+                        }
+                        for record in onboarding_result.dokploy_target_ids
+                    ],
+                    "runtime_environment_records": [
+                        {
+                            "scope": record.scope,
+                            "context": record.context,
+                            "instance": record.instance,
+                            "env_keys": sorted(record.env),
+                            "updated_at": record.updated_at,
+                            "source_label": record.source_label,
+                        }
+                        for record in onboarding_result.runtime_environments
+                    ],
+                    "secret_bindings": [
+                        {
+                            "binding_id": binding.binding_id,
+                            "integration": binding.integration,
+                            "binding_key": binding.binding_key,
+                            "context": binding.context,
+                            "instance": binding.instance,
+                            "status": binding.status,
+                            "updated_at": binding.updated_at,
+                        }
+                        for binding in onboarding_result.secret_bindings
+                    ],
                 }
             elif path == "/v1/drivers/launchplane/self-deploy":
                 self_deploy_request = LaunchplaneSelfDeployEnvelope.model_validate(payload)

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -44,6 +44,8 @@ VeriReel product paths:
   - `POST /v1/product-profiles`
 - product config write route:
   - `POST /v1/product-config/apply`
+- product onboarding route:
+  - `POST /v1/product-onboarding/apply`
 - product context cutover route:
   - `POST /v1/product-profiles/context-cutover/apply`
 - product legacy context cleanup route:
@@ -344,6 +346,15 @@ is submitted without `LAUNCHPLANE_MASTER_ENCRYPTION_KEY` in the trusted
 Launchplane runtime. Request bodies for this route must not be copied into logs,
 issues, docs, or workflow artifacts because they can contain plaintext secret
 values.
+
+Product onboarding uses `POST /v1/product-onboarding/apply`. The route accepts
+the same operator-approved manifest as `launchplane product-onboarding apply`
+and writes the full Launchplane-owned bundle: product profile, Dokploy target
+records, target-id records, runtime-environment records, and managed secret
+binding placeholders. It is restricted to Launchplane service deploy authority,
+requires DB-backed storage, returns only sanitized summaries, and exists so the
+Launchplane deploy workflow can seed product records without product repos
+storing live lifecycle truth.
 
 Generic web deploys use `POST /v1/drivers/generic-web/deploy`. The request names
 the product, target instance, immutable artifact/image reference, and source ref;

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1233,6 +1233,121 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ["sellyouroutboard"],
         )
 
+    def test_product_onboarding_endpoint_writes_full_launchplane_owned_bundle(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["launchplane_service_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/product-onboarding/apply",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "manifest": {
+                        "product": "discord-blue",
+                        "display_name": "Discord Blue",
+                        "repository": "cbusillo/discord-blue",
+                        "driver_id": "generic-web",
+                        "image_repository": "ghcr.io/cbusillo/discord-blue",
+                        "runtime_port": 8787,
+                        "health_path": "/health",
+                        "lanes": [
+                            {
+                                "instance": "prod",
+                                "context": "discord-blue",
+                            }
+                        ],
+                        "dokploy_targets": [
+                            {
+                                "context": "discord-blue",
+                                "instance": "prod",
+                                "target_id": "app-discord-blue",
+                                "target_type": "application",
+                                "target_name": "discord-blue",
+                                "healthcheck_enabled": False,
+                            }
+                        ],
+                        "runtime_environments": [
+                            {
+                                "scope": "instance",
+                                "context": "discord-blue",
+                                "instance": "prod",
+                                "env": {"DISCORD_BLUE_STATE_DIR": "/var/lib/discord-blue"},
+                            }
+                        ],
+                        "secret_bindings": [
+                            {
+                                "binding_key": "DISCORD_TOKEN",
+                                "context": "discord-blue",
+                                "instance": "prod",
+                            }
+                        ],
+                        "updated_at": "2026-05-04T18:00:00Z",
+                        "source_label": "test:discord-blue-onboarding",
+                    },
+                },
+                headers={"Idempotency-Key": "product-onboarding-discord-blue"},
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                profile = store.read_product_profile_record("discord-blue")
+                target = store.read_dokploy_target_record(
+                    context_name="discord-blue", instance_name="prod"
+                )
+                target_id = store.read_dokploy_target_id_record(
+                    context_name="discord-blue", instance_name="prod"
+                )
+                runtime_records = store.list_runtime_environment_records()
+                secret_bindings = store.list_secret_bindings()
+            finally:
+                store.close()
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["records"]["product_profile"], "discord-blue")
+        self.assertEqual(payload["records"]["dokploy_target_count"], "1")
+        self.assertEqual(payload["records"]["dokploy_target_id_count"], "1")
+        self.assertEqual(profile.driver_id, "generic-web")
+        self.assertEqual(profile.runtime_port, 8787)
+        self.assertEqual(target.target_type, "application")
+        self.assertFalse(target.healthcheck_enabled)
+        self.assertEqual(target_id.target_id, "app-discord-blue")
+        self.assertEqual(runtime_records[0].env, {"DISCORD_BLUE_STATE_DIR": "/var/lib/discord-blue"})
+        self.assertEqual(secret_bindings[0].binding_key, "DISCORD_TOKEN")
+        self.assertNotIn("secret_id", json.dumps(payload, sort_keys=True))
+
     def test_product_overview_endpoint_is_generic_web_profile_driven(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add authenticated DB-backed /v1/product-onboarding/apply service route
- let Launchplane self-deploy seed the Discord Blue product profile/target bundle and deploy grant
- document the onboarding route in the service boundary

## Validation
- uv run python -m unittest tests.test_product_onboarding tests.test_service.LaunchplaneServiceTests
- uv run --extra dev ruff check control_plane/service.py tests/test_service.py
- actionlint .github/workflows/deploy-launchplane.yml
- git diff --check

## Notes
- Discord Blue target-id is intentionally not guessed here; deploy remains fail-closed until a live Dokploy application target id is registered.

Closes part of #164
Related cbusillo/discord-blue#38