### PR TITLE
Ignore incomplete unrelated Dokploy target ids

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -446,7 +446,11 @@ def read_control_plane_environment_values(*, control_plane_root: Path) -> dict[s
     return control_plane_secrets.overlay_dokploy_environment_values(environment_values={})
 
 
-def read_control_plane_dokploy_source_of_truth(*, control_plane_root: Path) -> DokploySourceOfTruth:
+def read_control_plane_dokploy_source_of_truth(
+    *,
+    control_plane_root: Path,
+    allow_incomplete_target_ids: bool = False,
+) -> DokploySourceOfTruth:
     del control_plane_root
     database_url = resolve_database_url()
     if not database_url:
@@ -454,7 +458,8 @@ def read_control_plane_dokploy_source_of_truth(*, control_plane_root: Path) -> D
             "Missing Launchplane tracked Dokploy target authority. Configure DB-backed tracked target records."
         )
     source_of_truth = _load_optional_dokploy_source_of_truth_from_database(
-        database_url=database_url
+        database_url=database_url,
+        allow_incomplete_target_ids=allow_incomplete_target_ids,
     )
     if source_of_truth is None:
         raise click.ClickException("Missing DB-backed Launchplane tracked Dokploy target records.")
@@ -498,6 +503,8 @@ def build_dokploy_target_record_from_definition(
 def build_dokploy_source_of_truth_from_records(
     target_records: tuple[DokployTargetRecord, ...],
     target_id_records: tuple[DokployTargetIdRecord, ...],
+    *,
+    allow_incomplete_target_ids: bool = False,
 ) -> DokploySourceOfTruth:
     target_id_map = {
         (record.context.strip(), record.instance.strip()): record.target_id
@@ -509,6 +516,8 @@ def build_dokploy_source_of_truth_from_records(
         target_route = (record.context.strip(), record.instance.strip())
         target_id = target_id_map.get(target_route, "").strip()
         if not target_id:
+            if allow_incomplete_target_ids:
+                continue
             raise click.ClickException(
                 "Missing DB-backed Dokploy target-id record for "
                 f"{record.context}/{record.instance}."
@@ -554,23 +563,32 @@ def build_dokploy_source_of_truth_from_records(
 
 
 def load_optional_dokploy_source_of_truth_from_store(
-    *, record_store: DokployTargetRecordStore
+    *,
+    record_store: DokployTargetRecordStore,
+    allow_incomplete_target_ids: bool = False,
 ) -> DokploySourceOfTruth | None:
     target_records = record_store.list_dokploy_target_records()
     if not target_records:
         return None
     target_id_records = record_store.list_dokploy_target_id_records()
-    return build_dokploy_source_of_truth_from_records(target_records, target_id_records)
+    return build_dokploy_source_of_truth_from_records(
+        target_records,
+        target_id_records,
+        allow_incomplete_target_ids=allow_incomplete_target_ids,
+    )
 
 
 def _load_optional_dokploy_source_of_truth_from_database(
-    *, database_url: str
+    *, database_url: str, allow_incomplete_target_ids: bool = False
 ) -> DokploySourceOfTruth | None:
     record_store: PostgresRecordStore | None = None
     try:
         record_store = PostgresRecordStore(database_url=database_url)
         record_store.ensure_schema()
-        return load_optional_dokploy_source_of_truth_from_store(record_store=record_store)
+        return load_optional_dokploy_source_of_truth_from_store(
+            record_store=record_store,
+            allow_incomplete_target_ids=allow_incomplete_target_ids,
+        )
     except click.ClickException:
         raise
     except Exception as error:

--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -571,6 +571,7 @@ def _read_template_payload(
 ) -> tuple[control_plane_dokploy.DokployTargetDefinition | None, JsonObject | None, str]:
     source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
         control_plane_root=control_plane_root,
+        allow_incomplete_target_ids=True,
     )
     target_definition = control_plane_dokploy.find_dokploy_target_definition(
         source_of_truth,

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -1324,6 +1324,57 @@ target_type = "compose"
             "Missing DB-backed Dokploy target-id record for opw/prod", str(raised_error.exception)
         )
 
+    def test_read_control_plane_dokploy_source_of_truth_can_ignore_incomplete_unrelated_targets(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_dokploy_target_record(
+                DokployTargetRecord(
+                    context="sellyouroutboard",
+                    instance="testing",
+                    target_type="application",
+                    target_name="syo-testing",
+                    updated_at="2026-05-04T19:00:00Z",
+                    source_label="test",
+                )
+            )
+            store.write_dokploy_target_record(
+                DokployTargetRecord(
+                    context="discord-blue",
+                    instance="prod",
+                    target_type="application",
+                    target_name="discord-blue",
+                    updated_at="2026-05-04T19:00:00Z",
+                    source_label="test",
+                )
+            )
+            store.write_dokploy_target_id_record(
+                DokployTargetIdRecord(
+                    context="sellyouroutboard",
+                    instance="testing",
+                    target_id="app-syo-testing",
+                    updated_at="2026-05-04T19:00:00Z",
+                    source_label="test",
+                )
+            )
+
+            with patch.dict(os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True):
+                source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
+                    control_plane_root=control_plane_root,
+                    allow_incomplete_target_ids=True,
+                )
+
+            store.close()
+
+        self.assertEqual(
+            [(target.context, target.instance, target.target_id) for target in source_of_truth.targets],
+            [("sellyouroutboard", "testing", "app-syo-testing")],
+        )
+
     def test_read_control_plane_dokploy_source_of_truth_reads_database_target_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -1410,6 +1461,24 @@ protected_store_keys = ["yps-your-part-supplier"]
         self.assertIn(
             "Missing DB-backed Dokploy target-id record for opw/prod", str(raised_error.exception)
         )
+
+        source_of_truth = control_plane_dokploy.build_dokploy_source_of_truth_from_records(
+            (
+                control_plane_dokploy.build_dokploy_target_record_from_definition(
+                    control_plane_dokploy.DokployTargetDefinition(
+                        context="opw",
+                        instance="prod",
+                        target_id="compose-placeholder",
+                        target_type="compose",
+                    ),
+                    updated_at="2026-04-22T00:00:00Z",
+                    source_label="test",
+                ),
+            ),
+            (),
+            allow_incomplete_target_ids=True,
+        )
+        self.assertEqual(source_of_truth.targets, ())
 
     def test_read_control_plane_dokploy_source_of_truth_rejects_duplicate_context_instance_targets(
         self,


### PR DESCRIPTION
## Summary
- allow preview-template source-of-truth reads to ignore incomplete unrelated target records
- keep default Dokploy source-of-truth reads fail-closed when any target id is missing
- add regression coverage so a missing discord-blue/prod target id cannot block SYO preview template lookup

## Validation
- uv run --extra dev ruff check control_plane/dokploy.py control_plane/workflows/generic_web_preview.py tests/test_dokploy.py
- uv run python -m unittest tests.test_dokploy.DokployConfigTests tests.test_generic_web_preview tests.test_generic_web_deploy
- actionlint .github/workflows/deploy-launchplane.yml
- git diff --check

Fixes the SYO preview blockage observed in cbusillo/sellyouroutboard run 25338896712.
Related #164