### PR TITLE
Seed Discord Blue Dokploy target id

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -49,6 +49,7 @@ jobs:
       LAUNCHPLANE_PUBLIC_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
       LAUNCHPLANE_COOKIE_SECURE: ${{ vars.LAUNCHPLANE_COOKIE_SECURE }}
       LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS: ${{ vars.LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS }}
+      DISCORD_BLUE_DOKPLOY_TARGET_ID: ${{ vars.DISCORD_BLUE_DOKPLOY_TARGET_ID }}
       LAUNCHPLANE_GITHUB_CLIENT_SECRET: ${{ secrets.LAUNCHPLANE_GITHUB_CLIENT_SECRET }}
       LAUNCHPLANE_SESSION_SECRET: ${{ secrets.LAUNCHPLANE_SESSION_SECRET }}
     steps:
@@ -359,6 +360,7 @@ jobs:
 
             request_payload="$({
               jq -n \
+                --arg target_id "${DISCORD_BLUE_DOKPLOY_TARGET_ID:-}" \
                 '{
                   schema_version: 1,
                   product: "launchplane",
@@ -380,6 +382,7 @@ jobs:
                       {
                         context: "discord-blue",
                         instance: "prod",
+                        target_id: $target_id,
                         target_type: "application",
                         target_name: "discord-blue",
                         healthcheck_enabled: false,


### PR DESCRIPTION
## Summary
- pass DISCORD_BLUE_DOKPLOY_TARGET_ID into the Launchplane deploy workflow
- include that value in the Discord Blue onboarding manifest so Launchplane writes the DB-backed target-id record

## Validation
- uv run --extra dev ruff check control_plane/dokploy.py control_plane/workflows/generic_web_preview.py tests/test_dokploy.py
- uv run python -m unittest tests.test_dokploy.DokployConfigTests tests.test_generic_web_preview tests.test_generic_web_deploy
- actionlint .github/workflows/deploy-launchplane.yml
- git diff --check

## Operational note
The repo variable is set to the newly-created Dokploy application id: 1_VFzKDy-frXk1v_H5O7W.

Related #164
Related cbusillo/discord-blue#38