### PR TITLE
Require target ids for product onboarding

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -358,6 +358,11 @@ jobs:
             local idempotency_suffix="$1"
             local request_payload response_file status_code
 
+            if [ -z "${DISCORD_BLUE_DOKPLOY_TARGET_ID:-}" ]; then
+              echo "DISCORD_BLUE_DOKPLOY_TARGET_ID is required before Discord Blue onboarding." >&2
+              return 1
+            fi
+
             request_payload="$({
               jq -n \
                 --arg target_id "${DISCORD_BLUE_DOKPLOY_TARGET_ID:-}" \

--- a/control_plane/contracts/product_onboarding_manifest.py
+++ b/control_plane/contracts/product_onboarding_manifest.py
@@ -79,6 +79,8 @@ class ProductOnboardingTargetManifest(BaseModel):
             raise ValueError("product onboarding target requires context")
         if not self.instance.strip():
             raise ValueError("product onboarding target requires instance")
+        if not self.target_id.strip():
+            raise ValueError("product onboarding target requires target_id")
         if self.healthcheck_path and not self.healthcheck_path.startswith("/"):
             raise ValueError("product onboarding target healthcheck_path must start with /")
         return self

--- a/docs/new-product-repo.md
+++ b/docs/new-product-repo.md
@@ -62,6 +62,10 @@ The manifest is applied idempotently and writes Launchplane-owned records for:
 - runtime-environment records for non-secret settings
 - disabled managed secret binding placeholders for required secret keys
 
+Each onboarding `dokploy_targets` entry must include the live provider
+`target_id`. Launchplane fails closed instead of seeding a target record that a
+later deploy cannot resolve.
+
 Then import or update DB-backed authz policy records for the product's GitHub
 Actions workflows. Authz policy merging remains a separate operator step so a
 new product onboarding manifest cannot accidentally replace unrelated product

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -209,6 +209,8 @@ Required GitHub configuration for that workflow:
   - optional `LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS`
   - optional `LAUNCHPLANE_DEPLOY_HEALTH_TIMEOUT_SECONDS`
   - optional `LAUNCHPLANE_IMAGE_REPOSITORY`
+  - `DISCORD_BLUE_DOKPLOY_TARGET_ID` while this workflow seeds the Discord Blue
+    onboarding bundle
 
 The workflow should use GitHub OIDC to call Launchplane's own service API and
 update the image digest plus known OAuth env only. DB-backed authz policy records

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -54,6 +54,7 @@ def _manifest_payload() -> dict[str, object]:
             {
                 "context": "example-site-prod",
                 "instance": "prod",
+                "target_id": "app-prod-123",
                 "target_type": "application",
                 "target_name": "example-site-prod",
                 "domains": ["example.invalid"],
@@ -111,7 +112,7 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertEqual(profile.lanes[0].health_url, "https://testing.example.invalid/api/health")
         self.assertEqual(profile.lanes[1].health_url, "https://example.invalid/status")
         self.assertEqual(len(targets), 2)
-        self.assertEqual(len(target_ids), 1)
+        self.assertEqual(len(target_ids), 2)
         self.assertEqual(len(runtime_records), 1)
         self.assertEqual(len(secret_bindings), 1)
         self.assertEqual(secret_bindings[0].binding_key, "SMTP_PASSWORD")
@@ -123,11 +124,26 @@ class ProductOnboardingTests(unittest.TestCase):
             {
                 "context": "other-product-prod",
                 "instance": "prod",
+                "target_id": "app-other-prod",
                 "target_type": "application",
             }
         ]
 
         with self.assertRaisesRegex(ValueError, "target must match a stable lane"):
+            ProductOnboardingManifest.model_validate(payload)
+
+    def test_product_onboarding_manifest_rejects_missing_target_id(self) -> None:
+        payload = _manifest_payload()
+        payload["dokploy_targets"] = [
+            {
+                "context": "example-site-prod",
+                "instance": "prod",
+                "target_id": "",
+                "target_type": "application",
+            }
+        ]
+
+        with self.assertRaisesRegex(ValueError, "target requires target_id"):
             ProductOnboardingManifest.model_validate(payload)
 
     def test_product_onboarding_cli_applies_manifest_without_secret_values(self) -> None:


### PR DESCRIPTION
## Summary
- require product onboarding Dokploy targets to include a live target id
- fail the Launchplane deploy workflow before Discord Blue onboarding when the target variable is missing
- document the fail-closed onboarding requirement

## Validation
- uv run python -m unittest tests.test_product_onboarding tests.test_service.LaunchplaneServiceTests.test_product_onboarding_endpoint_writes_full_launchplane_owned_bundle
- uv run --extra dev ruff check control_plane/contracts/product_onboarding_manifest.py tests/test_product_onboarding.py
- uv run --extra dev ruff format --check control_plane/contracts/product_onboarding_manifest.py tests/test_product_onboarding.py
- docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/deploy-launchplane.yml