### PR TITLE
Key onboarding idempotency by target id

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -362,6 +362,7 @@ jobs:
               echo "DISCORD_BLUE_DOKPLOY_TARGET_ID is required before Discord Blue onboarding." >&2
               return 1
             fi
+            idempotency_suffix="${idempotency_suffix}:${DISCORD_BLUE_DOKPLOY_TARGET_ID}"
 
             request_payload="$({
               jq -n \


### PR DESCRIPTION
## Summary
- include the Discord Blue Dokploy target id in the onboarding idempotency suffix
- allows intentional target moves to reseed Launchplane records without colliding with the previous onboarding payload for the same commit

## Validation
- docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/deploy-launchplane.yml
- git diff --check