### PR TITLE
Preserve preview template lane when target id is missing

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -290,10 +290,6 @@ class DokployTargetDefinition(BaseModel):
             raise ValueError("Dokploy target requires non-empty context")
         if not self.instance.strip():
             raise ValueError("Dokploy target requires non-empty instance")
-        if not self.target_id.strip():
-            raise ValueError(
-                f"Dokploy target {self.context}/{self.instance} requires non-empty target_id"
-            )
         return self
 
 
@@ -450,6 +446,7 @@ def read_control_plane_dokploy_source_of_truth(
     *,
     control_plane_root: Path,
     allow_incomplete_target_ids: bool = False,
+    allowed_incomplete_target_routes: tuple[tuple[str, str], ...] = (),
 ) -> DokploySourceOfTruth:
     del control_plane_root
     database_url = resolve_database_url()
@@ -460,6 +457,7 @@ def read_control_plane_dokploy_source_of_truth(
     source_of_truth = _load_optional_dokploy_source_of_truth_from_database(
         database_url=database_url,
         allow_incomplete_target_ids=allow_incomplete_target_ids,
+        allowed_incomplete_target_routes=allowed_incomplete_target_routes,
     )
     if source_of_truth is None:
         raise click.ClickException("Missing DB-backed Launchplane tracked Dokploy target records.")
@@ -505,24 +503,32 @@ def build_dokploy_source_of_truth_from_records(
     target_id_records: tuple[DokployTargetIdRecord, ...],
     *,
     allow_incomplete_target_ids: bool = False,
+    allowed_incomplete_target_routes: tuple[tuple[str, str], ...] = (),
 ) -> DokploySourceOfTruth:
     target_id_map = {
         (record.context.strip(), record.instance.strip()): record.target_id
         for record in target_id_records
     }
     remaining_target_id_routes = set(target_id_map)
+    allowed_incomplete_routes = {
+        (context_name.strip(), instance_name.strip())
+        for context_name, instance_name in allowed_incomplete_target_routes
+    }
     targets_payload: list[dict[str, object]] = []
     for record in target_records:
         target_route = (record.context.strip(), record.instance.strip())
         target_id = target_id_map.get(target_route, "").strip()
         if not target_id:
             if allow_incomplete_target_ids:
-                continue
-            raise click.ClickException(
-                "Missing DB-backed Dokploy target-id record for "
-                f"{record.context}/{record.instance}."
-            )
-        remaining_target_id_routes.discard(target_route)
+                if target_route not in allowed_incomplete_routes:
+                    continue
+            else:
+                raise click.ClickException(
+                    "Missing DB-backed Dokploy target-id record for "
+                    f"{record.context}/{record.instance}."
+                )
+        else:
+            remaining_target_id_routes.discard(target_route)
         targets_payload.append(
             {
                 "context": record.context,
@@ -566,6 +572,7 @@ def load_optional_dokploy_source_of_truth_from_store(
     *,
     record_store: DokployTargetRecordStore,
     allow_incomplete_target_ids: bool = False,
+    allowed_incomplete_target_routes: tuple[tuple[str, str], ...] = (),
 ) -> DokploySourceOfTruth | None:
     target_records = record_store.list_dokploy_target_records()
     if not target_records:
@@ -575,11 +582,15 @@ def load_optional_dokploy_source_of_truth_from_store(
         target_records,
         target_id_records,
         allow_incomplete_target_ids=allow_incomplete_target_ids,
+        allowed_incomplete_target_routes=allowed_incomplete_target_routes,
     )
 
 
 def _load_optional_dokploy_source_of_truth_from_database(
-    *, database_url: str, allow_incomplete_target_ids: bool = False
+    *,
+    database_url: str,
+    allow_incomplete_target_ids: bool = False,
+    allowed_incomplete_target_routes: tuple[tuple[str, str], ...] = (),
 ) -> DokploySourceOfTruth | None:
     record_store: PostgresRecordStore | None = None
     try:
@@ -588,6 +599,7 @@ def _load_optional_dokploy_source_of_truth_from_database(
         return load_optional_dokploy_source_of_truth_from_store(
             record_store=record_store,
             allow_incomplete_target_ids=allow_incomplete_target_ids,
+            allowed_incomplete_target_routes=allowed_incomplete_target_routes,
         )
     except click.ClickException:
         raise

--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -572,6 +572,7 @@ def _read_template_payload(
     source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
         control_plane_root=control_plane_root,
         allow_incomplete_target_ids=True,
+        allowed_incomplete_target_routes=((template_lane.context, template_lane.instance),),
     )
     target_definition = control_plane_dokploy.find_dokploy_target_definition(
         source_of_truth,

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -1371,8 +1371,57 @@ target_type = "compose"
             store.close()
 
         self.assertEqual(
-            [(target.context, target.instance, target.target_id) for target in source_of_truth.targets],
+            [
+                (target.context, target.instance, target.target_id)
+                for target in source_of_truth.targets
+            ],
             [("sellyouroutboard", "testing", "app-syo-testing")],
+        )
+
+    def test_read_control_plane_dokploy_source_of_truth_can_preserve_allowed_incomplete_target(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_dokploy_target_record(
+                DokployTargetRecord(
+                    context="sellyouroutboard-testing",
+                    instance="testing",
+                    target_type="application",
+                    target_name="syo-testing",
+                    updated_at="2026-05-04T19:00:00Z",
+                    source_label="test",
+                )
+            )
+            store.write_dokploy_target_record(
+                DokployTargetRecord(
+                    context="discord-blue",
+                    instance="prod",
+                    target_type="application",
+                    target_name="discord-blue",
+                    updated_at="2026-05-04T19:00:00Z",
+                    source_label="test",
+                )
+            )
+
+            with patch.dict(os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True):
+                source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
+                    control_plane_root=control_plane_root,
+                    allow_incomplete_target_ids=True,
+                    allowed_incomplete_target_routes=(("sellyouroutboard-testing", "testing"),),
+                )
+
+            store.close()
+
+        self.assertEqual(
+            [
+                (target.context, target.instance, target.target_id)
+                for target in source_of_truth.targets
+            ],
+            [("sellyouroutboard-testing", "testing", "")],
         )
 
     def test_read_control_plane_dokploy_source_of_truth_reads_database_target_records(self) -> None:

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -290,6 +290,56 @@ class GenericWebPreviewTests(unittest.TestCase):
             ["template_env", "template_provider_fields", "transport_policy"],
         )
 
+    def test_evaluate_generic_web_preview_readiness_keeps_template_lane_when_target_id_missing(
+        self,
+    ) -> None:
+        store = _GenericWebPreviewStore(_profile())
+        source = DokploySourceOfTruth(
+            schema_version=1,
+            targets=(
+                DokployTargetDefinition(
+                    context="sellyouroutboard-testing",
+                    instance="testing",
+                    target_type="application",
+                    target_id="",
+                    target_name="sellyouroutboard-testing",
+                ),
+            ),
+        )
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                return_value=source,
+            ) as source_of_truth,
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config"
+            ) as read_dokploy_config,
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.fetch_dokploy_target_payload"
+            ) as fetch_dokploy_target_payload,
+        ):
+            result = evaluate_generic_web_preview_readiness(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebPreviewReadinessRequest(product="sellyouroutboard"),
+                checked_at="2026-04-30T21:00:00Z",
+            )
+
+        self.assertEqual(result.readiness_status, "blocked")
+        self.assertEqual(result.template_context, "sellyouroutboard-testing")
+        self.assertEqual(result.template_instance, "testing")
+        self.assertEqual(result.template_target_id, "")
+        self.assertEqual([check.check_id for check in result.checks], ["template_target"])
+        self.assertIn("template lane to have a Dokploy target_id", result.checks[0].message)
+        source_of_truth.assert_called_once_with(
+            control_plane_root=Path("."),
+            allow_incomplete_target_ids=True,
+            allowed_incomplete_target_routes=(("sellyouroutboard-testing", "testing"),),
+        )
+        read_dokploy_config.assert_not_called()
+        fetch_dokploy_target_payload.assert_not_called()
+
     def test_execute_generic_web_preview_refresh_blocks_before_provider_mutation(self) -> None:
         store = _GenericWebPreviewStore(_profile())
         source = DokploySourceOfTruth(


### PR DESCRIPTION
## Summary
- let Dokploy source-of-truth reads preserve explicitly requested incomplete target routes
- use that path for generic-web preview template readiness so missing template target ids produce the specific readiness error
- keep default source-of-truth reads fail-closed and unrelated incomplete targets ignored when requested

## Validation
- uv run python -m unittest tests.test_generic_web_preview tests.test_generic_web_deploy tests.test_dokploy
- uv run --extra dev ruff check control_plane/dokploy.py control_plane/workflows/generic_web_preview.py tests/test_dokploy.py tests/test_generic_web_preview.py
- uv run --extra dev ruff format --check control_plane/dokploy.py control_plane/workflows/generic_web_preview.py tests/test_dokploy.py tests/test_generic_web_preview.py