### PR TITLE
Add Dokploy target adoption command

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -121,6 +121,7 @@ from control_plane.workflows.launchplane import (
     verify_github_webhook_signature,
 )
 from control_plane.workflows.inventory import build_environment_inventory
+from control_plane.workflows.dokploy_target_adoption import adopt_dokploy_target
 from control_plane.workflows.product_onboarding import apply_product_onboarding_manifest
 from control_plane.workflows.odoo_artifact_publish import (
     OdooArtifactPublishRequest,
@@ -8811,6 +8812,20 @@ def _summarize_dokploy_target_record(
     }
 
 
+def _fetch_dokploy_target_payload_for_adoption(
+    host: str,
+    token: str,
+    target_type: str,
+    target_id: str,
+) -> dict[str, control_plane_dokploy.JsonValue]:
+    return control_plane_dokploy.fetch_dokploy_target_payload(
+        host=host,
+        token=token,
+        target_type=target_type,
+        target_id=target_id,
+    )
+
+
 def _clone_dokploy_target_record(
     *,
     target_record: DokployTargetRecord,
@@ -12424,6 +12439,108 @@ def dokploy_targets_show(database_url: str, context_name: str, instance_name: st
     click.echo(
         json.dumps(
             _summarize_dokploy_target_record(record, target_id=target_id_record.target_id),
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+@dokploy_targets.command("adopt")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane tracked Dokploy target records.",
+)
+@click.option("--context", "context_name", required=True)
+@click.option("--instance", "instance_name", required=True)
+@click.option(
+    "--target-type",
+    type=click.Choice(["application", "compose"]),
+    required=True,
+    help="Dokploy target type to adopt.",
+)
+@click.option("--target-id", required=True, help="Live Dokploy application or compose id.")
+@click.option("--project-name", default="", help="Override project name stored on the record.")
+@click.option("--target-name", default="", help="Override target name stored on the record.")
+@click.option("--source-git-ref", default="origin/main", show_default=True)
+@click.option("--healthcheck-path", default="", help="Healthcheck path stored on the record.")
+@click.option("--domain", "domains", multiple=True, help="Domain stored on the record.")
+@click.option(
+    "--deploy-timeout-seconds",
+    type=int,
+    default=None,
+    help="Optional rollout timeout stored on the record.",
+)
+@click.option("--source-label", default="cli:dokploy-targets:adopt", show_default=True)
+@click.option("--updated-at", default="", help="Override updated timestamp.")
+@click.option("--apply", "apply_changes", is_flag=True, help="Write the adopted records.")
+@click.option(
+    "--control-plane-root",
+    type=click.Path(path_type=Path, file_okay=False),
+    default=None,
+    help="Optional Launchplane repo root used to resolve Dokploy credentials.",
+)
+def dokploy_targets_adopt(
+    database_url: str,
+    context_name: str,
+    instance_name: str,
+    target_type: str,
+    target_id: str,
+    project_name: str,
+    target_name: str,
+    source_git_ref: str,
+    healthcheck_path: str,
+    domains: tuple[str, ...],
+    deploy_timeout_seconds: int | None,
+    source_label: str,
+    updated_at: str,
+    apply_changes: bool,
+    control_plane_root: Path | None,
+) -> None:
+    if deploy_timeout_seconds is not None and deploy_timeout_seconds < 1:
+        raise click.ClickException("--deploy-timeout-seconds must be at least 1.")
+    launchplane_root = control_plane_root or _control_plane_root()
+    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=launchplane_root)
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    postgres_store.ensure_schema()
+    try:
+        result = adopt_dokploy_target(
+            record_store=postgres_store,
+            host=host,
+            token=token,
+            context=context_name,
+            instance=instance_name,
+            target_type=_normalize_dokploy_target_type(target_type),
+            target_id=target_id,
+            project_name=project_name,
+            target_name=target_name,
+            source_git_ref=source_git_ref,
+            healthcheck_path=healthcheck_path,
+            domains=domains,
+            deploy_timeout_seconds=deploy_timeout_seconds,
+            source_label=source_label,
+            updated_at=updated_at,
+            apply=apply_changes,
+            fetch_target_payload=_fetch_dokploy_target_payload_for_adoption,
+        )
+    except ValueError as error:
+        raise click.ClickException(str(error)) from error
+    finally:
+        postgres_store.close()
+    click.echo(
+        json.dumps(
+            {
+                "status": "ok",
+                "mode": "apply" if result.applied else "dry_run",
+                "applied": result.applied,
+                "record": _summarize_dokploy_target_record(
+                    result.target_record,
+                    target_id=result.target_id_record.target_id,
+                ),
+                "provider_fields": result.provider_fields,
+                "warnings": list(result.warnings),
+            },
             indent=2,
             sort_keys=True,
         )

--- a/control_plane/workflows/dokploy_target_adoption.py
+++ b/control_plane/workflows/dokploy_target_adoption.py
@@ -1,0 +1,185 @@
+from collections.abc import Callable
+from typing import Protocol
+
+from pydantic import BaseModel, ConfigDict
+
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord, DokployTargetType
+from control_plane.dokploy import JsonObject
+from control_plane.workflows.ship import utc_now_timestamp
+
+
+class DokployTargetAdoptionRecordStore(Protocol):
+    def write_dokploy_target_record(self, record: DokployTargetRecord) -> None: ...
+
+    def write_dokploy_target_id_record(self, record: DokployTargetIdRecord) -> None: ...
+
+
+class DokployTargetAdoptionResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    applied: bool
+    target_record: DokployTargetRecord
+    target_id_record: DokployTargetIdRecord
+    provider_fields: dict[str, str] = {}
+    warnings: tuple[str, ...] = ()
+
+
+FetchDokployTargetPayload = Callable[[str, str, DokployTargetType, str], JsonObject]
+
+
+def adopt_dokploy_target(
+    *,
+    record_store: DokployTargetAdoptionRecordStore,
+    host: str,
+    token: str,
+    context: str,
+    instance: str,
+    target_type: DokployTargetType,
+    target_id: str,
+    project_name: str = "",
+    target_name: str = "",
+    source_git_ref: str = "origin/main",
+    healthcheck_path: str = "",
+    domains: tuple[str, ...] = (),
+    deploy_timeout_seconds: int | None = None,
+    source_label: str = "cli:dokploy-targets:adopt",
+    updated_at: str = "",
+    apply: bool = False,
+    fetch_target_payload: FetchDokployTargetPayload,
+) -> DokployTargetAdoptionResult:
+    normalized_context = _require_non_empty(context, "context")
+    normalized_instance = _require_non_empty(instance, "instance")
+    normalized_target_id = _require_non_empty(target_id, "target_id")
+    normalized_source_git_ref = source_git_ref.strip() or "origin/main"
+    recorded_at = updated_at.strip() or utc_now_timestamp()
+    provider_payload = fetch_target_payload(host, token, target_type, normalized_target_id)
+    provider_fields = _provider_fields(provider_payload=provider_payload, target_type=target_type)
+    resolved_target_name = target_name.strip() or provider_fields.get("target_name", "")
+    resolved_project_name = project_name.strip() or provider_fields.get("project_name", "")
+    resolved_healthcheck_path = healthcheck_path.strip()
+    if target_type == "compose" and not resolved_healthcheck_path:
+        resolved_healthcheck_path = "/web/health"
+
+    warnings = _adoption_warnings(
+        target_type=target_type,
+        provider_payload=provider_payload,
+        target_name=resolved_target_name,
+        project_name=resolved_project_name,
+    )
+    target_record = DokployTargetRecord(
+        context=normalized_context,
+        instance=normalized_instance,
+        project_name=resolved_project_name,
+        target_type=target_type,
+        target_name=resolved_target_name,
+        source_git_ref=normalized_source_git_ref,
+        source_type=provider_fields.get("source_type", ""),
+        custom_git_url=provider_fields.get("custom_git_url", ""),
+        custom_git_branch=provider_fields.get("custom_git_branch", ""),
+        compose_path=provider_fields.get("compose_path", ""),
+        deploy_timeout_seconds=deploy_timeout_seconds,
+        healthcheck_path=resolved_healthcheck_path,
+        domains=domains,
+        updated_at=recorded_at,
+        source_label=source_label.strip() or "cli:dokploy-targets:adopt",
+    )
+    target_id_record = DokployTargetIdRecord(
+        context=normalized_context,
+        instance=normalized_instance,
+        target_id=normalized_target_id,
+        updated_at=recorded_at,
+        source_label=source_label.strip() or "cli:dokploy-targets:adopt",
+    )
+
+    if apply:
+        record_store.write_dokploy_target_record(target_record)
+        record_store.write_dokploy_target_id_record(target_id_record)
+
+    return DokployTargetAdoptionResult(
+        applied=apply,
+        target_record=target_record,
+        target_id_record=target_id_record,
+        provider_fields=provider_fields,
+        warnings=warnings,
+    )
+
+
+def _require_non_empty(value: str, field_name: str) -> str:
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise ValueError(f"Dokploy target adoption requires {field_name}")
+    return normalized_value
+
+
+def _provider_fields(
+    *, provider_payload: JsonObject, target_type: DokployTargetType
+) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    name = _string_field(provider_payload, "name")
+    if name:
+        fields["target_name"] = name
+    project_name = _nested_string_field(provider_payload, ("project",), "name")
+    if project_name:
+        fields["project_name"] = project_name
+    environment_project_name = _nested_string_field(
+        provider_payload, ("environment", "project"), "name"
+    )
+    if environment_project_name:
+        fields["project_name"] = environment_project_name
+
+    if target_type == "compose":
+        _put_if_present(fields, "source_type", _string_field(provider_payload, "sourceType"))
+        _put_if_present(fields, "custom_git_url", _string_field(provider_payload, "customGitUrl"))
+        _put_if_present(
+            fields, "custom_git_branch", _string_field(provider_payload, "customGitBranch")
+        )
+        _put_if_present(fields, "compose_path", _string_field(provider_payload, "composePath"))
+    return fields
+
+
+def _adoption_warnings(
+    *,
+    target_type: DokployTargetType,
+    provider_payload: JsonObject,
+    target_name: str,
+    project_name: str,
+) -> tuple[str, ...]:
+    warnings: list[str] = []
+    if not target_name:
+        warnings.append("provider target name was not discovered; pass --target-name if needed")
+    if not project_name:
+        warnings.append("provider project name was not discovered; pass --project-name if needed")
+    if target_type == "application":
+        env_text = _string_field(provider_payload, "env")
+        if env_text:
+            warnings.append(
+                "provider env exists but was not copied; store runtime values through Launchplane runtime/secret records"
+            )
+    return tuple(warnings)
+
+
+def _put_if_present(fields: dict[str, str], key: str, value: str) -> None:
+    if value:
+        fields[key] = value
+
+
+def _string_field(payload: JsonObject, key: str) -> str:
+    value = payload.get(key)
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _nested_string_field(payload: JsonObject, path: tuple[str, ...], key: str) -> str:
+    current: object = payload
+    for path_key in path:
+        if not isinstance(current, dict):
+            return ""
+        current = current.get(path_key)
+    if not isinstance(current, dict):
+        return ""
+    value = current.get(key)
+    if value is None:
+        return ""
+    return str(value).strip()

--- a/docs/dokploy-service-deployments.md
+++ b/docs/dokploy-service-deployments.md
@@ -62,6 +62,13 @@ Each stable lane also needs DB-backed Dokploy target records:
 - `env` only for non-secret provider settings that Launchplane owns
 - sibling `DokployTargetIdRecord` carrying the live Dokploy application id
 
+For an existing Dokploy app, use `launchplane dokploy-targets adopt` to create
+or refresh those target and target-id records from the live provider id. The
+adoption command is dry-run by default and requires `--apply` to write records;
+it does not copy provider env text into Launchplane. Provider application
+creation remains an operator-approved setup step until Launchplane grows a
+first-class create-target action.
+
 Product repos may document these expected facts, but they must not store live
 Launchplane product profiles, target ids, provider credentials, or lifecycle
 records as repo-local authority.

--- a/docs/new-product-repo.md
+++ b/docs/new-product-repo.md
@@ -66,6 +66,26 @@ Each onboarding `dokploy_targets` entry must include the live provider
 `target_id`. Launchplane fails closed instead of seeding a target record that a
 later deploy cannot resolve.
 
+When the Dokploy application or compose target already exists, adopt it into
+Launchplane before or after onboarding instead of hand-editing target ids into
+repo-local files:
+
+```sh
+uv run launchplane dokploy-targets adopt \
+  --database-url "$LAUNCHPLANE_DATABASE_URL" \
+  --context <product-context> \
+  --instance prod \
+  --target-type application \
+  --target-id <dokploy-application-id>
+```
+
+The command is a dry run unless `--apply` is supplied. It fetches the live
+Dokploy target, stores only Launchplane-owned target metadata and the target-id
+record, and intentionally does not copy provider env text or secret-shaped
+values. Use `--project-name`, `--target-name`, `--domain`, and
+`--healthcheck-path` when the provider payload does not expose enough redacted
+metadata for the record.
+
 Then import or update DB-backed authz policy records for the product's GitHub
 Actions workflows. Authz policy merging remains a separate operator step so a
 new product onboarding manifest cannot accidentally replace unrelated product

--- a/tests/test_dokploy_target_adoption.py
+++ b/tests/test_dokploy_target_adoption.py
@@ -1,0 +1,274 @@
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from control_plane.cli import main
+from control_plane import secrets as control_plane_secrets
+from control_plane.dokploy import JsonObject
+from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.workflows.dokploy_target_adoption import adopt_dokploy_target
+
+
+def _sqlite_database_url(database_path: Path) -> str:
+    return f"sqlite+pysqlite:///{database_path}"
+
+
+def _write_dokploy_managed_secrets(*, store: PostgresRecordStore) -> None:
+    control_plane_secrets.write_secret_value(
+        record_store=store,
+        scope="global",
+        integration=control_plane_secrets.DOKPLOY_SECRET_INTEGRATION,
+        name="host",
+        plaintext_value="https://dokploy.example.invalid",
+        binding_key="DOKPLOY_HOST",
+        actor="test",
+    )
+    control_plane_secrets.write_secret_value(
+        record_store=store,
+        scope="global",
+        integration=control_plane_secrets.DOKPLOY_SECRET_INTEGRATION,
+        name="token",
+        plaintext_value="token",
+        binding_key="DOKPLOY_TOKEN",
+        actor="test",
+    )
+
+
+class DokployTargetAdoptionTests(unittest.TestCase):
+    def test_adopt_application_target_dry_run_does_not_write_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
+            )
+            store.ensure_schema()
+            result = adopt_dokploy_target(
+                record_store=store,
+                host="https://dokploy.example.invalid",
+                token="token",
+                context="discord-blue",
+                instance="prod",
+                target_type="application",
+                target_id="app-123",
+                healthcheck_path="/health",
+                domains=("discord-blue.internal",),
+                updated_at="2026-05-04T22:30:00Z",
+                apply=False,
+                fetch_target_payload=lambda *_args: {
+                    "name": "discord-blue-lxc",
+                    "env": "DISCORD_TOKEN=secret",
+                    "environment": {"project": {"name": "Discord Blue"}},
+                },
+            )
+            target_records = store.list_dokploy_target_records()
+            target_id_records = store.list_dokploy_target_id_records()
+            store.close()
+
+        self.assertFalse(result.applied)
+        self.assertEqual(result.target_record.target_name, "discord-blue-lxc")
+        self.assertEqual(result.target_record.project_name, "Discord Blue")
+        self.assertEqual(result.target_record.domains, ("discord-blue.internal",))
+        self.assertEqual(result.target_id_record.target_id, "app-123")
+        self.assertIn("provider env exists", result.warnings[0])
+        self.assertEqual(target_records, ())
+        self.assertEqual(target_id_records, ())
+
+    def test_adopt_compose_target_applies_source_metadata_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
+            )
+            store.ensure_schema()
+            result = adopt_dokploy_target(
+                record_store=store,
+                host="https://dokploy.example.invalid",
+                token="token",
+                context="odoo-tenant-cm",
+                instance="testing",
+                target_type="compose",
+                target_id="compose-123",
+                updated_at="2026-05-04T22:35:00Z",
+                apply=True,
+                fetch_target_payload=lambda *_args: {
+                    "name": "cm-testing",
+                    "sourceType": "git",
+                    "customGitUrl": "git@github.com:cbusillo/odoo-tenant-cm.git",
+                    "customGitBranch": "main",
+                    "composePath": "docker-compose.yml",
+                    "project": {"name": "CM"},
+                },
+            )
+            target_record = store.read_dokploy_target_record(
+                context_name="odoo-tenant-cm", instance_name="testing"
+            )
+            target_id_record = store.read_dokploy_target_id_record(
+                context_name="odoo-tenant-cm", instance_name="testing"
+            )
+            store.close()
+
+        self.assertTrue(result.applied)
+        self.assertEqual(target_record.target_name, "cm-testing")
+        self.assertEqual(target_record.source_type, "git")
+        self.assertEqual(target_record.compose_path, "docker-compose.yml")
+        self.assertEqual(target_record.healthcheck_path, "/web/health")
+        self.assertEqual(target_id_record.target_id, "compose-123")
+
+    def test_cli_adopt_defaults_to_dry_run(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(temporary_directory / "db.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            with patch.dict(
+                "os.environ",
+                {
+                    "LAUNCHPLANE_DATABASE_URL": database_url,
+                    control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                },
+                clear=True,
+            ):
+                _write_dokploy_managed_secrets(store=store)
+            store.close()
+
+            with patch(
+                "control_plane.cli.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "name": "discord-blue-lxc",
+                    "environment": {"project": {"name": "Discord Blue"}},
+                },
+            ):
+                with patch.dict(
+                    "os.environ",
+                    {
+                        "LAUNCHPLANE_DATABASE_URL": database_url,
+                        control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                    },
+                    clear=True,
+                ):
+                    result = CliRunner().invoke(
+                        main,
+                        [
+                            "dokploy-targets",
+                            "adopt",
+                            "--database-url",
+                            database_url,
+                            "--context",
+                            "discord-blue",
+                            "--instance",
+                            "prod",
+                            "--target-type",
+                            "application",
+                            "--target-id",
+                            "app-123",
+                            "--healthcheck-path",
+                            "/health",
+                        ],
+                    )
+
+            with patch.dict(
+                "os.environ",
+                {
+                    "LAUNCHPLANE_DATABASE_URL": database_url,
+                    control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                },
+                clear=True,
+            ):
+                store = PostgresRecordStore(database_url=database_url)
+                store.ensure_schema()
+                records = store.list_dokploy_target_records()
+                store.close()
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["mode"], "dry_run")
+        self.assertFalse(payload["applied"])
+        self.assertEqual(payload["record"]["target_id"], "app-123")
+        self.assertEqual(records, ())
+
+    def test_cli_adopt_apply_writes_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(temporary_directory / "db.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            with patch.dict(
+                "os.environ",
+                {
+                    "LAUNCHPLANE_DATABASE_URL": database_url,
+                    control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                },
+                clear=True,
+            ):
+                _write_dokploy_managed_secrets(store=store)
+            store.close()
+
+            def fetch_payload(**_kwargs: object) -> JsonObject:
+                return {
+                    "name": "discord-blue-lxc",
+                    "environment": {"project": {"name": "Discord Blue"}},
+                }
+
+            with patch(
+                "control_plane.cli.control_plane_dokploy.fetch_dokploy_target_payload",
+                side_effect=fetch_payload,
+            ):
+                with patch.dict(
+                    "os.environ",
+                    {
+                        "LAUNCHPLANE_DATABASE_URL": database_url,
+                        control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                    },
+                    clear=True,
+                ):
+                    result = CliRunner().invoke(
+                        main,
+                        [
+                            "dokploy-targets",
+                            "adopt",
+                            "--database-url",
+                            database_url,
+                            "--context",
+                            "discord-blue",
+                            "--instance",
+                            "prod",
+                            "--target-type",
+                            "application",
+                            "--target-id",
+                            "app-123",
+                            "--target-name",
+                            "discord-blue-prod",
+                            "--project-name",
+                            "Discord Blue",
+                            "--source-label",
+                            "test:adopt",
+                            "--updated-at",
+                            "2026-05-04T22:45:00Z",
+                            "--apply",
+                        ],
+                    )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            target_record = store.read_dokploy_target_record(
+                context_name="discord-blue", instance_name="prod"
+            )
+            target_id_record = store.read_dokploy_target_id_record(
+                context_name="discord-blue", instance_name="prod"
+            )
+            store.close()
+
+        payload = json.loads(result.output)
+        self.assertEqual(payload["mode"], "apply")
+        self.assertTrue(payload["applied"])
+        self.assertEqual(target_record.target_name, "discord-blue-prod")
+        self.assertEqual(target_record.source_label, "test:adopt")
+        self.assertEqual(target_id_record.target_id, "app-123")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a dry-run-by-default `launchplane dokploy-targets adopt` command
- fetch live Dokploy app/compose metadata and write tracked target plus target-id records only with `--apply`
- document adoption as the current operator path for existing Dokploy targets

## Validation
- `uv run python -m unittest tests.test_dokploy_target_adoption tests.test_product_onboarding tests.test_dokploy`
- `uv run --extra dev ruff format --check control_plane/cli.py control_plane/workflows/dokploy_target_adoption.py tests/test_dokploy_target_adoption.py`
- `uv run --extra dev ruff check control_plane/cli.py control_plane/workflows/dokploy_target_adoption.py tests/test_dokploy_target_adoption.py`
- `uv run python -m unittest`
- `uv run --extra dev mypy control_plane tests`

Part of #254.