### PR TITLE
Add Dokploy application target creation

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -121,7 +121,10 @@ from control_plane.workflows.launchplane import (
     verify_github_webhook_signature,
 )
 from control_plane.workflows.inventory import build_environment_inventory
-from control_plane.workflows.dokploy_target_adoption import adopt_dokploy_target
+from control_plane.workflows.dokploy_target_adoption import (
+    adopt_dokploy_target,
+    create_dokploy_application_target,
+)
 from control_plane.workflows.product_onboarding import apply_product_onboarding_manifest
 from control_plane.workflows.odoo_artifact_publish import (
     OdooArtifactPublishRequest,
@@ -8826,6 +8829,25 @@ def _fetch_dokploy_target_payload_for_adoption(
     )
 
 
+def _mutate_dokploy_payload_for_target_creation(
+    host: str,
+    token: str,
+    path: str,
+    payload: dict[str, control_plane_dokploy.JsonValue],
+) -> dict[str, control_plane_dokploy.JsonValue]:
+    response = control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path=path,
+        method="POST",
+        payload=payload,
+    )
+    response_object = control_plane_dokploy.as_json_object(response)
+    if response_object is None:
+        raise click.ClickException(f"Dokploy API POST {path} returned an invalid response.")
+    return response_object
+
+
 def _clone_dokploy_target_record(
     *,
     target_record: DokployTargetRecord,
@@ -12539,6 +12561,136 @@ def dokploy_targets_adopt(
                     target_id=result.target_id_record.target_id,
                 ),
                 "provider_fields": result.provider_fields,
+                "warnings": list(result.warnings),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+@dokploy_targets.command("create-application")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane tracked Dokploy target records.",
+)
+@click.option("--context", "context_name", required=True)
+@click.option("--instance", "instance_name", required=True)
+@click.option("--target-name", required=True, help="Dokploy application display name.")
+@click.option("--project-id", default="", help="Existing Dokploy project id to use.")
+@click.option("--project-name", default="", help="Dokploy project name to create or record.")
+@click.option("--project-description", default="", help="Optional project description.")
+@click.option("--environment-id", default="", help="Existing Dokploy environment id to use.")
+@click.option(
+    "--environment-name",
+    default="",
+    help="Dokploy environment name to create; defaults to --instance.",
+)
+@click.option("--environment-description", default="", help="Optional environment description.")
+@click.option("--server-id", default="", help="Optional Dokploy server id for remote apps.")
+@click.option("--app-name", default="", help="Optional Dokploy internal app name.")
+@click.option("--application-description", default="", help="Optional application description.")
+@click.option("--source-git-ref", default="origin/main", show_default=True)
+@click.option("--healthcheck-path", default="", help="Healthcheck path stored on the record.")
+@click.option("--domain", "domains", multiple=True, help="Domain stored on the record.")
+@click.option(
+    "--deploy-timeout-seconds",
+    type=int,
+    default=None,
+    help="Optional rollout timeout stored on the record.",
+)
+@click.option(
+    "--source-label",
+    default="cli:dokploy-targets:create-application",
+    show_default=True,
+)
+@click.option("--updated-at", default="", help="Override updated timestamp.")
+@click.option(
+    "--apply", "apply_changes", is_flag=True, help="Create provider target and write records."
+)
+@click.option(
+    "--control-plane-root",
+    type=click.Path(path_type=Path, file_okay=False),
+    default=None,
+    help="Optional Launchplane repo root used to resolve Dokploy credentials.",
+)
+def dokploy_targets_create_application(
+    database_url: str,
+    context_name: str,
+    instance_name: str,
+    target_name: str,
+    project_id: str,
+    project_name: str,
+    project_description: str,
+    environment_id: str,
+    environment_name: str,
+    environment_description: str,
+    server_id: str,
+    app_name: str,
+    application_description: str,
+    source_git_ref: str,
+    healthcheck_path: str,
+    domains: tuple[str, ...],
+    deploy_timeout_seconds: int | None,
+    source_label: str,
+    updated_at: str,
+    apply_changes: bool,
+    control_plane_root: Path | None,
+) -> None:
+    if deploy_timeout_seconds is not None and deploy_timeout_seconds < 1:
+        raise click.ClickException("--deploy-timeout-seconds must be at least 1.")
+    launchplane_root = control_plane_root or _control_plane_root()
+    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=launchplane_root)
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    postgres_store.ensure_schema()
+    try:
+        result = create_dokploy_application_target(
+            record_store=postgres_store,
+            host=host,
+            token=token,
+            context=context_name,
+            instance=instance_name,
+            target_name=target_name,
+            project_id=project_id,
+            project_name=project_name,
+            project_description=project_description,
+            environment_id=environment_id,
+            environment_name=environment_name,
+            environment_description=environment_description,
+            server_id=server_id,
+            app_name=app_name,
+            application_description=application_description,
+            source_git_ref=source_git_ref,
+            healthcheck_path=healthcheck_path,
+            domains=domains,
+            deploy_timeout_seconds=deploy_timeout_seconds,
+            source_label=source_label,
+            updated_at=updated_at,
+            apply=apply_changes,
+            mutate_provider=_mutate_dokploy_payload_for_target_creation,
+            fetch_target_payload=_fetch_dokploy_target_payload_for_adoption,
+        )
+    except ValueError as error:
+        raise click.ClickException(str(error)) from error
+    finally:
+        postgres_store.close()
+    click.echo(
+        json.dumps(
+            {
+                "status": "ok",
+                "mode": "apply" if result.applied else "dry_run",
+                "applied": result.applied,
+                "plan": result.plan.model_dump(mode="json"),
+                "project_id": result.project_id,
+                "environment_id": result.environment_id,
+                "record": _summarize_dokploy_target_record(
+                    result.target_record,
+                    target_id=result.target_id_record.target_id,
+                ),
+                "provider_fields": result.provider_fields,
+                "provider_requests": list(result.provider_requests),
                 "warnings": list(result.warnings),
             },
             indent=2,

--- a/control_plane/workflows/dokploy_target_adoption.py
+++ b/control_plane/workflows/dokploy_target_adoption.py
@@ -26,6 +26,29 @@ class DokployTargetAdoptionResult(BaseModel):
 
 
 FetchDokployTargetPayload = Callable[[str, str, DokployTargetType, str], JsonObject]
+MutateDokployPayload = Callable[[str, str, str, JsonObject], JsonObject]
+
+
+class DokployTargetCreatePlan(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    project: dict[str, str]
+    environment: dict[str, str]
+    application: dict[str, str]
+
+
+class DokployTargetCreateResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    applied: bool
+    plan: DokployTargetCreatePlan
+    project_id: str = ""
+    environment_id: str = ""
+    target_record: DokployTargetRecord
+    target_id_record: DokployTargetIdRecord
+    provider_fields: dict[str, str] = {}
+    provider_requests: tuple[dict[str, object], ...] = ()
+    warnings: tuple[str, ...] = ()
 
 
 def adopt_dokploy_target(
@@ -105,11 +128,245 @@ def adopt_dokploy_target(
     )
 
 
+def create_dokploy_application_target(
+    *,
+    record_store: DokployTargetAdoptionRecordStore,
+    host: str,
+    token: str,
+    context: str,
+    instance: str,
+    target_name: str,
+    project_id: str = "",
+    project_name: str = "",
+    project_description: str = "",
+    environment_id: str = "",
+    environment_name: str = "",
+    environment_description: str = "",
+    server_id: str = "",
+    app_name: str = "",
+    application_description: str = "",
+    source_git_ref: str = "origin/main",
+    healthcheck_path: str = "",
+    domains: tuple[str, ...] = (),
+    deploy_timeout_seconds: int | None = None,
+    source_label: str = "cli:dokploy-targets:create-application",
+    updated_at: str = "",
+    apply: bool = False,
+    mutate_provider: MutateDokployPayload,
+    fetch_target_payload: FetchDokployTargetPayload,
+) -> DokployTargetCreateResult:
+    normalized_context = _require_non_empty(context, "context")
+    normalized_instance = _require_non_empty(instance, "instance")
+    normalized_target_name = _require_non_empty(target_name, "target_name")
+    normalized_project_id = project_id.strip()
+    normalized_project_name = project_name.strip()
+    normalized_environment_id = environment_id.strip()
+    normalized_environment_name = environment_name.strip() or normalized_instance
+    if not normalized_environment_id and not normalized_project_id and not normalized_project_name:
+        raise ValueError(
+            "Dokploy target creation requires --project-id or --project-name when --environment-id is not supplied"
+        )
+
+    provider_requests = _planned_provider_requests(
+        project_id=normalized_project_id,
+        project_name=normalized_project_name,
+        project_description=project_description,
+        environment_id=normalized_environment_id,
+        environment_name=normalized_environment_name,
+        environment_description=environment_description,
+        target_name=normalized_target_name,
+        app_name=app_name,
+        application_description=application_description,
+        server_id=server_id,
+    )
+    plan = DokployTargetCreatePlan(
+        project={
+            "action": _project_plan_action(
+                project_id=normalized_project_id,
+                environment_id=normalized_environment_id,
+            ),
+            "project_id": normalized_project_id,
+            "project_name": normalized_project_name,
+        },
+        environment={
+            "action": "use_existing" if normalized_environment_id else "create",
+            "environment_id": normalized_environment_id,
+            "environment_name": normalized_environment_name,
+        },
+        application={
+            "action": "create",
+            "target_name": normalized_target_name,
+            "app_name": app_name.strip(),
+            "server_id": server_id.strip(),
+        },
+    )
+
+    if not apply:
+        target_record = DokployTargetRecord(
+            context=normalized_context,
+            instance=normalized_instance,
+            project_name=normalized_project_name,
+            target_type="application",
+            target_name=normalized_target_name,
+            source_git_ref=source_git_ref.strip() or "origin/main",
+            deploy_timeout_seconds=deploy_timeout_seconds,
+            healthcheck_path=healthcheck_path.strip(),
+            domains=domains,
+            updated_at=updated_at.strip() or utc_now_timestamp(),
+            source_label=source_label.strip() or "cli:dokploy-targets:create-application",
+        )
+        target_id_record = DokployTargetIdRecord(
+            context=normalized_context,
+            instance=normalized_instance,
+            target_id="planned-application-id",
+            updated_at=target_record.updated_at,
+            source_label=target_record.source_label,
+        )
+        return DokployTargetCreateResult(
+            applied=False,
+            plan=plan,
+            target_record=target_record,
+            target_id_record=target_id_record,
+            provider_requests=provider_requests,
+            warnings=("dry run only; provider was not mutated and records were not written",),
+        )
+
+    created_project_id = normalized_project_id
+    if not created_project_id and not normalized_environment_id:
+        project_payload: JsonObject = {"name": normalized_project_name}
+        if project_description.strip():
+            project_payload["description"] = project_description.strip()
+        created_project = mutate_provider(host, token, "/api/project.create", project_payload)
+        created_project_id = _extract_provider_id(created_project, "projectId", "project")
+
+    created_environment_id = normalized_environment_id
+    if not created_environment_id:
+        environment_payload: JsonObject = {
+            "name": normalized_environment_name,
+            "projectId": created_project_id,
+        }
+        if environment_description.strip():
+            environment_payload["description"] = environment_description.strip()
+        created_environment = mutate_provider(
+            host, token, "/api/environment.create", environment_payload
+        )
+        created_environment_id = _extract_provider_id(
+            created_environment, "environmentId", "environment"
+        )
+
+    application_payload: JsonObject = {
+        "name": normalized_target_name,
+        "environmentId": created_environment_id,
+    }
+    if app_name.strip():
+        application_payload["appName"] = app_name.strip()
+    if application_description.strip():
+        application_payload["description"] = application_description.strip()
+    if server_id.strip():
+        application_payload["serverId"] = server_id.strip()
+    created_application = mutate_provider(
+        host, token, "/api/application.create", application_payload
+    )
+    application_id = _extract_provider_id(created_application, "applicationId", "application")
+
+    adoption = adopt_dokploy_target(
+        record_store=record_store,
+        host=host,
+        token=token,
+        context=normalized_context,
+        instance=normalized_instance,
+        target_type="application",
+        target_id=application_id,
+        project_name=normalized_project_name,
+        target_name=normalized_target_name,
+        source_git_ref=source_git_ref,
+        healthcheck_path=healthcheck_path,
+        domains=domains,
+        deploy_timeout_seconds=deploy_timeout_seconds,
+        source_label=source_label,
+        updated_at=updated_at,
+        apply=True,
+        fetch_target_payload=fetch_target_payload,
+    )
+    return DokployTargetCreateResult(
+        applied=True,
+        plan=plan,
+        project_id=created_project_id,
+        environment_id=created_environment_id,
+        target_record=adoption.target_record,
+        target_id_record=adoption.target_id_record,
+        provider_fields=adoption.provider_fields,
+        provider_requests=provider_requests,
+        warnings=adoption.warnings,
+    )
+
+
 def _require_non_empty(value: str, field_name: str) -> str:
     normalized_value = value.strip()
     if not normalized_value:
         raise ValueError(f"Dokploy target adoption requires {field_name}")
     return normalized_value
+
+
+def _planned_provider_requests(
+    *,
+    project_id: str,
+    project_name: str,
+    project_description: str,
+    environment_id: str,
+    environment_name: str,
+    environment_description: str,
+    target_name: str,
+    app_name: str,
+    application_description: str,
+    server_id: str,
+) -> tuple[dict[str, object], ...]:
+    requests: list[dict[str, object]] = []
+    if not environment_id and not project_id:
+        project_payload: dict[str, object] = {"name": project_name}
+        if project_description.strip():
+            project_payload["description"] = project_description.strip()
+        requests.append({"path": "/api/project.create", "payload": project_payload})
+    if not environment_id:
+        environment_payload: dict[str, object] = {
+            "name": environment_name,
+            "projectId": project_id or "<created-project-id>",
+        }
+        if environment_description.strip():
+            environment_payload["description"] = environment_description.strip()
+        requests.append({"path": "/api/environment.create", "payload": environment_payload})
+    application_payload: dict[str, object] = {
+        "name": target_name,
+        "environmentId": environment_id or "<created-environment-id>",
+    }
+    if app_name.strip():
+        application_payload["appName"] = app_name.strip()
+    if application_description.strip():
+        application_payload["description"] = application_description.strip()
+    if server_id.strip():
+        application_payload["serverId"] = server_id.strip()
+    requests.append({"path": "/api/application.create", "payload": application_payload})
+    return tuple(requests)
+
+
+def _project_plan_action(*, project_id: str, environment_id: str) -> str:
+    if project_id:
+        return "use_existing"
+    if environment_id:
+        return "not_required"
+    return "create"
+
+
+def _extract_provider_id(payload: JsonObject, id_key: str, object_key: str) -> str:
+    direct_id = _string_field(payload, id_key) or _string_field(payload, "id")
+    if direct_id:
+        return direct_id
+    nested_id = _nested_string_field(payload, (object_key,), id_key) or _nested_string_field(
+        payload, (object_key,), "id"
+    )
+    if nested_id:
+        return nested_id
+    raise ValueError(f"Dokploy {object_key}.create did not return {id_key}")
 
 
 def _provider_fields(

--- a/docs/dokploy-service-deployments.md
+++ b/docs/dokploy-service-deployments.md
@@ -66,8 +66,12 @@ For an existing Dokploy app, use `launchplane dokploy-targets adopt` to create
 or refresh those target and target-id records from the live provider id. The
 adoption command is dry-run by default and requires `--apply` to write records;
 it does not copy provider env text into Launchplane. Provider application
-creation remains an operator-approved setup step until Launchplane grows a
-first-class create-target action.
+creation for application targets is available through
+`launchplane dokploy-targets create-application`. That command is also dry-run
+by default; with `--apply`, it can create or reuse the Dokploy project and
+environment, create the application, and immediately persist the matching target
+records. It still leaves runtime env, managed secrets, volumes, ports, and
+health behavior as explicit setup rather than inferred provider state.
 
 Product repos may document these expected facts, but they must not store live
 Launchplane product profiles, target ids, provider credentials, or lifecycle

--- a/docs/new-product-repo.md
+++ b/docs/new-product-repo.md
@@ -86,6 +86,25 @@ values. Use `--project-name`, `--target-name`, `--domain`, and
 `--healthcheck-path` when the provider payload does not expose enough redacted
 metadata for the record.
 
+When the Dokploy application does not exist yet, let Launchplane plan and apply
+the provider mutation so the app id is captured in records immediately:
+
+```sh
+uv run launchplane dokploy-targets create-application \
+  --database-url "$LAUNCHPLANE_DATABASE_URL" \
+  --context <product-context> \
+  --instance prod \
+  --target-name <dokploy-application-name> \
+  --project-name <dokploy-project-name>
+```
+
+This command is also dry-run by default. With `--apply`, it can create a
+Dokploy project, environment, and application, then write the matching tracked
+target and target-id records. Use `--project-id` or `--environment-id` to reuse
+existing provider containers, and `--server-id` when the app belongs on a remote
+Dokploy server. It still does not configure secrets or copy provider env text;
+runtime and secret records remain separate Launchplane-owned setup steps.
+
 Then import or update DB-backed authz policy records for the product's GitHub
 Actions workflows. Authz policy merging remains a separate operator step so a
 new product onboarding manifest cannot accidentally replace unrelated product

--- a/tests/test_dokploy_target_adoption.py
+++ b/tests/test_dokploy_target_adoption.py
@@ -10,7 +10,10 @@ from control_plane.cli import main
 from control_plane import secrets as control_plane_secrets
 from control_plane.dokploy import JsonObject
 from control_plane.storage.postgres import PostgresRecordStore
-from control_plane.workflows.dokploy_target_adoption import adopt_dokploy_target
+from control_plane.workflows.dokploy_target_adoption import (
+    adopt_dokploy_target,
+    create_dokploy_application_target,
+)
 
 
 def _sqlite_database_url(database_path: Path) -> str:
@@ -268,6 +271,210 @@ class DokployTargetAdoptionTests(unittest.TestCase):
         self.assertEqual(target_record.target_name, "discord-blue-prod")
         self.assertEqual(target_record.source_label, "test:adopt")
         self.assertEqual(target_id_record.target_id, "app-123")
+
+    def test_create_application_target_dry_run_plans_provider_requests(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
+            )
+            store.ensure_schema()
+            requests: list[tuple[str, JsonObject]] = []
+
+            def mutate_provider(
+                _host: str, _token: str, path: str, payload: JsonObject
+            ) -> JsonObject:
+                requests.append((path, payload))
+                return {}
+
+            result = create_dokploy_application_target(
+                record_store=store,
+                host="https://dokploy.example.invalid",
+                token="token",
+                context="discord-blue",
+                instance="prod",
+                target_name="discord-blue-prod",
+                project_name="Discord Blue",
+                environment_name="prod",
+                server_id="server-123",
+                healthcheck_path="/health",
+                updated_at="2026-05-04T23:00:00Z",
+                apply=False,
+                mutate_provider=mutate_provider,
+                fetch_target_payload=lambda *_args: {},
+            )
+            target_records = store.list_dokploy_target_records()
+            store.close()
+
+        self.assertFalse(result.applied)
+        self.assertEqual(requests, [])
+        self.assertEqual(
+            [item["path"] for item in result.provider_requests],
+            [
+                "/api/project.create",
+                "/api/environment.create",
+                "/api/application.create",
+            ],
+        )
+        self.assertEqual(result.target_record.target_name, "discord-blue-prod")
+        self.assertEqual(result.target_id_record.target_id, "planned-application-id")
+        self.assertEqual(target_records, ())
+
+    def test_create_application_target_applies_provider_and_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
+            )
+            store.ensure_schema()
+            requests: list[tuple[str, JsonObject]] = []
+
+            def mutate_provider(
+                _host: str, _token: str, path: str, payload: JsonObject
+            ) -> JsonObject:
+                requests.append((path, payload))
+                if path == "/api/project.create":
+                    return {"projectId": "project-123"}
+                if path == "/api/environment.create":
+                    self.assertEqual(payload["projectId"], "project-123")
+                    return {"environmentId": "env-123"}
+                if path == "/api/application.create":
+                    self.assertEqual(payload["environmentId"], "env-123")
+                    return {"applicationId": "app-123"}
+                raise AssertionError(path)
+
+            result = create_dokploy_application_target(
+                record_store=store,
+                host="https://dokploy.example.invalid",
+                token="token",
+                context="discord-blue",
+                instance="prod",
+                target_name="discord-blue-prod",
+                project_name="Discord Blue",
+                environment_name="prod",
+                server_id="server-123",
+                healthcheck_path="/health",
+                updated_at="2026-05-04T23:05:00Z",
+                apply=True,
+                mutate_provider=mutate_provider,
+                fetch_target_payload=lambda *_args: {
+                    "name": "discord-blue-prod",
+                    "environment": {"project": {"name": "Discord Blue"}},
+                },
+            )
+            target_record = store.read_dokploy_target_record(
+                context_name="discord-blue", instance_name="prod"
+            )
+            target_id_record = store.read_dokploy_target_id_record(
+                context_name="discord-blue", instance_name="prod"
+            )
+            store.close()
+
+        self.assertTrue(result.applied)
+        self.assertEqual(
+            [path for path, _payload in requests],
+            [
+                "/api/project.create",
+                "/api/environment.create",
+                "/api/application.create",
+            ],
+        )
+        self.assertEqual(result.project_id, "project-123")
+        self.assertEqual(result.environment_id, "env-123")
+        self.assertEqual(target_record.target_name, "discord-blue-prod")
+        self.assertEqual(target_record.healthcheck_path, "/health")
+        self.assertEqual(target_id_record.target_id, "app-123")
+
+    def test_create_application_target_reuses_existing_environment(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
+            )
+            store.ensure_schema()
+            requests: list[tuple[str, JsonObject]] = []
+
+            def mutate_provider(
+                _host: str, _token: str, path: str, payload: JsonObject
+            ) -> JsonObject:
+                requests.append((path, payload))
+                return {"applicationId": "app-456"}
+
+            result = create_dokploy_application_target(
+                record_store=store,
+                host="https://dokploy.example.invalid",
+                token="token",
+                context="verireel",
+                instance="testing",
+                target_name="verireel-testing",
+                project_name="VeriReel",
+                environment_id="env-existing",
+                apply=True,
+                mutate_provider=mutate_provider,
+                fetch_target_payload=lambda *_args: {"name": "verireel-testing"},
+            )
+            target_id_record = store.read_dokploy_target_id_record(
+                context_name="verireel", instance_name="testing"
+            )
+            store.close()
+
+        self.assertTrue(result.applied)
+        self.assertEqual([path for path, _payload in requests], ["/api/application.create"])
+        self.assertEqual(requests[0][1]["environmentId"], "env-existing")
+        self.assertEqual(target_id_record.target_id, "app-456")
+
+    def test_cli_create_application_dry_run_outputs_plan(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(temporary_directory / "db.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            with patch.dict(
+                "os.environ",
+                {
+                    "LAUNCHPLANE_DATABASE_URL": database_url,
+                    control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                },
+                clear=True,
+            ):
+                _write_dokploy_managed_secrets(store=store)
+            store.close()
+
+            with patch.dict(
+                "os.environ",
+                {
+                    "LAUNCHPLANE_DATABASE_URL": database_url,
+                    control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                },
+                clear=True,
+            ):
+                result = CliRunner().invoke(
+                    main,
+                    [
+                        "dokploy-targets",
+                        "create-application",
+                        "--database-url",
+                        database_url,
+                        "--context",
+                        "discord-blue",
+                        "--instance",
+                        "prod",
+                        "--target-name",
+                        "discord-blue-prod",
+                        "--project-name",
+                        "Discord Blue",
+                        "--server-id",
+                        "server-123",
+                    ],
+                )
+
+            store = PostgresRecordStore(database_url=database_url)
+            records = store.list_dokploy_target_records()
+            store.close()
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["mode"], "dry_run")
+        self.assertEqual(payload["plan"]["application"]["target_name"], "discord-blue-prod")
+        self.assertEqual(len(payload["provider_requests"]), 3)
+        self.assertEqual(records, ())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add dry-run-by-default `launchplane dokploy-targets create-application`
- support creating or reusing Dokploy project/environment containers before creating the app
- immediately adopt the created app into Launchplane target and target-id records under `--apply`
- document create vs adopt operator flows

## Validation
- `uv run python -m unittest tests.test_dokploy_target_adoption tests.test_product_onboarding tests.test_dokploy`
- `uv run --extra dev ruff format --check control_plane/cli.py control_plane/workflows/dokploy_target_adoption.py tests/test_dokploy_target_adoption.py`
- `uv run --extra dev ruff check control_plane/cli.py control_plane/workflows/dokploy_target_adoption.py tests/test_dokploy_target_adoption.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`

Continues #254.