### PR TITLE
Add authz diagnostics to preview feedback denials

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2034,6 +2034,9 @@ def _authz_diagnostic_payload(
     identity: LaunchplaneIdentity,
     authz_policy_sha256_value: str,
     authz_policy_source: str,
+    action: str = "",
+    product: str = "",
+    context: str = "",
 ) -> dict[str, object]:
     if isinstance(identity, GitHubHumanIdentity):
         identity_payload: dict[str, object] = {
@@ -2053,11 +2056,18 @@ def _authz_diagnostic_payload(
             "environment": identity.environment,
             "subject": identity.subject,
         }
-    return {
+    payload: dict[str, object] = {
         "identity": identity_payload,
         "policy_source": authz_policy_source,
         "policy_sha256": authz_policy_sha256_value,
     }
+    if action or product or context:
+        payload["request"] = {
+            "action": action,
+            "product": product,
+            "context": context,
+        }
+    return payload
 
 
 def _product_profile_context_cutover_allowed_contexts(
@@ -4149,9 +4159,7 @@ def create_launchplane_service_app(
                     "product_profile": onboarding_result.product_profile.product,
                     "dokploy_target_count": len(onboarding_result.dokploy_targets),
                     "dokploy_target_id_count": len(onboarding_result.dokploy_target_ids),
-                    "runtime_environment_record_count": len(
-                        onboarding_result.runtime_environments
-                    ),
+                    "runtime_environment_record_count": len(onboarding_result.runtime_environments),
                     "secret_binding_count": len(onboarding_result.secret_bindings),
                 }
                 driver_result = {
@@ -5673,6 +5681,7 @@ def create_launchplane_service_app(
                     context=preview_pr_feedback_request.context,
                     status=preview_pr_feedback_request.status,
                 ):
+                    feedback_authz_action = "preview_pr_feedback.write"
                     return _json_response(
                         start_response=start_response,
                         status_code=403,
@@ -5686,6 +5695,14 @@ def create_launchplane_service_app(
                                     " product/context."
                                 ),
                             },
+                            "authz": _authz_diagnostic_payload(
+                                identity=identity,
+                                authz_policy_sha256_value=resolved_authz_policy_sha256,
+                                authz_policy_source=resolved_authz_policy_source,
+                                action=feedback_authz_action,
+                                product=preview_pr_feedback_request.product,
+                                context=preview_pr_feedback_request.context,
+                            ),
                         },
                     )
                 idempotent_response = _check_idempotent_request(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1344,7 +1344,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(target.target_type, "application")
         self.assertFalse(target.healthcheck_enabled)
         self.assertEqual(target_id.target_id, "app-discord-blue")
-        self.assertEqual(runtime_records[0].env, {"DISCORD_BLUE_STATE_DIR": "/var/lib/discord-blue"})
+        self.assertEqual(
+            runtime_records[0].env, {"DISCORD_BLUE_STATE_DIR": "/var/lib/discord-blue"}
+        )
         self.assertEqual(secret_bindings[0].binding_key, "DISCORD_TOKEN")
         self.assertNotIn("secret_id", json.dumps(payload, sort_keys=True))
 
@@ -7504,6 +7506,17 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertEqual(payload["authz"]["identity"]["repository"], "every/verireel")
+        self.assertEqual(
+            payload["authz"]["identity"]["workflow_ref"],
+            "every/verireel/.github/workflows/preview-control-plane.yml@refs/pull/42/merge",
+        )
+        self.assertEqual(payload["authz"]["identity"]["event_name"], "pull_request")
+        self.assertEqual(payload["authz"]["request"]["action"], "preview_pr_feedback.write")
+        self.assertEqual(payload["authz"]["request"]["product"], "verireel")
+        self.assertEqual(payload["authz"]["request"]["context"], "verireel-testing")
+        self.assertIn("policy_sha256", payload["authz"])
+        self.assertIn("policy_source", payload["authz"])
 
     def test_preview_lifecycle_cleanup_endpoint_records_report_only_cleanup(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- include safe request action/product/context details in authz diagnostics
- return authz diagnostics on denied preview PR feedback writes
- cover the VeriReel denial path so workflow refs and requested scope are visible without logging tokens

## Validation
- `uv run python -m unittest tests.test_service`
- `uv run --extra dev ruff format --check control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/service.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`

Fixes #82.