### PR TITLE
Add reusable Launchplane request action

### DIFF
--- a/.github/actions/launchplane-request/action.yml
+++ b/.github/actions/launchplane-request/action.yml
@@ -1,0 +1,86 @@
+---
+name: Launchplane request
+description: Send an OIDC-authenticated JSON request to Launchplane.
+
+inputs:
+  launchplane-url:
+    description: Base URL for the Launchplane service.
+    required: true
+  route-path:
+    description: >-
+      Absolute Launchplane API route path, such as
+      /v1/drivers/generic-web/deploy.
+    required: true
+  payload:
+    description: Inline JSON request payload.
+    required: false
+    default: ""
+  payload-file:
+    description: >-
+      Path to a JSON request payload file. Used when payload is empty.
+    required: false
+    default: ""
+  method:
+    description: HTTP method to use.
+    required: false
+    default: POST
+  audience:
+    description: GitHub OIDC audience. Defaults to the Launchplane URL host.
+    required: false
+    default: ""
+  idempotency-key:
+    description: Stable idempotency key for mutation requests.
+    required: false
+    default: ""
+  timeout-ms:
+    description: >-
+      Launchplane request timeout in milliseconds. Use 0 to disable.
+    required: false
+    default: "0"
+  oidc-timeout-ms:
+    description: >-
+      GitHub OIDC token request timeout in milliseconds. Use 0 to disable.
+    required: false
+    default: "30000"
+  retry-attempts:
+    description: >-
+      Number of network retry attempts for OIDC and Launchplane calls.
+    required: false
+    default: "3"
+  retry-delay-ms:
+    description: Base retry delay in milliseconds.
+    required: false
+    default: "250"
+  fail-result-statuses:
+    description: >-
+      Comma-separated result status values that should fail the action.
+    required: false
+    default: fail,blocked
+  fail-result-paths:
+    description: >-
+      Comma-separated JSON paths to inspect for fail-result-statuses.
+    required: false
+    default: >-
+      result.refresh_status,result.deploy_status,result.rollout_status,
+      result.migration_status,result.health_status
+  output-paths:
+    description: >-
+      Comma-separated output=json.path mappings to expose as action outputs.
+    required: false
+    default: ""
+
+outputs:
+  launchplane-url:
+    description: Fully resolved Launchplane request URL.
+  route-path:
+    description: Launchplane route path called by the action.
+  audience:
+    description: GitHub OIDC audience used for the request.
+  status-code:
+    description: HTTP status code returned by Launchplane.
+  response-body:
+    description: Raw Launchplane response body.
+
+runs:
+  using: node20
+  main: dist/index.js

--- a/.github/actions/launchplane-request/dist/index.js
+++ b/.github/actions/launchplane-request/dist/index.js
@@ -1,0 +1,272 @@
+const fs = require("node:fs");
+const os = require("node:os");
+
+function inputNameToEnvKey(name) {
+  return `INPUT_${name.replace(/ /g, "_").replace(/-/g, "_").toUpperCase()}`;
+}
+
+function getInput(name, options = {}) {
+  const value = String(
+    process.env[inputNameToEnvKey(name)] ?? options.defaultValue ?? "",
+  ).trim();
+  if (options.required && !value) {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+}
+
+function parsePositiveInteger(value, label) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+function parseNonNegativeInteger(value, label) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${label} must be a non-negative integer.`);
+  }
+  return parsed;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isAbortError(error) {
+  return error instanceof DOMException
+    ? error.name === "AbortError" || error.name === "TimeoutError"
+    : error?.name === "AbortError" || error?.name === "TimeoutError";
+}
+
+function describeError(error) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+async function fetchWithRetry(url, init, options) {
+  const attempts = parsePositiveInteger(options.retryAttempts, "retry-attempts");
+  const delayMs = parseNonNegativeInteger(options.retryDelayMs, "retry-delay-ms");
+  let lastError = null;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await fetch(url, init);
+    } catch (error) {
+      lastError = error;
+      if (isAbortError(error) || attempt >= attempts) {
+        break;
+      }
+      await sleep(delayMs * attempt);
+    }
+  }
+  throw new Error(
+    `${options.label} failed after ${attempts} attempts: ${describeError(lastError)}`,
+  );
+}
+
+function buildAbortSignal(timeoutMs) {
+  const normalizedTimeoutMs = parseNonNegativeInteger(timeoutMs, "timeout-ms");
+  if (!normalizedTimeoutMs) {
+    return undefined;
+  }
+  return AbortSignal.timeout(normalizedTimeoutMs);
+}
+
+async function requestGitHubOidcToken(audience, options) {
+  const requestUrl = String(process.env.ACTIONS_ID_TOKEN_REQUEST_URL ?? "").trim();
+  const requestToken = String(process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN ?? "").trim();
+  if (!requestUrl || !requestToken) {
+    throw new Error(
+      "GitHub OIDC request environment is missing. Ensure the workflow job grants id-token: write.",
+    );
+  }
+
+  const tokenUrl = new URL(requestUrl);
+  tokenUrl.searchParams.set("audience", audience);
+  const response = await fetchWithRetry(
+    tokenUrl.toString(),
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${requestToken}`,
+        Accept: "application/json",
+      },
+      signal: buildAbortSignal(options.oidcTimeoutMs),
+    },
+    { ...options, label: "GitHub OIDC token request" },
+  );
+  const body = await response.text();
+  if (!response.ok) {
+    throw new Error(`GitHub OIDC token request failed with ${response.status}: ${body}`);
+  }
+  const parsed = body ? JSON.parse(body) : {};
+  const token = String(parsed.value ?? "").trim();
+  if (!token) {
+    throw new Error("GitHub OIDC token response did not include a token value.");
+  }
+  return token;
+}
+
+function readPayload() {
+  const inlinePayload = getInput("payload");
+  const payloadFile = getInput("payload-file");
+  if (inlinePayload && payloadFile) {
+    throw new Error("Use payload or payload-file, not both.");
+  }
+  if (inlinePayload) {
+    return JSON.parse(inlinePayload);
+  }
+  if (payloadFile) {
+    return JSON.parse(fs.readFileSync(payloadFile, "utf8"));
+  }
+  return null;
+}
+
+function splitCommaSeparated(value) {
+  return String(value ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function readJsonPath(value, path) {
+  let cursor = value;
+  for (const segment of path.split(".").filter(Boolean)) {
+    if (cursor === null || typeof cursor !== "object" || !(segment in cursor)) {
+      return undefined;
+    }
+    cursor = cursor[segment];
+  }
+  return cursor;
+}
+
+function setOutput(name, value) {
+  const outputPath = String(process.env.GITHUB_OUTPUT ?? "").trim();
+  if (!outputPath) {
+    return;
+  }
+  const normalizedValue = String(value ?? "");
+  const delimiter = `EOF_${name.toUpperCase().replace(/[^A-Z0-9_]/g, "_")}_${Date.now()}`;
+  fs.appendFileSync(
+    outputPath,
+    `${name}<<${delimiter}${os.EOL}${normalizedValue}${os.EOL}${delimiter}${os.EOL}`,
+    "utf8",
+  );
+}
+
+function writeMappedOutputs(responseBody) {
+  const mappings = splitCommaSeparated(getInput("output-paths"));
+  for (const mapping of mappings) {
+    const [rawName, rawPath] = mapping.split("=");
+    const name = String(rawName ?? "").trim();
+    const path = String(rawPath ?? "").trim();
+    if (!name || !path) {
+      throw new Error(`Invalid output mapping '${mapping}'. Use output=json.path.`);
+    }
+    setOutput(name, readJsonPath(responseBody, path) ?? "");
+  }
+}
+
+function assertResultStatuses(responseBody) {
+  const failStatuses = new Set(
+    splitCommaSeparated(
+      getInput("fail-result-statuses", { defaultValue: "fail,blocked" }),
+    ).map((status) => status.toLowerCase()),
+  );
+  const failResultPaths = splitCommaSeparated(
+    getInput("fail-result-paths", {
+      defaultValue:
+        "result.refresh_status,result.deploy_status,result.rollout_status," +
+        "result.migration_status,result.health_status",
+    }),
+  );
+  if (failStatuses.size === 0 || failResultPaths.length === 0) {
+    return;
+  }
+  for (const path of failResultPaths) {
+    const value = readJsonPath(responseBody, path);
+    const normalizedValue = String(value ?? "").trim().toLowerCase();
+    if (normalizedValue && failStatuses.has(normalizedValue)) {
+      const message = String(
+        readJsonPath(responseBody, "result.error_message") ?? "",
+      ).trim();
+      throw new Error(message || `Launchplane result ${path} was ${normalizedValue}.`);
+    }
+  }
+}
+
+function getActionOptions() {
+  return {
+    oidcTimeoutMs: getInput("oidc-timeout-ms", { defaultValue: "30000" }),
+    retryAttempts: getInput("retry-attempts", { defaultValue: "3" }),
+    retryDelayMs: getInput("retry-delay-ms", { defaultValue: "250" }),
+  };
+}
+
+async function main() {
+  const launchplaneUrl = new URL(getInput("launchplane-url", { required: true }));
+  const routePath = getInput("route-path", { required: true });
+  const method = getInput("method", { defaultValue: "POST" });
+  const requestUrl = new URL(routePath, launchplaneUrl).toString();
+  const audience = getInput("audience") || launchplaneUrl.host;
+  const idempotencyKey = getInput("idempotency-key");
+  const payload = readPayload();
+  const options = getActionOptions();
+  const token = await requestGitHubOidcToken(audience, options);
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/json",
+  };
+  const requestInit = {
+    method,
+    headers,
+    signal: buildAbortSignal(getInput("timeout-ms", { defaultValue: "0" })),
+  };
+  if (idempotencyKey) {
+    headers["Idempotency-Key"] = idempotencyKey;
+  }
+  if (payload !== null) {
+    headers["Content-Type"] = "application/json";
+    requestInit.body = JSON.stringify(payload);
+  }
+
+  const response = await fetchWithRetry(requestUrl, requestInit, {
+    ...options,
+    label: "Launchplane request",
+  });
+  const responseText = await response.text();
+  let responseBody = {};
+  if (responseText) {
+    try {
+      responseBody = JSON.parse(responseText);
+    } catch (error) {
+      if (response.ok) {
+        throw error;
+      }
+    }
+  }
+
+  setOutput("launchplane-url", requestUrl);
+  setOutput("route-path", routePath);
+  setOutput("audience", audience);
+  setOutput("status-code", response.status);
+  setOutput("response-body", responseText);
+  writeMappedOutputs(responseBody);
+
+  process.stdout.write(`${JSON.stringify(responseBody, null, 2)}\n`);
+  if (!response.ok) {
+    throw new Error(
+      `Launchplane request failed with ${response.status}: ${responseText || "empty response"}`,
+    );
+  }
+  assertResultStatuses(responseBody);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/docs/new-product-repo.md
+++ b/docs/new-product-repo.md
@@ -133,6 +133,12 @@ The Launchplane trigger steps should use GitHub Actions OIDC and pass minimal
 facts only: product key, source ref or SHA, PR number when relevant, immutable
 artifact reference, and optional run URL.
 
+For direct JSON calls to Launchplane service routes, use the reusable
+`cbusillo/launchplane/.github/actions/launchplane-request` action rather than
+copying an OIDC/fetch helper into the product repo. Product repos can still keep
+small scripts that assemble product-specific payload JSON until Launchplane owns
+that request-shaping layer too.
+
 ## Choose A Driver
 
 Use `generic-web` when the product is a stateless or mostly stateless web app,

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -130,13 +130,44 @@ For an existing repo, classify each workflow and script before deleting code:
   driver route.
 - `delete`: stale compatibility code with no active caller or with a proven
   Launchplane replacement.
-- `adapter`: temporary OIDC trigger glue that should shrink or move into a
-  reusable Launchplane GitHub Action/CLI.
+- `adapter`: temporary OIDC trigger glue. Prefer the reusable
+  `cbusillo/launchplane/.github/actions/launchplane-request` GitHub Action for
+  raw Launchplane HTTP calls, then keep only the product-specific payload
+  assembly that cannot yet move into a driver route.
 
 Start with low-risk deletions and documentation, then replace active workflow
 behavior in small slices. Do not remove active backup, promotion, rollback,
 runtime health, or cleanup safety gates until Launchplane owns the equivalent
 behavior and tests.
+
+## Reusable Launchplane Request Action
+
+Product workflows that only need to send JSON to an existing Launchplane route
+should not carry their own GitHub OIDC transport client. Use the Launchplane
+repo action instead:
+
+```yaml
+- name: Request Launchplane preview refresh
+  uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+  with:
+    launchplane-url: ${{ vars.LAUNCHPLANE_URL }}
+    audience: ${{ vars.LAUNCHPLANE_AUDIENCE }}
+    route-path: /v1/drivers/generic-web/preview-refresh
+    payload-file: ${{ runner.temp }}/launchplane-preview-refresh.json
+    idempotency-key: >-
+      generic-web-preview-refresh:${{ github.event.number }}:${{ github.sha }}
+    timeout-ms: "900000"
+    output-paths: >-
+      refresh_status=result.refresh_status,
+      application_id=result.application_id,
+      preview_url=result.preview_url,
+      error_message=result.error_message
+```
+
+The action requests a GitHub OIDC token, sends the JSON request with a stable
+`Idempotency-Key`, exposes the raw response body, and can map response JSON paths
+to GitHub outputs. Product repos may still need small payload-builder scripts
+until Launchplane owns the next layer of product-specific request assembly.
 
 ## New Repo Checklist
 

--- a/tests/test_launchplane_request_action.py
+++ b/tests/test_launchplane_request_action.py
@@ -1,0 +1,122 @@
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+
+ACTION_ENTRYPOINT = Path(".github/actions/launchplane-request/dist/index.js")
+
+
+class LaunchplaneRequestActionTests(unittest.TestCase):
+    def run_action(
+        self,
+        *,
+        inputs: dict[str, str],
+        environment: dict[str, str] | None = None,
+        output_path: Path | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        if shutil.which("node") is None:
+            self.skipTest("node is required to test the Launchplane request action")
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
+                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://oidc.example/token",
+            }
+        )
+        if output_path is not None:
+            env["GITHUB_OUTPUT"] = str(output_path)
+        if environment:
+            env.update(environment)
+        for name, value in inputs.items():
+            env[f"INPUT_{name.replace('-', '_').upper()}"] = value
+
+        script = f"""
+const calls = [];
+global.fetch = async (url, init) => {{
+  calls.push({{url, init}});
+  if (url.startsWith('https://oidc.example/token')) {{
+    return new Response(JSON.stringify({{value: 'oidc-token'}}), {{status: 200}});
+  }}
+  return new Response(JSON.stringify({{
+    ok: true,
+    result: {{
+      refresh_status: process.env.TEST_REFRESH_STATUS || 'pass',
+      error_message: process.env.TEST_ERROR_MESSAGE || '',
+      application_id: 'app-123'
+    }}
+  }}), {{status: Number(process.env.TEST_STATUS || '200')}});
+}};
+require('./{ACTION_ENTRYPOINT.as_posix()}');
+process.on('beforeExit', () => {{
+  console.error(JSON.stringify(calls.map((call) => ({{
+    url: call.url,
+    method: call.init.method,
+    headers: call.init.headers,
+    body: call.init.body || ''
+  }}))));
+}});
+"""
+        return subprocess.run(
+            ["node", "-e", script],
+            check=False,
+            capture_output=True,
+            env=env,
+            text=True,
+        )
+
+    def test_posts_oidc_authenticated_json_with_idempotency_key(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            output_path = Path(temporary_directory) / "github-output.txt"
+            result = self.run_action(
+                output_path=output_path,
+                inputs={
+                    "launchplane-url": "https://launchplane.example",
+                    "route-path": "/v1/drivers/generic-web/preview-refresh",
+                    "payload": '{"schema_version":1,"product":"sellyouroutboard"}',
+                    "idempotency-key": "generic-web-preview-refresh:sellyouroutboard:42:sha",
+                    "output-paths": "application_id=result.application_id",
+                },
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            calls = json.loads(result.stderr.strip().splitlines()[-1])
+            self.assertEqual(
+                calls[0]["url"],
+                "https://oidc.example/token?audience=launchplane.example",
+            )
+            self.assertEqual(
+                calls[1]["url"],
+                "https://launchplane.example/v1/drivers/generic-web/preview-refresh",
+            )
+            self.assertEqual(calls[1]["headers"]["Authorization"], "Bearer oidc-token")
+            self.assertEqual(
+                calls[1]["headers"]["Idempotency-Key"],
+                "generic-web-preview-refresh:sellyouroutboard:42:sha",
+            )
+            self.assertEqual(json.loads(calls[1]["body"])["product"], "sellyouroutboard")
+            self.assertIn("application_id<<", output_path.read_text(encoding="utf-8"))
+
+    def test_fails_when_driver_result_status_is_configured_as_failure(self) -> None:
+        result = self.run_action(
+            inputs={
+                "launchplane-url": "https://launchplane.example",
+                "route-path": "/v1/drivers/generic-web/preview-refresh",
+                "payload": '{"schema_version":1,"product":"sellyouroutboard"}',
+            },
+            environment={
+                "TEST_REFRESH_STATUS": "blocked",
+                "TEST_ERROR_MESSAGE": "Preview refresh blocked.",
+            },
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Preview refresh blocked.", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a reusable OIDC-authenticated Launchplane request GitHub Action
- support payload files, idempotency keys, retries, timeouts, response outputs, and driver result failure statuses
- document the action as the replacement path for product-local OIDC/fetch helper scripts

Refs #164.

## Validation
- `uv run python -m unittest tests.test_launchplane_request_action`
- `node --check .github/actions/launchplane-request/dist/index.js`
- `uv run --extra dev ruff check --diff tests/test_launchplane_request_action.py`
- `uv run --extra dev ruff check tests/test_launchplane_request_action.py`
- `uv run python -m unittest`