### PR TITLE
Fix Launchplane request action input names

### DIFF
--- a/.github/actions/launchplane-request/dist/index.js
+++ b/.github/actions/launchplane-request/dist/index.js
@@ -2,7 +2,7 @@ const fs = require("node:fs");
 const os = require("node:os");
 
 function inputNameToEnvKey(name) {
-  return `INPUT_${name.replace(/ /g, "_").replace(/-/g, "_").toUpperCase()}`;
+  return `INPUT_${name.replace(/ /g, "_").toUpperCase()}`;
 }
 
 function getInput(name, options = {}) {

--- a/tests/test_launchplane_request_action.py
+++ b/tests/test_launchplane_request_action.py
@@ -33,7 +33,7 @@ class LaunchplaneRequestActionTests(unittest.TestCase):
         if environment:
             env.update(environment)
         for name, value in inputs.items():
-            env[f"INPUT_{name.replace('-', '_').upper()}"] = value
+            env[f"INPUT_{name.upper()}"] = value
 
         script = f"""
 const calls = [];


### PR DESCRIPTION
## Summary
- read GitHub action inputs using the hyphenated env variable names GitHub actually exposes
- update the action test harness to match the live GitHub Actions input shape

This fixes the live SYO publish failure in cbusillo/sellyouroutboard@647bc008 where the shared action could not read `launchplane-url`.

Refs #164.

## Validation
- `uv run python -m unittest tests.test_launchplane_request_action`
- `node --check .github/actions/launchplane-request/dist/index.js`
- `uv run --extra dev ruff check --diff tests/test_launchplane_request_action.py`
- `uv run --extra dev ruff check tests/test_launchplane_request_action.py`
- `uv run python -m unittest`