### PR TITLE
Validate Dokploy create healthcheck path before mutation

### DIFF
--- a/control_plane/workflows/dokploy_target_adoption.py
+++ b/control_plane/workflows/dokploy_target_adoption.py
@@ -179,6 +179,9 @@ def create_dokploy_application_target(
     normalized_project_name = project_name.strip()
     normalized_environment_id = environment_id.strip()
     normalized_environment_name = environment_name.strip() or normalized_instance
+    normalized_healthcheck_path = healthcheck_path.strip()
+    if normalized_healthcheck_path and not normalized_healthcheck_path.startswith("/"):
+        raise ValueError("Dokploy target creation requires --healthcheck-path to start with /")
     if not normalized_environment_id and not normalized_project_id and not normalized_project_name:
         raise ValueError(
             "Dokploy target creation requires --project-id or --project-name when --environment-id is not supplied"
@@ -227,7 +230,7 @@ def create_dokploy_application_target(
             target_name=normalized_target_name,
             source_git_ref=source_git_ref.strip() or "origin/main",
             deploy_timeout_seconds=deploy_timeout_seconds,
-            healthcheck_path=healthcheck_path.strip(),
+            healthcheck_path=normalized_healthcheck_path,
             domains=domains,
             updated_at=updated_at.strip() or utc_now_timestamp(),
             source_label=source_label.strip() or "cli:dokploy-targets:create-application",
@@ -297,7 +300,7 @@ def create_dokploy_application_target(
         project_name=normalized_project_name,
         target_name=normalized_target_name,
         source_git_ref=source_git_ref,
-        healthcheck_path=healthcheck_path,
+        healthcheck_path=normalized_healthcheck_path,
         domains=domains,
         deploy_timeout_seconds=deploy_timeout_seconds,
         source_label=source_label,

--- a/tests/test_dokploy_target_adoption.py
+++ b/tests/test_dokploy_target_adoption.py
@@ -597,6 +597,40 @@ class DokployTargetAdoptionTests(unittest.TestCase):
         self.assertEqual(requests[0][1]["environmentId"], "env-existing")
         self.assertEqual(target_id_record.target_id, "app-456")
 
+    def test_create_application_target_rejects_healthcheck_path_before_provider_mutation(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
+            )
+            store.ensure_schema()
+            requests: list[tuple[str, JsonObject]] = []
+
+            def mutate_provider(
+                _host: str, _token: str, path: str, payload: JsonObject
+            ) -> JsonObject:
+                requests.append((path, payload))
+                return {"projectId": "project-123"}
+
+            with self.assertRaisesRegex(ValueError, "healthcheck-path to start with /"):
+                create_dokploy_application_target(
+                    record_store=store,
+                    host="https://dokploy.example.invalid",
+                    token="token",
+                    context="discord-blue",
+                    instance="prod",
+                    target_name="discord-blue-prod",
+                    project_name="Discord Blue",
+                    healthcheck_path="health",
+                    apply=True,
+                    mutate_provider=mutate_provider,
+                    fetch_target_payload=lambda *_args: {},
+                )
+            store.close()
+
+        self.assertEqual(requests, [])
+
     def test_cli_create_application_dry_run_outputs_plan(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             temporary_directory = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- validate create-application healthcheck paths before any Dokploy provider mutation
- reuse the normalized healthcheck path for dry-run records and adoption
- add regression coverage proving invalid paths do not call the provider

Refs #164.

## Validation
- `uv run python -m unittest tests.test_dokploy_target_adoption`
- `uv run --extra dev ruff check --diff control_plane/workflows/dokploy_target_adoption.py tests/test_dokploy_target_adoption.py`
- `uv run --extra dev ruff check control_plane/workflows/dokploy_target_adoption.py tests/test_dokploy_target_adoption.py`
- `uv run --extra dev mypy control_plane/workflows/dokploy_target_adoption.py tests/test_dokploy_target_adoption.py`
- `uv run python -m unittest`