### PR TITLE
Respect frontend base path for icon links

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,8 +3,15 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" type="image/svg+xml" href="/assets/brand/launchplane-icon.svg" />
-    <link rel="apple-touch-icon" href="/assets/brand/launchplane-icon-1024.png" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="%BASE_URL%assets/brand/launchplane-icon.svg"
+    />
+    <link
+      rel="apple-touch-icon"
+      href="%BASE_URL%assets/brand/launchplane-icon-1024.png"
+    />
     <title>Launchplane</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- use Vite's %BASE_URL% placeholder for favicon and Apple touch icon links
- keeps built icon URLs under /ui/ instead of the domain root

## Validation
- pnpm --dir frontend exec prettier --check index.html
- pnpm --dir frontend validate