### PR TITLE
Add polling to Launchplane request action

### DIFF
--- a/.github/actions/launchplane-request/action.yml
+++ b/.github/actions/launchplane-request/action.yml
@@ -51,6 +51,25 @@ inputs:
     description: Base retry delay in milliseconds.
     required: false
     default: "250"
+  poll-result-path:
+    description: >-
+      JSON path to inspect after each Launchplane response. When set, the action
+      repeats the request while the value matches poll-result-statuses.
+    required: false
+    default: ""
+  poll-result-statuses:
+    description: >-
+      Comma-separated result status values that should keep polling.
+    required: false
+    default: pending
+  poll-interval-ms:
+    description: Delay between polling requests in milliseconds.
+    required: false
+    default: "30000"
+  poll-timeout-ms:
+    description: Maximum polling duration in milliseconds.
+    required: false
+    default: "600000"
   fail-result-statuses:
     description: >-
       Comma-separated result status values that should fail the action.

--- a/.github/actions/launchplane-request/dist/index.js
+++ b/.github/actions/launchplane-request/dist/index.js
@@ -68,6 +68,21 @@ async function fetchWithRetry(url, init, options) {
   );
 }
 
+async function readJsonResponse(response) {
+  const responseText = await response.text();
+  let responseBody = {};
+  if (responseText) {
+    try {
+      responseBody = JSON.parse(responseText);
+    } catch (error) {
+      if (response.ok) {
+        throw error;
+      }
+    }
+  }
+  return { responseBody, responseText };
+}
+
 function buildAbortSignal(timeoutMs) {
   const normalizedTimeoutMs = parseNonNegativeInteger(timeoutMs, "timeout-ms");
   if (!normalizedTimeoutMs) {
@@ -202,9 +217,70 @@ function assertResultStatuses(responseBody) {
 function getActionOptions() {
   return {
     oidcTimeoutMs: getInput("oidc-timeout-ms", { defaultValue: "30000" }),
+    pollIntervalMs: getInput("poll-interval-ms", { defaultValue: "30000" }),
+    pollResultPath: getInput("poll-result-path"),
+    pollResultStatuses: getInput("poll-result-statuses", { defaultValue: "pending" }),
+    pollTimeoutMs: getInput("poll-timeout-ms", { defaultValue: "600000" }),
     retryAttempts: getInput("retry-attempts", { defaultValue: "3" }),
     retryDelayMs: getInput("retry-delay-ms", { defaultValue: "250" }),
   };
+}
+
+function shouldPollResponse(responseBody, options) {
+  const pollResultPath = String(options.pollResultPath ?? "").trim();
+  if (!pollResultPath) {
+    return false;
+  }
+  const pollStatuses = new Set(
+    splitCommaSeparated(options.pollResultStatuses).map((status) =>
+      status.toLowerCase(),
+    ),
+  );
+  if (pollStatuses.size === 0) {
+    return false;
+  }
+  const value = readJsonPath(responseBody, pollResultPath);
+  const normalizedValue = String(value ?? "").trim().toLowerCase();
+  return Boolean(normalizedValue && pollStatuses.has(normalizedValue));
+}
+
+async function requestLaunchplaneUntilComplete(requestUrl, requestInit, options) {
+  const pollResultPath = String(options.pollResultPath ?? "").trim();
+  const pollTimeoutMs = parseNonNegativeInteger(
+    options.pollTimeoutMs,
+    "poll-timeout-ms",
+  );
+  const pollIntervalMs = parseNonNegativeInteger(
+    options.pollIntervalMs,
+    "poll-interval-ms",
+  );
+  const deadline = Date.now() + pollTimeoutMs;
+  let lastPollValue = "";
+  let attempt = 0;
+
+  while (true) {
+    attempt += 1;
+    const response = await fetchWithRetry(requestUrl, requestInit, {
+      ...options,
+      label: "Launchplane request",
+    });
+    const { responseBody, responseText } = await readJsonResponse(response);
+    if (!response.ok || !shouldPollResponse(responseBody, options)) {
+      return { response, responseBody, responseText };
+    }
+
+    lastPollValue = String(readJsonPath(responseBody, pollResultPath) ?? "").trim();
+    if (!pollTimeoutMs || Date.now() + pollIntervalMs > deadline) {
+      throw new Error(
+        `Timed out waiting for Launchplane result ${pollResultPath} to leave ` +
+          `${lastPollValue || "the polling status"} after ${pollTimeoutMs}ms.`,
+      );
+    }
+    process.stderr.write(
+      `Launchplane result ${pollResultPath} is ${lastPollValue}; polling again in ${pollIntervalMs}ms.\n`,
+    );
+    await sleep(pollIntervalMs);
+  }
 }
 
 async function main() {
@@ -234,21 +310,11 @@ async function main() {
     requestInit.body = JSON.stringify(payload);
   }
 
-  const response = await fetchWithRetry(requestUrl, requestInit, {
-    ...options,
-    label: "Launchplane request",
-  });
-  const responseText = await response.text();
-  let responseBody = {};
-  if (responseText) {
-    try {
-      responseBody = JSON.parse(responseText);
-    } catch (error) {
-      if (response.ok) {
-        throw error;
-      }
-    }
-  }
+  const { response, responseBody, responseText } = await requestLaunchplaneUntilComplete(
+    requestUrl,
+    requestInit,
+    options,
+  );
 
   setOutput("launchplane-url", requestUrl);
   setOutput("route-path", routePath);

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -169,6 +169,33 @@ The action requests a GitHub OIDC token, sends the JSON request with a stable
 to GitHub outputs. Product repos may still need small payload-builder scripts
 until Launchplane owns the next layer of product-specific request assembly.
 
+For asynchronous Launchplane routes that report a temporary status, configure
+polling instead of reimplementing OIDC and retry logic in the product repo:
+
+```yaml
+- name: Request Launchplane backup gate
+  uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+  with:
+    launchplane-url: ${{ vars.LAUNCHPLANE_URL }}
+    audience: ${{ vars.LAUNCHPLANE_AUDIENCE }}
+    route-path: /v1/drivers/verireel/prod-backup-gate
+    payload: ${{ steps.backup_payload.outputs.payload }}
+    idempotency-key: ${{ steps.backup_payload.outputs.idempotency_key }}
+    poll-result-path: result.backup_status
+    poll-result-statuses: pending
+    poll-interval-ms: "30000"
+    poll-timeout-ms: "2400000"
+    fail-result-paths: result.backup_status
+    output-paths: >-
+      backup_status=result.backup_status,
+      snapshot_name=result.snapshot_name,
+      backup_gate_record_id=records.backup_gate_record_id
+```
+
+Polling repeats the same idempotent request while the configured JSON path
+matches a polling status. After polling finishes, the normal fail-result and
+output mapping rules still apply.
+
 ## New Repo Checklist
 
 When creating a new website repo for Launchplane:

--- a/tests/test_launchplane_request_action.py
+++ b/tests/test_launchplane_request_action.py
@@ -37,15 +37,19 @@ class LaunchplaneRequestActionTests(unittest.TestCase):
 
         script = f"""
 const calls = [];
+let launchplaneRequestCount = 0;
 global.fetch = async (url, init) => {{
   calls.push({{url, init}});
   if (url.startsWith('https://oidc.example/token')) {{
     return new Response(JSON.stringify({{value: 'oidc-token'}}), {{status: 200}});
   }}
+  launchplaneRequestCount += 1;
+  const configuredStatuses = String(process.env.TEST_REFRESH_STATUSES || '').split(',').filter(Boolean);
+  const refreshStatus = configuredStatuses[launchplaneRequestCount - 1] || process.env.TEST_REFRESH_STATUS || 'pass';
   return new Response(JSON.stringify({{
     ok: true,
     result: {{
-      refresh_status: process.env.TEST_REFRESH_STATUS || 'pass',
+      refresh_status: refreshStatus,
       error_message: process.env.TEST_ERROR_MESSAGE || '',
       application_id: 'app-123'
     }}
@@ -116,6 +120,52 @@ process.on('beforeExit', () => {{
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("Preview refresh blocked.", result.stderr)
+
+    def test_polls_until_driver_status_leaves_pending(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            output_path = Path(temporary_directory) / "github-output.txt"
+            result = self.run_action(
+                output_path=output_path,
+                inputs={
+                    "launchplane-url": "https://launchplane.example",
+                    "route-path": "/v1/drivers/generic-web/preview-refresh",
+                    "payload": '{"schema_version":1,"product":"sellyouroutboard"}',
+                    "poll-result-path": "result.refresh_status",
+                    "poll-result-statuses": "pending",
+                    "poll-interval-ms": "1",
+                    "poll-timeout-ms": "1000",
+                    "output-paths": "refresh_status=result.refresh_status",
+                },
+                environment={"TEST_REFRESH_STATUSES": "pending,pending,pass"},
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            calls = json.loads(result.stderr.strip().splitlines()[-1])
+            launchplane_calls = [
+                call
+                for call in calls
+                if call["url"]
+                == "https://launchplane.example/v1/drivers/generic-web/preview-refresh"
+            ]
+            self.assertEqual(len(launchplane_calls), 3)
+            self.assertIn("refresh_status<<", output_path.read_text(encoding="utf-8"))
+
+    def test_fails_when_polling_times_out(self) -> None:
+        result = self.run_action(
+            inputs={
+                "launchplane-url": "https://launchplane.example",
+                "route-path": "/v1/drivers/generic-web/preview-refresh",
+                "payload": '{"schema_version":1,"product":"sellyouroutboard"}',
+                "poll-result-path": "result.refresh_status",
+                "poll-result-statuses": "pending",
+                "poll-interval-ms": "1",
+                "poll-timeout-ms": "1",
+            },
+            environment={"TEST_REFRESH_STATUS": "pending"},
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Timed out waiting for Launchplane result", result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add optional polling inputs to the reusable Launchplane request action
- repeat idempotent requests while a configured response JSON path reports a pending status
- preserve existing fail-result and output-path behavior after polling completes
- document polling usage for product repos

## Validation
- uv run python -m unittest tests.test_launchplane_request_action
- uv run --extra dev ruff check --diff tests/test_launchplane_request_action.py
- uv run --extra dev ruff check tests/test_launchplane_request_action.py