### PR TITLE
Persist adopted Dokploy branch fallback

### DIFF
--- a/control_plane/workflows/dokploy_target_adoption.py
+++ b/control_plane/workflows/dokploy_target_adoption.py
@@ -109,7 +109,8 @@ def adopt_dokploy_target(
         target_type=target_type,
         target_name=resolved_target_name,
         source_git_ref=normalized_source_git_ref,
-        git_branch=str(provider_fields.get("git_branch") or ""),
+        git_branch=_provider_string_field(provider_fields, "git_branch")
+        or _provider_string_field(provider_fields, "branch"),
         source_type=_provider_string_field(provider_fields, "source_type"),
         custom_git_url=_provider_string_field(provider_fields, "custom_git_url"),
         custom_git_branch=_provider_string_field(provider_fields, "custom_git_branch"),

--- a/tests/test_dokploy_target_adoption.py
+++ b/tests/test_dokploy_target_adoption.py
@@ -239,6 +239,43 @@ class DokployTargetAdoptionTests(unittest.TestCase):
         self.assertFalse(target_record.enable_submodules)
         self.assertEqual(result.provider_fields["source_git_ref"], "origin/release")
 
+    def test_adopt_compose_target_uses_branch_when_git_branch_is_absent(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
+            )
+            store.ensure_schema()
+            result = adopt_dokploy_target(
+                record_store=store,
+                host="https://dokploy.example.invalid",
+                token="token",
+                context="odoo-tenant-cm",
+                instance="testing",
+                target_type="compose",
+                target_id="compose-123",
+                source_git_ref="",
+                updated_at="2026-05-05T19:30:00Z",
+                apply=True,
+                fetch_target_payload=lambda *_args: {
+                    "name": "cm-testing",
+                    "sourceType": "git",
+                    "branch": "feature/adopted-branch",
+                    "composePath": "docker-compose.yml",
+                    "project": {"name": "CM"},
+                },
+            )
+            target_record = store.read_dokploy_target_record(
+                context_name="odoo-tenant-cm", instance_name="testing"
+            )
+            store.close()
+
+        self.assertTrue(result.applied)
+        self.assertEqual(target_record.source_git_ref, "feature/adopted-branch")
+        self.assertEqual(target_record.git_branch, "feature/adopted-branch")
+        self.assertEqual(result.provider_fields["branch"], "feature/adopted-branch")
+
     def test_cli_adopt_uses_live_source_ref_by_default(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             temporary_directory = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- persist provider branch metadata as git_branch when Dokploy omits gitBranch
- keep existing source_git_ref fallback behavior for branch-only provider payloads
- add regression coverage for branch-only compose adoption payloads

## Validation
- uv run python -m unittest tests.test_dokploy_target_adoption
- uv run --extra dev ruff check --diff control_plane/workflows/dokploy_target_adoption.py tests/test_dokploy_target_adoption.py
- uv run --extra dev ruff check control_plane/workflows/dokploy_target_adoption.py tests/test_dokploy_target_adoption.py