### PR TITLE
Add runtime key safety policy

### DIFF
--- a/control_plane/contracts/runtime_key_safety_policy.py
+++ b/control_plane/contracts/runtime_key_safety_policy.py
@@ -1,0 +1,118 @@
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+RuntimeEnvironmentClass = Literal["prod", "testing", "preview", "dev", "unknown"]
+RuntimeSecretClass = Literal["prod_only", "testing", "preview", "non_prod", "shared_safe"]
+RuntimeKeySafetyStatus = Literal["pass", "fail"]
+RuntimeKeySafetyFindingCode = Literal[
+    "ambiguous_binding",
+    "binding_disabled",
+    "binding_missing",
+    "context_not_allowed",
+    "instance_not_allowed",
+    "secret_class_not_allowed",
+    "unclassified_binding",
+    "unknown_environment_class",
+]
+
+
+class RuntimeKeySafetyTarget(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    context: str
+    instance: str
+    environment_class: RuntimeEnvironmentClass
+
+    @model_validator(mode="after")
+    def _validate_target(self) -> "RuntimeKeySafetyTarget":
+        if not self.context.strip():
+            raise ValueError("runtime key safety target requires context")
+        if not self.instance.strip():
+            raise ValueError("runtime key safety target requires instance")
+        self.context = self.context.strip()
+        self.instance = self.instance.strip()
+        return self
+
+
+class RuntimeSecretSafetyRule(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    binding_key: str
+    secret_class: RuntimeSecretClass
+    allowed_contexts: tuple[str, ...] = ()
+    allowed_instances: tuple[str, ...] = ()
+    description: str = ""
+
+    @model_validator(mode="after")
+    def _validate_rule(self) -> "RuntimeSecretSafetyRule":
+        binding_key = self.binding_key.strip()
+        if not binding_key:
+            raise ValueError("runtime secret safety rule requires binding_key")
+        self.binding_key = binding_key
+        self.allowed_contexts = _normalize_unique_values(
+            self.allowed_contexts,
+            "runtime secret safety allowed_contexts values must be non-empty",
+        )
+        self.allowed_instances = _normalize_unique_values(
+            self.allowed_instances,
+            "runtime secret safety allowed_instances values must be non-empty",
+        )
+        self.description = self.description.strip()
+        return self
+
+
+class RuntimeKeySafetyFinding(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: RuntimeKeySafetyFindingCode
+    binding_key: str = ""
+    binding_id: str = ""
+    secret_id: str = ""
+    secret_class: str = ""
+    detail: str
+
+    @model_validator(mode="after")
+    def _validate_finding(self) -> "RuntimeKeySafetyFinding":
+        if not self.detail.strip():
+            raise ValueError("runtime key safety finding requires detail")
+        self.binding_key = self.binding_key.strip()
+        self.binding_id = self.binding_id.strip()
+        self.secret_id = self.secret_id.strip()
+        self.secret_class = self.secret_class.strip()
+        self.detail = self.detail.strip()
+        return self
+
+
+class RuntimeKeySafetyEvaluation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    status: RuntimeKeySafetyStatus
+    target: RuntimeKeySafetyTarget
+    checked_binding_keys: tuple[str, ...]
+    findings: tuple[RuntimeKeySafetyFinding, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_evaluation(self) -> "RuntimeKeySafetyEvaluation":
+        self.checked_binding_keys = _normalize_unique_values(
+            self.checked_binding_keys,
+            "runtime key safety checked binding keys must be non-empty",
+        )
+        if self.status == "pass" and self.findings:
+            raise ValueError("passing runtime key safety evaluation cannot include findings")
+        if self.status == "fail" and not self.findings:
+            raise ValueError("failing runtime key safety evaluation requires findings")
+        return self
+
+
+def _normalize_unique_values(values: tuple[str, ...], empty_message: str) -> tuple[str, ...]:
+    normalized: list[str] = []
+    for raw_value in values:
+        value = raw_value.strip()
+        if not value:
+            raise ValueError(empty_message)
+        if value not in normalized:
+            normalized.append(value)
+    return tuple(normalized)

--- a/control_plane/runtime_key_safety.py
+++ b/control_plane/runtime_key_safety.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from control_plane.contracts.runtime_key_safety_policy import (
+    RuntimeEnvironmentClass,
+    RuntimeKeySafetyEvaluation,
+    RuntimeKeySafetyFinding,
+    RuntimeKeySafetyTarget,
+    RuntimeSecretClass,
+    RuntimeSecretSafetyRule,
+)
+from control_plane.contracts.secret_record import SecretBinding
+
+
+ALLOWED_SECRET_CLASSES_BY_ENVIRONMENT: dict[RuntimeEnvironmentClass, set[RuntimeSecretClass]] = {
+    "prod": {"prod_only", "shared_safe"},
+    "testing": {"testing", "non_prod", "shared_safe"},
+    "preview": {"preview", "non_prod", "shared_safe"},
+    "dev": {"non_prod", "shared_safe"},
+    "unknown": set(),
+}
+
+
+def evaluate_runtime_key_safety(
+    *,
+    target: RuntimeKeySafetyTarget,
+    required_binding_keys: Iterable[str],
+    secret_bindings: Iterable[SecretBinding],
+    secret_rules: Iterable[RuntimeSecretSafetyRule],
+) -> RuntimeKeySafetyEvaluation:
+    checked_binding_keys = _normalize_required_binding_keys(required_binding_keys)
+    rules_by_binding_key = _rules_by_binding_key(secret_rules)
+    bindings_by_binding_key = _bindings_by_binding_key(secret_bindings)
+    findings: list[RuntimeKeySafetyFinding] = []
+
+    if target.environment_class == "unknown":
+        findings.append(
+            RuntimeKeySafetyFinding(
+                code="unknown_environment_class",
+                detail="Runtime key safety target has unknown environment class.",
+            )
+        )
+
+    for binding_key in checked_binding_keys:
+        bindings = bindings_by_binding_key.get(binding_key, ())
+        if not bindings:
+            findings.append(
+                RuntimeKeySafetyFinding(
+                    code="binding_missing",
+                    binding_key=binding_key,
+                    detail=f"Required managed secret binding {binding_key!r} is missing.",
+                )
+            )
+            continue
+        if len(bindings) > 1:
+            findings.append(
+                RuntimeKeySafetyFinding(
+                    code="ambiguous_binding",
+                    binding_key=binding_key,
+                    detail=f"Required managed secret binding {binding_key!r} resolved to multiple records.",
+                )
+            )
+            continue
+
+        binding = bindings[0]
+        if binding.status != "configured":
+            findings.append(
+                RuntimeKeySafetyFinding(
+                    code="binding_disabled",
+                    binding_key=binding.binding_key,
+                    binding_id=binding.binding_id,
+                    secret_id=binding.secret_id,
+                    detail=f"Managed secret binding {binding.binding_key!r} is not configured.",
+                )
+            )
+            continue
+
+        rule = rules_by_binding_key.get(binding.binding_key)
+        if rule is None:
+            findings.append(
+                RuntimeKeySafetyFinding(
+                    code="unclassified_binding",
+                    binding_key=binding.binding_key,
+                    binding_id=binding.binding_id,
+                    secret_id=binding.secret_id,
+                    detail=f"Managed secret binding {binding.binding_key!r} has no runtime key safety rule.",
+                )
+            )
+            continue
+
+        findings.extend(_evaluate_binding_rule(target=target, binding=binding, rule=rule))
+
+    return RuntimeKeySafetyEvaluation(
+        status="fail" if findings else "pass",
+        target=target,
+        checked_binding_keys=checked_binding_keys,
+        findings=tuple(findings),
+    )
+
+
+def _normalize_required_binding_keys(required_binding_keys: Iterable[str]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    for raw_key in required_binding_keys:
+        binding_key = raw_key.strip()
+        if not binding_key:
+            raise ValueError("runtime key safety required binding keys must be non-empty")
+        if binding_key not in normalized:
+            normalized.append(binding_key)
+    if not normalized:
+        raise ValueError("runtime key safety requires at least one binding key")
+    return tuple(normalized)
+
+
+def _rules_by_binding_key(
+    secret_rules: Iterable[RuntimeSecretSafetyRule],
+) -> dict[str, RuntimeSecretSafetyRule]:
+    rules_by_binding_key: dict[str, RuntimeSecretSafetyRule] = {}
+    for rule in secret_rules:
+        rules_by_binding_key[rule.binding_key] = rule
+    return rules_by_binding_key
+
+
+def _bindings_by_binding_key(
+    secret_bindings: Iterable[SecretBinding],
+) -> dict[str, tuple[SecretBinding, ...]]:
+    grouped: dict[str, list[SecretBinding]] = {}
+    for binding in secret_bindings:
+        grouped.setdefault(binding.binding_key, []).append(binding)
+    return {key: tuple(bindings) for key, bindings in grouped.items()}
+
+
+def _evaluate_binding_rule(
+    *,
+    target: RuntimeKeySafetyTarget,
+    binding: SecretBinding,
+    rule: RuntimeSecretSafetyRule,
+) -> tuple[RuntimeKeySafetyFinding, ...]:
+    findings: list[RuntimeKeySafetyFinding] = []
+    allowed_secret_classes = ALLOWED_SECRET_CLASSES_BY_ENVIRONMENT[target.environment_class]
+    if rule.secret_class not in allowed_secret_classes:
+        findings.append(
+            RuntimeKeySafetyFinding(
+                code="secret_class_not_allowed",
+                binding_key=binding.binding_key,
+                binding_id=binding.binding_id,
+                secret_id=binding.secret_id,
+                secret_class=rule.secret_class,
+                detail=(
+                    f"Managed secret binding {binding.binding_key!r} is classified as "
+                    f"{rule.secret_class!r}, which is not allowed for "
+                    f"{target.environment_class!r} environments."
+                ),
+            )
+        )
+    if rule.allowed_contexts and target.context not in rule.allowed_contexts:
+        findings.append(
+            RuntimeKeySafetyFinding(
+                code="context_not_allowed",
+                binding_key=binding.binding_key,
+                binding_id=binding.binding_id,
+                secret_id=binding.secret_id,
+                secret_class=rule.secret_class,
+                detail=(
+                    f"Managed secret binding {binding.binding_key!r} is not allowed "
+                    f"for context {target.context!r}."
+                ),
+            )
+        )
+    if rule.allowed_instances and target.instance not in rule.allowed_instances:
+        findings.append(
+            RuntimeKeySafetyFinding(
+                code="instance_not_allowed",
+                binding_key=binding.binding_key,
+                binding_id=binding.binding_id,
+                secret_id=binding.secret_id,
+                secret_class=rule.secret_class,
+                detail=(
+                    f"Managed secret binding {binding.binding_key!r} is not allowed "
+                    f"for instance {target.instance!r}."
+                ),
+            )
+        )
+    return tuple(findings)

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -10,10 +10,10 @@ title: Secrets
 ## Current Contract
 
 - Dokploy credentials belong to `launchplane`.
-- Launchplane can now persist managed secret values in the Postgres shared-service
-  backend when `LAUNCHPLANE_DATABASE_URL` is configured.
-- Managed secret values are encrypted before Launchplane stores them; the master key
-  stays outside the database in `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`.
+- Launchplane can now persist managed secret values in the Postgres
+  shared-service backend when `LAUNCHPLANE_DATABASE_URL` is configured.
+- Managed secret values are encrypted before Launchplane stores them; the master
+  key stays outside the database in `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`.
 - Keep bootstrap values only in process env long enough to write the real
   Launchplane-managed secret records.
 - Runtime environment truth should live in Launchplane DB records in steady
@@ -44,8 +44,23 @@ title: Secrets
 - Runtime environment records do not fall back to repo or XDG files.
 - Dokploy credentials do not fall back to repo files, XDG files, or process
   env. Missing managed bindings are a hard error.
-- Secret status surfaces return metadata only. Launchplane does not expose routine
-  plaintext read commands or service endpoints.
+- Secret status surfaces return metadata only. Launchplane does not expose
+  routine plaintext read commands or service endpoints.
+
+## Runtime Key-Safety Gates
+
+- Runtime key-safety gates classify managed secret bindings by binding key and
+  Launchplane metadata, not by plaintext value. The initial classification
+  contract is `prod_only`, `testing`, `preview`, `non_prod`, and `shared_safe`.
+- Gates fail closed when a required binding is missing, disabled, ambiguous,
+  unclassified, or scoped outside the target context/instance. A target with an
+  unknown environment class also fails closed.
+- `prod_only` bindings are allowed only for `prod` runtime targets. `testing`
+  targets may use `testing`, `non_prod`, or `shared_safe` bindings. `preview`
+  targets may use `preview`, `non_prod`, or `shared_safe` bindings.
+- Gate output may include binding keys, binding ids, secret ids,
+  classifications, and finding codes. It must not include secret plaintext,
+  ciphertext, provider env dumps, or token prefixes.
 
 ## Bootstrap-Only Env
 
@@ -69,15 +84,15 @@ title: Secrets
 - Never commit alternate secret files or rendered env artifacts.
 - Do not rely on a repo-local `.env` for control-plane-owned secrets.
 - Missing Dokploy credentials are a hard error, not a silent fallback.
-- Missing `LAUNCHPLANE_MASTER_ENCRYPTION_KEY` is a hard error when Launchplane needs to
-  read or write DB-backed managed secrets.
+- Missing `LAUNCHPLANE_MASTER_ENCRYPTION_KEY` is a hard error when Launchplane
+  needs to read or write DB-backed managed secrets.
 - The live Launchplane Dokploy target should expose bootstrap env such as
   `LAUNCHPLANE_DATABASE_URL` and `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`, while
   Dokploy credentials and runtime/product values should resolve from
   Launchplane-managed records instead of target env.
-- Use `uv run launchplane service inspect-dokploy-target ...` to verify that the
-  live Launchplane target has the required secret-backed contract without printing
-  plaintext secret values.
+- Use `uv run launchplane service inspect-dokploy-target ...` to verify that
+  the live Launchplane target has the required secret-backed contract without
+  printing plaintext secret values.
 
 ## Local Runtime Contract
 
@@ -103,9 +118,9 @@ title: Secrets
   updates stale source metadata without changing runtime values.
 - In steady state that payload comes from Launchplane DB-backed runtime
   environment records.
-- Launchplane preview write/build helpers read `LAUNCHPLANE_PREVIEW_BASE_URL` from the
-  shared plus context-scoped runtime environment contract, with shared values
-  providing the default and context values allowed to override it.
+- Launchplane preview write/build helpers read `LAUNCHPLANE_PREVIEW_BASE_URL`
+  from the shared plus context-scoped runtime environment contract, with shared
+  values providing the default and context values allowed to override it.
 - `odoo-devkit` may consume that contract when the operator points
   `ODOO_CONTROL_PLANE_ROOT` at a valid `launchplane` checkout.
 - When `odoo-devkit` is configured to use the control-plane contract, legacy

--- a/tests/test_runtime_key_safety.py
+++ b/tests/test_runtime_key_safety.py
@@ -1,0 +1,164 @@
+import unittest
+
+from control_plane.contracts.runtime_key_safety_policy import (
+    RuntimeKeySafetyTarget,
+    RuntimeSecretSafetyRule,
+)
+from control_plane.contracts.secret_record import SecretBinding
+from control_plane.contracts.secret_record import SecretStatus
+from control_plane.runtime_key_safety import evaluate_runtime_key_safety
+
+
+def _binding(
+    *,
+    binding_key: str,
+    binding_id: str = "binding-shopify-token",
+    secret_id: str = "secret-shopify-token",
+    status: SecretStatus = "configured",
+) -> SecretBinding:
+    return SecretBinding(
+        binding_id=binding_id,
+        secret_id=secret_id,
+        integration="runtime_environment",
+        binding_key=binding_key,
+        context="opw",
+        instance="testing",
+        status=status,
+        created_at="2026-05-05T20:00:00Z",
+        updated_at="2026-05-05T20:00:00Z",
+    )
+
+
+class RuntimeKeySafetyTests(unittest.TestCase):
+    def test_testing_environment_rejects_prod_only_secret(self) -> None:
+        evaluation = evaluate_runtime_key_safety(
+            target=RuntimeKeySafetyTarget(
+                context="opw",
+                instance="testing",
+                environment_class="testing",
+            ),
+            required_binding_keys=("SHOPIFY_ACCESS_TOKEN",),
+            secret_bindings=(
+                _binding(binding_key="SHOPIFY_ACCESS_TOKEN", secret_id="secret-prod-shopify-token"),
+            ),
+            secret_rules=(
+                RuntimeSecretSafetyRule(
+                    binding_key="SHOPIFY_ACCESS_TOKEN",
+                    secret_class="prod_only",
+                ),
+            ),
+        )
+
+        self.assertEqual(evaluation.status, "fail")
+        self.assertEqual(evaluation.findings[0].code, "secret_class_not_allowed")
+        self.assertEqual(evaluation.findings[0].binding_key, "SHOPIFY_ACCESS_TOKEN")
+        self.assertEqual(evaluation.findings[0].secret_id, "secret-prod-shopify-token")
+
+    def test_testing_environment_accepts_testing_secret(self) -> None:
+        evaluation = evaluate_runtime_key_safety(
+            target=RuntimeKeySafetyTarget(
+                context="opw",
+                instance="testing",
+                environment_class="testing",
+            ),
+            required_binding_keys=("SHOPIFY_ACCESS_TOKEN",),
+            secret_bindings=(_binding(binding_key="SHOPIFY_ACCESS_TOKEN"),),
+            secret_rules=(
+                RuntimeSecretSafetyRule(
+                    binding_key="SHOPIFY_ACCESS_TOKEN",
+                    secret_class="testing",
+                    allowed_contexts=("opw",),
+                    allowed_instances=("testing",),
+                ),
+            ),
+        )
+
+        self.assertEqual(evaluation.status, "pass")
+        self.assertEqual(evaluation.findings, ())
+        self.assertEqual(evaluation.checked_binding_keys, ("SHOPIFY_ACCESS_TOKEN",))
+
+    def test_unclassified_secret_fails_closed(self) -> None:
+        evaluation = evaluate_runtime_key_safety(
+            target=RuntimeKeySafetyTarget(
+                context="opw",
+                instance="testing",
+                environment_class="testing",
+            ),
+            required_binding_keys=("SHOPIFY_ACCESS_TOKEN",),
+            secret_bindings=(_binding(binding_key="SHOPIFY_ACCESS_TOKEN"),),
+            secret_rules=(),
+        )
+
+        self.assertEqual(evaluation.status, "fail")
+        self.assertEqual(evaluation.findings[0].code, "unclassified_binding")
+
+    def test_missing_or_disabled_secret_binding_fails_closed(self) -> None:
+        missing_evaluation = evaluate_runtime_key_safety(
+            target=RuntimeKeySafetyTarget(
+                context="opw",
+                instance="testing",
+                environment_class="testing",
+            ),
+            required_binding_keys=("SHOPIFY_ACCESS_TOKEN",),
+            secret_bindings=(),
+            secret_rules=(
+                RuntimeSecretSafetyRule(
+                    binding_key="SHOPIFY_ACCESS_TOKEN",
+                    secret_class="testing",
+                ),
+            ),
+        )
+        disabled_evaluation = evaluate_runtime_key_safety(
+            target=RuntimeKeySafetyTarget(
+                context="opw",
+                instance="testing",
+                environment_class="testing",
+            ),
+            required_binding_keys=("SHOPIFY_ACCESS_TOKEN",),
+            secret_bindings=(
+                _binding(
+                    binding_key="SHOPIFY_ACCESS_TOKEN",
+                    status="disabled",
+                ),
+            ),
+            secret_rules=(
+                RuntimeSecretSafetyRule(
+                    binding_key="SHOPIFY_ACCESS_TOKEN",
+                    secret_class="testing",
+                ),
+            ),
+        )
+
+        self.assertEqual(missing_evaluation.status, "fail")
+        self.assertEqual(missing_evaluation.findings[0].code, "binding_missing")
+        self.assertEqual(disabled_evaluation.status, "fail")
+        self.assertEqual(disabled_evaluation.findings[0].code, "binding_disabled")
+
+    def test_context_and_instance_restrictions_fail_closed(self) -> None:
+        evaluation = evaluate_runtime_key_safety(
+            target=RuntimeKeySafetyTarget(
+                context="opw",
+                instance="testing",
+                environment_class="testing",
+            ),
+            required_binding_keys=("SHOPIFY_ACCESS_TOKEN",),
+            secret_bindings=(_binding(binding_key="SHOPIFY_ACCESS_TOKEN"),),
+            secret_rules=(
+                RuntimeSecretSafetyRule(
+                    binding_key="SHOPIFY_ACCESS_TOKEN",
+                    secret_class="testing",
+                    allowed_contexts=("cm",),
+                    allowed_instances=("preview",),
+                ),
+            ),
+        )
+
+        self.assertEqual(evaluation.status, "fail")
+        self.assertEqual(
+            [finding.code for finding in evaluation.findings],
+            ["context_not_allowed", "instance_not_allowed"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a typed runtime key-safety policy contract for classified managed secret bindings
- add fail-closed evaluation for missing, disabled, ambiguous, unclassified, prod-only, and route-restricted bindings
- document the metadata-only runtime key-safety gate behavior

## Verification
- `uv run python -m unittest tests.test_runtime_key_safety`
- `uv run --extra dev ruff check control_plane/contracts/runtime_key_safety_policy.py control_plane/runtime_key_safety.py tests/test_runtime_key_safety.py --diff`
- `uv run --extra dev ruff check control_plane/contracts/runtime_key_safety_policy.py control_plane/runtime_key_safety.py tests/test_runtime_key_safety.py`
- `uv run --extra dev mypy control_plane/contracts/runtime_key_safety_policy.py control_plane/runtime_key_safety.py tests/test_runtime_key_safety.py`
- `git diff --check`

Refs #248