### PR TITLE
Add runtime key safety policy records

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -82,6 +82,13 @@ from control_plane.contracts.runtime_environment_record import (
     RuntimeEnvironmentRecord,
     ScalarValue,
 )
+from control_plane.contracts.runtime_key_safety_policy import (
+    RuntimeEnvironmentClass,
+    RuntimeKeySafetyPolicyRecord,
+    RuntimeKeySafetyPolicyStatus,
+    RuntimeKeySafetyTarget,
+    RuntimeSecretSafetyRule,
+)
 from control_plane.contracts.secret_record import SecretBinding, SecretScope
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.drivers.registry import build_driver_context_view
@@ -95,6 +102,10 @@ from control_plane.service import serve_launchplane_service
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.factory import build_record_store, resolve_database_url
 from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.runtime_key_safety import (
+    evaluate_runtime_key_safety_from_store,
+    latest_active_runtime_key_safety_policy,
+)
 from control_plane.service_auth import load_authz_policy
 from control_plane.tracked_target_logs import build_tracked_target_logs_payload
 from control_plane.workflows.launchplane import (
@@ -308,6 +319,52 @@ def _summarize_authz_policy_record(record: LaunchplaneAuthzPolicyRecord) -> dict
         "github_actions_rule_count": len(record.policy.github_actions),
         "github_humans_rule_count": len(record.policy.github_humans),
     }
+
+
+def _summarize_runtime_key_safety_policy_record(
+    record: RuntimeKeySafetyPolicyRecord,
+) -> dict[str, object]:
+    return {
+        "record_id": record.record_id,
+        "status": record.status,
+        "source": record.source,
+        "updated_at": record.updated_at,
+        "policy_sha256": record.policy_sha256,
+        "rule_count": len(record.rules),
+        "binding_keys": [rule.binding_key for rule in record.rules],
+    }
+
+
+def _build_runtime_key_safety_policy_record(
+    *,
+    policy_file: Path,
+    source_label: str,
+    status: RuntimeKeySafetyPolicyStatus = "active",
+) -> RuntimeKeySafetyPolicyRecord:
+    payload = _load_json_file(policy_file)
+    raw_rules = payload.get("rules")
+    if not isinstance(raw_rules, list):
+        raise click.ClickException("Runtime key-safety policy JSON requires a rules array.")
+    try:
+        rules = tuple(RuntimeSecretSafetyRule.model_validate(rule) for rule in raw_rules)
+        updated_at = str(payload.get("updated_at") or utc_now_timestamp())
+        source = str(payload.get("source") or source_label).strip() or source_label
+        record = RuntimeKeySafetyPolicyRecord(
+            record_id="runtime-key-safety-policy-pending",
+            status=status,
+            source=source,
+            updated_at=updated_at,
+            rules=rules,
+        )
+    except ValidationError as error:
+        raise click.ClickException(str(error)) from error
+    final_record = record.model_copy(
+        update={
+            "record_id": "runtime-key-safety-policy-"
+            f"{_launchplane_action_slug(updated_at)}-{record.policy_sha256[:12]}",
+        }
+    )
+    return RuntimeKeySafetyPolicyRecord.model_validate(final_record.model_dump(mode="json"))
 
 
 def _summarize_product_profile_record(record: LaunchplaneProductProfileRecord) -> dict[str, object]:
@@ -12094,6 +12151,11 @@ def authz_policies() -> None:
     """DB-backed Launchplane authorization policy commands."""
 
 
+@main.group("runtime-key-safety")
+def runtime_key_safety() -> None:
+    """DB-backed runtime key-safety policy and evaluation commands."""
+
+
 @main.group("product-profiles")
 def product_profiles() -> None:
     """DB-backed Launchplane product profile commands."""
@@ -12151,6 +12213,129 @@ def authz_policies_import_toml(database_url: str, policy_file: Path, source_labe
     click.echo(
         json.dumps(
             {"status": "ok", "record": _summarize_authz_policy_record(record)},
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+@runtime_key_safety.command("list-policies")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for runtime key-safety policy records.",
+)
+@click.option("--status", "status_filter", default="", help="Optional policy status filter.")
+def runtime_key_safety_list_policies(database_url: str, status_filter: str) -> None:
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    try:
+        records = postgres_store.list_runtime_key_safety_policy_records(status=status_filter)
+    finally:
+        postgres_store.close()
+    click.echo(
+        json.dumps(
+            {
+                "status": "ok",
+                "count": len(records),
+                "records": [
+                    _summarize_runtime_key_safety_policy_record(record) for record in records
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+@runtime_key_safety.command("import-policy")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for runtime key-safety policy records.",
+)
+@click.option(
+    "--policy-file",
+    type=click.Path(exists=True, path_type=Path),
+    required=True,
+    help="JSON policy file containing runtime key-safety rules.",
+)
+@click.option("--status", type=click.Choice(["active", "superseded"]), default="active")
+@click.option("--source-label", default="cli:import-policy", show_default=True)
+def runtime_key_safety_import_policy(
+    database_url: str,
+    policy_file: Path,
+    status: RuntimeKeySafetyPolicyStatus,
+    source_label: str,
+) -> None:
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    postgres_store.ensure_schema()
+    record = _build_runtime_key_safety_policy_record(
+        policy_file=policy_file,
+        source_label=source_label,
+        status=status,
+    )
+    try:
+        postgres_store.write_runtime_key_safety_policy_record(record)
+    finally:
+        postgres_store.close()
+    click.echo(
+        json.dumps(
+            {"status": "ok", "record": _summarize_runtime_key_safety_policy_record(record)},
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+@runtime_key_safety.command("evaluate")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for runtime key-safety policy records.",
+)
+@click.option("--context", "context_name", required=True)
+@click.option("--instance", "instance_name", required=True)
+@click.option(
+    "--environment-class",
+    "environment_class",
+    type=click.Choice(["prod", "testing", "preview", "dev", "unknown"]),
+    required=True,
+)
+@click.option("--binding-key", "binding_keys", multiple=True, required=True)
+def runtime_key_safety_evaluate(
+    database_url: str,
+    context_name: str,
+    instance_name: str,
+    environment_class: RuntimeEnvironmentClass,
+    binding_keys: tuple[str, ...],
+) -> None:
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    try:
+        policy_record = latest_active_runtime_key_safety_policy(postgres_store)
+        evaluation = evaluate_runtime_key_safety_from_store(
+            record_store=postgres_store,
+            policy_record=policy_record,
+            target=RuntimeKeySafetyTarget(
+                context=context_name,
+                instance=instance_name,
+                environment_class=environment_class,
+            ),
+            required_binding_keys=binding_keys,
+        )
+    except ValueError as error:
+        raise click.ClickException(str(error)) from error
+    finally:
+        postgres_store.close()
+    click.echo(
+        json.dumps(
+            {
+                "status": "ok",
+                "policy": _summarize_runtime_key_safety_policy_record(policy_record),
+                "evaluation": evaluation.model_dump(mode="json"),
+            },
             indent=2,
             sort_keys=True,
         )

--- a/control_plane/contracts/runtime_key_safety_policy.py
+++ b/control_plane/contracts/runtime_key_safety_policy.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -6,6 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 RuntimeEnvironmentClass = Literal["prod", "testing", "preview", "dev", "unknown"]
 RuntimeSecretClass = Literal["prod_only", "testing", "preview", "non_prod", "shared_safe"]
 RuntimeKeySafetyStatus = Literal["pass", "fail"]
+RuntimeKeySafetyPolicyStatus = Literal["active", "superseded"]
 RuntimeKeySafetyFindingCode = Literal[
     "ambiguous_binding",
     "binding_disabled",
@@ -61,6 +64,47 @@ class RuntimeSecretSafetyRule(BaseModel):
         )
         self.description = self.description.strip()
         return self
+
+
+class RuntimeKeySafetyPolicyRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    record_id: str
+    status: RuntimeKeySafetyPolicyStatus = "active"
+    source: str
+    updated_at: str
+    rules: tuple[RuntimeSecretSafetyRule, ...]
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "RuntimeKeySafetyPolicyRecord":
+        if not self.record_id.strip():
+            raise ValueError("runtime key safety policy record requires record_id")
+        if not self.source.strip():
+            raise ValueError("runtime key safety policy record requires source")
+        if not self.updated_at.strip():
+            raise ValueError("runtime key safety policy record requires updated_at")
+        if not self.rules:
+            raise ValueError("runtime key safety policy record requires at least one rule")
+        binding_keys: list[str] = []
+        for rule in self.rules:
+            if rule.binding_key in binding_keys:
+                raise ValueError("runtime key safety policy rules must be unique by binding_key")
+            binding_keys.append(rule.binding_key)
+        self.record_id = self.record_id.strip()
+        self.source = self.source.strip()
+        self.updated_at = self.updated_at.strip()
+        return self
+
+    @property
+    def policy_sha256(self) -> str:
+        return runtime_key_safety_policy_sha256(self)
+
+
+def runtime_key_safety_policy_sha256(record: RuntimeKeySafetyPolicyRecord) -> str:
+    payload = record.model_dump(mode="json", exclude={"record_id", "source", "updated_at"})
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 class RuntimeKeySafetyFinding(BaseModel):

--- a/control_plane/runtime_key_safety.py
+++ b/control_plane/runtime_key_safety.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import Protocol
 
 from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeEnvironmentClass,
     RuntimeKeySafetyEvaluation,
+    RuntimeKeySafetyPolicyRecord,
     RuntimeKeySafetyFinding,
     RuntimeKeySafetyTarget,
     RuntimeSecretClass,
@@ -20,6 +22,54 @@ ALLOWED_SECRET_CLASSES_BY_ENVIRONMENT: dict[RuntimeEnvironmentClass, set[Runtime
     "dev": {"non_prod", "shared_safe"},
     "unknown": set(),
 }
+
+
+class RuntimeKeySafetyPolicyReadStore(Protocol):
+    def list_runtime_key_safety_policy_records(
+        self,
+        *,
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[RuntimeKeySafetyPolicyRecord, ...]: ...
+
+    def list_secret_bindings(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[SecretBinding, ...]: ...
+
+
+def latest_active_runtime_key_safety_policy(
+    record_store: RuntimeKeySafetyPolicyReadStore,
+) -> RuntimeKeySafetyPolicyRecord:
+    records = record_store.list_runtime_key_safety_policy_records(status="active", limit=1)
+    if not records:
+        raise ValueError("No active runtime key-safety policy record found.")
+    return records[0]
+
+
+def evaluate_runtime_key_safety_from_store(
+    *,
+    record_store: RuntimeKeySafetyPolicyReadStore,
+    target: RuntimeKeySafetyTarget,
+    required_binding_keys: Iterable[str],
+    policy_record: RuntimeKeySafetyPolicyRecord | None = None,
+) -> RuntimeKeySafetyEvaluation:
+    policy = policy_record or latest_active_runtime_key_safety_policy(record_store)
+    return evaluate_runtime_key_safety(
+        target=target,
+        required_binding_keys=required_binding_keys,
+        secret_bindings=record_store.list_secret_bindings(
+            integration="runtime_environment",
+            context_name=target.context,
+            instance_name=target.instance,
+            limit=None,
+        ),
+        secret_rules=policy.rules,
+    )
 
 
 def evaluate_runtime_key_safety(

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -22,6 +22,7 @@ from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyPolicyRecord
 
 RecordModel = TypeVar("RecordModel", bound=BaseModel)
 
@@ -42,7 +43,9 @@ class FilesystemRecordStore:
         )
         return record_path
 
-    def _read_model(self, model_type: type[BaseModel], record_type: str, record_id: str) -> BaseModel:
+    def _read_model(
+        self, model_type: type[BaseModel], record_type: str, record_id: str
+    ) -> BaseModel:
         record_path = self._record_path(record_type, record_id)
         payload = json.loads(record_path.read_text(encoding="utf-8"))
         return model_type.model_validate(payload)
@@ -50,7 +53,9 @@ class FilesystemRecordStore:
     def _record_dir(self, record_type: str) -> Path:
         return self.state_dir / record_type
 
-    def _list_models(self, model_type: type[RecordModel], record_type: str) -> tuple[RecordModel, ...]:
+    def _list_models(
+        self, model_type: type[RecordModel], record_type: str
+    ) -> tuple[RecordModel, ...]:
         record_dir = self._record_dir(record_type)
         if not record_dir.exists():
             return ()
@@ -70,7 +75,9 @@ class FilesystemRecordStore:
 
     def read_artifact_manifest(self, artifact_id: str) -> ArtifactIdentityManifest:
         return ArtifactIdentityManifest.model_validate(
-            self._read_model(ArtifactIdentityManifest, "artifacts", artifact_id).model_dump(mode="json")
+            self._read_model(ArtifactIdentityManifest, "artifacts", artifact_id).model_dump(
+                mode="json"
+            )
         )
 
     def list_artifact_manifests(self) -> tuple[ArtifactIdentityManifest, ...]:
@@ -83,6 +90,30 @@ class FilesystemRecordStore:
 
     def write_authz_policy_record(self, record: LaunchplaneAuthzPolicyRecord) -> Path:
         return self._write_model("launchplane_authz_policies", record.record_id, record)
+
+    def write_runtime_key_safety_policy_record(self, record: RuntimeKeySafetyPolicyRecord) -> Path:
+        return self._write_model(
+            "launchplane_runtime_key_safety_policies", record.record_id, record
+        )
+
+    def list_runtime_key_safety_policy_records(
+        self,
+        *,
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[RuntimeKeySafetyPolicyRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                RuntimeKeySafetyPolicyRecord,
+                "launchplane_runtime_key_safety_policies",
+            )
+            if not status or record.status == status
+        ]
+        records.sort(key=lambda record: (record.updated_at, record.record_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
 
     def write_product_profile_record(self, record: LaunchplaneProductProfileRecord) -> Path:
         return self._write_model("launchplane_product_profiles", record.product, record)
@@ -127,7 +158,9 @@ class FilesystemRecordStore:
             records = records[:limit]
         return tuple(records)
 
-    def read_release_tuple_record(self, *, context_name: str, channel_name: str) -> ReleaseTupleRecord:
+    def read_release_tuple_record(
+        self, *, context_name: str, channel_name: str
+    ) -> ReleaseTupleRecord:
         return ReleaseTupleRecord.model_validate(
             self._read_model(
                 ReleaseTupleRecord,
@@ -178,7 +211,8 @@ class FilesystemRecordStore:
         records = [
             record
             for record in self._list_models(BackupGateRecord, "backup_gates")
-            if (not context_name or record.context == context_name) and (not instance_name or record.instance == instance_name)
+            if (not context_name or record.context == context_name)
+            and (not instance_name or record.instance == instance_name)
         ]
         records.sort(key=lambda record: (record.created_at, record.record_id), reverse=True)
         if limit is not None:
@@ -209,7 +243,10 @@ class FilesystemRecordStore:
             and (not to_instance_name or record.to_instance == to_instance_name)
         ]
         records.sort(
-            key=lambda record: (*self._record_sort_timestamp(record.deploy.finished_at, record.deploy.started_at), record.record_id),
+            key=lambda record: (
+                *self._record_sort_timestamp(record.deploy.finished_at, record.deploy.started_at),
+                record.record_id,
+            ),
             reverse=True,
         )
         if limit is not None:
@@ -234,10 +271,14 @@ class FilesystemRecordStore:
         records = [
             record
             for record in self._list_models(DeploymentRecord, "deployments")
-            if (not context_name or record.context == context_name) and (not instance_name or record.instance == instance_name)
+            if (not context_name or record.context == context_name)
+            and (not instance_name or record.instance == instance_name)
         ]
         records.sort(
-            key=lambda record: (*self._record_sort_timestamp(record.deploy.finished_at, record.deploy.started_at), record.record_id),
+            key=lambda record: (
+                *self._record_sort_timestamp(record.deploy.finished_at, record.deploy.started_at),
+                record.record_id,
+            ),
             reverse=True,
         )
         if limit is not None:
@@ -247,7 +288,9 @@ class FilesystemRecordStore:
     def write_environment_inventory(self, record: EnvironmentInventory) -> Path:
         return self._write_model("inventory", f"{record.context}-{record.instance}", record)
 
-    def read_environment_inventory(self, *, context_name: str, instance_name: str) -> EnvironmentInventory:
+    def read_environment_inventory(
+        self, *, context_name: str, instance_name: str
+    ) -> EnvironmentInventory:
         record_id = f"{context_name}-{instance_name}"
         return EnvironmentInventory.model_validate(
             self._read_model(EnvironmentInventory, "inventory", record_id).model_dump(mode="json")
@@ -257,12 +300,18 @@ class FilesystemRecordStore:
         return self._list_models(EnvironmentInventory, "inventory")
 
     def write_odoo_instance_override_record(self, record: OdooInstanceOverrideRecord) -> Path:
-        return self._write_model("odoo_instance_overrides", f"{record.context}-{record.instance}", record)
+        return self._write_model(
+            "odoo_instance_overrides", f"{record.context}-{record.instance}", record
+        )
 
-    def read_odoo_instance_override_record(self, *, context_name: str, instance_name: str) -> OdooInstanceOverrideRecord:
+    def read_odoo_instance_override_record(
+        self, *, context_name: str, instance_name: str
+    ) -> OdooInstanceOverrideRecord:
         record_id = f"{context_name}-{instance_name}"
         return OdooInstanceOverrideRecord.model_validate(
-            self._read_model(OdooInstanceOverrideRecord, "odoo_instance_overrides", record_id).model_dump(mode="json")
+            self._read_model(
+                OdooInstanceOverrideRecord, "odoo_instance_overrides", record_id
+            ).model_dump(mode="json")
         )
 
     def list_odoo_instance_override_records(self) -> tuple[OdooInstanceOverrideRecord, ...]:
@@ -275,7 +324,9 @@ class FilesystemRecordStore:
 
     def read_preview_record(self, preview_id: str) -> PreviewRecord:
         return PreviewRecord.model_validate(
-            self._read_model(PreviewRecord, "launchplane_previews", preview_id).model_dump(mode="json")
+            self._read_model(PreviewRecord, "launchplane_previews", preview_id).model_dump(
+                mode="json"
+            )
         )
 
     def list_preview_records(
@@ -303,9 +354,9 @@ class FilesystemRecordStore:
 
     def read_preview_enablement_record(self, record_id: str) -> PreviewEnablementRecord:
         return PreviewEnablementRecord.model_validate(
-            self._read_model(PreviewEnablementRecord, "launchplane_preview_enablement", record_id).model_dump(
-                mode="json"
-            )
+            self._read_model(
+                PreviewEnablementRecord, "launchplane_preview_enablement", record_id
+            ).model_dump(mode="json")
         )
 
     def list_preview_enablement_records(
@@ -318,7 +369,9 @@ class FilesystemRecordStore:
     ) -> tuple[PreviewEnablementRecord, ...]:
         records = [
             record
-            for record in self._list_models(PreviewEnablementRecord, "launchplane_preview_enablement")
+            for record in self._list_models(
+                PreviewEnablementRecord, "launchplane_preview_enablement"
+            )
             if (not context_name or record.context == context_name)
             and (not anchor_repo or record.anchor_repo == anchor_repo)
             and (not pr_state or record.pr_state == pr_state)
@@ -348,7 +401,9 @@ class FilesystemRecordStore:
     ) -> tuple[PreviewGenerationRecord, ...]:
         records = [
             record
-            for record in self._list_models(PreviewGenerationRecord, "launchplane_preview_generations")
+            for record in self._list_models(
+                PreviewGenerationRecord, "launchplane_preview_generations"
+            )
             if not preview_id or record.preview_id == preview_id
         ]
         records.sort(key=lambda record: (record.sequence, record.generation_id), reverse=True)
@@ -378,7 +433,9 @@ class FilesystemRecordStore:
         return tuple(records)
 
     def write_preview_desired_state_record(self, record: PreviewDesiredStateRecord) -> Path:
-        return self._write_model("launchplane_preview_desired_states", record.desired_state_id, record)
+        return self._write_model(
+            "launchplane_preview_desired_states", record.desired_state_id, record
+        )
 
     def list_preview_desired_state_records(
         self,
@@ -393,7 +450,9 @@ class FilesystemRecordStore:
             )
             if not context_name or record.context == context_name
         ]
-        records.sort(key=lambda record: (record.discovered_at, record.desired_state_id), reverse=True)
+        records.sort(
+            key=lambda record: (record.discovered_at, record.desired_state_id), reverse=True
+        )
         if limit is not None:
             records = records[:limit]
         return tuple(records)
@@ -419,10 +478,10 @@ class FilesystemRecordStore:
             records = records[:limit]
         return tuple(records)
 
-    def write_preview_lifecycle_cleanup_record(
-        self, record: PreviewLifecycleCleanupRecord
-    ) -> Path:
-        return self._write_model("launchplane_preview_lifecycle_cleanups", record.cleanup_id, record)
+    def write_preview_lifecycle_cleanup_record(self, record: PreviewLifecycleCleanupRecord) -> Path:
+        return self._write_model(
+            "launchplane_preview_lifecycle_cleanups", record.cleanup_id, record
+        )
 
     def list_preview_lifecycle_cleanup_records(
         self,

--- a/control_plane/storage/migrations/versions/f1a3c5e7b9d0_add_runtime_key_safety_policies.py
+++ b/control_plane/storage/migrations/versions/f1a3c5e7b9d0_add_runtime_key_safety_policies.py
@@ -1,0 +1,48 @@
+"""add runtime key safety policies
+
+Revision ID: f1a3c5e7b9d0
+Revises: c0d2e4f6a8b1
+Create Date: 2026-05-05 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "f1a3c5e7b9d0"
+down_revision: str | None = "c0d2e4f6a8b1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "launchplane_runtime_key_safety_policies",
+        sa.Column("record_id", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("source", sa.String(), nullable=False),
+        sa.Column("updated_at", sa.String(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("record_id"),
+    )
+    op.create_index(
+        "launchplane_runtime_key_safety_policies_updated_idx",
+        "launchplane_runtime_key_safety_policies",
+        [sa.text("updated_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "launchplane_runtime_key_safety_policies_updated_idx",
+        table_name="launchplane_runtime_key_safety_policies",
+    )
+    op.drop_table("launchplane_runtime_key_safety_policies")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -45,6 +45,7 @@ from control_plane.contracts.runtime_environment_record import (
     RuntimeEnvironmentDeleteEvent,
     RuntimeEnvironmentRecord,
 )
+from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyPolicyRecord
 from control_plane.contracts.secret_record import (
     SecretAuditEvent,
     SecretBinding,
@@ -337,6 +338,19 @@ class LaunchplaneAuthzPolicyRow(Base):
     source: Mapped[str] = mapped_column(String, nullable=False)
     updated_at: Mapped[str] = mapped_column(String, nullable=False)
     policy_sha256: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneRuntimeKeySafetyPolicyRow(Base):
+    __tablename__ = "launchplane_runtime_key_safety_policies"
+    __table_args__ = (
+        Index("launchplane_runtime_key_safety_policies_updated_idx", desc("updated_at")),
+    )
+
+    record_id: Mapped[str] = mapped_column(String, primary_key=True)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    source: Mapped[str] = mapped_column(String, nullable=False)
+    updated_at: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -1594,6 +1608,37 @@ class PostgresRecordStore(HumanSessionStore):
             ),
         )
 
+    def write_runtime_key_safety_policy_record(self, record: RuntimeKeySafetyPolicyRecord) -> None:
+        self._write_row(
+            LaunchplaneRuntimeKeySafetyPolicyRow(
+                record_id=record.record_id,
+                status=record.status,
+                source=record.source,
+                updated_at=record.updated_at,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def list_runtime_key_safety_policy_records(
+        self,
+        *,
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[RuntimeKeySafetyPolicyRecord, ...]:
+        filters: list[object] = []
+        if status:
+            filters.append(LaunchplaneRuntimeKeySafetyPolicyRow.status == status)
+        return self._list_models(
+            model_type=RuntimeKeySafetyPolicyRecord,
+            orm_model=LaunchplaneRuntimeKeySafetyPolicyRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneRuntimeKeySafetyPolicyRow.updated_at.desc(),
+                LaunchplaneRuntimeKeySafetyPolicyRow.record_id.desc(),
+            ),
+            limit=limit,
+        )
+
     def read_lane_summary(self, *, context_name: str, instance_name: str) -> LaunchplaneLaneSummary:
         runtime_environment_records = (
             *self.list_runtime_environment_records(scope="global"),
@@ -1903,6 +1948,7 @@ class PostgresRecordStore(HumanSessionStore):
             "preview_lifecycle_plans": 0,
             "preview_pr_feedback": 0,
             "release_tuples": 0,
+            "runtime_key_safety_policies": 0,
         }
         for artifact_manifest in filesystem_store.list_artifact_manifests():
             self.write_artifact_manifest(artifact_manifest)
@@ -1910,6 +1956,9 @@ class PostgresRecordStore(HumanSessionStore):
         for authz_policy_record in filesystem_store.list_authz_policy_records():
             self.write_authz_policy_record(authz_policy_record)
             counts["authz_policies"] += 1
+        for policy_record in filesystem_store.list_runtime_key_safety_policy_records():
+            self.write_runtime_key_safety_policy_record(policy_record)
+            counts["runtime_key_safety_policies"] += 1
         for backup_gate_record in filesystem_store.list_backup_gate_records():
             self.write_backup_gate_record(backup_gate_record)
             counts["backup_gates"] += 1

--- a/docs/records.md
+++ b/docs/records.md
@@ -404,6 +404,19 @@ state/
   environment key for each managed secret binding, and the driver asserts those
   keys before invoking Odoo.
 
+## Runtime Key-Safety Policy Record
+
+- One record per imported runtime key-safety policy version under
+  `launchplane_runtime_key_safety_policies`.
+- Store policy metadata, status, source, timestamp, and binding-key
+  classifications only. Do not store secret plaintext, ciphertext, provider env
+  dumps, token prefixes, or operator-local overrides in these records.
+- Active policy records are the Launchplane-owned authority for deciding whether
+  a managed secret binding may be used by a target runtime class. Evaluation
+  fails closed when no active policy record exists or when a required binding is
+  missing, disabled, ambiguous, unclassified, or outside the allowed
+  context/instance.
+
 ## Launchplane Preview Record
 
 - One file per stable Launchplane preview identity.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -61,6 +61,15 @@ title: Secrets
 - Gate output may include binding keys, binding ids, secret ids,
   classifications, and finding codes. It must not include secret plaintext,
   ciphertext, provider env dumps, or token prefixes.
+- Runtime key-safety policy records live in
+  `launchplane_runtime_key_safety_policies`. Operators import JSON policy
+  records with `launchplane runtime-key-safety import-policy`, inspect active
+  records with `launchplane runtime-key-safety list-policies`, and run a
+  metadata-only check with `launchplane runtime-key-safety evaluate` before a
+  workflow mutates runtime keys.
+- Evaluation reads only Launchplane managed secret bindings for the requested
+  context and instance. If no active policy record exists, the gate fails closed
+  instead of falling back to service-host env or product-local scripts.
 
 ## Bootstrap-Only Env
 

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -32,6 +32,10 @@ from control_plane.contracts.promotion_record import (
     PromotionRecord,
 )
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+from control_plane.contracts.runtime_key_safety_policy import (
+    RuntimeKeySafetyPolicyRecord,
+    RuntimeSecretSafetyRule,
+)
 from control_plane.storage.filesystem import FilesystemRecordStore
 
 
@@ -94,7 +98,52 @@ class FilesystemRecordStoreTests(unittest.TestCase):
 
         self.assertEqual(loaded_record.driver_id, "generic-web")
         self.assertEqual(loaded_record.preview.context, "sellyouroutboard-testing")
-        self.assertEqual([listed_record.product for listed_record in listed_records], ["sellyouroutboard"])
+        self.assertEqual(
+            [listed_record.product for listed_record in listed_records], ["sellyouroutboard"]
+        )
+
+    def test_write_and_list_runtime_key_safety_policy_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            older_record = RuntimeKeySafetyPolicyRecord(
+                record_id="runtime-key-safety-policy-20260505T190000Z-old",
+                status="superseded",
+                source="test",
+                updated_at="2026-05-05T19:00:00Z",
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key="SHOPIFY_ACCESS_TOKEN",
+                        secret_class="testing",
+                    ),
+                ),
+            )
+            active_record = RuntimeKeySafetyPolicyRecord(
+                record_id="runtime-key-safety-policy-20260505T200000Z-active",
+                status="active",
+                source="test",
+                updated_at="2026-05-05T20:00:00Z",
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key="SHOPIFY_ACCESS_TOKEN",
+                        secret_class="testing",
+                        allowed_contexts=("opw",),
+                        allowed_instances=("testing",),
+                    ),
+                ),
+            )
+
+            store.write_runtime_key_safety_policy_record(older_record)
+            written_path = store.write_runtime_key_safety_policy_record(active_record)
+            listed_records = store.list_runtime_key_safety_policy_records(status="active")
+
+        self.assertEqual(
+            written_path.relative_to(state_dir).as_posix(),
+            "launchplane_runtime_key_safety_policies/"
+            "runtime-key-safety-policy-20260505T200000Z-active.json",
+        )
+        self.assertEqual([record.record_id for record in listed_records], [active_record.record_id])
+        self.assertEqual(listed_records[0].rules[0].allowed_contexts, ("opw",))
 
     def test_write_and_read_artifact_manifest(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -250,12 +299,17 @@ class FilesystemRecordStoreTests(unittest.TestCase):
                 )
             )
 
-            listed_records = store.list_backup_gate_records(context_name="opw", instance_name="prod", limit=2)
+            listed_records = store.list_backup_gate_records(
+                context_name="opw", instance_name="prod", limit=2
+            )
 
-            self.assertEqual([record.record_id for record in listed_records], [
-                "backup-opw-prod-20260411T182231Z",
-                "backup-opw-prod-20260410T182231Z",
-            ])
+            self.assertEqual(
+                [record.record_id for record in listed_records],
+                [
+                    "backup-opw-prod-20260411T182231Z",
+                    "backup-opw-prod-20260410T182231Z",
+                ],
+            )
 
     def test_write_and_read_promotion_record(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -344,8 +398,12 @@ class FilesystemRecordStoreTests(unittest.TestCase):
                     context="opw",
                     from_instance="testing",
                     to_instance="prod",
-                    deploy=DeploymentEvidence(target_name="opw-prod", target_type="compose",
-                                              deploy_mode="dokploy-compose-api", started_at="2026-04-13T18:22:31Z"),
+                    deploy=DeploymentEvidence(
+                        target_name="opw-prod",
+                        target_type="compose",
+                        deploy_mode="dokploy-compose-api",
+                        started_at="2026-04-13T18:22:31Z",
+                    ),
                 )
             )
 
@@ -356,10 +414,13 @@ class FilesystemRecordStoreTests(unittest.TestCase):
                 limit=2,
             )
 
-            self.assertEqual([record.record_id for record in listed_records], [
-                "promotion-20260413T182231Z-opw-testing-to-prod",
-                "promotion-20260411T182231Z-opw-testing-to-prod",
-            ])
+            self.assertEqual(
+                [record.record_id for record in listed_records],
+                [
+                    "promotion-20260413T182231Z-opw-testing-to-prod",
+                    "promotion-20260411T182231Z-opw-testing-to-prod",
+                ],
+            )
 
     def test_write_and_read_deployment_record(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -455,17 +516,26 @@ class FilesystemRecordStoreTests(unittest.TestCase):
                     context="opw",
                     instance="prod",
                     source_git_ref="jkl012",
-                    deploy=DeploymentEvidence(target_name="opw-prod", target_type="compose",
-                                              deploy_mode="dokploy-compose-api", started_at="2026-04-13T18:22:31Z"),
+                    deploy=DeploymentEvidence(
+                        target_name="opw-prod",
+                        target_type="compose",
+                        deploy_mode="dokploy-compose-api",
+                        started_at="2026-04-13T18:22:31Z",
+                    ),
                 )
             )
 
-            listed_records = store.list_deployment_records(context_name="opw", instance_name="prod", limit=2)
+            listed_records = store.list_deployment_records(
+                context_name="opw", instance_name="prod", limit=2
+            )
 
-            self.assertEqual([record.record_id for record in listed_records], [
-                "deployment-20260413T182231Z-opw-prod",
-                "deployment-20260411T182231Z-opw-prod",
-            ])
+            self.assertEqual(
+                [record.record_id for record in listed_records],
+                [
+                    "deployment-20260413T182231Z-opw-prod",
+                    "deployment-20260411T182231Z-opw-prod",
+                ],
+            )
 
     def test_artifacts_ingest_writes_manifest(self) -> None:
         runner = CliRunner()
@@ -479,9 +549,7 @@ class FilesystemRecordStoreTests(unittest.TestCase):
                     source_commit="f45db648",
                     enterprise_base_digest="sha256:enterprise123",
                     addon_sources=(
-                        ArtifactAddonSource(
-                            repository="cbusillo/disable_odoo_online", ref="main"
-                        ),
+                        ArtifactAddonSource(repository="cbusillo/disable_odoo_online", ref="main"),
                     ),
                     image=ArtifactImageReference(
                         repository="ghcr.io/cbusillo/odoo-private",
@@ -584,13 +652,17 @@ class FilesystemRecordStoreTests(unittest.TestCase):
             )
 
             written_path = store.write_environment_inventory(record)
-            loaded_record = store.read_environment_inventory(context_name="opw", instance_name="prod")
+            loaded_record = store.read_environment_inventory(
+                context_name="opw", instance_name="prod"
+            )
             listed_records = store.list_environment_inventory()
 
             self.assertTrue(written_path.exists())
             self.assertEqual(loaded_record.context, "opw")
             self.assertEqual(loaded_record.instance, "prod")
-            self.assertEqual(loaded_record.promotion_record_id, "promotion-20260410T182231Z-opw-testing-to-prod")
+            self.assertEqual(
+                loaded_record.promotion_record_id, "promotion-20260410T182231Z-opw-testing-to-prod"
+            )
             self.assertEqual(len(listed_records), 1)
 
     def test_write_and_read_odoo_instance_override_record(self) -> None:
@@ -603,7 +675,9 @@ class FilesystemRecordStoreTests(unittest.TestCase):
                 config_parameters=(
                     OdooConfigParameterOverride(
                         key="web.base.url",
-                        value=OdooOverrideValue(source="literal", value="https://opw-prod.example.com"),
+                        value=OdooOverrideValue(
+                            source="literal", value="https://opw-prod.example.com"
+                        ),
                     ),
                 ),
                 addon_settings=(
@@ -621,9 +695,19 @@ class FilesystemRecordStoreTests(unittest.TestCase):
             )
 
             written_path = store.write_odoo_instance_override_record(record)
-            loaded_record = store.read_odoo_instance_override_record(context_name="opw", instance_name="prod")
+            loaded_record = store.read_odoo_instance_override_record(
+                context_name="opw", instance_name="prod"
+            )
             listed_records = store.list_odoo_instance_override_records()
 
-            self.assertEqual(written_path.relative_to(state_dir).as_posix(), "odoo_instance_overrides/opw-prod.json")
-            self.assertEqual(loaded_record.addon_settings[0].value.secret_binding_id, "secret-binding-shopify-token")
-            self.assertEqual([(record.context, record.instance) for record in listed_records], [("opw", "prod")])
+            self.assertEqual(
+                written_path.relative_to(state_dir).as_posix(),
+                "odoo_instance_overrides/opw-prod.json",
+            )
+            self.assertEqual(
+                loaded_record.addon_settings[0].value.secret_binding_id,
+                "secret-binding-shopify-token",
+            )
+            self.assertEqual(
+                [(record.context, record.instance) for record in listed_records], [("opw", "prod")]
+            )

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -58,6 +58,10 @@ from control_plane.contracts.runtime_environment_record import (
     RuntimeEnvironmentRecord,
     RuntimeEnvironmentScope,
 )
+from control_plane.contracts.runtime_key_safety_policy import (
+    RuntimeKeySafetyPolicyRecord,
+    RuntimeSecretSafetyRule,
+)
 from control_plane.contracts.secret_record import (
     SecretAuditEvent,
     SecretBinding,
@@ -76,7 +80,9 @@ def _sqlite_database_url(database_path: Path) -> str:
     return f"sqlite+pysqlite:///{database_path}"
 
 
-def _product_profile_record(*, product: str = "sellyouroutboard") -> LaunchplaneProductProfileRecord:
+def _product_profile_record(
+    *, product: str = "sellyouroutboard"
+) -> LaunchplaneProductProfileRecord:
     return LaunchplaneProductProfileRecord(
         product=product,
         display_name="SellYourOutboard.com",
@@ -802,8 +808,134 @@ class PostgresRecordStoreTests(unittest.TestCase):
             store.close()
 
         self.assertEqual(len(listed_records), 1)
-        self.assertEqual(listed_records[0].record_id, "launchplane-authz-policy-20260420T100500Z-test")
-        self.assertEqual(listed_records[0].policy.github_actions[0].repository, "cbusillo/launchplane")
+        self.assertEqual(
+            listed_records[0].record_id, "launchplane-authz-policy-20260420T100500Z-test"
+        )
+        self.assertEqual(
+            listed_records[0].policy.github_actions[0].repository, "cbusillo/launchplane"
+        )
+
+    def test_runtime_key_safety_policy_records_round_trip(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_runtime_key_safety_policy_record(
+                RuntimeKeySafetyPolicyRecord(
+                    record_id="runtime-key-safety-policy-20260505T200000Z-test",
+                    status="active",
+                    source="test",
+                    updated_at="2026-05-05T20:00:00Z",
+                    rules=(
+                        RuntimeSecretSafetyRule(
+                            binding_key="SHOPIFY_ACCESS_TOKEN",
+                            secret_class="testing",
+                            allowed_contexts=("opw",),
+                            allowed_instances=("testing",),
+                        ),
+                    ),
+                )
+            )
+            listed_records = store.list_runtime_key_safety_policy_records(status="active", limit=1)
+            store.close()
+
+        self.assertEqual(len(listed_records), 1)
+        self.assertEqual(
+            listed_records[0].record_id,
+            "runtime-key-safety-policy-20260505T200000Z-test",
+        )
+        self.assertEqual(listed_records[0].rules[0].secret_class, "testing")
+
+    def test_runtime_key_safety_cli_imports_lists_and_evaluates_policy(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            policy_file = Path(temporary_directory_name) / "runtime-key-safety.json"
+            policy_file.write_text(
+                json.dumps(
+                    {
+                        "updated_at": "2026-05-05T20:00:00Z",
+                        "rules": [
+                            {
+                                "binding_key": "SHOPIFY_ACCESS_TOKEN",
+                                "secret_class": "testing",
+                                "allowed_contexts": ["opw"],
+                                "allowed_instances": ["testing"],
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_secret_binding(
+                SecretBinding(
+                    binding_id="binding-shopify-token",
+                    secret_id="secret-shopify-token",
+                    integration="runtime_environment",
+                    binding_key="SHOPIFY_ACCESS_TOKEN",
+                    context="opw",
+                    instance="testing",
+                    created_at="2026-05-05T20:00:00Z",
+                    updated_at="2026-05-05T20:00:00Z",
+                )
+            )
+            store.close()
+            runner = CliRunner()
+
+            import_result = runner.invoke(
+                main,
+                [
+                    "runtime-key-safety",
+                    "import-policy",
+                    "--database-url",
+                    database_url,
+                    "--policy-file",
+                    str(policy_file),
+                    "--source-label",
+                    "test",
+                ],
+            )
+            list_result = runner.invoke(
+                main,
+                [
+                    "runtime-key-safety",
+                    "list-policies",
+                    "--database-url",
+                    database_url,
+                    "--status",
+                    "active",
+                ],
+            )
+            evaluate_result = runner.invoke(
+                main,
+                [
+                    "runtime-key-safety",
+                    "evaluate",
+                    "--database-url",
+                    database_url,
+                    "--context",
+                    "opw",
+                    "--instance",
+                    "testing",
+                    "--environment-class",
+                    "testing",
+                    "--binding-key",
+                    "SHOPIFY_ACCESS_TOKEN",
+                ],
+            )
+
+        self.assertEqual(import_result.exit_code, 0, import_result.output)
+        self.assertIn('"rule_count": 1', import_result.output)
+        self.assertEqual(list_result.exit_code, 0, list_result.output)
+        self.assertIn('"count": 1', list_result.output)
+        self.assertEqual(evaluate_result.exit_code, 0, evaluate_result.output)
+        self.assertIn('"status": "pass"', evaluate_result.output)
 
     def test_product_profile_records_round_trip(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -822,11 +954,15 @@ class PostgresRecordStoreTests(unittest.TestCase):
         self.assertEqual(loaded_record.driver_id, "generic-web")
         self.assertEqual(loaded_record.image.repository, "ghcr.io/cbusillo/sellyouroutboard")
         self.assertEqual(loaded_record.preview.context, "sellyouroutboard-testing")
-        self.assertEqual([record.product for record in listed_records], ["internal-tool", "sellyouroutboard"])
+        self.assertEqual(
+            [record.product for record in listed_records], ["internal-tool", "sellyouroutboard"]
+        )
 
     def test_product_profiles_cli_upserts_lists_and_shows_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
-            database_url = _sqlite_database_url(Path(temporary_directory_name) / "launchplane.sqlite3")
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
             lanes_json = json.dumps(
                 [
                     {
@@ -1193,17 +1329,13 @@ class PostgresRecordStoreTests(unittest.TestCase):
         assert inventory is not None
         inventory_artifact_identity = inventory.artifact_identity
         assert inventory_artifact_identity is not None
-        self.assertEqual(
-            inventory_artifact_identity.artifact_id, "artifact-20260420-a1b2c3d4"
-        )
+        self.assertEqual(inventory_artifact_identity.artifact_id, "artifact-20260420-a1b2c3d4")
         release_tuple = summary.release_tuple
         assert release_tuple is not None
         self.assertEqual(release_tuple.channel, "testing")
         latest_deployment = summary.latest_deployment
         assert latest_deployment is not None
-        self.assertEqual(
-            latest_deployment.record_id, "deployment-20260420T153000Z-opw-testing"
-        )
+        self.assertEqual(latest_deployment.record_id, "deployment-20260420T153000Z-opw-testing")
         self.assertIsNone(summary.latest_promotion)
         self.assertIsNone(summary.latest_backup_gate)
         dokploy_target_id = summary.dokploy_target_id
@@ -1451,6 +1583,20 @@ class PostgresRecordStoreTests(unittest.TestCase):
             )
             filesystem_store.write_release_tuple_record(_release_tuple_record())
             filesystem_store.write_product_profile_record(_product_profile_record())
+            filesystem_store.write_runtime_key_safety_policy_record(
+                RuntimeKeySafetyPolicyRecord(
+                    record_id="runtime-key-safety-policy-20260505T200000Z-test",
+                    status="active",
+                    source="test",
+                    updated_at="2026-05-05T20:00:00Z",
+                    rules=(
+                        RuntimeSecretSafetyRule(
+                            binding_key="SHOPIFY_ACCESS_TOKEN",
+                            secret_class="testing",
+                        ),
+                    ),
+                )
+            )
 
             counts = store.import_core_records_from_filesystem(filesystem_store)
             self.assertEqual(
@@ -1472,6 +1618,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     "preview_lifecycle_plans": 1,
                     "preview_pr_feedback": 1,
                     "release_tuples": 1,
+                    "runtime_key_safety_policies": 1,
                 },
             )
             self.assertEqual(
@@ -1520,5 +1667,11 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     limit=1,
                 )[0].feedback_id,
                 "preview-pr-feedback-verireel-testing-pr-123-20260420T100800Z",
+            )
+            self.assertEqual(
+                store.list_runtime_key_safety_policy_records(status="active", limit=1)[0]
+                .rules[0]
+                .binding_key,
+                "SHOPIFY_ACCESS_TOKEN",
             )
             store.close()

--- a/tests/test_runtime_key_safety.py
+++ b/tests/test_runtime_key_safety.py
@@ -1,12 +1,58 @@
 import unittest
 
 from control_plane.contracts.runtime_key_safety_policy import (
+    RuntimeKeySafetyPolicyRecord,
     RuntimeKeySafetyTarget,
     RuntimeSecretSafetyRule,
 )
 from control_plane.contracts.secret_record import SecretBinding
 from control_plane.contracts.secret_record import SecretStatus
-from control_plane.runtime_key_safety import evaluate_runtime_key_safety
+from control_plane.runtime_key_safety import (
+    evaluate_runtime_key_safety,
+    evaluate_runtime_key_safety_from_store,
+    latest_active_runtime_key_safety_policy,
+)
+
+
+class _FakeRuntimeKeySafetyStore:
+    def __init__(
+        self,
+        *,
+        policies: tuple[RuntimeKeySafetyPolicyRecord, ...],
+        bindings: tuple[SecretBinding, ...],
+    ) -> None:
+        self.policies = policies
+        self.bindings = bindings
+        self.requested_context = ""
+        self.requested_instance = ""
+
+    def list_runtime_key_safety_policy_records(
+        self,
+        *,
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[RuntimeKeySafetyPolicyRecord, ...]:
+        records = tuple(record for record in self.policies if not status or record.status == status)
+        return records[:limit] if limit is not None else records
+
+    def list_secret_bindings(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[SecretBinding, ...]:
+        self.requested_context = context_name
+        self.requested_instance = instance_name
+        records = tuple(
+            binding
+            for binding in self.bindings
+            if (not integration or binding.integration == integration)
+            and (not context_name or binding.context == context_name)
+            and (not instance_name or binding.instance == instance_name)
+        )
+        return records[:limit] if limit is not None else records
 
 
 def _binding(
@@ -158,6 +204,93 @@ class RuntimeKeySafetyTests(unittest.TestCase):
             [finding.code for finding in evaluation.findings],
             ["context_not_allowed", "instance_not_allowed"],
         )
+
+    def test_policy_record_rejects_duplicate_binding_keys(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unique by binding_key"):
+            RuntimeKeySafetyPolicyRecord(
+                record_id="runtime-key-safety-policy-test",
+                source="test",
+                updated_at="2026-05-05T20:00:00Z",
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key="SHOPIFY_ACCESS_TOKEN",
+                        secret_class="testing",
+                    ),
+                    RuntimeSecretSafetyRule(
+                        binding_key="SHOPIFY_ACCESS_TOKEN",
+                        secret_class="preview",
+                    ),
+                ),
+            )
+
+    def test_policy_sha256_ignores_record_metadata(self) -> None:
+        first_record = RuntimeKeySafetyPolicyRecord(
+            record_id="runtime-key-safety-policy-first",
+            source="test:first",
+            updated_at="2026-05-05T20:00:00Z",
+            rules=(
+                RuntimeSecretSafetyRule(
+                    binding_key="SHOPIFY_ACCESS_TOKEN",
+                    secret_class="testing",
+                ),
+            ),
+        )
+        second_record = first_record.model_copy(
+            update={
+                "record_id": "runtime-key-safety-policy-second",
+                "source": "test:second",
+                "updated_at": "2026-05-05T21:00:00Z",
+            }
+        )
+
+        self.assertEqual(first_record.policy_sha256, second_record.policy_sha256)
+
+    def test_evaluate_from_store_uses_latest_active_policy_and_target_bindings(self) -> None:
+        policy = RuntimeKeySafetyPolicyRecord(
+            record_id="runtime-key-safety-policy-20260505T200000Z-test",
+            status="active",
+            source="test",
+            updated_at="2026-05-05T20:00:00Z",
+            rules=(
+                RuntimeSecretSafetyRule(
+                    binding_key="SHOPIFY_ACCESS_TOKEN",
+                    secret_class="testing",
+                    allowed_contexts=("opw",),
+                    allowed_instances=("testing",),
+                ),
+            ),
+        )
+        store = _FakeRuntimeKeySafetyStore(
+            policies=(policy,),
+            bindings=(
+                _binding(binding_key="SHOPIFY_ACCESS_TOKEN"),
+                _binding(
+                    binding_key="SHOPIFY_ACCESS_TOKEN",
+                    binding_id="binding-other-token",
+                    secret_id="secret-other-token",
+                ).model_copy(update={"context": "other", "instance": "testing"}),
+            ),
+        )
+
+        evaluation = evaluate_runtime_key_safety_from_store(
+            record_store=store,
+            target=RuntimeKeySafetyTarget(
+                context="opw",
+                instance="testing",
+                environment_class="testing",
+            ),
+            required_binding_keys=("SHOPIFY_ACCESS_TOKEN",),
+        )
+
+        self.assertEqual(evaluation.status, "pass")
+        self.assertEqual(store.requested_context, "opw")
+        self.assertEqual(store.requested_instance, "testing")
+
+    def test_missing_active_policy_fails_closed(self) -> None:
+        store = _FakeRuntimeKeySafetyStore(policies=(), bindings=())
+
+        with self.assertRaisesRegex(ValueError, "No active runtime key-safety policy"):
+            latest_active_runtime_key_safety_policy(store)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add DB/file-backed runtime key-safety policy records and Alembic migration
- add runtime-key-safety CLI import/list/evaluate commands that use managed secret binding metadata only
- document the runtime key-safety policy record contract

Refs #248

## Verification
- uv run python -m unittest tests.test_runtime_key_safety tests.test_filesystem_store tests.test_postgres_store
- uv run --extra dev ruff check control_plane/cli.py control_plane/contracts/runtime_key_safety_policy.py control_plane/runtime_key_safety.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/f1a3c5e7b9d0_add_runtime_key_safety_policies.py tests/test_filesystem_store.py tests/test_postgres_store.py tests/test_runtime_key_safety.py
- uv run --extra dev ruff format --check control_plane/cli.py control_plane/contracts/runtime_key_safety_policy.py control_plane/runtime_key_safety.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/f1a3c5e7b9d0_add_runtime_key_safety_policies.py tests/test_filesystem_store.py tests/test_postgres_store.py tests/test_runtime_key_safety.py
- uv run --extra dev mypy control_plane/cli.py control_plane/contracts/runtime_key_safety_policy.py control_plane/runtime_key_safety.py control_plane/storage/filesystem.py control_plane/storage/postgres.py tests/test_filesystem_store.py tests/test_postgres_store.py tests/test_runtime_key_safety.py