### PR TITLE
Enforce runtime key safety for product config secrets

### DIFF
--- a/control_plane/product_config.py
+++ b/control_plane/product_config.py
@@ -10,7 +10,17 @@ from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentScope
 from control_plane.contracts.runtime_environment_record import ScalarValue
+from control_plane.contracts.runtime_key_safety_policy import (
+    RuntimeEnvironmentClass,
+    RuntimeKeySafetyPolicyRecord,
+    RuntimeKeySafetyTarget,
+)
+from control_plane.contracts.secret_record import SecretBinding
 from control_plane.contracts.secret_record import SecretScope
+from control_plane.runtime_key_safety import (
+    evaluate_runtime_key_safety,
+    latest_active_runtime_key_safety_policy,
+)
 from control_plane.workflows.ship import utc_now_timestamp
 
 
@@ -26,6 +36,13 @@ class ProductConfigStore(control_plane_secrets.SecretWriteStore, Protocol):
     ) -> tuple[RuntimeEnvironmentRecord, ...]: ...
 
     def write_runtime_environment_record(self, record: RuntimeEnvironmentRecord) -> None: ...
+
+    def list_runtime_key_safety_policy_records(
+        self,
+        *,
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[RuntimeKeySafetyPolicyRecord, ...]: ...
 
 
 class ProductConfigError(ValueError):
@@ -124,6 +141,12 @@ def apply_product_config_bundle(
         source_label=source_label,
     )
     secret_summaries: list[dict[str, object]] = []
+    runtime_key_safety_summary = _evaluate_product_config_runtime_key_safety(
+        record_store=record_store,
+        context_name=context_name,
+        instance_name=instance_name,
+        secrets=secrets,
+    )
     apply_changes = mode == "apply"
     for secret in secrets:
         planned_action, existing_secret_id = _product_config_secret_current_action(
@@ -178,6 +201,7 @@ def apply_product_config_bundle(
         "actor": actor,
         "source_label": source_label,
         "runtime_environment": runtime_summary,
+        "runtime_key_safety": runtime_key_safety_summary,
         "secrets": secret_summaries,
         "summary": {
             "runtime_changed_key_count": len(
@@ -426,6 +450,126 @@ def _product_config_secret_current_action(
     ):
         return "unchanged", existing_record.secret_id
     return "rotated", existing_record.secret_id
+
+
+def _evaluate_product_config_runtime_key_safety(
+    *,
+    record_store: ProductConfigStore,
+    context_name: str,
+    instance_name: str,
+    secrets: tuple[dict[str, object], ...],
+) -> dict[str, object]:
+    runtime_secrets = tuple(
+        secret
+        for secret in secrets
+        if secret["integration"] == control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION
+    )
+    if not runtime_secrets:
+        return {"required": False, "status": "skipped", "checked_binding_keys": []}
+    try:
+        policy_record = latest_active_runtime_key_safety_policy(record_store)
+    except ValueError as error:
+        raise ProductConfigError(
+            "Product config runtime key-safety policy is unavailable.",
+            code="runtime_key_safety_unavailable",
+        ) from error
+    target = RuntimeKeySafetyTarget(
+        context=context_name,
+        instance=instance_name,
+        environment_class=_product_config_runtime_environment_class(instance_name),
+    )
+    evaluation = evaluate_runtime_key_safety(
+        target=target,
+        required_binding_keys=(str(secret["binding_key"]) for secret in runtime_secrets),
+        secret_bindings=_planned_runtime_secret_bindings(
+            record_store=record_store,
+            secrets=runtime_secrets,
+        ),
+        secret_rules=policy_record.rules,
+    )
+    summary: dict[str, object] = {
+        "required": True,
+        "status": evaluation.status,
+        "policy_record_id": policy_record.record_id,
+        "policy_sha256": policy_record.policy_sha256,
+        "target": evaluation.target.model_dump(mode="json"),
+        "checked_binding_keys": list(evaluation.checked_binding_keys),
+        "findings": [finding.model_dump(mode="json") for finding in evaluation.findings],
+    }
+    if evaluation.status != "pass":
+        raise ProductConfigError(
+            "Product config runtime key-safety gate failed.",
+            code="runtime_key_safety_failed",
+        )
+    return summary
+
+
+def _planned_runtime_secret_bindings(
+    *,
+    record_store: ProductConfigStore,
+    secrets: tuple[dict[str, object], ...],
+) -> tuple[SecretBinding, ...]:
+    existing_bindings = {
+        binding.binding_id: binding
+        for binding in record_store.list_secret_bindings(
+            integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+            limit=None,
+        )
+    }
+    planned_bindings: list[SecretBinding] = []
+    for secret in secrets:
+        existing_record = record_store.find_secret_record(
+            scope=str(secret["scope"]),
+            integration=str(secret["integration"]),
+            name=str(secret["name"]),
+            context=str(secret["context"]),
+            instance=str(secret["instance"]),
+        )
+        secret_id = (
+            existing_record.secret_id
+            if existing_record is not None
+            else control_plane_secrets.expected_secret_id(
+                integration=str(secret["integration"]),
+                name=str(secret["name"]),
+                context=str(secret["context"]),
+                instance=str(secret["instance"]),
+            )
+        )
+        binding_id = control_plane_secrets.expected_secret_binding_id(
+            secret_id=secret_id,
+            binding_key=str(secret["binding_key"]),
+        )
+        existing_binding = existing_bindings.get(binding_id)
+        now = utc_now_timestamp()
+        planned_bindings.append(
+            SecretBinding(
+                binding_id=binding_id,
+                secret_id=secret_id,
+                integration=str(secret["integration"]),
+                binding_key=str(secret["binding_key"]),
+                context=str(secret["context"]),
+                instance=str(secret["instance"]),
+                status="configured",
+                created_at=existing_binding.created_at if existing_binding is not None else now,
+                updated_at=now,
+            )
+        )
+    return tuple(planned_bindings)
+
+
+def _product_config_runtime_environment_class(
+    instance_name: str,
+) -> RuntimeEnvironmentClass:
+    normalized_instance = instance_name.strip().lower()
+    if normalized_instance in {"prod", "production"}:
+        return "prod"
+    if normalized_instance in {"testing", "test", "staging", "stage"}:
+        return "testing"
+    if normalized_instance in {"preview", "pr"} or normalized_instance.startswith("pr-"):
+        return "preview"
+    if normalized_instance in {"dev", "local", "development"}:
+        return "dev"
+    return "unknown"
 
 
 def _summarize_product_config_secret_input(

--- a/control_plane/secrets.py
+++ b/control_plane/secrets.py
@@ -360,6 +360,12 @@ def expected_secret_binding_id(*, secret_id: str, binding_key: str) -> str:
     return _binding_id(secret_id=secret_id, binding_key=binding_key)
 
 
+def expected_secret_id(
+    *, integration: str, name: str, context: str = "", instance: str = ""
+) -> str:
+    return _secret_id(integration=integration, name=name, context=context, instance=instance)
+
+
 def relabel_secret_binding(
     *,
     record_store: SecretWriteStore,

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -4020,6 +4020,11 @@ def create_launchplane_service_app(
                         error_message = (
                             "Launchplane service is missing required secret write configuration."
                         )
+                    if error_code == "runtime_key_safety_unavailable":
+                        status_code = 503
+                        error_message = "Launchplane runtime key-safety policy is unavailable."
+                    if error_code == "runtime_key_safety_failed":
+                        error_message = "Product config runtime key-safety gate failed."
                     return _json_response(
                         start_response=start_response,
                         status_code=status_code,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -401,15 +401,17 @@ Current derived-state behavior:
   `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`. Runtime and secret scopes default from
   the top-level `context`/`instance`; nested `runtime_env` and secret routes must
   match that top-level target. Dry-run validates secret scope/route
-  compatibility before reporting a plan, so apply does not discover invalid
-  secret scopes after writing earlier secrets.
+  compatibility and runtime key-safety policy before reporting a plan, so apply
+  does not discover invalid secret scopes or disallowed runtime secret bindings
+  after writing earlier secrets.
 - `POST /v1/product-config/apply` exposes the same planner/writer through the
   authenticated service API for operator UI use. Submit `mode: "dry-run"` to
   preview with `product_config.plan`, then `mode: "apply"` with
   `product_config.apply` after review. The service response is redacted and the
   route rejects nested runtime or secret targets that differ from the authorized
   top-level context/instance. It fails closed when secret writes are requested
-  without the Launchplane master encryption key in the service runtime.
+  without the Launchplane master encryption key in the service runtime or when
+  no active runtime key-safety policy allows the requested binding.
 - The operator UI uses the same service route. It requires a successful dry-run
   result before enabling apply, clears rendered secret input values after each
   submit, and shows only key/action/count metadata from Launchplane responses.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -119,7 +119,9 @@ title: Secrets
   from a trusted Launchplane context with current `LAUNCHPLANE_DATABASE_URL` and,
   when secrets are present, `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`. Dry-run and
   apply both reject invalid secret scopes or scope/context/instance mismatches
-  before any managed secret write starts.
+  before any managed secret write starts. Runtime-environment secret bundles
+  also require an active runtime key-safety policy that allows each requested
+  binding for the target runtime class.
 - `uv run launchplane environments unset --scope <scope> --key KEY` removes
   stale keys from DB-backed runtime-environment records without reading or
   printing plaintext values.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -343,9 +343,10 @@ It reuses the same planner/writer as `launchplane product-config apply`, returns
 only actions, keys, counts, actor/source metadata, and secret IDs, uses generic
 validation messages for rejected requests, and fails closed when a secret bundle
 is submitted without `LAUNCHPLANE_MASTER_ENCRYPTION_KEY` in the trusted
-Launchplane runtime. Request bodies for this route must not be copied into logs,
-issues, docs, or workflow artifacts because they can contain plaintext secret
-values.
+Launchplane runtime or without an active runtime key-safety policy that allows
+the requested managed secret binding for the target runtime class. Request
+bodies for this route must not be copied into logs, issues, docs, or workflow
+artifacts because they can contain plaintext secret values.
 
 Product onboarding uses `POST /v1/product-onboarding/apply`. The route accepts
 the same operator-approved manifest as `launchplane product-onboarding apply`

--- a/tests/test_runtime_environments.py
+++ b/tests/test_runtime_environments.py
@@ -20,6 +20,11 @@ from control_plane.contracts.runtime_environment_record import (
     RuntimeEnvironmentDeleteEvent,
     RuntimeEnvironmentRecord,
 )
+from control_plane.contracts.runtime_key_safety_policy import (
+    RuntimeSecretClass,
+    RuntimeKeySafetyPolicyRecord,
+    RuntimeSecretSafetyRule,
+)
 from control_plane.contracts.secret_record import SecretAuditEvent
 from control_plane.contracts.secret_record import SecretBinding
 from control_plane.contracts.secret_record import SecretRecord
@@ -81,6 +86,37 @@ def _seed_dokploy_target_records(*, database_url: str, payload: str) -> None:
         store.close()
 
 
+def _write_runtime_key_safety_policy(
+    *,
+    database_url: str,
+    binding_key: str = "SMTP_PASSWORD",
+    secret_class: RuntimeSecretClass = "prod_only",
+    context_name: str = "sellyouroutboard",
+    instance_name: str = "prod",
+) -> None:
+    store = PostgresRecordStore(database_url=database_url)
+    store.ensure_schema()
+    try:
+        store.write_runtime_key_safety_policy_record(
+            RuntimeKeySafetyPolicyRecord(
+                record_id=f"runtime-key-safety-policy-{binding_key.lower().replace('_', '-')}",
+                status="active",
+                source="test",
+                updated_at="2026-05-05T20:00:00Z",
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key=binding_key,
+                        secret_class=secret_class,
+                        allowed_contexts=(context_name,),
+                        allowed_instances=(instance_name,),
+                    ),
+                ),
+            )
+        )
+    finally:
+        store.close()
+
+
 class _FakeProductConfigStore:
     def __init__(self) -> None:
         self.runtime_environment_records: dict[tuple[str, str, str], RuntimeEnvironmentRecord] = {}
@@ -88,6 +124,22 @@ class _FakeProductConfigStore:
         self.secret_versions: dict[str, SecretVersion] = {}
         self.secret_bindings: dict[str, SecretBinding] = {}
         self.secret_audit_events: list[SecretAuditEvent] = []
+        self.runtime_key_safety_policy_records: tuple[RuntimeKeySafetyPolicyRecord, ...] = (
+            RuntimeKeySafetyPolicyRecord(
+                record_id="runtime-key-safety-policy-test",
+                status="active",
+                source="test",
+                updated_at="2026-05-05T20:00:00Z",
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key="SMTP_PASSWORD",
+                        secret_class="prod_only",
+                        allowed_contexts=("sellyouroutboard",),
+                        allowed_instances=("prod",),
+                    ),
+                ),
+            ),
+        )
 
     def list_runtime_environment_records(
         self, *, context_name: str = "", instance_name: str = ""
@@ -182,6 +234,19 @@ class _FakeProductConfigStore:
     def list_secret_audit_events(self, *, secret_id: str) -> tuple[SecretAuditEvent, ...]:
         return tuple(event for event in self.secret_audit_events if event.secret_id == secret_id)
 
+    def list_runtime_key_safety_policy_records(
+        self,
+        *,
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[RuntimeKeySafetyPolicyRecord, ...]:
+        records = tuple(
+            record
+            for record in self.runtime_key_safety_policy_records
+            if not status or record.status == status
+        )
+        return records[:limit] if limit is not None else records
+
 
 class _FakeRuntimeEnvironmentStore:
     def __init__(self, records: tuple[RuntimeEnvironmentRecord, ...]) -> None:
@@ -243,6 +308,7 @@ class RuntimeEnvironmentTests(unittest.TestCase):
         )
 
         self.assertIsNone(definition)
+
     def test_product_config_apply_uses_structural_store_boundary(self) -> None:
         store = _FakeProductConfigStore()
 
@@ -1411,6 +1477,7 @@ ODOO_DB_PASSWORD = "file-secret"
             control_plane_root = Path(temporary_directory_name)
             database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
             input_file = control_plane_root / "product-config.json"
+            _write_runtime_key_safety_policy(database_url=database_url)
             input_file.write_text(
                 json.dumps(
                     {
@@ -1476,6 +1543,7 @@ ODOO_DB_PASSWORD = "file-secret"
             control_plane_root = Path(temporary_directory_name)
             database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
             input_file = control_plane_root / "product-config.json"
+            _write_runtime_key_safety_policy(database_url=database_url)
             input_file.write_text(
                 json.dumps(
                     {
@@ -1592,6 +1660,99 @@ ODOO_DB_PASSWORD = "file-secret"
                 self.assertEqual(store.list_runtime_environment_records(), ())
             finally:
                 store.close()
+
+    def test_product_config_apply_requires_active_runtime_key_safety_policy(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            input_file = control_plane_root / "product-config.json"
+            input_file.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "context": "sellyouroutboard",
+                        "instance": "prod",
+                        "runtime_env": {},
+                        "secrets": [
+                            {
+                                "name": "smtp-password",
+                                "binding_key": "SMTP_PASSWORD",
+                                "value": "smtp-secret-value",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_MASTER_ENCRYPTION_KEY": "test-master-key"},
+                clear=True,
+            ):
+                result = CliRunner().invoke(
+                    main,
+                    [
+                        "product-config",
+                        "apply",
+                        "--database-url",
+                        database_url,
+                        "--input-file",
+                        str(input_file),
+                        "--dry-run",
+                    ],
+                )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("runtime key-safety policy is unavailable", result.output)
+
+    def test_product_config_apply_rejects_disallowed_runtime_key_secret_class(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            _write_runtime_key_safety_policy(database_url=database_url, secret_class="testing")
+            input_file = control_plane_root / "product-config.json"
+            input_file.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "context": "sellyouroutboard",
+                        "instance": "prod",
+                        "runtime_env": {},
+                        "secrets": [
+                            {
+                                "name": "smtp-password",
+                                "binding_key": "SMTP_PASSWORD",
+                                "value": "smtp-secret-value",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_MASTER_ENCRYPTION_KEY": "test-master-key"},
+                clear=True,
+            ):
+                result = CliRunner().invoke(
+                    main,
+                    [
+                        "product-config",
+                        "apply",
+                        "--database-url",
+                        database_url,
+                        "--input-file",
+                        str(input_file),
+                        "--dry-run",
+                    ],
+                )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("runtime key-safety gate failed", result.output)
 
     def test_product_config_apply_rejects_secret_route_that_differs_from_top_level(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -44,6 +44,10 @@ from control_plane.contracts.promotion_record import (
     PromotionRecord,
 )
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
+from control_plane.contracts.runtime_key_safety_policy import (
+    RuntimeKeySafetyPolicyRecord,
+    RuntimeSecretSafetyRule,
+)
 from control_plane.service import create_launchplane_service_app
 from control_plane.service_auth import (
     GitHubActionsIdentity,
@@ -297,6 +301,32 @@ def _generic_site_profile_payload(product: str = "example-site") -> dict[str, ob
 
 def _sqlite_database_url(database_path: Path) -> str:
     return f"sqlite+pysqlite:///{database_path}"
+
+
+def _write_runtime_key_safety_policy(
+    *, database_url: str, context_name: str = "sellyouroutboard-prod", instance_name: str = "prod"
+) -> None:
+    store = PostgresRecordStore(database_url=database_url)
+    store.ensure_schema()
+    try:
+        store.write_runtime_key_safety_policy_record(
+            RuntimeKeySafetyPolicyRecord(
+                record_id="runtime-key-safety-policy-service-test",
+                status="active",
+                source="test",
+                updated_at="2026-05-05T20:00:00Z",
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key="SMTP_PASSWORD",
+                        secret_class="prod_only",
+                        allowed_contexts=(context_name,),
+                        allowed_instances=(instance_name,),
+                    ),
+                ),
+            )
+        )
+    finally:
+        store.close()
 
 
 def _seed_tracked_target_records(
@@ -2079,6 +2109,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 control_plane_root_path=root,
                 database_url=database_url,
             )
+            _write_runtime_key_safety_policy(database_url=database_url)
 
             with patch.dict(
                 os.environ,
@@ -2137,6 +2168,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 control_plane_root_path=root,
                 database_url=database_url,
             )
+            _write_runtime_key_safety_policy(database_url=database_url)
             request_payload = {**_product_config_payload(), "mode": "apply"}
 
             with patch.dict(
@@ -2229,6 +2261,54 @@ class LaunchplaneServiceTests(unittest.TestCase):
             "Launchplane service is missing required secret write configuration.",
         )
         self.assertNotIn("LAUNCHPLANE_MASTER_ENCRYPTION_KEY", json.dumps(payload))
+
+    def test_product_config_api_requires_runtime_key_safety_policy(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-prod"],
+                            "actions": ["product_config.plan"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            with patch.dict(
+                os.environ,
+                {control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"},
+                clear=True,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/product-config/apply",
+                    payload=_product_config_payload(),
+                    headers={"Idempotency-Key": "product-config-missing-key-policy"},
+                )
+
+        self.assertEqual(status_code, 503)
+        self.assertEqual(payload["error"]["code"], "runtime_key_safety_unavailable")
+        self.assertEqual(
+            payload["error"]["message"],
+            "Launchplane runtime key-safety policy is unavailable.",
+        )
 
     def test_product_config_api_rejects_secret_shaped_runtime_key(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- gate product-config runtime managed-secret bundles on the active runtime key-safety policy before dry-run/apply planning completes
- return sanitized service errors for missing policy and denied key-safety evaluations
- document the fail-closed runtime key-safety requirement for CLI and service product-config writes

Refs #248

## Verification
- uv run python -m unittest tests.test_runtime_environments tests.test_service
- uv run --extra dev ruff check control_plane/product_config.py control_plane/secrets.py control_plane/service.py tests/test_runtime_environments.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/product_config.py control_plane/secrets.py control_plane/service.py tests/test_runtime_environments.py tests/test_service.py
- uv run --extra dev mypy control_plane/product_config.py control_plane/secrets.py control_plane/service.py tests/test_runtime_environments.py tests/test_service.py