### PR TITLE
Gate live target runtime sync on key safety

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -7879,6 +7879,7 @@ def _evaluate_runtime_key_safety_for_live_target_sync(
     record_store: RuntimeKeySafetyPolicyReadStore,
     context_name: str,
     instance_name: str,
+    require_policy: bool = True,
 ) -> dict[str, object]:
     bindings = record_store.list_secret_bindings(
         integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
@@ -7902,6 +7903,12 @@ def _evaluate_runtime_key_safety_for_live_target_sync(
             required_binding_keys=binding_keys,
         )
     except ValueError as error:
+        if not require_policy:
+            return {
+                "required": True,
+                "status": "unavailable",
+                "checked_binding_keys": list(binding_keys),
+            }
         raise click.ClickException(
             "Runtime key-safety policy is unavailable for live target runtime sync."
         ) from error
@@ -7987,6 +7994,7 @@ def _apply_live_target_runtime_environment(
                     record_store=postgres_store,
                     context_name=context_name,
                     instance_name=instance_name,
+                    require_policy=apply_changes,
                 )
             finally:
                 postgres_store.close()

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -103,6 +103,7 @@ from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.factory import build_record_store, resolve_database_url
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.runtime_key_safety import (
+    RuntimeKeySafetyPolicyReadStore,
     evaluate_runtime_key_safety_from_store,
     latest_active_runtime_key_safety_policy,
 )
@@ -7860,6 +7861,70 @@ def _runtime_env_live_target_delta(
     }
 
 
+def _runtime_key_safety_environment_class(instance_name: str) -> RuntimeEnvironmentClass:
+    normalized_instance = instance_name.strip().lower()
+    if normalized_instance in {"prod", "production"}:
+        return "prod"
+    if normalized_instance in {"testing", "test", "staging", "stage"}:
+        return "testing"
+    if normalized_instance in {"preview", "pr"} or normalized_instance.startswith("pr-"):
+        return "preview"
+    if normalized_instance in {"dev", "local", "development"}:
+        return "dev"
+    return "unknown"
+
+
+def _evaluate_runtime_key_safety_for_live_target_sync(
+    *,
+    record_store: RuntimeKeySafetyPolicyReadStore,
+    context_name: str,
+    instance_name: str,
+) -> dict[str, object]:
+    bindings = record_store.list_secret_bindings(
+        integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+        context_name=context_name,
+        instance_name=instance_name,
+        limit=None,
+    )
+    binding_keys = tuple(binding.binding_key for binding in bindings)
+    if not binding_keys:
+        return {"required": False, "status": "skipped", "checked_binding_keys": []}
+    try:
+        policy_record = latest_active_runtime_key_safety_policy(record_store)
+        evaluation = evaluate_runtime_key_safety_from_store(
+            record_store=record_store,
+            policy_record=policy_record,
+            target=RuntimeKeySafetyTarget(
+                context=context_name,
+                instance=instance_name,
+                environment_class=_runtime_key_safety_environment_class(instance_name),
+            ),
+            required_binding_keys=binding_keys,
+        )
+    except ValueError as error:
+        raise click.ClickException(
+            "Runtime key-safety policy is unavailable for live target runtime sync."
+        ) from error
+    summary: dict[str, object] = {
+        "required": True,
+        "status": evaluation.status,
+        "policy_record_id": policy_record.record_id,
+        "policy_sha256": policy_record.policy_sha256,
+        "target": evaluation.target.model_dump(mode="json"),
+        "checked_binding_keys": list(evaluation.checked_binding_keys),
+        "findings": [finding.model_dump(mode="json") for finding in evaluation.findings],
+    }
+    if evaluation.status != "pass":
+        finding_codes = sorted({finding.code for finding in evaluation.findings})
+        suffix = f": {', '.join(finding_codes)}" if finding_codes else ""
+        raise click.ClickException(f"Runtime key-safety gate failed for live target sync{suffix}.")
+    return summary
+
+
+def _skipped_runtime_key_safety_summary() -> dict[str, object]:
+    return {"required": False, "status": "skipped", "checked_binding_keys": []}
+
+
 def _apply_live_target_runtime_environment(
     *,
     context_name: str,
@@ -7905,11 +7970,26 @@ def _apply_live_target_runtime_environment(
     )
     changed_keys = initial_delta["changed_keys"]
     changed_key_count = len(changed_keys) if isinstance(changed_keys, list) else 0
+    runtime_key_safety = _skipped_runtime_key_safety_summary()
     deploy_result: dict[str, str] | None = None
     verification: dict[str, object] = {
         "status": "skipped",
         "reason": "dry_run" if not apply_changes else "no_runtime_env_changes",
     }
+
+    if not apply_changes or changed_key_count or deploy:
+        database_url = resolve_database_url(None)
+        if database_url is not None:
+            postgres_store = PostgresRecordStore(database_url=database_url)
+            postgres_store.ensure_schema()
+            try:
+                runtime_key_safety = _evaluate_runtime_key_safety_for_live_target_sync(
+                    record_store=postgres_store,
+                    context_name=context_name,
+                    instance_name=instance_name,
+                )
+            finally:
+                postgres_store.close()
 
     if apply_changes and changed_key_count:
         refreshed_payload = control_plane_dokploy.fetch_dokploy_target_payload(
@@ -7980,6 +8060,7 @@ def _apply_live_target_runtime_environment(
             "target_name": target_definition.target_name,
         },
         "runtime_environment": initial_delta,
+        "runtime_key_safety": runtime_key_safety,
         "apply": {
             "applied": apply_changes,
             "env_updated": bool(apply_changes and changed_key_count),
@@ -8016,6 +8097,19 @@ def _sync_artifact_image_reference_for_target(
             instance_name=instance_name,
         )
     )
+    database_url = resolve_database_url(None)
+    runtime_key_safety = _skipped_runtime_key_safety_summary()
+    if database_url is not None:
+        postgres_store = PostgresRecordStore(database_url=database_url)
+        postgres_store.ensure_schema()
+        try:
+            runtime_key_safety = _evaluate_runtime_key_safety_for_live_target_sync(
+                record_store=postgres_store,
+                context_name=context_name,
+                instance_name=instance_name,
+            )
+        finally:
+            postgres_store.close()
     desired_env_map = dict(env_map)
     desired_env_map.update(runtime_environment_values)
 
@@ -8053,6 +8147,13 @@ def _sync_artifact_image_reference_for_target(
             runtime_environment_values=runtime_environment_values,
             changed=desired_env_map != env_map,
         )
+    )
+    runtime_source_evidence["runtime_key_safety_status"] = str(runtime_key_safety["status"])
+    runtime_source_evidence["runtime_key_safety_required"] = (
+        "true" if runtime_key_safety["required"] else "false"
+    )
+    runtime_source_evidence["runtime_key_safety_policy_sha256"] = str(
+        runtime_key_safety.get("policy_sha256", "")
     )
     if desired_env_map != env_map:
         control_plane_dokploy.update_dokploy_target_env(

--- a/docs/dokploy-service-deployments.md
+++ b/docs/dokploy-service-deployments.md
@@ -107,6 +107,9 @@ Non-secret runtime settings belong in Launchplane runtime-environment records.
 Secret settings belong in Launchplane managed secret records and bindings. A
 product workflow may pass the product key, source ref, run URL, and immutable
 image reference; it should not pass secret values or render a Dokploy env file.
+Launchplane live-target runtime sync evaluates runtime key-safety policy for
+managed runtime secret bindings before updating Dokploy environment variables,
+and records only key-safety status and policy hash evidence.
 
 Dokploy-owned persistent volumes are allowed for service state, but the volume
 mapping is provider target configuration, not product-repo lifecycle state.

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 import click
 from click.testing import CliRunner
 
+from control_plane import secrets as control_plane_secrets
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane.cli import (
@@ -35,6 +36,12 @@ from control_plane.contracts.promotion_record import (
     ReleaseStatus,
 )
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
+from control_plane.contracts.runtime_key_safety_policy import (
+    RuntimeKeySafetyPolicyRecord,
+    RuntimeSecretClass,
+    RuntimeSecretSafetyRule,
+)
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.ship import build_deployment_record
@@ -175,6 +182,60 @@ def _write_runtime_environments_file(repo_root: Path, payload: str) -> Path:
     finally:
         store.close()
     return runtime_environments_file
+
+
+def _write_runtime_secret_and_safety_policy(
+    repo_root: Path,
+    *,
+    context: str,
+    instance: str,
+    binding_key: str = "SMTP_PASSWORD",
+    secret_class: RuntimeSecretClass = "testing",
+) -> None:
+    store = PostgresRecordStore(database_url=_runtime_environments_database_url(repo_root))
+    store.ensure_schema()
+    try:
+        with patch.dict(os.environ, {"LAUNCHPLANE_MASTER_ENCRYPTION_KEY": "test-master-key"}):
+            control_plane_secrets.write_secret_value(
+                record_store=store,
+                scope="context_instance",
+                integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+                name=binding_key.lower().replace("_", "-"),
+                plaintext_value="managed-secret-value",
+                binding_key=binding_key,
+                context_name=context,
+                instance_name=instance,
+                actor="test",
+                source_label="test",
+            )
+        store.write_runtime_environment_record(
+            RuntimeEnvironmentRecord(
+                scope="instance",
+                context=context,
+                instance=instance,
+                env={"ODOO_ADDONS_PATH": "/odoo/addons,/opt/project/addons,/opt/project/addons/shared"},
+                updated_at="2026-05-05T21:00:00Z",
+                source_label="test",
+            )
+        )
+        store.write_runtime_key_safety_policy_record(
+            RuntimeKeySafetyPolicyRecord(
+                record_id="runtime-key-safety-policy-promote-test",
+                status="active",
+                source="test",
+                updated_at="2026-05-05T21:00:00Z",
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key=binding_key,
+                        secret_class=secret_class,
+                        allowed_contexts=(context,),
+                        allowed_instances=(instance,),
+                    ),
+                ),
+            )
+        )
+    finally:
+        store.close()
 
 
 def _runtime_environments_database_url(repo_root: Path) -> str:
@@ -436,44 +497,109 @@ class ArtifactImageOverrideTests(unittest.TestCase):
             "ODOO_ADDONS_PATH=/odoo/addons,/opt/project/addons"
         )
 
-        with patch(
-            "control_plane.dokploy.read_dokploy_config",
-            return_value=("https://dokploy.example.com", "token-123"),
-        ), patch(
-            "control_plane.runtime_environments.resolve_runtime_environment_values",
-            return_value={"ODOO_ADDONS_PATH": "/odoo/addons,/opt/project/addons,/opt/project/addons/shared"},
-        ), patch(
-            "control_plane.dokploy.fetch_dokploy_target_payload",
-            side_effect=[
-                {"env": stale_env},
-                {
-                    "env": (
-                        "DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/odoo-private@sha256:image456\n"
-                        "ODOO_ADDONS_PATH=/odoo/addons,/opt/project/addons,/opt/project/addons/shared"
-                    )
-                },
-            ],
-        ), patch(
-            "control_plane.dokploy.sync_dokploy_compose_raw_source",
-            return_value={"source_type": "raw", "compose_sha256": "abc123"},
-        ), patch(
-            "control_plane.dokploy.update_dokploy_target_env",
-            side_effect=lambda **kwargs: captured_update.update(kwargs),
-        ):
-            runtime_source = _sync_artifact_image_reference_for_target(
-                context_name="cm",
-                instance_name="testing",
-                artifact_manifest=artifact_manifest,
-                resolved_target=resolved_target,
+        with TemporaryDirectory() as temporary_directory_name:
+            repo_root = Path(temporary_directory_name)
+            database_url = _runtime_environments_database_url(repo_root)
+            _write_runtime_secret_and_safety_policy(
+                repo_root,
+                context="cm",
+                instance="testing",
             )
+            with patch(
+                "control_plane.dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example.com", "token-123"),
+            ), patch(
+                "control_plane.dokploy.fetch_dokploy_target_payload",
+                side_effect=[
+                    {"env": stale_env},
+                    {
+                        "env": (
+                            "DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/odoo-private@sha256:image456\n"
+                            "ODOO_ADDONS_PATH=/odoo/addons,/opt/project/addons,/opt/project/addons/shared\n"
+                            "SMTP_PASSWORD=managed-secret-value"
+                        )
+                    },
+                ],
+            ), patch(
+                "control_plane.dokploy.sync_dokploy_compose_raw_source",
+                return_value={"source_type": "raw", "compose_sha256": "abc123"},
+            ), patch(
+                "control_plane.dokploy.update_dokploy_target_env",
+                side_effect=lambda **kwargs: captured_update.update(kwargs),
+            ), patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_DATABASE_URL": database_url,
+                    "LAUNCHPLANE_MASTER_ENCRYPTION_KEY": "test-master-key",
+                },
+                clear=True,
+            ):
+                runtime_source = _sync_artifact_image_reference_for_target(
+                    context_name="cm",
+                    instance_name="testing",
+                    artifact_manifest=artifact_manifest,
+                    resolved_target=resolved_target,
+                )
 
         self.assertIn(
             "ODOO_ADDONS_PATH=/odoo/addons,/opt/project/addons,/opt/project/addons/shared",
             str(captured_update["env_text"]),
         )
+        self.assertIn("SMTP_PASSWORD=managed-secret-value", str(captured_update["env_text"]))
         self.assertEqual(runtime_source["runtime_env_source"], "launchplane-db")
         self.assertEqual(runtime_source["runtime_env_changed"], "true")
+        self.assertEqual(runtime_source["runtime_key_safety_required"], "true")
+        self.assertEqual(runtime_source["runtime_key_safety_status"], "pass")
         self.assertEqual(runtime_source["runtime_env_verified"], "true")
+
+    def test_sync_artifact_image_reference_blocks_unsafe_runtime_secret_binding(self) -> None:
+        resolved_target = ResolvedTargetEvidence(target_type="compose", target_id="compose-123", target_name="cm-prod")
+        artifact_manifest = ArtifactIdentityManifest.model_validate(
+            {
+                "artifact_id": "artifact-sha256-image456",
+                "source_commit": "abc1234",
+                "enterprise_base_digest": "sha256:enterprise123",
+                "image": {
+                    "repository": "ghcr.io/cbusillo/odoo-private",
+                    "digest": "sha256:image456",
+                    "tags": ["sha-abc123"],
+                },
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            repo_root = Path(temporary_directory_name)
+            database_url = _runtime_environments_database_url(repo_root)
+            _write_runtime_secret_and_safety_policy(
+                repo_root,
+                context="cm",
+                instance="prod",
+                secret_class="testing",
+            )
+            with patch(
+                "control_plane.dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example.com", "token-123"),
+            ), patch(
+                "control_plane.runtime_environments.resolve_runtime_environment_values",
+                return_value={"SMTP_PASSWORD": "managed-secret-value"},
+            ), patch(
+                "control_plane.dokploy.fetch_dokploy_target_payload",
+                return_value={"env": "DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/odoo-private@sha256:old"},
+            ), patch(
+                "control_plane.dokploy.update_dokploy_target_env"
+            ) as update_target_env, patch.dict(
+                os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True
+            ):
+                with self.assertRaises(click.ClickException) as error_context:
+                    _sync_artifact_image_reference_for_target(
+                        context_name="cm",
+                        instance_name="prod",
+                        artifact_manifest=artifact_manifest,
+                        resolved_target=resolved_target,
+                    )
+
+        self.assertIn("Runtime key-safety gate failed", str(error_context.exception))
+        self.assertIn("secret_class_not_allowed", str(error_context.exception))
+        update_target_env.assert_not_called()
 
     def test_sync_artifact_image_reference_rejects_legacy_monorepo_target_source(self) -> None:
         resolved_target = ResolvedTargetEvidence(target_type="compose", target_id="compose-123", target_name="opw-testing")


### PR DESCRIPTION
## Summary
- evaluate runtime key-safety metadata for managed runtime secret bindings before live Dokploy runtime env sync writes or deploys
- include runtime key-safety status/policy hash in runtime source evidence without exposing plaintext values
- add promotion sync tests for allowed managed runtime secrets and blocked unsafe prod bindings

Refs #248

## Verification
- uv run python -m unittest tests.test_promote
- uv run --extra dev ruff check control_plane/cli.py tests/test_promote.py
- uv run --extra dev mypy control_plane/cli.py tests/test_promote.py

Note: `uv run --extra dev ruff format --check tests/test_promote.py` still wants to reformat pre-existing broad style in that module, so this PR avoids unrelated formatting churn.