### PR TITLE
Gate VeriReel preview runtime secrets

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -5174,6 +5174,9 @@ def create_launchplane_service_app(
                     return idempotent_response
                 driver_result = execute_verireel_preview_refresh(
                     control_plane_root=resolved_root,
+                    record_store=record_store
+                    if isinstance(record_store, PostgresRecordStore)
+                    else None,
                     request=verireel_preview_refresh_request.refresh,
                 )
                 result = _apply_verireel_preview_refresh_records(

--- a/control_plane/workflows/verireel_preview_driver.py
+++ b/control_plane/workflows/verireel_preview_driver.py
@@ -16,7 +16,14 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import runtime_environments as control_plane_runtime_environments
+from control_plane import secrets as control_plane_secrets
 from control_plane.dokploy import JsonObject
+from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyTarget
+from control_plane.runtime_key_safety import (
+    RuntimeKeySafetyPolicyReadStore,
+    evaluate_runtime_key_safety,
+    latest_active_runtime_key_safety_policy,
+)
 from control_plane.workflows.ship import utc_now_timestamp
 
 
@@ -24,6 +31,7 @@ DEFAULT_PREVIEW_TIMEOUT_SECONDS = 300
 PREVIEW_APP_PREFIX = "ver-preview"
 PREVIEW_DATABASE_PREFIX = "verireel_preview_"
 PREVIEW_BASE_URL_ENV_KEY = "LAUNCHPLANE_PREVIEW_BASE_URL"
+_SECRET_SHAPED_RUNTIME_ENV_KEY_PARTS = {"PASSWORD", "TOKEN", "SECRET", "KEY"}
 
 
 def _expected_preview_slug(anchor_pr_number: int) -> str:
@@ -274,6 +282,73 @@ def _parse_database_url(database_url: str) -> _DatabaseParts:
         database=database_name,
         username=username,
         password=password,
+    )
+
+
+def _runtime_environment_key_requires_secret_store(key_name: str) -> bool:
+    return any(
+        key_part in _SECRET_SHAPED_RUNTIME_ENV_KEY_PARTS
+        for key_part in key_name.strip().upper().split("_")
+    )
+
+
+def _verireel_template_runtime_secret_keys(
+    template_env_map: dict[str, str],
+) -> tuple[str, ...]:
+    required_keys: list[str] = []
+    for key, value in template_env_map.items():
+        normalized_key = key.strip()
+        if not normalized_key or not str(value).strip():
+            continue
+        if normalized_key == "DATABASE_URL" or _runtime_environment_key_requires_secret_store(
+            normalized_key
+        ):
+            required_keys.append(normalized_key)
+    return tuple(dict.fromkeys(required_keys))
+
+
+def _enforce_verireel_preview_runtime_key_safety(
+    *,
+    record_store: RuntimeKeySafetyPolicyReadStore | None,
+    template_target: control_plane_dokploy.DokployTargetDefinition,
+    template_env_map: dict[str, str],
+    request: VeriReelPreviewRefreshRequest,
+) -> None:
+    required_binding_keys = _verireel_template_runtime_secret_keys(template_env_map)
+    if not required_binding_keys:
+        return
+    if record_store is None:
+        raise click.ClickException(
+            "VeriReel preview refresh copied runtime secrets require Launchplane database storage."
+        )
+    try:
+        policy_record = latest_active_runtime_key_safety_policy(record_store)
+    except ValueError as exc:
+        raise click.ClickException(
+            "VeriReel preview refresh copied runtime secrets require an active runtime "
+            "key-safety policy."
+        ) from exc
+    evaluation = evaluate_runtime_key_safety(
+        target=RuntimeKeySafetyTarget(
+            context=request.context,
+            instance=request.preview_slug,
+            environment_class="preview",
+        ),
+        required_binding_keys=required_binding_keys,
+        secret_bindings=record_store.list_secret_bindings(
+            integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+            context_name=template_target.context,
+            instance_name=template_target.instance,
+            limit=None,
+        ),
+        secret_rules=policy_record.rules,
+    )
+    if evaluation.status == "pass":
+        return
+    finding_codes = ", ".join(finding.code for finding in evaluation.findings)
+    checked_keys = ", ".join(evaluation.checked_binding_keys)
+    raise click.ClickException(
+        f"VeriReel preview runtime key-safety gate failed for {checked_keys}: {finding_codes}."
     )
 
 
@@ -1003,6 +1078,7 @@ def execute_verireel_preview_refresh(
     *,
     control_plane_root: Path,
     request: VeriReelPreviewRefreshRequest,
+    record_store: RuntimeKeySafetyPolicyReadStore | None = None,
 ) -> VeriReelPreviewRefreshResult:
     host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
     template_target, template_application = _template_application_payload(
@@ -1016,6 +1092,12 @@ def execute_verireel_preview_refresh(
     template_database_url = str(template_env_map.get("DATABASE_URL") or "").strip()
     if not template_database_url:
         raise click.ClickException("VeriReel testing template application is missing DATABASE_URL.")
+    _enforce_verireel_preview_runtime_key_safety(
+        record_store=record_store,
+        template_target=template_target,
+        template_env_map=template_env_map,
+        request=request,
+    )
     template_database = _parse_database_url(template_database_url)
 
     started_at = utc_now_timestamp()

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -70,6 +70,12 @@ title: Secrets
 - Evaluation reads only Launchplane managed secret bindings for the requested
   context and instance. If no active policy record exists, the gate fails closed
   instead of falling back to service-host env or product-local scripts.
+- Product-specific preview drivers that derive runtime secrets from a template,
+  such as VeriReel's preview database bootstrap, must run the same metadata-only
+  gate before creating databases, rendering preview env, or starting preview
+  instances. Template secret-shaped keys and semantic secret keys such as
+  `DATABASE_URL` must resolve to managed template-lane bindings, and the active
+  policy must allow those bindings for the preview target.
 
 ## Bootstrap-Only Env
 

--- a/tests/test_verireel_preview_driver.py
+++ b/tests/test_verireel_preview_driver.py
@@ -6,12 +6,125 @@ from unittest.mock import patch
 
 import click
 
+from control_plane.contracts.runtime_key_safety_policy import (
+    RuntimeKeySafetyPolicyRecord,
+    RuntimeSecretClass,
+    RuntimeSecretSafetyRule,
+)
+from control_plane.contracts.secret_record import SecretBinding
+from control_plane.dokploy import DokployTargetDefinition
 from control_plane.workflows.verireel_preview_driver import VeriReelPreviewDestroyRequest
 from control_plane.workflows.verireel_preview_driver import VeriReelPreviewRefreshRequest
 from control_plane.workflows.verireel_preview_driver import _build_preview_database_command
+from control_plane.workflows.verireel_preview_driver import (
+    _enforce_verireel_preview_runtime_key_safety,
+)
 from control_plane.workflows.verireel_preview_driver import _preview_database_admin_module_source
 from control_plane.workflows.verireel_preview_driver import _resolve_preview_url
 from control_plane.workflows.verireel_preview_driver import _run_application_command_with_retries
+from control_plane.workflows.verireel_preview_driver import execute_verireel_preview_refresh
+
+
+class _RuntimeKeySafetyStore:
+    def __init__(
+        self,
+        *,
+        policies: tuple[RuntimeKeySafetyPolicyRecord, ...] = (),
+        bindings: tuple[SecretBinding, ...] = (),
+    ) -> None:
+        self.policies = policies
+        self.bindings = bindings
+
+    def list_runtime_key_safety_policy_records(
+        self,
+        *,
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[RuntimeKeySafetyPolicyRecord, ...]:
+        records = tuple(record for record in self.policies if not status or record.status == status)
+        if limit is not None:
+            return records[:limit]
+        return records
+
+    def list_secret_bindings(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[SecretBinding, ...]:
+        bindings = tuple(
+            binding
+            for binding in self.bindings
+            if (not integration or binding.integration == integration)
+            and (not context_name or binding.context == context_name)
+            and (not instance_name or binding.instance == instance_name)
+        )
+        if limit is not None:
+            return bindings[:limit]
+        return bindings
+
+
+def _runtime_policy(
+    *, secret_class: RuntimeSecretClass = "preview"
+) -> RuntimeKeySafetyPolicyRecord:
+    return RuntimeKeySafetyPolicyRecord(
+        record_id="runtime-key-safety-policy-test",
+        status="active",
+        source="test",
+        updated_at="2026-05-05T22:15:00Z",
+        rules=(
+            RuntimeSecretSafetyRule(
+                binding_key="DATABASE_URL",
+                secret_class=secret_class,
+                allowed_contexts=("verireel-testing",),
+            ),
+            RuntimeSecretSafetyRule(
+                binding_key="BETTER_AUTH_SECRET",
+                secret_class=secret_class,
+                allowed_contexts=("verireel-testing",),
+            ),
+        ),
+    )
+
+
+def _runtime_binding(binding_key: str) -> SecretBinding:
+    normalized_key = binding_key.lower().replace("_", "-")
+    return SecretBinding(
+        binding_id=f"secret-{normalized_key}-binding-{normalized_key}",
+        secret_id=f"secret-{normalized_key}",
+        integration="runtime_environment",
+        binding_key=binding_key,
+        context="verireel",
+        instance="testing",
+        status="configured",
+        created_at="2026-05-05T22:15:00Z",
+        updated_at="2026-05-05T22:15:00Z",
+    )
+
+
+def _template_target() -> DokployTargetDefinition:
+    return DokployTargetDefinition(
+        context="verireel",
+        instance="testing",
+        target_type="application",
+        target_id="app-template",
+        target_name="verireel-testing",
+    )
+
+
+def _refresh_request() -> VeriReelPreviewRefreshRequest:
+    return VeriReelPreviewRefreshRequest.model_validate(
+        {
+            "anchor_pr_number": 71,
+            "anchor_pr_url": "https://github.com/every/verireel/pull/71",
+            "anchor_head_sha": "6b3c9d7e8f901234567890abcdef1234567890ab",
+            "preview_slug": "pr-71",
+            "preview_url": "https://pr-71.ver-preview.shinycomputers.com",
+            "image_reference": "ghcr.io/every/verireel-app:pr-71-sha-6b3c9d7",
+        }
+    )
 
 
 class VeriReelPreviewDriverTests(unittest.TestCase):
@@ -77,7 +190,9 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
             TemporaryDirectory() as temporary_directory_name,
             patch(
                 "control_plane.workflows.verireel_preview_driver.control_plane_runtime_environments.resolve_runtime_context_values",
-                return_value={"LAUNCHPLANE_PREVIEW_BASE_URL": "https://ver-preview.shinycomputers.com"},
+                return_value={
+                    "LAUNCHPLANE_PREVIEW_BASE_URL": "https://ver-preview.shinycomputers.com"
+                },
             ) as resolve_values,
         ):
             preview_url = _resolve_preview_url(
@@ -90,6 +205,88 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
             control_plane_root=Path(temporary_directory_name),
             context_name="verireel-testing",
         )
+
+    def test_verireel_preview_runtime_key_safety_rejects_missing_store(self) -> None:
+        with self.assertRaisesRegex(click.ClickException, "database storage"):
+            _enforce_verireel_preview_runtime_key_safety(
+                record_store=None,
+                template_target=_template_target(),
+                template_env_map={
+                    "DATABASE_URL": "postgresql://user:pass@db.example/verireel_testing",
+                },
+                request=_refresh_request(),
+            )
+
+    def test_verireel_preview_runtime_key_safety_blocks_prod_only_template_secret(
+        self,
+    ) -> None:
+        store = _RuntimeKeySafetyStore(
+            policies=(_runtime_policy(secret_class="prod_only"),),
+            bindings=(_runtime_binding("DATABASE_URL"),),
+        )
+
+        with self.assertRaisesRegex(click.ClickException, "secret_class_not_allowed"):
+            _enforce_verireel_preview_runtime_key_safety(
+                record_store=store,
+                template_target=_template_target(),
+                template_env_map={
+                    "DATABASE_URL": "postgresql://user:pass@db.example/verireel_testing",
+                },
+                request=_refresh_request(),
+            )
+
+    def test_verireel_preview_runtime_key_safety_allows_preview_template_secrets(
+        self,
+    ) -> None:
+        store = _RuntimeKeySafetyStore(
+            policies=(_runtime_policy(),),
+            bindings=(
+                _runtime_binding("DATABASE_URL"),
+                _runtime_binding("BETTER_AUTH_SECRET"),
+            ),
+        )
+
+        _enforce_verireel_preview_runtime_key_safety(
+            record_store=store,
+            template_target=_template_target(),
+            template_env_map={
+                "DATABASE_URL": "postgresql://user:pass@db.example/verireel_testing",
+                "BETTER_AUTH_SECRET": "auth-secret",
+                "NEXT_PUBLIC_SITE_URL": "https://testing.example",
+            },
+            request=_refresh_request(),
+        )
+
+    def test_preview_refresh_blocks_before_database_bootstrap_without_key_safety_store(
+        self,
+    ) -> None:
+        with (
+            patch(
+                "control_plane.workflows.verireel_preview_driver.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver._template_application_payload",
+                return_value=(
+                    _template_target(),
+                    {
+                        "applicationId": "app-template",
+                        "env": "DATABASE_URL=postgresql://user:pass@db.example/verireel_testing\n",
+                    },
+                ),
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver._run_application_command"
+            ) as run_command,
+        ):
+            with self.assertRaisesRegex(click.ClickException, "database storage"):
+                execute_verireel_preview_refresh(
+                    control_plane_root=Path("."),
+                    request=_refresh_request(),
+                    record_store=None,
+                )
+
+        run_command.assert_not_called()
 
     def test_preview_destroy_request_requires_pr_scoped_preview_slug(self) -> None:
         with self.assertRaisesRegex(ValueError, "preview_slug to match anchor_pr_number"):


### PR DESCRIPTION
## Summary
- require VeriReel preview refresh to run runtime key-safety before DB bootstrap or preview env writes
- classify template DATABASE_URL and secret-shaped template env keys as copied runtime secret requirements
- pass the Postgres store into the service route and document product-specific preview driver gates

Refs #248

## Verification
- uv run python -m unittest tests.test_verireel_preview_driver
- uv run --extra dev ruff check --diff control_plane/workflows/verireel_preview_driver.py control_plane/service.py tests/test_verireel_preview_driver.py
- uv run --extra dev ruff format control_plane/workflows/verireel_preview_driver.py control_plane/service.py tests/test_verireel_preview_driver.py
- uv run --extra dev ruff check control_plane/workflows/verireel_preview_driver.py control_plane/service.py tests/test_verireel_preview_driver.py
- uv run --extra dev ruff format --check control_plane/workflows/verireel_preview_driver.py control_plane/service.py tests/test_verireel_preview_driver.py
- uv run --extra dev mypy control_plane/workflows/verireel_preview_driver.py control_plane/service.py tests/test_verireel_preview_driver.py