### PR TITLE
Gate VeriReel worker runtime secrets

### DIFF
--- a/control_plane/workflows/verireel_prod_backup_gate.py
+++ b/control_plane/workflows/verireel_prod_backup_gate.py
@@ -14,6 +14,7 @@ from control_plane import runtime_environments as control_plane_runtime_environm
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.ship import utc_now_timestamp
+from control_plane.workflows.worker_runtime_key_safety import enforce_worker_runtime_key_safety
 
 
 DEFAULT_TIMEOUT_SECONDS = 1800
@@ -117,6 +118,12 @@ def _worker_environment(
     control_plane_root: Path,
     request: VeriReelProdBackupGateWorkerRequest,
 ) -> dict[str, str]:
+    enforce_worker_runtime_key_safety(
+        context_name=request.context,
+        instance_name=request.instance,
+        allowed_worker_keys=WORKER_RUNTIME_ENV_KEYS,
+        operation_name="VeriReel prod backup gate worker",
+    )
     environment = {
         key: value for key, value in os.environ.items() if key not in WORKER_RUNTIME_ENV_KEYS
     }

--- a/control_plane/workflows/verireel_prod_rollback.py
+++ b/control_plane/workflows/verireel_prod_rollback.py
@@ -21,6 +21,7 @@ from control_plane.contracts.promotion_record import (
 )
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.ship import utc_now_timestamp
+from control_plane.workflows.worker_runtime_key_safety import enforce_worker_runtime_key_safety
 from control_plane.workflows.verireel_prod_promotion import (
     _read_backup_gate_record,
 )
@@ -314,6 +315,12 @@ def _worker_environment(
     control_plane_root: Path,
     request: VeriReelProdRollbackWorkerRequest,
 ) -> dict[str, str]:
+    enforce_worker_runtime_key_safety(
+        context_name=request.context,
+        instance_name=request.instance,
+        allowed_worker_keys=WORKER_RUNTIME_ENV_KEYS,
+        operation_name="VeriReel prod rollback worker",
+    )
     environment = {
         key: value for key, value in os.environ.items() if key not in WORKER_RUNTIME_ENV_KEYS
     }

--- a/control_plane/workflows/worker_runtime_key_safety.py
+++ b/control_plane/workflows/worker_runtime_key_safety.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import click
+
+from control_plane import secrets as control_plane_secrets
+from control_plane.contracts.runtime_key_safety_policy import (
+    RuntimeEnvironmentClass,
+    RuntimeKeySafetyTarget,
+)
+from control_plane.runtime_key_safety import (
+    evaluate_runtime_key_safety_from_store,
+    latest_active_runtime_key_safety_policy,
+)
+from control_plane.storage.factory import resolve_database_url
+from control_plane.storage.postgres import PostgresRecordStore
+
+
+def _runtime_key_safety_environment_class(instance_name: str) -> RuntimeEnvironmentClass:
+    normalized_instance = instance_name.strip().lower()
+    if normalized_instance in {"prod", "production"}:
+        return "prod"
+    if normalized_instance in {"testing", "test", "staging", "stage"}:
+        return "testing"
+    if normalized_instance in {"preview", "pr"} or normalized_instance.startswith("pr-"):
+        return "preview"
+    if normalized_instance in {"dev", "local", "development"}:
+        return "dev"
+    return "unknown"
+
+
+def enforce_worker_runtime_key_safety(
+    *,
+    context_name: str,
+    instance_name: str,
+    allowed_worker_keys: tuple[str, ...],
+    operation_name: str,
+) -> None:
+    database_url = resolve_database_url(None)
+    if database_url is None:
+        return
+
+    record_store = PostgresRecordStore(database_url=database_url)
+    record_store.ensure_schema()
+    try:
+        bindings = record_store.list_secret_bindings(
+            integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+            context_name=context_name,
+            instance_name=instance_name,
+            limit=None,
+        )
+        allowed_key_set = set(allowed_worker_keys)
+        binding_keys = tuple(
+            binding.binding_key for binding in bindings if binding.binding_key in allowed_key_set
+        )
+        if not binding_keys:
+            return
+        try:
+            policy_record = latest_active_runtime_key_safety_policy(record_store)
+            evaluation = evaluate_runtime_key_safety_from_store(
+                record_store=record_store,
+                policy_record=policy_record,
+                target=RuntimeKeySafetyTarget(
+                    context=context_name,
+                    instance=instance_name,
+                    environment_class=_runtime_key_safety_environment_class(instance_name),
+                ),
+                required_binding_keys=binding_keys,
+            )
+        except ValueError as exc:
+            raise click.ClickException(
+                f"Runtime key-safety policy is unavailable for {operation_name}."
+            ) from exc
+        if evaluation.status == "pass":
+            return
+        finding_codes = sorted({finding.code for finding in evaluation.findings})
+        suffix = f": {', '.join(finding_codes)}" if finding_codes else ""
+        raise click.ClickException(f"Runtime key-safety gate failed for {operation_name}{suffix}.")
+    finally:
+        record_store.close()

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -76,6 +76,11 @@ title: Secrets
   instances. Template secret-shaped keys and semantic secret keys such as
   `DATABASE_URL` must resolve to managed template-lane bindings, and the active
   policy must allow those bindings for the preview target.
+- Delegated worker workflows that overlay managed runtime secrets into
+  subprocess environments, such as VeriReel prod backup and rollback workers,
+  must evaluate the managed bindings for the worker target before the worker
+  process starts. The worker receives plaintext only after the metadata gate has
+  confirmed the active policy allows those bindings for that runtime class.
 
 ## Bootstrap-Only Env
 

--- a/tests/test_verireel_prod_backup_gate.py
+++ b/tests/test_verireel_prod_backup_gate.py
@@ -8,6 +8,12 @@ import click
 
 from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane.contracts.backup_gate_record import BackupGateRecord
+from control_plane.contracts.runtime_key_safety_policy import (
+    RuntimeKeySafetyPolicyRecord,
+    RuntimeSecretClass,
+    RuntimeSecretSafetyRule,
+)
+from control_plane.contracts.secret_record import SecretBinding
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows import verireel_prod_backup_gate_worker
@@ -27,6 +33,43 @@ class VeriReelProdBackupGateWorkflowTests(unittest.TestCase):
 
     def _record_store(self, root: Path) -> FilesystemRecordStore:
         return FilesystemRecordStore(root / "state")
+
+    def _write_prod_worker_secret_binding(
+        self,
+        store: PostgresRecordStore,
+        *,
+        secret_class: RuntimeSecretClass = "prod_only",
+    ) -> None:
+        binding_key = "VERIREEL_PROD_PROXMOX_SSH_PRIVATE_KEY"
+        store.write_secret_binding(
+            SecretBinding(
+                binding_id="secret-verireel-prod-proxmox-ssh-private-key-binding",
+                secret_id="secret-verireel-prod-proxmox-ssh-private-key",
+                integration="runtime_environment",
+                binding_key=binding_key,
+                context="verireel",
+                instance="prod",
+                status="configured",
+                created_at="2026-05-05T22:30:00Z",
+                updated_at="2026-05-05T22:30:00Z",
+            )
+        )
+        store.write_runtime_key_safety_policy_record(
+            RuntimeKeySafetyPolicyRecord(
+                record_id="runtime-key-safety-policy-test",
+                status="active",
+                source="test",
+                updated_at="2026-05-05T22:30:00Z",
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key=binding_key,
+                        secret_class=secret_class,
+                        allowed_contexts=("verireel",),
+                        allowed_instances=("prod",),
+                    ),
+                ),
+            )
+        )
 
     def test_run_delegated_worker_prefers_runtime_environment_values(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -111,7 +154,13 @@ class VeriReelProdBackupGateWorkflowTests(unittest.TestCase):
         self.assertEqual(result.status, "pass")
         self.assertEqual(
             captured["command"],
-            ["uv", "run", "python", "-m", "control_plane.workflows.verireel_prod_backup_gate_worker"],
+            [
+                "uv",
+                "run",
+                "python",
+                "-m",
+                "control_plane.workflows.verireel_prod_backup_gate_worker",
+            ],
         )
         worker_env = captured["env"]
         assert isinstance(worker_env, dict)
@@ -122,6 +171,33 @@ class VeriReelProdBackupGateWorkflowTests(unittest.TestCase):
         self.assertEqual(worker_env["VERIREEL_PROD_PROXMOX_SSH_KNOWN_HOSTS"], "runtime-known-hosts")
         self.assertEqual(worker_env["VERIREEL_PROD_BACKUP_STORAGE"], "pbs-runtime")
         self.assertEqual(worker_env["VERIREEL_PROD_GATE_HEALTH_TIMEOUT_MS"], "25000")
+
+    def test_run_delegated_worker_blocks_unsafe_managed_runtime_secret(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = self._sqlite_database_url(root)
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                self._write_prod_worker_secret_binding(store, secret_class="testing")
+            finally:
+                store.close()
+
+            with (
+                patch.dict("os.environ", {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True),
+                patch("control_plane.workflows.verireel_prod_backup_gate.subprocess.run") as run,
+            ):
+                with self.assertRaisesRegex(click.ClickException, "key-safety gate failed"):
+                    _run_delegated_worker(
+                        control_plane_root=root,
+                        request=VeriReelProdBackupGateWorkerRequest(
+                            context="verireel",
+                            instance="prod",
+                            backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                        ),
+                    )
+
+        run.assert_not_called()
 
     def test_prod_backup_gate_default_timeout_allows_longer_vzdump_backup(self) -> None:
         self.assertEqual(DEFAULT_TIMEOUT_SECONDS, 1800)
@@ -190,9 +266,7 @@ class VeriReelProdBackupGateWorkflowTests(unittest.TestCase):
             with (
                 patch(
                     "control_plane.workflows.verireel_prod_backup_gate._worker_environment",
-                    return_value={
-                        "LAUNCHPLANE_VERIREEL_PROD_BACKUP_GATE_WORKER_COMMAND": "worker"
-                    },
+                    return_value={"LAUNCHPLANE_VERIREEL_PROD_BACKUP_GATE_WORKER_COMMAND": "worker"},
                 ),
                 patch(
                     "control_plane.workflows.verireel_prod_backup_gate.subprocess.run",
@@ -270,7 +344,9 @@ class VeriReelProdBackupGateWorkflowTests(unittest.TestCase):
         self.assertEqual(command[0], "ssh")
         self.assertIn("runtime-user@proxmox.runtime.example", command)
         remote_command_start = command.index("runtime-user@proxmox.runtime.example") + 1
-        self.assertEqual(command[remote_command_start:remote_command_start + 3], ["pct", "snapshot", "211"])
+        self.assertEqual(
+            command[remote_command_start : remote_command_start + 3], ["pct", "snapshot", "211"]
+        )
         self.assertRegex(
             command[remote_command_start + 3],
             r"^ver-predeploy-\d{8}-\d{6}-[0-9a-f]{6}$",

--- a/tests/test_verireel_prod_rollback.py
+++ b/tests/test_verireel_prod_rollback.py
@@ -13,6 +13,12 @@ from control_plane.contracts.promotion_record import (
     DeploymentEvidence,
     PromotionRecord,
 )
+from control_plane.contracts.runtime_key_safety_policy import (
+    RuntimeKeySafetyPolicyRecord,
+    RuntimeSecretClass,
+    RuntimeSecretSafetyRule,
+)
+from control_plane.contracts.secret_record import SecretBinding
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows import verireel_prod_rollback_worker
@@ -33,6 +39,43 @@ class VeriReelProdRollbackWorkflowTests(unittest.TestCase):
 
     def _record_store(self, root: Path) -> FilesystemRecordStore:
         return FilesystemRecordStore(root / "state")
+
+    def _write_prod_worker_secret_binding(
+        self,
+        store: PostgresRecordStore,
+        *,
+        secret_class: RuntimeSecretClass = "prod_only",
+    ) -> None:
+        binding_key = "VERIREEL_PROD_PROXMOX_SSH_PRIVATE_KEY"
+        store.write_secret_binding(
+            SecretBinding(
+                binding_id="secret-verireel-prod-proxmox-ssh-private-key-binding",
+                secret_id="secret-verireel-prod-proxmox-ssh-private-key",
+                integration="runtime_environment",
+                binding_key=binding_key,
+                context="verireel",
+                instance="prod",
+                status="configured",
+                created_at="2026-05-05T22:30:00Z",
+                updated_at="2026-05-05T22:30:00Z",
+            )
+        )
+        store.write_runtime_key_safety_policy_record(
+            RuntimeKeySafetyPolicyRecord(
+                record_id="runtime-key-safety-policy-test",
+                status="active",
+                source="test",
+                updated_at="2026-05-05T22:30:00Z",
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key=binding_key,
+                        secret_class=secret_class,
+                        allowed_contexts=("verireel",),
+                        allowed_instances=("prod",),
+                    ),
+                ),
+            )
+        )
 
     def _write_backup_gate(self, record_store: FilesystemRecordStore) -> None:
         record_store.write_backup_gate_record(
@@ -165,6 +208,35 @@ class VeriReelProdRollbackWorkflowTests(unittest.TestCase):
         self.assertEqual(worker_env["VERIREEL_PROD_PROXMOX_SSH_PRIVATE_KEY"], "runtime-private-key")
         self.assertEqual(worker_env["VERIREEL_PROD_PROXMOX_SSH_KNOWN_HOSTS"], "runtime-known-hosts")
 
+    def test_run_delegated_worker_blocks_unsafe_managed_runtime_secret(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = self._sqlite_database_url(root)
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                self._write_prod_worker_secret_binding(store, secret_class="testing")
+            finally:
+                store.close()
+
+            with (
+                patch.dict("os.environ", {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True),
+                patch("control_plane.workflows.verireel_prod_rollback.subprocess.run") as run,
+            ):
+                with self.assertRaisesRegex(click.ClickException, "key-safety gate failed"):
+                    _run_delegated_worker(
+                        control_plane_root=root,
+                        request=VeriReelProdRollbackWorkerRequest(
+                            context="verireel",
+                            instance="prod",
+                            promotion_record_id="promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                            backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                            snapshot_name="ver-predeploy-20260421-180000",
+                        ),
+                    )
+
+        run.assert_not_called()
+
     def test_rollout_base_url_resolution_accepts_rollback_request_shape(self) -> None:
         request = VeriReelProdRollbackRequest(
             promotion_record_id="promotion-verireel-testing-to-prod-run-12345-attempt-1",
@@ -184,7 +256,9 @@ class VeriReelProdRollbackWorkflowTests(unittest.TestCase):
             ) as find_target,
             patch(
                 "control_plane.workflows.verireel_rollout.control_plane_runtime_environments.resolve_runtime_environment_values",
-                return_value={"VERIREEL_PROD_OPERATOR_BASE_URL": "https://ver-prod.shinycomputers.com"},
+                return_value={
+                    "VERIREEL_PROD_OPERATOR_BASE_URL": "https://ver-prod.shinycomputers.com"
+                },
             ) as resolve_environment,
             patch(
                 "control_plane.workflows.verireel_rollout.control_plane_dokploy.resolve_healthcheck_base_urls",


### PR DESCRIPTION
## Summary
- add a shared worker runtime key-safety helper for managed runtime secret bindings
- gate VeriReel prod backup and rollback delegated worker environments before subprocess launch
- document worker runtime-secret safety expectations

Refs #248

## Verification
- uv run python -m unittest tests.test_verireel_prod_backup_gate tests.test_verireel_prod_rollback
- uv run --extra dev ruff check --diff control_plane/workflows/worker_runtime_key_safety.py control_plane/workflows/verireel_prod_backup_gate.py control_plane/workflows/verireel_prod_rollback.py tests/test_verireel_prod_backup_gate.py tests/test_verireel_prod_rollback.py
- uv run --extra dev ruff format tests/test_verireel_prod_backup_gate.py tests/test_verireel_prod_rollback.py
- uv run --extra dev ruff check control_plane/workflows/worker_runtime_key_safety.py control_plane/workflows/verireel_prod_backup_gate.py control_plane/workflows/verireel_prod_rollback.py tests/test_verireel_prod_backup_gate.py tests/test_verireel_prod_rollback.py
- uv run --extra dev ruff format --check control_plane/workflows/worker_runtime_key_safety.py control_plane/workflows/verireel_prod_backup_gate.py control_plane/workflows/verireel_prod_rollback.py tests/test_verireel_prod_backup_gate.py tests/test_verireel_prod_rollback.py
- uv run --extra dev mypy control_plane/workflows/worker_runtime_key_safety.py control_plane/workflows/verireel_prod_backup_gate.py control_plane/workflows/verireel_prod_rollback.py tests/test_verireel_prod_backup_gate.py tests/test_verireel_prod_rollback.py