### PR TITLE
Gate Odoo rollback runtime secret sync

### DIFF
--- a/control_plane/runtime_key_safety.py
+++ b/control_plane/runtime_key_safety.py
@@ -24,6 +24,19 @@ ALLOWED_SECRET_CLASSES_BY_ENVIRONMENT: dict[RuntimeEnvironmentClass, set[Runtime
 }
 
 
+def runtime_key_safety_environment_class(instance_name: str) -> RuntimeEnvironmentClass:
+    normalized_instance = instance_name.strip().lower()
+    if normalized_instance in {"prod", "production"}:
+        return "prod"
+    if normalized_instance in {"testing", "test", "staging", "stage"}:
+        return "testing"
+    if normalized_instance in {"preview", "pr"} or normalized_instance.startswith("pr-"):
+        return "preview"
+    if normalized_instance in {"dev", "local", "development"}:
+        return "dev"
+    return "unknown"
+
+
 class RuntimeKeySafetyPolicyReadStore(Protocol):
     def list_runtime_key_safety_policy_records(
         self,

--- a/control_plane/workflows/odoo_prod_rollback.py
+++ b/control_plane/workflows/odoo_prod_rollback.py
@@ -25,8 +25,15 @@ from control_plane.contracts.promotion_record import (
     RollbackExecutionEvidence,
 )
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyTarget
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.release_tuples import build_release_tuple_record_from_artifact_manifest
+from control_plane.runtime_key_safety import (
+    RuntimeKeySafetyPolicyReadStore,
+    evaluate_runtime_key_safety_from_store,
+    latest_active_runtime_key_safety_policy,
+    runtime_key_safety_environment_class,
+)
 from control_plane.workflows.inventory import build_environment_inventory
 from control_plane.workflows.odoo_post_deploy import OdooPostDeployRequest, execute_odoo_post_deploy
 from control_plane.workflows.ship import (
@@ -48,7 +55,7 @@ class _RollbackSource:
     detail: str
 
 
-class OdooProdRollbackStore(Protocol):
+class OdooProdRollbackStore(RuntimeKeySafetyPolicyReadStore, Protocol):
     def read_release_tuple_record(
         self, *, context_name: str, channel_name: str
     ) -> ReleaseTupleRecord: ...
@@ -373,6 +380,7 @@ def _resolve_ship_request(
 def _sync_artifact_image_reference_for_target(
     *,
     control_plane_root: Path,
+    record_store: RuntimeKeySafetyPolicyReadStore,
     target_definition: control_plane_dokploy.DokployTargetDefinition,
     artifact_manifest: ArtifactIdentityManifest,
 ) -> None:
@@ -390,6 +398,12 @@ def _sync_artifact_image_reference_for_target(
             context_name=target_definition.context,
             instance_name=target_definition.instance,
         )
+    )
+    _enforce_runtime_key_safety_for_target_env_sync(
+        record_store=record_store,
+        context_name=target_definition.context,
+        instance_name=target_definition.instance,
+        runtime_environment_values=runtime_environment_values,
     )
     desired_image_reference = _artifact_image_reference_from_manifest(artifact_manifest)
     if target_definition.target_type == "compose":
@@ -436,6 +450,51 @@ def _sync_artifact_image_reference_for_target(
             "Dokploy target env did not persist Launchplane DB-backed runtime key(s): "
             + ", ".join(missing_or_mismatched_keys)
         )
+
+
+def _enforce_runtime_key_safety_for_target_env_sync(
+    *,
+    record_store: RuntimeKeySafetyPolicyReadStore,
+    context_name: str,
+    instance_name: str,
+    runtime_environment_values: dict[str, str],
+) -> None:
+    bindings = record_store.list_secret_bindings(
+        integration="runtime_environment",
+        context_name=context_name,
+        instance_name=instance_name,
+        limit=None,
+    )
+    binding_keys = tuple(
+        binding.binding_key
+        for binding in bindings
+        if binding.binding_key in runtime_environment_values
+    )
+    if not binding_keys:
+        return
+    try:
+        policy_record = latest_active_runtime_key_safety_policy(record_store)
+        evaluation = evaluate_runtime_key_safety_from_store(
+            record_store=record_store,
+            policy_record=policy_record,
+            target=RuntimeKeySafetyTarget(
+                context=context_name,
+                instance=instance_name,
+                environment_class=runtime_key_safety_environment_class(instance_name),
+            ),
+            required_binding_keys=binding_keys,
+        )
+    except ValueError as exc:
+        raise click.ClickException(
+            "Runtime key-safety policy is unavailable for Odoo prod rollback target env sync."
+        ) from exc
+    if evaluation.status == "pass":
+        return
+    finding_codes = sorted({finding.code for finding in evaluation.findings})
+    suffix = f": {', '.join(finding_codes)}" if finding_codes else ""
+    raise click.ClickException(
+        f"Runtime key-safety gate failed for Odoo prod rollback target env sync{suffix}."
+    )
 
 
 def _trigger_dokploy_deploy(
@@ -629,6 +688,7 @@ def execute_odoo_prod_rollback(
     try:
         _sync_artifact_image_reference_for_target(
             control_plane_root=control_plane_root,
+            record_store=typed_record_store,
             target_definition=target_definition,
             artifact_manifest=artifact_manifest,
         )

--- a/control_plane/workflows/worker_runtime_key_safety.py
+++ b/control_plane/workflows/worker_runtime_key_safety.py
@@ -3,29 +3,14 @@ from __future__ import annotations
 import click
 
 from control_plane import secrets as control_plane_secrets
-from control_plane.contracts.runtime_key_safety_policy import (
-    RuntimeEnvironmentClass,
-    RuntimeKeySafetyTarget,
-)
+from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyTarget
 from control_plane.runtime_key_safety import (
     evaluate_runtime_key_safety_from_store,
     latest_active_runtime_key_safety_policy,
+    runtime_key_safety_environment_class,
 )
 from control_plane.storage.factory import resolve_database_url
 from control_plane.storage.postgres import PostgresRecordStore
-
-
-def _runtime_key_safety_environment_class(instance_name: str) -> RuntimeEnvironmentClass:
-    normalized_instance = instance_name.strip().lower()
-    if normalized_instance in {"prod", "production"}:
-        return "prod"
-    if normalized_instance in {"testing", "test", "staging", "stage"}:
-        return "testing"
-    if normalized_instance in {"preview", "pr"} or normalized_instance.startswith("pr-"):
-        return "preview"
-    if normalized_instance in {"dev", "local", "development"}:
-        return "dev"
-    return "unknown"
 
 
 def enforce_worker_runtime_key_safety(
@@ -62,7 +47,7 @@ def enforce_worker_runtime_key_safety(
                 target=RuntimeKeySafetyTarget(
                     context=context_name,
                     instance=instance_name,
-                    environment_class=_runtime_key_safety_environment_class(instance_name),
+                    environment_class=runtime_key_safety_environment_class(instance_name),
                 ),
                 required_binding_keys=binding_keys,
             )

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -81,6 +81,9 @@ title: Secrets
   must evaluate the managed bindings for the worker target before the worker
   process starts. The worker receives plaintext only after the metadata gate has
   confirmed the active policy allows those bindings for that runtime class.
+- Product-specific workflows that sync resolved runtime environment values into
+  live Dokploy targets, such as Odoo prod rollback target env updates, must
+  evaluate managed runtime secret bindings before writing the live env payload.
 
 ## Bootstrap-Only Env
 

--- a/tests/test_odoo_prod_rollback.py
+++ b/tests/test_odoo_prod_rollback.py
@@ -23,6 +23,12 @@ from control_plane.contracts.promotion_record import (
     PromotionRecord,
 )
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+from control_plane.contracts.runtime_key_safety_policy import (
+    RuntimeKeySafetyPolicyRecord,
+    RuntimeSecretClass,
+    RuntimeSecretSafetyRule,
+)
+from control_plane.contracts.secret_record import SecretBinding
 from control_plane.workflows.odoo_post_deploy import OdooPostDeployResult
 from control_plane.workflows.odoo_prod_rollback import (
     OdooProdRollbackRequest,
@@ -163,7 +169,46 @@ class OdooProdRollbackWorkflowTests(unittest.TestCase):
         record_store.read_promotion_record.return_value = _promotion_record()
         record_store.read_dokploy_target_record.return_value = _target_record()
         record_store.read_dokploy_target_id_record.return_value = _target_id_record()
+        record_store.list_secret_bindings.return_value = ()
+        record_store.list_runtime_key_safety_policy_records.return_value = ()
         return record_store
+
+    def _write_prod_secret_binding(
+        self,
+        record_store: Mock,
+        *,
+        secret_class: RuntimeSecretClass = "prod_only",
+    ) -> None:
+        binding_key = "ODOO_DB_PASSWORD"
+        record_store.list_secret_bindings.return_value = (
+            SecretBinding(
+                binding_id="secret-odoo-db-password-binding",
+                secret_id="secret-odoo-db-password",
+                integration="runtime_environment",
+                binding_key=binding_key,
+                context="opw",
+                instance="prod",
+                status="configured",
+                created_at="2026-05-05T22:45:00Z",
+                updated_at="2026-05-05T22:45:00Z",
+            ),
+        )
+        record_store.list_runtime_key_safety_policy_records.return_value = (
+            RuntimeKeySafetyPolicyRecord(
+                record_id="runtime-key-safety-policy-test",
+                status="active",
+                source="test",
+                updated_at="2026-05-05T22:45:00Z",
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key=binding_key,
+                        secret_class=secret_class,
+                        allowed_contexts=("opw",),
+                        allowed_instances=("prod",),
+                    ),
+                ),
+            ),
+        )
 
     def test_rollback_to_testing_tuple_records_successful_evidence(self) -> None:
         record_store = self._record_store()
@@ -367,6 +412,47 @@ class OdooProdRollbackWorkflowTests(unittest.TestCase):
 
         self.assertEqual(result.rollback_status, "fail")
         self.assertIn("deploy failed", result.error_message)
+        final_promotion = record_store.write_promotion_record.call_args_list[-1].args[0]
+        self.assertEqual(final_promotion.rollback.status, "fail")
+
+    def test_runtime_key_safety_blocks_managed_secret_target_env_sync(self) -> None:
+        record_store = self._record_store()
+        self._write_prod_secret_binding(record_store, secret_class="testing")
+
+        with (
+            patch(
+                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={"env": ""},
+            ),
+            patch(
+                "control_plane.workflows.odoo_prod_rollback.control_plane_runtime_environments.resolve_runtime_environment_values",
+                return_value={"ODOO_DB_PASSWORD": "managed-secret-value"},
+            ),
+            patch(
+                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.sync_dokploy_compose_raw_source"
+            ) as sync_compose_mock,
+            patch(
+                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.update_dokploy_target_env"
+            ) as update_env_mock,
+            patch(
+                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.trigger_deployment"
+            ) as trigger_deployment_mock,
+        ):
+            result = execute_odoo_prod_rollback(
+                control_plane_root=Path("/control-plane"),
+                record_store=record_store,
+                request=OdooProdRollbackRequest(context="opw"),
+            )
+
+        self.assertEqual(result.rollback_status, "fail")
+        self.assertIn("Runtime key-safety gate failed", result.error_message)
+        sync_compose_mock.assert_not_called()
+        update_env_mock.assert_not_called()
+        trigger_deployment_mock.assert_not_called()
         final_promotion = record_store.write_promotion_record.call_args_list[-1].args[0]
         self.assertEqual(final_promotion.rollback.status, "fail")
 


### PR DESCRIPTION
## Summary
- share the runtime key-safety environment-class helper with worker and rollout paths
- gate Odoo prod rollback managed runtime secret bindings before writing resolved runtime env into Dokploy
- document product-specific live target env sync safety requirements

Refs #248

## Verification
- uv run python -m unittest tests.test_odoo_prod_rollback
- uv run --extra dev ruff check --diff control_plane/runtime_key_safety.py control_plane/workflows/worker_runtime_key_safety.py control_plane/workflows/odoo_prod_rollback.py tests/test_odoo_prod_rollback.py
- uv run --extra dev ruff check control_plane/runtime_key_safety.py control_plane/workflows/worker_runtime_key_safety.py control_plane/workflows/odoo_prod_rollback.py tests/test_odoo_prod_rollback.py
- uv run --extra dev ruff format --check control_plane/runtime_key_safety.py control_plane/workflows/worker_runtime_key_safety.py control_plane/workflows/odoo_prod_rollback.py tests/test_odoo_prod_rollback.py
- uv run --extra dev mypy control_plane/runtime_key_safety.py control_plane/workflows/worker_runtime_key_safety.py control_plane/workflows/odoo_prod_rollback.py tests/test_odoo_prod_rollback.py