### PR TITLE
Gate Odoo artifact publish runtime payload

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -8,7 +8,7 @@ import subprocess
 import time
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Literal, overload
+from typing import Literal, cast, overload
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit
 from urllib.request import Request, urlopen
@@ -140,6 +140,7 @@ from control_plane.workflows.dokploy_target_adoption import (
 from control_plane.workflows.product_onboarding import apply_product_onboarding_manifest
 from control_plane.workflows.odoo_artifact_publish import (
     OdooArtifactPublishRequest,
+    OdooArtifactPublishStore,
     execute_odoo_artifact_publish,
 )
 from control_plane.workflows.odoo_prod_backup_gate import (
@@ -10200,7 +10201,7 @@ def odoo_artifacts_publish(
     record_store = _store(Path("state"), database_url=database_url)
     result = execute_odoo_artifact_publish(
         control_plane_root=_control_plane_root(),
-        record_store=record_store,
+        record_store=cast(OdooArtifactPublishStore, record_store),
         request=OdooArtifactPublishRequest(
             context=context,
             instance=instance,

--- a/control_plane/workflows/odoo_artifact_publish.py
+++ b/control_plane/workflows/odoo_artifact_publish.py
@@ -32,8 +32,14 @@ PUBLISH_RUNTIME_ENVIRONMENT_KEYS = (
 )
 
 
-class OdooArtifactPublishStore(RuntimeKeySafetyPolicyReadStore, Protocol):
+class OdooArtifactPublishEvidenceStore(Protocol):
     def write_artifact_manifest(self, manifest: ArtifactIdentityManifest) -> Path | None: ...
+
+
+class OdooArtifactPublishStore(
+    RuntimeKeySafetyPolicyReadStore, OdooArtifactPublishEvidenceStore, Protocol
+):
+    pass
 
 
 class OdooArtifactPublishRequest(BaseModel):
@@ -293,7 +299,7 @@ def _read_manifest(
 
 def ingest_odoo_artifact_publish_evidence(
     *,
-    record_store: OdooArtifactPublishStore,
+    record_store: OdooArtifactPublishEvidenceStore,
     request: OdooArtifactPublishEvidenceRequest,
 ) -> OdooArtifactPublishResult:
     try:

--- a/control_plane/workflows/odoo_artifact_publish.py
+++ b/control_plane/workflows/odoo_artifact_publish.py
@@ -12,6 +12,13 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
+from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyTarget
+from control_plane.runtime_key_safety import (
+    RuntimeKeySafetyPolicyReadStore,
+    evaluate_runtime_key_safety_from_store,
+    latest_active_runtime_key_safety_policy,
+    runtime_key_safety_environment_class,
+)
 
 DEVKIT_RUNTIME_ENVIRONMENT_PAYLOAD_KEY = "ODOO_DEVKIT_RUNTIME_ENVIRONMENT_JSON"
 PUBLISH_RUNTIME_ENVIRONMENT_KEYS = (
@@ -25,7 +32,7 @@ PUBLISH_RUNTIME_ENVIRONMENT_KEYS = (
 )
 
 
-class OdooArtifactPublishStore(Protocol):
+class OdooArtifactPublishStore(RuntimeKeySafetyPolicyReadStore, Protocol):
     def write_artifact_manifest(self, manifest: ArtifactIdentityManifest) -> Path | None: ...
 
 
@@ -128,12 +135,21 @@ def _validate_manifest_context(*, manifest: ArtifactIdentityManifest, context: s
 
 
 def _runtime_environment_payload(
-    *, request: OdooArtifactPublishRequest, control_plane_root: Path
+    *,
+    record_store: RuntimeKeySafetyPolicyReadStore,
+    request: OdooArtifactPublishRequest,
+    control_plane_root: Path,
 ) -> str:
     environment_values = control_plane_runtime_environments.resolve_runtime_environment_values(
         control_plane_root=control_plane_root,
         context_name=request.context,
         instance_name=request.instance,
+    )
+    _enforce_runtime_key_safety_for_publish_payload(
+        record_store=record_store,
+        context_name=request.context,
+        instance_name=request.instance,
+        environment_values=environment_values,
     )
     return json.dumps(
         {
@@ -142,6 +158,49 @@ def _runtime_environment_payload(
             "environment": environment_values,
         },
         sort_keys=True,
+    )
+
+
+def _enforce_runtime_key_safety_for_publish_payload(
+    *,
+    record_store: RuntimeKeySafetyPolicyReadStore,
+    context_name: str,
+    instance_name: str,
+    environment_values: dict[str, str],
+) -> None:
+    bindings = record_store.list_secret_bindings(
+        integration="runtime_environment",
+        context_name=context_name,
+        instance_name=instance_name,
+        limit=None,
+    )
+    binding_keys = tuple(
+        binding.binding_key for binding in bindings if binding.binding_key in environment_values
+    )
+    if not binding_keys:
+        return
+    try:
+        policy_record = latest_active_runtime_key_safety_policy(record_store)
+        evaluation = evaluate_runtime_key_safety_from_store(
+            record_store=record_store,
+            policy_record=policy_record,
+            target=RuntimeKeySafetyTarget(
+                context=context_name,
+                instance=instance_name,
+                environment_class=runtime_key_safety_environment_class(instance_name),
+            ),
+            required_binding_keys=binding_keys,
+        )
+    except ValueError as exc:
+        raise click.ClickException(
+            "Runtime key-safety policy is unavailable for Odoo artifact publish runtime payload."
+        ) from exc
+    if evaluation.status == "pass":
+        return
+    finding_codes = sorted({finding.code for finding in evaluation.findings})
+    suffix = f": {', '.join(finding_codes)}" if finding_codes else ""
+    raise click.ClickException(
+        f"Runtime key-safety gate failed for Odoo artifact publish runtime payload{suffix}."
     )
 
 
@@ -267,13 +326,14 @@ def execute_odoo_artifact_publish(
     record_store: OdooArtifactPublishStore,
     request: OdooArtifactPublishRequest,
 ) -> OdooArtifactPublishResult:
-    runtime_payload = _runtime_environment_payload(
-        request=request,
-        control_plane_root=control_plane_root,
-    )
     with tempfile.TemporaryDirectory(prefix="launchplane-odoo-artifact-") as temporary_directory:
         output_file = request.output_file or Path(temporary_directory) / "artifact.json"
         try:
+            runtime_payload = _runtime_environment_payload(
+                record_store=record_store,
+                request=request,
+                control_plane_root=control_plane_root,
+            )
             _run_devkit_publish(
                 request=request,
                 runtime_payload=runtime_payload,

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -84,6 +84,9 @@ title: Secrets
 - Product-specific workflows that sync resolved runtime environment values into
   live Dokploy targets, such as Odoo prod rollback target env updates, must
   evaluate managed runtime secret bindings before writing the live env payload.
+- Product-specific artifact/build workflows that pass resolved runtime
+  environment payloads to delegated tooling, such as Odoo artifact publish,
+  must evaluate managed runtime secret bindings before starting that tooling.
 
 ## Bootstrap-Only Env
 

--- a/tests/test_odoo_artifact_publish.py
+++ b/tests/test_odoo_artifact_publish.py
@@ -6,6 +6,12 @@ from unittest.mock import Mock, patch
 from pydantic import ValidationError
 
 from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
+from control_plane.contracts.runtime_key_safety_policy import (
+    RuntimeKeySafetyPolicyRecord,
+    RuntimeSecretClass,
+    RuntimeSecretSafetyRule,
+)
+from control_plane.contracts.secret_record import SecretBinding
 from control_plane.workflows.odoo_artifact_publish import (
     DEVKIT_RUNTIME_ENVIRONMENT_PAYLOAD_KEY,
     OdooArtifactPublishEvidenceRequest,
@@ -34,6 +40,49 @@ def _artifact_manifest(payload: dict[str, object] | None = None) -> ArtifactIden
 
 
 class OdooArtifactPublishWorkflowTests(unittest.TestCase):
+    def _record_store(self) -> Mock:
+        record_store = Mock()
+        record_store.list_secret_bindings.return_value = ()
+        record_store.list_runtime_key_safety_policy_records.return_value = ()
+        return record_store
+
+    def _write_secret_binding(
+        self,
+        record_store: Mock,
+        *,
+        secret_class: RuntimeSecretClass = "testing",
+    ) -> None:
+        binding_key = "ODOO_MASTER_PASSWORD"
+        record_store.list_secret_bindings.return_value = (
+            SecretBinding(
+                binding_id="secret-odoo-master-password-binding",
+                secret_id="secret-odoo-master-password",
+                integration="runtime_environment",
+                binding_key=binding_key,
+                context="cm",
+                instance="testing",
+                status="configured",
+                created_at="2026-05-05T23:00:00Z",
+                updated_at="2026-05-05T23:00:00Z",
+            ),
+        )
+        record_store.list_runtime_key_safety_policy_records.return_value = (
+            RuntimeKeySafetyPolicyRecord(
+                record_id="runtime-key-safety-policy-test",
+                status="active",
+                source="test",
+                updated_at="2026-05-05T23:00:00Z",
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key=binding_key,
+                        secret_class=secret_class,
+                        allowed_contexts=("cm",),
+                        allowed_instances=("testing",),
+                    ),
+                ),
+            ),
+        )
+
     def test_publish_requests_accept_profile_owned_contexts(self) -> None:
         publish_request = OdooArtifactPublishRequest(
             context=" New-Site ",
@@ -74,7 +123,8 @@ class OdooArtifactPublishWorkflowTests(unittest.TestCase):
             OdooArtifactPublishInputsRequest(context=" ", instance="testing")
 
     def test_publish_resolves_launchplane_env_and_writes_artifact(self) -> None:
-        record_store = Mock()
+        record_store = self._record_store()
+        self._write_secret_binding(record_store)
         captured_env: dict[str, str] = {}
 
         def fake_run(
@@ -126,8 +176,36 @@ class OdooArtifactPublishWorkflowTests(unittest.TestCase):
         written_manifest = record_store.write_artifact_manifest.call_args.args[0]
         self.assertEqual(written_manifest.artifact_id, "artifact-cm-005c291b63b6")
 
+    def test_publish_blocks_unsafe_managed_secret_payload(self) -> None:
+        record_store = self._record_store()
+        self._write_secret_binding(record_store, secret_class="prod_only")
+
+        with (
+            patch(
+                "control_plane.workflows.odoo_artifact_publish.control_plane_runtime_environments.resolve_runtime_environment_values",
+                return_value={"ODOO_MASTER_PASSWORD": "managed-secret"},
+            ),
+            patch("control_plane.workflows.odoo_artifact_publish.subprocess.run") as run_mock,
+        ):
+            result = execute_odoo_artifact_publish(
+                control_plane_root=Path("/launchplane"),
+                record_store=record_store,
+                request=OdooArtifactPublishRequest(
+                    context="cm",
+                    manifest_path=Path("/work/cm/workspace.toml"),
+                    devkit_root=Path("/work/odoo-devkit"),
+                    image_repository="ghcr.io/cbusillo/odoo-tenant-cm",
+                    image_tag="cm-20260426-005c291b",
+                ),
+            )
+
+        self.assertEqual(result.status, "fail")
+        self.assertIn("Runtime key-safety gate failed", result.error_message)
+        run_mock.assert_not_called()
+        record_store.write_artifact_manifest.assert_not_called()
+
     def test_publish_rejects_wrong_context_artifact(self) -> None:
-        record_store = Mock()
+        record_store = self._record_store()
 
         def fake_run(
             command: list[str], *, capture_output: bool, text: bool, env: dict[str, str]
@@ -165,7 +243,7 @@ class OdooArtifactPublishWorkflowTests(unittest.TestCase):
         record_store.write_artifact_manifest.assert_not_called()
 
     def test_ingest_publish_evidence_writes_artifact_manifest(self) -> None:
-        record_store = Mock()
+        record_store = self._record_store()
 
         result = ingest_odoo_artifact_publish_evidence(
             record_store=record_store,


### PR DESCRIPTION
## Summary
- require runtime key-safety evaluation before Odoo artifact publish sends managed runtime secrets to devkit
- keep build-input payload filtering unchanged for non-secret publish metadata
- document delegated artifact/build tooling runtime-secret safety expectations

Refs #248

## Verification
- uv run python -m unittest tests.test_odoo_artifact_publish
- uv run --extra dev ruff check control_plane/workflows/odoo_artifact_publish.py tests/test_odoo_artifact_publish.py
- uv run --extra dev ruff format --check control_plane/workflows/odoo_artifact_publish.py tests/test_odoo_artifact_publish.py
- uv run --extra dev mypy control_plane/workflows/odoo_artifact_publish.py tests/test_odoo_artifact_publish.py