### PR TITLE
feat(every-code): add durable work requests

### DIFF
--- a/control_plane/contracts/every_code_work_request.py
+++ b/control_plane/contracts/every_code_work_request.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+EveryCodeWorkRequestSource = Literal["github_issue_label", "manual", "reconciliation"]
+EveryCodeWorkRequestState = Literal["queued", "claimed", "running", "done", "blocked"]
+
+
+class EveryCodeWorkRequestRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    request_id: str
+    source: EveryCodeWorkRequestSource
+    state: EveryCodeWorkRequestState
+    repository: str
+    issue_number: int = Field(ge=1)
+    issue_url: str
+    issue_title: str = ""
+    trigger_label: str
+    trigger_actor: str = ""
+    github_delivery_id: str = ""
+    queued_at: str
+    updated_at: str
+    claimed_at: str = ""
+    claimed_by_host: str = ""
+    started_at: str = ""
+    finished_at: str = ""
+    result_pr_url: str = ""
+    result_summary: str = ""
+    error_message: str = ""
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "EveryCodeWorkRequestRecord":
+        if not self.request_id.strip():
+            raise ValueError("Every Code work request requires request_id")
+        if not self.repository.strip() or "/" not in self.repository.strip():
+            raise ValueError("Every Code work request requires owner/repo repository")
+        if not self.issue_url.strip():
+            raise ValueError("Every Code work request requires issue_url")
+        if not self.trigger_label.strip():
+            raise ValueError("Every Code work request requires trigger_label")
+        if not self.queued_at.strip():
+            raise ValueError("Every Code work request requires queued_at")
+        if not self.updated_at.strip():
+            raise ValueError("Every Code work request requires updated_at")
+        if self.state in {"claimed", "running", "done", "blocked"}:
+            if not self.claimed_at.strip():
+                raise ValueError("claimed Every Code work request requires claimed_at")
+            if not self.claimed_by_host.strip():
+                raise ValueError("claimed Every Code work request requires claimed_by_host")
+        if self.state in {"running", "done"} and not self.started_at.strip():
+            raise ValueError("running Every Code work request requires started_at")
+        if self.state in {"done", "blocked"} and not self.finished_at.strip():
+            raise ValueError("finished Every Code work request requires finished_at")
+        if self.state == "done" and self.error_message.strip():
+            raise ValueError("done Every Code work request must not include error_message")
+        if self.state == "blocked" and not self.error_message.strip():
+            raise ValueError("blocked Every Code work request requires error_message")
+        return self
+
+
+class EveryCodeWorkRequestStatusUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    state: Literal["running", "done", "blocked"]
+    host: str
+    updated_at: str
+    result_pr_url: str = ""
+    result_summary: str = ""
+    error_message: str = ""
+
+    @model_validator(mode="after")
+    def _validate_update(self) -> "EveryCodeWorkRequestStatusUpdate":
+        if not self.host.strip():
+            raise ValueError("Every Code status update requires host")
+        if not self.updated_at.strip():
+            raise ValueError("Every Code status update requires updated_at")
+        if self.state == "done" and self.error_message.strip():
+            raise ValueError("done Every Code status update must not include error_message")
+        if self.state == "blocked" and not self.error_message.strip():
+            raise ValueError("blocked Every Code status update requires error_message")
+        return self
+
+
+def build_every_code_work_request_id(
+    *, repository: str, issue_number: int, trigger_label: str
+) -> str:
+    normalized_repository = repository.strip().lower()
+    normalized_label = trigger_label.strip().lower()
+    if not normalized_repository or issue_number < 1 or not normalized_label:
+        raise ValueError("Every Code work request id requires repository, issue_number, and trigger_label")
+    digest = hashlib.sha256(
+        f"{normalized_repository}#{issue_number}:{normalized_label}".encode("utf-8")
+    ).hexdigest()[:16]
+    return f"every-code-{normalized_repository.replace('/', '-')}-{issue_number}-{digest}"
+
+
+def claim_every_code_work_request(
+    record: EveryCodeWorkRequestRecord, *, host: str, claimed_at: str
+) -> EveryCodeWorkRequestRecord | None:
+    normalized_host = host.strip()
+    if not normalized_host:
+        raise ValueError("Every Code work request claim requires host")
+    if not claimed_at.strip():
+        raise ValueError("Every Code work request claim requires claimed_at")
+    if record.state != "queued":
+        return None
+    return record.model_copy(
+        update={
+            "state": "claimed",
+            "claimed_at": claimed_at,
+            "claimed_by_host": normalized_host,
+            "updated_at": claimed_at,
+        }
+    )
+
+
+def apply_every_code_work_request_status(
+    record: EveryCodeWorkRequestRecord, update: EveryCodeWorkRequestStatusUpdate
+) -> EveryCodeWorkRequestRecord:
+    if record.state == "queued":
+        raise ValueError("Every Code work request must be claimed before status updates")
+    if record.state in {"done", "blocked"}:
+        raise ValueError("finished Every Code work request cannot be updated")
+    if record.claimed_by_host.strip() != update.host.strip():
+        raise ValueError("Every Code status update host does not match claim host")
+
+    updates: dict[str, object] = {
+        "state": update.state,
+        "updated_at": update.updated_at,
+        "result_pr_url": update.result_pr_url,
+        "result_summary": update.result_summary,
+        "error_message": update.error_message,
+    }
+    if update.state == "running" and not record.started_at.strip():
+        updates["started_at"] = update.updated_at
+    if update.state in {"done", "blocked"}:
+        updates["finished_at"] = update.updated_at
+        if not record.started_at.strip():
+            updates["started_at"] = update.updated_at
+    return record.model_copy(update=updates)

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -12,7 +12,7 @@ import secrets
 from socketserver import ThreadingMixIn
 import uuid
 from pathlib import Path
-from typing import BinaryIO, Callable, Generic, Protocol, TypeVar, cast
+from typing import BinaryIO, Callable, Generic, Literal, Protocol, TypeVar, cast
 from urllib.parse import parse_qs, unquote
 from wsgiref.simple_server import WSGIServer, make_server
 from wsgiref.types import WSGIApplication
@@ -33,6 +33,12 @@ from control_plane.contracts.authz_policy_record import (
 )
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
+from control_plane.contracts.every_code_work_request import (
+    EveryCodeWorkRequestRecord,
+    EveryCodeWorkRequestStatusUpdate,
+    apply_every_code_work_request_status,
+    build_every_code_work_request_id,
+)
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.idempotency_record import build_launchplane_idempotency_record_id
 from control_plane.contracts.preview_mutation_request import (
@@ -1183,6 +1189,47 @@ class LaunchplaneSelfDeployEnvelope(BaseModel):
         return self
 
 
+class EveryCodeWorkRequestCreateEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    repository: str
+    issue_number: int = Field(ge=1)
+    issue_url: str
+    issue_title: str = ""
+    trigger_label: str = "every-code"
+    trigger_actor: str = ""
+    github_delivery_id: str = ""
+    source: Literal["github_issue_label", "manual", "reconciliation"] = "manual"
+    queued_at: str = ""
+
+
+class EveryCodeWorkRequestClaimEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    request_id: str
+    host: str
+
+    @model_validator(mode="after")
+    def _validate_claim(self) -> "EveryCodeWorkRequestClaimEnvelope":
+        if not self.request_id.strip():
+            raise ValueError("Every Code work request claim requires request_id")
+        if not self.host.strip():
+            raise ValueError("Every Code work request claim requires host")
+        return self
+
+
+class EveryCodeWorkRequestStatusEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    request_id: str
+    host: str
+    state: Literal["running", "done", "blocked"]
+    result_pr_url: str = ""
+    result_summary: str = ""
+    error_message: str = ""
+    updated_at: str = ""
+
+
 class AuthzPolicyGitHubActionsGrant(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -1565,6 +1612,10 @@ def _serve_ui_route(
 
 def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
     segments = [segment for segment in path.split("/") if segment]
+    if len(segments) == 3 and segments == ["v1", "every-code", "work-requests"]:
+        return "every_code_work_request.read", {}
+    if len(segments) == 4 and segments[:3] == ["v1", "every-code", "work-requests"]:
+        return "every_code_work_request.read", {"request_id": segments[3]}
     if len(segments) == 2 and segments == ["v1", "drivers"]:
         return "driver.read", {}
     if len(segments) == 3 and segments[:2] == ["v1", "drivers"]:
@@ -1675,6 +1726,9 @@ def _driver_write_routes_from_descriptors() -> frozenset[str]:
 
 def _build_write_routes() -> frozenset[str]:
     launchplane_write_routes = {
+        "/v1/every-code/work-requests/create",
+        "/v1/every-code/work-requests/claim",
+        "/v1/every-code/work-requests/status",
         "/v1/evidence/deployments",
         "/v1/evidence/backup-gates",
         "/v1/evidence/previews/generations",
@@ -1699,6 +1753,40 @@ def _secret_capable_store(record_store: object) -> control_plane_secrets.SecretR
     if hasattr(record_store, "read_secret_record") and hasattr(record_store, "list_secret_records"):
         return cast(control_plane_secrets.SecretReadStore, record_store)
     return None
+
+
+class _EveryCodeWorkRequestStore(Protocol):
+    def write_every_code_work_request_record(self, record: EveryCodeWorkRequestRecord) -> object: ...
+
+    def read_every_code_work_request_record(self, request_id: str) -> EveryCodeWorkRequestRecord: ...
+
+    def list_every_code_work_request_records(
+        self,
+        *,
+        state: str = "",
+        repository: str = "",
+        limit: int | None = None,
+    ) -> tuple[EveryCodeWorkRequestRecord, ...]: ...
+
+    def claim_every_code_work_request_record(
+        self,
+        *,
+        request_id: str,
+        host: str,
+        claimed_at: str,
+    ) -> EveryCodeWorkRequestRecord | None: ...
+
+
+def _every_code_work_request_store(record_store: object) -> _EveryCodeWorkRequestStore:
+    required_methods = (
+        "write_every_code_work_request_record",
+        "read_every_code_work_request_record",
+        "list_every_code_work_request_records",
+        "claim_every_code_work_request_record",
+    )
+    if all(hasattr(record_store, method_name) for method_name in required_methods):
+        return cast(_EveryCodeWorkRequestStore, record_store)
+    raise TypeError("record store does not support Every Code work requests")
 
 
 def _idempotency_capable_store(record_store: object) -> _IdempotencyCapableStore | None:
@@ -1811,6 +1899,8 @@ def _accepted_payload(
                 "image_reference",
                 "artifact_id",
                 "transition",
+                "request_id",
+                "state",
             }
         },
         **({"result": serialized_driver_result} if serialized_driver_result else {}),
@@ -2179,6 +2269,29 @@ def _safe_return_to(value: str) -> str:
 
 def _now_timestamp() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _build_every_code_work_request_record(
+    request: EveryCodeWorkRequestCreateEnvelope, *, queued_at: str
+) -> EveryCodeWorkRequestRecord:
+    return EveryCodeWorkRequestRecord(
+        request_id=build_every_code_work_request_id(
+            repository=request.repository,
+            issue_number=request.issue_number,
+            trigger_label=request.trigger_label,
+        ),
+        source=request.source,
+        state="queued",
+        repository=request.repository.strip(),
+        issue_number=request.issue_number,
+        issue_url=request.issue_url.strip(),
+        issue_title=request.issue_title.strip(),
+        trigger_label=request.trigger_label.strip(),
+        trigger_actor=request.trigger_actor.strip(),
+        github_delivery_id=request.github_delivery_id.strip(),
+        queued_at=queued_at,
+        updated_at=queued_at,
+    )
 
 
 def _bootstrap_policy_source_from_env() -> str:
@@ -3532,6 +3645,60 @@ def create_launchplane_service_app(
                             ),
                         },
                     )
+                if action == "every_code_work_request.read":
+                    if not authz_policy.allows(
+                        identity=identity,
+                        action=action,
+                        product="launchplane",
+                        context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                    ):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=403,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "authorization_denied",
+                                    "message": "Workflow cannot read Every Code work requests.",
+                                },
+                            },
+                        )
+                    every_code_store = _every_code_work_request_store(record_store)
+                    if "request_id" in params:
+                        record = every_code_store.read_every_code_work_request_record(
+                            params["request_id"]
+                        )
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=200,
+                            payload={
+                                "status": "ok",
+                                "trace_id": request_trace_id,
+                                "request": record.model_dump(mode="json"),
+                            },
+                        )
+                    state_filter = str((query.get("state") or [""])[0] or "").strip()
+                    repository_filter = str(
+                        (query.get("repository") or [""])[0] or ""
+                    ).strip()
+                    limit = int(str((query.get("limit") or ["50"])[0] or "50"))
+                    records = every_code_store.list_every_code_work_request_records(
+                        state=state_filter,
+                        repository=repository_filter,
+                        limit=limit,
+                    )
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=200,
+                        payload={
+                            "status": "ok",
+                            "trace_id": request_trace_id,
+                            "state": state_filter,
+                            "repository": repository_filter,
+                            "requests": [record.model_dump(mode="json") for record in records],
+                        },
+                    )
                 if action == "product_profile.read":
                     if "product" in params:
                         profile = record_store.read_product_profile_record(params["product"])
@@ -3872,7 +4039,147 @@ def create_launchplane_service_app(
             request_fingerprint = _idempotency_request_fingerprint(route_path=path, payload=payload)
             driver_result: BaseModel | dict[str, object] | None = None
             result: dict[str, object] = {}
-            if path == "/v1/evidence/deployments":
+            if path == "/v1/every-code/work-requests/create":
+                every_code_request = EveryCodeWorkRequestCreateEnvelope.model_validate(payload)
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="every_code_work_request.write",
+                    product="launchplane",
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot create Every Code work requests.",
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                every_code_store = _every_code_work_request_store(record_store)
+                record = _build_every_code_work_request_record(
+                    every_code_request,
+                    queued_at=every_code_request.queued_at.strip() or _utc_now_timestamp(),
+                )
+                every_code_store.write_every_code_work_request_record(record)
+                result = {"request_id": record.request_id, "state": record.state}
+                driver_result = {"request": record.model_dump(mode="json")}
+            elif path == "/v1/every-code/work-requests/claim":
+                claim_request = EveryCodeWorkRequestClaimEnvelope.model_validate(payload)
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="every_code_work_request.claim",
+                    product="launchplane",
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot claim Every Code work requests.",
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                every_code_store = _every_code_work_request_store(record_store)
+                claimed_record = every_code_store.claim_every_code_work_request_record(
+                    request_id=claim_request.request_id.strip(),
+                    host=claim_request.host.strip(),
+                    claimed_at=_utc_now_timestamp(),
+                )
+                if claimed_record is None:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=409,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "work_request_already_claimed",
+                                "message": "Every Code work request is not queued for claim.",
+                            },
+                        },
+                    )
+                result = {"request_id": claimed_record.request_id, "state": claimed_record.state}
+                driver_result = {"request": claimed_record.model_dump(mode="json")}
+            elif path == "/v1/every-code/work-requests/status":
+                status_request = EveryCodeWorkRequestStatusEnvelope.model_validate(payload)
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="every_code_work_request.update",
+                    product="launchplane",
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot update Every Code work requests.",
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                every_code_store = _every_code_work_request_store(record_store)
+                existing_record = every_code_store.read_every_code_work_request_record(
+                    status_request.request_id.strip()
+                )
+                updated_record = apply_every_code_work_request_status(
+                    existing_record,
+                    EveryCodeWorkRequestStatusUpdate(
+                        state=status_request.state,
+                        host=status_request.host,
+                        updated_at=status_request.updated_at.strip() or _utc_now_timestamp(),
+                        result_pr_url=status_request.result_pr_url,
+                        result_summary=status_request.result_summary,
+                        error_message=status_request.error_message,
+                    ),
+                )
+                every_code_store.write_every_code_work_request_record(updated_record)
+                result = {"request_id": updated_record.request_id, "state": updated_record.state}
+                driver_result = {"request": updated_record.model_dump(mode="json")}
+            elif path == "/v1/evidence/deployments":
                 deployment_request = DeploymentEvidenceEnvelope.model_validate(payload)
                 if not authz_policy.allows(
                     identity=identity,

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -9,6 +9,10 @@ from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRe
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.every_code_work_request import (
+    EveryCodeWorkRequestRecord,
+    claim_every_code_work_request,
+)
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.preview_enablement_record import PreviewEnablementRecord
@@ -114,6 +118,53 @@ class FilesystemRecordStore:
         if limit is not None:
             records = records[:limit]
         return tuple(records)
+
+    def write_every_code_work_request_record(self, record: EveryCodeWorkRequestRecord) -> Path:
+        return self._write_model("launchplane_every_code_work_requests", record.request_id, record)
+
+    def read_every_code_work_request_record(self, request_id: str) -> EveryCodeWorkRequestRecord:
+        return EveryCodeWorkRequestRecord.model_validate(
+            self._read_model(
+                EveryCodeWorkRequestRecord,
+                "launchplane_every_code_work_requests",
+                request_id,
+            ).model_dump(mode="json")
+        )
+
+    def list_every_code_work_request_records(
+        self,
+        *,
+        state: str = "",
+        repository: str = "",
+        limit: int | None = None,
+    ) -> tuple[EveryCodeWorkRequestRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                EveryCodeWorkRequestRecord,
+                "launchplane_every_code_work_requests",
+            )
+            if (not state or record.state == state)
+            and (not repository or record.repository == repository)
+        ]
+        records.sort(key=lambda record: (record.updated_at, record.request_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def claim_every_code_work_request_record(
+        self,
+        *,
+        request_id: str,
+        host: str,
+        claimed_at: str,
+    ) -> EveryCodeWorkRequestRecord | None:
+        record = self.read_every_code_work_request_record(request_id)
+        claimed_record = claim_every_code_work_request(record, host=host, claimed_at=claimed_at)
+        if claimed_record is None:
+            return None
+        self.write_every_code_work_request_record(claimed_record)
+        return claimed_record
 
     def write_product_profile_record(self, record: LaunchplaneProductProfileRecord) -> Path:
         return self._write_model("launchplane_product_profiles", record.product, record)

--- a/control_plane/storage/migrations/versions/ab12cd34ef56_add_every_code_work_requests.py
+++ b/control_plane/storage/migrations/versions/ab12cd34ef56_add_every_code_work_requests.py
@@ -1,0 +1,61 @@
+"""add Every Code work requests
+
+Revision ID: ab12cd34ef56
+Revises: f1a3c5e7b9d0
+Create Date: 2026-05-05 22:40:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "ab12cd34ef56"
+down_revision: str | None = "f1a3c5e7b9d0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "launchplane_every_code_work_requests",
+        sa.Column("request_id", sa.String(), nullable=False),
+        sa.Column("source", sa.String(), nullable=False),
+        sa.Column("state", sa.String(), nullable=False),
+        sa.Column("repository", sa.String(), nullable=False),
+        sa.Column("issue_number", sa.Integer(), nullable=False),
+        sa.Column("trigger_label", sa.String(), nullable=False),
+        sa.Column("updated_at", sa.String(), nullable=False),
+        sa.Column("claimed_by_host", sa.String(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("request_id"),
+    )
+    op.create_index(
+        "launchplane_every_code_work_requests_state_updated_idx",
+        "launchplane_every_code_work_requests",
+        ["state", sa.text("updated_at DESC")],
+    )
+    op.create_index(
+        "launchplane_every_code_work_requests_repo_issue_idx",
+        "launchplane_every_code_work_requests",
+        ["repository", "issue_number"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "launchplane_every_code_work_requests_repo_issue_idx",
+        table_name="launchplane_every_code_work_requests",
+    )
+    op.drop_index(
+        "launchplane_every_code_work_requests_state_updated_idx",
+        table_name="launchplane_every_code_work_requests",
+    )
+    op.drop_table("launchplane_every_code_work_requests")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -27,6 +27,10 @@ from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.every_code_work_request import (
+    EveryCodeWorkRequestRecord,
+    claim_every_code_work_request,
+)
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
@@ -427,6 +431,32 @@ class LaunchplaneOdooInstanceOverrideRow(Base):
     context: Mapped[str] = mapped_column(String, primary_key=True)
     instance: Mapped[str] = mapped_column(String, primary_key=True)
     updated_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneEveryCodeWorkRequestRow(Base):
+    __tablename__ = "launchplane_every_code_work_requests"
+    __table_args__ = (
+        Index(
+            "launchplane_every_code_work_requests_state_updated_idx",
+            "state",
+            desc("updated_at"),
+        ),
+        Index(
+            "launchplane_every_code_work_requests_repo_issue_idx",
+            "repository",
+            "issue_number",
+        ),
+    )
+
+    request_id: Mapped[str] = mapped_column(String, primary_key=True)
+    source: Mapped[str] = mapped_column(String, nullable=False)
+    state: Mapped[str] = mapped_column(String, nullable=False)
+    repository: Mapped[str] = mapped_column(String, nullable=False)
+    issue_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    trigger_label: Mapped[str] = mapped_column(String, nullable=False)
+    updated_at: Mapped[str] = mapped_column(String, nullable=False)
+    claimed_by_host: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -1130,6 +1160,84 @@ class PostgresRecordStore(HumanSessionStore):
             ),
             limit=limit,
         )
+
+    def write_every_code_work_request_record(self, record: EveryCodeWorkRequestRecord) -> None:
+        self._write_row(
+            LaunchplaneEveryCodeWorkRequestRow(
+                request_id=record.request_id,
+                source=record.source,
+                state=record.state,
+                repository=record.repository,
+                issue_number=record.issue_number,
+                trigger_label=record.trigger_label,
+                updated_at=record.updated_at,
+                claimed_by_host=record.claimed_by_host,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def read_every_code_work_request_record(self, request_id: str) -> EveryCodeWorkRequestRecord:
+        return self._read_model(
+            model_type=EveryCodeWorkRequestRecord,
+            orm_model=LaunchplaneEveryCodeWorkRequestRow,
+            filters=(LaunchplaneEveryCodeWorkRequestRow.request_id == request_id,),
+        )
+
+    def list_every_code_work_request_records(
+        self,
+        *,
+        state: str = "",
+        repository: str = "",
+        limit: int | None = None,
+    ) -> tuple[EveryCodeWorkRequestRecord, ...]:
+        filters: list[_SqlFilter] = []
+        if state:
+            filters.append(LaunchplaneEveryCodeWorkRequestRow.state == state)
+        if repository:
+            filters.append(LaunchplaneEveryCodeWorkRequestRow.repository == repository)
+        return self._list_models(
+            model_type=EveryCodeWorkRequestRecord,
+            orm_model=LaunchplaneEveryCodeWorkRequestRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneEveryCodeWorkRequestRow.updated_at.desc(),
+                LaunchplaneEveryCodeWorkRequestRow.request_id.desc(),
+            ),
+            limit=limit,
+        )
+
+    def claim_every_code_work_request_record(
+        self,
+        *,
+        request_id: str,
+        host: str,
+        claimed_at: str,
+    ) -> EveryCodeWorkRequestRecord | None:
+        with self._session_factory() as session:
+            statement = (
+                select(LaunchplaneEveryCodeWorkRequestRow)
+                .where(LaunchplaneEveryCodeWorkRequestRow.request_id == request_id)
+                .limit(1)
+            )
+            if not self.database_url.startswith("sqlite"):
+                statement = statement.with_for_update()
+            row = session.scalar(statement)
+            if row is None:
+                raise FileNotFoundError(request_id)
+            record = self._read_payload(model_type=EveryCodeWorkRequestRecord, payload=row.payload)
+            claimed_record = claim_every_code_work_request(
+                record,
+                host=host,
+                claimed_at=claimed_at,
+            )
+            if claimed_record is None:
+                return None
+            row.state = claimed_record.state
+            row.updated_at = claimed_record.updated_at
+            row.claimed_by_host = claimed_record.claimed_by_host
+            row.payload = self._payload_dict(claimed_record)
+            session.commit()
+            return claimed_record
 
     def write_preview_lifecycle_plan_record(self, record: PreviewLifecyclePlanRecord) -> None:
         self._write_row(

--- a/docs/records.md
+++ b/docs/records.md
@@ -533,6 +533,19 @@ state/
   GitHub comments themselves. This keeps PR feedback aligned with Launchplane's
   durable preview lifecycle records.
 
+## Every Code Work Request Record
+
+- One durable request per approved Every Code automation trigger.
+- Record the source, repository, issue number and URL, trigger label, trigger
+  actor, optional GitHub delivery id, queue/update timestamps, claim host, run
+  timestamps, PR URL, result summary, and blocked error message.
+- State is `queued`, `claimed`, `running`, `done`, or `blocked`. Workers claim a
+  queued request before reporting progress. Terminal states are immutable through
+  the service status route.
+- Launchplane owns this coordination record so GitHub webhooks, reconciliation,
+  local Mac workers, and the future operator UI share one inspectable source of
+  truth instead of relying on GitHub API polling or local shell lock files.
+
 ## Inventory
 
 - Inventory records are keyed by environment.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -52,6 +52,12 @@ VeriReel product paths:
   - `POST /v1/product-profiles/legacy-context-cleanup/apply`
 - authz policy maintenance route:
   - `POST /v1/authz-policies/github-actions/grants`
+- Every Code local automation work-request routes:
+  - `GET /v1/every-code/work-requests`
+  - `GET /v1/every-code/work-requests/{request_id}`
+  - `POST /v1/every-code/work-requests/create`
+  - `POST /v1/every-code/work-requests/claim`
+  - `POST /v1/every-code/work-requests/status`
 - product driver routes:
   - `POST /v1/drivers/generic-web/deploy`
   - `POST /v1/drivers/generic-web/prod-promotion`

--- a/tests/test_every_code_work_request.py
+++ b/tests/test_every_code_work_request.py
@@ -1,0 +1,122 @@
+import unittest
+
+from control_plane.contracts.every_code_work_request import (
+    EveryCodeWorkRequestRecord,
+    EveryCodeWorkRequestStatusUpdate,
+    apply_every_code_work_request_status,
+    build_every_code_work_request_id,
+    claim_every_code_work_request,
+)
+
+
+def _queued_record() -> EveryCodeWorkRequestRecord:
+    return EveryCodeWorkRequestRecord(
+        request_id="every-code-cbusillo-code-123-test",
+        source="manual",
+        state="queued",
+        repository="cbusillo/code",
+        issue_number=123,
+        issue_url="https://github.com/cbusillo/code/issues/123",
+        trigger_label="every-code",
+        queued_at="2026-05-05T22:00:00Z",
+        updated_at="2026-05-05T22:00:00Z",
+    )
+
+
+class EveryCodeWorkRequestRecordTests(unittest.TestCase):
+    def test_build_id_is_deterministic(self) -> None:
+        first = build_every_code_work_request_id(
+            repository="cbusillo/code",
+            issue_number=123,
+            trigger_label="every-code",
+        )
+        second = build_every_code_work_request_id(
+            repository="CBUSILLO/CODE",
+            issue_number=123,
+            trigger_label="EVERY-CODE",
+        )
+
+        self.assertEqual(first, second)
+        self.assertTrue(first.startswith("every-code-cbusillo-code-123-"))
+
+    def test_claim_requires_queued_state(self) -> None:
+        queued_record = _queued_record()
+        claimed_record = claim_every_code_work_request(
+            queued_record,
+            host="Chris-Studio",
+            claimed_at="2026-05-05T22:01:00Z",
+        )
+
+        self.assertIsNotNone(claimed_record)
+        assert claimed_record is not None
+        self.assertEqual(claimed_record.state, "claimed")
+        self.assertEqual(claimed_record.claimed_by_host, "Chris-Studio")
+        self.assertIsNone(
+            claim_every_code_work_request(
+                claimed_record,
+                host="Other-Host",
+                claimed_at="2026-05-05T22:02:00Z",
+            )
+        )
+
+    def test_status_update_enforces_claim_host(self) -> None:
+        claimed_record = claim_every_code_work_request(
+            _queued_record(),
+            host="Chris-Studio",
+            claimed_at="2026-05-05T22:01:00Z",
+        )
+        assert claimed_record is not None
+
+        with self.assertRaises(ValueError):
+            apply_every_code_work_request_status(
+                claimed_record,
+                EveryCodeWorkRequestStatusUpdate(
+                    state="running",
+                    host="Other-Host",
+                    updated_at="2026-05-05T22:02:00Z",
+                ),
+            )
+
+    def test_done_status_sets_started_and_finished_when_worker_finishes_directly(self) -> None:
+        claimed_record = claim_every_code_work_request(
+            _queued_record(),
+            host="Chris-Studio",
+            claimed_at="2026-05-05T22:01:00Z",
+        )
+        assert claimed_record is not None
+
+        done_record = apply_every_code_work_request_status(
+            claimed_record,
+            EveryCodeWorkRequestStatusUpdate(
+                state="done",
+                host="Chris-Studio",
+                updated_at="2026-05-05T22:03:00Z",
+                result_pr_url="https://github.com/cbusillo/code/pull/99",
+            ),
+        )
+
+        self.assertEqual(done_record.state, "done")
+        self.assertEqual(done_record.started_at, "2026-05-05T22:03:00Z")
+        self.assertEqual(done_record.finished_at, "2026-05-05T22:03:00Z")
+        self.assertEqual(done_record.result_pr_url, "https://github.com/cbusillo/code/pull/99")
+
+    def test_blocked_requires_error_message(self) -> None:
+        with self.assertRaises(ValueError):
+            EveryCodeWorkRequestRecord(
+                request_id="every-code-cbusillo-code-123-test",
+                source="manual",
+                state="blocked",
+                repository="cbusillo/code",
+                issue_number=123,
+                issue_url="https://github.com/cbusillo/code/issues/123",
+                trigger_label="every-code",
+                queued_at="2026-05-05T22:00:00Z",
+                updated_at="2026-05-05T22:03:00Z",
+                claimed_at="2026-05-05T22:01:00Z",
+                claimed_by_host="Chris-Studio",
+                finished_at="2026-05-05T22:03:00Z",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -21,6 +21,7 @@ from control_plane.contracts.deployment_record import DeploymentRecord, Resolved
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.idempotency_record import build_launchplane_idempotency_record_id
 from control_plane.contracts.odoo_instance_override_record import OdooConfigParameterOverride
@@ -219,6 +220,35 @@ def _dokploy_target_record(*, context: str = "opw", instance: str = "prod") -> D
         updated_at="2026-04-21T18:30:00Z",
         source_label="import:test",
     )
+
+
+def _every_code_work_request(
+    *,
+    request_id: str = "every-code-cbusillo-code-123-test",
+    state: str = "queued",
+    updated_at: str = "2026-05-05T22:00:00Z",
+) -> EveryCodeWorkRequestRecord:
+    payload = {
+        "request_id": request_id,
+        "source": "manual",
+        "state": state,
+        "repository": "cbusillo/code",
+        "issue_number": 123,
+        "issue_url": "https://github.com/cbusillo/code/issues/123",
+        "trigger_label": "every-code",
+        "queued_at": "2026-05-05T22:00:00Z",
+        "updated_at": updated_at,
+    }
+    if state in {"claimed", "running", "done", "blocked"}:
+        payload["claimed_at"] = "2026-05-05T22:01:00Z"
+        payload["claimed_by_host"] = "Chris-Studio"
+    if state in {"running", "done"}:
+        payload["started_at"] = "2026-05-05T22:02:00Z"
+    if state in {"done", "blocked"}:
+        payload["finished_at"] = "2026-05-05T22:03:00Z"
+    if state == "blocked":
+        payload["error_message"] = "checkout missing"
+    return EveryCodeWorkRequestRecord.model_validate(payload)
 
 
 def _runtime_environment_record(
@@ -524,6 +554,41 @@ class PostgresRecordStoreTests(unittest.TestCase):
             assert loaded is not None
             self.assertEqual(loaded.request_fingerprint, "fingerprint-123")
             self.assertEqual(loaded.response_payload["records"]["preview_id"], "preview-35")
+
+    def test_every_code_work_requests_round_trip_list_and_claim_once(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            store = PostgresRecordStore(database_url=_sqlite_database_url(database_path))
+            store.ensure_schema()
+
+            older_record = _every_code_work_request(
+                request_id="every-code-cbusillo-code-122-test",
+                updated_at="2026-05-05T21:00:00Z",
+            )
+            newer_record = _every_code_work_request()
+            store.write_every_code_work_request_record(older_record)
+            store.write_every_code_work_request_record(newer_record)
+
+            listed = store.list_every_code_work_request_records(state="queued")
+            claimed = store.claim_every_code_work_request_record(
+                request_id=newer_record.request_id,
+                host="Chris-Studio",
+                claimed_at="2026-05-05T22:01:00Z",
+            )
+            second_claim = store.claim_every_code_work_request_record(
+                request_id=newer_record.request_id,
+                host="Other-Host",
+                claimed_at="2026-05-05T22:02:00Z",
+            )
+            loaded = store.read_every_code_work_request_record(newer_record.request_id)
+
+        self.assertEqual([record.request_id for record in listed], [newer_record.request_id, older_record.request_id])
+        self.assertIsNotNone(claimed)
+        assert claimed is not None
+        self.assertEqual(claimed.state, "claimed")
+        self.assertEqual(claimed.claimed_by_host, "Chris-Studio")
+        self.assertIsNone(second_claim)
+        self.assertEqual(loaded.state, "claimed")
 
     def test_human_sessions_round_trip_and_delete(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -743,6 +743,135 @@ class GitHubHumanAuthTests(unittest.TestCase):
 
 
 class LaunchplaneServiceTests(unittest.TestCase):
+    def test_every_code_work_request_create_list_claim_and_status_flow(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main"
+                        ],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": [
+                            "every_code_work_request.write",
+                            "every_code_work_request.read",
+                            "every_code_work_request.claim",
+                            "every_code_work_request.update",
+                        ],
+                    }
+                ]
+            }
+        )
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
+            event_name="workflow_dispatch",
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(identity),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            create_status, create_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/create",
+                payload={
+                    "repository": "cbusillo/code",
+                    "issue_number": 123,
+                    "issue_url": "https://github.com/cbusillo/code/issues/123",
+                    "issue_title": "Wire local automation",
+                    "trigger_label": "every-code",
+                    "trigger_actor": "cbusillo",
+                    "source": "manual",
+                    "queued_at": "2026-05-05T22:00:00Z",
+                },
+                headers={"Idempotency-Key": "every-code-create-code-123"},
+            )
+            request_id = str(create_payload["records"]["request_id"])
+            list_status, list_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/every-code/work-requests",
+                query_string="state=queued",
+            )
+            claim_status, claim_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/claim",
+                payload={"request_id": request_id, "host": "Chris-Studio"},
+                headers={"Idempotency-Key": "every-code-claim-code-123"},
+            )
+            second_claim_status, second_claim_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/claim",
+                payload={"request_id": request_id, "host": "Other-Host"},
+                headers={"Idempotency-Key": "every-code-claim-code-123-other"},
+            )
+            status_status, status_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/status",
+                payload={
+                    "request_id": request_id,
+                    "host": "Chris-Studio",
+                    "state": "done",
+                    "result_pr_url": "https://github.com/cbusillo/code/pull/26",
+                    "updated_at": "2026-05-05T22:05:00Z",
+                },
+                headers={"Idempotency-Key": "every-code-status-code-123-done"},
+            )
+            show_status, show_payload = _invoke_app(
+                app,
+                method="GET",
+                path=f"/v1/every-code/work-requests/{request_id}",
+            )
+
+        self.assertEqual(create_status, 202)
+        self.assertEqual(create_payload["records"]["state"], "queued")
+        self.assertEqual(list_status, 200)
+        self.assertEqual(len(list_payload["requests"]), 1)
+        self.assertEqual(claim_status, 202)
+        self.assertEqual(claim_payload["records"]["state"], "claimed")
+        self.assertEqual(second_claim_status, 409)
+        self.assertEqual(second_claim_payload["error"]["code"], "work_request_already_claimed")
+        self.assertEqual(status_status, 202)
+        self.assertEqual(status_payload["records"]["state"], "done")
+        self.assertEqual(show_status, 200)
+        self.assertEqual(show_payload["request"]["state"], "done")
+        self.assertEqual(
+            show_payload["request"]["result_pr_url"],
+            "https://github.com/cbusillo/code/pull/26",
+        )
+
+    def test_every_code_work_request_create_rejects_unauthorized_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/create",
+                payload={
+                    "repository": "cbusillo/code",
+                    "issue_number": 123,
+                    "issue_url": "https://github.com/cbusillo/code/issues/123",
+                },
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
     def test_health_endpoint_reports_storage_backend(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             app = create_launchplane_service_app(


### PR DESCRIPTION
## Summary
- add Every Code work-request contract, storage, and Alembic migration
- expose Launchplane service APIs to create, list, claim, and update work requests
- document the work-request record and service routes

Refs #279

## Validation
- uv run python -m unittest tests.test_every_code_work_request tests.test_postgres_store.PostgresRecordStoreTests.test_every_code_work_requests_round_trip_list_and_claim_once tests.test_service.LaunchplaneServiceTests.test_every_code_work_request_create_list_claim_and_status_flow tests.test_service.LaunchplaneServiceTests.test_every_code_work_request_create_rejects_unauthorized_identity
- uv run python -m compileall control_plane tests/test_every_code_work_request.py
- uv run python -m unittest