### PR TITLE
Redact runtime environment resolve output

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -183,6 +183,7 @@ _LAUNCHPLANE_SERVICE_POLICY_ENV_KEYS = (
 _SERVICE_TARGET_TYPE_ENV_KEYS = ("LAUNCHPLANE_DOKPLOY_TARGET_TYPE",)
 _SERVICE_TARGET_ID_ENV_KEYS = ("LAUNCHPLANE_DOKPLOY_TARGET_ID",)
 _SECRET_SHAPED_RUNTIME_ENV_KEY_PARTS = {"PASSWORD", "TOKEN", "SECRET", "KEY"}
+_REDACTED_RUNTIME_ENVIRONMENT_VALUE = "<redacted>"
 _SUCCESSFUL_DOKPLOY_STATUSES = {"success", "succeeded", "done", "completed", "healthy", "finished"}
 
 
@@ -8599,6 +8600,17 @@ def _runtime_environment_key_requires_secret_store(key_name: str) -> bool:
     )
 
 
+def _redact_runtime_environment_values(environment_values: dict[str, str]) -> dict[str, str]:
+    return {
+        key: (
+            _REDACTED_RUNTIME_ENVIRONMENT_VALUE
+            if _runtime_environment_key_requires_secret_store(key)
+            else value
+        )
+        for key, value in environment_values.items()
+    }
+
+
 def _validate_runtime_environment_scope_route(
     *,
     scope: str,
@@ -12165,11 +12177,27 @@ def environments_list(database_url: str) -> None:
 @click.option("--context", "context_name", required=True)
 @click.option("--instance", "instance_name", default="local", show_default=True)
 @click.option("--json-output", is_flag=True, default=False)
-def environments_resolve(context_name: str, instance_name: str, json_output: bool) -> None:
+@click.option(
+    "--include-secret-values",
+    is_flag=True,
+    default=False,
+    help="Print resolved secret-shaped values. Use only in trusted operator shells.",
+)
+def environments_resolve(
+    context_name: str,
+    instance_name: str,
+    json_output: bool,
+    include_secret_values: bool,
+) -> None:
     environment_values = control_plane_runtime_environments.resolve_runtime_environment_values(
         control_plane_root=_control_plane_root(),
         context_name=context_name,
         instance_name=instance_name,
+    )
+    output_values = (
+        environment_values
+        if include_secret_values
+        else _redact_runtime_environment_values(environment_values)
     )
     if json_output:
         click.echo(
@@ -12177,15 +12205,16 @@ def environments_resolve(context_name: str, instance_name: str, json_output: boo
                 {
                     "context": context_name,
                     "instance": instance_name,
-                    "environment": environment_values,
+                    "environment": output_values,
+                    "redacted": not include_secret_values,
                 },
                 indent=2,
                 sort_keys=True,
             )
         )
         return
-    for environment_key in sorted(environment_values):
-        click.echo(f"{environment_key}={environment_values[environment_key]}")
+    for environment_key in sorted(output_values):
+        click.echo(f"{environment_key}={output_values[environment_key]}")
 
 
 @environments.command("show-live-target")

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -430,7 +430,8 @@ Current derived-state behavior:
 - `environments list` shows DB-backed runtime-environment record metadata and
   keys without echoing plaintext values.
 - `environments resolve` reads the control-plane-owned runtime environment
-  contract for a context and instance.
+  contract for a context and instance. Output redacts secret-shaped keys by
+  default; use `--include-secret-values` only in a trusted operator shell.
 - `environments apply-live-target --dry-run|--apply` resolves the DB-backed
   runtime environment and managed secret overlay for a tracked Dokploy target,
   compares it against the live target env by key, and can apply those keys

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -124,7 +124,9 @@ title: Secrets
 
 - `uv run launchplane environments resolve --context <ctx> --instance
 <instance> --json-output`
-  emits the resolved runtime environment payload for a tenant environment.
+  emits the resolved runtime environment payload for a tenant environment with
+  secret-shaped values redacted by default. Use `--include-secret-values` only
+  from a trusted operator shell when plaintext resolved values are required.
 - `uv run launchplane environments put --scope <scope> --set KEY=VALUE` writes
   non-secret runtime values directly to DB-backed runtime-environment records
   and redacts values from command output. Secret-shaped keys are rejected and

--- a/tests/test_runtime_environments.py
+++ b/tests/test_runtime_environments.py
@@ -1426,7 +1426,7 @@ ODOO_DB_PASSWORD = "file-secret"
                         control_plane_root=control_plane_root,
                     )
 
-    def test_environments_resolve_command_emits_json_payload(self) -> None:
+    def test_environments_resolve_command_redacts_json_payload_by_default(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
             database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
@@ -1469,8 +1469,102 @@ ODOO_DB_PASSWORD = "file-secret"
         payload = json.loads(result.output)
         self.assertEqual(payload["context"], "opw")
         self.assertEqual(payload["instance"], "local")
+        self.assertTrue(payload["redacted"])
+        self.assertEqual(payload["environment"]["ODOO_MASTER_PASSWORD"], "<redacted>")
+        self.assertEqual(payload["environment"]["ODOO_DB_PASSWORD"], "<redacted>")
+        self.assertNotIn("shared-master", result.output)
+        self.assertNotIn("local-secret", result.output)
+
+    def test_environments_resolve_command_can_emit_secret_json_payload_when_requested(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            _seed_runtime_environment_records(
+                database_url=database_url,
+                definition=control_plane_runtime_environments.RuntimeEnvironmentDefinition(
+                    schema_version=1,
+                    shared_env={"ODOO_MASTER_PASSWORD": "shared-master"},
+                    contexts={
+                        "opw": control_plane_runtime_environments.RuntimeEnvironmentContextDefinition(
+                            shared_env={},
+                            instances={
+                                "local": control_plane_runtime_environments.RuntimeEnvironmentInstanceDefinition(
+                                    env={"ODOO_DB_PASSWORD": "local-secret"}
+                                )
+                            },
+                        )
+                    },
+                ),
+            )
+            command_runner = CliRunner()
+            with (
+                patch("control_plane.cli._control_plane_root", return_value=control_plane_root),
+                patch.dict(os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True),
+            ):
+                result = command_runner.invoke(
+                    main,
+                    [
+                        "environments",
+                        "resolve",
+                        "--context",
+                        "opw",
+                        "--instance",
+                        "local",
+                        "--json-output",
+                        "--include-secret-values",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0)
+        payload = json.loads(result.output)
+        self.assertFalse(payload["redacted"])
         self.assertEqual(payload["environment"]["ODOO_MASTER_PASSWORD"], "shared-master")
         self.assertEqual(payload["environment"]["ODOO_DB_PASSWORD"], "local-secret")
+
+    def test_environments_resolve_command_redacts_key_value_output_by_default(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            _seed_runtime_environment_records(
+                database_url=database_url,
+                definition=control_plane_runtime_environments.RuntimeEnvironmentDefinition(
+                    schema_version=1,
+                    shared_env={"ODOO_DB_USER": "odoo"},
+                    contexts={
+                        "opw": control_plane_runtime_environments.RuntimeEnvironmentContextDefinition(
+                            shared_env={},
+                            instances={
+                                "local": control_plane_runtime_environments.RuntimeEnvironmentInstanceDefinition(
+                                    env={"SMTP_PASSWORD": "smtp-secret"}
+                                )
+                            },
+                        )
+                    },
+                ),
+            )
+            command_runner = CliRunner()
+            with (
+                patch("control_plane.cli._control_plane_root", return_value=control_plane_root),
+                patch.dict(os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True),
+            ):
+                result = command_runner.invoke(
+                    main,
+                    [
+                        "environments",
+                        "resolve",
+                        "--context",
+                        "opw",
+                        "--instance",
+                        "local",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("ODOO_DB_USER=odoo", result.output)
+        self.assertIn("SMTP_PASSWORD=<redacted>", result.output)
+        self.assertNotIn("smtp-secret", result.output)
 
     def test_product_config_apply_dry_run_redacts_and_does_not_write(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- redact secret-shaped values from `launchplane environments resolve` output by default
- add an explicit `--include-secret-values` opt-in for trusted operator shells
- update runtime environment CLI docs and tests for JSON and KEY=VALUE output

Refs #248

## Verification
- uv run python -m unittest tests.test_runtime_environments
- uv run --extra dev ruff check --diff control_plane/cli.py tests/test_runtime_environments.py docs/secrets.md docs/operations.md
- uv run --extra dev ruff check control_plane/cli.py tests/test_runtime_environments.py
- uv run --extra dev ruff format --check control_plane/cli.py tests/test_runtime_environments.py
- uv run --extra dev mypy control_plane/cli.py tests/test_runtime_environments.py