### PR TITLE
Add Every Code GitHub webhook ingress

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -154,7 +154,7 @@ from control_plane.workflows.preview_pr_feedback import (
     DEFAULT_PREVIEW_FEEDBACK_MARKER,
     build_preview_pr_feedback_record,
 )
-from control_plane.workflows.launchplane import find_preview_record
+from control_plane.workflows.launchplane import find_preview_record, verify_github_webhook_signature
 from control_plane.workflows.odoo_artifact_publish import (
     OdooArtifactPublishEvidenceRequest,
     OdooArtifactPublishInputsRequest,
@@ -218,6 +218,9 @@ from control_plane.workflows.verireel_preview_driver import (
 
 
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
+_EVERY_CODE_GITHUB_WEBHOOK_ROUTE = "/v1/every-code/github-webhook"
+_EVERY_CODE_GITHUB_WEBHOOK_SECRET_ENV_KEY = "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET"
+_EVERY_CODE_TRIGGER_LABEL = "every-code"
 
 
 @dataclass(frozen=True)
@@ -1726,6 +1729,7 @@ def _driver_write_routes_from_descriptors() -> frozenset[str]:
 
 def _build_write_routes() -> frozenset[str]:
     launchplane_write_routes = {
+        _EVERY_CODE_GITHUB_WEBHOOK_ROUTE,
         "/v1/every-code/work-requests/create",
         "/v1/every-code/work-requests/claim",
         "/v1/every-code/work-requests/status",
@@ -1756,9 +1760,13 @@ def _secret_capable_store(record_store: object) -> control_plane_secrets.SecretR
 
 
 class _EveryCodeWorkRequestStore(Protocol):
-    def write_every_code_work_request_record(self, record: EveryCodeWorkRequestRecord) -> object: ...
+    def write_every_code_work_request_record(
+        self, record: EveryCodeWorkRequestRecord
+    ) -> object: ...
 
-    def read_every_code_work_request_record(self, request_id: str) -> EveryCodeWorkRequestRecord: ...
+    def read_every_code_work_request_record(
+        self, request_id: str
+    ) -> EveryCodeWorkRequestRecord: ...
 
     def list_every_code_work_request_records(
         self,
@@ -1787,6 +1795,159 @@ def _every_code_work_request_store(record_store: object) -> _EveryCodeWorkReques
     if all(hasattr(record_store, method_name) for method_name in required_methods):
         return cast(_EveryCodeWorkRequestStore, record_store)
     raise TypeError("record store does not support Every Code work requests")
+
+
+def _github_webhook_header(environ: dict[str, object], name: str) -> str:
+    return str(environ.get(f"HTTP_{name.upper().replace('-', '_')}", "")).strip()
+
+
+def _github_webhook_mapping(payload: dict[str, object], key: str) -> dict[str, object] | None:
+    value = payload.get(key)
+    if isinstance(value, dict):
+        return cast(dict[str, object], value)
+    return None
+
+
+def _github_webhook_string(mapping: dict[str, object] | None, key: str) -> str:
+    if mapping is None:
+        return ""
+    value = mapping.get(key)
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _handle_every_code_github_webhook(
+    *,
+    environ: dict[str, object],
+    start_response: _StartResponse,
+    trace_id: str,
+    record_store: object,
+) -> list[bytes]:
+    secret = os.environ.get(_EVERY_CODE_GITHUB_WEBHOOK_SECRET_ENV_KEY, "").strip()
+    if not secret:
+        return _json_response(
+            start_response=start_response,
+            status_code=503,
+            payload={
+                "status": "rejected",
+                "trace_id": trace_id,
+                "error": {
+                    "code": "webhook_secret_not_configured",
+                    "message": "Every Code GitHub webhook secret is not configured.",
+                },
+            },
+        )
+
+    body_bytes = _read_request_body(environ)
+    try:
+        verify_github_webhook_signature(
+            payload_bytes=body_bytes,
+            signature_header=_github_webhook_header(environ, "X-Hub-Signature-256"),
+            secret=secret,
+        )
+    except click.ClickException:
+        return _json_response(
+            start_response=start_response,
+            status_code=401,
+            payload={
+                "status": "rejected",
+                "trace_id": trace_id,
+                "error": {
+                    "code": "webhook_signature_invalid",
+                    "message": "GitHub webhook signature verification failed.",
+                },
+            },
+        )
+
+    delivery_id = _github_webhook_header(environ, "X-GitHub-Delivery")
+    if not delivery_id:
+        return _json_response(
+            start_response=start_response,
+            status_code=400,
+            payload={
+                "status": "rejected",
+                "trace_id": trace_id,
+                "error": {
+                    "code": "github_delivery_required",
+                    "message": "GitHub webhook delivery id is required.",
+                },
+            },
+        )
+
+    payload = _decode_json_request_body(body_bytes)
+    event_name = _github_webhook_header(environ, "X-GitHub-Event")
+    if event_name != "issues":
+        return _json_response(
+            start_response=start_response,
+            status_code=202,
+            payload={
+                "status": "accepted",
+                "trace_id": trace_id,
+                "skipped": True,
+                "reason": "unsupported_event",
+            },
+        )
+    if payload.get("action") != "labeled":
+        return _json_response(
+            start_response=start_response,
+            status_code=202,
+            payload={
+                "status": "accepted",
+                "trace_id": trace_id,
+                "skipped": True,
+                "reason": "unsupported_action",
+            },
+        )
+
+    label = _github_webhook_mapping(payload, "label")
+    label_name = _github_webhook_string(label, "name")
+    if label_name.strip().lower() != _EVERY_CODE_TRIGGER_LABEL:
+        return _json_response(
+            start_response=start_response,
+            status_code=202,
+            payload={
+                "status": "accepted",
+                "trace_id": trace_id,
+                "skipped": True,
+                "reason": "label_not_matched",
+            },
+        )
+
+    repository_payload = _github_webhook_mapping(payload, "repository")
+    issue_payload = _github_webhook_mapping(payload, "issue")
+    sender_payload = _github_webhook_mapping(payload, "sender")
+    issue_number_value = issue_payload.get("number") if issue_payload is not None else None
+    if not isinstance(issue_number_value, int):
+        raise ValueError("GitHub issue webhook requires integer issue.number")
+
+    request = EveryCodeWorkRequestCreateEnvelope(
+        repository=_github_webhook_string(repository_payload, "full_name"),
+        issue_number=issue_number_value,
+        issue_url=_github_webhook_string(issue_payload, "html_url"),
+        issue_title=_github_webhook_string(issue_payload, "title"),
+        trigger_label=_EVERY_CODE_TRIGGER_LABEL,
+        trigger_actor=_github_webhook_string(sender_payload, "login"),
+        github_delivery_id=delivery_id,
+        source="github_issue_label",
+        queued_at=_utc_now_timestamp(),
+    )
+    record = _build_every_code_work_request_record(request, queued_at=request.queued_at)
+    every_code_store = _every_code_work_request_store(record_store)
+    try:
+        stored_record = every_code_store.read_every_code_work_request_record(record.request_id)
+        deduped = True
+    except FileNotFoundError:
+        every_code_store.write_every_code_work_request_record(record)
+        stored_record = record
+        deduped = False
+
+    accepted_payload = _accepted_payload(
+        trace_id=trace_id,
+        result={"request_id": stored_record.request_id, "state": stored_record.state},
+        driver_result={"request": stored_record.model_dump(mode="json")},
+    )
+    accepted_payload["deduped"] = deduped
+    accepted_payload["github_delivery_id"] = delivery_id
+    return _json_response(start_response=start_response, status_code=202, payload=accepted_payload)
 
 
 def _idempotency_capable_store(record_store: object) -> _IdempotencyCapableStore | None:
@@ -2060,11 +2221,19 @@ def _should_store_idempotency_record(
 
 
 def _read_json_request(environ: dict[str, object]) -> dict[str, object]:
-    content_length = int(str(environ.get("CONTENT_LENGTH", "0") or "0"))
-    body_stream = cast(BinaryIO | None, environ.get("wsgi.input"))
-    body_bytes = body_stream.read(content_length) if body_stream is not None else b""
+    body_bytes = _read_request_body(environ)
     if not body_bytes:
         raise ValueError("Request body is required.")
+    return _decode_json_request_body(body_bytes)
+
+
+def _read_request_body(environ: dict[str, object]) -> bytes:
+    content_length = int(str(environ.get("CONTENT_LENGTH", "0") or "0"))
+    body_stream = cast(BinaryIO | None, environ.get("wsgi.input"))
+    return body_stream.read(content_length) if body_stream is not None else b""
+
+
+def _decode_json_request_body(body_bytes: bytes) -> dict[str, object]:
     try:
         payload = json.loads(body_bytes.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
@@ -3240,6 +3409,27 @@ def create_launchplane_service_app(
                     },
                 },
             )
+        if method == "POST" and path == _EVERY_CODE_GITHUB_WEBHOOK_ROUTE:
+            try:
+                return _handle_every_code_github_webhook(
+                    environ=environ,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                    record_store=record_store,
+                )
+            except ValueError:
+                return _json_response(
+                    start_response=start_response,
+                    status_code=400,
+                    payload={
+                        "status": "rejected",
+                        "trace_id": request_trace_id,
+                        "error": {
+                            "code": "invalid_request",
+                            "message": "GitHub webhook payload is invalid.",
+                        },
+                    },
+                )
         try:
             if method == "GET":
                 identity = _read_identity(
@@ -3679,9 +3869,7 @@ def create_launchplane_service_app(
                             },
                         )
                     state_filter = str((query.get("state") or [""])[0] or "").strip()
-                    repository_filter = str(
-                        (query.get("repository") or [""])[0] or ""
-                    ).strip()
+                    repository_filter = str((query.get("repository") or [""])[0] or "").strip()
                     limit = int(str((query.get("limit") or ["50"])[0] or "50"))
                     records = every_code_store.list_every_code_work_request_records(
                         state=state_filter,

--- a/docs/config-boundary.md
+++ b/docs/config-boundary.md
@@ -38,6 +38,7 @@ it can reach, trust, or decrypt DB-backed state.
 | Authz bootstrap | `LAUNCHPLANE_POLICY_TOML`, `LAUNCHPLANE_POLICY_B64`, `LAUNCHPLANE_POLICY_FILE` | Minimal bootstrap env/file | Root of trust for first start and DB policy repair only. Live product/workflow grants are DB-backed authz policy records. |
 | Launchplane self image ref | `DOCKER_IMAGE_REFERENCE` | Service target env | Needed for Launchplane self-deploy and rollback posture. |
 | Process wiring | `LAUNCHPLANE_SERVICE_HOST`, `LAUNCHPLANE_SERVICE_PORT`, `LAUNCHPLANE_SERVICE_AUDIENCE`, `LAUNCHPLANE_STATE_DIR`, `LAUNCHPLANE_APP_ROOT` | Service target env | Runtime/process wiring, not product config. |
+| Every Code webhook ingress secret | `LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET` | Bootstrap env or platform secret | Required before unauthenticated GitHub webhook ingress can trust the request body. Store it outside repository config. |
 
 ### DB Authoritative
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -545,6 +545,11 @@ state/
 - Launchplane owns this coordination record so GitHub webhooks, reconciliation,
   local Mac workers, and the future operator UI share one inspectable source of
   truth instead of relying on GitHub API polling or local shell lock files.
+- GitHub webhook ingress accepts signed `issues.labeled` deliveries for the
+  `every-code` label through `POST /v1/every-code/github-webhook`. The route
+  uses `X-Hub-Signature-256`, requires `X-GitHub-Delivery`, and dedupes repeated
+  deliveries by the deterministic repository/issue/label request id without
+  overwriting a request that is already claimed or finished.
 
 ## Inventory
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -53,6 +53,7 @@ VeriReel product paths:
 - authz policy maintenance route:
   - `POST /v1/authz-policies/github-actions/grants`
 - Every Code local automation work-request routes:
+  - `POST /v1/every-code/github-webhook`
   - `GET /v1/every-code/work-requests`
   - `GET /v1/every-code/work-requests/{request_id}`
   - `POST /v1/every-code/work-requests/create`

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,5 +1,6 @@
 import base64
 import hashlib
+import hmac
 import io
 import json
 import os
@@ -391,6 +392,32 @@ def _product_config_payload() -> dict[str, object]:
     }
 
 
+def _github_webhook_signature(payload: Mapping[str, object], secret: str) -> str:
+    body_bytes = json.dumps(payload).encode("utf-8")
+    signature = hmac.new(secret.encode("utf-8"), body_bytes, hashlib.sha256).hexdigest()
+    return f"sha256={signature}"
+
+
+def _every_code_github_issue_labeled_payload(
+    *,
+    label: str = "every-code",
+    action: str = "labeled",
+    repository: str = "cbusillo/code",
+    issue_number: int = 123,
+) -> dict[str, object]:
+    return {
+        "action": action,
+        "label": {"name": label},
+        "repository": {"full_name": repository},
+        "issue": {
+            "number": issue_number,
+            "html_url": f"https://github.com/{repository}/issues/{issue_number}",
+            "title": "Wire local automation",
+        },
+        "sender": {"login": "cbusillo"},
+    }
+
+
 def _invoke_app(
     app: WsgiApp,
     *,
@@ -743,6 +770,261 @@ class GitHubHumanAuthTests(unittest.TestCase):
 
 
 class LaunchplaneServiceTests(unittest.TestCase):
+    def test_every_code_github_webhook_creates_work_request(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main"
+                        ],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["every_code_work_request.read"],
+                    }
+                ]
+            }
+        )
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
+            event_name="workflow_dispatch",
+        )
+        webhook_payload = _every_code_github_issue_labeled_payload(label="EVERY-CODE")
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(identity),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            webhook_status, webhook_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=webhook_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-1",
+                    "X-Hub-Signature-256": _github_webhook_signature(webhook_payload, secret),
+                },
+            )
+            list_status, list_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/every-code/work-requests",
+                query_string="state=queued",
+            )
+
+        self.assertEqual(webhook_status, 202)
+        self.assertFalse(webhook_response["deduped"])
+        self.assertEqual(webhook_response["records"]["state"], "queued")
+        self.assertEqual(webhook_response["github_delivery_id"], "delivery-1")
+        self.assertEqual(list_status, 200)
+        self.assertEqual(len(list_payload["requests"]), 1)
+        request = list_payload["requests"][0]
+        self.assertEqual(request["source"], "github_issue_label")
+        self.assertEqual(request["repository"], "cbusillo/code")
+        self.assertEqual(request["issue_number"], 123)
+        self.assertEqual(request["trigger_label"], "every-code")
+        self.assertEqual(request["trigger_actor"], "cbusillo")
+        self.assertEqual(request["github_delivery_id"], "delivery-1")
+
+    def test_every_code_github_webhook_dedupes_existing_request(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main"
+                        ],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": [
+                            "every_code_work_request.read",
+                            "every_code_work_request.claim",
+                        ],
+                    }
+                ]
+            }
+        )
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
+            event_name="workflow_dispatch",
+        )
+        webhook_payload = _every_code_github_issue_labeled_payload()
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(identity),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            first_status, first_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=webhook_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-1",
+                    "X-Hub-Signature-256": _github_webhook_signature(webhook_payload, secret),
+                },
+            )
+            request_id = str(first_payload["records"]["request_id"])
+            claim_status, _claim_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/claim",
+                payload={"request_id": request_id, "host": "Chris-Studio"},
+                headers={"Idempotency-Key": "every-code-webhook-claim"},
+            )
+            second_status, second_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=webhook_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-2",
+                    "X-Hub-Signature-256": _github_webhook_signature(webhook_payload, secret),
+                },
+            )
+            show_status, show_payload = _invoke_app(
+                app,
+                method="GET",
+                path=f"/v1/every-code/work-requests/{request_id}",
+            )
+
+        self.assertEqual(first_status, 202)
+        self.assertEqual(claim_status, 202)
+        self.assertEqual(second_status, 202)
+        self.assertTrue(second_payload["deduped"])
+        self.assertEqual(second_payload["records"]["state"], "claimed")
+        self.assertEqual(show_status, 200)
+        self.assertEqual(show_payload["request"]["state"], "claimed")
+        self.assertEqual(show_payload["request"]["github_delivery_id"], "delivery-1")
+
+    def test_every_code_github_webhook_rejects_invalid_signature(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        webhook_payload = _every_code_github_issue_labeled_payload()
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=webhook_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-1",
+                    "X-Hub-Signature-256": "sha256=invalid",
+                },
+            )
+
+        self.assertEqual(status_code, 401)
+        self.assertEqual(payload["error"]["code"], "webhook_signature_invalid")
+
+    def test_every_code_github_webhook_ignores_other_labels(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        webhook_payload = _every_code_github_issue_labeled_payload(label="bug")
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=webhook_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-1",
+                    "X-Hub-Signature-256": _github_webhook_signature(webhook_payload, secret),
+                },
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertTrue(payload["skipped"])
+        self.assertEqual(payload["reason"], "label_not_matched")
+
+    def test_every_code_github_webhook_requires_configured_secret(self) -> None:
+        webhook_payload = _every_code_github_issue_labeled_payload()
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": ""},
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=webhook_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-1",
+                    "X-Hub-Signature-256": _github_webhook_signature(
+                        webhook_payload, "unused-secret"
+                    ),
+                },
+            )
+
+        self.assertEqual(status_code, 503)
+        self.assertEqual(payload["error"]["code"], "webhook_secret_not_configured")
+
     def test_every_code_work_request_create_list_claim_and_status_flow(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(
             {


### PR DESCRIPTION
## Summary
- add signed GitHub `issues.labeled` webhook ingress for the Every Code trigger label
- create or dedupe durable Every Code work requests without requiring GitHub API polling
- document the webhook route and bootstrap ingress secret boundary

Refs #278
Refs #280

## Verification
- uv run python -m unittest tests.test_every_code_work_request tests.test_service.LaunchplaneServiceTests.test_every_code_github_webhook_creates_work_request tests.test_service.LaunchplaneServiceTests.test_every_code_github_webhook_dedupes_existing_request tests.test_service.LaunchplaneServiceTests.test_every_code_github_webhook_rejects_invalid_signature tests.test_service.LaunchplaneServiceTests.test_every_code_github_webhook_ignores_other_labels tests.test_service.LaunchplaneServiceTests.test_every_code_github_webhook_requires_configured_secret tests.test_service.LaunchplaneServiceTests.test_every_code_work_request_create_list_claim_and_status_flow
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_service.py docs/config-boundary.md docs/records.md docs/service-boundary.md
- uv run --extra dev ruff check control_plane/service.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_service.py
- uv run --extra dev mypy control_plane/service.py tests/test_service.py