### PR TITLE
Add Every Code local worker handoff

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -92,6 +92,7 @@ from control_plane.contracts.runtime_key_safety_policy import (
 from control_plane.contracts.secret_record import SecretBinding, SecretScope
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.drivers.registry import build_driver_context_view
+from control_plane.every_code_worker import run_every_code_worker_once
 from control_plane.launchplane_mutations import (
     apply_launchplane_destroy_preview as shared_apply_launchplane_destroy_preview,
     apply_launchplane_generation_evidence as shared_apply_launchplane_generation_evidence,
@@ -9493,6 +9494,76 @@ def odoo_rollbacks() -> None:
 @main.group()
 def service() -> None:
     """Launchplane service commands."""
+
+
+@main.group("every-code")
+def every_code() -> None:
+    """Every Code local worker commands."""
+
+
+@every_code.command("run-once")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    default="",
+    show_default=False,
+    help="Optional Postgres connection string for Launchplane work-request records.",
+)
+@click.option(
+    "--state-dir",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    default=Path("state"),
+    show_default=True,
+    help="Filesystem state directory used when --database-url is not set.",
+)
+@click.option("--host", default="", help="Worker host name recorded on the claim.")
+@click.option(
+    "--workspace-root",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    default=Path.home() / "Developer",
+    show_default=True,
+    help="Directory containing repository checkouts.",
+)
+@click.option(
+    "--checkout-root",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    default=None,
+    help="Explicit checkout root for the claimed request.",
+)
+@click.option("--repository", default="", help="Optional owner/repo queue filter.")
+@click.option(
+    "--command-template",
+    default="",
+    help="Optional shell command template for tmux. Fields include {issue_url} and {request_id}.",
+)
+@click.option("--tmux-binary", default="tmux", show_default=True)
+def every_code_run_once(
+    database_url: str,
+    state_dir: Path,
+    host: str,
+    workspace_root: Path,
+    checkout_root: Path | None,
+    repository: str,
+    command_template: str,
+    tmux_binary: str,
+) -> None:
+    resolved_host = host.strip() or os.uname().nodename
+    record_store = _store(state_dir=state_dir, database_url=database_url)
+    try:
+        result = run_every_code_worker_once(
+            record_store=record_store,
+            host=resolved_host,
+            workspace_root=workspace_root,
+            checkout_root=checkout_root,
+            repository=repository,
+            command_template=command_template,
+            tmux_binary=tmux_binary,
+        )
+    finally:
+        close = getattr(record_store, "close", None)
+        if callable(close):
+            close()
+    click.echo(json.dumps(result.as_payload(), indent=2, sort_keys=True))
 
 
 @main.group()

--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import shlex
+import subprocess
+from typing import Callable, Literal, Protocol, Sequence
+
+from control_plane.contracts.every_code_work_request import (
+    EveryCodeWorkRequestRecord,
+    EveryCodeWorkRequestStatusUpdate,
+    apply_every_code_work_request_status,
+)
+from control_plane.workflows.ship import utc_now_timestamp
+
+
+EveryCodeWorkerStatus = Literal["empty", "running", "blocked"]
+
+
+class EveryCodeWorkerStore(Protocol):
+    def read_every_code_work_request_record(
+        self, request_id: str
+    ) -> EveryCodeWorkRequestRecord: ...
+
+    def list_every_code_work_request_records(
+        self,
+        *,
+        state: str = "",
+        repository: str = "",
+        limit: int | None = None,
+    ) -> tuple[EveryCodeWorkRequestRecord, ...]: ...
+
+    def claim_every_code_work_request_record(
+        self,
+        *,
+        request_id: str,
+        host: str,
+        claimed_at: str,
+    ) -> EveryCodeWorkRequestRecord | None: ...
+
+    def write_every_code_work_request_record(
+        self, record: EveryCodeWorkRequestRecord
+    ) -> object: ...
+
+
+Runner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True)
+class EveryCodeWorkerHandoffResult:
+    status: EveryCodeWorkerStatus
+    detail: str
+    request_id: str = ""
+    repository: str = ""
+    issue_number: int = 0
+    session_name: str = ""
+    checkout_root: str = ""
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "status": self.status,
+            "detail": self.detail,
+            "request_id": self.request_id,
+            "repository": self.repository,
+            "issue_number": self.issue_number,
+            "session_name": self.session_name,
+            "checkout_root": self.checkout_root,
+        }
+
+
+def every_code_tmux_session_name(request_id: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9_.:-]+", "-", request_id.strip()).strip("-._:")
+    return f"every-code-{normalized or 'request'}"[:80]
+
+
+def default_every_code_command(record: EveryCodeWorkRequestRecord) -> str:
+    prompt = (
+        f"Work on {record.repository} issue #{record.issue_number}: {record.issue_title}. "
+        f"Issue URL: {record.issue_url}. Launchplane request: {record.request_id}."
+    )
+    return "code " + shlex.quote(prompt)
+
+
+def render_every_code_command(
+    record: EveryCodeWorkRequestRecord,
+    *,
+    command_template: str,
+) -> str:
+    template = command_template.strip()
+    if not template:
+        return default_every_code_command(record)
+    return template.format(
+        request_id=record.request_id,
+        repository=record.repository,
+        issue_number=record.issue_number,
+        issue_url=record.issue_url,
+        issue_title=record.issue_title,
+        trigger_label=record.trigger_label,
+    )
+
+
+def resolve_every_code_checkout_root(
+    record: EveryCodeWorkRequestRecord,
+    *,
+    workspace_root: Path,
+    checkout_root: Path | None = None,
+) -> Path:
+    if checkout_root is not None:
+        return checkout_root.expanduser().resolve()
+    repository_name = record.repository.strip().rsplit("/", 1)[-1]
+    return (workspace_root.expanduser() / repository_name).resolve()
+
+
+def run_every_code_worker_once(
+    *,
+    record_store: EveryCodeWorkerStore,
+    host: str,
+    workspace_root: Path,
+    checkout_root: Path | None = None,
+    repository: str = "",
+    command_template: str = "",
+    tmux_binary: str = "tmux",
+    runner: Runner | None = None,
+) -> EveryCodeWorkerHandoffResult:
+    normalized_host = host.strip()
+    if not normalized_host:
+        raise ValueError("Every Code worker requires a host name")
+    queued_records = record_store.list_every_code_work_request_records(
+        state="queued",
+        repository=repository.strip(),
+        limit=1,
+    )
+    if not queued_records:
+        return EveryCodeWorkerHandoffResult(
+            status="empty", detail="No queued Every Code work request."
+        )
+
+    queued_record = queued_records[0]
+    claimed_record = record_store.claim_every_code_work_request_record(
+        request_id=queued_record.request_id,
+        host=normalized_host,
+        claimed_at=utc_now_timestamp(),
+    )
+    if claimed_record is None:
+        return EveryCodeWorkerHandoffResult(
+            status="empty",
+            detail="Queued Every Code work request was claimed by another worker.",
+            request_id=queued_record.request_id,
+            repository=queued_record.repository,
+            issue_number=queued_record.issue_number,
+        )
+
+    resolved_checkout_root = resolve_every_code_checkout_root(
+        claimed_record,
+        workspace_root=workspace_root,
+        checkout_root=checkout_root,
+    )
+    session_name = every_code_tmux_session_name(claimed_record.request_id)
+    if not resolved_checkout_root.is_dir():
+        return _block_every_code_request(
+            record_store=record_store,
+            record=claimed_record,
+            host=normalized_host,
+            detail=f"Checkout root does not exist: {resolved_checkout_root}",
+            session_name=session_name,
+            checkout_root=resolved_checkout_root,
+        )
+
+    run = runner or _run_subprocess
+    existing_session = _tmux_session_exists(
+        tmux_binary=tmux_binary,
+        session_name=session_name,
+        runner=run,
+    )
+    if existing_session is None:
+        return _block_every_code_request(
+            record_store=record_store,
+            record=claimed_record,
+            host=normalized_host,
+            detail=f"Could not inspect tmux session {session_name!r}.",
+            session_name=session_name,
+            checkout_root=resolved_checkout_root,
+        )
+    if not existing_session:
+        command = render_every_code_command(claimed_record, command_template=command_template)
+        try:
+            launch_result = run(
+                (
+                    tmux_binary,
+                    "new-session",
+                    "-d",
+                    "-s",
+                    session_name,
+                    "-c",
+                    str(resolved_checkout_root),
+                    command,
+                )
+            )
+        except OSError as exc:
+            return _block_every_code_request(
+                record_store=record_store,
+                record=claimed_record,
+                host=normalized_host,
+                detail=f"Could not launch tmux session: {exc}",
+                session_name=session_name,
+                checkout_root=resolved_checkout_root,
+            )
+        if launch_result.returncode != 0:
+            return _block_every_code_request(
+                record_store=record_store,
+                record=claimed_record,
+                host=normalized_host,
+                detail=f"tmux launch failed: {launch_result.stderr.strip()}",
+                session_name=session_name,
+                checkout_root=resolved_checkout_root,
+            )
+
+    running_record = apply_every_code_work_request_status(
+        record_store.read_every_code_work_request_record(claimed_record.request_id),
+        EveryCodeWorkRequestStatusUpdate(
+            state="running",
+            host=normalized_host,
+            updated_at=utc_now_timestamp(),
+            result_summary=f"Visible tmux session: {session_name}",
+        ),
+    )
+    record_store.write_every_code_work_request_record(running_record)
+    return EveryCodeWorkerHandoffResult(
+        status="running",
+        detail="Every Code work request handed off to a visible tmux session.",
+        request_id=running_record.request_id,
+        repository=running_record.repository,
+        issue_number=running_record.issue_number,
+        session_name=session_name,
+        checkout_root=str(resolved_checkout_root),
+    )
+
+
+def _run_subprocess(args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, capture_output=True, check=False, text=True)
+
+
+def _tmux_session_exists(*, tmux_binary: str, session_name: str, runner: Runner) -> bool | None:
+    try:
+        result = runner((tmux_binary, "has-session", "-t", session_name))
+    except OSError:
+        return None
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    return None
+
+
+def _block_every_code_request(
+    *,
+    record_store: EveryCodeWorkerStore,
+    record: EveryCodeWorkRequestRecord,
+    host: str,
+    detail: str,
+    session_name: str,
+    checkout_root: Path,
+) -> EveryCodeWorkerHandoffResult:
+    blocked_record = apply_every_code_work_request_status(
+        record_store.read_every_code_work_request_record(record.request_id),
+        EveryCodeWorkRequestStatusUpdate(
+            state="blocked",
+            host=host,
+            updated_at=utc_now_timestamp(),
+            error_message=detail,
+        ),
+    )
+    record_store.write_every_code_work_request_record(blocked_record)
+    return EveryCodeWorkerHandoffResult(
+        status="blocked",
+        detail=detail,
+        request_id=blocked_record.request_id,
+        repository=blocked_record.repository,
+        issue_number=blocked_record.issue_number,
+        session_name=session_name,
+        checkout_root=str(checkout_root),
+    )

--- a/docs/records.md
+++ b/docs/records.md
@@ -542,6 +542,9 @@ state/
 - State is `queued`, `claimed`, `running`, `done`, or `blocked`. Workers claim a
   queued request before reporting progress. Terminal states are immutable through
   the service status route.
+- The first local worker handoff is `uv run launchplane every-code run-once`.
+  It claims one queued request, opens or reuses a deterministic visible tmux
+  session for the local checkout, and records `running` or `blocked` status.
 - Launchplane owns this coordination record so GitHub webhooks, reconciliation,
   local Mac workers, and the future operator UI share one inspectable source of
   truth instead of relying on GitHub API polling or local shell lock files.

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -1,0 +1,113 @@
+import subprocess
+import unittest
+from collections.abc import Sequence
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
+from control_plane.every_code_worker import (
+    default_every_code_command,
+    every_code_tmux_session_name,
+    run_every_code_worker_once,
+)
+from control_plane.storage.filesystem import FilesystemRecordStore
+
+
+def _queued_record() -> EveryCodeWorkRequestRecord:
+    return EveryCodeWorkRequestRecord(
+        request_id="every-code-cbusillo-code-123-test",
+        source="github_issue_label",
+        state="queued",
+        repository="cbusillo/code",
+        issue_number=123,
+        issue_url="https://github.com/cbusillo/code/issues/123",
+        issue_title="Wire local automation",
+        trigger_label="every-code",
+        trigger_actor="cbusillo",
+        github_delivery_id="delivery-1",
+        queued_at="2026-05-05T22:00:00Z",
+        updated_at="2026-05-05T22:00:00Z",
+    )
+
+
+class _Runner:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+
+    def __call__(self, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        self.calls.append(tuple(args))
+        if args[1] == "has-session":
+            return subprocess.CompletedProcess(args, 1, "", "no session")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+
+class EveryCodeWorkerTests(unittest.TestCase):
+    def test_session_name_is_stable_and_tmux_safe(self) -> None:
+        session_name = every_code_tmux_session_name("every code/cbusillo/code#123 !")
+
+        self.assertEqual(session_name, "every-code-every-code-cbusillo-code-123")
+
+    def test_default_command_includes_issue_and_request(self) -> None:
+        command = default_every_code_command(_queued_record())
+
+        self.assertIn("https://github.com/cbusillo/code/issues/123", command)
+        self.assertIn("every-code-cbusillo-code-123-test", command)
+
+    def test_run_once_claims_request_and_launches_tmux_session(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            runner = _Runner()
+
+            result = run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                runner=runner,
+            )
+            record = store.read_every_code_work_request_record("every-code-cbusillo-code-123-test")
+
+        self.assertEqual(result.status, "running")
+        self.assertEqual(record.state, "running")
+        self.assertEqual(record.claimed_by_host, "Chris-Studio")
+        self.assertEqual(result.checkout_root, str(checkout_root.resolve()))
+        self.assertEqual(runner.calls[0][1], "has-session")
+        self.assertEqual(runner.calls[1][1], "new-session")
+
+    def test_run_once_marks_missing_checkout_blocked(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+
+            result = run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                runner=_Runner(),
+            )
+            record = store.read_every_code_work_request_record("every-code-cbusillo-code-123-test")
+
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(record.state, "blocked")
+        self.assertIn("Checkout root does not exist", record.error_message)
+
+    def test_run_once_returns_empty_when_no_queued_request_exists(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            result = run_every_code_worker_once(
+                record_store=FilesystemRecordStore(
+                    state_dir=Path(temporary_directory_name) / "state"
+                ),
+                host="Chris-Studio",
+                workspace_root=Path(temporary_directory_name) / "Developer",
+                runner=_Runner(),
+            )
+
+        self.assertEqual(result.status, "empty")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a local `launchplane every-code run-once` worker handoff command
- claim one queued Every Code request, launch or reuse a deterministic visible tmux session, and mark running or blocked
- document the first local worker handoff contract and cover the claim/launch/block paths

Refs #278
Refs #281

## Verification
- uv run python -m unittest tests.test_every_code_worker tests.test_every_code_work_request
- uv run --extra dev ruff check --diff control_plane/every_code_worker.py control_plane/cli.py tests/test_every_code_worker.py docs/records.md
- uv run --extra dev ruff check control_plane/every_code_worker.py control_plane/cli.py tests/test_every_code_worker.py
- uv run --extra dev ruff format --check control_plane/every_code_worker.py control_plane/cli.py tests/test_every_code_worker.py
- uv run --extra dev mypy control_plane/every_code_worker.py control_plane/cli.py tests/test_every_code_worker.py