### PR TITLE
feat(every-code): add polling worker mode

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -92,7 +92,7 @@ from control_plane.contracts.runtime_key_safety_policy import (
 from control_plane.contracts.secret_record import SecretBinding, SecretScope
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.drivers.registry import build_driver_context_view
-from control_plane.every_code_worker import run_every_code_worker_once
+from control_plane.every_code_worker import run_every_code_worker_loop, run_every_code_worker_once
 from control_plane.launchplane_mutations import (
     apply_launchplane_destroy_preview as shared_apply_launchplane_destroy_preview,
     apply_launchplane_generation_evidence as shared_apply_launchplane_generation_evidence,
@@ -9559,6 +9559,91 @@ def every_code_run_once(
             command_template=command_template,
             tmux_binary=tmux_binary,
         )
+    finally:
+        close = getattr(record_store, "close", None)
+        if callable(close):
+            close()
+    click.echo(json.dumps(result.as_payload(), indent=2, sort_keys=True))
+
+
+@every_code.command("run")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    default="",
+    show_default=False,
+    help="Optional Postgres connection string for Launchplane work-request records.",
+)
+@click.option(
+    "--state-dir",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    default=Path("state"),
+    show_default=True,
+    help="Filesystem state directory used when --database-url is not set.",
+)
+@click.option("--host", default="", help="Worker host name recorded on claims.")
+@click.option(
+    "--workspace-root",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    default=Path.home() / "Developer",
+    show_default=True,
+    help="Directory containing repository checkouts.",
+)
+@click.option(
+    "--checkout-root",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    default=None,
+    help="Explicit checkout root for claimed requests.",
+)
+@click.option("--repository", default="", help="Optional owner/repo queue filter.")
+@click.option(
+    "--command-template",
+    default="",
+    help="Optional shell command template for tmux. Fields include {issue_url} and {request_id}.",
+)
+@click.option("--tmux-binary", default="tmux", show_default=True)
+@click.option(
+    "--interval-seconds",
+    type=click.FloatRange(min=0),
+    default=60.0,
+    show_default=True,
+    help="Seconds to sleep between queue scans.",
+)
+@click.option(
+    "--max-iterations",
+    type=click.IntRange(min=0),
+    default=0,
+    show_default=True,
+    help="Stop after this many scans; 0 runs until interrupted.",
+)
+def every_code_run(
+    database_url: str,
+    state_dir: Path,
+    host: str,
+    workspace_root: Path,
+    checkout_root: Path | None,
+    repository: str,
+    command_template: str,
+    tmux_binary: str,
+    interval_seconds: float,
+    max_iterations: int,
+) -> None:
+    resolved_host = host.strip() or os.uname().nodename
+    record_store = _store(state_dir=state_dir, database_url=database_url)
+    try:
+        result = run_every_code_worker_loop(
+            record_store=record_store,
+            host=resolved_host,
+            workspace_root=workspace_root,
+            checkout_root=checkout_root,
+            repository=repository,
+            command_template=command_template,
+            tmux_binary=tmux_binary,
+            interval_seconds=interval_seconds,
+            max_iterations=max_iterations,
+        )
+    except KeyboardInterrupt:
+        raise click.ClickException("Every Code worker stopped by interrupt.") from None
     finally:
         close = getattr(record_store, "close", None)
         if callable(close):

--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import re
 import shlex
 import subprocess
+import time
 from typing import Callable, Literal, Protocol, Sequence
 
 from control_plane.contracts.every_code_work_request import (
@@ -66,6 +67,26 @@ class EveryCodeWorkerHandoffResult:
             "issue_number": self.issue_number,
             "session_name": self.session_name,
             "checkout_root": self.checkout_root,
+        }
+
+
+@dataclass(frozen=True)
+class EveryCodeWorkerLoopResult:
+    iterations: int
+    handed_off: int
+    blocked: int
+    empty: int
+    stopped_reason: str
+    last_result: EveryCodeWorkerHandoffResult
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "iterations": self.iterations,
+            "handed_off": self.handed_off,
+            "blocked": self.blocked,
+            "empty": self.empty,
+            "stopped_reason": self.stopped_reason,
+            "last_result": self.last_result.as_payload(),
         }
 
 
@@ -234,6 +255,72 @@ def run_every_code_worker_once(
         issue_number=running_record.issue_number,
         session_name=session_name,
         checkout_root=str(resolved_checkout_root),
+    )
+
+
+def run_every_code_worker_loop(
+    *,
+    record_store: EveryCodeWorkerStore,
+    host: str,
+    workspace_root: Path,
+    checkout_root: Path | None = None,
+    repository: str = "",
+    command_template: str = "",
+    tmux_binary: str = "tmux",
+    interval_seconds: float = 60.0,
+    max_iterations: int = 0,
+    runner: Runner | None = None,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> EveryCodeWorkerLoopResult:
+    if interval_seconds < 0:
+        raise ValueError("Every Code worker interval must be non-negative")
+    if max_iterations < 0:
+        raise ValueError("Every Code worker max_iterations must be non-negative")
+
+    iterations = 0
+    handed_off = 0
+    blocked = 0
+    empty = 0
+    last_result = EveryCodeWorkerHandoffResult(
+        status="empty",
+        detail="Every Code worker loop has not run yet.",
+    )
+    while max_iterations == 0 or iterations < max_iterations:
+        iterations += 1
+        last_result = run_every_code_worker_once(
+            record_store=record_store,
+            host=host,
+            workspace_root=workspace_root,
+            checkout_root=checkout_root,
+            repository=repository,
+            command_template=command_template,
+            tmux_binary=tmux_binary,
+            runner=runner,
+        )
+        if last_result.status == "running":
+            handed_off += 1
+        elif last_result.status == "blocked":
+            blocked += 1
+        else:
+            empty += 1
+        if max_iterations != 0 and iterations >= max_iterations:
+            return EveryCodeWorkerLoopResult(
+                iterations=iterations,
+                handed_off=handed_off,
+                blocked=blocked,
+                empty=empty,
+                stopped_reason="max_iterations",
+                last_result=last_result,
+            )
+        sleeper(interval_seconds)
+
+    return EveryCodeWorkerLoopResult(
+        iterations=iterations,
+        handed_off=handed_off,
+        blocked=blocked,
+        empty=empty,
+        stopped_reason="stopped",
+        last_result=last_result,
     )
 
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -542,9 +542,10 @@ state/
 - State is `queued`, `claimed`, `running`, `done`, or `blocked`. Workers claim a
   queued request before reporting progress. Terminal states are immutable through
   the service status route.
-- The first local worker handoff is `uv run launchplane every-code run-once`.
-  It claims one queued request, opens or reuses a deterministic visible tmux
-  session for the local checkout, and records `running` or `blocked` status.
+- The local worker handoff is `uv run launchplane every-code run` for polling or
+  `uv run launchplane every-code run-once` for a single scan. It claims queued
+  requests, opens or reuses deterministic visible tmux sessions for local
+  checkouts, and records `running` or `blocked` status.
 - Launchplane owns this coordination record so GitHub webhooks, reconciliation,
   local Mac workers, and the future operator UI share one inspectable source of
   truth instead of relying on GitHub API polling or local shell lock files.

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -1,13 +1,18 @@
 import subprocess
 import unittest
 from collections.abc import Sequence
+import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from click.testing import CliRunner
+
+from control_plane.cli import main
 from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
 from control_plane.every_code_worker import (
     default_every_code_command,
     every_code_tmux_session_name,
+    run_every_code_worker_loop,
     run_every_code_worker_once,
 )
 from control_plane.storage.filesystem import FilesystemRecordStore
@@ -107,6 +112,71 @@ class EveryCodeWorkerTests(unittest.TestCase):
             )
 
         self.assertEqual(result.status, "empty")
+
+    def test_run_loop_processes_until_max_iterations(self) -> None:
+        sleeps: list[float] = []
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            runner = _Runner()
+
+            result = run_every_code_worker_loop(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                interval_seconds=2.5,
+                max_iterations=2,
+                runner=runner,
+                sleeper=sleeps.append,
+            )
+
+        self.assertEqual(result.iterations, 2)
+        self.assertEqual(result.handed_off, 1)
+        self.assertEqual(result.empty, 1)
+        self.assertEqual(result.blocked, 0)
+        self.assertEqual(result.stopped_reason, "max_iterations")
+        self.assertEqual(sleeps, [2.5])
+
+    def test_run_loop_rejects_negative_interval(self) -> None:
+        with self.assertRaises(ValueError):
+            run_every_code_worker_loop(
+                record_store=FilesystemRecordStore(state_dir=Path("state")),
+                host="Chris-Studio",
+                workspace_root=Path("."),
+                interval_seconds=-1,
+                max_iterations=1,
+                sleeper=lambda _seconds: None,
+            )
+
+    def test_cli_run_reports_loop_summary(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            result = CliRunner().invoke(
+                main,
+                [
+                    "every-code",
+                    "run",
+                    "--state-dir",
+                    str(temporary_root / "state"),
+                    "--workspace-root",
+                    str(temporary_root / "Developer"),
+                    "--host",
+                    "Chris-Studio",
+                    "--interval-seconds",
+                    "0",
+                    "--max-iterations",
+                    "1",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["iterations"], 1)
+        self.assertEqual(payload["empty"], 1)
+        self.assertEqual(payload["stopped_reason"], "max_iterations")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add `uv run launchplane every-code run` for polling queued Every Code work requests.
- Add a loop result payload with iteration, handoff, blocked, and empty counts.
- Keep `run-once` behavior unchanged while allowing bounded `--max-iterations` for tests and operator probes.
- Update records docs to describe polling vs single-scan worker handoff.

## Verification

- `uv run python -m unittest tests.test_every_code_worker`
- `uv run python -m unittest`

Refs #281
