### PR TITLE
Add Every Code issue reconciliation

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -17,6 +17,7 @@ import click
 from pydantic import ValidationError
 
 from control_plane import dokploy as control_plane_dokploy
+from control_plane import every_code_reconciliation as control_plane_every_code_reconciliation
 from control_plane import odoo_instance_overrides as control_plane_odoo_instance_overrides
 from control_plane import product_config as control_plane_product_config
 from control_plane import product_context_audit as control_plane_product_context_audit
@@ -9559,6 +9560,65 @@ def every_code_run_once(
             command_template=command_template,
             tmux_binary=tmux_binary,
         )
+    finally:
+        close = getattr(record_store, "close", None)
+        if callable(close):
+            close()
+    click.echo(json.dumps(result.as_payload(), indent=2, sort_keys=True))
+
+
+@every_code.command("reconcile-issue")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    default="",
+    show_default=False,
+    help="Optional Postgres connection string for Launchplane work-request records.",
+)
+@click.option(
+    "--state-dir",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    default=Path("state"),
+    show_default=True,
+    help="Filesystem state directory used when --database-url is not set.",
+)
+@click.option("--repository", required=True, help="GitHub owner/repo name.")
+@click.option("--issue-number", type=int, required=True, help="GitHub issue number.")
+@click.option("--issue-url", required=True, help="GitHub issue URL.")
+@click.option("--issue-title", default="", help="GitHub issue title.")
+@click.option(
+    "--label",
+    "labels",
+    multiple=True,
+    help="Issue label name. Repeat for each current issue label.",
+)
+@click.option("--trigger-label", default="every-code", show_default=True)
+@click.option("--actor", default="reconciliation", show_default=True)
+def every_code_reconcile_issue(
+    database_url: str,
+    state_dir: Path,
+    repository: str,
+    issue_number: int,
+    issue_url: str,
+    issue_title: str,
+    labels: tuple[str, ...],
+    trigger_label: str,
+    actor: str,
+) -> None:
+    record_store = _store(state_dir=state_dir, database_url=database_url)
+    try:
+        result = control_plane_every_code_reconciliation.reconcile_every_code_issue(
+            record_store=record_store,
+            repository=repository,
+            issue_number=issue_number,
+            issue_url=issue_url,
+            issue_title=issue_title,
+            labels=labels,
+            trigger_label=trigger_label,
+            actor=actor,
+        )
+    except ValueError as error:
+        raise click.ClickException(str(error)) from error
     finally:
         close = getattr(record_store, "close", None)
         if callable(close):

--- a/control_plane/every_code_reconciliation.py
+++ b/control_plane/every_code_reconciliation.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Protocol, Sequence
+
+from control_plane.contracts.every_code_work_request import (
+    EveryCodeWorkRequestRecord,
+    build_every_code_work_request_id,
+)
+from control_plane.workflows.ship import utc_now_timestamp
+
+
+EveryCodeReconciliationStatus = Literal["created", "deduped", "skipped"]
+
+
+class EveryCodeReconciliationStore(Protocol):
+    def create_every_code_work_request_record_if_absent(
+        self, record: EveryCodeWorkRequestRecord
+    ) -> tuple[EveryCodeWorkRequestRecord, bool]: ...
+
+
+@dataclass(frozen=True)
+class EveryCodeIssueReconciliationResult:
+    status: EveryCodeReconciliationStatus
+    detail: str
+    request: EveryCodeWorkRequestRecord | None = None
+
+    def as_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {"status": self.status, "detail": self.detail}
+        if self.request is not None:
+            payload["request"] = self.request.model_dump(mode="json")
+        return payload
+
+
+def reconcile_every_code_issue(
+    *,
+    record_store: EveryCodeReconciliationStore,
+    repository: str,
+    issue_number: int,
+    issue_url: str,
+    issue_title: str,
+    labels: Sequence[str],
+    trigger_label: str = "every-code",
+    actor: str = "reconciliation",
+) -> EveryCodeIssueReconciliationResult:
+    normalized_repository = repository.strip()
+    normalized_issue_url = issue_url.strip()
+    normalized_trigger_label = trigger_label.strip()
+    normalized_labels = tuple(label.strip() for label in labels if label.strip())
+
+    if not normalized_trigger_label:
+        raise ValueError("Every Code issue reconciliation requires a trigger label")
+    if not normalized_repository or "/" not in normalized_repository:
+        raise ValueError("Every Code issue reconciliation requires owner/repo repository")
+    if issue_number < 1:
+        raise ValueError("Every Code issue reconciliation requires a positive issue number")
+    if not normalized_issue_url:
+        raise ValueError("Every Code issue reconciliation requires issue_url")
+
+    if normalized_trigger_label.casefold() not in {label.casefold() for label in normalized_labels}:
+        return EveryCodeIssueReconciliationResult(
+            status="skipped",
+            detail=f"Issue is not labeled {normalized_trigger_label!r}.",
+        )
+
+    now = utc_now_timestamp()
+    record = EveryCodeWorkRequestRecord(
+        request_id=build_every_code_work_request_id(
+            repository=normalized_repository,
+            issue_number=issue_number,
+            trigger_label=normalized_trigger_label,
+        ),
+        source="reconciliation",
+        state="queued",
+        repository=normalized_repository,
+        issue_number=issue_number,
+        issue_url=normalized_issue_url,
+        issue_title=issue_title.strip(),
+        trigger_label=normalized_trigger_label,
+        trigger_actor=actor.strip(),
+        queued_at=now,
+        updated_at=now,
+    )
+    stored_record, created = record_store.create_every_code_work_request_record_if_absent(record)
+    if created:
+        return EveryCodeIssueReconciliationResult(
+            status="created",
+            detail="Queued Every Code work request from reconciled issue facts.",
+            request=stored_record,
+        )
+    return EveryCodeIssueReconciliationResult(
+        status="deduped",
+        detail="Every Code work request already exists for this issue and label.",
+        request=stored_record,
+    )

--- a/docs/records.md
+++ b/docs/records.md
@@ -545,6 +545,12 @@ state/
 - The first local worker handoff is `uv run launchplane every-code run-once`.
   It claims one queued request, opens or reuses a deterministic visible tmux
   session for the local checkout, and records `running` or `blocked` status.
+- Missed or manually inspected issue labels can be reconciled without polling by
+  running `uv run launchplane every-code reconcile-issue` with the known issue
+  repository, number, URL, title, and current labels. Reconciliation creates the
+  same deterministic request id when the trigger label is present, dedupes an
+  existing request without overwriting worker state, and skips issues that do
+  not currently carry the trigger label.
 - Launchplane owns this coordination record so GitHub webhooks, reconciliation,
   local Mac workers, and the future operator UI share one inspectable source of
   truth instead of relying on GitHub API polling or local shell lock files.

--- a/tests/test_every_code_reconciliation.py
+++ b/tests/test_every_code_reconciliation.py
@@ -1,0 +1,129 @@
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from click.testing import CliRunner
+
+from control_plane.cli import main
+from control_plane.every_code_reconciliation import reconcile_every_code_issue
+from control_plane.storage.filesystem import FilesystemRecordStore
+
+
+class EveryCodeIssueReconciliationTests(unittest.TestCase):
+    def test_creates_queued_request_when_trigger_label_is_present(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            store = FilesystemRecordStore(state_dir=Path(tempdir))
+
+            result = reconcile_every_code_issue(
+                record_store=store,
+                repository="cbusillo/launchplane",
+                issue_number=278,
+                issue_url="https://github.com/cbusillo/launchplane/issues/278",
+                issue_title="Build Launchplane-backed Every Code automation",
+                labels=("plan", "Every-Code"),
+                actor="ops",
+            )
+
+            self.assertEqual(result.status, "created")
+            self.assertIsNotNone(result.request)
+            assert result.request is not None
+            self.assertEqual(result.request.source, "reconciliation")
+            self.assertEqual(result.request.state, "queued")
+            self.assertEqual(result.request.repository, "cbusillo/launchplane")
+            self.assertEqual(result.request.issue_number, 278)
+            self.assertEqual(result.request.trigger_actor, "ops")
+
+    def test_dedupes_existing_request_without_overwriting_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            store = FilesystemRecordStore(state_dir=Path(tempdir))
+            first = reconcile_every_code_issue(
+                record_store=store,
+                repository="cbusillo/launchplane",
+                issue_number=278,
+                issue_url="https://github.com/cbusillo/launchplane/issues/278",
+                issue_title="Original title",
+                labels=("every-code",),
+                actor="first",
+            )
+            assert first.request is not None
+            claimed = store.claim_every_code_work_request_record(
+                request_id=first.request.request_id,
+                host="worker-host",
+                claimed_at="2026-05-06T00:00:00Z",
+            )
+            self.assertIsNotNone(claimed)
+
+            second = reconcile_every_code_issue(
+                record_store=store,
+                repository="CBUSILLO/LAUNCHPLANE",
+                issue_number=278,
+                issue_url="https://github.com/cbusillo/launchplane/issues/278",
+                issue_title="Changed title",
+                labels=("EVERY-CODE",),
+                actor="second",
+            )
+
+            self.assertEqual(second.status, "deduped")
+            self.assertIsNotNone(second.request)
+            assert second.request is not None
+            self.assertEqual(second.request.state, "claimed")
+            self.assertEqual(second.request.issue_title, "Original title")
+            self.assertEqual(second.request.trigger_actor, "first")
+
+    def test_skips_when_trigger_label_is_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            store = FilesystemRecordStore(state_dir=Path(tempdir))
+
+            result = reconcile_every_code_issue(
+                record_store=store,
+                repository="cbusillo/launchplane",
+                issue_number=278,
+                issue_url="https://github.com/cbusillo/launchplane/issues/278",
+                issue_title="Build Launchplane-backed Every Code automation",
+                labels=("plan",),
+            )
+
+            self.assertEqual(result.status, "skipped")
+            self.assertEqual(
+                store.list_every_code_work_request_records(limit=10),
+                (),
+            )
+
+    def test_cli_reconcile_issue_writes_json_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            runner = CliRunner()
+
+            result = runner.invoke(
+                main,
+                [
+                    "every-code",
+                    "reconcile-issue",
+                    "--state-dir",
+                    tempdir,
+                    "--repository",
+                    "cbusillo/launchplane",
+                    "--issue-number",
+                    "278",
+                    "--issue-url",
+                    "https://github.com/cbusillo/launchplane/issues/278",
+                    "--issue-title",
+                    "Build Launchplane-backed Every Code automation",
+                    "--label",
+                    "plan",
+                    "--label",
+                    "every-code",
+                    "--actor",
+                    "ops",
+                ],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            payload = json.loads(result.output)
+            self.assertEqual(payload["status"], "created")
+            self.assertEqual(payload["request"]["source"], "reconciliation")
+            self.assertEqual(payload["request"]["state"], "queued")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `launchplane every-code reconcile-issue` for operator-provided issue facts
- create or dedupe the deterministic Every Code work request only when the trigger label is present
- document the fallback reconciliation path as event/manual input rather than GitHub API polling

Refs #278

## Verification
- uv run python -m unittest tests.test_every_code_reconciliation tests.test_every_code_worker tests.test_every_code_work_request
- uv run --extra dev ruff check --diff control_plane/every_code_reconciliation.py control_plane/cli.py tests/test_every_code_reconciliation.py docs/records.md
- uv run --extra dev ruff check control_plane/every_code_reconciliation.py control_plane/cli.py tests/test_every_code_reconciliation.py
- uv run --extra dev ruff format --check control_plane/every_code_reconciliation.py control_plane/cli.py tests/test_every_code_reconciliation.py
- uv run --extra dev mypy control_plane/every_code_reconciliation.py control_plane/cli.py tests/test_every_code_reconciliation.py
- git diff --check