### PR TITLE
feat(every-code): add worker start stop status

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -93,7 +93,14 @@ from control_plane.contracts.runtime_key_safety_policy import (
 from control_plane.contracts.secret_record import SecretBinding, SecretScope
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.drivers.registry import build_driver_context_view
-from control_plane.every_code_worker import run_every_code_worker_loop, run_every_code_worker_once
+from control_plane.every_code_worker import (
+    build_every_code_worker_daemon_spec,
+    every_code_worker_daemon_status,
+    run_every_code_worker_loop,
+    run_every_code_worker_once,
+    start_every_code_worker_daemon,
+    stop_every_code_worker_daemon,
+)
 from control_plane.launchplane_mutations import (
     apply_launchplane_destroy_preview as shared_apply_launchplane_destroy_preview,
     apply_launchplane_generation_evidence as shared_apply_launchplane_generation_evidence,
@@ -9649,6 +9656,103 @@ def every_code_run(
         close = getattr(record_store, "close", None)
         if callable(close):
             close()
+    click.echo(json.dumps(result.as_payload(), indent=2, sort_keys=True))
+
+
+@every_code.command("start")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    default="",
+    show_default=False,
+    help="Optional Postgres connection string for Launchplane work-request records.",
+)
+@click.option(
+    "--state-dir",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    default=Path("state"),
+    show_default=True,
+    help="Filesystem state directory used when --database-url is not set.",
+)
+@click.option("--host", default="", help="Worker host name recorded on claims.")
+@click.option(
+    "--workspace-root",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    default=Path.home() / "Developer",
+    show_default=True,
+    help="Directory containing repository checkouts.",
+)
+@click.option(
+    "--checkout-root",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    default=None,
+    help="Explicit checkout root for claimed requests.",
+)
+@click.option("--repository", default="", help="Optional owner/repo queue filter.")
+@click.option(
+    "--command-template",
+    default="",
+    help="Optional shell command template for tmux. Fields include {issue_url} and {request_id}.",
+)
+@click.option("--tmux-binary", default="tmux", show_default=True)
+@click.option(
+    "--interval-seconds",
+    type=click.FloatRange(min=0),
+    default=60.0,
+    show_default=True,
+    help="Seconds to sleep between queue scans.",
+)
+def every_code_start(
+    database_url: str,
+    state_dir: Path,
+    host: str,
+    workspace_root: Path,
+    checkout_root: Path | None,
+    repository: str,
+    command_template: str,
+    tmux_binary: str,
+    interval_seconds: float,
+) -> None:
+    spec = build_every_code_worker_daemon_spec(
+        state_dir=state_dir,
+        database_url=database_url,
+        host=host.strip() or os.uname().nodename,
+        workspace_root=workspace_root,
+        checkout_root=checkout_root,
+        repository=repository,
+        command_template=command_template,
+        tmux_binary=tmux_binary,
+        interval_seconds=interval_seconds,
+    )
+    result = start_every_code_worker_daemon(spec=spec, cwd=Path.cwd())
+    click.echo(json.dumps(result.as_payload(), indent=2, sort_keys=True))
+
+
+@every_code.command("stop")
+@click.option(
+    "--state-dir",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    default=Path("state"),
+    show_default=True,
+    help="Filesystem state directory containing the worker pid file.",
+)
+def every_code_stop(state_dir: Path) -> None:
+    spec = build_every_code_worker_daemon_spec(state_dir=state_dir)
+    result = stop_every_code_worker_daemon(spec=spec)
+    click.echo(json.dumps(result.as_payload(), indent=2, sort_keys=True))
+
+
+@every_code.command("status")
+@click.option(
+    "--state-dir",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    default=Path("state"),
+    show_default=True,
+    help="Filesystem state directory containing the worker pid file.",
+)
+def every_code_status(state_dir: Path) -> None:
+    spec = build_every_code_worker_daemon_spec(state_dir=state_dir)
+    result = every_code_worker_daemon_status(spec=spec)
     click.echo(json.dumps(result.as_payload(), indent=2, sort_keys=True))
 
 

--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
+import os
 from pathlib import Path
 import re
 import shlex
+import signal
 import subprocess
 import time
 from typing import Callable, Literal, Protocol, Sequence
@@ -46,6 +49,9 @@ class EveryCodeWorkerStore(Protocol):
 
 
 Runner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+ProcessLauncher = Callable[
+    [Sequence[str], Path, Path], subprocess.Popen[str]
+]
 
 
 @dataclass(frozen=True)
@@ -88,6 +94,60 @@ class EveryCodeWorkerLoopResult:
             "stopped_reason": self.stopped_reason,
             "last_result": self.last_result.as_payload(),
         }
+
+
+@dataclass(frozen=True)
+class EveryCodeWorkerDaemonSpec:
+    pid_file: Path
+    log_file: Path
+    command: tuple[str, ...]
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "pid_file": str(self.pid_file),
+            "log_file": str(self.log_file),
+            "command": list(self.command),
+        }
+
+
+@dataclass(frozen=True)
+class EveryCodeWorkerDaemonStatus:
+    running: bool
+    pid: int | None
+    pid_file: Path
+    log_file: Path
+    detail: str
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "running": self.running,
+            "pid": self.pid,
+            "pid_file": str(self.pid_file),
+            "log_file": str(self.log_file),
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class EveryCodeWorkerStartResult:
+    status: Literal["started", "already_running"]
+    pid: int
+    spec: EveryCodeWorkerDaemonSpec
+
+    def as_payload(self) -> dict[str, object]:
+        payload = self.spec.as_payload()
+        payload.update({"status": self.status, "pid": self.pid})
+        return payload
+
+
+@dataclass(frozen=True)
+class EveryCodeWorkerStopResult:
+    status: Literal["stopped", "not_running"]
+    pid: int | None
+    detail: str
+
+    def as_payload(self) -> dict[str, object]:
+        return {"status": self.status, "pid": self.pid, "detail": self.detail}
 
 
 def every_code_tmux_session_name(request_id: str) -> str:
@@ -324,8 +384,268 @@ def run_every_code_worker_loop(
     )
 
 
+def build_every_code_worker_daemon_spec(
+    *,
+    state_dir: Path,
+    database_url: str = "",
+    host: str = "",
+    workspace_root: Path = Path.home() / "Developer",
+    checkout_root: Path | None = None,
+    repository: str = "",
+    command_template: str = "",
+    tmux_binary: str = "tmux",
+    interval_seconds: float = 60.0,
+) -> EveryCodeWorkerDaemonSpec:
+    resolved_state_dir = state_dir.expanduser().resolve()
+    worker_dir = resolved_state_dir / "every-code-worker"
+    command: list[str] = [
+        "uv",
+        "run",
+        "launchplane",
+        "every-code",
+        "run",
+        "--state-dir",
+        str(resolved_state_dir),
+        "--workspace-root",
+        str(workspace_root.expanduser().resolve()),
+        "--tmux-binary",
+        tmux_binary,
+        "--interval-seconds",
+        str(interval_seconds),
+    ]
+    if database_url.strip():
+        command.extend(("--database-url", database_url.strip()))
+    if host.strip():
+        command.extend(("--host", host.strip()))
+    if checkout_root is not None:
+        command.extend(("--checkout-root", str(checkout_root.expanduser().resolve())))
+    if repository.strip():
+        command.extend(("--repository", repository.strip()))
+    if command_template.strip():
+        command.extend(("--command-template", command_template))
+    return EveryCodeWorkerDaemonSpec(
+        pid_file=worker_dir / "worker.pid",
+        log_file=worker_dir / "worker.log",
+        command=tuple(command),
+    )
+
+
+def every_code_worker_daemon_status(
+    *, spec: EveryCodeWorkerDaemonSpec
+) -> EveryCodeWorkerDaemonStatus:
+    pid_payload = _read_pid_file(spec.pid_file)
+    if pid_payload is None:
+        return EveryCodeWorkerDaemonStatus(
+            running=False,
+            pid=None,
+            pid_file=spec.pid_file,
+            log_file=spec.log_file,
+            detail="Every Code worker is not running.",
+        )
+    pid, expected_command = pid_payload
+    if _process_is_running(pid):
+        command = expected_command or spec.command
+        if not _process_matches_expected_command(pid, command):
+            return EveryCodeWorkerDaemonStatus(
+                running=False,
+                pid=pid,
+                pid_file=spec.pid_file,
+                log_file=spec.log_file,
+                detail="Every Code worker pid file belongs to a different process.",
+            )
+        return EveryCodeWorkerDaemonStatus(
+            running=True,
+            pid=pid,
+            pid_file=spec.pid_file,
+            log_file=spec.log_file,
+            detail="Every Code worker is running.",
+        )
+    return EveryCodeWorkerDaemonStatus(
+        running=False,
+        pid=pid,
+        pid_file=spec.pid_file,
+        log_file=spec.log_file,
+        detail="Every Code worker pid file is stale.",
+    )
+
+
+def start_every_code_worker_daemon(
+    *,
+    spec: EveryCodeWorkerDaemonSpec,
+    cwd: Path,
+    launcher: ProcessLauncher | None = None,
+) -> EveryCodeWorkerStartResult:
+    status = every_code_worker_daemon_status(spec=spec)
+    if status.running and status.pid is not None:
+        return EveryCodeWorkerStartResult(
+            status="already_running", pid=status.pid, spec=spec
+        )
+    spec.pid_file.parent.mkdir(parents=True, exist_ok=True)
+    spec.log_file.parent.mkdir(parents=True, exist_ok=True)
+    lock_file = spec.pid_file.with_suffix(".lock")
+    lock_fd = _acquire_start_lock(lock_file)
+    if lock_fd is None:
+        racing_status = every_code_worker_daemon_status(spec=spec)
+        if racing_status.running and racing_status.pid is not None:
+            return EveryCodeWorkerStartResult(
+                status="already_running", pid=racing_status.pid, spec=spec
+            )
+        raise RuntimeError("Every Code worker start is already in progress.")
+    try:
+        locked_status = every_code_worker_daemon_status(spec=spec)
+        if locked_status.running and locked_status.pid is not None:
+            return EveryCodeWorkerStartResult(
+                status="already_running", pid=locked_status.pid, spec=spec
+            )
+        launch = launcher or _launch_daemon_process
+        process = launch(spec.command, spec.log_file, cwd.expanduser().resolve())
+        _write_pid_file(spec.pid_file, process.pid, spec.command)
+        return EveryCodeWorkerStartResult(status="started", pid=process.pid, spec=spec)
+    finally:
+        os.close(lock_fd)
+        lock_file.unlink(missing_ok=True)
+
+
+def stop_every_code_worker_daemon(
+    *,
+    spec: EveryCodeWorkerDaemonSpec,
+    timeout_seconds: float = 5.0,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> EveryCodeWorkerStopResult:
+    status = every_code_worker_daemon_status(spec=spec)
+    if not status.running or status.pid is None:
+        if spec.pid_file.exists():
+            spec.pid_file.unlink()
+        return EveryCodeWorkerStopResult(
+            status="not_running", pid=status.pid, detail=status.detail
+        )
+    os.kill(status.pid, signal.SIGTERM)
+    deadline = time.monotonic() + max(timeout_seconds, 0)
+    while time.monotonic() < deadline:
+        if not _process_is_running(status.pid):
+            spec.pid_file.unlink(missing_ok=True)
+            return EveryCodeWorkerStopResult(
+                status="stopped",
+                pid=status.pid,
+                detail="Every Code worker stopped.",
+            )
+        sleeper(0.1)
+    if _process_is_running(status.pid):
+        pid_payload = _read_pid_file(spec.pid_file)
+        expected_command = pid_payload[1] if pid_payload is not None else spec.command
+        if _process_matches_expected_command(status.pid, expected_command):
+            os.kill(status.pid, signal.SIGKILL)
+    spec.pid_file.unlink(missing_ok=True)
+    return EveryCodeWorkerStopResult(
+        status="stopped",
+        pid=status.pid,
+        detail="Every Code worker stop signal sent.",
+    )
+
+
 def _run_subprocess(args: Sequence[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(args, capture_output=True, check=False, text=True)
+
+
+def _launch_daemon_process(
+    args: Sequence[str], log_file: Path, cwd: Path
+) -> subprocess.Popen[str]:
+    log_handle = log_file.open("a", encoding="utf-8")
+    try:
+        return subprocess.Popen(
+            args,
+            cwd=cwd,
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+            text=True,
+            start_new_session=True,
+        )
+    finally:
+        log_handle.close()
+
+
+def _write_pid_file(pid_file: Path, pid: int, command: Sequence[str]) -> None:
+    temporary_file = pid_file.with_suffix(".tmp")
+    temporary_file.write_text(
+        json.dumps({"pid": pid, "command": list(command)}, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary_file.replace(pid_file)
+
+
+def _acquire_start_lock(lock_file: Path) -> int | None:
+    stale_lock_pid = _read_lock_pid(lock_file)
+    if stale_lock_pid is not None and not _process_is_running(stale_lock_pid):
+        lock_file.unlink(missing_ok=True)
+    try:
+        lock_fd = os.open(str(lock_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError:
+        return None
+    os.write(lock_fd, str(os.getpid()).encode("utf-8"))
+    return lock_fd
+
+
+def _read_lock_pid(lock_file: Path) -> int | None:
+    try:
+        lock_text = lock_file.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    try:
+        pid = int(lock_text)
+    except ValueError:
+        return None
+    if pid > 0:
+        return pid
+    return None
+
+
+def _read_pid_file(pid_file: Path) -> tuple[int, tuple[str, ...]] | None:
+    try:
+        payload = json.loads(pid_file.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+    pid = payload.get("pid") if isinstance(payload, dict) else None
+    if isinstance(pid, int) and pid > 0:
+        command = payload.get("command")
+        if isinstance(command, list) and all(
+            isinstance(part, str) for part in command
+        ):
+            return pid, tuple(command)
+        return pid, ()
+    return None
+
+
+def _process_is_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _process_matches_expected_command(pid: int, expected_command: Sequence[str]) -> bool:
+    if not expected_command:
+        return True
+    try:
+        result = subprocess.run(
+            ("ps", "-ww", "-p", str(pid), "-o", "command="),
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except OSError:
+        return False
+    if result.returncode != 0:
+        return False
+    command_text = result.stdout.strip()
+    if not command_text:
+        return False
+    expected_tail = " ".join(expected_command[1:])
+    if expected_tail:
+        return expected_tail in command_text
+    return expected_command[0] in command_text
 
 
 def _tmux_session_exists(*, tmux_binary: str, session_name: str, runner: Runner) -> bool | None:

--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -49,9 +49,12 @@ class EveryCodeWorkerStore(Protocol):
 
 
 Runner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
-ProcessLauncher = Callable[
-    [Sequence[str], Path, Path], subprocess.Popen[str]
-]
+
+class DaemonProcess(Protocol):
+    pid: int
+
+
+ProcessLauncher = Callable[[Sequence[str], Path, Path], DaemonProcess]
 
 
 @dataclass(frozen=True)

--- a/docs/records.md
+++ b/docs/records.md
@@ -546,6 +546,12 @@ state/
   `uv run launchplane every-code run-once` for a single scan. It claims queued
   requests, opens or reuses deterministic visible tmux sessions for local
   checkouts, and records `running` or `blocked` status.
+- A Mac host can leave the poller running with
+  `uv run launchplane every-code start`, inspect it with
+  `uv run launchplane every-code status`, and stop it with
+  `uv run launchplane every-code stop`. The supervisor writes a pid file and log
+  under `state/every-code-worker/` by default while the worker-created tmux
+  sessions remain visible and independently attachable.
 - Missed or manually inspected issue labels can be reconciled without polling by
   running `uv run launchplane every-code reconcile-issue` with the known issue
   repository, number, URL, title, and current labels. Reconciliation creates the

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -3,17 +3,23 @@ import unittest
 from collections.abc import Sequence
 import json
 from pathlib import Path
+import signal
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
 from control_plane.cli import main
 from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
 from control_plane.every_code_worker import (
+    build_every_code_worker_daemon_spec,
     default_every_code_command,
     every_code_tmux_session_name,
+    every_code_worker_daemon_status,
     run_every_code_worker_loop,
     run_every_code_worker_once,
+    start_every_code_worker_daemon,
+    stop_every_code_worker_daemon,
 )
 from control_plane.storage.filesystem import FilesystemRecordStore
 
@@ -44,6 +50,11 @@ class _Runner:
         if args[1] == "has-session":
             return subprocess.CompletedProcess(args, 1, "", "no session")
         return subprocess.CompletedProcess(args, 0, "", "")
+
+
+class _Process:
+    def __init__(self, pid: int) -> None:
+        self.pid = pid
 
 
 class EveryCodeWorkerTests(unittest.TestCase):
@@ -177,6 +188,211 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(payload["iterations"], 1)
         self.assertEqual(payload["empty"], 1)
         self.assertEqual(payload["stopped_reason"], "max_iterations")
+
+    def test_daemon_spec_builds_worker_run_command(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            spec = build_every_code_worker_daemon_spec(
+                state_dir=temporary_root / "state",
+                database_url="postgres://example",
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                repository="cbusillo/code",
+                interval_seconds=15,
+            )
+
+        self.assertEqual(spec.pid_file.name, "worker.pid")
+        self.assertIn("every-code", spec.command)
+        self.assertIn("run", spec.command)
+        self.assertIn("--database-url", spec.command)
+        self.assertIn("postgres://example", spec.command)
+        self.assertIn("cbusillo/code", spec.command)
+
+    def test_start_daemon_writes_pid_file_and_log_path(self) -> None:
+        launched: list[tuple[tuple[str, ...], Path, Path]] = []
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            spec = build_every_code_worker_daemon_spec(state_dir=temporary_root / "state")
+
+            result = start_every_code_worker_daemon(
+                spec=spec,
+                cwd=temporary_root,
+                launcher=lambda args, log_file, cwd: launched.append(
+                    (tuple(args), log_file, cwd)
+                )
+                or _Process(4242),
+            )
+            payload = json.loads(spec.pid_file.read_text(encoding="utf-8"))
+
+        self.assertEqual(result.status, "started")
+        self.assertEqual(result.pid, 4242)
+        self.assertEqual(payload["pid"], 4242)
+        self.assertEqual(launched[0][1], spec.log_file)
+
+    def test_start_daemon_reuses_running_pid(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            spec = build_every_code_worker_daemon_spec(state_dir=temporary_root / "state")
+            spec.pid_file.parent.mkdir(parents=True)
+            spec.pid_file.write_text('{"pid": 4242}\n', encoding="utf-8")
+            with patch("control_plane.every_code_worker.os.kill") as kill:
+                with patch(
+                    "control_plane.every_code_worker._process_matches_expected_command",
+                    return_value=True,
+                ):
+                    result = start_every_code_worker_daemon(
+                        spec=spec,
+                        cwd=temporary_root,
+                        launcher=lambda _args, _log_file, _cwd: self.fail(
+                            "launcher should not run"
+                        ),
+                    )
+
+        kill.assert_called_once_with(4242, 0)
+        self.assertEqual(result.status, "already_running")
+        self.assertEqual(result.pid, 4242)
+
+    def test_status_rejects_reused_pid_for_unrelated_process(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            spec = build_every_code_worker_daemon_spec(state_dir=temporary_root / "state")
+            spec.pid_file.parent.mkdir(parents=True)
+            spec.pid_file.write_text(
+                '{"pid": 4242, "command": ["uv", "run", "launchplane"]}\n',
+                encoding="utf-8",
+            )
+            with patch("control_plane.every_code_worker.os.kill"):
+                with patch(
+                    "control_plane.every_code_worker._process_matches_expected_command",
+                    return_value=False,
+                ):
+                    status = every_code_worker_daemon_status(spec=spec)
+
+        self.assertFalse(status.running)
+        self.assertEqual(status.pid, 4242)
+        self.assertIn("different process", status.detail)
+
+    def test_start_daemon_replaces_reused_pid_file(self) -> None:
+        launched: list[int] = []
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            spec = build_every_code_worker_daemon_spec(state_dir=temporary_root / "state")
+            spec.pid_file.parent.mkdir(parents=True)
+            spec.pid_file.write_text(
+                '{"pid": 4242, "command": ["uv", "run", "launchplane"]}\n',
+                encoding="utf-8",
+            )
+            with patch("control_plane.every_code_worker.os.kill"):
+                with patch(
+                    "control_plane.every_code_worker._process_matches_expected_command",
+                    return_value=False,
+                ):
+                    result = start_every_code_worker_daemon(
+                        spec=spec,
+                        cwd=temporary_root,
+                        launcher=lambda _args, _log_file, _cwd: launched.append(1)
+                        or _Process(5252),
+                    )
+
+        self.assertEqual(result.status, "started")
+        self.assertEqual(result.pid, 5252)
+        self.assertEqual(launched, [1])
+
+    def test_start_daemon_rejects_concurrent_start(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            spec = build_every_code_worker_daemon_spec(state_dir=temporary_root / "state")
+            spec.pid_file.parent.mkdir(parents=True)
+            spec.pid_file.with_suffix(".lock").write_text("4242", encoding="utf-8")
+            with patch("control_plane.every_code_worker.os.kill"):
+                with self.assertRaisesRegex(RuntimeError, "already in progress"):
+                    start_every_code_worker_daemon(
+                        spec=spec,
+                        cwd=temporary_root,
+                        launcher=lambda _args, _log_file, _cwd: self.fail(
+                            "launcher should not run"
+                        ),
+                    )
+
+    def test_start_daemon_removes_stale_lock(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            spec = build_every_code_worker_daemon_spec(state_dir=temporary_root / "state")
+            spec.pid_file.parent.mkdir(parents=True)
+            spec.pid_file.with_suffix(".lock").write_text("4242", encoding="utf-8")
+
+            with patch(
+                "control_plane.every_code_worker.os.kill",
+                side_effect=ProcessLookupError,
+            ):
+                start_every_code_worker_daemon(
+                    spec=spec,
+                    cwd=temporary_root,
+                    launcher=lambda _args, _log_file, _cwd: _Process(5252),
+                )
+
+            lock_exists = spec.pid_file.with_suffix(".lock").exists()
+
+        self.assertFalse(lock_exists)
+
+    def test_status_reports_stale_pid_file(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            spec = build_every_code_worker_daemon_spec(state_dir=temporary_root / "state")
+            spec.pid_file.parent.mkdir(parents=True)
+            spec.pid_file.write_text('{"pid": 4242}\n', encoding="utf-8")
+            with patch(
+                "control_plane.every_code_worker.os.kill",
+                side_effect=ProcessLookupError,
+            ):
+                status = every_code_worker_daemon_status(spec=spec)
+
+        self.assertFalse(status.running)
+        self.assertEqual(status.pid, 4242)
+        self.assertIn("stale", status.detail)
+
+    def test_stop_daemon_signals_running_pid_and_removes_pid_file(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            spec = build_every_code_worker_daemon_spec(state_dir=temporary_root / "state")
+            spec.pid_file.parent.mkdir(parents=True)
+            spec.pid_file.write_text('{"pid": 4242}\n', encoding="utf-8")
+            calls: list[tuple[int, int]] = []
+
+            def fake_kill(pid: int, signal_number: int) -> None:
+                calls.append((pid, signal_number))
+
+            with patch("control_plane.every_code_worker.os.kill", side_effect=fake_kill):
+                with patch(
+                    "control_plane.every_code_worker._process_matches_expected_command",
+                    return_value=True,
+                ):
+                    result = stop_every_code_worker_daemon(
+                        spec=spec,
+                        timeout_seconds=0,
+                    )
+
+            pid_file_exists = spec.pid_file.exists()
+
+        self.assertEqual(result.status, "stopped")
+        self.assertFalse(pid_file_exists)
+        self.assertEqual(
+            calls,
+            [(4242, 0), (4242, signal.SIGTERM), (4242, 0), (4242, signal.SIGKILL)],
+        )
+
+    def test_cli_status_reports_not_running(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            result = CliRunner().invoke(
+                main,
+                ["every-code", "status", "--state-dir", str(temporary_root / "state")],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertFalse(payload["running"])
+        self.assertIsNone(payload["pid"])
 
 
 if __name__ == "__main__":

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -214,13 +214,14 @@ class EveryCodeWorkerTests(unittest.TestCase):
             temporary_root = Path(temporary_directory_name)
             spec = build_every_code_worker_daemon_spec(state_dir=temporary_root / "state")
 
+            def launcher(args: Sequence[str], log_file: Path, cwd: Path) -> _Process:
+                launched.append((tuple(args), log_file, cwd))
+                return _Process(4242)
+
             result = start_every_code_worker_daemon(
                 spec=spec,
                 cwd=temporary_root,
-                launcher=lambda args, log_file, cwd: launched.append(
-                    (tuple(args), log_file, cwd)
-                )
-                or _Process(4242),
+                launcher=launcher,
             )
             payload = json.loads(spec.pid_file.read_text(encoding="utf-8"))
 
@@ -287,11 +288,16 @@ class EveryCodeWorkerTests(unittest.TestCase):
                     "control_plane.every_code_worker._process_matches_expected_command",
                     return_value=False,
                 ):
+                    def launcher(
+                        _args: Sequence[str], _log_file: Path, _cwd: Path
+                    ) -> _Process:
+                        launched.append(1)
+                        return _Process(5252)
+
                     result = start_every_code_worker_daemon(
                         spec=spec,
                         cwd=temporary_root,
-                        launcher=lambda _args, _log_file, _cwd: launched.append(1)
-                        or _Process(5252),
+                        launcher=launcher,
                     )
 
         self.assertEqual(result.status, "started")


### PR DESCRIPTION
## Summary
- Add `uv run launchplane every-code start`, `status`, and `stop` for host-local worker control.
- Track the detached poller with pid/log files under `state/every-code-worker/` and guard start with a self-cleaning lock.
- Detect stale or reused pids before reporting a worker as running, and stop with SIGTERM plus a bounded SIGKILL fallback.
- Document the start/status/stop flow and expand worker lifecycle tests.

## Verification
- `uv run python -m unittest tests.test_every_code_worker`
- `uv run python -m unittest`

Refs #281
