### PR TITLE
feat(every-code): report terminal worker status

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -96,6 +96,7 @@ from control_plane.drivers.registry import build_driver_context_view
 from control_plane.every_code_worker import (
     build_every_code_worker_daemon_spec,
     every_code_worker_daemon_status,
+    finish_every_code_work_request,
     run_every_code_worker_loop,
     run_every_code_worker_once,
     start_every_code_worker_daemon,
@@ -9565,6 +9566,8 @@ def every_code_run_once(
             checkout_root=checkout_root,
             repository=repository,
             command_template=command_template,
+            state_dir=state_dir,
+            database_url=database_url,
             tmux_binary=tmux_binary,
         )
     finally:
@@ -9646,6 +9649,8 @@ def every_code_run(
             checkout_root=checkout_root,
             repository=repository,
             command_template=command_template,
+            state_dir=state_dir,
+            database_url=database_url,
             tmux_binary=tmux_binary,
             interval_seconds=interval_seconds,
             max_iterations=max_iterations,
@@ -9753,6 +9758,53 @@ def every_code_stop(state_dir: Path) -> None:
 def every_code_status(state_dir: Path) -> None:
     spec = build_every_code_worker_daemon_spec(state_dir=state_dir)
     result = every_code_worker_daemon_status(spec=spec)
+    click.echo(json.dumps(result.as_payload(), indent=2, sort_keys=True))
+
+
+@every_code.command("finish")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    default="",
+    show_default=False,
+    help="Optional Postgres connection string for Launchplane work-request records.",
+)
+@click.option(
+    "--state-dir",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    default=Path("state"),
+    show_default=True,
+    help="Filesystem state directory used when --database-url is not set.",
+)
+@click.option("--request-id", required=True, help="Every Code work request id.")
+@click.option("--host", default="", help="Worker host name that claimed the request.")
+@click.option("--exit-code", type=int, required=True, help="Visible session exit code.")
+@click.option("--result-pr-url", default="", help="Optional PR URL created by the session.")
+@click.option("--result-summary", default="", help="Optional terminal result summary.")
+def every_code_finish(
+    database_url: str,
+    state_dir: Path,
+    request_id: str,
+    host: str,
+    exit_code: int,
+    result_pr_url: str,
+    result_summary: str,
+) -> None:
+    resolved_host = host.strip() or os.uname().nodename
+    record_store = _store(state_dir=state_dir, database_url=database_url)
+    try:
+        result = finish_every_code_work_request(
+            record_store=record_store,
+            request_id=request_id,
+            host=resolved_host,
+            exit_code=exit_code,
+            result_pr_url=result_pr_url,
+            result_summary=result_summary,
+        )
+    finally:
+        close = getattr(record_store, "close", None)
+        if callable(close):
+            close()
     click.echo(json.dumps(result.as_payload(), indent=2, sort_keys=True))
 
 

--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -20,6 +20,7 @@ from control_plane.workflows.ship import utc_now_timestamp
 
 
 EveryCodeWorkerStatus = Literal["empty", "running", "blocked"]
+EveryCodeWorkerFinishStatus = Literal["done", "blocked"]
 
 
 class EveryCodeWorkerStore(Protocol):
@@ -49,6 +50,7 @@ class EveryCodeWorkerStore(Protocol):
 
 
 Runner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
 
 class DaemonProcess(Protocol):
     pid: int
@@ -153,6 +155,26 @@ class EveryCodeWorkerStopResult:
         return {"status": self.status, "pid": self.pid, "detail": self.detail}
 
 
+@dataclass(frozen=True)
+class EveryCodeWorkerFinishResult:
+    status: EveryCodeWorkerFinishStatus
+    detail: str
+    request_id: str
+    repository: str
+    issue_number: int
+    result_pr_url: str = ""
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "status": self.status,
+            "detail": self.detail,
+            "request_id": self.request_id,
+            "repository": self.repository,
+            "issue_number": self.issue_number,
+            "result_pr_url": self.result_pr_url,
+        }
+
+
 def every_code_tmux_session_name(request_id: str) -> str:
     normalized = re.sub(r"[^A-Za-z0-9_.:-]+", "-", request_id.strip()).strip("-._:")
     return f"every-code-{normalized or 'request'}"[:80]
@@ -184,6 +206,42 @@ def render_every_code_command(
     )
 
 
+def build_every_code_session_command(
+    *,
+    record: EveryCodeWorkRequestRecord,
+    command: str,
+    state_dir: Path,
+    host: str,
+    database_url: str = "",
+) -> str:
+    finish_command = [
+        "uv",
+        "run",
+        "launchplane",
+        "every-code",
+        "finish",
+        "--state-dir",
+        str(state_dir.expanduser().resolve()),
+        "--request-id",
+        record.request_id,
+        "--host",
+        host.strip(),
+        "--exit-code",
+        "$status",
+    ]
+    if database_url.strip():
+        finish_command.extend(("--database-url", database_url.strip()))
+    finish_shell = " ".join(
+        "$status" if part == "$status" else shlex.quote(part) for part in finish_command
+    )
+    return (
+        f"{command}\n"
+        "status=$?\n"
+        f"{finish_shell}\n"
+        "exit $status"
+    )
+
+
 def resolve_every_code_checkout_root(
     record: EveryCodeWorkRequestRecord,
     *,
@@ -204,6 +262,8 @@ def run_every_code_worker_once(
     checkout_root: Path | None = None,
     repository: str = "",
     command_template: str = "",
+    state_dir: Path | None = None,
+    database_url: str = "",
     tmux_binary: str = "tmux",
     runner: Runner | None = None,
 ) -> EveryCodeWorkerHandoffResult:
@@ -268,6 +328,14 @@ def run_every_code_worker_once(
         )
     if not existing_session:
         command = render_every_code_command(claimed_record, command_template=command_template)
+        if state_dir is not None:
+            command = build_every_code_session_command(
+                record=claimed_record,
+                command=command,
+                state_dir=state_dir,
+                database_url=database_url,
+                host=normalized_host,
+            )
         try:
             launch_result = run(
                 (
@@ -329,6 +397,8 @@ def run_every_code_worker_loop(
     checkout_root: Path | None = None,
     repository: str = "",
     command_template: str = "",
+    state_dir: Path | None = None,
+    database_url: str = "",
     tmux_binary: str = "tmux",
     interval_seconds: float = 60.0,
     max_iterations: int = 0,
@@ -357,6 +427,8 @@ def run_every_code_worker_loop(
             checkout_root=checkout_root,
             repository=repository,
             command_template=command_template,
+            state_dir=state_dir,
+            database_url=database_url,
             tmux_binary=tmux_binary,
             runner=runner,
         )
@@ -543,6 +615,44 @@ def stop_every_code_worker_daemon(
         status="stopped",
         pid=status.pid,
         detail="Every Code worker stop signal sent.",
+    )
+
+
+def finish_every_code_work_request(
+    *,
+    record_store: EveryCodeWorkerStore,
+    request_id: str,
+    host: str,
+    exit_code: int,
+    result_pr_url: str = "",
+    result_summary: str = "",
+) -> EveryCodeWorkerFinishResult:
+    record = record_store.read_every_code_work_request_record(request_id.strip())
+    succeeded = exit_code == 0
+    summary = result_summary.strip() or (
+        "Every Code session completed successfully."
+        if succeeded
+        else f"Every Code session exited with status {exit_code}."
+    )
+    updated_record = apply_every_code_work_request_status(
+        record,
+        EveryCodeWorkRequestStatusUpdate(
+            state="done" if succeeded else "blocked",
+            host=host.strip(),
+            updated_at=utc_now_timestamp(),
+            result_pr_url=result_pr_url.strip(),
+            result_summary=summary,
+            error_message="" if succeeded else summary,
+        ),
+    )
+    record_store.write_every_code_work_request_record(updated_record)
+    return EveryCodeWorkerFinishResult(
+        status="done" if succeeded else "blocked",
+        detail=summary,
+        request_id=updated_record.request_id,
+        repository=updated_record.repository,
+        issue_number=updated_record.issue_number,
+        result_pr_url=updated_record.result_pr_url,
     )
 
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -545,7 +545,9 @@ state/
 - The local worker handoff is `uv run launchplane every-code run` for polling or
   `uv run launchplane every-code run-once` for a single scan. It claims queued
   requests, opens or reuses deterministic visible tmux sessions for local
-  checkouts, and records `running` or `blocked` status.
+  checkouts, records `running` or immediate `blocked` status, and wraps the
+  visible command so terminal success or failure calls
+  `uv run launchplane every-code finish`.
 - A Mac host can leave the poller running with
   `uv run launchplane every-code start`, inspect it with
   `uv run launchplane every-code status`, and stop it with

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -13,9 +13,11 @@ from control_plane.cli import main
 from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
 from control_plane.every_code_worker import (
     build_every_code_worker_daemon_spec,
+    build_every_code_session_command,
     default_every_code_command,
     every_code_tmux_session_name,
     every_code_worker_daemon_status,
+    finish_every_code_work_request,
     run_every_code_worker_loop,
     run_every_code_worker_once,
     start_every_code_worker_daemon,
@@ -69,6 +71,19 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertIn("https://github.com/cbusillo/code/issues/123", command)
         self.assertIn("every-code-cbusillo-code-123-test", command)
 
+    def test_session_command_reports_terminal_status(self) -> None:
+        command = build_every_code_session_command(
+            record=_queued_record(),
+            command="code issue",
+            state_dir=Path("state"),
+            host="Chris-Studio",
+        )
+
+        self.assertIn("code issue", command)
+        self.assertIn("every-code finish", command)
+        self.assertIn("--request-id every-code-cbusillo-code-123-test", command)
+        self.assertIn("--exit-code $status", command)
+
     def test_run_once_claims_request_and_launches_tmux_session(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             temporary_root = Path(temporary_directory_name)
@@ -82,6 +97,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
                 record_store=store,
                 host="Chris-Studio",
                 workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "state",
                 runner=runner,
             )
             record = store.read_every_code_work_request_record("every-code-cbusillo-code-123-test")
@@ -92,6 +108,63 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(result.checkout_root, str(checkout_root.resolve()))
         self.assertEqual(runner.calls[0][1], "has-session")
         self.assertEqual(runner.calls[1][1], "new-session")
+        self.assertIn("every-code finish", runner.calls[1][-1])
+
+    def test_finish_marks_running_request_done(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "state",
+                runner=_Runner(),
+            )
+
+            result = finish_every_code_work_request(
+                record_store=store,
+                request_id="every-code-cbusillo-code-123-test",
+                host="Chris-Studio",
+                exit_code=0,
+                result_pr_url="https://github.com/cbusillo/code/pull/99",
+            )
+            record = store.read_every_code_work_request_record("every-code-cbusillo-code-123-test")
+
+        self.assertEqual(result.status, "done")
+        self.assertEqual(record.state, "done")
+        self.assertEqual(record.result_pr_url, "https://github.com/cbusillo/code/pull/99")
+        self.assertEqual(record.error_message, "")
+
+    def test_finish_marks_failed_session_blocked(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "state",
+                runner=_Runner(),
+            )
+
+            result = finish_every_code_work_request(
+                record_store=store,
+                request_id="every-code-cbusillo-code-123-test",
+                host="Chris-Studio",
+                exit_code=7,
+            )
+            record = store.read_every_code_work_request_record("every-code-cbusillo-code-123-test")
+
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(record.state, "blocked")
+        self.assertIn("exited with status 7", record.error_message)
 
     def test_run_once_marks_missing_checkout_blocked(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -399,6 +472,41 @@ class EveryCodeWorkerTests(unittest.TestCase):
         payload = json.loads(result.output)
         self.assertFalse(payload["running"])
         self.assertIsNone(payload["pid"])
+
+    def test_cli_finish_reports_done(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "state",
+                runner=_Runner(),
+            )
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "every-code",
+                    "finish",
+                    "--state-dir",
+                    str(temporary_root / "state"),
+                    "--request-id",
+                    "every-code-cbusillo-code-123-test",
+                    "--host",
+                    "Chris-Studio",
+                    "--exit-code",
+                    "0",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["status"], "done")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `uv run launchplane every-code finish` to mark handed-off work requests `done` or `blocked` from a visible session exit code.
- Wrap worker-launched tmux commands so they preserve the user command exit code while reporting terminal status back to Launchplane.
- Extend worker tests for the finish command, successful terminal updates, failed-session blocking, and wrapper command generation.
- Update records docs to describe terminal status reporting.

## Verification
- `uv run python -m unittest tests.test_every_code_worker`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`

Refs #281
