### PR TITLE
Rank work graph planning snapshots

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -92,6 +92,10 @@ from control_plane.contracts.runtime_key_safety_policy import (
 )
 from control_plane.contracts.secret_record import SecretBinding, SecretScope
 from control_plane.contracts.ship_request import ShipRequest
+from control_plane.contracts.work_graph_read_model import (
+    WorkGraphSnapshot,
+    build_work_graph_queue,
+)
 from control_plane.drivers.registry import build_driver_context_view
 from control_plane.every_code_worker import (
     build_every_code_worker_daemon_spec,
@@ -9508,6 +9512,29 @@ def service() -> None:
 @main.group("every-code")
 def every_code() -> None:
     """Every Code local worker commands."""
+
+
+@main.group("work-graph")
+def work_graph() -> None:
+    """Work graph recommendation commands."""
+
+
+@work_graph.command("rank")
+@click.option(
+    "--snapshot-file",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False),
+    required=True,
+    help="Operator-provided Code Plans/GitHub work graph snapshot JSON.",
+)
+@click.option("--limit", type=click.IntRange(min=1), default=25, show_default=True)
+def work_graph_rank(snapshot_file: Path, limit: int) -> None:
+    try:
+        snapshot_payload = json.loads(snapshot_file.read_text())
+        snapshot = WorkGraphSnapshot.model_validate(snapshot_payload)
+        queue = build_work_graph_queue(snapshot, limit=limit)
+    except (OSError, JSONDecodeError, ValidationError, ValueError) as error:
+        raise click.ClickException(str(error)) from error
+    click.echo(json.dumps(queue.model_dump(mode="json"), indent=2, sort_keys=True))
 
 
 @every_code.command("run-once")

--- a/control_plane/contracts/work_graph_read_model.py
+++ b/control_plane/contracts/work_graph_read_model.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+RepoClassification = Literal[
+    "managed_runtime",
+    "active_awareness",
+    "support_dependency",
+    "out_of_scope",
+]
+WorkItemFocus = Literal["Now", "Next", "Waiting", "Later", "Done", "Unknown"]
+WorkItemState = Literal["ready", "waiting", "blocked", "done", "hidden"]
+WorkItemRecommendation = Literal[
+    "quick_win",
+    "deep_work",
+    "switch_projects",
+    "blocked_cleanup",
+    "attention_needed",
+    "watch",
+]
+
+
+class WorkGraphRepoSnapshot(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    repository: str
+    classification: RepoClassification
+    product: str = ""
+    display_name: str = ""
+
+    @model_validator(mode="after")
+    def _validate_repo(self) -> "WorkGraphRepoSnapshot":
+        if not self.repository.strip() or "/" not in self.repository.strip():
+            raise ValueError("work graph repo snapshot requires owner/repo repository")
+        if self.classification == "managed_runtime" and not self.product.strip():
+            raise ValueError("managed runtime repo snapshot requires product")
+        return self
+
+
+class WorkGraphIssueSnapshot(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    repository: str
+    number: int = Field(ge=1)
+    title: str
+    url: str
+    state: Literal["open", "closed"] = "open"
+    focus: WorkItemFocus = "Unknown"
+    manager: str = ""
+    finish_line: str = ""
+    labels: tuple[str, ...] = ()
+    blocked_by: int = Field(default=0, ge=0)
+    blocking: int = Field(default=0, ge=0)
+    subissues_total: int = Field(default=0, ge=0)
+    subissues_completed: int = Field(default=0, ge=0)
+    updated_at: str = ""
+    is_pull_request: bool = False
+    check_state: Literal["success", "pending", "failure", "unknown"] = "unknown"
+    deploy_state: Literal["success", "pending", "failure", "unknown"] = "unknown"
+
+    @model_validator(mode="after")
+    def _validate_issue(self) -> "WorkGraphIssueSnapshot":
+        if not self.repository.strip() or "/" not in self.repository.strip():
+            raise ValueError("work graph issue snapshot requires owner/repo repository")
+        if not self.title.strip():
+            raise ValueError("work graph issue snapshot requires title")
+        if not self.url.strip():
+            raise ValueError("work graph issue snapshot requires url")
+        if self.subissues_completed > self.subissues_total:
+            raise ValueError("completed subissue count cannot exceed total subissue count")
+        return self
+
+
+class WorkGraphSnapshot(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    generated_at: str
+    repos: tuple[WorkGraphRepoSnapshot, ...] = ()
+    issues: tuple[WorkGraphIssueSnapshot, ...]
+
+    @model_validator(mode="after")
+    def _validate_snapshot(self) -> "WorkGraphSnapshot":
+        if not self.generated_at.strip():
+            raise ValueError("work graph snapshot requires generated_at")
+        repositories = {repo.repository.strip().lower() for repo in self.repos}
+        missing = sorted(
+            {
+                issue.repository.strip().lower()
+                for issue in self.issues
+                if issue.repository.strip().lower() not in repositories
+            }
+        )
+        if missing:
+            raise ValueError(
+                "work graph snapshot is missing repo classifications: " + ", ".join(missing)
+            )
+        return self
+
+
+class WorkGraphRecommendationReason(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: str
+    detail: str
+
+
+class WorkGraphQueueItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    repository: str
+    repo_classification: RepoClassification
+    product: str = ""
+    product_display_name: str = ""
+    number: int
+    title: str
+    url: str
+    focus: WorkItemFocus
+    manager: str = ""
+    finish_line: str = ""
+    state: WorkItemState
+    recommendation: WorkItemRecommendation
+    score: int
+    updated_at: str = ""
+    reasons: tuple[WorkGraphRecommendationReason, ...]
+
+
+class WorkGraphQueue(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    generated_at: str
+    items: tuple[WorkGraphQueueItem, ...]
+    hidden_count: int = Field(default=0, ge=0)
+
+
+def build_work_graph_queue(snapshot: WorkGraphSnapshot, *, limit: int = 25) -> WorkGraphQueue:
+    if limit < 1:
+        raise ValueError("work graph queue limit must be positive")
+    repos = {repo.repository.strip().lower(): repo for repo in snapshot.repos}
+    ranked_items: list[WorkGraphQueueItem] = []
+    hidden_count = 0
+    for issue in snapshot.issues:
+        repo = repos[issue.repository.strip().lower()]
+        item = _build_queue_item(issue=issue, repo=repo)
+        if item.state == "hidden":
+            hidden_count += 1
+            continue
+        ranked_items.append(item)
+    ranked_items.sort(key=_queue_sort_key)
+    return WorkGraphQueue(
+        generated_at=snapshot.generated_at,
+        items=tuple(ranked_items[:limit]),
+        hidden_count=hidden_count + max(0, len(ranked_items) - limit),
+    )
+
+
+def _build_queue_item(
+    *, issue: WorkGraphIssueSnapshot, repo: WorkGraphRepoSnapshot
+) -> WorkGraphQueueItem:
+    state = _work_item_state(issue)
+    recommendation = _recommendation(issue=issue, state=state)
+    reasons = _recommendation_reasons(issue=issue, repo=repo, state=state)
+    return WorkGraphQueueItem(
+        repository=issue.repository,
+        repo_classification=repo.classification,
+        product=repo.product,
+        product_display_name=repo.display_name,
+        number=issue.number,
+        title=issue.title,
+        url=issue.url,
+        focus=issue.focus,
+        manager=issue.manager,
+        finish_line=issue.finish_line,
+        state=state,
+        recommendation=recommendation,
+        score=_score(issue=issue, repo=repo, state=state, recommendation=recommendation),
+        updated_at=issue.updated_at,
+        reasons=reasons,
+    )
+
+
+def _work_item_state(issue: WorkGraphIssueSnapshot) -> WorkItemState:
+    if issue.state == "closed" or issue.focus == "Done":
+        return "hidden"
+    if "plan:blocked" in issue.labels or issue.blocked_by > 0:
+        return "blocked"
+    if issue.focus == "Waiting":
+        return "waiting"
+    if issue.check_state == "failure" or issue.deploy_state == "failure":
+        return "ready"
+    if issue.focus in {"Now", "Next"}:
+        return "ready"
+    return "waiting"
+
+
+def _recommendation(
+    *, issue: WorkGraphIssueSnapshot, state: WorkItemState
+) -> WorkItemRecommendation:
+    if state == "blocked":
+        return "blocked_cleanup"
+    if issue.check_state == "failure" or issue.deploy_state == "failure":
+        return "attention_needed"
+    if issue.focus == "Now":
+        return "deep_work"
+    if issue.focus == "Next" and issue.subissues_total == 0:
+        return "quick_win"
+    if issue.focus == "Next":
+        return "deep_work"
+    if state == "waiting":
+        return "watch"
+    return "switch_projects"
+
+
+def _score(
+    *,
+    issue: WorkGraphIssueSnapshot,
+    repo: WorkGraphRepoSnapshot,
+    state: WorkItemState,
+    recommendation: WorkItemRecommendation,
+) -> int:
+    if state == "hidden":
+        return 0
+    score = 0
+    score += {
+        "ready": 70,
+        "waiting": 30,
+        "blocked": 20,
+        "done": 0,
+        "hidden": 0,
+    }[state]
+    score += {"Now": 30, "Next": 22, "Waiting": 0, "Later": -8, "Done": -100, "Unknown": -2}[
+        issue.focus
+    ]
+    score += {
+        "attention_needed": 24,
+        "quick_win": 18,
+        "deep_work": 12,
+        "switch_projects": 8,
+        "blocked_cleanup": 4,
+        "watch": 0,
+    }[recommendation]
+    if issue.check_state == "failure" or issue.deploy_state == "failure":
+        score += 36
+    if repo.classification == "managed_runtime":
+        score += 8
+    if issue.blocking:
+        score += min(issue.blocking * 3, 12)
+    if issue.subissues_total:
+        remaining = issue.subissues_total - issue.subissues_completed
+        score -= min(remaining * 2, 12)
+    return score
+
+
+def _recommendation_reasons(
+    *, issue: WorkGraphIssueSnapshot, repo: WorkGraphRepoSnapshot, state: WorkItemState
+) -> tuple[WorkGraphRecommendationReason, ...]:
+    reasons: list[WorkGraphRecommendationReason] = [
+        WorkGraphRecommendationReason(
+            code="repo_classification",
+            detail=f"{repo.repository} is {repo.classification.replace('_', ' ')}.",
+        ),
+        WorkGraphRecommendationReason(
+            code="state",
+            detail=f"Work item is {state}.",
+        ),
+    ]
+    if issue.focus != "Unknown":
+        reasons.append(
+            WorkGraphRecommendationReason(
+                code="focus", detail=f"Code Plans focus is {issue.focus}."
+            )
+        )
+    if issue.check_state == "failure" or issue.deploy_state == "failure":
+        reasons.append(
+            WorkGraphRecommendationReason(
+                code="failed_signal",
+                detail="A check or deploy signal is failing and needs operator attention.",
+            )
+        )
+    if issue.blocked_by:
+        reasons.append(
+            WorkGraphRecommendationReason(
+                code="blocked_by", detail=f"Blocked by {issue.blocked_by} dependency item(s)."
+            )
+        )
+    if issue.blocking:
+        reasons.append(
+            WorkGraphRecommendationReason(
+                code="blocking", detail=f"Unblocks {issue.blocking} other item(s)."
+            )
+        )
+    if issue.finish_line.strip():
+        reasons.append(WorkGraphRecommendationReason(code="finish_line", detail=issue.finish_line))
+    return tuple(reasons)
+
+
+def _queue_sort_key(item: WorkGraphQueueItem) -> tuple[int, str, str, int]:
+    return (-item.score, item.repository, item.updated_at, item.number)

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,8 @@ Use these docs as the source of truth for `launchplane`.
   review rubric.
 - [operator-experience.md](operator-experience.md) — API-first product,
   environment, settings, promotion, cleanup, and UI rebuild contract.
+- [work-graph-read-model.md](work-graph-read-model.md) — Code Plans/GitHub work
+  graph snapshot and recommendation queue contract.
 - [operations.md](operations.md) — operator workflows and runtime boundary rules.
 - [records.md](records.md) — persisted record formats and storage policy.
 - [public-readiness.md](public-readiness.md) — current blockers and exit criteria

--- a/docs/work-graph-read-model.md
+++ b/docs/work-graph-read-model.md
@@ -1,0 +1,55 @@
+---
+title: Work Graph Read Model
+---
+
+## Purpose
+
+The work graph read model ranks operator work from caller-supplied GitHub and
+Code Plans facts. It is a chooser surface, not a second planning database:
+GitHub issues, PRs, Projects, checks, and deployments remain the source of
+truth.
+
+The first slice accepts a typed snapshot and returns a ranked queue with compact
+recommendation reasons. Later service/UI slices can add live GitHub ingestion or
+cached snapshots behind the same queue contract.
+
+## Snapshot Contract
+
+A snapshot contains:
+
+- repo classifications: `managed_runtime`, `active_awareness`,
+  `support_dependency`, or `out_of_scope`
+- issue or PR facts: repository, number, title, URL, Focus, Manager, Finish
+  Line, labels, dependency counts, subissue counts, updated time, and optional
+  check/deploy state
+
+Every issue must have a matching repo classification. Managed runtime repos must
+also identify the Launchplane product they belong to. This keeps the chooser
+explicit about awareness versus operational ownership.
+
+## CLI
+
+Rank a snapshot without persisting it:
+
+```sh
+uv run launchplane work-graph rank \
+  --snapshot-file work-graph-snapshot.json \
+  --limit 25
+```
+
+The command prints a `WorkGraphQueue` JSON payload with:
+
+- ranked items
+- ready/waiting/blocked state
+- recommendation category, such as `quick_win`, `deep_work`, or
+  `attention_needed`
+- score and explanation reasons
+- hidden count for closed, done, or overflow items
+
+## Boundary
+
+Do not store copied issue bodies or Project fields as Launchplane authority.
+When Launchplane needs durable history, store snapshots with provenance and make
+their freshness visible. The normal operator view should link back to GitHub for
+planning details and use Launchplane only to rank, explain, and connect work to
+product/environment evidence.

--- a/tests/test_work_graph_read_model.py
+++ b/tests/test_work_graph_read_model.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import unittest
+
+from pydantic import ValidationError
+
+from control_plane.contracts.work_graph_read_model import (
+    WorkGraphIssueSnapshot,
+    WorkGraphRepoSnapshot,
+    WorkGraphSnapshot,
+    build_work_graph_queue,
+)
+
+
+def _repo(
+    repository: str = "cbusillo/launchplane",
+    classification: str = "managed_runtime",
+) -> WorkGraphRepoSnapshot:
+    return WorkGraphRepoSnapshot.model_validate(
+        {
+            "repository": repository,
+            "classification": classification,
+            "product": "launchplane" if classification == "managed_runtime" else "",
+            "display_name": "Launchplane",
+        }
+    )
+
+
+def _issue(**overrides: object) -> WorkGraphIssueSnapshot:
+    payload: dict[str, object] = {
+        "repository": "cbusillo/launchplane",
+        "number": 190,
+        "title": "Build What To Work On Next cockpit",
+        "url": "https://github.com/cbusillo/launchplane/issues/190",
+        "focus": "Next",
+        "manager": "Chris",
+        "finish_line": "Ranked Launchplane work queue from Code Plans with links.",
+        "labels": ("plan", "plan:active"),
+        "updated_at": "2026-05-06T01:39:23Z",
+    }
+    payload.update(overrides)
+    return WorkGraphIssueSnapshot.model_validate(payload)
+
+
+class WorkGraphReadModelTests(unittest.TestCase):
+    def test_build_queue_ranks_ready_plan_items_with_reasons(self) -> None:
+        snapshot = WorkGraphSnapshot.model_validate(
+            {
+                "generated_at": "2026-05-06T01:45:00Z",
+                "repos": (_repo().model_dump(mode="json"),),
+                "issues": (
+                    _issue(number=190, focus="Next", blocking=2).model_dump(mode="json"),
+                    _issue(
+                        number=260,
+                        title="Blocked tenant work",
+                        url="https://github.com/cbusillo/launchplane/issues/260",
+                        focus="Waiting",
+                        labels=("plan", "plan:blocked"),
+                        blocked_by=1,
+                    ).model_dump(mode="json"),
+                ),
+            }
+        )
+
+        queue = build_work_graph_queue(snapshot)
+
+        self.assertEqual(queue.generated_at, "2026-05-06T01:45:00Z")
+        self.assertEqual([item.number for item in queue.items], [190, 260])
+        first = queue.items[0]
+        self.assertEqual(first.state, "ready")
+        self.assertEqual(first.recommendation, "quick_win")
+        self.assertEqual(first.repo_classification, "managed_runtime")
+        self.assertEqual(first.product, "launchplane")
+        self.assertGreater(first.score, queue.items[1].score)
+        self.assertIn("repo_classification", {reason.code for reason in first.reasons})
+        self.assertIn("finish_line", {reason.code for reason in first.reasons})
+
+    def test_failed_signal_becomes_attention_needed(self) -> None:
+        snapshot = WorkGraphSnapshot.model_validate(
+            {
+                "generated_at": "2026-05-06T01:45:00Z",
+                "repos": (_repo().model_dump(mode="json"),),
+                "issues": (
+                    _issue(number=153, focus="Later", check_state="failure").model_dump(
+                        mode="json"
+                    ),
+                    _issue(number=190, focus="Next").model_dump(mode="json"),
+                ),
+            }
+        )
+
+        queue = build_work_graph_queue(snapshot)
+
+        self.assertEqual(queue.items[0].number, 153)
+        self.assertEqual(queue.items[0].state, "ready")
+        self.assertEqual(queue.items[0].recommendation, "attention_needed")
+        self.assertIn("failed_signal", {reason.code for reason in queue.items[0].reasons})
+
+    def test_closed_and_done_items_are_hidden(self) -> None:
+        snapshot = WorkGraphSnapshot.model_validate(
+            {
+                "generated_at": "2026-05-06T01:45:00Z",
+                "repos": (_repo().model_dump(mode="json"),),
+                "issues": (
+                    _issue(number=153, state="closed", focus="Done").model_dump(mode="json"),
+                    _issue(number=190, focus="Next").model_dump(mode="json"),
+                ),
+            }
+        )
+
+        queue = build_work_graph_queue(snapshot)
+
+        self.assertEqual([item.number for item in queue.items], [190])
+        self.assertEqual(queue.hidden_count, 1)
+
+    def test_limit_counts_hidden_overflow(self) -> None:
+        snapshot = WorkGraphSnapshot.model_validate(
+            {
+                "generated_at": "2026-05-06T01:45:00Z",
+                "repos": (_repo().model_dump(mode="json"),),
+                "issues": (
+                    _issue(number=190).model_dump(mode="json"),
+                    _issue(
+                        number=191, title="Next item", url="https://github.com/x/y/1"
+                    ).model_dump(mode="json"),
+                ),
+            }
+        )
+
+        queue = build_work_graph_queue(snapshot, limit=1)
+
+        self.assertEqual(len(queue.items), 1)
+        self.assertEqual(queue.hidden_count, 1)
+
+    def test_snapshot_requires_repo_classification_for_each_issue(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "missing repo classifications"):
+            WorkGraphSnapshot.model_validate(
+                {
+                    "generated_at": "2026-05-06T01:45:00Z",
+                    "repos": (),
+                    "issues": (_issue().model_dump(mode="json"),),
+                }
+            )
+
+    def test_managed_runtime_repo_requires_product(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "requires product"):
+            WorkGraphRepoSnapshot.model_validate(
+                {"repository": "cbusillo/launchplane", "classification": "managed_runtime"}
+            )
+
+    def test_rejects_invalid_limit(self) -> None:
+        snapshot = WorkGraphSnapshot.model_validate(
+            {
+                "generated_at": "2026-05-06T01:45:00Z",
+                "repos": (_repo().model_dump(mode="json"),),
+                "issues": (_issue().model_dump(mode="json"),),
+            }
+        )
+
+        with self.assertRaisesRegex(ValueError, "limit must be positive"):
+            build_work_graph_queue(snapshot, limit=0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a typed Work Graph snapshot and queue read-model contract for Code Plans/GitHub facts
- add `launchplane work-graph rank` to rank caller-supplied snapshots without persisting GitHub as Launchplane authority
- document the snapshot/queue boundary and recommendation categories

Refs #190

## Verification
- uv run python -m unittest tests.test_work_graph_read_model
- uv run --extra dev ruff check --diff control_plane/contracts/work_graph_read_model.py control_plane/cli.py tests/test_work_graph_read_model.py docs/work-graph-read-model.md docs/README.md
- uv run --extra dev ruff check control_plane/contracts/work_graph_read_model.py control_plane/cli.py tests/test_work_graph_read_model.py
- uv run --extra dev ruff format --check control_plane/contracts/work_graph_read_model.py control_plane/cli.py tests/test_work_graph_read_model.py
- uv run --extra dev mypy control_plane/contracts/work_graph_read_model.py control_plane/cli.py tests/test_work_graph_read_model.py
- uv run launchplane work-graph rank --snapshot-file /tmp/launchplane-work-graph-smoke.json --limit 5