### PR TITLE
Expose work graph ranking service route

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -77,6 +77,10 @@ from control_plane.contracts.promotion_record import (
     PromotionRecord,
     ReleaseStatus,
 )
+from control_plane.contracts.work_graph_read_model import (
+    WorkGraphSnapshot,
+    build_work_graph_queue,
+)
 from control_plane.drivers.registry import (
     build_driver_context_view,
     list_driver_descriptors,
@@ -1233,6 +1237,14 @@ class EveryCodeWorkRequestStatusEnvelope(BaseModel):
     updated_at: str = ""
 
 
+class WorkGraphRankEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    snapshot: WorkGraphSnapshot
+    limit: int = Field(default=25, ge=1, le=100)
+
+
 class AuthzPolicyGitHubActionsGrant(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -1733,6 +1745,7 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/every-code/work-requests/create",
         "/v1/every-code/work-requests/claim",
         "/v1/every-code/work-requests/status",
+        "/v1/work-graph/rank",
         "/v1/evidence/deployments",
         "/v1/evidence/backup-gates",
         "/v1/evidence/previews/generations",
@@ -4369,6 +4382,32 @@ def create_launchplane_service_app(
                 every_code_store.write_every_code_work_request_record(updated_record)
                 result = {"request_id": updated_record.request_id, "state": updated_record.state}
                 driver_result = {"request": updated_record.model_dump(mode="json")}
+            elif path == "/v1/work-graph/rank":
+                rank_request = WorkGraphRankEnvelope.model_validate(payload)
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="work_graph.rank",
+                    product="launchplane",
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot rank Launchplane work graph snapshots.",
+                            },
+                        },
+                    )
+                queue = build_work_graph_queue(
+                    rank_request.snapshot,
+                    limit=rank_request.limit,
+                )
+                result = {"item_count": len(queue.items), "hidden_count": queue.hidden_count}
+                driver_result = {"queue": queue.model_dump(mode="json")}
             elif path == "/v1/evidence/deployments":
                 deployment_request = DeploymentEvidenceEnvelope.model_validate(payload)
                 if not authz_policy.allows(

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -59,6 +59,8 @@ VeriReel product paths:
   - `POST /v1/every-code/work-requests/create`
   - `POST /v1/every-code/work-requests/claim`
   - `POST /v1/every-code/work-requests/status`
+- work graph chooser route:
+  - `POST /v1/work-graph/rank`
 - product driver routes:
   - `POST /v1/drivers/generic-web/deploy`
   - `POST /v1/drivers/generic-web/prod-promotion`
@@ -107,6 +109,12 @@ queues work for the `every-code` label. Other signed events, actions, or labels
 return `202` with `skipped: true`. Matching deliveries create or return the
 durable Every Code work request and include `deduped` plus the delivery id in
 the response.
+
+`POST /v1/work-graph/rank` ranks a caller-supplied work graph snapshot and
+returns the queue payload under `result.queue`. The route requires the
+`work_graph.rank` action for product/context `launchplane`, performs no storage
+writes, and does not make Launchplane authoritative for copied GitHub or Code
+Plans state.
 
 ## Host Assumption
 

--- a/docs/work-graph-read-model.md
+++ b/docs/work-graph-read-model.md
@@ -46,6 +46,18 @@ The command prints a `WorkGraphQueue` JSON payload with:
 - score and explanation reasons
 - hidden count for closed, done, or overflow items
 
+## Service Route
+
+Authenticated callers can request the same stateless ranking over HTTP:
+
+```sh
+POST /v1/work-graph/rank
+```
+
+The request body contains `snapshot` and optional `limit`. Launchplane returns
+the queue at `result.queue`, requires `work_graph.rank` authorization for
+product/context `launchplane`, and does not persist the supplied snapshot.
+
 ## Boundary
 
 Do not store copied issue bodies or Project fields as Launchplane authority.

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -418,6 +418,45 @@ def _every_code_github_issue_labeled_payload(
     }
 
 
+def _work_graph_snapshot_payload() -> dict[str, object]:
+    return {
+        "generated_at": "2026-05-06T01:45:00Z",
+        "repos": [
+            {
+                "repository": "cbusillo/launchplane",
+                "classification": "managed_runtime",
+                "product": "launchplane",
+                "display_name": "Launchplane",
+            }
+        ],
+        "issues": [
+            {
+                "repository": "cbusillo/launchplane",
+                "number": 190,
+                "title": "Build operator work graph",
+                "url": "https://github.com/cbusillo/launchplane/issues/190",
+                "focus": "Now",
+                "manager": "Code",
+                "finish_line": "Ranked work queue is available to the operator UI.",
+                "labels": ["plan", "plan:active"],
+                "blocking": 2,
+                "subissues_total": 2,
+                "subissues_completed": 1,
+                "check_state": "success",
+                "deploy_state": "success",
+            },
+            {
+                "repository": "cbusillo/launchplane",
+                "number": 164,
+                "title": "Absorb product orchestration",
+                "url": "https://github.com/cbusillo/launchplane/issues/164",
+                "state": "closed",
+                "focus": "Done",
+            },
+        ],
+    }
+
+
 def _invoke_app(
     app: WsgiApp,
     *,
@@ -1250,6 +1289,102 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_work_graph_rank_returns_ranked_queue(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main"
+                        ],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["work_graph.rank"],
+                    }
+                ]
+            }
+        )
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
+            event_name="workflow_dispatch",
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(identity),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/work-graph/rank",
+                payload={"snapshot": _work_graph_snapshot_payload(), "limit": 1},
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["status"], "accepted")
+        queue = payload["result"]["queue"]
+        self.assertEqual(len(queue["items"]), 1)
+        self.assertEqual(queue["hidden_count"], 1)
+        self.assertEqual(queue["items"][0]["number"], 190)
+        self.assertEqual(queue["items"][0]["recommendation"], "deep_work")
+
+    def test_work_graph_rank_rejects_unauthorized_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/work-graph/rank",
+                payload={"snapshot": _work_graph_snapshot_payload()},
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_work_graph_rank_rejects_unclassified_issue(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": ["*"],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["work_graph.rank"],
+                    }
+                ]
+            }
+        )
+        snapshot = _work_graph_snapshot_payload()
+        snapshot["repos"] = []
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/work-graph/rank",
+                payload={"snapshot": snapshot},
+            )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_request")
 
     def test_health_endpoint_reports_storage_backend(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add authenticated `POST /v1/work-graph/rank` for stateless work graph queue ranking
- require `work_graph.rank` authorization for Launchplane service context
- document the service route and cover ranked, unauthorized, and invalid snapshot paths

Refs #190

## Verification
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_work_graph_rank_returns_ranked_queue tests.test_service.LaunchplaneServiceTests.test_work_graph_rank_rejects_unauthorized_identity tests.test_service.LaunchplaneServiceTests.test_work_graph_rank_rejects_unclassified_issue
- uv run python -m unittest tests.test_work_graph_read_model
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_service.py docs/service-boundary.md docs/work-graph-read-model.md
- uv run --extra dev ruff check control_plane/service.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_service.py
- uv run --extra dev mypy control_plane/service.py tests/test_service.py