### PR TITLE
Assemble work graph snapshots in Launchplane

### DIFF
--- a/control_plane/contracts/work_graph_read_model.py
+++ b/control_plane/contracts/work_graph_read_model.py
@@ -4,6 +4,9 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
+from control_plane.contracts.product_environment_read_model import ProductSiteOverview
+
 
 RepoClassification = Literal[
     "managed_runtime",
@@ -137,6 +140,42 @@ class WorkGraphQueue(BaseModel):
     hidden_count: int = Field(default=0, ge=0)
 
 
+def build_work_graph_snapshot_from_records(
+    *,
+    generated_at: str,
+    product_overviews: tuple[ProductSiteOverview, ...],
+    work_requests: tuple[EveryCodeWorkRequestRecord, ...],
+) -> WorkGraphSnapshot:
+    repo_snapshots: dict[str, WorkGraphRepoSnapshot] = {}
+    for product in product_overviews:
+        repository = product.repository.strip()
+        if not repository or "/" not in repository:
+            continue
+        repo_snapshots[repository.lower()] = WorkGraphRepoSnapshot(
+            repository=repository,
+            classification="managed_runtime",
+            product=product.product,
+            display_name=product.display_name or product.product,
+        )
+    for request in work_requests:
+        repository = request.repository.strip()
+        if not repository or "/" not in repository:
+            continue
+        repo_snapshots.setdefault(
+            repository.lower(),
+            WorkGraphRepoSnapshot(
+                repository=repository,
+                classification="active_awareness",
+                display_name=repository.rsplit("/", maxsplit=1)[-1],
+            ),
+        )
+    return WorkGraphSnapshot(
+        generated_at=generated_at,
+        repos=tuple(repo_snapshots.values()),
+        issues=tuple(_work_request_issue_snapshot(request) for request in work_requests),
+    )
+
+
 def build_work_graph_queue(snapshot: WorkGraphSnapshot, *, limit: int = 25) -> WorkGraphQueue:
     if limit < 1:
         raise ValueError("work graph queue limit must be positive")
@@ -156,6 +195,33 @@ def build_work_graph_queue(snapshot: WorkGraphSnapshot, *, limit: int = 25) -> W
         items=tuple(ranked_items[:limit]),
         hidden_count=hidden_count + max(0, len(ranked_items) - limit),
     )
+
+
+def _work_request_issue_snapshot(request: EveryCodeWorkRequestRecord) -> WorkGraphIssueSnapshot:
+    return WorkGraphIssueSnapshot(
+        repository=request.repository,
+        number=request.issue_number,
+        title=request.issue_title or f"Issue #{request.issue_number}",
+        url=request.issue_url,
+        state="closed" if request.state == "done" else "open",
+        focus=_work_request_focus(request),
+        manager=request.claimed_by_host or request.trigger_actor or "Code",
+        finish_line=request.result_summary,
+        labels=tuple(label for label in (request.trigger_label,) if label),
+        blocked_by=1 if request.state == "blocked" else 0,
+        updated_at=request.updated_at or request.queued_at,
+        check_state="failure" if request.state == "blocked" else "unknown",
+    )
+
+
+def _work_request_focus(request: EveryCodeWorkRequestRecord) -> WorkItemFocus:
+    if request.state == "blocked":
+        return "Waiting"
+    if request.state == "done":
+        return "Done"
+    if request.state in {"claimed", "running"}:
+        return "Now"
+    return "Next"
 
 
 def _build_queue_item(

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -80,6 +80,7 @@ from control_plane.contracts.promotion_record import (
 from control_plane.contracts.work_graph_read_model import (
     WorkGraphSnapshot,
     build_work_graph_queue,
+    build_work_graph_snapshot_from_records,
 )
 from control_plane.drivers.registry import (
     build_driver_context_view,
@@ -1681,6 +1682,8 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "operations.read", {"context": segments[2]}
     if len(segments) == 3 and segments == ["v1", "service", "runtime"]:
         return "launchplane_service.read", {}
+    if len(segments) == 3 and segments == ["v1", "work-graph", "snapshot"]:
+        return "work_graph.rank", {}
     if len(segments) == 2 and segments == ["v1", "product-profiles"]:
         return "product_profile.read", {}
     if (
@@ -3904,6 +3907,61 @@ def create_launchplane_service_app(
                             "state": state_filter,
                             "repository": repository_filter,
                             "requests": [record.model_dump(mode="json") for record in records],
+                        },
+                    )
+                if action == "work_graph.rank":
+                    if not authz_policy.allows(
+                        identity=identity,
+                        action=action,
+                        product="launchplane",
+                        context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                    ):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=403,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "authorization_denied",
+                                    "message": "Workflow cannot read the Launchplane work graph snapshot.",
+                                },
+                            },
+                        )
+
+                    def work_graph_product_action_allowed(
+                        requested_action: str, requested_product: str, requested_context: str
+                    ) -> bool:
+                        return authz_policy.allows(
+                            identity=identity,
+                            action=requested_action,
+                            product=requested_product,
+                            context=requested_context,
+                        )
+
+                    work_requests = _every_code_work_request_store(
+                        record_store
+                    ).list_every_code_work_request_records(limit=100)
+                    product_overviews = build_product_site_overviews(
+                        record_store=record_store,
+                        action_allowed=work_graph_product_action_allowed,
+                    )
+                    snapshot = build_work_graph_snapshot_from_records(
+                        generated_at=_utc_now_timestamp(),
+                        product_overviews=product_overviews,
+                        work_requests=work_requests,
+                    )
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=200,
+                        payload={
+                            "status": "ok",
+                            "trace_id": request_trace_id,
+                            "snapshot": snapshot.model_dump(mode="json"),
+                            "source": {
+                                "product_count": len(product_overviews),
+                                "work_request_count": len(work_requests),
+                            },
                         },
                     )
                 if action == "product_profile.read":

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -60,6 +60,7 @@ VeriReel product paths:
   - `POST /v1/every-code/work-requests/claim`
   - `POST /v1/every-code/work-requests/status`
 - work graph chooser route:
+  - `GET /v1/work-graph/snapshot`
   - `POST /v1/work-graph/rank`
 - product driver routes:
   - `POST /v1/drivers/generic-web/deploy`
@@ -115,6 +116,12 @@ returns the queue payload under `result.queue`. The route requires the
 `work_graph.rank` action for product/context `launchplane`, performs no storage
 writes, and does not make Launchplane authoritative for copied GitHub or Code
 Plans state.
+
+`GET /v1/work-graph/snapshot` returns the current Launchplane-assembled work
+graph snapshot for the same authorization boundary. It composes product
+overviews and Every Code work-request records into the typed snapshot contract
+without fetching live GitHub issue bodies, copying Code Plans project fields, or
+writing new state.
 
 ## Host Assumption
 

--- a/docs/work-graph-read-model.md
+++ b/docs/work-graph-read-model.md
@@ -9,9 +9,10 @@ Code Plans facts. It is a chooser surface, not a second planning database:
 GitHub issues, PRs, Projects, checks, and deployments remain the source of
 truth.
 
-The first slice accepts a typed snapshot and returns a ranked queue with compact
-recommendation reasons. Later service/UI slices can add live GitHub ingestion or
-cached snapshots behind the same queue contract.
+The first slices accept typed snapshots, assemble Launchplane-owned snapshots
+from existing product and Every Code records, and return ranked queues with
+compact recommendation reasons. Later service/UI slices can add live GitHub or
+Code Plans ingestion behind the same snapshot and queue contracts.
 
 ## Snapshot Contract
 
@@ -57,6 +58,19 @@ POST /v1/work-graph/rank
 The request body contains `snapshot` and optional `limit`. Launchplane returns
 the queue at `result.queue`, requires `work_graph.rank` authorization for
 product/context `launchplane`, and does not persist the supplied snapshot.
+
+Authenticated callers can also read the current Launchplane-assembled snapshot:
+
+```sh
+GET /v1/work-graph/snapshot
+```
+
+The snapshot route uses the same `work_graph.rank` authorization. It composes
+current product overviews with durable Every Code work-request records,
+classifies product repositories as `managed_runtime`, classifies other request
+repositories as `active_awareness`, and returns source counts with the snapshot.
+It does not fetch live GitHub issue bodies or Project fields and does not write
+new records.
 
 ## Boundary
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,7 @@ import {
   logout,
   readAuthSession,
   readDriverView,
+  readWorkGraphSnapshot,
   rankWorkGraphSnapshot,
 } from "./api";
 import type {
@@ -67,7 +68,6 @@ import type {
   FreshnessStatus,
   WorkGraphQueueItem,
   WorkGraphRecommendation,
-  WorkGraphSnapshot,
   WorkGraphState,
 } from "./types";
 
@@ -498,10 +498,11 @@ export function App() {
           setPreviewView(previewPayload?.view ?? null);
           setProductOverviews(productsPayload.products);
           setWorkRequests(workRequestsPayload.requests);
-          const workGraphSnapshot = buildWorkGraphSnapshot(
-            productsPayload.products,
-            workRequestsPayload.requests,
-          );
+          const workGraphSnapshotPayload = await readWorkGraphSnapshot();
+          if (controller.signal.aborted) {
+            return;
+          }
+          const workGraphSnapshot = workGraphSnapshotPayload.snapshot;
           if (!workGraphSnapshot.issues.length) {
             setWorkGraphItems([]);
             setWorkGraphHiddenCount(0);
@@ -4386,73 +4387,6 @@ function workGraphStateStatus(state: WorkGraphState): Status | string {
 
 function recommendationLabel(recommendation: WorkGraphRecommendation): string {
   return recommendation.replaceAll("_", " ");
-}
-
-function focusForWorkRequest(
-  request: EveryCodeWorkRequestRecord,
-): WorkGraphSnapshot["issues"][number]["focus"] {
-  if (request.state === "blocked") {
-    return "Waiting";
-  }
-  if (request.state === "done") {
-    return "Done";
-  }
-  if (request.state === "running" || request.state === "claimed") {
-    return "Now";
-  }
-  return "Next";
-}
-
-function buildWorkGraphSnapshot(
-  products: ProductSiteOverview[],
-  workRequests: EveryCodeWorkRequestRecord[],
-): WorkGraphSnapshot {
-  const repoSnapshots = new Map<string, WorkGraphSnapshot["repos"][number]>();
-  for (const product of products) {
-    const repository = product.repository.trim();
-    if (!repository || !repository.includes("/")) {
-      continue;
-    }
-    repoSnapshots.set(repository.toLowerCase(), {
-      repository,
-      classification: "managed_runtime",
-      product: product.product,
-      display_name: product.display_name || product.product,
-    });
-  }
-  for (const request of workRequests) {
-    const repository = request.repository.trim();
-    if (!repository || !repository.includes("/")) {
-      continue;
-    }
-    if (!repoSnapshots.has(repository.toLowerCase())) {
-      repoSnapshots.set(repository.toLowerCase(), {
-        repository,
-        classification: "active_awareness",
-        display_name: repository.split("/").at(-1) ?? repository,
-      });
-    }
-  }
-  return {
-    schema_version: 1,
-    generated_at: new Date().toISOString(),
-    repos: Array.from(repoSnapshots.values()),
-    issues: workRequests.map((request) => ({
-      repository: request.repository,
-      number: request.issue_number,
-      title: request.issue_title || `Issue #${request.issue_number}`,
-      url: request.issue_url,
-      state: request.state === "done" ? "closed" : "open",
-      focus: focusForWorkRequest(request),
-      manager: request.claimed_by_host || request.trigger_actor || "Code",
-      finish_line: request.result_summary,
-      labels: [request.trigger_label].filter(Boolean),
-      blocked_by: request.state === "blocked" ? 1 : 0,
-      updated_at: request.updated_at || request.queued_at,
-      check_state: request.state === "blocked" ? "failure" : "unknown",
-      deploy_state: "unknown",
-    })),
-  };
 }
 
 function safetyLabel(safety: Safety): string {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -15,6 +15,7 @@ import type {
   ProductProfileListPayload,
   WorkGraphRankPayload,
   WorkGraphSnapshot,
+  WorkGraphSnapshotPayload,
 } from "./types";
 
 export class LaunchplaneApiError extends Error {
@@ -103,6 +104,10 @@ export function listEveryCodeWorkRequests(
   return requestJson<EveryCodeWorkRequestListPayload>(
     `/v1/every-code/work-requests?limit=${encodeURIComponent(String(limit))}`,
   );
+}
+
+export function readWorkGraphSnapshot(): Promise<WorkGraphSnapshotPayload> {
+  return requestJson<WorkGraphSnapshotPayload>("/v1/work-graph/snapshot");
 }
 
 export function rankWorkGraphSnapshot(

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -553,6 +553,16 @@ export interface WorkGraphSnapshot {
   issues: WorkGraphIssueSnapshot[];
 }
 
+export interface WorkGraphSnapshotPayload {
+  status: "ok";
+  trace_id: string;
+  snapshot: WorkGraphSnapshot;
+  source: {
+    product_count: number;
+    work_request_count: number;
+  };
+}
+
 export interface WorkGraphQueueItem {
   repository: string;
   repo_classification: WorkGraphRepoClassification;

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1423,6 +1423,93 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 202)
         self.assertEqual(payload["result"]["queue"]["items"][0]["number"], 190)
 
+    def test_work_graph_snapshot_returns_launchplane_assembled_snapshot(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": ["*"],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane", "example-site"],
+                        "contexts": ["launchplane", "example-site"],
+                        "actions": [
+                            "work_graph.rank",
+                            "product_environment.read",
+                            "every_code_work_request.write",
+                        ],
+                    }
+                ]
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            status_code, create_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/create",
+                payload={
+                    "repository": "every/example-site",
+                    "issue_number": 190,
+                    "issue_url": "https://github.com/every/example-site/issues/190",
+                    "issue_title": "Build operator chooser",
+                    "trigger_label": "every-code",
+                    "trigger_actor": "cbusillo",
+                    "source": "manual",
+                    "queued_at": "2026-05-06T02:00:00Z",
+                },
+                headers={"Idempotency-Key": "every-code-create-example-site-190"},
+            )
+            self.assertEqual(status_code, 202)
+            self.assertEqual(create_payload["result"]["request"]["state"], "queued")
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/work-graph/snapshot",
+            )
+
+        self.assertEqual(status_code, 200)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["source"]["product_count"], 1)
+        self.assertEqual(payload["source"]["work_request_count"], 1)
+        snapshot = payload["snapshot"]
+        self.assertEqual(snapshot["schema_version"], 1)
+        self.assertEqual(snapshot["repos"][0]["classification"], "managed_runtime")
+        self.assertEqual(snapshot["repos"][0]["product"], "example-site")
+        self.assertEqual(snapshot["issues"][0]["repository"], "every/example-site")
+        self.assertEqual(snapshot["issues"][0]["focus"], "Next")
+
+    def test_work_graph_snapshot_rejects_unauthorized_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/work-graph/snapshot",
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
     def test_health_endpoint_reports_storage_backend(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             app = create_launchplane_service_app(

--- a/tests/test_work_graph_read_model.py
+++ b/tests/test_work_graph_read_model.py
@@ -4,11 +4,14 @@ import unittest
 
 from pydantic import ValidationError
 
+from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
+from control_plane.contracts.product_environment_read_model import ProductSiteOverview
 from control_plane.contracts.work_graph_read_model import (
     WorkGraphIssueSnapshot,
     WorkGraphRepoSnapshot,
     WorkGraphSnapshot,
     build_work_graph_queue,
+    build_work_graph_snapshot_from_records,
 )
 
 
@@ -40,6 +43,39 @@ def _issue(**overrides: object) -> WorkGraphIssueSnapshot:
     }
     payload.update(overrides)
     return WorkGraphIssueSnapshot.model_validate(payload)
+
+
+def _product_overview(**overrides: object) -> ProductSiteOverview:
+    payload: dict[str, object] = {
+        "product": "launchplane",
+        "display_name": "Launchplane",
+        "repository": "cbusillo/launchplane",
+        "driver_id": "launchplane-service",
+        "preview": {"enabled": False},
+        "trust_state": "recorded",
+        "provenance": {"source_kind": "record", "freshness_status": "recorded"},
+    }
+    payload.update(overrides)
+    return ProductSiteOverview.model_validate(payload)
+
+
+def _work_request(**overrides: object) -> EveryCodeWorkRequestRecord:
+    payload: dict[str, object] = {
+        "request_id": "every-code-cbusillo-launchplane-190",
+        "source": "github_issue_label",
+        "state": "queued",
+        "repository": "cbusillo/launchplane",
+        "issue_number": 190,
+        "issue_url": "https://github.com/cbusillo/launchplane/issues/190",
+        "issue_title": "Build What To Work On Next cockpit",
+        "trigger_label": "every-code",
+        "trigger_actor": "cbusillo",
+        "github_delivery_id": "delivery-190",
+        "queued_at": "2026-05-06T02:00:00Z",
+        "updated_at": "2026-05-06T02:00:00Z",
+    }
+    payload.update(overrides)
+    return EveryCodeWorkRequestRecord.model_validate(payload)
 
 
 class WorkGraphReadModelTests(unittest.TestCase):
@@ -159,6 +195,40 @@ class WorkGraphReadModelTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "limit must be positive"):
             build_work_graph_queue(snapshot, limit=0)
+
+    def test_build_snapshot_from_launchplane_records_classifies_product_and_awareness_repos(
+        self,
+    ) -> None:
+        snapshot = build_work_graph_snapshot_from_records(
+            generated_at="2026-05-06T03:05:00Z",
+            product_overviews=(_product_overview(),),
+            work_requests=(
+                _work_request(),
+                _work_request(
+                    request_id="every-code-cbusillo-code-12",
+                    repository="cbusillo/code",
+                    issue_number=12,
+                    issue_url="https://github.com/cbusillo/code/issues/12",
+                    issue_title="Improve local worker",
+                    state="blocked",
+                    claimed_at="2026-05-06T02:05:00Z",
+                    claimed_by_host="mac-mini",
+                    started_at="2026-05-06T02:06:00Z",
+                    finished_at="2026-05-06T02:07:00Z",
+                    updated_at="2026-05-06T02:07:00Z",
+                    error_message="Checkout is missing.",
+                ),
+            ),
+        )
+
+        repos = {repo.repository: repo for repo in snapshot.repos}
+        self.assertEqual(repos["cbusillo/launchplane"].classification, "managed_runtime")
+        self.assertEqual(repos["cbusillo/launchplane"].product, "launchplane")
+        self.assertEqual(repos["cbusillo/code"].classification, "active_awareness")
+        issues = {issue.repository: issue for issue in snapshot.issues}
+        self.assertEqual(issues["cbusillo/launchplane"].focus, "Next")
+        self.assertEqual(issues["cbusillo/code"].focus, "Waiting")
+        self.assertEqual(issues["cbusillo/code"].blocked_by, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a Launchplane-owned work graph snapshot builder from product overviews and Every Code work requests
- expose authenticated `GET /v1/work-graph/snapshot` using the existing `work_graph.rank` boundary
- wire the operator UI to consume the snapshot route before ranking instead of building snapshots in React

Refs #190

## Verification
- uv run python -m unittest tests.test_work_graph_read_model tests.test_service.LaunchplaneServiceTests.test_work_graph_snapshot_returns_launchplane_assembled_snapshot tests.test_service.LaunchplaneServiceTests.test_work_graph_snapshot_rejects_unauthorized_identity tests.test_service.LaunchplaneServiceTests.test_work_graph_rank_returns_ranked_queue tests.test_service.LaunchplaneServiceTests.test_human_session_can_rank_work_graph_snapshot
- uv run --extra dev ruff check --diff control_plane/contracts/work_graph_read_model.py control_plane/service.py tests/test_work_graph_read_model.py tests/test_service.py docs/work-graph-read-model.md docs/service-boundary.md
- uv run --extra dev ruff check control_plane/contracts/work_graph_read_model.py control_plane/service.py tests/test_work_graph_read_model.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/contracts/work_graph_read_model.py control_plane/service.py tests/test_work_graph_read_model.py tests/test_service.py
- uv run --extra dev mypy control_plane/contracts/work_graph_read_model.py control_plane/service.py tests/test_work_graph_read_model.py tests/test_service.py
- pnpm --dir frontend typecheck
- pnpm --dir frontend build