### PR TITLE
Show work graph row evidence

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1132,19 +1132,37 @@ function WorkGraphQueue({
           rel="noreferrer"
         >
           <span className="work-graph-score">{item.score}</span>
-          <span className="work-graph-title">
-            <strong>{item.title}</strong>
-            <code>
-              {item.repository}#{item.number}
-            </code>
-          </span>
-          <span className="work-graph-tags">
-            <span className="status-pill" data-status={workGraphStateStatus(item.state)}>
-              <StatusIcon status={workGraphStateStatus(item.state)} />
-              {item.state}
+          <span className="work-graph-content">
+            <span className="work-graph-title">
+              <strong>{item.title}</strong>
+              <code>
+                {item.repository}#{item.number}
+              </code>
             </span>
-            <span className="recommendation-chip">
-              {recommendationLabel(item.recommendation)}
+            <span className="work-graph-meta">
+              <span>{item.focus}</span>
+              <span>{item.manager || "Unassigned"}</span>
+              <span>{formatTime(item.updated_at)}</span>
+              <span>
+                {item.product_display_name || item.product || item.repo_classification}
+              </span>
+            </span>
+            {item.finish_line ? (
+              <span className="work-graph-finish">{item.finish_line}</span>
+            ) : null}
+            <span className="work-graph-tags">
+              <span className="status-pill" data-status={workGraphStateStatus(item.state)}>
+                <StatusIcon status={workGraphStateStatus(item.state)} />
+                {item.state}
+              </span>
+              <span className="recommendation-chip">
+                {recommendationLabel(item.recommendation)}
+              </span>
+              {item.reasons.slice(0, 2).map((reason) => (
+                <span className="reason-chip" key={`${item.repository}:${item.number}:${reason.code}`}>
+                  {reasonLabel(reason.code)}
+                </span>
+              ))}
             </span>
           </span>
         </a>
@@ -4387,6 +4405,10 @@ function workGraphStateStatus(state: WorkGraphState): Status | string {
 
 function recommendationLabel(recommendation: WorkGraphRecommendation): string {
   return recommendation.replaceAll("_", " ");
+}
+
+function reasonLabel(code: string): string {
+  return code.replaceAll("_", " ");
 }
 
 function safetyLabel(safety: Safety): string {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -470,9 +470,40 @@ p {
   gap: 2px;
 }
 
+.work-graph-content {
+  display: grid;
+  min-width: 0;
+  gap: 6px;
+}
+
 .work-graph-title strong,
 .work-graph-title code {
   overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.work-graph-meta {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 5px 10px;
+  color: var(--fg-faint);
+  font-size: 11px;
+}
+
+.work-graph-meta span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.work-graph-finish {
+  overflow: hidden;
+  color: var(--fg-muted);
+  font-size: 12px;
+  line-height: 1.35;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -485,7 +516,8 @@ p {
   gap: 5px;
 }
 
-.recommendation-chip {
+.recommendation-chip,
+.reason-chip {
   display: inline-flex;
   min-height: 24px;
   align-items: center;
@@ -495,6 +527,14 @@ p {
   color: var(--fg-muted);
   padding: 0 8px;
   font-size: 11px;
+}
+
+.reason-chip {
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--fg-faint);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .work-graph-hidden {


### PR DESCRIPTION
## Summary
- enrich What next rows with manager, focus, updated time, product context, finish line, and compact reason chips
- keep recommendation/state chips scannable while preserving mobile overflow safety
- verify the fixture cockpit in browser at desktop and mobile widths

Refs #190

## Verification
- pnpm --dir frontend install --frozen-lockfile
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- Browser fixture review at http://127.0.0.1:5175/ui/?fixtures=1
- Mobile overflow diagnostic: document/client/body width all 390px, canScrollX=false