### PR TITLE
Expose switch project chooser mode

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1108,6 +1108,7 @@ function WorkGraphQueue({
             { value: "all", label: "Any" },
             { value: "quick_win", label: "Quick" },
             { value: "deep_work", label: "Deep" },
+            { value: "switch_projects", label: "Switch" },
             { value: "attention_needed", label: "Needs" },
           ]}
           onChange={onModeChange}
@@ -3239,6 +3240,23 @@ function StateFixtureGallery({
       score: 42,
       updated_at: "2026-05-05T23:00:00Z",
       reasons: [{ code: "blocked", detail: "Waiting on downstream validation" }],
+    },
+    {
+      repository: "cbusillo/odoo-tenant-opw",
+      repo_classification: "active_awareness",
+      product: "",
+      product_display_name: "",
+      number: 302,
+      title: "Revisit tenant thinning follow-up",
+      url: "https://github.com/cbusillo/odoo-tenant-opw/issues/302",
+      focus: "Later",
+      manager: "Unassigned",
+      finish_line: "Choose whether this belongs in Launchplane or stays tenant-owned.",
+      state: "ready",
+      recommendation: "switch_projects",
+      score: 58,
+      updated_at: "2026-05-05T21:30:00Z",
+      reasons: [{ code: "repo_classification", detail: "Awareness-only repo." }],
     },
   ];
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -416,7 +416,7 @@ p {
 
 .segmented-control {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(64px, 1fr));
   gap: 1px;
   overflow: hidden;
   border: 1px solid var(--hair);


### PR DESCRIPTION
## Summary
- make Switch a first-class What next chooser mode alongside Quick and Deep
- add a switch-project fixture item so the operator cockpit covers all three promised chooser prompts
- make segmented controls adapt to the number of options without mobile overflow

Refs #190

## Verification
- pnpm --dir frontend install --frozen-lockfile
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- Browser fixture review at http://127.0.0.1:5176/ui/?fixtures=1
- Mobile overflow diagnostic: document/client/body width all 390px, canScrollX=false; five mode buttons fit at ~66px each