### PR TITLE
Overlay work graph planning facts

### DIFF
--- a/control_plane/contracts/work_graph_read_model.py
+++ b/control_plane/contracts/work_graph_read_model.py
@@ -77,6 +77,38 @@ class WorkGraphIssueSnapshot(BaseModel):
         return self
 
 
+class WorkGraphPlanningIssueFacts(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    repository: str
+    number: int = Field(ge=1)
+    state: Literal["open", "closed"] | None = None
+    focus: WorkItemFocus | None = None
+    manager: str = ""
+    finish_line: str = ""
+    labels: tuple[str, ...] = ()
+    blocked_by: int | None = Field(default=None, ge=0)
+    blocking: int | None = Field(default=None, ge=0)
+    subissues_total: int | None = Field(default=None, ge=0)
+    subissues_completed: int | None = Field(default=None, ge=0)
+    updated_at: str = ""
+    is_pull_request: bool | None = None
+    check_state: Literal["success", "pending", "failure", "unknown"] | None = None
+    deploy_state: Literal["success", "pending", "failure", "unknown"] | None = None
+
+    @model_validator(mode="after")
+    def _validate_planning_facts(self) -> "WorkGraphPlanningIssueFacts":
+        if not self.repository.strip() or "/" not in self.repository.strip():
+            raise ValueError("work graph planning facts require owner/repo repository")
+        if (
+            self.subissues_total is not None
+            and self.subissues_completed is not None
+            and self.subissues_completed > self.subissues_total
+        ):
+            raise ValueError("completed subissue count cannot exceed total subissue count")
+        return self
+
+
 class WorkGraphSnapshot(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -145,6 +177,7 @@ def build_work_graph_snapshot_from_records(
     generated_at: str,
     product_overviews: tuple[ProductSiteOverview, ...],
     work_requests: tuple[EveryCodeWorkRequestRecord, ...],
+    planning_issue_facts: tuple[WorkGraphPlanningIssueFacts, ...] = (),
 ) -> WorkGraphSnapshot:
     repo_snapshots: dict[str, WorkGraphRepoSnapshot] = {}
     for product in product_overviews:
@@ -169,10 +202,20 @@ def build_work_graph_snapshot_from_records(
                 display_name=repository.rsplit("/", maxsplit=1)[-1],
             ),
         )
+    planning_facts_by_issue = {
+        (facts.repository.strip().lower(), facts.number): facts for facts in planning_issue_facts
+    }
+    issues = tuple(
+        _apply_planning_issue_facts(
+            _work_request_issue_snapshot(request),
+            planning_facts_by_issue.get((request.repository.strip().lower(), request.issue_number)),
+        )
+        for request in work_requests
+    )
     return WorkGraphSnapshot(
         generated_at=generated_at,
         repos=tuple(repo_snapshots.values()),
-        issues=tuple(_work_request_issue_snapshot(request) for request in work_requests),
+        issues=issues,
     )
 
 
@@ -212,6 +255,61 @@ def _work_request_issue_snapshot(request: EveryCodeWorkRequestRecord) -> WorkGra
         updated_at=request.updated_at or request.queued_at,
         check_state="failure" if request.state == "blocked" else "unknown",
     )
+
+
+def _apply_planning_issue_facts(
+    issue: WorkGraphIssueSnapshot, facts: WorkGraphPlanningIssueFacts | None
+) -> WorkGraphIssueSnapshot:
+    if facts is None:
+        return issue
+    updates: dict[str, object] = {}
+    if facts.state is not None:
+        updates["state"] = facts.state
+    if facts.focus is not None:
+        updates["focus"] = facts.focus
+    if facts.manager.strip():
+        updates["manager"] = facts.manager
+    if facts.finish_line.strip():
+        updates["finish_line"] = facts.finish_line
+    if facts.labels:
+        updates["labels"] = _merge_labels(issue.labels, facts.labels)
+    for field_name in (
+        "blocked_by",
+        "blocking",
+        "subissues_total",
+        "is_pull_request",
+        "check_state",
+        "deploy_state",
+    ):
+        value = getattr(facts, field_name)
+        if value is not None:
+            updates[field_name] = value
+    if facts.subissues_completed is not None:
+        next_total = (
+            facts.subissues_total if facts.subissues_total is not None else issue.subissues_total
+        )
+        if next_total:
+            updates["subissues_completed"] = facts.subissues_completed
+    if facts.updated_at.strip():
+        updates["updated_at"] = facts.updated_at
+    if not updates:
+        return issue
+    return WorkGraphIssueSnapshot.model_validate(issue.model_dump(mode="python") | updates)
+
+
+def _merge_labels(
+    existing_labels: tuple[str, ...], incoming_labels: tuple[str, ...]
+) -> tuple[str, ...]:
+    labels: list[str] = []
+    seen: set[str] = set()
+    for label in (*existing_labels, *incoming_labels):
+        normalized = label.strip()
+        key = normalized.lower()
+        if not normalized or key in seen:
+            continue
+        labels.append(normalized)
+        seen.add(key)
+    return tuple(labels)
 
 
 def _work_request_focus(request: EveryCodeWorkRequestRecord) -> WorkItemFocus:

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -78,6 +78,7 @@ from control_plane.contracts.promotion_record import (
     ReleaseStatus,
 )
 from control_plane.contracts.work_graph_read_model import (
+    WorkGraphPlanningIssueFacts,
     WorkGraphSnapshot,
     build_work_graph_queue,
     build_work_graph_snapshot_from_records,
@@ -226,6 +227,7 @@ _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 _EVERY_CODE_GITHUB_WEBHOOK_ROUTE = "/v1/every-code/github-webhook"
 _EVERY_CODE_GITHUB_WEBHOOK_SECRET_ENV_KEY = "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET"
 _EVERY_CODE_TRIGGER_LABEL = "every-code"
+_WorkGraphPlanningFactsProvider = Callable[[], tuple[WorkGraphPlanningIssueFacts, ...]]
 
 
 @dataclass(frozen=True)
@@ -3185,6 +3187,7 @@ def create_launchplane_service_app(
     github_oauth_config: GitHubOAuthConfig | None = None,
     github_oauth_client: GitHubOAuthClient | None = None,
     human_session_store: HumanSessionStore | None = None,
+    work_graph_planning_facts_provider: _WorkGraphPlanningFactsProvider | None = None,
 ) -> _WsgiApp:
     resolved_root = control_plane_root_path or control_plane_root()
     ui_static_root = resolved_root / "control_plane" / "ui_static"
@@ -3946,10 +3949,16 @@ def create_launchplane_service_app(
                         record_store=record_store,
                         action_allowed=work_graph_product_action_allowed,
                     )
+                    planning_issue_facts = (
+                        work_graph_planning_facts_provider()
+                        if work_graph_planning_facts_provider is not None
+                        else ()
+                    )
                     snapshot = build_work_graph_snapshot_from_records(
                         generated_at=_utc_now_timestamp(),
                         product_overviews=product_overviews,
                         work_requests=work_requests,
+                        planning_issue_facts=planning_issue_facts,
                     )
                     return _json_response(
                         start_response=start_response,
@@ -3961,6 +3970,7 @@ def create_launchplane_service_app(
                             "source": {
                                 "product_count": len(product_overviews),
                                 "work_request_count": len(work_requests),
+                                "planning_fact_count": len(planning_issue_facts),
                             },
                         },
                     )

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -119,9 +119,12 @@ Plans state.
 
 `GET /v1/work-graph/snapshot` returns the current Launchplane-assembled work
 graph snapshot for the same authorization boundary. It composes product
-overviews and Every Code work-request records into the typed snapshot contract
-without fetching live GitHub issue bodies, copying Code Plans project fields, or
-writing new state.
+overviews and Every Code work-request records into the typed snapshot contract.
+When a caller-owned planning ingestion provider is configured, the route can
+overlay compact GitHub/Code Plans facts such as Focus, Manager, Finish Line,
+dependency counts, subissue counts, updated time, labels, and check/deploy
+state. The route reports product, work-request, and planning-fact source counts,
+does not fetch or store GitHub issue bodies, and writes no state.
 
 ## Host Assumption
 

--- a/docs/work-graph-read-model.md
+++ b/docs/work-graph-read-model.md
@@ -69,13 +69,17 @@ The snapshot route uses the same `work_graph.rank` authorization. It composes
 current product overviews with durable Every Code work-request records,
 classifies product repositories as `managed_runtime`, classifies other request
 repositories as `active_awareness`, and returns source counts with the snapshot.
-It does not fetch live GitHub issue bodies or Project fields and does not write
-new records.
+The route can also apply compact planning facts from a caller-owned ingestion
+provider, such as Focus, Manager, Finish Line, labels, dependency counts,
+subissue counts, updated time, and check/deploy state. Empty planning facts do
+not erase Every Code work-request facts. It does not fetch or store GitHub issue
+bodies and does not write new records.
 
 ## Boundary
 
-Do not store copied issue bodies or Project fields as Launchplane authority.
-When Launchplane needs durable history, store snapshots with provenance and make
-their freshness visible. The normal operator view should link back to GitHub for
-planning details and use Launchplane only to rank, explain, and connect work to
-product/environment evidence.
+Do not store copied issue bodies as Launchplane authority. Project fields may be
+used as compact transient facts for ranking and display, but GitHub Projects
+remain the source of truth. When Launchplane needs durable history, store
+snapshots with provenance and make their freshness visible. The normal operator
+view should link back to GitHub for planning details and use Launchplane only to
+rank, explain, and connect work to product/environment evidence.

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -560,6 +560,7 @@ export interface WorkGraphSnapshotPayload {
   source: {
     product_count: number;
     work_request_count: number;
+    planning_fact_count?: number;
   };
 }
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -49,6 +49,7 @@ from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeKeySafetyPolicyRecord,
     RuntimeSecretSafetyRule,
 )
+from control_plane.contracts.work_graph_read_model import WorkGraphPlanningIssueFacts
 from control_plane.service import create_launchplane_service_app
 from control_plane.service_auth import (
     GitHubActionsIdentity,
@@ -1492,6 +1493,88 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(snapshot["repos"][0]["product"], "example-site")
         self.assertEqual(snapshot["issues"][0]["repository"], "every/example-site")
         self.assertEqual(snapshot["issues"][0]["focus"], "Next")
+        self.assertEqual(payload["source"]["planning_fact_count"], 0)
+
+    def test_work_graph_snapshot_uses_compact_planning_facts_when_available(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": ["*"],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane", "example-site"],
+                        "contexts": ["launchplane", "example-site"],
+                        "actions": [
+                            "work_graph.rank",
+                            "product_environment.read",
+                            "every_code_work_request.write",
+                        ],
+                    }
+                ]
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                work_graph_planning_facts_provider=lambda: (
+                    WorkGraphPlanningIssueFacts.model_validate(
+                        {
+                            "repository": "every/example-site",
+                            "number": 190,
+                            "focus": "Now",
+                            "manager": "Chris",
+                            "finish_line": "Project fields are visible in the cockpit.",
+                            "labels": ("plan", "plan:active"),
+                            "blocking": 1,
+                            "updated_at": "2026-05-06T03:54:00Z",
+                        }
+                    ),
+                ),
+            )
+            create_status, _ = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/create",
+                payload={
+                    "repository": "every/example-site",
+                    "issue_number": 190,
+                    "issue_url": "https://github.com/every/example-site/issues/190",
+                    "issue_title": "Build operator chooser",
+                    "trigger_label": "every-code",
+                    "trigger_actor": "cbusillo",
+                    "source": "manual",
+                    "queued_at": "2026-05-06T02:00:00Z",
+                },
+                headers={"Idempotency-Key": "every-code-create-example-site-190"},
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/work-graph/snapshot",
+            )
+
+        self.assertEqual(create_status, 202)
+        self.assertEqual(status_code, 200)
+        self.assertEqual(payload["source"]["planning_fact_count"], 1)
+        issue = payload["snapshot"]["issues"][0]
+        self.assertEqual(issue["focus"], "Now")
+        self.assertEqual(issue["manager"], "Chris")
+        self.assertEqual(issue["finish_line"], "Project fields are visible in the cockpit.")
+        self.assertEqual(issue["labels"], ["every-code", "plan", "plan:active"])
+        self.assertEqual(issue["blocking"], 1)
+        self.assertEqual(issue["updated_at"], "2026-05-06T03:54:00Z")
 
     def test_work_graph_snapshot_rejects_unauthorized_identity(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_work_graph_read_model.py
+++ b/tests/test_work_graph_read_model.py
@@ -8,6 +8,7 @@ from control_plane.contracts.every_code_work_request import EveryCodeWorkRequest
 from control_plane.contracts.product_environment_read_model import ProductSiteOverview
 from control_plane.contracts.work_graph_read_model import (
     WorkGraphIssueSnapshot,
+    WorkGraphPlanningIssueFacts,
     WorkGraphRepoSnapshot,
     WorkGraphSnapshot,
     build_work_graph_queue,
@@ -229,6 +230,83 @@ class WorkGraphReadModelTests(unittest.TestCase):
         self.assertEqual(issues["cbusillo/launchplane"].focus, "Next")
         self.assertEqual(issues["cbusillo/code"].focus, "Waiting")
         self.assertEqual(issues["cbusillo/code"].blocked_by, 1)
+
+    def test_build_snapshot_applies_compact_planning_facts_without_copying_bodies(
+        self,
+    ) -> None:
+        snapshot = build_work_graph_snapshot_from_records(
+            generated_at="2026-05-06T03:55:00Z",
+            product_overviews=(_product_overview(),),
+            work_requests=(_work_request(trigger_label="every-code"),),
+            planning_issue_facts=(
+                WorkGraphPlanningIssueFacts.model_validate(
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "number": 190,
+                        "focus": "Now",
+                        "manager": "Chris",
+                        "finish_line": "Ranked queue is driven by Code Plans fields.",
+                        "labels": ("plan", "plan:active"),
+                        "blocking": 2,
+                        "updated_at": "2026-05-06T03:54:00Z",
+                        "check_state": "success",
+                    }
+                ),
+            ),
+        )
+
+        issue = snapshot.issues[0]
+        self.assertEqual(issue.focus, "Now")
+        self.assertEqual(issue.manager, "Chris")
+        self.assertEqual(issue.finish_line, "Ranked queue is driven by Code Plans fields.")
+        self.assertEqual(issue.labels, ("every-code", "plan", "plan:active"))
+        self.assertEqual(issue.blocking, 2)
+        self.assertEqual(issue.updated_at, "2026-05-06T03:54:00Z")
+        self.assertEqual(issue.check_state, "success")
+
+    def test_empty_planning_facts_do_not_erase_every_code_facts(self) -> None:
+        snapshot = build_work_graph_snapshot_from_records(
+            generated_at="2026-05-06T03:55:00Z",
+            product_overviews=(_product_overview(),),
+            work_requests=(
+                _work_request(
+                    state="claimed",
+                    claimed_at="2026-05-06T03:49:00Z",
+                    claimed_by_host="local-mac",
+                    updated_at="2026-05-06T03:50:00Z",
+                ),
+            ),
+            planning_issue_facts=(
+                WorkGraphPlanningIssueFacts.model_validate(
+                    {"repository": "cbusillo/launchplane", "number": 190}
+                ),
+            ),
+        )
+
+        issue = snapshot.issues[0]
+        self.assertEqual(issue.focus, "Now")
+        self.assertEqual(issue.manager, "local-mac")
+        self.assertEqual(issue.updated_at, "2026-05-06T03:50:00Z")
+
+    def test_sparse_planning_subissue_completion_does_not_break_snapshot(self) -> None:
+        snapshot = build_work_graph_snapshot_from_records(
+            generated_at="2026-05-06T03:55:00Z",
+            product_overviews=(_product_overview(),),
+            work_requests=(_work_request(),),
+            planning_issue_facts=(
+                WorkGraphPlanningIssueFacts.model_validate(
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "number": 190,
+                        "subissues_completed": 1,
+                    }
+                ),
+            ),
+        )
+
+        issue = snapshot.issues[0]
+        self.assertEqual(issue.subissues_total, 0)
+        self.assertEqual(issue.subissues_completed, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a compact `WorkGraphPlanningIssueFacts` overlay for Focus, Manager, Finish Line, labels, dependency counts, subissues, timestamps, and signal state
- let the service snapshot route apply caller-owned planning facts without storing copied GitHub issue bodies
- document the transient GitHub/Code Plans fact boundary and expose the planning-fact source count to the frontend type

Refs #190

## Verification
- uv run python -m unittest tests.test_work_graph_read_model tests.test_service.LaunchplaneServiceTests.test_work_graph_snapshot_returns_launchplane_assembled_snapshot tests.test_service.LaunchplaneServiceTests.test_work_graph_snapshot_uses_compact_planning_facts_when_available tests.test_service.LaunchplaneServiceTests.test_work_graph_snapshot_rejects_unauthorized_identity
- uv run --extra dev ruff check --diff control_plane/contracts/work_graph_read_model.py control_plane/service.py tests/test_work_graph_read_model.py tests/test_service.py
- uv run --extra dev ruff check control_plane/contracts/work_graph_read_model.py control_plane/service.py tests/test_work_graph_read_model.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/contracts/work_graph_read_model.py control_plane/service.py tests/test_work_graph_read_model.py tests/test_service.py
- uv run --extra dev mypy control_plane/contracts/work_graph_read_model.py control_plane/service.py tests/test_work_graph_read_model.py tests/test_service.py
- pnpm --dir frontend install --frozen-lockfile
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- Review agent checked overlay behavior and found a sparse subissue edge; fixed and covered by test