### PR TITLE
Read work graph Project fields

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -117,6 +117,10 @@ from control_plane.storage.factory import build_record_store, storage_backend_na
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.tracked_target_logs import build_tracked_target_logs_payload
+from control_plane.work_graph_github_projects import (
+    build_github_project_planning_facts,
+    load_github_project_planning_facts_config_from_env,
+)
 from control_plane.workflows.evidence_ingestion import (
     apply_deployment_evidence,
     apply_promotion_evidence,
@@ -6593,11 +6597,18 @@ def serve_launchplane_service(
 
     authz_policy = load_authz_policy(policy_file)
     verifier = GitHubOidcVerifier(audience=audience)
+    work_graph_project_config = load_github_project_planning_facts_config_from_env(dict(os.environ))
+    work_graph_planning_facts_provider = (
+        (lambda: build_github_project_planning_facts(work_graph_project_config))
+        if work_graph_project_config is not None
+        else None
+    )
     application = create_launchplane_service_app(
         state_dir=state_dir,
         verifier=verifier,
         authz_policy=authz_policy,
         database_url=database_url,
+        work_graph_planning_facts_provider=work_graph_planning_facts_provider,
     )
     with make_server(
         host,

--- a/control_plane/work_graph_github_projects.py
+++ b/control_plane/work_graph_github_projects.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, cast
+from urllib.parse import urlparse
+
+import click
+
+from control_plane.contracts.work_graph_read_model import (
+    WorkGraphPlanningIssueFacts,
+    WorkItemFocus,
+)
+
+
+@dataclass(frozen=True)
+class GitHubProjectPlanningFactsConfig:
+    owner: str
+    project_number: int
+    limit: int = 200
+    gh_binary: str = "gh"
+
+    def __post_init__(self) -> None:
+        if not self.owner.strip():
+            raise ValueError("GitHub Project planning facts require an owner")
+        if self.project_number < 1:
+            raise ValueError("GitHub Project planning facts require a positive project number")
+        if self.limit < 1:
+            raise ValueError("GitHub Project planning facts require a positive limit")
+        if not self.gh_binary.strip():
+            raise ValueError("GitHub Project planning facts require a gh binary")
+
+
+def build_github_project_planning_facts(
+    config: GitHubProjectPlanningFactsConfig,
+) -> tuple[WorkGraphPlanningIssueFacts, ...]:
+    payload = _run_gh_json(
+        (
+            config.gh_binary,
+            "project",
+            "item-list",
+            str(config.project_number),
+            "--owner",
+            config.owner,
+            "--format",
+            "json",
+            "--limit",
+            str(config.limit),
+        )
+    )
+    raw_items = payload.get("items")
+    if not isinstance(raw_items, list):
+        raise click.ClickException("GitHub Project item-list did not return an items array")
+    facts: list[WorkGraphPlanningIssueFacts] = []
+    for raw_item in raw_items:
+        item = _as_object(raw_item)
+        if item is None:
+            continue
+        fact = _project_item_to_planning_facts(item)
+        if fact is not None:
+            facts.append(fact)
+    return tuple(facts)
+
+
+def load_github_project_planning_facts_config_from_env(
+    environ: dict[str, str],
+) -> GitHubProjectPlanningFactsConfig | None:
+    owner = environ.get("LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER", "").strip()
+    project_number_value = environ.get("LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER", "").strip()
+    if not owner and not project_number_value:
+        return None
+    if not owner or not project_number_value:
+        raise click.ClickException(
+            "Set both LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER and "
+            "LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER to enable work graph Project facts."
+        )
+    try:
+        project_number = int(project_number_value)
+    except ValueError as error:
+        raise click.ClickException(
+            "LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER must be a positive integer."
+        ) from error
+    limit_value = environ.get("LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT", "").strip()
+    try:
+        limit = int(limit_value) if limit_value else 200
+    except ValueError as error:
+        raise click.ClickException(
+            "LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT must be a positive integer."
+        ) from error
+    return GitHubProjectPlanningFactsConfig(
+        owner=owner,
+        project_number=project_number,
+        limit=limit,
+        gh_binary=environ.get("LAUNCHPLANE_WORK_GRAPH_GH_BINARY", "gh").strip() or "gh",
+    )
+
+
+def _run_gh_json(command: Sequence[str]) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as error:
+        raise click.ClickException(
+            "GitHub CLI is required for work graph Project facts."
+        ) from error
+    except subprocess.CalledProcessError as error:
+        detail = (error.stderr or error.stdout or str(error)).strip()
+        raise click.ClickException(
+            f"GitHub Project planning facts could not be loaded: {detail}"
+        ) from error
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise click.ClickException("GitHub Project item-list returned invalid JSON.") from error
+    data = _as_object(payload)
+    if data is None:
+        raise click.ClickException("GitHub Project item-list returned invalid JSON.")
+    return data
+
+
+def _project_item_to_planning_facts(item: dict[str, Any]) -> WorkGraphPlanningIssueFacts | None:
+    content = _as_object(item.get("content"))
+    if content is None:
+        return None
+    issue_type = _string(content.get("type")).lower()
+    if issue_type not in {"issue", "pullrequest", "pull request"}:
+        return None
+    repository = _repository_from_project_item(item=item, content=content)
+    number = _positive_int(content.get("number"))
+    if not repository or number is None:
+        return None
+    status = _string(item.get("status"))
+    focus = _focus_from_project_item(item=item, status=status)
+    state = "closed" if status.lower() == "done" or focus == "Done" else None
+    return WorkGraphPlanningIssueFacts.model_validate(
+        {
+            "repository": repository,
+            "number": number,
+            "state": state,
+            "focus": focus,
+            "manager": _string(item.get("manager")),
+            "finish_line": _string(item.get("finish Line") or item.get("Finish Line")),
+            "labels": tuple(_labels(item.get("labels"))),
+            "updated_at": _string(content.get("updatedAt") or content.get("updated_at")),
+            "is_pull_request": issue_type in {"pullrequest", "pull request"},
+        }
+    )
+
+
+def _repository_from_project_item(*, item: dict[str, Any], content: dict[str, Any]) -> str:
+    content_repository = _string(content.get("repository"))
+    if "/" in content_repository and not content_repository.startswith("http"):
+        return content_repository
+    item_repository = _string(item.get("repository"))
+    for candidate in (content_repository, item_repository):
+        parsed = _repository_from_url(candidate)
+        if parsed:
+            return parsed
+    content_url = _string(content.get("url"))
+    return _repository_from_url(content_url)
+
+
+def _repository_from_url(value: str) -> str:
+    if not value.strip():
+        return ""
+    parsed = urlparse(value.strip())
+    if parsed.netloc.lower() not in {"github.com", "www.github.com"}:
+        return ""
+    parts = [part for part in parsed.path.strip("/").split("/") if part]
+    if len(parts) < 2:
+        return ""
+    return f"{parts[0]}/{parts[1]}"
+
+
+def _focus_from_project_item(*, item: dict[str, Any], status: str) -> WorkItemFocus | None:
+    focus = _string(item.get("focus") or item.get("Focus"))
+    if focus in {"Now", "Next", "Waiting", "Later", "Done", "Unknown"}:
+        return cast(WorkItemFocus, focus)
+    if status == "Done":
+        return "Done"
+    if status == "Waiting":
+        return "Waiting"
+    return None
+
+
+def _labels(raw_labels: object) -> tuple[str, ...]:
+    if not isinstance(raw_labels, list):
+        return ()
+    labels: list[str] = []
+    for raw_label in raw_labels:
+        if isinstance(raw_label, str) and raw_label.strip():
+            labels.append(raw_label.strip())
+            continue
+        label = _as_object(raw_label)
+        if label is None:
+            continue
+        name = _string(label.get("name"))
+        if name:
+            labels.append(name)
+    return tuple(labels)
+
+
+def _positive_int(value: object) -> int | None:
+    if isinstance(value, int) and value >= 1:
+        return value
+    if isinstance(value, str) and value.isdigit():
+        number = int(value)
+        if number >= 1:
+            return number
+    return None
+
+
+def _string(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _as_object(value: object) -> dict[str, Any] | None:
+    return value if isinstance(value, dict) else None

--- a/docs/config-boundary.md
+++ b/docs/config-boundary.md
@@ -39,6 +39,7 @@ it can reach, trust, or decrypt DB-backed state.
 | Launchplane self image ref | `DOCKER_IMAGE_REFERENCE` | Service target env | Needed for Launchplane self-deploy and rollback posture. |
 | Process wiring | `LAUNCHPLANE_SERVICE_HOST`, `LAUNCHPLANE_SERVICE_PORT`, `LAUNCHPLANE_SERVICE_AUDIENCE`, `LAUNCHPLANE_STATE_DIR`, `LAUNCHPLANE_APP_ROOT` | Service target env | Runtime/process wiring, not product config. |
 | Every Code webhook ingress secret | `LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET` | Bootstrap env or platform secret | Required before unauthenticated GitHub webhook ingress can trust the request body. Store it outside repository config. |
+| Work graph GitHub Project read source | `LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER`, `LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER`, optional `LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT`, optional `LAUNCHPLANE_WORK_GRAPH_GH_BINARY` | Service target env | Opt-in read source for compact Project fields. Requires a `gh` credential with the GitHub CLI `project` scope. Does not store copied issue bodies. |
 
 ### DB Authoritative
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -121,10 +121,14 @@ Plans state.
 graph snapshot for the same authorization boundary. It composes product
 overviews and Every Code work-request records into the typed snapshot contract.
 When a caller-owned planning ingestion provider is configured, the route can
-overlay compact GitHub/Code Plans facts such as Focus, Manager, Finish Line,
-dependency counts, subissue counts, updated time, labels, and check/deploy
-state. The route reports product, work-request, and planning-fact source counts,
-does not fetch or store GitHub issue bodies, and writes no state.
+overlay compact GitHub/Code Plans facts. The first provider is opt-in via
+`LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER` and
+`LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER`, reads `gh project item-list --format
+json`, and supplies Project Focus, Manager, Finish Line, labels, status, updated
+time, and PR-vs-issue type. The route reports product, work-request, and
+planning-fact source counts, does not fetch or store GitHub issue bodies, and
+writes no state. A configured Project read failure returns an error instead of a
+silently incomplete snapshot.
 
 ## Host Assumption
 

--- a/docs/work-graph-read-model.md
+++ b/docs/work-graph-read-model.md
@@ -70,10 +70,25 @@ current product overviews with durable Every Code work-request records,
 classifies product repositories as `managed_runtime`, classifies other request
 repositories as `active_awareness`, and returns source counts with the snapshot.
 The route can also apply compact planning facts from a caller-owned ingestion
-provider, such as Focus, Manager, Finish Line, labels, dependency counts,
-subissue counts, updated time, and check/deploy state. Empty planning facts do
-not erase Every Code work-request facts. It does not fetch or store GitHub issue
-bodies and does not write new records.
+provider. The first provider reads GitHub Project item fields through the
+GitHub CLI when `LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER` and
+`LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER` are configured. It supplies Focus,
+Manager, Finish Line, labels, item status, updated time, and PR-vs-issue type;
+the broader overlay contract also leaves room for dependency counts, subissue
+counts, and check/deploy state as later GitHub sources are added. Empty planning
+facts do not erase Every Code work-request facts. The snapshot route does not
+fetch or store GitHub issue bodies and does not write new records.
+
+The GitHub Project provider shells out to:
+
+```sh
+gh project item-list <number> --owner <owner> --format json --limit <limit>
+```
+
+The service account running Launchplane must already have GitHub CLI credentials
+with the `project` scope, for example from `gh auth refresh -s project`. A
+configured Project that cannot be read fails the snapshot request instead of
+silently dropping Project fields.
 
 ## Boundary
 

--- a/tests/test_work_graph_github_projects.py
+++ b/tests/test_work_graph_github_projects.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import stat
+from tempfile import TemporaryDirectory
+import unittest
+
+import click
+
+from control_plane.work_graph_github_projects import (
+    GitHubProjectPlanningFactsConfig,
+    build_github_project_planning_facts,
+    load_github_project_planning_facts_config_from_env,
+)
+
+
+def _write_fake_gh(
+    directory: Path, *, stdout: object, exit_code: int = 0, stderr: str = ""
+) -> Path:
+    script = directory / "gh"
+    script.write_text(
+        "#!/bin/sh\n"
+        'printf \'%s\n\' "$@" > "$FAKE_GH_ARGS"\n'
+        f"printf '%s' {json.dumps(json.dumps(stdout))}\n"
+        + (f"printf '%s' {json.dumps(stderr)} >&2\n" if stderr else "")
+        + f"exit {exit_code}\n"
+    )
+    script.chmod(script.stat().st_mode | stat.S_IXUSR)
+    return script
+
+
+class GitHubProjectPlanningFactsTests(unittest.TestCase):
+    def test_build_project_facts_from_gh_item_list(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            directory = Path(temporary_directory_name)
+            args_file = directory / "args.txt"
+            fake_gh = _write_fake_gh(
+                directory,
+                stdout={
+                    "items": [
+                        {
+                            "content": {
+                                "number": 190,
+                                "repository": "cbusillo/launchplane",
+                                "title": "Build What To Work On Next cockpit",
+                                "type": "Issue",
+                                "updatedAt": "2026-05-06T04:00:00Z",
+                                "url": "https://github.com/cbusillo/launchplane/issues/190",
+                                "body": "This body must not be copied.",
+                            },
+                            "finish Line": "Ranked queue includes Project fields.",
+                            "focus": "Now",
+                            "id": "PVTI_123",
+                            "labels": ["plan", "plan:active"],
+                            "manager": "@cellmechanic",
+                            "repository": "https://github.com/cbusillo/launchplane",
+                            "status": "In Progress",
+                            "title": "Build What To Work On Next cockpit",
+                        },
+                        {
+                            "content": {
+                                "number": 14,
+                                "repository": "cbusillo/code",
+                                "title": "Done item",
+                                "type": "Issue",
+                                "url": "https://github.com/cbusillo/code/issues/14",
+                            },
+                            "finish Line": "Done plan disappears from active queue.",
+                            "labels": ["plan", "plan:done"],
+                            "manager": "@cellmechanic",
+                            "repository": "https://github.com/cbusillo/code",
+                            "status": "Done",
+                            "title": "Done item",
+                        },
+                        {"content": {"type": "DraftIssue", "title": "Skip draft"}},
+                    ]
+                },
+            )
+            previous_args = os.environ.get("FAKE_GH_ARGS")
+            os.environ["FAKE_GH_ARGS"] = str(args_file)
+            try:
+                facts = build_github_project_planning_facts(
+                    GitHubProjectPlanningFactsConfig(
+                        owner="cbusillo",
+                        project_number=4,
+                        limit=50,
+                        gh_binary=str(fake_gh),
+                    )
+                )
+            finally:
+                if previous_args is None:
+                    os.environ.pop("FAKE_GH_ARGS", None)
+                else:
+                    os.environ["FAKE_GH_ARGS"] = previous_args
+            recorded_args = args_file.read_text().splitlines()[:5]
+
+        self.assertEqual(len(facts), 2)
+        self.assertEqual(facts[0].repository, "cbusillo/launchplane")
+        self.assertEqual(facts[0].number, 190)
+        self.assertEqual(facts[0].focus, "Now")
+        self.assertEqual(facts[0].manager, "@cellmechanic")
+        self.assertEqual(facts[0].finish_line, "Ranked queue includes Project fields.")
+        self.assertEqual(facts[0].labels, ("plan", "plan:active"))
+        self.assertEqual(facts[0].updated_at, "2026-05-06T04:00:00Z")
+        self.assertIs(facts[0].is_pull_request, False)
+        self.assertEqual(facts[1].repository, "cbusillo/code")
+        self.assertEqual(facts[1].focus, "Done")
+        self.assertEqual(facts[1].state, "closed")
+        self.assertEqual(recorded_args, ["project", "item-list", "4", "--owner", "cbusillo"])
+
+    def test_project_item_repository_can_be_derived_from_project_field_url(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            directory = Path(temporary_directory_name)
+            args_file = directory / "args.txt"
+            fake_gh = _write_fake_gh(
+                directory,
+                stdout={
+                    "items": [
+                        {
+                            "content": {
+                                "number": 168,
+                                "title": "Adopt intents",
+                                "type": "PullRequest",
+                                "url": "https://github.com/cbusillo/verireel/pull/168",
+                            },
+                            "repository": "https://github.com/cbusillo/verireel",
+                            "status": "Ready",
+                        }
+                    ]
+                },
+            )
+            previous_args = os.environ.get("FAKE_GH_ARGS")
+            os.environ["FAKE_GH_ARGS"] = str(args_file)
+            try:
+                facts = build_github_project_planning_facts(
+                    GitHubProjectPlanningFactsConfig(
+                        owner="cbusillo",
+                        project_number=4,
+                        gh_binary=str(fake_gh),
+                    )
+                )
+            finally:
+                if previous_args is None:
+                    os.environ.pop("FAKE_GH_ARGS", None)
+                else:
+                    os.environ["FAKE_GH_ARGS"] = previous_args
+
+        self.assertEqual(facts[0].repository, "cbusillo/verireel")
+        self.assertEqual(facts[0].number, 168)
+        self.assertIs(facts[0].is_pull_request, True)
+
+    def test_env_config_is_none_when_project_is_not_configured(self) -> None:
+        self.assertIsNone(load_github_project_planning_facts_config_from_env({}))
+
+    def test_env_config_requires_owner_and_project_number_together(self) -> None:
+        with self.assertRaises(click.ClickException):
+            load_github_project_planning_facts_config_from_env(
+                {"LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER": "cbusillo"}
+            )
+
+    def test_failed_gh_call_is_operator_visible(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            directory = Path(temporary_directory_name)
+            args_file = directory / "args.txt"
+            fake_gh = _write_fake_gh(
+                directory,
+                stdout={},
+                exit_code=1,
+                stderr="missing project scope",
+            )
+            previous_args = os.environ.get("FAKE_GH_ARGS")
+            os.environ["FAKE_GH_ARGS"] = str(args_file)
+            try:
+                with self.assertRaisesRegex(click.ClickException, "missing project scope"):
+                    build_github_project_planning_facts(
+                        GitHubProjectPlanningFactsConfig(
+                            owner="cbusillo",
+                            project_number=4,
+                            gh_binary=str(fake_gh),
+                        )
+                    )
+            finally:
+                if previous_args is None:
+                    os.environ.pop("FAKE_GH_ARGS", None)
+                else:
+                    os.environ["FAKE_GH_ARGS"] = previous_args
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an opt-in GitHub Project item-list provider for work graph planning facts
- wire service startup to feed Project Focus, Manager, Finish Line, labels, status, updated time, and PR/issue type into the existing overlay contract
- document the env vars and GitHub CLI project-scope requirement

Refs #190

## Verification
- uv run python -m unittest tests.test_work_graph_github_projects tests.test_work_graph_read_model tests.test_service.LaunchplaneServiceTests.test_work_graph_snapshot_returns_launchplane_assembled_snapshot tests.test_service.LaunchplaneServiceTests.test_work_graph_snapshot_uses_compact_planning_facts_when_available tests.test_service.LaunchplaneServiceTests.test_work_graph_snapshot_rejects_unauthorized_identity
- uv run --extra dev ruff check --diff control_plane/work_graph_github_projects.py control_plane/service.py tests/test_work_graph_github_projects.py docs/config-boundary.md docs/work-graph-read-model.md docs/service-boundary.md
- uv run --extra dev ruff check control_plane/work_graph_github_projects.py control_plane/service.py tests/test_work_graph_github_projects.py
- uv run --extra dev ruff format --check control_plane/work_graph_github_projects.py control_plane/service.py tests/test_work_graph_github_projects.py
- uv run --extra dev mypy control_plane/work_graph_github_projects.py control_plane/service.py tests/test_work_graph_github_projects.py

Docs checked: GitHub CLI manual for `gh project item-list`.