### PR TITLE
Enrich work graph GitHub signals

### DIFF
--- a/control_plane/work_graph_github_projects.py
+++ b/control_plane/work_graph_github_projects.py
@@ -4,7 +4,7 @@ import json
 import subprocess
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Literal, cast
 from urllib.parse import urlparse
 
 import click
@@ -15,11 +15,16 @@ from control_plane.contracts.work_graph_read_model import (
 )
 
 
+_API_VERSION_ARGS = ("-H", "X-GitHub-Api-Version: 2022-11-28")
+GitHubCheckState = Literal["success", "pending", "failure", "unknown"]
+
+
 @dataclass(frozen=True)
 class GitHubProjectPlanningFactsConfig:
     owner: str
     project_number: int
     limit: int = 200
+    signal_limit: int = 50
     gh_binary: str = "gh"
 
     def __post_init__(self) -> None:
@@ -29,6 +34,8 @@ class GitHubProjectPlanningFactsConfig:
             raise ValueError("GitHub Project planning facts require a positive project number")
         if self.limit < 1:
             raise ValueError("GitHub Project planning facts require a positive limit")
+        if self.signal_limit < 1:
+            raise ValueError("GitHub Project planning facts require a positive signal limit")
         if not self.gh_binary.strip():
             raise ValueError("GitHub Project planning facts require a gh binary")
 
@@ -61,7 +68,7 @@ def build_github_project_planning_facts(
         fact = _project_item_to_planning_facts(item)
         if fact is not None:
             facts.append(fact)
-    return tuple(facts)
+    return _enrich_planning_facts_with_github_signals(config=config, facts=tuple(facts))
 
 
 def load_github_project_planning_facts_config_from_env(
@@ -89,10 +96,18 @@ def load_github_project_planning_facts_config_from_env(
         raise click.ClickException(
             "LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT must be a positive integer."
         ) from error
+    signal_limit_value = environ.get("LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT", "").strip()
+    try:
+        signal_limit = int(signal_limit_value) if signal_limit_value else 50
+    except ValueError as error:
+        raise click.ClickException(
+            "LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT must be a positive integer."
+        ) from error
     return GitHubProjectPlanningFactsConfig(
         owner=owner,
         project_number=project_number,
         limit=limit,
+        signal_limit=signal_limit,
         gh_binary=environ.get("LAUNCHPLANE_WORK_GRAPH_GH_BINARY", "gh").strip() or "gh",
     )
 
@@ -122,6 +137,153 @@ def _run_gh_json(command: Sequence[str]) -> dict[str, Any]:
     if data is None:
         raise click.ClickException("GitHub Project item-list returned invalid JSON.")
     return data
+
+
+def _enrich_planning_facts_with_github_signals(
+    *, config: GitHubProjectPlanningFactsConfig, facts: tuple[WorkGraphPlanningIssueFacts, ...]
+) -> tuple[WorkGraphPlanningIssueFacts, ...]:
+    enriched: list[WorkGraphPlanningIssueFacts] = []
+    for index, fact in enumerate(facts):
+        if index >= config.signal_limit:
+            enriched.append(fact)
+            continue
+        updates: dict[str, object] = {}
+        blocked_by = _github_issue_relation_count(config=config, fact=fact, endpoint="blocked_by")
+        blocking = _github_issue_relation_count(config=config, fact=fact, endpoint="blocking")
+        subissues = _github_subissue_counts(config=config, fact=fact)
+        if blocked_by is not None:
+            updates["blocked_by"] = blocked_by
+        if blocking is not None:
+            updates["blocking"] = blocking
+        if subissues is not None:
+            updates["subissues_total"] = subissues[0]
+            updates["subissues_completed"] = subissues[1]
+        if fact.is_pull_request:
+            check_state = _github_pr_check_state(config=config, fact=fact)
+            if check_state is not None:
+                updates["check_state"] = check_state
+        enriched.append(
+            fact
+            if not updates
+            else WorkGraphPlanningIssueFacts.model_validate(
+                fact.model_dump(mode="python") | updates
+            )
+        )
+    return tuple(enriched)
+
+
+def _github_issue_relation_count(
+    *, config: GitHubProjectPlanningFactsConfig, fact: WorkGraphPlanningIssueFacts, endpoint: str
+) -> int | None:
+    payload = _run_optional_gh_json(
+        (
+            config.gh_binary,
+            "api",
+            *_API_VERSION_ARGS,
+            f"repos/{fact.repository}/issues/{fact.number}/dependencies/{endpoint}",
+        )
+    )
+    if payload is None:
+        return None
+    if not isinstance(payload, list):
+        raise click.ClickException(
+            f"GitHub issue {endpoint} endpoint did not return an array for "
+            f"{fact.repository}#{fact.number}."
+        )
+    return len(payload)
+
+
+def _github_subissue_counts(
+    *, config: GitHubProjectPlanningFactsConfig, fact: WorkGraphPlanningIssueFacts
+) -> tuple[int, int] | None:
+    payload = _run_optional_gh_json(
+        (
+            config.gh_binary,
+            "api",
+            *_API_VERSION_ARGS,
+            f"repos/{fact.repository}/issues/{fact.number}/sub_issues",
+        )
+    )
+    if payload is None:
+        return None
+    if not isinstance(payload, list):
+        raise click.ClickException(
+            "GitHub sub_issues endpoint did not return an array for "
+            f"{fact.repository}#{fact.number}."
+        )
+    completed = 0
+    for raw_subissue in payload:
+        subissue = _as_object(raw_subissue)
+        if subissue is not None and _string(subissue.get("state")).lower() == "closed":
+            completed += 1
+    return len(payload), completed
+
+
+def _github_pr_check_state(
+    *, config: GitHubProjectPlanningFactsConfig, fact: WorkGraphPlanningIssueFacts
+) -> GitHubCheckState | None:
+    payload = _run_optional_gh_json(
+        (
+            config.gh_binary,
+            "pr",
+            "checks",
+            str(fact.number),
+            "--repo",
+            fact.repository,
+            "--json",
+            "bucket,state,name,workflow,completedAt,startedAt",
+        )
+    )
+    if payload is None:
+        return None
+    if not isinstance(payload, list):
+        raise click.ClickException(
+            f"GitHub PR checks did not return an array for {fact.repository}#{fact.number}."
+        )
+    buckets = {
+        _string(check.get("bucket")).lower()
+        for check in (_as_object(raw_check) for raw_check in payload)
+        if check is not None
+    }
+    if not buckets:
+        return "unknown"
+    if buckets & {"fail", "cancel"}:
+        return "failure"
+    if buckets & {"pending"}:
+        return "pending"
+    if buckets <= {"pass", "skipping"}:
+        return "success"
+    return "unknown"
+
+
+def _run_optional_gh_json(command: Sequence[str]) -> object | None:
+    try:
+        result = subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as error:
+        raise click.ClickException(
+            "GitHub CLI is required for work graph Project facts."
+        ) from error
+    except subprocess.CalledProcessError as error:
+        if error.returncode == 8 and tuple(command[1:3]) == ("pr", "checks"):
+            return [{"bucket": "pending"}]
+        detail = (error.stderr or error.stdout or str(error)).strip()
+        if "not found" in detail.lower() or "does not exist" in detail.lower():
+            return None
+        raise click.ClickException(
+            f"GitHub Project planning signals could not be loaded: {detail}"
+        ) from error
+    try:
+        payload: object = json.loads(result.stdout)
+        return payload
+    except json.JSONDecodeError as error:
+        raise click.ClickException(
+            "GitHub Project planning signals returned invalid JSON."
+        ) from error
 
 
 def _project_item_to_planning_facts(item: dict[str, Any]) -> WorkGraphPlanningIssueFacts | None:

--- a/docs/config-boundary.md
+++ b/docs/config-boundary.md
@@ -39,7 +39,7 @@ it can reach, trust, or decrypt DB-backed state.
 | Launchplane self image ref | `DOCKER_IMAGE_REFERENCE` | Service target env | Needed for Launchplane self-deploy and rollback posture. |
 | Process wiring | `LAUNCHPLANE_SERVICE_HOST`, `LAUNCHPLANE_SERVICE_PORT`, `LAUNCHPLANE_SERVICE_AUDIENCE`, `LAUNCHPLANE_STATE_DIR`, `LAUNCHPLANE_APP_ROOT` | Service target env | Runtime/process wiring, not product config. |
 | Every Code webhook ingress secret | `LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET` | Bootstrap env or platform secret | Required before unauthenticated GitHub webhook ingress can trust the request body. Store it outside repository config. |
-| Work graph GitHub Project read source | `LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER`, `LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER`, optional `LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT`, optional `LAUNCHPLANE_WORK_GRAPH_GH_BINARY` | Service target env | Opt-in read source for compact Project fields. Requires a `gh` credential with the GitHub CLI `project` scope. Does not store copied issue bodies. |
+| Work graph GitHub Project read source | `LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER`, `LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER`, optional `LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT`, optional `LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT`, optional `LAUNCHPLANE_WORK_GRAPH_GH_BINARY` | Service target env | Opt-in read source for compact Project fields plus bounded dependency, subissue, and PR check signals. Requires a `gh` credential with the GitHub CLI `project` scope. Does not store copied issue bodies. |
 
 ### DB Authoritative
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -125,10 +125,12 @@ overlay compact GitHub/Code Plans facts. The first provider is opt-in via
 `LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER` and
 `LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER`, reads `gh project item-list --format
 json`, and supplies Project Focus, Manager, Finish Line, labels, status, updated
-time, and PR-vs-issue type. The route reports product, work-request, and
-planning-fact source counts, does not fetch or store GitHub issue bodies, and
-writes no state. A configured Project read failure returns an error instead of a
-silently incomplete snapshot.
+time, PR-vs-issue type, dependency counts, subissue counts, and PR check state.
+`LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT` bounds the per-snapshot fan-out for
+dependency, subissue, and check reads after Project items are loaded. The route
+reports product, work-request, and planning-fact source counts, does not fetch or
+store GitHub issue bodies, and writes no state. A configured Project or signal
+read failure returns an error instead of a silently incomplete snapshot.
 
 ## Host Assumption
 

--- a/docs/work-graph-read-model.md
+++ b/docs/work-graph-read-model.md
@@ -74,16 +74,25 @@ provider. The first provider reads GitHub Project item fields through the
 GitHub CLI when `LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER` and
 `LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER` are configured. It supplies Focus,
 Manager, Finish Line, labels, item status, updated time, and PR-vs-issue type;
-the broader overlay contract also leaves room for dependency counts, subissue
-counts, and check/deploy state as later GitHub sources are added. Empty planning
-facts do not erase Every Code work-request facts. The snapshot route does not
-fetch or store GitHub issue bodies and does not write new records.
+then it uses bounded GitHub issue and pull-request reads to supply blocked-by,
+blocking, subissue, and PR check state. Empty planning facts do not erase Every
+Code work-request facts. The snapshot route does not fetch or store GitHub issue
+bodies and does not write new records.
 
 The GitHub Project provider shells out to:
 
 ```sh
 gh project item-list <number> --owner <owner> --format json --limit <limit>
+gh api repos/<owner>/<repo>/issues/<number>/dependencies/blocked_by
+gh api repos/<owner>/<repo>/issues/<number>/dependencies/blocking
+gh api repos/<owner>/<repo>/issues/<number>/sub_issues
+gh pr checks <number> --repo <owner>/<repo> --json bucket,state,name,workflow,completedAt,startedAt
 ```
+
+`LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT` bounds the per-snapshot dependency,
+subissue, and check fan-out after Project items are loaded. Items beyond that
+limit still receive Project field facts, but their live signal fields remain
+unknown until a later snapshot includes them inside the bound.
 
 The service account running Launchplane must already have GitHub CLI credentials
 with the `project` scope, for example from `gh auth refresh -s project`. A

--- a/tests/test_work_graph_github_projects.py
+++ b/tests/test_work_graph_github_projects.py
@@ -19,13 +19,31 @@ from control_plane.work_graph_github_projects import (
 def _write_fake_gh(
     directory: Path, *, stdout: object, exit_code: int = 0, stderr: str = ""
 ) -> Path:
+    return _write_fake_gh_sequence(
+        directory, responses=[{"stdout": stdout, "exit_code": exit_code, "stderr": stderr}]
+    )
+
+
+def _write_fake_gh_sequence(directory: Path, *, responses: list[dict[str, object]]) -> Path:
     script = directory / "gh"
+    responses_path = directory / "responses.jsonl"
+    responses_path.write_text("\n".join(json.dumps(response) for response in responses) + "\n")
     script.write_text(
         "#!/bin/sh\n"
-        'printf \'%s\n\' "$@" > "$FAKE_GH_ARGS"\n'
-        f"printf '%s' {json.dumps(json.dumps(stdout))}\n"
-        + (f"printf '%s' {json.dumps(stderr)} >&2\n" if stderr else "")
-        + f"exit {exit_code}\n"
+        'printf \'%s\n\' "$@" >> "$FAKE_GH_ARGS"\n'
+        f"responses_path={json.dumps(str(responses_path))}\n"
+        'if [ -s "$responses_path" ]; then\n'
+        "  response=$(sed -n '1p' \"$responses_path\")\n"
+        '  tail -n +2 "$responses_path" > "$responses_path.tmp"\n'
+        '  mv "$responses_path.tmp" "$responses_path"\n'
+        "else\n"
+        '  response=\'{"stdout":[],"exit_code":0,"stderr":""}\'\n'
+        "fi\n"
+        "printf '%s' \"$response\" | jq -c '.stdout'\n"
+        "stderr=$(printf '%s' \"$response\" | jq -r '.stderr // \"\"')\n"
+        'if [ -n "$stderr" ]; then printf \'%s\' "$stderr" >&2; fi\n'
+        "exit_code=$(printf '%s' \"$response\" | jq -r '.exit_code // 0')\n"
+        'exit "$exit_code"\n'
     )
     script.chmod(script.stat().st_mode | stat.S_IXUSR)
     return script
@@ -110,6 +128,128 @@ class GitHubProjectPlanningFactsTests(unittest.TestCase):
         self.assertEqual(facts[1].state, "closed")
         self.assertEqual(recorded_args, ["project", "item-list", "4", "--owner", "cbusillo"])
 
+    def test_project_facts_include_dependency_subissue_and_pr_check_signals(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            directory = Path(temporary_directory_name)
+            args_file = directory / "args.txt"
+            fake_gh = _write_fake_gh_sequence(
+                directory,
+                responses=[
+                    {
+                        "stdout": {
+                            "items": [
+                                {
+                                    "content": {
+                                        "number": 302,
+                                        "repository": "cbusillo/launchplane",
+                                        "title": "Read work graph Project fields",
+                                        "type": "PullRequest",
+                                        "url": "https://github.com/cbusillo/launchplane/pull/302",
+                                    },
+                                    "focus": "Next",
+                                    "status": "Ready",
+                                }
+                            ]
+                        }
+                    },
+                    {"stdout": [{"number": 190}]},
+                    {"stdout": [{"number": 153}, {"number": 164}]},
+                    {"stdout": [{"state": "closed"}, {"state": "open"}]},
+                    {
+                        "stdout": [
+                            {"bucket": "pass", "name": "test"},
+                            {"bucket": "pending", "name": "deploy"},
+                        ]
+                    },
+                ],
+            )
+            previous_args = os.environ.get("FAKE_GH_ARGS")
+            os.environ["FAKE_GH_ARGS"] = str(args_file)
+            try:
+                facts = build_github_project_planning_facts(
+                    GitHubProjectPlanningFactsConfig(
+                        owner="cbusillo",
+                        project_number=4,
+                        signal_limit=5,
+                        gh_binary=str(fake_gh),
+                    )
+                )
+            finally:
+                if previous_args is None:
+                    os.environ.pop("FAKE_GH_ARGS", None)
+                else:
+                    os.environ["FAKE_GH_ARGS"] = previous_args
+            recorded_args = args_file.read_text().splitlines()
+
+        self.assertEqual(len(facts), 1)
+        self.assertEqual(facts[0].blocked_by, 1)
+        self.assertEqual(facts[0].blocking, 2)
+        self.assertEqual(facts[0].subissues_total, 2)
+        self.assertEqual(facts[0].subissues_completed, 1)
+        self.assertEqual(facts[0].check_state, "pending")
+        self.assertIn("repos/cbusillo/launchplane/issues/302/sub_issues", recorded_args)
+        self.assertIn("pr", recorded_args)
+        self.assertIn("checks", recorded_args)
+
+    def test_project_signal_limit_bounds_extra_github_reads(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            directory = Path(temporary_directory_name)
+            args_file = directory / "args.txt"
+            fake_gh = _write_fake_gh_sequence(
+                directory,
+                responses=[
+                    {
+                        "stdout": {
+                            "items": [
+                                {
+                                    "content": {
+                                        "number": 190,
+                                        "repository": "cbusillo/launchplane",
+                                        "title": "First",
+                                        "type": "Issue",
+                                        "url": "https://github.com/cbusillo/launchplane/issues/190",
+                                    }
+                                },
+                                {
+                                    "content": {
+                                        "number": 191,
+                                        "repository": "cbusillo/launchplane",
+                                        "title": "Second",
+                                        "type": "Issue",
+                                        "url": "https://github.com/cbusillo/launchplane/issues/191",
+                                    }
+                                },
+                            ]
+                        }
+                    },
+                    {"stdout": []},
+                    {"stdout": []},
+                    {"stdout": []},
+                ],
+            )
+            previous_args = os.environ.get("FAKE_GH_ARGS")
+            os.environ["FAKE_GH_ARGS"] = str(args_file)
+            try:
+                facts = build_github_project_planning_facts(
+                    GitHubProjectPlanningFactsConfig(
+                        owner="cbusillo",
+                        project_number=4,
+                        signal_limit=1,
+                        gh_binary=str(fake_gh),
+                    )
+                )
+            finally:
+                if previous_args is None:
+                    os.environ.pop("FAKE_GH_ARGS", None)
+                else:
+                    os.environ["FAKE_GH_ARGS"] = previous_args
+            recorded_args = args_file.read_text().splitlines()
+
+        self.assertEqual(len(facts), 2)
+        self.assertEqual(facts[0].blocked_by, 0)
+        self.assertIsNone(facts[1].blocked_by)
+        self.assertEqual(recorded_args.count("api"), 3)
+
     def test_project_item_repository_can_be_derived_from_project_field_url(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             directory = Path(temporary_directory_name)
@@ -159,6 +299,19 @@ class GitHubProjectPlanningFactsTests(unittest.TestCase):
             load_github_project_planning_facts_config_from_env(
                 {"LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER": "cbusillo"}
             )
+
+    def test_env_config_accepts_signal_limit(self) -> None:
+        config = load_github_project_planning_facts_config_from_env(
+            {
+                "LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER": "cbusillo",
+                "LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER": "4",
+                "LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT": "12",
+            }
+        )
+
+        self.assertIsNotNone(config)
+        assert config is not None
+        self.assertEqual(config.signal_limit, 12)
 
     def test_failed_gh_call_is_operator_visible(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- enrich GitHub Project work graph facts with bounded dependency, blocking, subissue, and PR check-state reads
- add `LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT` so live signal fan-out stays capped per snapshot
- document the extra GitHub CLI/API reads without storing copied issue bodies

Refs #190

## Verification
- uv run python -m unittest tests.test_work_graph_github_projects tests.test_work_graph_read_model tests.test_service.LaunchplaneServiceTests.test_work_graph_snapshot_returns_launchplane_assembled_snapshot tests.test_service.LaunchplaneServiceTests.test_work_graph_snapshot_uses_compact_planning_facts_when_available tests.test_service.LaunchplaneServiceTests.test_work_graph_snapshot_rejects_unauthorized_identity
- uv run --extra dev ruff check --diff control_plane/work_graph_github_projects.py tests/test_work_graph_github_projects.py docs/config-boundary.md docs/work-graph-read-model.md docs/service-boundary.md
- uv run --extra dev ruff check control_plane/work_graph_github_projects.py tests/test_work_graph_github_projects.py
- uv run --extra dev ruff format --check control_plane/work_graph_github_projects.py tests/test_work_graph_github_projects.py
- uv run --extra dev mypy control_plane/work_graph_github_projects.py tests/test_work_graph_github_projects.py

Docs checked: `gh pr checks --help`, `gh api --help`, and live `gh api .../dependencies/...`, `.../sub_issues`, and `gh pr checks --json bucket` samples.