### PR TITLE
Add GitHub CLI to Launchplane runtime

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -57,6 +57,7 @@ jobs:
       DISCORD_BLUE_DOKPLOY_TARGET_ID: ${{ vars.DISCORD_BLUE_DOKPLOY_TARGET_ID }}
       LAUNCHPLANE_GITHUB_CLIENT_SECRET: ${{ secrets.LAUNCHPLANE_GITHUB_CLIENT_SECRET }}
       LAUNCHPLANE_SESSION_SECRET: ${{ secrets.LAUNCHPLANE_SESSION_SECRET }}
+      LAUNCHPLANE_WORK_GRAPH_GH_TOKEN: ${{ secrets.LAUNCHPLANE_WORK_GRAPH_GH_TOKEN }}
     steps:
       - name: Resolve deploy inputs
         id: prep
@@ -215,6 +216,7 @@ jobs:
                 --arg work_graph_project_limit "${LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT:-}" \
                 --arg work_graph_project_signal_limit "${LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT:-}" \
                 --arg work_graph_gh_binary "${LAUNCHPLANE_WORK_GRAPH_GH_BINARY:-}" \
+                --arg work_graph_gh_token "${LAUNCHPLANE_WORK_GRAPH_GH_TOKEN:-}" \
                 '{
                   LAUNCHPLANE_GITHUB_CLIENT_ID: $github_client_id,
                   LAUNCHPLANE_GITHUB_CLIENT_SECRET: $github_client_secret,
@@ -226,7 +228,8 @@ jobs:
                   LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER: $work_graph_project_number,
                   LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT: $work_graph_project_limit,
                   LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT: $work_graph_project_signal_limit,
-                  LAUNCHPLANE_WORK_GRAPH_GH_BINARY: $work_graph_gh_binary
+                  LAUNCHPLANE_WORK_GRAPH_GH_BINARY: $work_graph_gh_binary,
+                  GH_TOKEN: $work_graph_gh_token
                 } | with_entries(select(.value != ""))'
             })"
             request_payload="$({

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,19 @@ FROM python:3.13-slim
 LABEL org.opencontainers.image.source="https://github.com/cbusillo/launchplane"
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
+    GH_PROMPT_DISABLED=1 \
     PYTHONUNBUFFERED=1 \
     UV_LINK_MODE=copy
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends openssh-client \
+    && apt-get install -y --no-install-recommends ca-certificates gpg openssh-client wget \
+    && mkdir -p -m 755 /etc/apt/keyrings \
+    && wget -nv -O /etc/apt/keyrings/githubcli-archive-keyring.gpg https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && mkdir -p -m 755 /etc/apt/sources.list.d \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" >/etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir uv

--- a/docs/config-boundary.md
+++ b/docs/config-boundary.md
@@ -40,6 +40,7 @@ it can reach, trust, or decrypt DB-backed state.
 | Process wiring | `LAUNCHPLANE_SERVICE_HOST`, `LAUNCHPLANE_SERVICE_PORT`, `LAUNCHPLANE_SERVICE_AUDIENCE`, `LAUNCHPLANE_STATE_DIR`, `LAUNCHPLANE_APP_ROOT` | Service target env | Runtime/process wiring, not product config. |
 | Every Code webhook ingress secret | `LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET` | Bootstrap env or platform secret | Required before unauthenticated GitHub webhook ingress can trust the request body. Store it outside repository config. |
 | Work graph GitHub Project read source | `LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER`, `LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER`, optional `LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT`, optional `LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT`, optional `LAUNCHPLANE_WORK_GRAPH_GH_BINARY` | Service target env | Opt-in read source for compact Project fields plus bounded dependency, subissue, and PR check signals. Requires a `gh` credential with the GitHub CLI `project` scope. Does not store copied issue bodies. |
+| Work graph GitHub Project token | `GH_TOKEN` from deploy secret `LAUNCHPLANE_WORK_GRAPH_GH_TOKEN` | Platform secret projected into service target env | Authenticates the service's non-interactive `gh` reads. The token must have enough GitHub access for the configured Project and issue/PR signal reads. |
 
 ### DB Authoritative
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -131,6 +131,10 @@ dependency, subissue, and check reads after Project items are loaded. The route
 reports product, work-request, and planning-fact source counts, does not fetch or
 store GitHub issue bodies, and writes no state. A configured Project or signal
 read failure returns an error instead of a silently incomplete snapshot.
+The production image includes `gh` for this provider, and deploy automation maps
+the `LAUNCHPLANE_WORK_GRAPH_GH_TOKEN` repository secret into service `GH_TOKEN`
+when present. That token is not a Launchplane record and must remain outside the
+repo.
 
 ## Host Assumption
 

--- a/docs/work-graph-read-model.md
+++ b/docs/work-graph-read-model.md
@@ -94,10 +94,12 @@ subissue, and check fan-out after Project items are loaded. Items beyond that
 limit still receive Project field facts, but their live signal fields remain
 unknown until a later snapshot includes them inside the bound.
 
-The service account running Launchplane must already have GitHub CLI credentials
-with the `project` scope, for example from `gh auth refresh -s project`. A
-configured Project that cannot be read fails the snapshot request instead of
-silently dropping Project fields.
+The Launchplane image includes the GitHub CLI and disables interactive prompts
+for service use. The deployed service should receive `GH_TOKEN` from the
+`LAUNCHPLANE_WORK_GRAPH_GH_TOKEN` deploy secret; the token must have enough
+access for the configured Project plus issue dependency, subissue, and PR check
+reads. A configured Project or signal source that cannot be read fails the
+snapshot request instead of silently dropping Project fields.
 
 ## Boundary
 


### PR DESCRIPTION
## Summary
- install the GitHub CLI in the Launchplane runtime image for work graph Project reads
- disable interactive gh prompts in the service image and pass LAUNCHPLANE_WORK_GRAPH_GH_TOKEN into service GH_TOKEN during self-deploy
- document the runtime token boundary for Project, dependency, subissue, and PR check reads

Refs #190

## Verification
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-launchplane.yml"); puts "yaml ok"'
- docker build -t launchplane-gh-runtime:test .
- docker run --rm launchplane-gh-runtime:test gh --version
- docker run --rm launchplane-gh-runtime:test sh -lc 'test "$GH_PROMPT_DISABLED" = 1'

Docs checked: GitHub CLI manual for GH_TOKEN/GITHUB_TOKEN auth and official Linux install instructions for Debian packages.