### PR TITLE
Grant work graph snapshot validation authz

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -570,6 +570,14 @@ jobs:
             product_profile.write \
             deploy:product-legacy-context-cleanup-grant \
             product-legacy-context-cleanup
+          post_grant \
+            "$GITHUB_REPOSITORY" \
+            work-graph-snapshot-validate.yml \
+            launchplane \
+            launchplane \
+            work_graph.rank \
+            deploy:work-graph-snapshot-validate-grant \
+            work-graph-snapshot-validate
           post_syo_grant \
             promote-prod.yml \
             launchplane \


### PR DESCRIPTION
## Summary
- add the work graph snapshot validation workflow to deploy-time authz grant reconciliation
- grant work_graph.rank for product/context launchplane
- keep the validation workflow OIDC-only rather than relying on a browser session

Refs #190

## Verification
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-launchplane.yml"); puts "yaml ok"'