### PR TITLE
Include Project-only work graph issues

### DIFF
--- a/control_plane/contracts/work_graph_read_model.py
+++ b/control_plane/contracts/work_graph_read_model.py
@@ -82,6 +82,8 @@ class WorkGraphPlanningIssueFacts(BaseModel):
 
     repository: str
     number: int = Field(ge=1)
+    title: str = ""
+    url: str = ""
     state: Literal["open", "closed"] | None = None
     focus: WorkItemFocus | None = None
     manager: str = ""
@@ -205,17 +207,29 @@ def build_work_graph_snapshot_from_records(
     planning_facts_by_issue = {
         (facts.repository.strip().lower(), facts.number): facts for facts in planning_issue_facts
     }
-    issues = tuple(
-        _apply_planning_issue_facts(
-            _work_request_issue_snapshot(request),
-            planning_facts_by_issue.get((request.repository.strip().lower(), request.issue_number)),
+    request_issue_keys: set[tuple[str, int]] = set()
+    issues: list[WorkGraphIssueSnapshot] = []
+    for request in work_requests:
+        key = (request.repository.strip().lower(), request.issue_number)
+        request_issue_keys.add(key)
+        issues.append(
+            _apply_planning_issue_facts(
+                _work_request_issue_snapshot(request),
+                planning_facts_by_issue.get(key),
+            )
         )
-        for request in work_requests
-    )
+    for facts in planning_issue_facts:
+        repository_key = facts.repository.strip().lower()
+        key = (repository_key, facts.number)
+        if key in request_issue_keys or repository_key not in repo_snapshots:
+            continue
+        issue = _planning_facts_issue_snapshot(facts)
+        if issue is not None:
+            issues.append(issue)
     return WorkGraphSnapshot(
         generated_at=generated_at,
         repos=tuple(repo_snapshots.values()),
-        issues=issues,
+        issues=tuple(issues),
     )
 
 
@@ -254,6 +268,24 @@ def _work_request_issue_snapshot(request: EveryCodeWorkRequestRecord) -> WorkGra
         blocked_by=1 if request.state == "blocked" else 0,
         updated_at=request.updated_at or request.queued_at,
         check_state="failure" if request.state == "blocked" else "unknown",
+    )
+
+
+def _planning_facts_issue_snapshot(
+    facts: WorkGraphPlanningIssueFacts,
+) -> WorkGraphIssueSnapshot | None:
+    title = facts.title.strip()
+    url = facts.url.strip()
+    if not title or not url:
+        return None
+    return _apply_planning_issue_facts(
+        WorkGraphIssueSnapshot(
+            repository=facts.repository,
+            number=facts.number,
+            title=title,
+            url=url,
+        ),
+        facts,
     )
 
 

--- a/control_plane/work_graph_github_projects.py
+++ b/control_plane/work_graph_github_projects.py
@@ -304,6 +304,8 @@ def _project_item_to_planning_facts(item: dict[str, Any]) -> WorkGraphPlanningIs
         {
             "repository": repository,
             "number": number,
+            "title": _string(content.get("title") or item.get("title")),
+            "url": _string(content.get("url")),
             "state": state,
             "focus": focus,
             "manager": _string(item.get("manager")),

--- a/docs/work-graph-read-model.md
+++ b/docs/work-graph-read-model.md
@@ -73,11 +73,14 @@ The route can also apply compact planning facts from a caller-owned ingestion
 provider. The first provider reads GitHub Project item fields through the
 GitHub CLI when `LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER` and
 `LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER` are configured. It supplies Focus,
-Manager, Finish Line, labels, item status, updated time, and PR-vs-issue type;
-then it uses bounded GitHub issue and pull-request reads to supply blocked-by,
-blocking, subissue, and PR check state. Empty planning facts do not erase Every
-Code work-request facts. The snapshot route does not fetch or store GitHub issue
-bodies and does not write new records.
+Manager, Finish Line, labels, item status, title, URL, updated time, and
+PR-vs-issue type; then it uses bounded GitHub issue and pull-request reads to
+supply blocked-by, blocking, subissue, and PR check state. Planning facts can
+stand alone for known Launchplane-managed repos when no Every Code work request
+record exists yet; Project items for unclassified repos stay out of the snapshot
+until Launchplane has an explicit repo classification. Empty planning facts do
+not erase Every Code work-request facts. The snapshot route does not fetch or
+store GitHub issue bodies and does not write new records.
 
 The GitHub Project provider shells out to:
 

--- a/tests/test_work_graph_github_projects.py
+++ b/tests/test_work_graph_github_projects.py
@@ -117,6 +117,8 @@ class GitHubProjectPlanningFactsTests(unittest.TestCase):
         self.assertEqual(len(facts), 2)
         self.assertEqual(facts[0].repository, "cbusillo/launchplane")
         self.assertEqual(facts[0].number, 190)
+        self.assertEqual(facts[0].title, "Build What To Work On Next cockpit")
+        self.assertEqual(facts[0].url, "https://github.com/cbusillo/launchplane/issues/190")
         self.assertEqual(facts[0].focus, "Now")
         self.assertEqual(facts[0].manager, "@cellmechanic")
         self.assertEqual(facts[0].finish_line, "Ranked queue includes Project fields.")

--- a/tests/test_work_graph_read_model.py
+++ b/tests/test_work_graph_read_model.py
@@ -264,6 +264,50 @@ class WorkGraphReadModelTests(unittest.TestCase):
         self.assertEqual(issue.updated_at, "2026-05-06T03:54:00Z")
         self.assertEqual(issue.check_state, "success")
 
+    def test_build_snapshot_includes_project_only_planning_facts_for_known_repos(
+        self,
+    ) -> None:
+        snapshot = build_work_graph_snapshot_from_records(
+            generated_at="2026-05-06T14:20:00Z",
+            product_overviews=(_product_overview(),),
+            work_requests=(),
+            planning_issue_facts=(
+                WorkGraphPlanningIssueFacts.model_validate(
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "number": 307,
+                        "title": "Refactor large work graph and operator UI source files",
+                        "url": "https://github.com/cbusillo/launchplane/issues/307",
+                        "focus": "Next",
+                        "manager": "@cellmechanic",
+                        "finish_line": "Work graph changes land in focused modules.",
+                        "labels": ("plan", "plan:active"),
+                        "blocking": 1,
+                        "updated_at": "2026-05-06T13:28:25Z",
+                    }
+                ),
+                WorkGraphPlanningIssueFacts.model_validate(
+                    {
+                        "repository": "cbusillo/unmanaged",
+                        "number": 12,
+                        "title": "Unmanaged project issue",
+                        "url": "https://github.com/cbusillo/unmanaged/issues/12",
+                    }
+                ),
+            ),
+        )
+
+        self.assertEqual(len(snapshot.issues), 1)
+        issue = snapshot.issues[0]
+        self.assertEqual(issue.repository, "cbusillo/launchplane")
+        self.assertEqual(issue.number, 307)
+        self.assertEqual(issue.focus, "Next")
+        self.assertEqual(issue.manager, "@cellmechanic")
+        self.assertEqual(issue.finish_line, "Work graph changes land in focused modules.")
+        self.assertEqual(issue.labels, ("plan", "plan:active"))
+        self.assertEqual(issue.blocking, 1)
+        self.assertEqual(issue.updated_at, "2026-05-06T13:28:25Z")
+
     def test_empty_planning_facts_do_not_erase_every_code_facts(self) -> None:
         snapshot = build_work_graph_snapshot_from_records(
             generated_at="2026-05-06T03:55:00Z",


### PR DESCRIPTION
## Summary
- let work graph snapshots include Project planning facts for already-classified repos even when no Every Code work request record exists yet
- carry Project title and URL through compact planning facts without copying issue bodies
- keep unclassified Project items out of the snapshot until Launchplane has an explicit repo classification

Refs #190

## Verification
- uv run python -m unittest tests.test_work_graph_read_model tests.test_work_graph_github_projects
- uv run --extra dev ruff check --diff control_plane/contracts/work_graph_read_model.py control_plane/work_graph_github_projects.py tests/test_work_graph_read_model.py tests/test_work_graph_github_projects.py docs/work-graph-read-model.md
- uv run --extra dev ruff check control_plane/contracts/work_graph_read_model.py control_plane/work_graph_github_projects.py tests/test_work_graph_read_model.py tests/test_work_graph_github_projects.py
- uv run --extra dev ruff format --check control_plane/contracts/work_graph_read_model.py control_plane/work_graph_github_projects.py tests/test_work_graph_read_model.py tests/test_work_graph_github_projects.py
- uv run --extra dev mypy control_plane/contracts/work_graph_read_model.py control_plane/work_graph_github_projects.py tests/test_work_graph_read_model.py tests/test_work_graph_github_projects.py
- Live validation before this fix proved auth/token/runtime gh path but returned source.planning_fact_count=69 and snapshot.issues=0 because no Every Code work requests were present