### PR TITLE
Fix Every Code deploy bridge jq

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -239,8 +239,8 @@ jobs:
                   LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS: $bootstrap_admin_emails
                   }
                   + (
-                    if (not $omit_every_code_env)
-                      and (($enable_every_code_runtime_secrets | ascii_downcase) == "true") then
+                    if (($omit_every_code_env | not)
+                      and (($enable_every_code_runtime_secrets | ascii_downcase) == "true")) then
                       {
                         LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN: $every_code_worker_token,
                         LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET: $every_code_webhook_secret


### PR DESCRIPTION
## Summary
- fix the deploy workflow jq boolean expression for the omit_every_code_env bridge input
- smoke-test normal mode includes Every Code env and bridge mode omits it

Refs #190

## Verification
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-launchplane.yml"); puts "yaml ok"'
- jq smoke: omit_every_code_env=false includes LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN and LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET
- jq smoke: omit_every_code_env=true emits an empty Every Code env object