### PR TITLE
fix(every-code): prefer closing issue links

### DIFF
--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -363,7 +363,13 @@ def _post_every_code_claim_comment(
 def default_every_code_command(record: EveryCodeWorkRequestRecord) -> str:
     prompt = (
         f"Work on {record.repository} issue #{record.issue_number}: {record.issue_title}. "
-        f"Issue URL: {record.issue_url}. Launchplane request: {record.request_id}."
+        f"Issue URL: {record.issue_url}. Launchplane request: {record.request_id}. "
+        "Open a pull request for the change. If the PR fully resolves the issue, "
+        f"include `Closes #{record.issue_number}` or `Fixes #{record.issue_number}` "
+        "in the PR body so GitHub closes the issue when the PR merges. Use "
+        "`Refs` only when the PR is partial or still needs reporter validation. "
+        "When the PR is open and your checks are complete, let the session exit "
+        "so Launchplane can mark this request finished."
     )
     return "code " + shlex.quote(prompt)
 

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -201,6 +201,9 @@ class EveryCodeWorkerTests(unittest.TestCase):
 
         self.assertIn("https://github.com/cbusillo/code/issues/123", command)
         self.assertIn("every-code-cbusillo-code-123-test", command)
+        self.assertIn("Closes #123", command)
+        self.assertIn("Use `Refs` only", command)
+        self.assertIn("let the session exit", command)
 
     def test_claim_comment_body_marks_issue_as_in_progress(self) -> None:
         body = every_code_claim_comment_body(


### PR DESCRIPTION
## Summary
- tell Every Code sessions to use closing keywords when their PR fully resolves the labeled issue
- reserve `Refs` for partial fixes or work that still needs reporter validation
- remind sessions to exit after PR/check completion so Launchplane can mark the request finished

## Tests
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest tests.test_every_code_worker
