### PR TITLE
Reconcile runtime key safety policy in deploy

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -486,6 +486,57 @@ jobs:
             return 1
           }
 
+          apply_runtime_key_safety_policy() {
+            local idempotency_suffix="$1"
+            local request_payload response_file status_code
+
+            request_payload="$({
+              jq -n \
+                '{
+                  schema_version: 1,
+                  product: "launchplane",
+                  source_label: "deploy:runtime-key-safety-policy",
+                  rules: [
+                    {
+                      binding_key: "DISCORD_TOKEN",
+                      secret_class: "prod_only",
+                      allowed_contexts: ["discord-blue"],
+                      allowed_instances: ["prod"]
+                    },
+                    {
+                      binding_key: "RESEND_API_KEY",
+                      secret_class: "prod_only",
+                      allowed_contexts: ["sellyouroutboard-prod"],
+                      allowed_instances: ["prod"]
+                    },
+                    {
+                      binding_key: "SMTP_PASSWORD",
+                      secret_class: "prod_only",
+                      allowed_contexts: ["sellyouroutboard-prod"],
+                      allowed_instances: ["prod"]
+                    }
+                  ]
+                }'
+            })"
+            response_file="$(mktemp)"
+            status_code="$(curl -sS \
+              -o "$response_file" \
+              -w '%{http_code}' \
+              -X POST \
+              -H "Authorization: Bearer ${oidc_token}" \
+              -H 'Content-Type: application/json' \
+              -H "Idempotency-Key: launchplane-runtime-key-safety-policy:${idempotency_suffix}:${GITHUB_SHA}" \
+              --data "$request_payload" \
+              "${{ steps.service.outputs.service_url }}/v1/runtime-key-safety/policies/apply")"
+            if [ "$status_code" = "200" ] || [ "$status_code" = "202" ]; then
+              cat "$response_file"
+              return 0
+            fi
+            cat "$response_file" >&2
+            echo "Launchplane runtime key-safety policy request failed with HTTP ${status_code}." >&2
+            return 1
+          }
+
           post_launchplane_grant() {
             local workflow_file="$1"
             local action_name="$2"
@@ -601,6 +652,16 @@ jobs:
             work_graph.rank \
             deploy:work-graph-snapshot-validate-grant \
             work-graph-snapshot-validate
+          post_grant \
+            "$GITHUB_REPOSITORY" \
+            deploy-launchplane.yml \
+            launchplane \
+            launchplane \
+            runtime_key_safety.write \
+            deploy:runtime-key-safety-policy-grant \
+            runtime-key-safety-policy
+          apply_runtime_key_safety_policy \
+            launchplane-runtime-secret-classes
           post_syo_grant \
             promote-prod.yml \
             launchplane \

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -77,6 +77,10 @@ from control_plane.contracts.promotion_record import (
     PromotionRecord,
     ReleaseStatus,
 )
+from control_plane.contracts.runtime_key_safety_policy import (
+    RuntimeKeySafetyPolicyRecord,
+    RuntimeSecretSafetyRule,
+)
 from control_plane.contracts.work_graph_read_model import (
     WorkGraphPlanningIssueFacts,
     WorkGraphSnapshot,
@@ -1326,6 +1330,25 @@ class AuthzPolicyGitHubActionsGrantEnvelope(BaseModel):
         return self
 
 
+class RuntimeKeySafetyPolicyApplyEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    source_label: str = "service:runtime-key-safety-policy"
+    rules: tuple[RuntimeSecretSafetyRule, ...]
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "RuntimeKeySafetyPolicyApplyEnvelope":
+        if self.product.strip() != "launchplane":
+            raise ValueError("Runtime key-safety policy writes require product 'launchplane'.")
+        self.product = "launchplane"
+        self.source_label = self.source_label.strip() or "service:runtime-key-safety-policy"
+        if not self.rules:
+            raise ValueError("Runtime key-safety policy writes require at least one rule.")
+        return self
+
+
 class ProductOnboardingApplyEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -1769,6 +1792,7 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/evidence/previews/generations",
         "/v1/evidence/previews/destroyed",
         "/v1/authz-policies/github-actions/grants",
+        "/v1/runtime-key-safety/policies/apply",
         "/v1/product-onboarding/apply",
         "/v1/product-config/apply",
         "/v1/product-profiles/context-cutover/apply",
@@ -2081,6 +2105,7 @@ def _accepted_payload(
                 "preview_lifecycle_cleanup_id",
                 "preview_lifecycle_plan_id",
                 "authz_policy_record_id",
+                "runtime_key_safety_policy_record_id",
                 "product_profile",
                 "dokploy_target_count",
                 "dokploy_target_id_count",
@@ -2613,6 +2638,14 @@ def _now_timestamp() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+def _record_slug(value: str) -> str:
+    compact = "".join(
+        character.lower() if character.isalnum() else "-" for character in value.strip()
+    )
+    normalized = "-".join(part for part in compact.split("-") if part)
+    return normalized or "launchplane-record"
+
+
 def _build_every_code_work_request_record(
     request: EveryCodeWorkRequestCreateEnvelope, *, queued_at: str
 ) -> EveryCodeWorkRequestRecord:
@@ -2758,6 +2791,85 @@ def _write_github_actions_authz_policy_grant(
     )
     record_store.write_authz_policy_record(record)
     return updated_policy, record, changed
+
+
+def _summarize_runtime_key_safety_policy_record(
+    record: RuntimeKeySafetyPolicyRecord,
+) -> dict[str, object]:
+    return {
+        "record_id": record.record_id,
+        "status": record.status,
+        "source": record.source,
+        "updated_at": record.updated_at,
+        "policy_sha256": record.policy_sha256,
+        "rule_count": len(record.rules),
+        "binding_keys": [rule.binding_key for rule in record.rules],
+    }
+
+
+def _write_runtime_key_safety_policy(
+    *,
+    record_store: PostgresRecordStore,
+    request: RuntimeKeySafetyPolicyApplyEnvelope,
+) -> tuple[RuntimeKeySafetyPolicyRecord, bool]:
+    existing_records = record_store.list_runtime_key_safety_policy_records(status="active", limit=1)
+    existing_record = existing_records[0] if existing_records else None
+    rules = _merged_runtime_key_safety_rules(
+        existing_record.rules if existing_record is not None else (), request.rules
+    )
+    updated_at = _now_timestamp()
+    pending_record = RuntimeKeySafetyPolicyRecord(
+        record_id="runtime-key-safety-policy-pending",
+        status="active",
+        source=request.source_label,
+        updated_at=updated_at,
+        rules=rules,
+    )
+    if (
+        existing_record is not None
+        and existing_record.policy_sha256 == pending_record.policy_sha256
+    ):
+        return existing_record, False
+    record = pending_record.model_copy(
+        update={
+            "record_id": "runtime-key-safety-policy-"
+            f"{_record_slug(updated_at)}-{pending_record.policy_sha256[:12]}",
+        }
+    )
+    record_store.write_runtime_key_safety_policy_record(record)
+    return record, True
+
+
+def _merged_runtime_key_safety_rules(
+    existing_rules: tuple[RuntimeSecretSafetyRule, ...],
+    requested_rules: tuple[RuntimeSecretSafetyRule, ...],
+) -> tuple[RuntimeSecretSafetyRule, ...]:
+    rules_by_binding_key = {rule.binding_key: rule for rule in existing_rules}
+    for requested_rule in requested_rules:
+        existing_rule = rules_by_binding_key.get(requested_rule.binding_key)
+        if existing_rule is None or existing_rule.secret_class != requested_rule.secret_class:
+            rules_by_binding_key[requested_rule.binding_key] = requested_rule
+            continue
+        rules_by_binding_key[requested_rule.binding_key] = requested_rule.model_copy(
+            update={
+                "allowed_contexts": _merged_runtime_key_safety_scope_values(
+                    existing_rule.allowed_contexts, requested_rule.allowed_contexts
+                ),
+                "allowed_instances": _merged_runtime_key_safety_scope_values(
+                    existing_rule.allowed_instances, requested_rule.allowed_instances
+                ),
+                "description": requested_rule.description or existing_rule.description,
+            }
+        )
+    return tuple(rules_by_binding_key[key] for key in sorted(rules_by_binding_key))
+
+
+def _merged_runtime_key_safety_scope_values(
+    existing_values: tuple[str, ...], requested_values: tuple[str, ...]
+) -> tuple[str, ...]:
+    if not existing_values or not requested_values:
+        return ()
+    return tuple(sorted({*existing_values, *requested_values}))
 
 
 def _request_launchplane_self_deploy(
@@ -4834,6 +4946,64 @@ def create_launchplane_service_app(
                 }
                 driver_result = {
                     "authz_policy": _summarize_authz_policy_record(authz_policy_record),
+                    "changed": changed,
+                }
+            elif path == "/v1/runtime-key-safety/policies/apply":
+                runtime_policy_request = RuntimeKeySafetyPolicyApplyEnvelope.model_validate(payload)
+                if not isinstance(record_store, PostgresRecordStore):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "database_required",
+                                "message": "Runtime key-safety policy writes require Launchplane database storage.",
+                            },
+                        },
+                    )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="runtime_key_safety.write",
+                    product=runtime_policy_request.product,
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot write Launchplane runtime key-safety policy records.",
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                runtime_policy_record, changed = _write_runtime_key_safety_policy(
+                    record_store=record_store,
+                    request=runtime_policy_request,
+                )
+                result = {
+                    "runtime_key_safety_policy_record_id": runtime_policy_record.record_id,
+                    "runtime_key_safety_policy_changed": str(changed).lower(),
+                }
+                driver_result = {
+                    "runtime_key_safety_policy": _summarize_runtime_key_safety_policy_record(
+                        runtime_policy_record
+                    ),
                     "changed": changed,
                 }
             elif path == "/v1/product-onboarding/apply":

--- a/docs/config-boundary.md
+++ b/docs/config-boundary.md
@@ -59,6 +59,7 @@ Launchplane records/secrets instead of repo files or operator-local env.
 | Dokploy credentials | Launchplane managed secrets (`DOKPLOY_HOST`, `DOKPLOY_TOKEN`) | Launchplane managed secrets | Fail closed when the shared store does not have both bindings. |
 | Runtime environment values | Runtime-environment records | Launchplane runtime-environment records | Includes shared, context, and instance-scoped values. |
 | Secret-shaped runtime keys | Managed runtime secrets overlay | Launchplane managed secrets | Includes `*_PASSWORD`, `*_TOKEN`, `*_SECRET`, `*_KEY`. |
+| Runtime key-safety policy | `launchplane_runtime_key_safety_policies`, deploy-time reconciliation endpoint | Launchplane runtime key-safety policy records | Classifies managed secret binding keys by runtime class and scope. Deploy reconciliation carries metadata only and cannot replace secret values. |
 | Ship mode overrides | `DOKPLOY_SHIP_MODE`, `DOKPLOY_SHIP_MODE_<CTX>_<INSTANCE>` | Launchplane runtime-environment records | Mutable operator behavior, not bootstrap. |
 | Preview routing/config | `LAUNCHPLANE_PREVIEW_BASE_URL` | Launchplane runtime-environment records | Shared control-plane-owned runtime value. |
 | GitHub workflow runtime integration values | `GITHUB_TOKEN`, `GITHUB_WEBHOOK_SECRET` | Launchplane runtime-environment records and managed secrets | Current docs already classify these as DB-backed target state. |

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -67,6 +67,11 @@ title: Secrets
   records with `launchplane runtime-key-safety list-policies`, and run a
   metadata-only check with `launchplane runtime-key-safety evaluate` before a
   workflow mutates runtime keys.
+- The Launchplane deploy workflow may reconcile known runtime binding
+  classifications through `POST /v1/runtime-key-safety/policies/apply`. That
+  service path is OIDC-authenticated, DB-backed, additive by binding key, and
+  carries only binding metadata such as class, context, and instance scope. It
+  must not carry secret plaintext or provider env dumps.
 - Evaluation reads only Launchplane managed secret bindings for the requested
   context and instance. If no active policy record exists, the gate fails closed
   instead of falling back to service-host env or product-local scripts.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -406,6 +406,15 @@ the requested managed secret binding for the target runtime class. Request
 bodies for this route must not be copied into logs, issues, docs, or workflow
 artifacts because they can contain plaintext secret values.
 
+Runtime key-safety policy reconciliation uses
+`POST /v1/runtime-key-safety/policies/apply`. The route is restricted to
+workflows with `runtime_key_safety.write` for product/context `launchplane`,
+requires DB-backed storage, and writes metadata-only policy records for managed
+runtime secret binding keys. It merges requested rules into the latest active
+policy by binding key so deploy-time bootstrap can add required classifications
+without dropping existing policy coverage. Request and response payloads must
+not include secret plaintext.
+
 Product onboarding uses `POST /v1/product-onboarding/apply`. The route accepts
 the same operator-approved manifest as `launchplane product-onboarding apply`
 and writes the full Launchplane-owned bundle: product profile, Dokploy target

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -6421,6 +6421,173 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
 
+    def test_runtime_key_safety_policy_endpoint_reconciles_rules(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["runtime_key_safety.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            _write_runtime_key_safety_policy(database_url=database_url)
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/runtime-key-safety/policies/apply",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "source_label": "test:runtime-key-safety-policy",
+                    "rules": [
+                        {
+                            "binding_key": "SMTP_PASSWORD",
+                            "secret_class": "prod_only",
+                            "allowed_contexts": ["sellyouroutboard-prod"],
+                            "allowed_instances": ["prod"],
+                        },
+                        {
+                            "binding_key": "RESEND_API_KEY",
+                            "secret_class": "prod_only",
+                            "allowed_contexts": ["sellyouroutboard-prod"],
+                            "allowed_instances": ["prod"],
+                        },
+                    ],
+                },
+                headers={"Idempotency-Key": "runtime-key-safety-policy:test"},
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                active_policy = store.list_runtime_key_safety_policy_records(
+                    status="active", limit=1
+                )[0]
+            finally:
+                store.close()
+            repeat_status_code, repeat_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/runtime-key-safety/policies/apply",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "source_label": "test:runtime-key-safety-policy",
+                    "rules": [
+                        {
+                            "binding_key": "SMTP_PASSWORD",
+                            "secret_class": "prod_only",
+                            "allowed_contexts": ["sellyouroutboard-prod"],
+                            "allowed_instances": ["prod"],
+                        },
+                        {
+                            "binding_key": "RESEND_API_KEY",
+                            "secret_class": "prod_only",
+                            "allowed_contexts": ["sellyouroutboard-prod"],
+                            "allowed_instances": ["prod"],
+                        },
+                    ],
+                },
+                headers={"Idempotency-Key": "runtime-key-safety-policy:test-repeat"},
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(
+            payload["records"]["runtime_key_safety_policy_record_id"], active_policy.record_id
+        )
+        self.assertEqual(payload["result"]["changed"], True)
+        self.assertEqual(
+            payload["result"]["runtime_key_safety_policy"]["binding_keys"],
+            ["RESEND_API_KEY", "SMTP_PASSWORD"],
+        )
+        self.assertEqual(
+            [rule.binding_key for rule in active_policy.rules],
+            ["RESEND_API_KEY", "SMTP_PASSWORD"],
+        )
+        self.assertEqual(repeat_status_code, 202)
+        self.assertEqual(
+            repeat_payload["records"]["runtime_key_safety_policy_record_id"],
+            active_policy.record_id,
+        )
+        self.assertEqual(repeat_payload["result"]["changed"], False)
+
+    def test_runtime_key_safety_policy_endpoint_rejects_without_permission(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "actions": ["product_profile.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/runtime-key-safety/policies/apply",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "rules": [
+                        {
+                            "binding_key": "RESEND_API_KEY",
+                            "secret_class": "prod_only",
+                            "allowed_contexts": ["sellyouroutboard-prod"],
+                            "allowed_instances": ["prod"],
+                        }
+                    ],
+                },
+                headers={"Idempotency-Key": "runtime-key-safety-policy:unauthorized"},
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
     def test_preview_generation_endpoint_writes_records_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add an OIDC-authenticated service route to reconcile runtime key-safety policy records
- seed deploy-time classifications for known managed runtime secret bindings without carrying secret values
- merge policy rules additively by binding key so deploy bootstrap does not drop existing coverage

Refs #190

## Verification
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_runtime_key_safety_policy_endpoint_reconciles_rules tests.test_service.LaunchplaneServiceTests.test_runtime_key_safety_policy_endpoint_rejects_without_permission tests.test_service.LaunchplaneServiceTests.test_product_config_api_apply_writes_runtime_and_managed_secret
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-launchplane.yml"); puts "yaml ok"'
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_service.py
- uv run --extra dev ruff check control_plane/service.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_service.py
- uv run --extra dev mypy control_plane/service.py tests/test_service.py