### PR TITLE
feat(every-code): finish requests when linked PR closes

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -18,6 +18,7 @@ from pydantic import ValidationError
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import every_code_reconciliation as control_plane_every_code_reconciliation
+from control_plane import every_code_webhooks as control_plane_every_code_webhooks
 from control_plane import odoo_instance_overrides as control_plane_odoo_instance_overrides
 from control_plane import product_config as control_plane_product_config
 from control_plane import product_context_audit as control_plane_product_context_audit
@@ -9995,6 +9996,75 @@ def every_code_reconcile_issue(
         if callable(close):
             close()
     click.echo(json.dumps(result.as_payload(), indent=2, sort_keys=True))
+
+
+@every_code.command("sync-webhooks")
+@click.option("--owner", default="", help="GitHub owner to scan; defaults to gh api user.")
+@click.option("--topic", default="every-code", show_default=True)
+@click.option(
+    "--webhook-url",
+    default=control_plane_every_code_webhooks.EVERY_CODE_WEBHOOK_URL,
+    show_default=True,
+)
+@click.option(
+    "--webhook-secret-env",
+    default="LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET",
+    show_default=True,
+)
+def every_code_sync_webhooks(
+    owner: str,
+    topic: str,
+    webhook_url: str,
+    webhook_secret_env: str,
+) -> None:
+    resolved_owner = owner.strip() or _gh_current_user_login()
+    secret_env_key = webhook_secret_env.strip()
+    webhook_secret = os.environ.get(secret_env_key, "").strip()
+    if not webhook_secret:
+        raise click.ClickException(f"{secret_env_key} is required.")
+    try:
+        results = control_plane_every_code_webhooks.sync_every_code_webhooks(
+            owner=resolved_owner,
+            webhook_secret=webhook_secret,
+            webhook_url=webhook_url,
+            topic=topic,
+        )
+    except (ValueError, subprocess.CalledProcessError) as error:
+        raise click.ClickException(str(error)) from error
+    failed = [result for result in results if result.status == "error"]
+    click.echo(
+        json.dumps(
+            {
+                "status": "error" if failed else "ok",
+                "owner": resolved_owner,
+                "topic": topic,
+                "webhook_url": webhook_url,
+                "events": list(control_plane_every_code_webhooks.EVERY_CODE_WEBHOOK_EVENTS),
+                "repositories": [result.as_payload() for result in results],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    if failed:
+        raise click.ClickException(f"Failed to sync {len(failed)} Every Code webhook(s).")
+
+
+def _gh_current_user_login() -> str:
+    try:
+        result = subprocess.run(
+            ("gh", "api", "user", "--jq", ".login"),
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as error:
+        detail = (error.stderr or error.stdout or str(error)).strip()
+        raise click.ClickException(detail) from error
+    login = result.stdout.strip()
+    if not login:
+        raise click.ClickException("Could not determine GitHub user login from gh.")
+    return login
 
 
 @main.group()

--- a/control_plane/contracts/every_code_work_request.py
+++ b/control_plane/contracts/every_code_work_request.py
@@ -144,3 +144,40 @@ def apply_every_code_work_request_status(
         if not record.started_at.strip():
             updates["started_at"] = update.updated_at
     return record.model_copy(update=updates)
+
+
+def close_every_code_work_request_for_pull_request(
+    record: EveryCodeWorkRequestRecord,
+    *,
+    pr_url: str,
+    merged: bool,
+    closed_at: str,
+) -> EveryCodeWorkRequestRecord | None:
+    normalized_pr_url = pr_url.strip()
+    if not normalized_pr_url:
+        raise ValueError("Every Code PR close update requires pr_url")
+    if not closed_at.strip():
+        raise ValueError("Every Code PR close update requires closed_at")
+    if record.result_pr_url.strip() != normalized_pr_url:
+        return None
+    if record.state in {"queued", "done", "blocked"}:
+        return None
+
+    state: EveryCodeWorkRequestState = "done" if merged else "blocked"
+    summary = (
+        f"Linked pull request merged: {normalized_pr_url}"
+        if merged
+        else f"Linked pull request closed without merge: {normalized_pr_url}"
+    )
+    error_message = "" if merged else summary
+    updates: dict[str, object] = {
+        "state": state,
+        "updated_at": closed_at,
+        "finished_at": closed_at,
+        "result_pr_url": normalized_pr_url,
+        "result_summary": summary,
+        "error_message": error_message,
+    }
+    if not record.started_at.strip():
+        updates["started_at"] = closed_at
+    return record.model_copy(update=updates)

--- a/control_plane/every_code_webhooks.py
+++ b/control_plane/every_code_webhooks.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import subprocess
+from typing import Callable, Sequence
+
+
+EVERY_CODE_WEBHOOK_EVENTS = ("issues", "pull_request")
+EVERY_CODE_WEBHOOK_URL = "https://launchplane.shinycomputers.com/v1/every-code/github-webhook"
+
+Runner = Callable[[Sequence[str], str | None], subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True)
+class EveryCodeWebhookSyncResult:
+    repo: str
+    status: str
+    hook_id: int = 0
+    events: tuple[str, ...] = EVERY_CODE_WEBHOOK_EVENTS
+    error: str = ""
+
+    def as_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "repo": self.repo,
+            "status": self.status,
+            "events": list(self.events),
+        }
+        if self.hook_id:
+            payload["hook_id"] = self.hook_id
+        if self.error:
+            payload["error"] = self.error
+        return payload
+
+
+def sync_every_code_webhooks(
+    *,
+    owner: str,
+    webhook_secret: str,
+    webhook_url: str = EVERY_CODE_WEBHOOK_URL,
+    topic: str = "every-code",
+    events: tuple[str, ...] = EVERY_CODE_WEBHOOK_EVENTS,
+    runner: Runner | None = None,
+) -> tuple[EveryCodeWebhookSyncResult, ...]:
+    normalized_owner = owner.strip()
+    normalized_secret = webhook_secret.strip()
+    if not normalized_owner:
+        raise ValueError("Every Code webhook sync requires owner")
+    if not normalized_secret:
+        raise ValueError("Every Code webhook sync requires webhook_secret")
+    run = runner or _run_gh
+    repos = _topic_repositories(owner=normalized_owner, topic=topic, runner=run)
+    results: list[EveryCodeWebhookSyncResult] = []
+    for repo in repos:
+        try:
+            results.append(
+                _sync_repo_webhook(
+                    repo=repo,
+                    webhook_url=webhook_url,
+                    webhook_secret=normalized_secret,
+                    events=events,
+                    runner=run,
+                )
+            )
+        except subprocess.CalledProcessError as error:
+            detail = (error.stderr or error.stdout or str(error)).strip()
+            results.append(EveryCodeWebhookSyncResult(repo=repo, status="error", error=detail))
+    return tuple(results)
+
+
+def _topic_repositories(*, owner: str, topic: str, runner: Runner) -> tuple[str, ...]:
+    query = (
+        f'.[] | select(.isArchived == false) | '
+        f'select([(.repositoryTopics // [])[].name] | index("{topic}")) | .nameWithOwner'
+    )
+    result = runner(
+        (
+            "gh",
+            "repo",
+            "list",
+            owner,
+            "--limit",
+            "1000",
+            "--json",
+            "nameWithOwner,isArchived,repositoryTopics",
+            "--jq",
+            query,
+        ),
+        None,
+    )
+    return tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
+
+
+def _sync_repo_webhook(
+    *,
+    repo: str,
+    webhook_url: str,
+    webhook_secret: str,
+    events: tuple[str, ...],
+    runner: Runner,
+) -> EveryCodeWebhookSyncResult:
+    hooks_payload = runner(("gh", "api", f"repos/{repo}/hooks"), None).stdout
+    hooks = json.loads(hooks_payload)
+    if not isinstance(hooks, list):
+        raise ValueError(f"GitHub hooks response for {repo} must be a list")
+    existing_hook = _find_webhook(hooks, webhook_url=webhook_url)
+    hook_payload = json.dumps(
+        {
+            "name": "web",
+            "active": True,
+            "events": list(events),
+            "config": {
+                "url": webhook_url,
+                "content_type": "json",
+                "insecure_ssl": "0",
+                "secret": webhook_secret,
+            },
+        }
+    )
+    if existing_hook is not None:
+        hook_id_value = existing_hook.get("id")
+        hook_id = int(hook_id_value) if isinstance(hook_id_value, int | str) else 0
+        runner(("gh", "api", "-X", "PATCH", f"repos/{repo}/hooks/{hook_id}", "--input", "-"), hook_payload)
+        return EveryCodeWebhookSyncResult(repo=repo, status="updated", hook_id=hook_id)
+    result = runner(("gh", "api", "-X", "POST", f"repos/{repo}/hooks", "--input", "-"), hook_payload)
+    created_hook = json.loads(result.stdout)
+    hook_id = int(created_hook.get("id", 0)) if isinstance(created_hook, dict) else 0
+    return EveryCodeWebhookSyncResult(repo=repo, status="created", hook_id=hook_id)
+
+
+def _find_webhook(hooks: list[object], *, webhook_url: str) -> dict[str, object] | None:
+    for hook in hooks:
+        if not isinstance(hook, dict):
+            continue
+        config = hook.get("config")
+        if isinstance(config, dict) and config.get("url") == webhook_url:
+            return hook
+    return None
+
+
+def _run_gh(args: Sequence[str], input_text: str | None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        tuple(args),
+        input=input_text,
+        text=True,
+        capture_output=True,
+        check=True,
+    )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -38,6 +38,7 @@ from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestStatusUpdate,
     apply_every_code_work_request_status,
     build_every_code_work_request_id,
+    close_every_code_work_request_for_pull_request,
 )
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.idempotency_record import build_launchplane_idempotency_record_id
@@ -1911,6 +1912,14 @@ def _handle_every_code_github_webhook(
 
     payload = _decode_json_request_body(body_bytes)
     event_name = _github_webhook_header(environ, "X-GitHub-Event")
+    if event_name == "pull_request":
+        return _handle_every_code_pull_request_webhook(
+            start_response=start_response,
+            trace_id=trace_id,
+            delivery_id=delivery_id,
+            payload=payload,
+            record_store=record_store,
+        )
     if event_name != "issues":
         return _json_response(
             start_response=start_response,
@@ -1979,6 +1988,92 @@ def _handle_every_code_github_webhook(
         driver_result={"request": stored_record.model_dump(mode="json")},
     )
     accepted_payload["deduped"] = deduped
+    accepted_payload["github_delivery_id"] = delivery_id
+    return _json_response(start_response=start_response, status_code=202, payload=accepted_payload)
+
+
+def _handle_every_code_pull_request_webhook(
+    *,
+    start_response: _StartResponse,
+    trace_id: str,
+    delivery_id: str,
+    payload: dict[str, object],
+    record_store: object,
+) -> list[bytes]:
+    if payload.get("action") != "closed":
+        return _json_response(
+            start_response=start_response,
+            status_code=202,
+            payload={
+                "status": "accepted",
+                "trace_id": trace_id,
+                "skipped": True,
+                "reason": "unsupported_action",
+            },
+        )
+
+    repository_payload = _github_webhook_mapping(payload, "repository")
+    pull_request_payload = _github_webhook_mapping(payload, "pull_request")
+    repository = _github_webhook_string(repository_payload, "full_name")
+    pr_url = _github_webhook_string(pull_request_payload, "html_url")
+    merged = bool(pull_request_payload.get("merged")) if pull_request_payload else False
+    closed_at = _github_webhook_string(pull_request_payload, "closed_at") or _utc_now_timestamp()
+    every_code_store = _every_code_work_request_store(record_store)
+    matched_record: EveryCodeWorkRequestRecord | None = None
+    updated_record: EveryCodeWorkRequestRecord | None = None
+    for record in every_code_store.list_every_code_work_request_records(
+        repository=repository,
+        limit=100,
+    ):
+        if record.result_pr_url.strip() != pr_url:
+            continue
+        matched_record = record
+        closed_record = close_every_code_work_request_for_pull_request(
+            record,
+            pr_url=pr_url,
+            merged=merged,
+            closed_at=closed_at,
+        )
+        if closed_record is None:
+            break
+        every_code_store.write_every_code_work_request_record(closed_record)
+        updated_record = closed_record
+        break
+
+    if matched_record is None:
+        return _json_response(
+            start_response=start_response,
+            status_code=202,
+            payload={
+                "status": "accepted",
+                "trace_id": trace_id,
+                "skipped": True,
+                "reason": "linked_every_code_request_not_found",
+                "github_delivery_id": delivery_id,
+            },
+        )
+    if updated_record is None:
+        return _json_response(
+            start_response=start_response,
+            status_code=202,
+            payload={
+                "status": "accepted",
+                "trace_id": trace_id,
+                "skipped": True,
+                "reason": "linked_every_code_request_already_terminal",
+                "result": {
+                    "request_id": matched_record.request_id,
+                    "state": matched_record.state,
+                },
+                "github_delivery_id": delivery_id,
+            },
+        )
+
+    accepted_payload = _accepted_payload(
+        trace_id=trace_id,
+        result={"request_id": updated_record.request_id, "state": updated_record.state},
+        driver_result={"request": updated_record.model_dump(mode="json")},
+    )
     accepted_payload["github_delivery_id"] = delivery_id
     return _json_response(start_response=start_response, status_code=202, payload=accepted_payload)
 

--- a/tests/test_every_code_webhooks.py
+++ b/tests/test_every_code_webhooks.py
@@ -1,0 +1,77 @@
+import json
+import subprocess
+import unittest
+from collections.abc import Sequence
+
+from control_plane.every_code_webhooks import sync_every_code_webhooks
+
+
+class _WebhookRunner:
+    def __init__(self, *, hooks: dict[str, list[dict[str, object]]]) -> None:
+        self.hooks = hooks
+        self.calls: list[tuple[tuple[str, ...], str | None]] = []
+
+    def __call__(
+        self, args: Sequence[str], input_text: str | None
+    ) -> subprocess.CompletedProcess[str]:
+        command = tuple(args)
+        self.calls.append((command, input_text))
+        if command[:4] == ("gh", "repo", "list", "cbusillo"):
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                "cbusillo/code\ncbusillo/launchplane\n",
+                "",
+            )
+        if command[:3] == ("gh", "api", "repos/cbusillo/code/hooks"):
+            return subprocess.CompletedProcess(command, 0, json.dumps(self.hooks["cbusillo/code"]), "")
+        if command[:3] == ("gh", "api", "repos/cbusillo/launchplane/hooks"):
+            return subprocess.CompletedProcess(
+                command, 0, json.dumps(self.hooks["cbusillo/launchplane"]), ""
+            )
+        if command[:5] == ("gh", "api", "-X", "PATCH", "repos/cbusillo/code/hooks/12"):
+            return subprocess.CompletedProcess(command, 0, json.dumps({"id": 12}), "")
+        if command[:5] == ("gh", "api", "-X", "POST", "repos/cbusillo/launchplane/hooks"):
+            return subprocess.CompletedProcess(command, 0, json.dumps({"id": 34}), "")
+        raise AssertionError(f"unexpected command: {command}")
+
+
+class EveryCodeWebhookSyncTests(unittest.TestCase):
+    def test_sync_updates_existing_hook_and_creates_missing_hook(self) -> None:
+        runner = _WebhookRunner(
+            hooks={
+                "cbusillo/code": [
+                    {
+                        "id": 12,
+                        "config": {
+                            "url": "https://launchplane.shinycomputers.com/v1/every-code/github-webhook"
+                        },
+                    }
+                ],
+                "cbusillo/launchplane": [],
+            }
+        )
+
+        results = sync_every_code_webhooks(
+            owner="cbusillo",
+            webhook_secret="secret",
+            runner=runner,
+        )
+
+        self.assertEqual([result.status for result in results], ["updated", "created"])
+        self.assertEqual(results[0].hook_id, 12)
+        self.assertEqual(results[1].hook_id, 34)
+        payloads = {
+            command[3]: json.loads(input_text or "{}")
+            for command, input_text in runner.calls
+            if command[:3] == ("gh", "api", "-X")
+        }
+        patch_payload = payloads["PATCH"]
+        post_payload = payloads["POST"]
+        self.assertEqual(patch_payload["events"], ["issues", "pull_request"])
+        self.assertEqual(post_payload["events"], ["issues", "pull_request"])
+        self.assertEqual(patch_payload["config"]["secret"], "secret")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_every_code_work_request.py
+++ b/tests/test_every_code_work_request.py
@@ -6,6 +6,7 @@ from control_plane.contracts.every_code_work_request import (
     apply_every_code_work_request_status,
     build_every_code_work_request_id,
     claim_every_code_work_request,
+    close_every_code_work_request_for_pull_request,
 )
 
 
@@ -99,6 +100,44 @@ class EveryCodeWorkRequestRecordTests(unittest.TestCase):
         self.assertEqual(done_record.started_at, "2026-05-05T22:03:00Z")
         self.assertEqual(done_record.finished_at, "2026-05-05T22:03:00Z")
         self.assertEqual(done_record.result_pr_url, "https://github.com/cbusillo/code/pull/99")
+
+    def test_pr_close_marks_matching_running_request_done(self) -> None:
+        claimed_record = claim_every_code_work_request(
+            _queued_record(),
+            host="Chris-Studio",
+            claimed_at="2026-05-05T22:01:00Z",
+        )
+        assert claimed_record is not None
+        running_record = apply_every_code_work_request_status(
+            claimed_record,
+            EveryCodeWorkRequestStatusUpdate(
+                state="running",
+                host="Chris-Studio",
+                updated_at="2026-05-05T22:03:00Z",
+                result_pr_url="https://github.com/cbusillo/code/pull/99",
+            ),
+        )
+
+        done_record = close_every_code_work_request_for_pull_request(
+            running_record,
+            pr_url="https://github.com/cbusillo/code/pull/99",
+            merged=True,
+            closed_at="2026-05-05T22:05:00Z",
+        )
+
+        self.assertIsNotNone(done_record)
+        assert done_record is not None
+        self.assertEqual(done_record.state, "done")
+        self.assertEqual(done_record.finished_at, "2026-05-05T22:05:00Z")
+        self.assertEqual(done_record.error_message, "")
+        self.assertIsNone(
+            close_every_code_work_request_for_pull_request(
+                done_record,
+                pr_url="https://github.com/cbusillo/code/pull/99",
+                merged=True,
+                closed_at="2026-05-05T22:06:00Z",
+            )
+        )
 
     def test_blocked_requires_error_message(self) -> None:
         with self.assertRaises(ValueError):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -419,6 +419,26 @@ def _every_code_github_issue_labeled_payload(
     }
 
 
+def _every_code_github_pull_request_closed_payload(
+    *,
+    repository: str = "cbusillo/code",
+    pr_number: int = 26,
+    merged: bool = True,
+    closed_at: str = "2026-05-06T16:20:00Z",
+) -> dict[str, object]:
+    return {
+        "action": "closed",
+        "repository": {"full_name": repository},
+        "pull_request": {
+            "number": pr_number,
+            "html_url": f"https://github.com/{repository}/pull/{pr_number}",
+            "merged": merged,
+            "closed_at": closed_at,
+        },
+        "sender": {"login": "cbusillo"},
+    }
+
+
 def _work_graph_snapshot_payload() -> dict[str, object]:
     return {
         "generated_at": "2026-05-06T01:45:00Z",
@@ -1063,6 +1083,235 @@ class LaunchplaneServiceTests(unittest.TestCase):
             second_payload["result"]["request"]["result_pr_url"],
             "https://github.com/cbusillo/code/pull/26",
         )
+
+    def test_every_code_pull_request_close_marks_linked_request_done(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main"
+                        ],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": [
+                            "every_code_work_request.read",
+                            "every_code_work_request.claim",
+                            "every_code_work_request.update",
+                        ],
+                    }
+                ]
+            }
+        )
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
+            event_name="workflow_dispatch",
+        )
+        issue_payload = _every_code_github_issue_labeled_payload()
+        pr_payload = _every_code_github_pull_request_closed_payload()
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(identity),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            create_status, create_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=issue_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-issue",
+                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                },
+            )
+            request_id = str(create_payload["records"]["request_id"])
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/claim",
+                payload={"request_id": request_id, "host": "Chris-Studio"},
+                headers={"Idempotency-Key": "every-code-close-claim"},
+            )
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/status",
+                payload={
+                    "request_id": request_id,
+                    "host": "Chris-Studio",
+                    "state": "running",
+                    "result_pr_url": "https://github.com/cbusillo/code/pull/26",
+                },
+                headers={"Idempotency-Key": "every-code-close-running"},
+            )
+
+            close_status, close_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=pr_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "pull_request",
+                    "X-GitHub-Delivery": "delivery-pr-close",
+                    "X-Hub-Signature-256": _github_webhook_signature(pr_payload, secret),
+                },
+            )
+
+        self.assertEqual(create_status, 202)
+        self.assertEqual(close_status, 202)
+        self.assertEqual(close_payload["records"]["state"], "done")
+        self.assertEqual(close_payload["result"]["request"]["finished_at"], "2026-05-06T16:20:00Z")
+        self.assertEqual(close_payload["result"]["request"]["error_message"], "")
+        self.assertEqual(
+            close_payload["result"]["request"]["result_summary"],
+            "Linked pull request merged: https://github.com/cbusillo/code/pull/26",
+        )
+
+    def test_every_code_pull_request_close_blocks_unmerged_linked_request(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main"
+                        ],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": [
+                            "every_code_work_request.read",
+                            "every_code_work_request.claim",
+                            "every_code_work_request.update",
+                        ],
+                    }
+                ]
+            }
+        )
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
+            event_name="workflow_dispatch",
+        )
+        issue_payload = _every_code_github_issue_labeled_payload()
+        pr_payload = _every_code_github_pull_request_closed_payload(merged=False)
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(identity),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            create_status, create_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=issue_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-issue",
+                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                },
+            )
+            request_id = str(create_payload["records"]["request_id"])
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/claim",
+                payload={"request_id": request_id, "host": "Chris-Studio"},
+                headers={"Idempotency-Key": "every-code-unmerged-close-claim"},
+            )
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/status",
+                payload={
+                    "request_id": request_id,
+                    "host": "Chris-Studio",
+                    "state": "running",
+                    "result_pr_url": "https://github.com/cbusillo/code/pull/26",
+                },
+                headers={"Idempotency-Key": "every-code-unmerged-close-running"},
+            )
+
+            close_status, close_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=pr_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "pull_request",
+                    "X-GitHub-Delivery": "delivery-pr-close",
+                    "X-Hub-Signature-256": _github_webhook_signature(pr_payload, secret),
+                },
+            )
+
+        self.assertEqual(create_status, 202)
+        self.assertEqual(close_status, 202)
+        self.assertEqual(close_payload["records"]["state"], "blocked")
+        self.assertIn("closed without merge", close_payload["result"]["request"]["error_message"])
+
+    def test_every_code_pull_request_close_ignores_unlinked_pr(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
+            event_name="workflow_dispatch",
+        )
+        pr_payload = _every_code_github_pull_request_closed_payload(pr_number=999)
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(identity),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=pr_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "pull_request",
+                    "X-GitHub-Delivery": "delivery-pr-close",
+                    "X-Hub-Signature-256": _github_webhook_signature(pr_payload, secret),
+                },
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertTrue(payload["skipped"])
+        self.assertEqual(payload["reason"], "linked_every_code_request_not_found")
 
     def test_every_code_github_webhook_rejects_invalid_signature(self) -> None:
         secret = "launchplane-every-code-webhook-secret"


### PR DESCRIPTION
## Summary
- accept signed Every Code `pull_request.closed` webhook deliveries
- mark requests with a matching recorded `result_pr_url` as `done` when merged and `blocked` when closed unmerged
- keep unrelated PR close events as accepted no-ops
- add `launchplane every-code sync-webhooks` so Launchplane can keep `every-code` topic repo hooks aligned with the canonical `issues` + `pull_request` event set

## Notes
- Matching is intentionally conservative: the PR URL must already be recorded on the Every Code request.
- `sync-webhooks` uses local `gh` auth and the configured webhook secret to create/update matching repo hooks.

## Tests
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest
