### PR TITLE
Allow deploy authority to seed runtime key safety

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -4963,11 +4963,19 @@ def create_launchplane_service_app(
                             },
                         },
                     )
-                if not authz_policy.allows(
-                    identity=identity,
-                    action="runtime_key_safety.write",
-                    product=runtime_policy_request.product,
-                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                if not (
+                    authz_policy.allows(
+                        identity=identity,
+                        action="runtime_key_safety.write",
+                        product=runtime_policy_request.product,
+                        context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                    )
+                    or authz_policy.allows(
+                        identity=identity,
+                        action="launchplane_service_deploy.execute",
+                        product=runtime_policy_request.product,
+                        context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                    )
                 ):
                     return _json_response(
                         start_response=start_response,


### PR DESCRIPTION
## Summary
- allow existing Launchplane self-deploy authority to reconcile runtime key-safety policy metadata
- keep the dedicated runtime_key_safety.write action as the narrow authority for non-bootstrap callers
- avoid same-process authz refresh dependency after deploy writes a new grant and immediately applies policy

Refs #190

## Verification
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_runtime_key_safety_policy_endpoint_reconciles_rules tests.test_service.LaunchplaneServiceTests.test_runtime_key_safety_policy_endpoint_rejects_without_permission
- git diff --check
- uv run --extra dev ruff check --diff control_plane/service.py
- uv run --extra dev ruff check control_plane/service.py
- uv run --extra dev ruff format --check control_plane/service.py
- uv run --extra dev mypy control_plane/service.py