### PR TITLE
Document API-first live runtime changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,9 @@ Treat this file as the launch checklist for every Codex session in
 - Never commit secrets or operator-local overrides.
 - Prefer Launchplane-owned runtime-environment records and managed secret
   records over ad hoc service-host env for product/runtime configuration.
+- Use the deployed Launchplane service API or the operator UI for shared and
+  production live mutations. Do not use local CLI live-target commands from an
+  arbitrary checkout as a fallback; add or use a service endpoint first.
 - Treat service-host env as bootstrap-only unless a repo doc explicitly calls
   out a narrower temporary compatibility fallback.
 - Update docs in the same change when behavior or ownership changes.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -10,7 +10,11 @@ top-level groups are:
 Today this CLI is the local Launchplane operator surface around the service API.
 It owns stable-lane deploy and promotion records for `testing` and `prod`, plus
 Launchplane preview records and read models for PR review flows. It should not
-be treated as the final cross-product ingress boundary for Launchplane.
+be treated as the final cross-product ingress boundary for Launchplane. Shared
+or production mutations must prefer the deployed service API with GitHub OIDC or
+the operator UI that calls it. If a live mutation still exists only as a local
+CLI command, stop and add or use a service API path instead of running the local
+command from an arbitrary checkout.
 
 - `artifacts`: write, ingest, and inspect artifact manifests.
 - `backup-gates`: write and inspect backup-gate records.
@@ -438,7 +442,10 @@ Current derived-state behavior:
   without requiring an artifact manifest. It preserves unrelated live env keys,
   verifies persistence by key/count metadata only, and never prints plaintext
   env or secret values. Add `--deploy` with `--apply` when the app should be
-  explicitly redeployed/reloaded after the config update.
+  explicitly redeployed/reloaded after the config update. This command is a
+  compatibility/local operator surface only: do not use it for shared or
+  production live changes from a local checkout. Use a deployed service API or
+  add one before applying live target runtime changes.
 - TOML/env files are not runtime import surfaces; use DB-native
   runtime-environment records and managed secrets instead.
 - Product repos and GitHub issues must not contain product secret values. Put

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -52,6 +52,12 @@ title: Secrets
 - Runtime key-safety gates classify managed secret bindings by binding key and
   Launchplane metadata, not by plaintext value. The initial classification
   contract is `prod_only`, `testing`, `preview`, `non_prod`, and `shared_safe`.
+- Shared and production runtime mutations must execute through the deployed
+  Launchplane service API or an operator UI path backed by that API. Do not use
+  local CLI live-target mutation commands from arbitrary checkouts as a fallback
+  when the service API is missing; add the service boundary first so the
+  deployed runtime resolves DB-backed target authority and records sanitized
+  audit evidence.
 - Gates fail closed when a required binding is missing, disabled, ambiguous,
   unclassified, or scoped outside the target context/instance. A target with an
   unknown environment class also fails closed.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -424,6 +424,14 @@ requires DB-backed storage, returns only sanitized summaries, and exists so the
 Launchplane deploy workflow can seed product records without product repos
 storing live lifecycle truth.
 
+Live target runtime applies are service-boundary work. Operators and agents must
+not run local CLI live-target mutation commands from arbitrary checkouts to make
+shared or production changes, because the local process may lack DB-backed
+tracked target authority or use stale bootstrap context. Add or use a deployed
+service API endpoint for live target runtime apply/redeploy flows so Launchplane
+can authorize with OIDC/session identity, resolve current DB-backed target
+records in the deployed runtime, and audit sanitized key/count evidence.
+
 Generic web deploys use `POST /v1/drivers/generic-web/deploy`. The request names
 the product, target instance, immutable artifact/image reference, and source ref;
 Launchplane resolves the context from the DB-backed product profile lane and the


### PR DESCRIPTION
## Summary
- clarify that shared/prod live runtime mutations should use deployed Launchplane service API or UI paths, not local CLI fallback
- mark apply-live-target as compatibility/local operator surface for non-shared use only
- document that missing live mutation API should be added before applying live target changes

Refs #190

## Verification
- git diff --check
- markdownlint/prettier editor validation reported zero markdown errors for touched docs