### PR TITLE
Use canonical SYO context in runtime policy

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -506,13 +506,13 @@ jobs:
                     {
                       binding_key: "RESEND_API_KEY",
                       secret_class: "prod_only",
-                      allowed_contexts: ["sellyouroutboard-prod"],
+                      allowed_contexts: ["sellyouroutboard"],
                       allowed_instances: ["prod"]
                     },
                     {
                       binding_key: "SMTP_PASSWORD",
                       secret_class: "prod_only",
-                      allowed_contexts: ["sellyouroutboard-prod"],
+                      allowed_contexts: ["sellyouroutboard"],
                       allowed_instances: ["prod"]
                     }
                   ]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -6719,13 +6719,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         {
                             "binding_key": "SMTP_PASSWORD",
                             "secret_class": "prod_only",
-                            "allowed_contexts": ["sellyouroutboard-prod"],
+                            "allowed_contexts": ["sellyouroutboard"],
                             "allowed_instances": ["prod"],
                         },
                         {
                             "binding_key": "RESEND_API_KEY",
                             "secret_class": "prod_only",
-                            "allowed_contexts": ["sellyouroutboard-prod"],
+                            "allowed_contexts": ["sellyouroutboard"],
                             "allowed_instances": ["prod"],
                         },
                     ],
@@ -6751,13 +6751,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         {
                             "binding_key": "SMTP_PASSWORD",
                             "secret_class": "prod_only",
-                            "allowed_contexts": ["sellyouroutboard-prod"],
+                            "allowed_contexts": ["sellyouroutboard"],
                             "allowed_instances": ["prod"],
                         },
                         {
                             "binding_key": "RESEND_API_KEY",
                             "secret_class": "prod_only",
-                            "allowed_contexts": ["sellyouroutboard-prod"],
+                            "allowed_contexts": ["sellyouroutboard"],
                             "allowed_instances": ["prod"],
                         },
                     ],


### PR DESCRIPTION
## Summary
- update the deploy-reconciled runtime key-safety policy to allow SellYourOutboard prod bindings for the canonical sellyouroutboard context
- stop seeding the stale sellyouroutboard-prod context for RESEND_API_KEY and SMTP_PASSWORD
- align the runtime policy endpoint test with the canonical production context

Refs #190

## Verification
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_runtime_key_safety_policy_endpoint_reconciles_rules
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-launchplane.yml"); puts "yaml ok"'
- uv run --extra dev ruff check --diff tests/test_service.py
- uv run --extra dev ruff check tests/test_service.py
- uv run --extra dev ruff format --check tests/test_service.py
- uv run --extra dev mypy tests/test_service.py

Operational note: Product Legacy Context Cleanup dry-run for sellyouroutboard-prod -> sellyouroutboard returned no mutable legacy records, so the remaining mismatch is the deploy-reconciled policy context.