### PR TITLE
Expose live target runtime API

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -673,6 +673,22 @@ jobs:
             generic_web_prod_promotion.execute \
             deploy:syo-prod-promotion-execute-grant \
             syo-prod-promotion-execute
+          post_grant \
+            "$GITHUB_REPOSITORY" \
+            live-target-runtime.yml \
+            sellyouroutboard \
+            sellyouroutboard \
+            live_target_runtime.plan \
+            deploy:syo-live-target-runtime-plan-grant \
+            syo-live-target-runtime-plan
+          post_grant \
+            "$GITHUB_REPOSITORY" \
+            live-target-runtime.yml \
+            sellyouroutboard \
+            sellyouroutboard \
+            live_target_runtime.apply \
+            deploy:syo-live-target-runtime-apply-grant \
+            syo-live-target-runtime-apply
           post_syo_preview_grants \
             sellyouroutboard-testing \
             legacy-context

--- a/.github/workflows/live-target-runtime.yml
+++ b/.github/workflows/live-target-runtime.yml
@@ -1,0 +1,135 @@
+name: Live Target Runtime
+
+on:
+  workflow_dispatch:
+    inputs:
+      product:
+        description: Product profile key
+        required: true
+        type: string
+      context:
+        description: Runtime context
+        required: true
+        type: string
+      instance:
+        description: Runtime instance
+        required: true
+        type: string
+      mode:
+        description: Plan or apply the live runtime sync
+        required: true
+        default: dry-run
+        type: choice
+        options:
+          - dry-run
+          - apply
+      deploy:
+        description: Trigger a deploy after applying env changes
+        required: true
+        default: false
+        type: boolean
+      no_cache:
+        description: Use no-cache when deploy is requested
+        required: true
+        default: false
+        type: boolean
+      deploy_timeout_seconds:
+        description: Optional deploy wait timeout in seconds
+        required: false
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  live-target-runtime:
+    name: ${{ inputs.mode }} ${{ inputs.context }}/${{ inputs.instance }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request live target runtime sync
+        env:
+          SERVICE_URL: https://launchplane.shinycomputers.com
+          PRODUCT: ${{ inputs.product }}
+          CONTEXT: ${{ inputs.context }}
+          INSTANCE: ${{ inputs.instance }}
+          MODE: ${{ inputs.mode }}
+          DEPLOY: ${{ inputs.deploy }}
+          NO_CACHE: ${{ inputs.no_cache }}
+          DEPLOY_TIMEOUT_SECONDS: ${{ inputs.deploy_timeout_seconds }}
+        run: |
+          set -euo pipefail
+
+          if [ "$MODE" = "dry-run" ]; then
+            if [ "$DEPLOY" = "true" ] || [ "$NO_CACHE" = "true" ] || [ -n "$DEPLOY_TIMEOUT_SECONDS" ]; then
+              echo "Deploy options require mode=apply." >&2
+              exit 1
+            fi
+          fi
+
+          token_json="$(curl -fsSL \
+            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=launchplane")"
+          oidc_token="$(jq -r '.value' <<<"$token_json")"
+          if [ -z "$oidc_token" ] || [ "$oidc_token" = "null" ]; then
+            echo "GitHub OIDC token response did not include a token." >&2
+            exit 1
+          fi
+
+          payload="$(jq -n \
+            --arg product "$PRODUCT" \
+            --arg context "$CONTEXT" \
+            --arg instance "$INSTANCE" \
+            --arg mode "$MODE" \
+            --argjson deploy "$DEPLOY" \
+            --argjson no_cache "$NO_CACHE" \
+            --arg deploy_timeout_seconds "$DEPLOY_TIMEOUT_SECONDS" \
+            '{
+              schema_version: 1,
+              product: $product,
+              context: $context,
+              instance: $instance,
+              mode: $mode,
+              deploy: $deploy,
+              no_cache: $no_cache
+            }
+            | if $deploy_timeout_seconds != "" then
+                . + {deploy_timeout_seconds: ($deploy_timeout_seconds | tonumber)}
+              else
+                .
+              end')"
+
+          response_file="live-target-runtime-response.json"
+          status_code="$(curl -sS -o "$response_file" -w '%{http_code}' \
+            -X POST \
+            -H "Authorization: Bearer ${oidc_token}" \
+            -H 'Content-Type: application/json' \
+            -H "Idempotency-Key: live-target-runtime:${MODE}:${CONTEXT}:${INSTANCE}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}" \
+            --data "$payload" \
+            "${SERVICE_URL}/v1/live-target-runtime/apply")"
+          cat "$response_file"
+          echo
+          if [ "$status_code" -lt 200 ] || [ "$status_code" -ge 300 ]; then
+            echo "Launchplane live target runtime request failed with HTTP ${status_code}." >&2
+            exit 1
+          fi
+
+          {
+            echo "## Live Target Runtime ${MODE}"
+            echo
+            jq -r '
+              .result as $result
+              | "- Context: \($result.context)/\($result.instance)",
+                "- Target: \($result.tracked_target.target_name) (\($result.tracked_target.target_type))",
+                "- Changed keys: \(($result.runtime_environment.changed_keys // []) | join(", "))",
+                "- Runtime key-safety: \($result.runtime_key_safety.status)",
+                "- Env updated: \($result.apply.env_updated)",
+                "- Deploy triggered: \($result.deploy.triggered)"
+            ' "$response_file"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Upload response artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: live-target-runtime-response
+          path: live-target-runtime-response.json

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -19,6 +19,7 @@ from pydantic import ValidationError
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import every_code_reconciliation as control_plane_every_code_reconciliation
 from control_plane import every_code_webhooks as control_plane_every_code_webhooks
+from control_plane import live_target_runtime as control_plane_live_target_runtime
 from control_plane import odoo_instance_overrides as control_plane_odoo_instance_overrides
 from control_plane import product_config as control_plane_product_config
 from control_plane import product_context_audit as control_plane_product_context_audit
@@ -120,7 +121,6 @@ from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.factory import build_record_store, resolve_database_url
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.runtime_key_safety import (
-    RuntimeKeySafetyPolicyReadStore,
     evaluate_runtime_key_safety_from_store,
     latest_active_runtime_key_safety_policy,
 )
@@ -6792,32 +6792,14 @@ def _trigger_and_wait_for_dokploy_target_deploy(
     deploy_timeout_seconds: int,
     no_cache: bool,
 ) -> dict[str, str]:
-    if deploy_timeout_seconds <= 0:
-        raise click.ClickException(
-            "Launchplane service deploy timeout must be greater than zero seconds."
-        )
-    latest_before = control_plane_dokploy.latest_deployment_for_target(
+    return control_plane_live_target_runtime.trigger_and_wait_for_dokploy_target_deploy(
         host=host,
         token=token,
         target_type=target_type,
         target_id=target_id,
-    )
-    control_plane_dokploy.trigger_deployment(
-        host=host,
-        token=token,
-        target_type=target_type,
-        target_id=target_id,
+        deploy_timeout_seconds=deploy_timeout_seconds,
         no_cache=no_cache,
     )
-    deployment_result = control_plane_dokploy.wait_for_target_deployment(
-        host=host,
-        token=token,
-        target_type=target_type,
-        target_id=target_id,
-        before_key=control_plane_dokploy.deployment_key(latest_before),
-        timeout_seconds=deploy_timeout_seconds,
-    )
-    return {"deployment_result": deployment_result}
 
 
 def _resolve_dokploy_target(
@@ -7854,104 +7836,6 @@ def _sync_live_target_from_tracked_contract(
     return payload
 
 
-def _runtime_env_live_target_delta(
-    *,
-    desired_env_map: dict[str, str],
-    live_env_map: dict[str, str],
-) -> dict[str, object]:
-    desired_keys = sorted(desired_env_map)
-    missing_keys = [env_key for env_key in desired_keys if env_key not in live_env_map]
-    different_keys = [
-        env_key
-        for env_key in desired_keys
-        if env_key in live_env_map and live_env_map[env_key] != desired_env_map[env_key]
-    ]
-    unchanged_keys = [
-        env_key
-        for env_key in desired_keys
-        if env_key in live_env_map and live_env_map[env_key] == desired_env_map[env_key]
-    ]
-    return {
-        "desired_key_count": len(desired_keys),
-        "live_key_count": len(live_env_map),
-        "missing_keys": missing_keys,
-        "different_keys": different_keys,
-        "changed_keys": sorted({*missing_keys, *different_keys}),
-        "unchanged_key_count": len(unchanged_keys),
-    }
-
-
-def _runtime_key_safety_environment_class(instance_name: str) -> RuntimeEnvironmentClass:
-    normalized_instance = instance_name.strip().lower()
-    if normalized_instance in {"prod", "production"}:
-        return "prod"
-    if normalized_instance in {"testing", "test", "staging", "stage"}:
-        return "testing"
-    if normalized_instance in {"preview", "pr"} or normalized_instance.startswith("pr-"):
-        return "preview"
-    if normalized_instance in {"dev", "local", "development"}:
-        return "dev"
-    return "unknown"
-
-
-def _evaluate_runtime_key_safety_for_live_target_sync(
-    *,
-    record_store: RuntimeKeySafetyPolicyReadStore,
-    context_name: str,
-    instance_name: str,
-    require_policy: bool = True,
-) -> dict[str, object]:
-    bindings = record_store.list_secret_bindings(
-        integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
-        context_name=context_name,
-        instance_name=instance_name,
-        limit=None,
-    )
-    binding_keys = tuple(binding.binding_key for binding in bindings)
-    if not binding_keys:
-        return {"required": False, "status": "skipped", "checked_binding_keys": []}
-    try:
-        policy_record = latest_active_runtime_key_safety_policy(record_store)
-        evaluation = evaluate_runtime_key_safety_from_store(
-            record_store=record_store,
-            policy_record=policy_record,
-            target=RuntimeKeySafetyTarget(
-                context=context_name,
-                instance=instance_name,
-                environment_class=_runtime_key_safety_environment_class(instance_name),
-            ),
-            required_binding_keys=binding_keys,
-        )
-    except ValueError as error:
-        if not require_policy:
-            return {
-                "required": True,
-                "status": "unavailable",
-                "checked_binding_keys": list(binding_keys),
-            }
-        raise click.ClickException(
-            "Runtime key-safety policy is unavailable for live target runtime sync."
-        ) from error
-    summary: dict[str, object] = {
-        "required": True,
-        "status": evaluation.status,
-        "policy_record_id": policy_record.record_id,
-        "policy_sha256": policy_record.policy_sha256,
-        "target": evaluation.target.model_dump(mode="json"),
-        "checked_binding_keys": list(evaluation.checked_binding_keys),
-        "findings": [finding.model_dump(mode="json") for finding in evaluation.findings],
-    }
-    if evaluation.status != "pass":
-        finding_codes = sorted({finding.code for finding in evaluation.findings})
-        suffix = f": {', '.join(finding_codes)}" if finding_codes else ""
-        raise click.ClickException(f"Runtime key-safety gate failed for live target sync{suffix}.")
-    return summary
-
-
-def _skipped_runtime_key_safety_summary() -> dict[str, object]:
-    return {"required": False, "status": "skipped", "checked_binding_keys": []}
-
-
 def _apply_live_target_runtime_environment(
     *,
     context_name: str,
@@ -7961,145 +7845,19 @@ def _apply_live_target_runtime_environment(
     no_cache: bool,
     deploy_timeout_seconds: int | None,
 ) -> dict[str, object]:
-    control_plane_root = _control_plane_root()
-    source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
-        control_plane_root=control_plane_root,
-    )
-    target_definition = _require_dokploy_target_definition(
-        source_of_truth=source_of_truth,
-        context_name=context_name,
-        instance_name=instance_name,
-        operation_name="Runtime environment live target apply",
-    )
-    desired_env_map = control_plane_runtime_environments.resolve_runtime_environment_values(
-        control_plane_root=control_plane_root,
-        context_name=context_name,
-        instance_name=instance_name,
-    )
-    if not desired_env_map:
-        raise click.ClickException(
-            f"No Launchplane runtime environment values resolved for {context_name}/{instance_name}."
-        )
-
-    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
-    target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
-        host=host,
-        token=token,
-        target_type=target_definition.target_type,
-        target_id=target_definition.target_id,
-    )
-    live_env_map = control_plane_dokploy.parse_dokploy_env_text(
-        str(target_payload.get("env") or "")
-    )
-    initial_delta = _runtime_env_live_target_delta(
-        desired_env_map=desired_env_map,
-        live_env_map=live_env_map,
-    )
-    changed_keys = initial_delta["changed_keys"]
-    changed_key_count = len(changed_keys) if isinstance(changed_keys, list) else 0
-    runtime_key_safety = _skipped_runtime_key_safety_summary()
-    deploy_result: dict[str, str] | None = None
-    verification: dict[str, object] = {
-        "status": "skipped",
-        "reason": "dry_run" if not apply_changes else "no_runtime_env_changes",
-    }
-
-    if not apply_changes or changed_key_count or deploy:
-        database_url = resolve_database_url(None)
-        if database_url is not None:
-            postgres_store = PostgresRecordStore(database_url=database_url)
-            postgres_store.ensure_schema()
-            try:
-                runtime_key_safety = _evaluate_runtime_key_safety_for_live_target_sync(
-                    record_store=postgres_store,
-                    context_name=context_name,
-                    instance_name=instance_name,
-                    require_policy=apply_changes,
-                )
-            finally:
-                postgres_store.close()
-
-    if apply_changes and changed_key_count:
-        refreshed_payload = control_plane_dokploy.fetch_dokploy_target_payload(
-            host=host,
-            token=token,
-            target_type=target_definition.target_type,
-            target_id=target_definition.target_id,
-        )
-        refreshed_env_map = control_plane_dokploy.parse_dokploy_env_text(
-            str(refreshed_payload.get("env") or "")
-        )
-        updated_env_map = dict(refreshed_env_map)
-        updated_env_map.update(desired_env_map)
-        control_plane_dokploy.update_dokploy_target_env(
-            host=host,
-            token=token,
-            target_type=target_definition.target_type,
-            target_id=target_definition.target_id,
-            target_payload=refreshed_payload,
-            env_text=control_plane_dokploy.serialize_dokploy_env_text(updated_env_map),
-        )
-        persisted_payload = control_plane_dokploy.fetch_dokploy_target_payload(
-            host=host,
-            token=token,
-            target_type=target_definition.target_type,
-            target_id=target_definition.target_id,
-        )
-        persisted_env_map = control_plane_dokploy.parse_dokploy_env_text(
-            str(persisted_payload.get("env") or "")
-        )
-        verification_delta = _runtime_env_live_target_delta(
-            desired_env_map=desired_env_map,
-            live_env_map=persisted_env_map,
-        )
-        verification_changed_keys = verification_delta["changed_keys"]
-        verification = {
-            "status": "pass" if verification_changed_keys == [] else "fail",
-            "missing_keys": verification_delta["missing_keys"],
-            "different_keys": verification_delta["different_keys"],
-            "verified_key_count": verification_delta["unchanged_key_count"],
-        }
-        if verification["status"] != "pass":
-            raise click.ClickException(
-                "Dokploy target env did not persist all Launchplane runtime environment keys."
-            )
-
-    if apply_changes and deploy:
-        deploy_result = _trigger_and_wait_for_dokploy_target_deploy(
-            host=host,
-            token=token,
-            target_type=target_definition.target_type,
-            target_id=target_definition.target_id,
-            deploy_timeout_seconds=control_plane_dokploy.resolve_ship_timeout_seconds(
-                timeout_override_seconds=deploy_timeout_seconds,
-                target_definition=target_definition,
-            ),
+    try:
+        return control_plane_live_target_runtime.apply_live_target_runtime_environment(
+            control_plane_root=_control_plane_root(),
+            context_name=context_name,
+            instance_name=instance_name,
+            apply_changes=apply_changes,
+            deploy=deploy,
             no_cache=no_cache,
+            deploy_timeout_seconds=deploy_timeout_seconds,
+            deploy_trigger=_trigger_and_wait_for_dokploy_target_deploy,
         )
-
-    return {
-        "status": "ok",
-        "mode": "apply" if apply_changes else "dry-run",
-        "context": context_name,
-        "instance": instance_name,
-        "tracked_target": {
-            "target_id": target_definition.target_id,
-            "target_type": target_definition.target_type,
-            "target_name": target_definition.target_name,
-        },
-        "runtime_environment": initial_delta,
-        "runtime_key_safety": runtime_key_safety,
-        "apply": {
-            "applied": apply_changes,
-            "env_updated": bool(apply_changes and changed_key_count),
-            "verification": verification,
-        },
-        "deploy": {
-            "requested": deploy,
-            "triggered": deploy_result is not None,
-            **({"result": deploy_result} if deploy_result is not None else {}),
-        },
-    }
+    except control_plane_live_target_runtime.LiveTargetRuntimeError as error:
+        raise click.ClickException(str(error)) from error
 
 
 def _sync_artifact_image_reference_for_target(
@@ -8126,16 +7884,19 @@ def _sync_artifact_image_reference_for_target(
         )
     )
     database_url = resolve_database_url(None)
-    runtime_key_safety = _skipped_runtime_key_safety_summary()
+    runtime_key_safety = control_plane_live_target_runtime.skipped_runtime_key_safety_summary()
     if database_url is not None:
         postgres_store = PostgresRecordStore(database_url=database_url)
         postgres_store.ensure_schema()
         try:
-            runtime_key_safety = _evaluate_runtime_key_safety_for_live_target_sync(
-                record_store=postgres_store,
-                context_name=context_name,
-                instance_name=instance_name,
-            )
+            try:
+                runtime_key_safety = control_plane_live_target_runtime.evaluate_runtime_key_safety_for_live_target_sync(
+                    record_store=postgres_store,
+                    context_name=context_name,
+                    instance_name=instance_name,
+                )
+            except control_plane_live_target_runtime.LiveTargetRuntimeError as error:
+                raise click.ClickException(str(error)) from error
         finally:
             postgres_store.close()
     desired_env_map = dict(env_map)
@@ -9637,9 +9398,7 @@ def _every_code_worker_store(
         token_env_key = worker_token_env.strip() or _EVERY_CODE_WORKER_TOKEN_ENV_KEY
         resolved_token = os.environ.get(token_env_key, "").strip()
         if not resolved_token:
-            raise click.ClickException(
-                f"{token_env_key} is required when --service-url is set."
-            )
+            raise click.ClickException(f"{token_env_key} is required when --service-url is set.")
         return EveryCodeWorkerApiStore(
             service_url=service_url.strip(),
             worker_token=resolved_token,
@@ -9828,9 +9587,7 @@ def every_code_start(
     if service_url.strip():
         token_env_key = worker_token_env.strip() or _EVERY_CODE_WORKER_TOKEN_ENV_KEY
         if not os.environ.get(token_env_key, "").strip():
-            raise click.ClickException(
-                f"{token_env_key} is required when --service-url is set."
-            )
+            raise click.ClickException(f"{token_env_key} is required when --service-url is set.")
     spec = build_every_code_worker_daemon_spec(
         state_dir=state_dir,
         database_url=database_url,

--- a/control_plane/live_target_runtime.py
+++ b/control_plane/live_target_runtime.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+import click
+
+from control_plane import dokploy as control_plane_dokploy
+from control_plane import runtime_environments as control_plane_runtime_environments
+from control_plane import secrets as control_plane_secrets
+from control_plane.contracts.runtime_key_safety_policy import (
+    RuntimeEnvironmentClass,
+    RuntimeKeySafetyTarget,
+)
+from control_plane.runtime_key_safety import (
+    RuntimeKeySafetyPolicyReadStore,
+    evaluate_runtime_key_safety_from_store,
+    latest_active_runtime_key_safety_policy,
+)
+from control_plane.storage.factory import resolve_database_url
+from control_plane.storage.postgres import PostgresRecordStore
+
+
+class LiveTargetRuntimeError(Exception):
+    def __init__(self, message: str, *, code: str = "live_target_runtime_failed") -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class DokployDeployTrigger(Protocol):
+    def __call__(
+        self,
+        *,
+        host: str,
+        token: str,
+        target_type: str,
+        target_id: str,
+        deploy_timeout_seconds: int,
+        no_cache: bool,
+    ) -> dict[str, str]: ...
+
+
+def runtime_env_live_target_delta(
+    *,
+    desired_env_map: dict[str, str],
+    live_env_map: dict[str, str],
+) -> dict[str, object]:
+    desired_keys = sorted(desired_env_map)
+    missing_keys = [env_key for env_key in desired_keys if env_key not in live_env_map]
+    different_keys = [
+        env_key
+        for env_key in desired_keys
+        if env_key in live_env_map and live_env_map[env_key] != desired_env_map[env_key]
+    ]
+    unchanged_keys = [
+        env_key
+        for env_key in desired_keys
+        if env_key in live_env_map and live_env_map[env_key] == desired_env_map[env_key]
+    ]
+    return {
+        "desired_key_count": len(desired_keys),
+        "live_key_count": len(live_env_map),
+        "missing_keys": missing_keys,
+        "different_keys": different_keys,
+        "changed_keys": sorted({*missing_keys, *different_keys}),
+        "unchanged_key_count": len(unchanged_keys),
+    }
+
+
+def runtime_key_safety_environment_class(instance_name: str) -> RuntimeEnvironmentClass:
+    normalized_instance = instance_name.strip().lower()
+    if normalized_instance in {"prod", "production"}:
+        return "prod"
+    if normalized_instance in {"testing", "test", "staging", "stage"}:
+        return "testing"
+    if normalized_instance in {"preview", "pr"} or normalized_instance.startswith("pr-"):
+        return "preview"
+    if normalized_instance in {"dev", "local", "development"}:
+        return "dev"
+    return "unknown"
+
+
+def evaluate_runtime_key_safety_for_live_target_sync(
+    *,
+    record_store: RuntimeKeySafetyPolicyReadStore,
+    context_name: str,
+    instance_name: str,
+    require_policy: bool = True,
+) -> dict[str, object]:
+    bindings = record_store.list_secret_bindings(
+        integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+        context_name=context_name,
+        instance_name=instance_name,
+        limit=None,
+    )
+    binding_keys = tuple(binding.binding_key for binding in bindings)
+    if not binding_keys:
+        return {"required": False, "status": "skipped", "checked_binding_keys": []}
+    try:
+        policy_record = latest_active_runtime_key_safety_policy(record_store)
+        evaluation = evaluate_runtime_key_safety_from_store(
+            record_store=record_store,
+            policy_record=policy_record,
+            target=RuntimeKeySafetyTarget(
+                context=context_name,
+                instance=instance_name,
+                environment_class=runtime_key_safety_environment_class(instance_name),
+            ),
+            required_binding_keys=binding_keys,
+        )
+    except ValueError as error:
+        if not require_policy:
+            return {
+                "required": True,
+                "status": "unavailable",
+                "checked_binding_keys": list(binding_keys),
+            }
+        raise LiveTargetRuntimeError(
+            "Runtime key-safety policy is unavailable for live target runtime sync.",
+            code="runtime_key_safety_unavailable",
+        ) from error
+    summary: dict[str, object] = {
+        "required": True,
+        "status": evaluation.status,
+        "policy_record_id": policy_record.record_id,
+        "policy_sha256": policy_record.policy_sha256,
+        "target": evaluation.target.model_dump(mode="json"),
+        "checked_binding_keys": list(evaluation.checked_binding_keys),
+        "findings": [finding.model_dump(mode="json") for finding in evaluation.findings],
+    }
+    if evaluation.status != "pass":
+        finding_codes = sorted({finding.code for finding in evaluation.findings})
+        suffix = f": {', '.join(finding_codes)}" if finding_codes else ""
+        raise LiveTargetRuntimeError(
+            f"Runtime key-safety gate failed for live target sync{suffix}.",
+            code="runtime_key_safety_failed",
+        )
+    return summary
+
+
+def skipped_runtime_key_safety_summary() -> dict[str, object]:
+    return {"required": False, "status": "skipped", "checked_binding_keys": []}
+
+
+def require_dokploy_target_definition(
+    *,
+    source_of_truth: control_plane_dokploy.DokploySourceOfTruth,
+    context_name: str,
+    instance_name: str,
+    operation_name: str,
+) -> control_plane_dokploy.DokployTargetDefinition:
+    target_definition = control_plane_dokploy.find_dokploy_target_definition(
+        source_of_truth,
+        context_name=context_name,
+        instance_name=instance_name,
+    )
+    if target_definition is None:
+        raise LiveTargetRuntimeError(
+            f"{operation_name} target {context_name}/{instance_name} is missing from the DB-backed tracked Dokploy targets.",
+            code="tracked_target_not_found",
+        )
+    return target_definition
+
+
+def apply_live_target_runtime_environment(
+    *,
+    control_plane_root: Path,
+    context_name: str,
+    instance_name: str,
+    apply_changes: bool,
+    deploy: bool,
+    no_cache: bool,
+    deploy_timeout_seconds: int | None,
+    deploy_trigger: DokployDeployTrigger,
+) -> dict[str, object]:
+    source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
+        control_plane_root=control_plane_root,
+    )
+    target_definition = require_dokploy_target_definition(
+        source_of_truth=source_of_truth,
+        context_name=context_name,
+        instance_name=instance_name,
+        operation_name="Runtime environment live target apply",
+    )
+    try:
+        desired_env_map = control_plane_runtime_environments.resolve_runtime_environment_values(
+            control_plane_root=control_plane_root,
+            context_name=context_name,
+            instance_name=instance_name,
+        )
+    except click.ClickException as error:
+        raise LiveTargetRuntimeError(str(error), code="runtime_environment_unavailable") from error
+    if not desired_env_map:
+        raise LiveTargetRuntimeError(
+            f"No Launchplane runtime environment values resolved for {context_name}/{instance_name}.",
+            code="runtime_environment_empty",
+        )
+
+    try:
+        host, token = control_plane_dokploy.read_dokploy_config(
+            control_plane_root=control_plane_root
+        )
+        target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
+            host=host,
+            token=token,
+            target_type=target_definition.target_type,
+            target_id=target_definition.target_id,
+        )
+    except click.ClickException as error:
+        raise LiveTargetRuntimeError(str(error), code="dokploy_target_read_failed") from error
+    live_env_map = control_plane_dokploy.parse_dokploy_env_text(
+        str(target_payload.get("env") or "")
+    )
+    initial_delta = runtime_env_live_target_delta(
+        desired_env_map=desired_env_map,
+        live_env_map=live_env_map,
+    )
+    changed_keys = initial_delta["changed_keys"]
+    changed_key_count = len(changed_keys) if isinstance(changed_keys, list) else 0
+    runtime_key_safety = skipped_runtime_key_safety_summary()
+    deploy_result: dict[str, str] | None = None
+    verification: dict[str, object] = {
+        "status": "skipped",
+        "reason": "dry_run" if not apply_changes else "no_runtime_env_changes",
+    }
+
+    if not apply_changes or changed_key_count or deploy:
+        database_url = resolve_database_url(None)
+        if database_url is not None:
+            postgres_store = PostgresRecordStore(database_url=database_url)
+            postgres_store.ensure_schema()
+            try:
+                runtime_key_safety = evaluate_runtime_key_safety_for_live_target_sync(
+                    record_store=postgres_store,
+                    context_name=context_name,
+                    instance_name=instance_name,
+                    require_policy=apply_changes,
+                )
+            finally:
+                postgres_store.close()
+
+    if apply_changes and changed_key_count:
+        try:
+            refreshed_payload = control_plane_dokploy.fetch_dokploy_target_payload(
+                host=host,
+                token=token,
+                target_type=target_definition.target_type,
+                target_id=target_definition.target_id,
+            )
+            refreshed_env_map = control_plane_dokploy.parse_dokploy_env_text(
+                str(refreshed_payload.get("env") or "")
+            )
+            updated_env_map = dict(refreshed_env_map)
+            updated_env_map.update(desired_env_map)
+            control_plane_dokploy.update_dokploy_target_env(
+                host=host,
+                token=token,
+                target_type=target_definition.target_type,
+                target_id=target_definition.target_id,
+                target_payload=refreshed_payload,
+                env_text=control_plane_dokploy.serialize_dokploy_env_text(updated_env_map),
+            )
+            persisted_payload = control_plane_dokploy.fetch_dokploy_target_payload(
+                host=host,
+                token=token,
+                target_type=target_definition.target_type,
+                target_id=target_definition.target_id,
+            )
+        except click.ClickException as error:
+            raise LiveTargetRuntimeError(str(error), code="dokploy_target_update_failed") from error
+        persisted_env_map = control_plane_dokploy.parse_dokploy_env_text(
+            str(persisted_payload.get("env") or "")
+        )
+        verification_delta = runtime_env_live_target_delta(
+            desired_env_map=desired_env_map,
+            live_env_map=persisted_env_map,
+        )
+        verification_changed_keys = verification_delta["changed_keys"]
+        verification = {
+            "status": "pass" if verification_changed_keys == [] else "fail",
+            "missing_keys": verification_delta["missing_keys"],
+            "different_keys": verification_delta["different_keys"],
+            "verified_key_count": verification_delta["unchanged_key_count"],
+        }
+        if verification["status"] != "pass":
+            raise LiveTargetRuntimeError(
+                "Dokploy target env did not persist all Launchplane runtime environment keys.",
+                code="dokploy_target_verification_failed",
+            )
+
+    if apply_changes and deploy:
+        try:
+            deploy_result = deploy_trigger(
+                host=host,
+                token=token,
+                target_type=target_definition.target_type,
+                target_id=target_definition.target_id,
+                deploy_timeout_seconds=control_plane_dokploy.resolve_ship_timeout_seconds(
+                    timeout_override_seconds=deploy_timeout_seconds,
+                    target_definition=target_definition,
+                ),
+                no_cache=no_cache,
+            )
+        except click.ClickException as error:
+            raise LiveTargetRuntimeError(str(error), code="dokploy_deploy_failed") from error
+
+    return {
+        "status": "ok",
+        "mode": "apply" if apply_changes else "dry-run",
+        "context": context_name,
+        "instance": instance_name,
+        "tracked_target": {
+            "target_id": target_definition.target_id,
+            "target_type": target_definition.target_type,
+            "target_name": target_definition.target_name,
+        },
+        "runtime_environment": initial_delta,
+        "runtime_key_safety": runtime_key_safety,
+        "apply": {
+            "applied": apply_changes,
+            "env_updated": bool(apply_changes and changed_key_count),
+            "verification": verification,
+        },
+        "deploy": {
+            "requested": deploy,
+            "triggered": deploy_result is not None,
+            "result": deploy_result,
+        },
+    }
+
+
+def trigger_and_wait_for_dokploy_target_deploy(
+    *,
+    host: str,
+    token: str,
+    target_type: str,
+    target_id: str,
+    deploy_timeout_seconds: int,
+    no_cache: bool,
+) -> dict[str, str]:
+    if deploy_timeout_seconds <= 0:
+        raise click.ClickException(
+            "Launchplane service deploy timeout must be greater than zero seconds."
+        )
+    latest_before = control_plane_dokploy.latest_deployment_for_target(
+        host=host,
+        token=token,
+        target_type=target_type,
+        target_id=target_id,
+    )
+    control_plane_dokploy.trigger_deployment(
+        host=host,
+        token=token,
+        target_type=target_type,
+        target_id=target_id,
+        no_cache=no_cache,
+    )
+    deployment_result = control_plane_dokploy.wait_for_target_deployment(
+        host=host,
+        token=token,
+        target_type=target_type,
+        target_id=target_id,
+        before_key=control_plane_dokploy.deployment_key(latest_before),
+        timeout_seconds=deploy_timeout_seconds,
+    )
+    return {"deployment_result": deployment_result}

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -25,6 +25,7 @@ from control_plane import dokploy as control_plane_dokploy
 from control_plane import product_config as control_plane_product_config
 from control_plane import product_context_audit as control_plane_product_context_audit
 from control_plane import product_context_cutover as control_plane_product_context_cutover
+from control_plane import live_target_runtime as control_plane_live_target_runtime
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.authz_policy_record import (
     LaunchplaneAuthzPolicyRecord,
@@ -1411,6 +1412,48 @@ class ProductConfigApplyEnvelope(BaseModel):
         return payload
 
 
+class LiveTargetRuntimeApplyEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    mode: str
+    product: str
+    context: str
+    instance: str
+    deploy: bool = False
+    no_cache: bool = False
+    deploy_timeout_seconds: int | None = Field(default=None, gt=0)
+
+    @field_validator("mode")
+    @classmethod
+    def _validate_mode(cls, value: str) -> str:
+        normalized_value = value.strip().lower()
+        if normalized_value not in {"dry-run", "apply"}:
+            raise ValueError("Live target runtime mode must be 'dry-run' or 'apply'.")
+        return normalized_value
+
+    @model_validator(mode="after")
+    def _validate_route(self) -> "LiveTargetRuntimeApplyEnvelope":
+        self.product = self.product.strip()
+        self.context = self.context.strip()
+        self.instance = self.instance.strip()
+        if not self.product:
+            raise ValueError("Live target runtime apply requires product.")
+        if not self.context:
+            raise ValueError("Live target runtime apply requires context.")
+        if not self.instance:
+            raise ValueError("Live target runtime apply requires instance.")
+        if self.mode == "dry-run" and (
+            self.deploy or self.no_cache or self.deploy_timeout_seconds is not None
+        ):
+            raise ValueError("Deploy options require live target runtime mode 'apply'.")
+        return self
+
+    @property
+    def apply_changes(self) -> bool:
+        return self.mode == "apply"
+
+
 class ThreadingWSGIServer(ThreadingMixIn, WSGIServer):
     daemon_threads = True
 
@@ -1794,6 +1837,7 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/evidence/previews/destroyed",
         "/v1/authz-policies/github-actions/grants",
         "/v1/runtime-key-safety/policies/apply",
+        "/v1/live-target-runtime/apply",
         "/v1/product-onboarding/apply",
         "/v1/product-config/apply",
         "/v1/product-profiles/context-cutover/apply",
@@ -5109,6 +5153,101 @@ def create_launchplane_service_app(
                     ),
                     "changed": changed,
                 }
+            elif path == "/v1/live-target-runtime/apply":
+                live_target_runtime_request = LiveTargetRuntimeApplyEnvelope.model_validate(payload)
+                action = (
+                    "live_target_runtime.apply"
+                    if live_target_runtime_request.apply_changes
+                    else "live_target_runtime.plan"
+                )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action=action,
+                    product=live_target_runtime_request.product,
+                    context=live_target_runtime_request.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot plan or apply live target runtime for"
+                                    " the requested product/context."
+                                ),
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                if not isinstance(record_store, PostgresRecordStore):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "database_required",
+                                "message": (
+                                    "Live target runtime apply requires DB-backed Launchplane"
+                                    " storage."
+                                ),
+                            },
+                        },
+                    )
+                try:
+                    driver_result = control_plane_live_target_runtime.apply_live_target_runtime_environment(
+                        control_plane_root=resolved_root,
+                        context_name=live_target_runtime_request.context,
+                        instance_name=live_target_runtime_request.instance,
+                        apply_changes=live_target_runtime_request.apply_changes,
+                        deploy=live_target_runtime_request.deploy,
+                        no_cache=live_target_runtime_request.no_cache,
+                        deploy_timeout_seconds=(live_target_runtime_request.deploy_timeout_seconds),
+                        deploy_trigger=(
+                            control_plane_live_target_runtime.trigger_and_wait_for_dokploy_target_deploy
+                        ),
+                    )
+                except control_plane_live_target_runtime.LiveTargetRuntimeError as error:
+                    status_code = 400
+                    if error.code in {
+                        "runtime_key_safety_unavailable",
+                        "runtime_environment_unavailable",
+                        "dokploy_target_read_failed",
+                    }:
+                        status_code = 503
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=status_code,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": error.code,
+                                "message": str(error),
+                            },
+                        },
+                    )
+                tracked_target = driver_result.get("tracked_target")
+                result = {}
+                if isinstance(tracked_target, dict):
+                    result = {
+                        "target_id": str(tracked_target.get("target_id", "")),
+                        "target_type": str(tracked_target.get("target_type", "")),
+                    }
             elif path == "/v1/product-onboarding/apply":
                 onboarding_request = ProductOnboardingApplyEnvelope.model_validate(payload)
                 if not isinstance(record_store, PostgresRecordStore):

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -446,6 +446,12 @@ Current derived-state behavior:
   compatibility/local operator surface only: do not use it for shared or
   production live changes from a local checkout. Use a deployed service API or
   add one before applying live target runtime changes.
+- `POST /v1/live-target-runtime/apply` is the deployed service equivalent for
+  shared and production live changes. Use `mode: "dry-run"` first, confirm the
+  returned `changed_keys` are expected, then use `mode: "apply"` through an
+  authorized workflow or operator API caller. The `live-target-runtime.yml`
+  workflow wraps this route with GitHub OIDC and uploads the sanitized response
+  artifact.
 - TOML/env files are not runtime import surfaces; use DB-native
   runtime-environment records and managed secrets instead.
 - Product repos and GitHub issues must not contain product secret values. Put

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -58,6 +58,9 @@ title: Secrets
   when the service API is missing; add the service boundary first so the
   deployed runtime resolves DB-backed target authority and records sanitized
   audit evidence.
+- Live target runtime sync uses `POST /v1/live-target-runtime/apply` or the
+  `live-target-runtime.yml` workflow wrapper. Dry-run and apply both evaluate
+  runtime key-safety policy before returning sanitized key/count evidence.
 - Gates fail closed when a required binding is missing, disabled, ambiguous,
   unclassified, or scoped outside the target context/instance. A target with an
   unknown environment class also fails closed.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -424,13 +424,24 @@ requires DB-backed storage, returns only sanitized summaries, and exists so the
 Launchplane deploy workflow can seed product records without product repos
 storing live lifecycle truth.
 
+Live target runtime sync uses `POST /v1/live-target-runtime/apply`. The route
+accepts `mode: "dry-run"` or `mode: "apply"`, product/context/instance, and
+optional apply-only deploy controls. Dry-run requires `live_target_runtime.plan`;
+apply requires `live_target_runtime.apply`. The route resolves DB-backed runtime
+environment records, managed runtime secrets, and the tracked Dokploy target in
+the deployed Launchplane service, evaluates runtime key-safety policy, compares
+desired and live env by key, and returns sanitized key/count evidence without
+runtime values or secret plaintext. Apply updates only the Launchplane-owned
+keys on the live target, preserves unrelated live env, verifies persistence by
+key metadata, and can explicitly trigger a deploy when requested.
+
 Live target runtime applies are service-boundary work. Operators and agents must
 not run local CLI live-target mutation commands from arbitrary checkouts to make
 shared or production changes, because the local process may lack DB-backed
-tracked target authority or use stale bootstrap context. Add or use a deployed
-service API endpoint for live target runtime apply/redeploy flows so Launchplane
-can authorize with OIDC/session identity, resolve current DB-backed target
-records in the deployed runtime, and audit sanitized key/count evidence.
+tracked target authority or use stale bootstrap context. Use the deployed
+service route or a workflow that calls it so Launchplane can authorize with
+OIDC/session identity, resolve current DB-backed target records in the deployed
+runtime, and audit sanitized key/count evidence.
 
 Generic web deploys use `POST /v1/drivers/generic-web/deploy`. The request names
 the product, target instance, immutable artifact/image reference, and source ref;

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -331,6 +331,27 @@ def _write_runtime_key_safety_policy(
         store.close()
 
 
+def _write_dokploy_managed_secrets(*, store: PostgresRecordStore) -> None:
+    control_plane_secrets.write_secret_value(
+        record_store=store,
+        scope="global",
+        integration=control_plane_secrets.DOKPLOY_SECRET_INTEGRATION,
+        name="host",
+        plaintext_value="https://dokploy.example.com",
+        binding_key="DOKPLOY_HOST",
+        actor="test",
+    )
+    control_plane_secrets.write_secret_value(
+        record_store=store,
+        scope="global",
+        integration=control_plane_secrets.DOKPLOY_SECRET_INTEGRATION,
+        name="token",
+        plaintext_value="dokploy-token",
+        binding_key="DOKPLOY_TOKEN",
+        actor="test",
+    )
+
+
 def _seed_tracked_target_records(
     *,
     database_url: str,
@@ -6832,6 +6853,281 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ],
                 },
                 headers={"Idempotency-Key": "runtime-key-safety-policy:unauthorized"},
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_live_target_runtime_api_dry_run_returns_redacted_delta(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                store.write_runtime_environment_record(
+                    RuntimeEnvironmentRecord(
+                        scope="instance",
+                        context="sellyouroutboard",
+                        instance="prod",
+                        env={"GOOGLE_ANALYTICS_MEASUREMENT_ID": "G-9KRMER45KG"},
+                        updated_at="2026-05-06T17:00:00Z",
+                        source_label="test",
+                    )
+                )
+                _seed_tracked_target_records(
+                    database_url=database_url,
+                    context="sellyouroutboard",
+                    instance="prod",
+                    target_id="application-syo-prod",
+                    target_type="application",
+                    target_name="syo-prod-app",
+                )
+                with patch.dict(
+                    os.environ,
+                    {
+                        "LAUNCHPLANE_DATABASE_URL": database_url,
+                        control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                    },
+                    clear=True,
+                ):
+                    _write_dokploy_managed_secrets(store=store)
+            finally:
+                store.close()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/live-target-runtime.yml@refs/heads/main"
+                            ],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard"],
+                            "actions": ["live_target_runtime.plan"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/live-target-runtime.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "LAUNCHPLANE_DATABASE_URL": database_url,
+                        control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                    },
+                    clear=True,
+                ),
+                patch(
+                    "control_plane.dokploy.fetch_dokploy_target_payload",
+                    return_value={
+                        "applicationId": "application-syo-prod",
+                        "name": "syo-prod-app",
+                        "env": "CONTACT_EMAIL_MODE=resend\n",
+                    },
+                ),
+                patch("control_plane.dokploy.update_dokploy_target_env") as update_env,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/live-target-runtime/apply",
+                    payload={
+                        "schema_version": 1,
+                        "mode": "dry-run",
+                        "product": "sellyouroutboard",
+                        "context": "sellyouroutboard",
+                        "instance": "prod",
+                    },
+                    headers={"Idempotency-Key": "live-target-runtime:dry-run"},
+                )
+
+        self.assertEqual(status_code, 202, msg=json.dumps(payload, indent=2, sort_keys=True))
+        update_env.assert_not_called()
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(payload["records"]["target_id"], "application-syo-prod")
+        result = payload["result"]
+        self.assertEqual(result["mode"], "dry-run")
+        self.assertEqual(
+            result["runtime_environment"]["missing_keys"],
+            ["GOOGLE_ANALYTICS_MEASUREMENT_ID"],
+        )
+        self.assertNotIn("G-9KRMER45KG", json.dumps(payload))
+
+    def test_live_target_runtime_api_apply_updates_env_and_verifies(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                store.write_runtime_environment_record(
+                    RuntimeEnvironmentRecord(
+                        scope="instance",
+                        context="sellyouroutboard",
+                        instance="prod",
+                        env={"GOOGLE_ANALYTICS_MEASUREMENT_ID": "G-9KRMER45KG"},
+                        updated_at="2026-05-06T17:00:00Z",
+                        source_label="test",
+                    )
+                )
+                _seed_tracked_target_records(
+                    database_url=database_url,
+                    context="sellyouroutboard",
+                    instance="prod",
+                    target_id="application-syo-prod",
+                    target_type="application",
+                    target_name="syo-prod-app",
+                )
+                with patch.dict(
+                    os.environ,
+                    {
+                        "LAUNCHPLANE_DATABASE_URL": database_url,
+                        control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                    },
+                    clear=True,
+                ):
+                    _write_dokploy_managed_secrets(store=store)
+            finally:
+                store.close()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/live-target-runtime.yml@refs/heads/main"
+                            ],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard"],
+                            "actions": ["live_target_runtime.apply"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/live-target-runtime.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            captured_env_updates: list[dict[str, object]] = []
+
+            def fetch_target_payload(**_kwargs: object) -> dict[str, object]:
+                env_text = "CONTACT_EMAIL_MODE=resend\n"
+                if captured_env_updates:
+                    env_text = str(captured_env_updates[-1]["env_text"])
+                return {
+                    "applicationId": "application-syo-prod",
+                    "name": "syo-prod-app",
+                    "env": env_text,
+                }
+
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "LAUNCHPLANE_DATABASE_URL": database_url,
+                        control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                    },
+                    clear=True,
+                ),
+                patch(
+                    "control_plane.dokploy.fetch_dokploy_target_payload",
+                    side_effect=fetch_target_payload,
+                ),
+                patch(
+                    "control_plane.dokploy.update_dokploy_target_env",
+                    side_effect=lambda **kwargs: captured_env_updates.append(kwargs),
+                ),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/live-target-runtime/apply",
+                    payload={
+                        "schema_version": 1,
+                        "mode": "apply",
+                        "product": "sellyouroutboard",
+                        "context": "sellyouroutboard",
+                        "instance": "prod",
+                    },
+                    headers={"Idempotency-Key": "live-target-runtime:apply"},
+                )
+
+        self.assertEqual(status_code, 202, msg=json.dumps(payload, indent=2, sort_keys=True))
+        self.assertEqual(len(captured_env_updates), 1)
+        env_text = str(captured_env_updates[0]["env_text"])
+        self.assertIn("GOOGLE_ANALYTICS_MEASUREMENT_ID=G-9KRMER45KG", env_text)
+        self.assertNotIn("G-9KRMER45KG", json.dumps(payload))
+        result = payload["result"]
+        self.assertEqual(result["mode"], "apply")
+        self.assertTrue(result["apply"]["env_updated"])
+        self.assertEqual(result["apply"]["verification"]["status"], "pass")
+
+    def test_live_target_runtime_api_apply_requires_apply_authorization(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard"],
+                            "actions": ["live_target_runtime.plan"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/live-target-runtime/apply",
+                payload={
+                    "schema_version": 1,
+                    "mode": "apply",
+                    "product": "sellyouroutboard",
+                    "context": "sellyouroutboard",
+                    "instance": "prod",
+                },
+                headers={"Idempotency-Key": "live-target-runtime:unauthorized"},
             )
 
         self.assertEqual(status_code, 403)


### PR DESCRIPTION
## Summary
- move live-target runtime sync into a shared module used by the CLI and service
- add POST /v1/live-target-runtime/apply with dry-run/apply authz, redacted responses, runtime key-safety checks, and optional deploy triggering
- add a GitHub OIDC workflow wrapper plus deploy-time authz grants for SellYourOutboard live runtime sync

Refs #325

## Verification
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_api_dry_run_returns_redacted_delta tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_api_apply_updates_env_and_verifies tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_api_apply_requires_apply_authorization tests.test_dokploy.DokployConfigTests.test_apply_live_target_dry_run_reports_runtime_key_delta_without_values tests.test_dokploy.DokployConfigTests.test_apply_live_target_updates_runtime_env_and_verifies_without_values tests.test_dokploy.DokployConfigTests.test_apply_live_target_deploy_is_explicit
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/live-target-runtime.yml"); YAML.load_file(".github/workflows/deploy-launchplane.yml"); puts "yaml ok"'
- uv run --extra dev ruff check --diff control_plane/live_target_runtime.py control_plane/cli.py control_plane/service.py tests/test_service.py docs/service-boundary.md docs/operations.md docs/secrets.md
- uv run --extra dev ruff check control_plane/live_target_runtime.py control_plane/cli.py control_plane/service.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/live_target_runtime.py control_plane/cli.py control_plane/service.py tests/test_service.py
- uv run --extra dev mypy control_plane/live_target_runtime.py control_plane/cli.py control_plane/service.py tests/test_service.py