### PR TITLE
feat(every-code): launch requests in isolated worktrees

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -9581,6 +9581,12 @@ def work_graph_rank(snapshot_file: Path, limit: int) -> None:
     default=None,
     help="Explicit checkout root for the claimed request.",
 )
+@click.option(
+    "--worktree-state-dir",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    default=None,
+    help="State directory where worker-owned request worktrees are created.",
+)
 @click.option("--repository", default="", help="Optional owner/repo queue filter.")
 @click.option(
     "--command-template",
@@ -9596,6 +9602,7 @@ def every_code_run_once(
     host: str,
     workspace_root: Path,
     checkout_root: Path | None,
+    worktree_state_dir: Path | None,
     repository: str,
     command_template: str,
     tmux_binary: str,
@@ -9613,6 +9620,7 @@ def every_code_run_once(
             host=resolved_host,
             workspace_root=workspace_root,
             checkout_root=checkout_root,
+            worktree_state_dir=worktree_state_dir,
             repository=repository,
             command_template=command_template,
             state_dir=state_dir,
@@ -9693,6 +9701,12 @@ def _close_store(record_store: object) -> None:
     default=None,
     help="Explicit checkout root for claimed requests.",
 )
+@click.option(
+    "--worktree-state-dir",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    default=None,
+    help="State directory where worker-owned request worktrees are created.",
+)
 @click.option("--repository", default="", help="Optional owner/repo queue filter.")
 @click.option(
     "--command-template",
@@ -9722,6 +9736,7 @@ def every_code_run(
     host: str,
     workspace_root: Path,
     checkout_root: Path | None,
+    worktree_state_dir: Path | None,
     repository: str,
     command_template: str,
     tmux_binary: str,
@@ -9741,6 +9756,7 @@ def every_code_run(
             host=resolved_host,
             workspace_root=workspace_root,
             checkout_root=checkout_root,
+            worktree_state_dir=worktree_state_dir,
             repository=repository,
             command_template=command_template,
             state_dir=state_dir,
@@ -9798,6 +9814,12 @@ def every_code_run(
     default=None,
     help="Explicit checkout root for claimed requests.",
 )
+@click.option(
+    "--worktree-state-dir",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    default=None,
+    help="State directory where worker-owned request worktrees are created.",
+)
 @click.option("--repository", default="", help="Optional owner/repo queue filter.")
 @click.option(
     "--command-template",
@@ -9820,6 +9842,7 @@ def every_code_start(
     host: str,
     workspace_root: Path,
     checkout_root: Path | None,
+    worktree_state_dir: Path | None,
     repository: str,
     command_template: str,
     tmux_binary: str,
@@ -9839,6 +9862,7 @@ def every_code_start(
         host=host.strip() or os.uname().nodename,
         workspace_root=workspace_root,
         checkout_root=checkout_root,
+        worktree_state_dir=worktree_state_dir,
         repository=repository,
         command_template=command_template,
         tmux_binary=tmux_binary,

--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -24,6 +24,7 @@ from control_plane.workflows.ship import utc_now_timestamp
 
 EveryCodeWorkerStatus = Literal["empty", "running", "blocked"]
 EveryCodeWorkerFinishStatus = Literal["done", "blocked"]
+TERMINAL_EVERY_CODE_STATES = {"done", "blocked"}
 
 
 class EveryCodeWorkerStore(Protocol):
@@ -314,6 +315,64 @@ class EveryCodeWorkerFinishResult:
 def every_code_tmux_session_name(request_id: str) -> str:
     normalized = re.sub(r"[^A-Za-z0-9_.:-]+", "-", request_id.strip()).strip("-._:")
     return f"every-code-{normalized or 'request'}"[:80]
+
+
+def every_code_session_state_path(*, state_dir: Path, request_id: str) -> Path:
+    normalized = re.sub(r"[^A-Za-z0-9_.:-]+", "-", request_id.strip()).strip("-._:")
+    return (
+        state_dir.expanduser().resolve()
+        / "every-code-worker"
+        / "sessions"
+        / f"{normalized or 'request'}.json"
+    )
+
+
+def write_every_code_session_state(
+    *,
+    state_dir: Path,
+    record: EveryCodeWorkRequestRecord,
+    session_name: str,
+    source_checkout_root: Path,
+    launch_root: Path,
+    worktree_branch: str,
+    host: str,
+) -> None:
+    path = every_code_session_state_path(state_dir=state_dir, request_id=record.request_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "request_id": record.request_id,
+        "session_name": session_name,
+        "source_checkout_root": str(source_checkout_root),
+        "launch_root": str(launch_root),
+        "worktree_branch": worktree_branch,
+        "host": host.strip(),
+        "created_at": utc_now_timestamp(),
+    }
+    path.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def read_every_code_session_state(path: Path) -> dict[str, str] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    result: dict[str, str] = {}
+    for key in (
+        "request_id",
+        "session_name",
+        "host",
+        "source_checkout_root",
+        "launch_root",
+        "worktree_branch",
+    ):
+        value = payload.get(key)
+        if isinstance(value, str):
+            result[key] = value
+    if not result.get("request_id") or not result.get("session_name"):
+        return None
+    return result
 
 
 def every_code_claim_comment_body(
@@ -664,6 +723,16 @@ def run_every_code_worker_once(
                 session_name=session_name,
                 checkout_root=prepared_checkout.source_checkout_root,
             )
+    if state_dir is not None:
+        write_every_code_session_state(
+            state_dir=state_dir,
+            record=claimed_record,
+            session_name=session_name,
+            source_checkout_root=prepared_checkout.source_checkout_root,
+            launch_root=resolved_checkout_root,
+            worktree_branch=prepared_checkout.worktree_branch,
+            host=normalized_host,
+        )
 
     claim_comment_warning = _post_every_code_claim_comment(
         record=claimed_record,
@@ -736,6 +805,13 @@ def run_every_code_worker_loop(
     )
     while max_iterations == 0 or iterations < max_iterations:
         iterations += 1
+        close_terminal_every_code_sessions(
+            record_store=record_store,
+            host=host,
+            state_dir=state_dir,
+            tmux_binary=tmux_binary,
+            runner=runner,
+        )
         last_result = run_every_code_worker_once(
             record_store=record_store,
             host=host,
@@ -776,6 +852,72 @@ def run_every_code_worker_loop(
         stopped_reason="stopped",
         last_result=last_result,
     )
+
+
+def close_terminal_every_code_sessions(
+    *,
+    record_store: EveryCodeWorkerStore,
+    host: str,
+    state_dir: Path | None,
+    tmux_binary: str = "tmux",
+    runner: Runner | None = None,
+) -> int:
+    if state_dir is None:
+        return 0
+    normalized_host = host.strip()
+    if not normalized_host:
+        raise ValueError("Every Code worker requires a host name")
+    sessions_dir = state_dir.expanduser().resolve() / "every-code-worker" / "sessions"
+    try:
+        session_state_paths = tuple(sessions_dir.glob("*.json"))
+    except OSError:
+        return 0
+
+    run = runner or _run_subprocess
+    closed = 0
+    for path in session_state_paths:
+        session_state = read_every_code_session_state(path)
+        if session_state is None:
+            continue
+        if session_state.get("host", normalized_host) != normalized_host:
+            continue
+        request_id = session_state["request_id"]
+        try:
+            record = record_store.read_every_code_work_request_record(request_id)
+        except Exception:
+            continue
+        if record.claimed_by_host.strip() != normalized_host:
+            continue
+        if record.state not in TERMINAL_EVERY_CODE_STATES:
+            continue
+
+        session_name = session_state["session_name"]
+        existing_session = _tmux_session_exists(
+            tmux_binary=tmux_binary,
+            session_name=session_name,
+            runner=run,
+        )
+        if existing_session is False:
+            path.unlink(missing_ok=True)
+            continue
+        if existing_session is None:
+            continue
+        pane_pid = _tmux_pane_pid(
+            tmux_binary=tmux_binary,
+            session_name=session_name,
+            runner=run,
+        )
+        if pane_pid is None:
+            continue
+        try:
+            os.killpg(pane_pid, signal.SIGTERM)
+        except ProcessLookupError:
+            path.unlink(missing_ok=True)
+            continue
+        except OSError:
+            continue
+        closed += 1
+    return closed
 
 
 def build_every_code_worker_daemon_spec(
@@ -957,6 +1099,17 @@ def finish_every_code_work_request(
     result_summary: str = "",
 ) -> EveryCodeWorkerFinishResult:
     record = record_store.read_every_code_work_request_record(request_id.strip())
+    if record.state in TERMINAL_EVERY_CODE_STATES:
+        return EveryCodeWorkerFinishResult(
+            status="done" if record.state == "done" else "blocked",
+            detail=record.result_summary
+            or record.error_message
+            or "Every Code request is already terminal.",
+            request_id=record.request_id,
+            repository=record.repository,
+            issue_number=record.issue_number,
+            result_pr_url=record.result_pr_url,
+        )
     succeeded = exit_code == 0
     summary = result_summary.strip() or (
         "Every Code session completed successfully."
@@ -1235,6 +1388,29 @@ def _tmux_session_exists(*, tmux_binary: str, session_name: str, runner: Runner)
     if result.returncode == 1:
         return False
     return None
+
+
+def _tmux_pane_pid(*, tmux_binary: str, session_name: str, runner: Runner) -> int | None:
+    try:
+        result = runner(
+            (
+                tmux_binary,
+                "display-message",
+                "-p",
+                "-t",
+                session_name,
+                "#{pane_pid}",
+            )
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        pane_pid = int(result.stdout.strip())
+    except ValueError:
+        return None
+    return pane_pid if pane_pid > 0 else None
 
 
 def _block_every_code_request(

--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -200,6 +200,8 @@ class EveryCodeWorkerHandoffResult:
     issue_number: int = 0
     session_name: str = ""
     checkout_root: str = ""
+    worktree_root: str = ""
+    worktree_branch: str = ""
 
     def as_payload(self) -> dict[str, object]:
         return {
@@ -210,6 +212,8 @@ class EveryCodeWorkerHandoffResult:
             "issue_number": self.issue_number,
             "session_name": self.session_name,
             "checkout_root": self.checkout_root,
+            "worktree_root": self.worktree_root,
+            "worktree_branch": self.worktree_branch,
         }
 
 
@@ -445,12 +449,82 @@ def resolve_every_code_checkout_root(
     return (workspace_root.expanduser() / repository_name).resolve()
 
 
+@dataclass(frozen=True)
+class EveryCodePreparedCheckout:
+    launch_root: Path
+    source_checkout_root: Path
+    worktree_branch: str = ""
+
+
+def every_code_worktree_root(
+    record: EveryCodeWorkRequestRecord,
+    *,
+    state_dir: Path,
+) -> Path:
+    repository_slug = _safe_path_component(record.repository.strip().replace("/", "-"))
+    request_slug = _safe_path_component(record.request_id)
+    return (
+        state_dir.expanduser().resolve()
+        / "every-code-worker"
+        / "worktrees"
+        / repository_slug
+        / request_slug
+    )
+
+
+def every_code_worktree_branch(record: EveryCodeWorkRequestRecord) -> str:
+    repository_slug = _safe_branch_component(record.repository.strip().replace("/", "-"))
+    request_slug = _safe_branch_component(record.request_id)
+    issue_part = str(record.issue_number) if record.issue_number > 0 else "request"
+    return f"every-code/{repository_slug}-{issue_part}-{request_slug}"[:180].rstrip("/.-")
+
+
+def prepare_every_code_checkout(
+    record: EveryCodeWorkRequestRecord,
+    *,
+    workspace_root: Path,
+    state_dir: Path | None,
+    checkout_root: Path | None = None,
+    runner: Runner | None = None,
+) -> EveryCodePreparedCheckout:
+    resolved_checkout_root = resolve_every_code_checkout_root(
+        record,
+        workspace_root=workspace_root,
+        checkout_root=checkout_root,
+    )
+    if checkout_root is not None or state_dir is None:
+        return EveryCodePreparedCheckout(
+            launch_root=resolved_checkout_root,
+            source_checkout_root=resolved_checkout_root,
+        )
+    if not resolved_checkout_root.is_dir():
+        return EveryCodePreparedCheckout(
+            launch_root=resolved_checkout_root,
+            source_checkout_root=resolved_checkout_root,
+        )
+    run = runner or _run_subprocess
+    worktree_root = every_code_worktree_root(record, state_dir=state_dir)
+    branch = every_code_worktree_branch(record)
+    _ensure_every_code_worktree(
+        source_checkout_root=resolved_checkout_root,
+        worktree_root=worktree_root,
+        branch=branch,
+        runner=run,
+    )
+    return EveryCodePreparedCheckout(
+        launch_root=worktree_root,
+        source_checkout_root=resolved_checkout_root,
+        worktree_branch=branch,
+    )
+
+
 def run_every_code_worker_once(
     *,
     record_store: EveryCodeWorkerStore,
     host: str,
     workspace_root: Path,
     checkout_root: Path | None = None,
+    worktree_state_dir: Path | None = None,
     repository: str = "",
     command_template: str = "",
     state_dir: Path | None = None,
@@ -488,23 +562,51 @@ def run_every_code_worker_once(
             issue_number=queued_record.issue_number,
         )
 
-    resolved_checkout_root = resolve_every_code_checkout_root(
-        claimed_record,
-        workspace_root=workspace_root,
-        checkout_root=checkout_root,
-    )
     session_name = every_code_tmux_session_name(claimed_record.request_id)
+    run = runner or _run_subprocess
+    resolved_worktree_state_dir = worktree_state_dir if worktree_state_dir is not None else state_dir
+    try:
+        prepared_checkout = prepare_every_code_checkout(
+            claimed_record,
+            workspace_root=workspace_root,
+            checkout_root=checkout_root,
+            state_dir=resolved_worktree_state_dir,
+            runner=run,
+        )
+    except RuntimeError as exc:
+        fallback_checkout_root = resolve_every_code_checkout_root(
+            claimed_record,
+            workspace_root=workspace_root,
+            checkout_root=checkout_root,
+        )
+        return _block_every_code_request(
+            record_store=record_store,
+            record=claimed_record,
+            host=normalized_host,
+            detail=str(exc),
+            session_name=session_name,
+            checkout_root=fallback_checkout_root,
+        )
+    resolved_checkout_root = prepared_checkout.launch_root
+    if not prepared_checkout.source_checkout_root.is_dir():
+        return _block_every_code_request(
+            record_store=record_store,
+            record=claimed_record,
+            host=normalized_host,
+            detail=f"Checkout root does not exist: {prepared_checkout.source_checkout_root}",
+            session_name=session_name,
+            checkout_root=prepared_checkout.source_checkout_root,
+        )
     if not resolved_checkout_root.is_dir():
         return _block_every_code_request(
             record_store=record_store,
             record=claimed_record,
             host=normalized_host,
-            detail=f"Checkout root does not exist: {resolved_checkout_root}",
+            detail=f"Every Code worktree root does not exist: {resolved_checkout_root}",
             session_name=session_name,
-            checkout_root=resolved_checkout_root,
+            checkout_root=prepared_checkout.source_checkout_root,
         )
 
-    run = runner or _run_subprocess
     existing_session = _tmux_session_exists(
         tmux_binary=tmux_binary,
         session_name=session_name,
@@ -517,7 +619,7 @@ def run_every_code_worker_once(
             host=normalized_host,
             detail=f"Could not inspect tmux session {session_name!r}.",
             session_name=session_name,
-            checkout_root=resolved_checkout_root,
+            checkout_root=prepared_checkout.source_checkout_root,
         )
     if not existing_session:
         command = render_every_code_command(claimed_record, command_template=command_template)
@@ -551,7 +653,7 @@ def run_every_code_worker_once(
                 host=normalized_host,
                 detail=f"Could not launch tmux session: {exc}",
                 session_name=session_name,
-                checkout_root=resolved_checkout_root,
+                checkout_root=prepared_checkout.source_checkout_root,
             )
         if launch_result.returncode != 0:
             return _block_every_code_request(
@@ -560,7 +662,7 @@ def run_every_code_worker_once(
                 host=normalized_host,
                 detail=f"tmux launch failed: {launch_result.stderr.strip()}",
                 session_name=session_name,
-                checkout_root=resolved_checkout_root,
+                checkout_root=prepared_checkout.source_checkout_root,
             )
 
     claim_comment_warning = _post_every_code_claim_comment(
@@ -579,6 +681,7 @@ def run_every_code_worker_once(
                 part
                 for part in (
                     f"Visible tmux session: {session_name}",
+                    f"Worktree: {resolved_checkout_root}",
                     claim_comment_warning,
                 )
                 if part
@@ -593,7 +696,9 @@ def run_every_code_worker_once(
         repository=running_record.repository,
         issue_number=running_record.issue_number,
         session_name=session_name,
-        checkout_root=str(resolved_checkout_root),
+        checkout_root=str(prepared_checkout.source_checkout_root),
+        worktree_root=str(resolved_checkout_root),
+        worktree_branch=prepared_checkout.worktree_branch,
     )
 
 
@@ -603,6 +708,7 @@ def run_every_code_worker_loop(
     host: str,
     workspace_root: Path,
     checkout_root: Path | None = None,
+    worktree_state_dir: Path | None = None,
     repository: str = "",
     command_template: str = "",
     state_dir: Path | None = None,
@@ -635,6 +741,7 @@ def run_every_code_worker_loop(
             host=host,
             workspace_root=workspace_root,
             checkout_root=checkout_root,
+            worktree_state_dir=worktree_state_dir,
             repository=repository,
             command_template=command_template,
             state_dir=state_dir,
@@ -680,6 +787,7 @@ def build_every_code_worker_daemon_spec(
     host: str = "",
     workspace_root: Path = Path.home() / "Developer",
     checkout_root: Path | None = None,
+    worktree_state_dir: Path | None = None,
     repository: str = "",
     command_template: str = "",
     tmux_binary: str = "tmux",
@@ -711,6 +819,10 @@ def build_every_code_worker_daemon_spec(
         command.extend(("--host", host.strip()))
     if checkout_root is not None:
         command.extend(("--checkout-root", str(checkout_root.expanduser().resolve())))
+    if worktree_state_dir is not None:
+        command.extend(
+            ("--worktree-state-dir", str(worktree_state_dir.expanduser().resolve()))
+        )
     if repository.strip():
         command.extend(("--repository", repository.strip()))
     if command_template.strip():
@@ -875,6 +987,141 @@ def finish_every_code_work_request(
 
 def _run_subprocess(args: Sequence[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(args, capture_output=True, check=False, text=True)
+
+
+def _ensure_every_code_worktree(
+    *,
+    source_checkout_root: Path,
+    worktree_root: Path,
+    branch: str,
+    runner: Runner,
+) -> None:
+    if not _is_git_checkout(source_checkout_root):
+        raise RuntimeError(f"Checkout root is not a git checkout: {source_checkout_root}")
+    if worktree_root.exists():
+        if not worktree_root.is_dir():
+            raise RuntimeError(f"Every Code worktree path is not a directory: {worktree_root}")
+        if not _is_git_checkout(worktree_root):
+            raise RuntimeError(
+                f"Existing Every Code worktree is not a git checkout: {worktree_root}"
+            )
+        actual_branch = _git_output(
+            ("git", "-C", str(worktree_root), "branch", "--show-current"),
+            runner=runner,
+            detail="inspect Every Code worktree branch",
+        )
+        if actual_branch != branch:
+            raise RuntimeError(
+                "Existing Every Code worktree uses unexpected branch "
+                f"{actual_branch!r}; expected {branch!r}: {worktree_root}"
+            )
+        return
+
+    worktree_root.parent.mkdir(parents=True, exist_ok=True)
+    if _git_branch_exists(source_checkout_root, branch=branch, runner=runner):
+        _git_checked(
+            (
+                "git",
+                "-C",
+                str(source_checkout_root),
+                "worktree",
+                "add",
+                str(worktree_root),
+                branch,
+            ),
+            runner=runner,
+            detail="create Every Code worktree from existing branch",
+        )
+    else:
+        default_branch = _git_default_branch(source_checkout_root, runner=runner)
+        _git_checked(
+            ("git", "-C", str(source_checkout_root), "fetch", "--quiet", "origin", default_branch),
+            runner=runner,
+            detail="fetch default branch before creating Every Code worktree",
+        )
+        _git_checked(
+            (
+                "git",
+                "-C",
+                str(source_checkout_root),
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                str(worktree_root),
+                f"origin/{default_branch}",
+            ),
+            runner=runner,
+            detail="create Every Code worktree",
+        )
+
+
+def _git_default_branch(source_checkout_root: Path, *, runner: Runner) -> str:
+    origin_head = _git_output(
+        ("git", "-C", str(source_checkout_root), "symbolic-ref", "--short", "refs/remotes/origin/HEAD"),
+        runner=runner,
+        detail="inspect origin default branch",
+    )
+    if origin_head.startswith("origin/"):
+        return origin_head.removeprefix("origin/")
+    if origin_head:
+        return origin_head
+    raise RuntimeError(f"Could not determine default branch for {source_checkout_root}")
+
+
+def _git_branch_exists(source_checkout_root: Path, *, branch: str, runner: Runner) -> bool:
+    try:
+        result = runner(
+            (
+                "git",
+                "-C",
+                str(source_checkout_root),
+                "show-ref",
+                "--verify",
+                "--quiet",
+                f"refs/heads/{branch}",
+            )
+        )
+    except OSError as exc:
+        raise RuntimeError(f"Could not inspect Every Code worktree branch: {exc}") from exc
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    message = result.stderr.strip() or result.stdout.strip() or "git show-ref failed"
+    raise RuntimeError(f"Could not inspect Every Code worktree branch: {message}")
+
+
+def _git_output(args: Sequence[str], *, runner: Runner, detail: str) -> str:
+    result = _git_checked(args, runner=runner, detail=detail)
+    return result.stdout.strip()
+
+
+def _git_checked(
+    args: Sequence[str], *, runner: Runner, detail: str
+) -> subprocess.CompletedProcess[str]:
+    try:
+        result = runner(args)
+    except OSError as exc:
+        raise RuntimeError(f"Could not {detail}: {exc}") from exc
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or f"{args[0]} failed"
+        raise RuntimeError(f"Could not {detail}: {message}")
+    return result
+
+
+def _is_git_checkout(path: Path) -> bool:
+    return (path / ".git").exists()
+
+
+def _safe_path_component(value: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip()).strip("-._")
+    return normalized or "request"
+
+
+def _safe_branch_component(value: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip()).strip("-._")
+    return normalized or "request"
 
 
 def _launch_daemon_process(

--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -368,6 +368,10 @@ def default_every_code_command(record: EveryCodeWorkRequestRecord) -> str:
     prompt = (
         f"Work on {record.repository} issue #{record.issue_number}: {record.issue_title}. "
         f"Issue URL: {record.issue_url}. Launchplane request: {record.request_id}. "
+        "Before changing files, read the issue body and every issue comment. "
+        "Treat newer comments as potentially more current than the original body. "
+        "Inspect linked references and any available images or attachments before deciding what to change. "
+        "You are already running inside the isolated Every Code worktree and branch for this request. "
         "Open a pull request for the change. If the PR fully resolves the issue, "
         f"include `Closes #{record.issue_number}` or `Fixes #{record.issue_number}` "
         "in the PR body so GitHub closes the issue when the PR merges. Use "

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -17,8 +17,10 @@ from control_plane.every_code_worker import (
     EveryCodeWorkerApiStore,
     build_every_code_worker_daemon_spec,
     build_every_code_session_command,
+    close_terminal_every_code_sessions,
     default_every_code_command,
     every_code_claim_comment_body,
+    every_code_session_state_path,
     every_code_tmux_session_name,
     every_code_worktree_branch,
     every_code_worktree_root,
@@ -80,8 +82,20 @@ class _Runner:
             if self.fail_issue_comment:
                 return subprocess.CompletedProcess(args, 1, "", "rate limited")
             return subprocess.CompletedProcess(args, 0, "", "")
+        if args[1] == "display-message":
+            return subprocess.CompletedProcess(args, 0, "4242\n", "")
         if args[1] == "has-session":
             return subprocess.CompletedProcess(args, 1, "", "no session")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+
+class _ExistingSessionRunner(_Runner):
+    def __call__(self, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        self.calls.append(tuple(args))
+        if args[1] == "has-session":
+            return subprocess.CompletedProcess(args, 0, "", "")
+        if args[1] == "display-message":
+            return subprocess.CompletedProcess(args, 0, "4242\n", "")
         return subprocess.CompletedProcess(args, 0, "", "")
 
 
@@ -381,7 +395,21 @@ class EveryCodeWorkerTests(unittest.TestCase):
                 runner=runner,
             )
             record = store.read_every_code_work_request_record("every-code-cbusillo-code-123-test")
+            state_path = every_code_session_state_path(
+                state_dir=temporary_root / "state",
+                request_id="every-code-cbusillo-code-123-test",
+            )
+            self.assertTrue(state_path.exists())
+            session_payload = json.loads(state_path.read_text(encoding="utf-8"))
 
+        self.assertEqual(session_payload["request_id"], "every-code-cbusillo-code-123-test")
+        self.assertEqual(session_payload["host"], "Chris-Studio")
+        self.assertEqual(session_payload["source_checkout_root"], str(checkout_root.resolve()))
+        self.assertEqual(
+            session_payload["launch_root"],
+            str(every_code_worktree_root(_queued_record(), state_dir=temporary_root / "state")),
+        )
+        self.assertEqual(session_payload["worktree_branch"], every_code_worktree_branch(_queued_record()))
         self.assertEqual(result.status, "running")
         self.assertEqual(record.state, "running")
         self.assertEqual(record.claimed_by_host, "Chris-Studio")
@@ -398,6 +426,87 @@ class EveryCodeWorkerTests(unittest.TestCase):
         )
         self.assertIn("every-code finish", launch_call[-1])
         self.assertTrue(any(call[:3] == ("gh", "issue", "comment") for call in runner.calls))
+
+    def test_terminal_host_request_sends_sigterm_to_session_process_group(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "state",
+                runner=_Runner(),
+            )
+            record = store.read_every_code_work_request_record(
+                "every-code-cbusillo-code-123-test"
+            ).model_copy(
+                update={
+                    "state": "done",
+                    "finished_at": "2026-05-06T00:02:00Z",
+                    "updated_at": "2026-05-06T00:02:00Z",
+                    "result_summary": "Linked pull request merged.",
+                }
+            )
+            store.write_every_code_work_request_record(record)
+            runner = _ExistingSessionRunner()
+
+            with patch("control_plane.every_code_worker.os.killpg") as killpg:
+                closed = close_terminal_every_code_sessions(
+                    record_store=store,
+                    host="Chris-Studio",
+                    state_dir=temporary_root / "state",
+                    runner=runner,
+                )
+
+        self.assertEqual(closed, 1)
+        killpg.assert_called_once_with(4242, signal.SIGTERM)
+        self.assertEqual(runner.calls[0][1], "has-session")
+        self.assertEqual(runner.calls[1][1], "display-message")
+
+    def test_terminal_request_claimed_by_other_host_is_ignored(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "state",
+                runner=_Runner(),
+            )
+            record = store.read_every_code_work_request_record(
+                "every-code-cbusillo-code-123-test"
+            ).model_copy(
+                update={
+                    "state": "done",
+                    "claimed_by_host": "Other-Mac",
+                    "finished_at": "2026-05-06T00:02:00Z",
+                    "updated_at": "2026-05-06T00:02:00Z",
+                    "result_summary": "Linked pull request merged.",
+                }
+            )
+            store.write_every_code_work_request_record(record)
+            runner = _ExistingSessionRunner()
+
+            with patch("control_plane.every_code_worker.os.killpg") as killpg:
+                closed = close_terminal_every_code_sessions(
+                    record_store=store,
+                    host="Chris-Studio",
+                    state_dir=temporary_root / "state",
+                    runner=runner,
+                )
+
+        self.assertEqual(closed, 0)
+        killpg.assert_not_called()
 
     def test_run_once_still_launches_tmux_when_claim_comment_fails(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -482,6 +591,43 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(result.status, "blocked")
         self.assertEqual(record.state, "blocked")
         self.assertIn("exited with status 7", record.error_message)
+
+    def test_finish_is_idempotent_when_request_already_terminal(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "state",
+                runner=_Runner(),
+            )
+            record = store.read_every_code_work_request_record(
+                "every-code-cbusillo-code-123-test"
+            ).model_copy(
+                update={
+                    "state": "done",
+                    "finished_at": "2026-05-06T00:02:00Z",
+                    "updated_at": "2026-05-06T00:02:00Z",
+                    "result_summary": "Linked pull request merged.",
+                }
+            )
+            store.write_every_code_work_request_record(record)
+
+            result = finish_every_code_work_request(
+                record_store=store,
+                request_id="every-code-cbusillo-code-123-test",
+                host="Chris-Studio",
+                exit_code=0,
+            )
+
+        self.assertEqual(result.status, "done")
+        self.assertEqual(result.detail, "Linked pull request merged.")
 
     def test_run_once_marks_missing_checkout_blocked(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -20,8 +20,11 @@ from control_plane.every_code_worker import (
     default_every_code_command,
     every_code_claim_comment_body,
     every_code_tmux_session_name,
+    every_code_worktree_branch,
+    every_code_worktree_root,
     every_code_worker_daemon_status,
     finish_every_code_work_request,
+    prepare_every_code_checkout,
     run_every_code_worker_loop,
     run_every_code_worker_once,
     start_every_code_worker_daemon,
@@ -48,12 +51,31 @@ def _queued_record() -> EveryCodeWorkRequestRecord:
 
 
 class _Runner:
-    def __init__(self, *, fail_issue_comment: bool = False) -> None:
+    def __init__(self, *, fail_issue_comment: bool = False, existing_branch: bool = False) -> None:
         self.calls: list[tuple[str, ...]] = []
         self.fail_issue_comment = fail_issue_comment
+        self.existing_branch = existing_branch
 
     def __call__(self, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
         self.calls.append(tuple(args))
+        if args[0] == "git" and args[3:6] == ("symbolic-ref", "--short", "refs/remotes/origin/HEAD"):
+            return subprocess.CompletedProcess(args, 0, "origin/main\n", "")
+        if args[0] == "git" and args[3:6] == ("show-ref", "--verify", "--quiet"):
+            return subprocess.CompletedProcess(args, 0 if self.existing_branch else 1, "", "")
+        if args[0] == "git" and args[3:5] == ("branch", "--show-current"):
+            return subprocess.CompletedProcess(args, 0, every_code_worktree_branch(_queued_record()) + "\n", "")
+        if args[0] == "git" and args[3:6] == ("worktree", "add", "-b"):
+            worktree_root = Path(args[7])
+            worktree_root.mkdir(parents=True, exist_ok=True)
+            (worktree_root / ".git").write_text("gitdir: test\n", encoding="utf-8")
+            return subprocess.CompletedProcess(args, 0, "", "")
+        if args[0] == "git" and args[3:5] == ("worktree", "add"):
+            worktree_root = Path(args[5])
+            worktree_root.mkdir(parents=True, exist_ok=True)
+            (worktree_root / ".git").write_text("gitdir: test\n", encoding="utf-8")
+            return subprocess.CompletedProcess(args, 0, "", "")
+        if args[0] == "git":
+            return subprocess.CompletedProcess(args, 0, "", "")
         if args[:3] == ("gh", "issue", "comment"):
             if self.fail_issue_comment:
                 return subprocess.CompletedProcess(args, 1, "", "rate limited")
@@ -218,6 +240,25 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertIn("`every-code-test`", body)
         self.assertIn("`every-code-cbusillo-code-123-test`", body)
 
+    def test_worktree_path_and_branch_are_deterministic(self) -> None:
+        record = _queued_record()
+        root = every_code_worktree_root(record, state_dir=Path("state"))
+        branch = every_code_worktree_branch(record)
+
+        self.assertEqual(
+            root,
+            Path("state")
+            .resolve()
+            / "every-code-worker"
+            / "worktrees"
+            / "cbusillo-code"
+            / "every-code-cbusillo-code-123-test",
+        )
+        self.assertEqual(
+            branch,
+            "every-code/cbusillo-code-123-every-code-cbusillo-code-123-test",
+        )
+
     def test_session_command_reports_terminal_status(self) -> None:
         command = build_every_code_session_command(
             record=_queued_record(),
@@ -234,11 +275,100 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertIn("--request-id every-code-cbusillo-code-123-test", command)
         self.assertIn("--exit-code $status", command)
 
+    def test_prepare_checkout_creates_worker_owned_worktree(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            state_dir = temporary_root / "state"
+            runner = _Runner()
+
+            prepared = prepare_every_code_checkout(
+                _queued_record(),
+                workspace_root=temporary_root / "Developer",
+                state_dir=state_dir,
+                runner=runner,
+            )
+
+        self.assertEqual(prepared.source_checkout_root, checkout_root.resolve())
+        self.assertEqual(
+            prepared.launch_root,
+            every_code_worktree_root(_queued_record(), state_dir=state_dir),
+        )
+        self.assertEqual(prepared.worktree_branch, every_code_worktree_branch(_queued_record()))
+        self.assertIn(("git", "-C", str(checkout_root.resolve()), "fetch", "--quiet", "origin", "main"), runner.calls)
+        self.assertTrue(any(call[3:6] == ("worktree", "add", "-b") for call in runner.calls))
+
+    def test_prepare_checkout_reuses_matching_worker_worktree(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            state_dir = temporary_root / "state"
+            worktree_root = every_code_worktree_root(_queued_record(), state_dir=state_dir)
+            worktree_root.mkdir(parents=True)
+            (worktree_root / ".git").write_text("gitdir: test\n", encoding="utf-8")
+            runner = _Runner()
+
+            prepared = prepare_every_code_checkout(
+                _queued_record(),
+                workspace_root=temporary_root / "Developer",
+                state_dir=state_dir,
+                runner=runner,
+            )
+
+        self.assertEqual(prepared.launch_root, worktree_root)
+        self.assertFalse(any(call[3:6] == ("worktree", "add", "-b") for call in runner.calls))
+
+    def test_prepare_checkout_reuses_existing_request_branch(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            state_dir = temporary_root / "state"
+            runner = _Runner(existing_branch=True)
+
+            prepared = prepare_every_code_checkout(
+                _queued_record(),
+                workspace_root=temporary_root / "Developer",
+                state_dir=state_dir,
+                runner=runner,
+            )
+
+        self.assertEqual(
+            prepared.launch_root,
+            every_code_worktree_root(_queued_record(), state_dir=state_dir),
+        )
+        self.assertFalse(any(call[3] == "fetch" for call in runner.calls))
+        self.assertTrue(any(call[3:5] == ("worktree", "add") for call in runner.calls))
+        self.assertFalse(any(call[3:6] == ("worktree", "add", "-b") for call in runner.calls))
+
+    def test_prepare_checkout_rejects_existing_non_git_worktree(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            state_dir = temporary_root / "state"
+            every_code_worktree_root(_queued_record(), state_dir=state_dir).mkdir(parents=True)
+
+            with self.assertRaisesRegex(RuntimeError, "not a git checkout"):
+                prepare_every_code_checkout(
+                    _queued_record(),
+                    workspace_root=temporary_root / "Developer",
+                    state_dir=state_dir,
+                    runner=_Runner(),
+                )
+
     def test_run_once_claims_request_and_launches_tmux_session(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             temporary_root = Path(temporary_directory_name)
             checkout_root = temporary_root / "Developer" / "code"
             checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
             store = FilesystemRecordStore(state_dir=temporary_root / "state")
             store.write_every_code_work_request_record(_queued_record())
             runner = _Runner()
@@ -256,16 +386,25 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(record.state, "running")
         self.assertEqual(record.claimed_by_host, "Chris-Studio")
         self.assertEqual(result.checkout_root, str(checkout_root.resolve()))
-        self.assertEqual(runner.calls[0][1], "has-session")
-        self.assertEqual(runner.calls[1][1], "new-session")
-        self.assertIn("every-code finish", runner.calls[1][-1])
-        self.assertEqual(runner.calls[2][:3], ("gh", "issue", "comment"))
+        self.assertEqual(
+            result.worktree_root,
+            str(every_code_worktree_root(_queued_record(), state_dir=temporary_root / "state")),
+        )
+        self.assertEqual(result.worktree_branch, every_code_worktree_branch(_queued_record()))
+        launch_call = next(call for call in runner.calls if call[1] == "new-session")
+        self.assertEqual(
+            launch_call[6],
+            str(every_code_worktree_root(_queued_record(), state_dir=temporary_root / "state")),
+        )
+        self.assertIn("every-code finish", launch_call[-1])
+        self.assertTrue(any(call[:3] == ("gh", "issue", "comment") for call in runner.calls))
 
     def test_run_once_still_launches_tmux_when_claim_comment_fails(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             temporary_root = Path(temporary_directory_name)
             checkout_root = temporary_root / "Developer" / "code"
             checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
             store = FilesystemRecordStore(state_dir=temporary_root / "state")
             store.write_every_code_work_request_record(_queued_record())
             runner = _Runner(fail_issue_comment=True)
@@ -283,14 +422,15 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(record.state, "running")
         self.assertIn("Visible tmux session", record.result_summary)
         self.assertIn("Could not post GitHub working comment", record.result_summary)
-        self.assertEqual(runner.calls[1][1], "new-session")
-        self.assertEqual(runner.calls[2][:3], ("gh", "issue", "comment"))
+        self.assertTrue(any(call[1] == "new-session" for call in runner.calls))
+        self.assertTrue(any(call[:3] == ("gh", "issue", "comment") for call in runner.calls))
 
     def test_finish_marks_running_request_done(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             temporary_root = Path(temporary_directory_name)
             checkout_root = temporary_root / "Developer" / "code"
             checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
             store = FilesystemRecordStore(state_dir=temporary_root / "state")
             store.write_every_code_work_request_record(_queued_record())
             run_every_code_worker_once(
@@ -320,6 +460,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
             temporary_root = Path(temporary_directory_name)
             checkout_root = temporary_root / "Developer" / "code"
             checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
             store = FilesystemRecordStore(state_dir=temporary_root / "state")
             store.write_every_code_work_request_record(_queued_record())
             run_every_code_worker_once(
@@ -379,6 +520,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
             temporary_root = Path(temporary_directory_name)
             checkout_root = temporary_root / "Developer" / "code"
             checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
             store = FilesystemRecordStore(state_dir=temporary_root / "state")
             store.write_every_code_work_request_record(_queued_record())
             runner = _Runner()
@@ -472,6 +614,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
                 service_url="https://launchplane.example",
                 host="Chris-Studio",
                 workspace_root=temporary_root / "Developer",
+                worktree_state_dir=temporary_root / "worktrees",
                 repository="cbusillo/code",
                 interval_seconds=15,
             )
@@ -483,6 +626,8 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertIn("postgres://example", spec.command)
         self.assertIn("--service-url", spec.command)
         self.assertIn("https://launchplane.example", spec.command)
+        self.assertIn("--worktree-state-dir", spec.command)
+        self.assertIn(str((temporary_root / "worktrees").resolve()), spec.command)
         self.assertIn("cbusillo/code", spec.command)
 
     def test_start_daemon_writes_pid_file_and_log_path(self) -> None:
@@ -682,6 +827,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
             temporary_root = Path(temporary_directory_name)
             checkout_root = temporary_root / "Developer" / "code"
             checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
             store = FilesystemRecordStore(state_dir=temporary_root / "state")
             store.write_every_code_work_request_record(_queued_record())
             run_every_code_worker_once(

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -223,6 +223,10 @@ class EveryCodeWorkerTests(unittest.TestCase):
 
         self.assertIn("https://github.com/cbusillo/code/issues/123", command)
         self.assertIn("every-code-cbusillo-code-123-test", command)
+        self.assertIn("read the issue body and every issue comment", command)
+        self.assertIn("newer comments", command)
+        self.assertIn("images or attachments", command)
+        self.assertIn("isolated Every Code worktree", command)
         self.assertIn("Closes #123", command)
         self.assertIn("Use `Refs` only", command)
         self.assertIn("let the session exit", command)


### PR DESCRIPTION
## Summary
- create deterministic worker-owned git worktrees for claimed Every Code requests
- launch tmux/Code from the isolated worktree while reporting the source checkout and branch
- add CLI plumbing for an optional worktree state directory and tests for create/reuse/fail-closed paths

Refs #328

## Validation
- uv run python -m unittest tests.test_every_code_worker
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest