### PR TITLE
feat(every-code): read full issue context before acting

### DIFF
--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -368,6 +368,10 @@ def default_every_code_command(record: EveryCodeWorkRequestRecord) -> str:
     prompt = (
         f"Work on {record.repository} issue #{record.issue_number}: {record.issue_title}. "
         f"Issue URL: {record.issue_url}. Launchplane request: {record.request_id}. "
+        "Before changing files, read the issue body and every issue comment. "
+        "Treat newer comments as potentially more current than the original body. "
+        "Inspect linked references and any available images or attachments before deciding what to change. "
+        "You are already running inside the isolated Every Code worktree and branch for this request. "
         "Open a pull request for the change. If the PR fully resolves the issue, "
         f"include `Closes #{record.issue_number}` or `Fixes #{record.issue_number}` "
         "in the PR body so GitHub closes the issue when the PR merges. Use "

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -223,6 +223,10 @@ class EveryCodeWorkerTests(unittest.TestCase):
 
         self.assertIn("https://github.com/cbusillo/code/issues/123", command)
         self.assertIn("every-code-cbusillo-code-123-test", command)
+        self.assertIn("read the issue body and every issue comment", command)
+        self.assertIn("newer comments", command)
+        self.assertIn("images or attachments", command)
+        self.assertIn("isolated Every Code worktree", command)
         self.assertIn("Closes #123", command)
         self.assertIn("Use `Refs` only", command)
         self.assertIn("let the session exit", command)


### PR DESCRIPTION
## Summary
- tell Every Code sessions to read the issue body and all comments before changing files
- call out newer comments, linked references, images, and attachments as part of the intake
- clarify that the session is already running in the isolated Every Code worktree/branch

Refs #329
Stacked on #336.

## Validation
- uv run python -m unittest tests.test_every_code_worker
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest