### PR TITLE
feat(every-code): close terminal local sessions

### DIFF
--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -24,6 +24,7 @@ from control_plane.workflows.ship import utc_now_timestamp
 
 EveryCodeWorkerStatus = Literal["empty", "running", "blocked"]
 EveryCodeWorkerFinishStatus = Literal["done", "blocked"]
+TERMINAL_EVERY_CODE_STATES = {"done", "blocked"}
 
 
 class EveryCodeWorkerStore(Protocol):
@@ -314,6 +315,64 @@ class EveryCodeWorkerFinishResult:
 def every_code_tmux_session_name(request_id: str) -> str:
     normalized = re.sub(r"[^A-Za-z0-9_.:-]+", "-", request_id.strip()).strip("-._:")
     return f"every-code-{normalized or 'request'}"[:80]
+
+
+def every_code_session_state_path(*, state_dir: Path, request_id: str) -> Path:
+    normalized = re.sub(r"[^A-Za-z0-9_.:-]+", "-", request_id.strip()).strip("-._:")
+    return (
+        state_dir.expanduser().resolve()
+        / "every-code-worker"
+        / "sessions"
+        / f"{normalized or 'request'}.json"
+    )
+
+
+def write_every_code_session_state(
+    *,
+    state_dir: Path,
+    record: EveryCodeWorkRequestRecord,
+    session_name: str,
+    source_checkout_root: Path,
+    launch_root: Path,
+    worktree_branch: str,
+    host: str,
+) -> None:
+    path = every_code_session_state_path(state_dir=state_dir, request_id=record.request_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "request_id": record.request_id,
+        "session_name": session_name,
+        "source_checkout_root": str(source_checkout_root),
+        "launch_root": str(launch_root),
+        "worktree_branch": worktree_branch,
+        "host": host.strip(),
+        "created_at": utc_now_timestamp(),
+    }
+    path.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def read_every_code_session_state(path: Path) -> dict[str, str] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    result: dict[str, str] = {}
+    for key in (
+        "request_id",
+        "session_name",
+        "host",
+        "source_checkout_root",
+        "launch_root",
+        "worktree_branch",
+    ):
+        value = payload.get(key)
+        if isinstance(value, str):
+            result[key] = value
+    if not result.get("request_id") or not result.get("session_name"):
+        return None
+    return result
 
 
 def every_code_claim_comment_body(
@@ -664,6 +723,16 @@ def run_every_code_worker_once(
                 session_name=session_name,
                 checkout_root=prepared_checkout.source_checkout_root,
             )
+    if state_dir is not None:
+        write_every_code_session_state(
+            state_dir=state_dir,
+            record=claimed_record,
+            session_name=session_name,
+            source_checkout_root=prepared_checkout.source_checkout_root,
+            launch_root=resolved_checkout_root,
+            worktree_branch=prepared_checkout.worktree_branch,
+            host=normalized_host,
+        )
 
     claim_comment_warning = _post_every_code_claim_comment(
         record=claimed_record,
@@ -736,6 +805,13 @@ def run_every_code_worker_loop(
     )
     while max_iterations == 0 or iterations < max_iterations:
         iterations += 1
+        close_terminal_every_code_sessions(
+            record_store=record_store,
+            host=host,
+            state_dir=state_dir,
+            tmux_binary=tmux_binary,
+            runner=runner,
+        )
         last_result = run_every_code_worker_once(
             record_store=record_store,
             host=host,
@@ -776,6 +852,72 @@ def run_every_code_worker_loop(
         stopped_reason="stopped",
         last_result=last_result,
     )
+
+
+def close_terminal_every_code_sessions(
+    *,
+    record_store: EveryCodeWorkerStore,
+    host: str,
+    state_dir: Path | None,
+    tmux_binary: str = "tmux",
+    runner: Runner | None = None,
+) -> int:
+    if state_dir is None:
+        return 0
+    normalized_host = host.strip()
+    if not normalized_host:
+        raise ValueError("Every Code worker requires a host name")
+    sessions_dir = state_dir.expanduser().resolve() / "every-code-worker" / "sessions"
+    try:
+        session_state_paths = tuple(sessions_dir.glob("*.json"))
+    except OSError:
+        return 0
+
+    run = runner or _run_subprocess
+    closed = 0
+    for path in session_state_paths:
+        session_state = read_every_code_session_state(path)
+        if session_state is None:
+            continue
+        if session_state.get("host", normalized_host) != normalized_host:
+            continue
+        request_id = session_state["request_id"]
+        try:
+            record = record_store.read_every_code_work_request_record(request_id)
+        except Exception:
+            continue
+        if record.claimed_by_host.strip() != normalized_host:
+            continue
+        if record.state not in TERMINAL_EVERY_CODE_STATES:
+            continue
+
+        session_name = session_state["session_name"]
+        existing_session = _tmux_session_exists(
+            tmux_binary=tmux_binary,
+            session_name=session_name,
+            runner=run,
+        )
+        if existing_session is False:
+            path.unlink(missing_ok=True)
+            continue
+        if existing_session is None:
+            continue
+        pane_pid = _tmux_pane_pid(
+            tmux_binary=tmux_binary,
+            session_name=session_name,
+            runner=run,
+        )
+        if pane_pid is None:
+            continue
+        try:
+            os.killpg(pane_pid, signal.SIGTERM)
+        except ProcessLookupError:
+            path.unlink(missing_ok=True)
+            continue
+        except OSError:
+            continue
+        closed += 1
+    return closed
 
 
 def build_every_code_worker_daemon_spec(
@@ -957,6 +1099,17 @@ def finish_every_code_work_request(
     result_summary: str = "",
 ) -> EveryCodeWorkerFinishResult:
     record = record_store.read_every_code_work_request_record(request_id.strip())
+    if record.state in TERMINAL_EVERY_CODE_STATES:
+        return EveryCodeWorkerFinishResult(
+            status="done" if record.state == "done" else "blocked",
+            detail=record.result_summary
+            or record.error_message
+            or "Every Code request is already terminal.",
+            request_id=record.request_id,
+            repository=record.repository,
+            issue_number=record.issue_number,
+            result_pr_url=record.result_pr_url,
+        )
     succeeded = exit_code == 0
     summary = result_summary.strip() or (
         "Every Code session completed successfully."
@@ -1235,6 +1388,29 @@ def _tmux_session_exists(*, tmux_binary: str, session_name: str, runner: Runner)
     if result.returncode == 1:
         return False
     return None
+
+
+def _tmux_pane_pid(*, tmux_binary: str, session_name: str, runner: Runner) -> int | None:
+    try:
+        result = runner(
+            (
+                tmux_binary,
+                "display-message",
+                "-p",
+                "-t",
+                session_name,
+                "#{pane_pid}",
+            )
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        pane_pid = int(result.stdout.strip())
+    except ValueError:
+        return None
+    return pane_pid if pane_pid > 0 else None
 
 
 def _block_every_code_request(

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -17,8 +17,10 @@ from control_plane.every_code_worker import (
     EveryCodeWorkerApiStore,
     build_every_code_worker_daemon_spec,
     build_every_code_session_command,
+    close_terminal_every_code_sessions,
     default_every_code_command,
     every_code_claim_comment_body,
+    every_code_session_state_path,
     every_code_tmux_session_name,
     every_code_worktree_branch,
     every_code_worktree_root,
@@ -80,8 +82,20 @@ class _Runner:
             if self.fail_issue_comment:
                 return subprocess.CompletedProcess(args, 1, "", "rate limited")
             return subprocess.CompletedProcess(args, 0, "", "")
+        if args[1] == "display-message":
+            return subprocess.CompletedProcess(args, 0, "4242\n", "")
         if args[1] == "has-session":
             return subprocess.CompletedProcess(args, 1, "", "no session")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+
+class _ExistingSessionRunner(_Runner):
+    def __call__(self, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        self.calls.append(tuple(args))
+        if args[1] == "has-session":
+            return subprocess.CompletedProcess(args, 0, "", "")
+        if args[1] == "display-message":
+            return subprocess.CompletedProcess(args, 0, "4242\n", "")
         return subprocess.CompletedProcess(args, 0, "", "")
 
 
@@ -381,7 +395,21 @@ class EveryCodeWorkerTests(unittest.TestCase):
                 runner=runner,
             )
             record = store.read_every_code_work_request_record("every-code-cbusillo-code-123-test")
+            state_path = every_code_session_state_path(
+                state_dir=temporary_root / "state",
+                request_id="every-code-cbusillo-code-123-test",
+            )
+            self.assertTrue(state_path.exists())
+            session_payload = json.loads(state_path.read_text(encoding="utf-8"))
 
+        self.assertEqual(session_payload["request_id"], "every-code-cbusillo-code-123-test")
+        self.assertEqual(session_payload["host"], "Chris-Studio")
+        self.assertEqual(session_payload["source_checkout_root"], str(checkout_root.resolve()))
+        self.assertEqual(
+            session_payload["launch_root"],
+            str(every_code_worktree_root(_queued_record(), state_dir=temporary_root / "state")),
+        )
+        self.assertEqual(session_payload["worktree_branch"], every_code_worktree_branch(_queued_record()))
         self.assertEqual(result.status, "running")
         self.assertEqual(record.state, "running")
         self.assertEqual(record.claimed_by_host, "Chris-Studio")
@@ -398,6 +426,87 @@ class EveryCodeWorkerTests(unittest.TestCase):
         )
         self.assertIn("every-code finish", launch_call[-1])
         self.assertTrue(any(call[:3] == ("gh", "issue", "comment") for call in runner.calls))
+
+    def test_terminal_host_request_sends_sigterm_to_session_process_group(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "state",
+                runner=_Runner(),
+            )
+            record = store.read_every_code_work_request_record(
+                "every-code-cbusillo-code-123-test"
+            ).model_copy(
+                update={
+                    "state": "done",
+                    "finished_at": "2026-05-06T00:02:00Z",
+                    "updated_at": "2026-05-06T00:02:00Z",
+                    "result_summary": "Linked pull request merged.",
+                }
+            )
+            store.write_every_code_work_request_record(record)
+            runner = _ExistingSessionRunner()
+
+            with patch("control_plane.every_code_worker.os.killpg") as killpg:
+                closed = close_terminal_every_code_sessions(
+                    record_store=store,
+                    host="Chris-Studio",
+                    state_dir=temporary_root / "state",
+                    runner=runner,
+                )
+
+        self.assertEqual(closed, 1)
+        killpg.assert_called_once_with(4242, signal.SIGTERM)
+        self.assertEqual(runner.calls[0][1], "has-session")
+        self.assertEqual(runner.calls[1][1], "display-message")
+
+    def test_terminal_request_claimed_by_other_host_is_ignored(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "state",
+                runner=_Runner(),
+            )
+            record = store.read_every_code_work_request_record(
+                "every-code-cbusillo-code-123-test"
+            ).model_copy(
+                update={
+                    "state": "done",
+                    "claimed_by_host": "Other-Mac",
+                    "finished_at": "2026-05-06T00:02:00Z",
+                    "updated_at": "2026-05-06T00:02:00Z",
+                    "result_summary": "Linked pull request merged.",
+                }
+            )
+            store.write_every_code_work_request_record(record)
+            runner = _ExistingSessionRunner()
+
+            with patch("control_plane.every_code_worker.os.killpg") as killpg:
+                closed = close_terminal_every_code_sessions(
+                    record_store=store,
+                    host="Chris-Studio",
+                    state_dir=temporary_root / "state",
+                    runner=runner,
+                )
+
+        self.assertEqual(closed, 0)
+        killpg.assert_not_called()
 
     def test_run_once_still_launches_tmux_when_claim_comment_fails(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -482,6 +591,43 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(result.status, "blocked")
         self.assertEqual(record.state, "blocked")
         self.assertIn("exited with status 7", record.error_message)
+
+    def test_finish_is_idempotent_when_request_already_terminal(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "state",
+                runner=_Runner(),
+            )
+            record = store.read_every_code_work_request_record(
+                "every-code-cbusillo-code-123-test"
+            ).model_copy(
+                update={
+                    "state": "done",
+                    "finished_at": "2026-05-06T00:02:00Z",
+                    "updated_at": "2026-05-06T00:02:00Z",
+                    "result_summary": "Linked pull request merged.",
+                }
+            )
+            store.write_every_code_work_request_record(record)
+
+            result = finish_every_code_work_request(
+                record_store=store,
+                request_id="every-code-cbusillo-code-123-test",
+                host="Chris-Studio",
+                exit_code=0,
+            )
+
+        self.assertEqual(result.status, "done")
+        self.assertEqual(result.detail, "Linked pull request merged.")
 
     def test_run_once_marks_missing_checkout_blocked(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- write local Every Code session markers when a worker launches tmux
- poll terminal work requests and SIGTERM the matching local tmux pane process group
- make `every-code finish` idempotent when a request already reached a terminal state

Refs #330
Stacked on #336.

## Validation
- uv run python -m unittest tests.test_every_code_worker
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest