### PR TITLE
feat(every-code): request previews for eligible PRs

### DIFF
--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -19,6 +19,11 @@ from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestStatusUpdate,
     apply_every_code_work_request_status,
 )
+from control_plane.workflows.launchplane import (
+    LAUNCHPLANE_PREVIEW_ENABLE_LABEL,
+    github_pull_request_reference,
+    launchplane_anchor_repo_eligible,
+)
 from control_plane.workflows.ship import utc_now_timestamp
 
 
@@ -1101,6 +1106,7 @@ def finish_every_code_work_request(
     exit_code: int,
     result_pr_url: str = "",
     result_summary: str = "",
+    runner: Runner | None = None,
 ) -> EveryCodeWorkerFinishResult:
     record = record_store.read_every_code_work_request_record(request_id.strip())
     if record.state in TERMINAL_EVERY_CODE_STATES:
@@ -1115,7 +1121,14 @@ def finish_every_code_work_request(
             result_pr_url=record.result_pr_url,
         )
     succeeded = exit_code == 0
-    summary = result_summary.strip() or (
+    preview_label_summary = ""
+    if succeeded and result_pr_url.strip():
+        preview_label_summary = request_every_code_pr_preview_label(
+            result_pr_url=result_pr_url,
+            runner=runner,
+        )
+    summary_parts = [part for part in (result_summary.strip(), preview_label_summary) if part]
+    summary = "; ".join(summary_parts) or (
         "Every Code session completed successfully."
         if succeeded
         else f"Every Code session exited with status {exit_code}."
@@ -1140,6 +1153,39 @@ def finish_every_code_work_request(
         issue_number=updated_record.issue_number,
         result_pr_url=updated_record.result_pr_url,
     )
+
+
+def request_every_code_pr_preview_label(
+    *,
+    result_pr_url: str,
+    runner: Runner | None = None,
+) -> str:
+    reference = github_pull_request_reference(pr_url=result_pr_url.strip())
+    if reference is None:
+        return ""
+    if not launchplane_anchor_repo_eligible(repo=reference["repo"]):
+        return ""
+    run = runner or _run_subprocess
+    repo = f"{reference['owner']}/{reference['repo']}"
+    try:
+        result = run(
+            (
+                "gh",
+                "pr",
+                "edit",
+                str(reference["pr_number"]),
+                "--repo",
+                repo,
+                "--add-label",
+                LAUNCHPLANE_PREVIEW_ENABLE_LABEL,
+            )
+        )
+    except OSError as exc:
+        return f"Could not request Launchplane preview: {exc}"
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "gh pr edit failed"
+        return f"Could not request Launchplane preview: {detail}"
+    return f"Requested Launchplane preview with `{LAUNCHPLANE_PREVIEW_ENABLE_LABEL}`."
 
 
 def _run_subprocess(args: Sequence[str]) -> subprocess.CompletedProcess[str]:

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -27,6 +27,7 @@ from control_plane.every_code_worker import (
     every_code_worker_daemon_status,
     finish_every_code_work_request,
     prepare_every_code_checkout,
+    request_every_code_pr_preview_label,
     run_every_code_worker_loop,
     run_every_code_worker_once,
     start_every_code_worker_daemon,
@@ -49,6 +50,16 @@ def _queued_record() -> EveryCodeWorkRequestRecord:
         github_delivery_id="delivery-1",
         queued_at="2026-05-05T22:00:00Z",
         updated_at="2026-05-05T22:00:00Z",
+    )
+
+
+def _queued_preview_record() -> EveryCodeWorkRequestRecord:
+    return _queued_record().model_copy(
+        update={
+            "request_id": "every-code-every-tenant-opw-123-test",
+            "repository": "every/tenant-opw",
+            "issue_url": "https://github.com/every/tenant-opw/issues/123",
+        }
     )
 
 
@@ -292,6 +303,40 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertIn("--worker-token-env LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN", command)
         self.assertIn("--request-id every-code-cbusillo-code-123-test", command)
         self.assertIn("--exit-code $status", command)
+
+    def test_preview_label_request_labels_eligible_pull_request(self) -> None:
+        runner = _Runner()
+
+        summary = request_every_code_pr_preview_label(
+            result_pr_url="https://github.com/every/tenant-opw/pull/123",
+            runner=runner,
+        )
+
+        self.assertIn("Requested Launchplane preview", summary)
+        self.assertIn(
+            (
+                "gh",
+                "pr",
+                "edit",
+                "123",
+                "--repo",
+                "every/tenant-opw",
+                "--add-label",
+                "launchplane-preview",
+            ),
+            runner.calls,
+        )
+
+    def test_preview_label_request_skips_ineligible_pull_request(self) -> None:
+        runner = _Runner()
+
+        summary = request_every_code_pr_preview_label(
+            result_pr_url="https://github.com/cbusillo/code/pull/123",
+            runner=runner,
+        )
+
+        self.assertEqual(summary, "")
+        self.assertEqual(runner.calls, [])
 
     def test_prepare_checkout_creates_worker_owned_worktree(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -567,6 +612,37 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(record.state, "done")
         self.assertEqual(record.result_pr_url, "https://github.com/cbusillo/code/pull/99")
         self.assertEqual(record.error_message, "")
+
+    def test_finish_requests_preview_label_for_eligible_pr(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "tenant-opw"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_preview_record())
+            runner = _Runner()
+            run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "state",
+                runner=runner,
+            )
+
+            result = finish_every_code_work_request(
+                record_store=store,
+                request_id="every-code-every-tenant-opw-123-test",
+                host="Chris-Studio",
+                exit_code=0,
+                result_pr_url="https://github.com/every/tenant-opw/pull/99",
+                runner=runner,
+            )
+            record = store.read_every_code_work_request_record("every-code-every-tenant-opw-123-test")
+
+        self.assertEqual(result.status, "done")
+        self.assertIn("Requested Launchplane preview", record.result_summary)
+        self.assertTrue(any(call[:3] == ("gh", "pr", "edit") for call in runner.calls))
 
     def test_finish_marks_failed_session_blocked(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- request the existing Launchplane `launchplane-preview` label when Every Code finishes with an eligible PR URL
- skip repos that are not Launchplane preview anchor repos
- include preview-label success/failure in the terminal result summary

Refs #331
Stacked on #336.

## Validation
- uv run python -m unittest tests.test_every_code_worker
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest