### PR TITLE
Put testing lane before prod

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -738,9 +738,9 @@ export function App() {
             />
             <section className="lane-grid" aria-busy={loading}>
               <LanePanel
-                title="Prod"
-                laneKind="prod"
-                lane={prodDriverView?.lane_summary ?? null}
+                title="Testing"
+                laneKind="testing"
+                lane={testingDriverView?.lane_summary ?? null}
                 loading={loading}
               />
               <PromotionBridge
@@ -754,9 +754,9 @@ export function App() {
                 onAction={setReviewAction}
               />
               <LanePanel
-                title="Testing"
-                laneKind="testing"
-                lane={testingDriverView?.lane_summary ?? null}
+                title="Prod"
+                laneKind="prod"
+                lane={prodDriverView?.lane_summary ?? null}
                 loading={loading}
               />
             </section>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1736,7 +1736,7 @@ p {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .lane-prod {
+  .lane-testing {
     order: 1;
   }
 
@@ -1744,7 +1744,7 @@ p {
     order: 2;
   }
 
-  .lane-testing {
+  .lane-prod {
     order: 3;
   }
 }


### PR DESCRIPTION
## Summary
- render the Testing lane before the promotion bridge and Prod lane in the operator cockpit
- keep the narrow responsive order aligned with the same testing-to-prod flow

Refs #341

## Verification
- git diff --check
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- Fixture browser smoke at http://127.0.0.1:5178/ui/?fixtures=1 confirmed the UI still renders after the lane-order change; the affected authenticated lane grid is source-order verified.