### PR TITLE
feat(every-code): record PR feedback webhooks

### DIFF
--- a/control_plane/contracts/every_code_pr_feedback_record.py
+++ b/control_plane/contracts/every_code_pr_feedback_record.py
@@ -1,6 +1,4 @@
 from __future__ import annotations
-
-import hashlib
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -72,9 +70,9 @@ def build_every_code_pr_feedback_id(
         raise ValueError(
             "Every Code PR feedback id requires repository, pr_number, delivery id, and feedback id"
         )
-    digest = hashlib.sha256(
-        f"{normalized_repository}#{pr_number}:{github_delivery_id.strip()}:{identity}".encode(
-            "utf-8"
-        )
-    ).hexdigest()[:16]
-    return f"every-code-pr-feedback-{normalized_repository.replace('/', '-')}-{pr_number}-{digest}"
+    identity_slug = "".join(
+        character.lower() if character.isalnum() else "-" for character in identity
+    ).strip("-")
+    if not identity_slug:
+        raise ValueError("Every Code PR feedback id requires a slug-safe feedback id")
+    return f"every-code-pr-feedback-{normalized_repository.replace('/', '-')}-{pr_number}-{identity_slug}"

--- a/control_plane/contracts/every_code_pr_feedback_record.py
+++ b/control_plane/contracts/every_code_pr_feedback_record.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+EveryCodePrFeedbackKind = Literal[
+    "issue_comment",
+    "pull_request_review",
+    "pull_request_review_comment",
+]
+EveryCodePrFeedbackStatus = Literal["pending", "applied", "ignored"]
+
+
+class EveryCodePrFeedbackRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    feedback_id: str
+    request_id: str
+    repository: str
+    pr_number: int = Field(ge=1)
+    pr_url: str
+    feedback_kind: EveryCodePrFeedbackKind
+    github_delivery_id: str
+    github_node_id: str = ""
+    github_id: str = ""
+    actor: str
+    author_association: str = ""
+    body: str
+    html_url: str = ""
+    submitted_at: str = ""
+    received_at: str
+    status: EveryCodePrFeedbackStatus = "pending"
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "EveryCodePrFeedbackRecord":
+        if not self.feedback_id.strip():
+            raise ValueError("Every Code PR feedback requires feedback_id")
+        if not self.request_id.strip():
+            raise ValueError("Every Code PR feedback requires request_id")
+        if not self.repository.strip() or "/" not in self.repository.strip():
+            raise ValueError("Every Code PR feedback requires owner/repo repository")
+        if not self.pr_url.strip():
+            raise ValueError("Every Code PR feedback requires pr_url")
+        if not self.github_delivery_id.strip():
+            raise ValueError("Every Code PR feedback requires github_delivery_id")
+        if not self.github_node_id.strip() and not self.github_id.strip():
+            raise ValueError("Every Code PR feedback requires github_node_id or github_id")
+        if not self.actor.strip():
+            raise ValueError("Every Code PR feedback requires actor")
+        if not self.body.strip():
+            raise ValueError("Every Code PR feedback requires body")
+        if not self.received_at.strip():
+            raise ValueError("Every Code PR feedback requires received_at")
+        return self
+
+
+def build_every_code_pr_feedback_id(
+    *,
+    repository: str,
+    pr_number: int,
+    github_delivery_id: str,
+    github_node_id: str = "",
+    github_id: str = "",
+) -> str:
+    normalized_repository = repository.strip().lower()
+    identity = github_node_id.strip() or github_id.strip()
+    if not normalized_repository or pr_number < 1 or not github_delivery_id.strip() or not identity:
+        raise ValueError(
+            "Every Code PR feedback id requires repository, pr_number, delivery id, and feedback id"
+        )
+    digest = hashlib.sha256(
+        f"{normalized_repository}#{pr_number}:{github_delivery_id.strip()}:{identity}".encode(
+            "utf-8"
+        )
+    ).hexdigest()[:16]
+    return f"every-code-pr-feedback-{normalized_repository.replace('/', '-')}-{pr_number}-{digest}"

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -41,6 +41,11 @@ from control_plane.contracts.every_code_work_request import (
     build_every_code_work_request_id,
     close_every_code_work_request_for_pull_request,
 )
+from control_plane.contracts.every_code_pr_feedback_record import (
+    EveryCodePrFeedbackKind,
+    EveryCodePrFeedbackRecord,
+    build_every_code_pr_feedback_id,
+)
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.idempotency_record import build_launchplane_idempotency_record_id
 from control_plane.contracts.preview_mutation_request import (
@@ -1888,6 +1893,20 @@ class _EveryCodeWorkRequestStore(Protocol):
         claimed_at: str,
     ) -> EveryCodeWorkRequestRecord | None: ...
 
+    def write_every_code_pr_feedback_record(
+        self, record: EveryCodePrFeedbackRecord
+    ) -> object: ...
+
+    def list_every_code_pr_feedback_records(
+        self,
+        *,
+        request_id: str = "",
+        repository: str = "",
+        pr_number: int | None = None,
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[EveryCodePrFeedbackRecord, ...]: ...
+
 
 def _every_code_work_request_store(record_store: object) -> _EveryCodeWorkRequestStore:
     required_methods = (
@@ -1896,6 +1915,8 @@ def _every_code_work_request_store(record_store: object) -> _EveryCodeWorkReques
         "read_every_code_work_request_record",
         "list_every_code_work_request_records",
         "claim_every_code_work_request_record",
+        "write_every_code_pr_feedback_record",
+        "list_every_code_pr_feedback_records",
     )
     if all(hasattr(record_store, method_name) for method_name in required_methods):
         return cast(_EveryCodeWorkRequestStore, record_store)
@@ -1911,6 +1932,13 @@ def _github_webhook_mapping(payload: dict[str, object], key: str) -> dict[str, o
     if isinstance(value, dict):
         return cast(dict[str, object], value)
     return None
+
+
+def _github_webhook_required_mapping(payload: dict[str, object], key: str) -> dict[str, object]:
+    value = _github_webhook_mapping(payload, key)
+    if value is None:
+        raise ValueError(f"GitHub webhook requires object field {key!r}")
+    return value
 
 
 def _github_webhook_string(mapping: dict[str, object] | None, key: str) -> str:
@@ -1980,6 +2008,15 @@ def _handle_every_code_github_webhook(
 
     payload = _decode_json_request_body(body_bytes)
     event_name = _github_webhook_header(environ, "X-GitHub-Event")
+    if event_name in {"issue_comment", "pull_request_review", "pull_request_review_comment"}:
+        return _handle_every_code_pr_feedback_webhook(
+            start_response=start_response,
+            trace_id=trace_id,
+            delivery_id=delivery_id,
+            event_name=event_name,
+            payload=payload,
+            record_store=record_store,
+        )
     if event_name == "pull_request":
         return _handle_every_code_pull_request_webhook(
             start_response=start_response,
@@ -2144,6 +2181,188 @@ def _handle_every_code_pull_request_webhook(
     )
     accepted_payload["github_delivery_id"] = delivery_id
     return _json_response(start_response=start_response, status_code=202, payload=accepted_payload)
+
+
+def _handle_every_code_pr_feedback_webhook(
+    *,
+    start_response: _StartResponse,
+    trace_id: str,
+    delivery_id: str,
+    event_name: str,
+    payload: dict[str, object],
+    record_store: object,
+) -> list[bytes]:
+    if not _every_code_pr_feedback_action_supported(
+        event_name=event_name,
+        action=str(payload.get("action", "")),
+    ):
+        return _json_response(
+            start_response=start_response,
+            status_code=202,
+            payload={
+                "status": "accepted",
+                "trace_id": trace_id,
+                "skipped": True,
+                "reason": "unsupported_action",
+                "github_delivery_id": delivery_id,
+            },
+        )
+
+    repository_payload = _github_webhook_mapping(payload, "repository")
+    repository = _github_webhook_string(repository_payload, "full_name")
+    pr_number, pr_url = _every_code_feedback_pr_reference(
+        event_name=event_name,
+        payload=payload,
+        repository=repository,
+    )
+    body_payload = _every_code_feedback_body_payload(event_name=event_name, payload=payload)
+    body = _github_webhook_string(body_payload, "body")
+    if not body.strip():
+        return _json_response(
+            start_response=start_response,
+            status_code=202,
+            payload={
+                "status": "accepted",
+                "trace_id": trace_id,
+                "skipped": True,
+                "reason": "empty_feedback_body",
+                "github_delivery_id": delivery_id,
+            },
+        )
+
+    every_code_store = _every_code_work_request_store(record_store)
+    matched_record: EveryCodeWorkRequestRecord | None = None
+    for record in every_code_store.list_every_code_work_request_records(
+        repository=repository,
+        limit=100,
+    ):
+        if record.result_pr_url.strip() == pr_url:
+            matched_record = record
+            break
+    if matched_record is None:
+        return _json_response(
+            start_response=start_response,
+            status_code=202,
+            payload={
+                "status": "accepted",
+                "trace_id": trace_id,
+                "skipped": True,
+                "reason": "linked_every_code_request_not_found",
+                "github_delivery_id": delivery_id,
+            },
+        )
+
+    sender_payload = _github_webhook_mapping(payload, "sender")
+    github_node_id = _github_webhook_string(body_payload, "node_id")
+    github_id_value = body_payload.get("id") if body_payload is not None else ""
+    github_id = str(github_id_value) if github_id_value is not None else ""
+    feedback_id = build_every_code_pr_feedback_id(
+        repository=repository,
+        pr_number=pr_number,
+        github_delivery_id=delivery_id,
+        github_node_id=github_node_id,
+        github_id=github_id,
+    )
+    existing_feedback_records = every_code_store.list_every_code_pr_feedback_records(
+        request_id=matched_record.request_id,
+        repository=repository,
+        pr_number=pr_number,
+        limit=100,
+    )
+    for existing_feedback in existing_feedback_records:
+        if existing_feedback.feedback_id == feedback_id:
+            return _json_response(
+                start_response=start_response,
+                status_code=202,
+                payload={
+                    "status": "accepted",
+                    "trace_id": trace_id,
+                    "deduped": True,
+                    "result": {
+                        "feedback_id": existing_feedback.feedback_id,
+                        "request_id": existing_feedback.request_id,
+                    },
+                    "github_delivery_id": delivery_id,
+                },
+            )
+
+    feedback_record = EveryCodePrFeedbackRecord(
+        feedback_id=feedback_id,
+        request_id=matched_record.request_id,
+        repository=repository,
+        pr_number=pr_number,
+        pr_url=pr_url,
+        feedback_kind=_every_code_feedback_kind(event_name),
+        github_delivery_id=delivery_id,
+        github_node_id=github_node_id,
+        github_id=github_id,
+        actor=_github_webhook_string(sender_payload, "login"),
+        author_association=_github_webhook_string(body_payload, "author_association"),
+        body=body,
+        html_url=_github_webhook_string(body_payload, "html_url"),
+        submitted_at=_github_webhook_string(body_payload, "submitted_at"),
+        received_at=_utc_now_timestamp(),
+    )
+    every_code_store.write_every_code_pr_feedback_record(feedback_record)
+
+    accepted_payload = _accepted_payload(
+        trace_id=trace_id,
+        result={
+            "feedback_id": feedback_record.feedback_id,
+            "request_id": feedback_record.request_id,
+            "status": feedback_record.status,
+        },
+        driver_result={"feedback": feedback_record.model_dump(mode="json")},
+    )
+    accepted_payload["github_delivery_id"] = delivery_id
+    return _json_response(start_response=start_response, status_code=202, payload=accepted_payload)
+
+
+def _every_code_pr_feedback_action_supported(*, event_name: str, action: str) -> bool:
+    if event_name == "issue_comment":
+        return action == "created"
+    if event_name == "pull_request_review":
+        return action == "submitted"
+    if event_name == "pull_request_review_comment":
+        return action == "created"
+    return False
+
+
+def _every_code_feedback_kind(event_name: str) -> EveryCodePrFeedbackKind:
+    if event_name == "issue_comment":
+        return "issue_comment"
+    if event_name == "pull_request_review":
+        return "pull_request_review"
+    if event_name == "pull_request_review_comment":
+        return "pull_request_review_comment"
+    raise ValueError(f"Unsupported Every Code PR feedback event {event_name!r}")
+
+
+def _every_code_feedback_body_payload(
+    *, event_name: str, payload: dict[str, object]
+) -> dict[str, object]:
+    key = "review" if event_name == "pull_request_review" else "comment"
+    return _github_webhook_required_mapping(payload, key)
+
+
+def _every_code_feedback_pr_reference(
+    *,
+    event_name: str,
+    payload: dict[str, object],
+    repository: str,
+) -> tuple[int, str]:
+    if event_name == "issue_comment":
+        issue_payload = _github_webhook_required_mapping(payload, "issue")
+        pull_request_marker = issue_payload.get("pull_request")
+        if not isinstance(pull_request_marker, dict):
+            raise ValueError("Every Code PR feedback issue_comment requires pull_request issue")
+        pr_number_value = issue_payload.get("number")
+    else:
+        pull_request_payload = _github_webhook_required_mapping(payload, "pull_request")
+        pr_number_value = pull_request_payload.get("number")
+    if not isinstance(pr_number_value, int):
+        raise ValueError("Every Code PR feedback requires integer pull request number")
+    return pr_number_value, f"https://github.com/{repository}/pull/{pr_number_value}"
 
 
 def _idempotency_capable_store(record_store: object) -> _IdempotencyCapableStore | None:

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -13,6 +13,7 @@ from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestRecord,
     claim_every_code_work_request,
 )
+from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.preview_enablement_record import PreviewEnablementRecord
@@ -195,6 +196,34 @@ class FilesystemRecordStore:
             return None
         self.write_every_code_work_request_record(claimed_record)
         return claimed_record
+
+    def write_every_code_pr_feedback_record(self, record: EveryCodePrFeedbackRecord) -> Path:
+        return self._write_model("launchplane_every_code_pr_feedback", record.feedback_id, record)
+
+    def list_every_code_pr_feedback_records(
+        self,
+        *,
+        request_id: str = "",
+        repository: str = "",
+        pr_number: int | None = None,
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[EveryCodePrFeedbackRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                EveryCodePrFeedbackRecord,
+                "launchplane_every_code_pr_feedback",
+            )
+            if (not request_id or record.request_id == request_id)
+            and (not repository or record.repository == repository)
+            and (pr_number is None or record.pr_number == pr_number)
+            and (not status or record.status == status)
+        ]
+        records.sort(key=lambda record: (record.received_at, record.feedback_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
 
     def write_product_profile_record(self, record: LaunchplaneProductProfileRecord) -> Path:
         return self._write_model("launchplane_product_profiles", record.product, record)

--- a/control_plane/storage/migrations/versions/ac23de45fa67_add_every_code_pr_feedback.py
+++ b/control_plane/storage/migrations/versions/ac23de45fa67_add_every_code_pr_feedback.py
@@ -1,0 +1,71 @@
+"""add Every Code PR feedback
+
+Revision ID: ac23de45fa67
+Revises: ab12cd34ef56
+Create Date: 2026-05-06 18:40:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "ac23de45fa67"
+down_revision: str | None = "ab12cd34ef56"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "launchplane_every_code_pr_feedback",
+        sa.Column("feedback_id", sa.String(), nullable=False),
+        sa.Column("request_id", sa.String(), nullable=False),
+        sa.Column("repository", sa.String(), nullable=False),
+        sa.Column("pr_number", sa.Integer(), nullable=False),
+        sa.Column("feedback_kind", sa.String(), nullable=False),
+        sa.Column("github_delivery_id", sa.String(), nullable=False),
+        sa.Column("actor", sa.String(), nullable=False),
+        sa.Column("received_at", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("feedback_id"),
+    )
+    op.create_index(
+        "launchplane_every_code_pr_feedback_request_idx",
+        "launchplane_every_code_pr_feedback",
+        ["request_id", sa.text("received_at DESC")],
+    )
+    op.create_index(
+        "launchplane_every_code_pr_feedback_pr_idx",
+        "launchplane_every_code_pr_feedback",
+        ["repository", "pr_number", sa.text("received_at DESC")],
+    )
+    op.create_index(
+        "launchplane_every_code_pr_feedback_status_idx",
+        "launchplane_every_code_pr_feedback",
+        ["status", sa.text("received_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "launchplane_every_code_pr_feedback_status_idx",
+        table_name="launchplane_every_code_pr_feedback",
+    )
+    op.drop_index(
+        "launchplane_every_code_pr_feedback_pr_idx",
+        table_name="launchplane_every_code_pr_feedback",
+    )
+    op.drop_index(
+        "launchplane_every_code_pr_feedback_request_idx",
+        table_name="launchplane_every_code_pr_feedback",
+    )
+    op.drop_table("launchplane_every_code_pr_feedback")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -32,6 +32,7 @@ from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestRecord,
     claim_every_code_work_request,
 )
+from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
@@ -458,6 +459,39 @@ class LaunchplaneEveryCodeWorkRequestRow(Base):
     trigger_label: Mapped[str] = mapped_column(String, nullable=False)
     updated_at: Mapped[str] = mapped_column(String, nullable=False)
     claimed_by_host: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneEveryCodePrFeedbackRow(Base):
+    __tablename__ = "launchplane_every_code_pr_feedback"
+    __table_args__ = (
+        Index(
+            "launchplane_every_code_pr_feedback_request_idx",
+            "request_id",
+            desc("received_at"),
+        ),
+        Index(
+            "launchplane_every_code_pr_feedback_pr_idx",
+            "repository",
+            "pr_number",
+            desc("received_at"),
+        ),
+        Index(
+            "launchplane_every_code_pr_feedback_status_idx",
+            "status",
+            desc("received_at"),
+        ),
+    )
+
+    feedback_id: Mapped[str] = mapped_column(String, primary_key=True)
+    request_id: Mapped[str] = mapped_column(String, nullable=False)
+    repository: Mapped[str] = mapped_column(String, nullable=False)
+    pr_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    feedback_kind: Mapped[str] = mapped_column(String, nullable=False)
+    github_delivery_id: Mapped[str] = mapped_column(String, nullable=False)
+    actor: Mapped[str] = mapped_column(String, nullable=False)
+    received_at: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -1263,6 +1297,51 @@ class PostgresRecordStore(HumanSessionStore):
             row.payload = self._payload_dict(claimed_record)
             session.commit()
             return claimed_record
+
+    def write_every_code_pr_feedback_record(self, record: EveryCodePrFeedbackRecord) -> None:
+        self._write_row(
+            LaunchplaneEveryCodePrFeedbackRow(
+                feedback_id=record.feedback_id,
+                request_id=record.request_id,
+                repository=record.repository,
+                pr_number=record.pr_number,
+                feedback_kind=record.feedback_kind,
+                github_delivery_id=record.github_delivery_id,
+                actor=record.actor,
+                received_at=record.received_at,
+                status=record.status,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def list_every_code_pr_feedback_records(
+        self,
+        *,
+        request_id: str = "",
+        repository: str = "",
+        pr_number: int | None = None,
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[EveryCodePrFeedbackRecord, ...]:
+        filters: list[object] = []
+        if request_id:
+            filters.append(LaunchplaneEveryCodePrFeedbackRow.request_id == request_id)
+        if repository:
+            filters.append(LaunchplaneEveryCodePrFeedbackRow.repository == repository)
+        if pr_number is not None:
+            filters.append(LaunchplaneEveryCodePrFeedbackRow.pr_number == pr_number)
+        if status:
+            filters.append(LaunchplaneEveryCodePrFeedbackRow.status == status)
+        return self._list_models(
+            model_type=EveryCodePrFeedbackRecord,
+            orm_model=LaunchplaneEveryCodePrFeedbackRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneEveryCodePrFeedbackRow.received_at.desc(),
+                LaunchplaneEveryCodePrFeedbackRow.feedback_id.desc(),
+            ),
+            limit=limit,
+        )
 
     def write_preview_lifecycle_plan_record(self, record: PreviewLifecyclePlanRecord) -> None:
         self._write_row(

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -14,6 +14,7 @@ from control_plane.contracts.artifact_identity import (
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
 from control_plane.contracts.odoo_instance_override_record import OdooAddonSettingOverride
 from control_plane.contracts.odoo_instance_override_record import OdooConfigParameterOverride
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
@@ -69,6 +70,45 @@ def _health_pass() -> HealthcheckEvidence:
 
 
 class FilesystemRecordStoreTests(unittest.TestCase):
+    def test_write_and_list_every_code_pr_feedback_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            older_record = EveryCodePrFeedbackRecord(
+                feedback_id="every-code-pr-feedback-cbusillo-code-26-old",
+                request_id="every-code-cbusillo-code-123-test",
+                repository="cbusillo/code",
+                pr_number=26,
+                pr_url="https://github.com/cbusillo/code/pull/26",
+                feedback_kind="issue_comment",
+                github_delivery_id="delivery-old",
+                github_id="100",
+                actor="cbusillo",
+                body="Please adjust the README wording.",
+                received_at="2026-05-06T17:00:00Z",
+            )
+            newer_record = older_record.model_copy(
+                update={
+                    "feedback_id": "every-code-pr-feedback-cbusillo-code-26-new",
+                    "github_delivery_id": "delivery-new",
+                    "github_id": "101",
+                    "received_at": "2026-05-06T18:00:00Z",
+                }
+            )
+
+            written_path = store.write_every_code_pr_feedback_record(older_record)
+            store.write_every_code_pr_feedback_record(newer_record)
+            listed_records = store.list_every_code_pr_feedback_records(
+                request_id="every-code-cbusillo-code-123-test",
+                status="pending",
+            )
+            self.assertTrue(written_path.exists())
+
+        self.assertEqual(
+            [record.feedback_id for record in listed_records],
+            [newer_record.feedback_id, older_record.feedback_id],
+        )
+
     def test_write_and_read_product_profile_record(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name)

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -21,6 +21,7 @@ from control_plane.contracts.deployment_record import DeploymentRecord, Resolved
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
 from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.idempotency_record import build_launchplane_idempotency_record_id
@@ -596,6 +597,46 @@ class PostgresRecordStoreTests(unittest.TestCase):
         self.assertEqual(claimed.claimed_by_host, "Chris-Studio")
         self.assertIsNone(second_claim)
         self.assertEqual(loaded.state, "claimed")
+
+    def test_every_code_pr_feedback_round_trip_and_filter(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            store = PostgresRecordStore(database_url=_sqlite_database_url(database_path))
+            store.ensure_schema()
+            older_record = EveryCodePrFeedbackRecord(
+                feedback_id="every-code-pr-feedback-cbusillo-code-26-old",
+                request_id="every-code-cbusillo-code-123-test",
+                repository="cbusillo/code",
+                pr_number=26,
+                pr_url="https://github.com/cbusillo/code/pull/26",
+                feedback_kind="issue_comment",
+                github_delivery_id="delivery-old",
+                github_id="100",
+                actor="cbusillo",
+                body="Please adjust the README wording.",
+                received_at="2026-05-06T17:00:00Z",
+            )
+            newer_record = older_record.model_copy(
+                update={
+                    "feedback_id": "every-code-pr-feedback-cbusillo-code-26-new",
+                    "github_delivery_id": "delivery-new",
+                    "github_id": "101",
+                    "received_at": "2026-05-06T18:00:00Z",
+                }
+            )
+            store.write_every_code_pr_feedback_record(older_record)
+            store.write_every_code_pr_feedback_record(newer_record)
+
+            listed = store.list_every_code_pr_feedback_records(
+                repository="cbusillo/code",
+                pr_number=26,
+                status="pending",
+            )
+
+        self.assertEqual(
+            [record.feedback_id for record in listed],
+            [newer_record.feedback_id, older_record.feedback_id],
+        )
 
     def test_human_sessions_round_trip_and_delete(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -460,6 +460,32 @@ def _every_code_github_pull_request_closed_payload(
     }
 
 
+def _every_code_github_pr_comment_payload(
+    *,
+    repository: str = "cbusillo/code",
+    pr_number: int = 26,
+    body: str = "Please tighten this wording before merge.",
+    comment_id: int = 1001,
+) -> dict[str, object]:
+    return {
+        "action": "created",
+        "repository": {"full_name": repository},
+        "issue": {
+            "number": pr_number,
+            "html_url": f"https://github.com/{repository}/pull/{pr_number}",
+            "pull_request": {"url": f"https://api.github.com/repos/{repository}/pulls/{pr_number}"},
+        },
+        "comment": {
+            "id": comment_id,
+            "node_id": f"IC_kwDO_test_{comment_id}",
+            "html_url": f"https://github.com/{repository}/pull/{pr_number}#issuecomment-{comment_id}",
+            "body": body,
+            "author_association": "OWNER",
+        },
+        "sender": {"login": "cbusillo"},
+    }
+
+
 def _work_graph_snapshot_payload() -> dict[str, object]:
     return {
         "generated_at": "2026-05-06T01:45:00Z",
@@ -879,7 +905,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
             TemporaryDirectory() as temporary_directory_name,
             patch.dict(
                 os.environ,
-                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+                {
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
             ),
         ):
             app = create_launchplane_service_app(
@@ -952,7 +981,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
             TemporaryDirectory() as temporary_directory_name,
             patch.dict(
                 os.environ,
-                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+                {
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
             ),
         ):
             app = create_launchplane_service_app(
@@ -1040,7 +1072,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
             TemporaryDirectory() as temporary_directory_name,
             patch.dict(
                 os.environ,
-                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+                {
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
             ),
         ):
             app = create_launchplane_service_app(
@@ -1138,7 +1173,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
             TemporaryDirectory() as temporary_directory_name,
             patch.dict(
                 os.environ,
-                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+                {
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
             ),
         ):
             app = create_launchplane_service_app(
@@ -1333,6 +1371,172 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 202)
         self.assertTrue(payload["skipped"])
         self.assertEqual(payload["reason"], "linked_every_code_request_not_found")
+
+    def test_every_code_pr_comment_webhook_records_feedback(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        issue_payload = _every_code_github_issue_labeled_payload()
+        comment_payload = _every_code_github_pr_comment_payload()
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            issue_status, issue_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=issue_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-issue",
+                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                },
+            )
+            request_id = issue_response["records"]["request_id"]
+            claim_status, claim_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/claim",
+                payload={"request_id": request_id, "host": "Chris-Studio"},
+                authorization="Bearer dev-worker-token",
+            )
+            status_status, _status_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/status",
+                payload={
+                    "request_id": request_id,
+                    "host": "Chris-Studio",
+                    "state": "done",
+                    "result_pr_url": "https://github.com/cbusillo/code/pull/26",
+                    "result_summary": "Opened PR.",
+                    "updated_at": "2026-05-06T16:00:00Z",
+                },
+                authorization="Bearer dev-worker-token",
+            )
+            feedback_status, feedback_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=comment_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issue_comment",
+                    "X-GitHub-Delivery": "delivery-comment",
+                    "X-Hub-Signature-256": _github_webhook_signature(comment_payload, secret),
+                },
+            )
+
+        self.assertEqual(issue_status, 202)
+        self.assertEqual(claim_status, 202)
+        self.assertEqual(status_status, 202)
+        self.assertEqual(claim_payload["result"]["request"]["state"], "claimed")
+        self.assertEqual(feedback_status, 202)
+        self.assertEqual(feedback_response["records"]["request_id"], request_id)
+        feedback = feedback_response["result"]["feedback"]
+        self.assertEqual(feedback["request_id"], request_id)
+        self.assertEqual(feedback["feedback_kind"], "issue_comment")
+        self.assertEqual(feedback["body"], "Please tighten this wording before merge.")
+
+    def test_every_code_pr_comment_webhook_dedupes_feedback(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        issue_payload = _every_code_github_issue_labeled_payload()
+        comment_payload = _every_code_github_pr_comment_payload(comment_id=2002)
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            issue_status, issue_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=issue_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-issue",
+                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                },
+            )
+            request_id = issue_response["records"]["request_id"]
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/claim",
+                payload={"request_id": request_id, "host": "Chris-Studio"},
+                authorization="Bearer dev-worker-token",
+            )
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/status",
+                payload={
+                    "request_id": request_id,
+                    "host": "Chris-Studio",
+                    "state": "done",
+                    "result_pr_url": "https://github.com/cbusillo/code/pull/26",
+                    "result_summary": "Opened PR.",
+                    "updated_at": "2026-05-06T16:00:00Z",
+                },
+                authorization="Bearer dev-worker-token",
+            )
+            first_status, first_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=comment_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issue_comment",
+                    "X-GitHub-Delivery": "delivery-comment",
+                    "X-Hub-Signature-256": _github_webhook_signature(comment_payload, secret),
+                },
+            )
+            second_status, second_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=comment_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issue_comment",
+                    "X-GitHub-Delivery": "delivery-comment",
+                    "X-Hub-Signature-256": _github_webhook_signature(comment_payload, secret),
+                },
+            )
+
+        self.assertEqual(issue_status, 202)
+        self.assertEqual(first_status, 202)
+        self.assertEqual(second_status, 202)
+        self.assertEqual(
+            first_response["result"]["feedback"]["feedback_id"],
+            second_response["result"]["feedback_id"],
+        )
+        self.assertTrue(second_response["deduped"])
 
     def test_every_code_github_webhook_rejects_invalid_signature(self) -> None:
         secret = "launchplane-every-code-webhook-secret"


### PR DESCRIPTION
## Summary
- add a durable Every Code PR feedback record contract and storage support
- ingest GitHub PR comment/review feedback webhooks for PRs linked to Every Code work requests
- dedupe feedback deliveries and persist them for a later worker resume/injection slice

Refs #332

## Validation
- `uv run python -m unittest tests.test_filesystem_store.FilesystemRecordStoreTests.test_write_and_list_every_code_pr_feedback_records tests.test_postgres_store.PostgresRecordStoreTests.test_every_code_pr_feedback_round_trip_and_filter tests.test_service.LaunchplaneServiceTests.test_every_code_pr_comment_webhook_records_feedback tests.test_service.LaunchplaneServiceTests.test_every_code_pr_comment_webhook_dedupes_feedback`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`
