### PR TITLE
Mark SYO PRs preview eligible

### DIFF
--- a/control_plane/workflows/launchplane.py
+++ b/control_plane/workflows/launchplane.py
@@ -50,6 +50,7 @@ LAUNCHPLANE_GITHUB_WEBHOOK_SECRET_ENV_KEY = "GITHUB_WEBHOOK_SECRET"
 DEFAULT_LAUNCHPLANE_BASELINE_CHANNEL = "testing"
 LaunchplanePullRequestAction = str
 LAUNCHPLANE_TENANT_ANCHOR_CONTEXTS: dict[str, str] = {
+    "sellyouroutboard": "sellyouroutboard-testing",
     "tenant-cm": "cm",
     "tenant-opw": "opw",
 }

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -71,12 +71,18 @@ class _Runner:
 
     def __call__(self, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
         self.calls.append(tuple(args))
-        if args[0] == "git" and args[3:6] == ("symbolic-ref", "--short", "refs/remotes/origin/HEAD"):
+        if args[0] == "git" and args[3:6] == (
+            "symbolic-ref",
+            "--short",
+            "refs/remotes/origin/HEAD",
+        ):
             return subprocess.CompletedProcess(args, 0, "origin/main\n", "")
         if args[0] == "git" and args[3:6] == ("show-ref", "--verify", "--quiet"):
             return subprocess.CompletedProcess(args, 0 if self.existing_branch else 1, "", "")
         if args[0] == "git" and args[3:5] == ("branch", "--show-current"):
-            return subprocess.CompletedProcess(args, 0, every_code_worktree_branch(_queued_record()) + "\n", "")
+            return subprocess.CompletedProcess(
+                args, 0, every_code_worktree_branch(_queued_record()) + "\n", ""
+            )
         if args[0] == "git" and args[3:6] == ("worktree", "add", "-b"):
             worktree_root = Path(args[7])
             worktree_root.mkdir(parents=True, exist_ok=True)
@@ -130,7 +136,10 @@ class _EveryCodeApiHandler(BaseHTTPRequestHandler):
             records = self.store.list_every_code_work_request_records(state="queued", limit=1)
             self._write_json(
                 200,
-                {"status": "ok", "requests": [record.model_dump(mode="json") for record in records]},
+                {
+                    "status": "ok",
+                    "requests": [record.model_dump(mode="json") for record in records],
+                },
             )
             return
         request_id = self.path.rsplit("/", 1)[-1]
@@ -199,9 +208,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
     def test_api_store_lists_claims_and_updates_via_service(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             temporary_root = Path(temporary_directory_name)
-            _EveryCodeApiHandler.store = FilesystemRecordStore(
-                state_dir=temporary_root / "state"
-            )
+            _EveryCodeApiHandler.store = FilesystemRecordStore(state_dir=temporary_root / "state")
             _EveryCodeApiHandler.store.write_every_code_work_request_record(_queued_record())
             server = ThreadingHTTPServer(("127.0.0.1", 0), _EveryCodeApiHandler)
             server_thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -276,8 +283,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
 
         self.assertEqual(
             root,
-            Path("state")
-            .resolve()
+            Path("state").resolve()
             / "every-code-worker"
             / "worktrees"
             / "cbusillo-code"
@@ -327,6 +333,29 @@ class EveryCodeWorkerTests(unittest.TestCase):
             runner.calls,
         )
 
+    def test_preview_label_request_labels_sellyouroutboard_pull_request(self) -> None:
+        runner = _Runner()
+
+        summary = request_every_code_pr_preview_label(
+            result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/71",
+            runner=runner,
+        )
+
+        self.assertIn("Requested Launchplane preview", summary)
+        self.assertIn(
+            (
+                "gh",
+                "pr",
+                "edit",
+                "71",
+                "--repo",
+                "cbusillo/sellyouroutboard",
+                "--add-label",
+                "launchplane-preview",
+            ),
+            runner.calls,
+        )
+
     def test_preview_label_request_skips_ineligible_pull_request(self) -> None:
         runner = _Runner()
 
@@ -360,7 +389,10 @@ class EveryCodeWorkerTests(unittest.TestCase):
             every_code_worktree_root(_queued_record(), state_dir=state_dir),
         )
         self.assertEqual(prepared.worktree_branch, every_code_worktree_branch(_queued_record()))
-        self.assertIn(("git", "-C", str(checkout_root.resolve()), "fetch", "--quiet", "origin", "main"), runner.calls)
+        self.assertIn(
+            ("git", "-C", str(checkout_root.resolve()), "fetch", "--quiet", "origin", "main"),
+            runner.calls,
+        )
         self.assertTrue(any(call[3:6] == ("worktree", "add", "-b") for call in runner.calls))
 
     def test_prepare_checkout_reuses_matching_worker_worktree(self) -> None:
@@ -458,7 +490,9 @@ class EveryCodeWorkerTests(unittest.TestCase):
             session_payload["launch_root"],
             str(every_code_worktree_root(_queued_record(), state_dir=temporary_root / "state")),
         )
-        self.assertEqual(session_payload["worktree_branch"], every_code_worktree_branch(_queued_record()))
+        self.assertEqual(
+            session_payload["worktree_branch"], every_code_worktree_branch(_queued_record())
+        )
         self.assertEqual(result.status, "running")
         self.assertEqual(record.state, "running")
         self.assertEqual(record.claimed_by_host, "Chris-Studio")
@@ -638,7 +672,9 @@ class EveryCodeWorkerTests(unittest.TestCase):
                 result_pr_url="https://github.com/every/tenant-opw/pull/99",
                 runner=runner,
             )
-            record = store.read_every_code_work_request_record("every-code-every-tenant-opw-123-test")
+            record = store.read_every_code_work_request_record(
+                "every-code-every-tenant-opw-123-test"
+            )
 
         self.assertEqual(result.status, "done")
         self.assertIn("Requested Launchplane preview", record.result_summary)
@@ -936,9 +972,8 @@ class EveryCodeWorkerTests(unittest.TestCase):
                     "control_plane.every_code_worker._process_matches_expected_command",
                     return_value=False,
                 ):
-                    def launcher(
-                        _args: Sequence[str], _log_file: Path, _cwd: Path
-                    ) -> _Process:
+
+                    def launcher(_args: Sequence[str], _log_file: Path, _cwd: Path) -> _Process:
                         launched.append(1)
                         return _Process(5252)
 


### PR DESCRIPTION
## Summary
- include SellYourOutboard in Launchplane preview-eligible PR repo classification
- cover Every Code result PR preview-label requests for cbusillo/sellyouroutboard

Refs #331

## Verification
- uv run python -m unittest tests.test_every_code_worker.EveryCodeWorkerTests.test_preview_label_request_labels_sellyouroutboard_pull_request tests.test_every_code_worker.EveryCodeWorkerTests.test_preview_label_request_labels_eligible_pull_request
- git diff --check
- uv run --extra dev ruff check --diff control_plane/workflows/launchplane.py tests/test_every_code_worker.py
- uv run --extra dev ruff check control_plane/workflows/launchplane.py tests/test_every_code_worker.py
- uv run --extra dev ruff format --check control_plane/workflows/launchplane.py tests/test_every_code_worker.py
- uv run --extra dev mypy control_plane/workflows/launchplane.py tests/test_every_code_worker.py

Live smoke context: Every Code opened cbusillo/sellyouroutboard#71 for issue #64, but Launchplane did not request `launchplane-preview` because the eligibility map only contained the older Odoo tenant repos.