### PR TITLE
feat(every-code): apply PR feedback to sessions

### DIFF
--- a/control_plane/contracts/every_code_pr_feedback_record.py
+++ b/control_plane/contracts/every_code_pr_feedback_record.py
@@ -76,3 +76,15 @@ def build_every_code_pr_feedback_id(
     if not identity_slug:
         raise ValueError("Every Code PR feedback id requires a slug-safe feedback id")
     return f"every-code-pr-feedback-{normalized_repository.replace('/', '-')}-{pr_number}-{identity_slug}"
+
+
+def apply_every_code_pr_feedback_status(
+    record: EveryCodePrFeedbackRecord,
+    *,
+    status: EveryCodePrFeedbackStatus,
+) -> EveryCodePrFeedbackRecord | None:
+    if record.status != "pending":
+        return None
+    if status == "pending":
+        return record
+    return record.model_copy(update={"status": status})

--- a/control_plane/contracts/every_code_work_request.py
+++ b/control_plane/contracts/every_code_work_request.py
@@ -146,6 +146,33 @@ def apply_every_code_work_request_status(
     return record.model_copy(update=updates)
 
 
+def resume_every_code_work_request(
+    record: EveryCodeWorkRequestRecord,
+    *,
+    host: str,
+    resumed_at: str,
+    result_summary: str,
+) -> EveryCodeWorkRequestRecord:
+    normalized_host = host.strip()
+    if not normalized_host:
+        raise ValueError("Every Code resume requires host")
+    if not resumed_at.strip():
+        raise ValueError("Every Code resume requires resumed_at")
+    if record.claimed_by_host.strip() != normalized_host:
+        raise ValueError("Every Code resume host does not match claim host")
+    if record.state not in {"done", "blocked"}:
+        raise ValueError("Every Code resume requires a terminal work request")
+    return record.model_copy(
+        update={
+            "state": "running",
+            "updated_at": resumed_at,
+            "finished_at": "",
+            "result_summary": result_summary.strip(),
+            "error_message": "",
+        }
+    )
+
+
 def close_every_code_work_request_for_pull_request(
     record: EveryCodeWorkRequestRecord,
     *,

--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -14,10 +14,15 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
+from control_plane.contracts.every_code_pr_feedback_record import (
+    EveryCodePrFeedbackRecord,
+    EveryCodePrFeedbackStatus,
+)
 from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestRecord,
     EveryCodeWorkRequestStatusUpdate,
     apply_every_code_work_request_status,
+    resume_every_code_work_request,
 )
 from control_plane.workflows.launchplane import (
     LAUNCHPLANE_PREVIEW_ENABLE_LABEL,
@@ -55,6 +60,20 @@ class EveryCodeWorkerStore(Protocol):
 
     def write_every_code_work_request_record(
         self, record: EveryCodeWorkRequestRecord
+    ) -> object: ...
+
+    def list_every_code_pr_feedback_records(
+        self,
+        *,
+        request_id: str = "",
+        repository: str = "",
+        pr_number: int | None = None,
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[EveryCodePrFeedbackRecord, ...]: ...
+
+    def write_every_code_pr_feedback_record(
+        self, record: EveryCodePrFeedbackRecord
     ) -> object: ...
 
 
@@ -156,6 +175,46 @@ class EveryCodeWorkerApiStore:
                 "updated_at": record.updated_at,
             },
             idempotency_key=f"every-code-status-{record.request_id}-{record.state}-{record.updated_at}",
+        )
+        return payload
+
+    def list_every_code_pr_feedback_records(
+        self,
+        *,
+        request_id: str = "",
+        repository: str = "",
+        pr_number: int | None = None,
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[EveryCodePrFeedbackRecord, ...]:
+        query: dict[str, object] = {}
+        if request_id.strip():
+            query["request_id"] = request_id.strip()
+        if repository.strip():
+            query["repository"] = repository.strip()
+        if pr_number is not None:
+            query["pr_number"] = pr_number
+        if status.strip():
+            query["status"] = status.strip()
+        if limit is not None:
+            query["limit"] = limit
+        suffix = f"?{urlencode(query)}" if query else ""
+        payload = self._request("GET", f"/v1/every-code/pr-feedback{suffix}")
+        feedback = payload.get("feedback", [])
+        if not isinstance(feedback, list):
+            raise EveryCodeWorkerApiError("Launchplane PR feedback list response is invalid")
+        return tuple(EveryCodePrFeedbackRecord.model_validate(item) for item in feedback)
+
+    def write_every_code_pr_feedback_record(self, record: EveryCodePrFeedbackRecord) -> object:
+        payload = self._request(
+            "POST",
+            "/v1/every-code/pr-feedback/status",
+            body={
+                "feedback_id": record.feedback_id,
+                "request_id": record.request_id,
+                "status": record.status,
+            },
+            idempotency_key=f"every-code-pr-feedback-{record.feedback_id}-{record.status}",
         )
         return payload
 
@@ -317,6 +376,24 @@ class EveryCodeWorkerFinishResult:
         }
 
 
+@dataclass(frozen=True)
+class EveryCodePrFeedbackApplyResult:
+    status: Literal["empty", "applied", "ignored", "blocked"]
+    detail: str
+    feedback_id: str = ""
+    request_id: str = ""
+    session_name: str = ""
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "status": self.status,
+            "detail": self.detail,
+            "feedback_id": self.feedback_id,
+            "request_id": self.request_id,
+            "session_name": self.session_name,
+        }
+
+
 def every_code_tmux_session_name(request_id: str) -> str:
     normalized = re.sub(r"[^A-Za-z0-9_.:-]+", "-", request_id.strip()).strip("-._:")
     return f"every-code-{normalized or 'request'}"[:80]
@@ -446,6 +523,32 @@ def default_every_code_command(record: EveryCodeWorkRequestRecord) -> str:
     return "code " + shlex.quote(prompt)
 
 
+def every_code_pr_feedback_prompt(feedback: EveryCodePrFeedbackRecord) -> str:
+    source = feedback.html_url.strip() or feedback.pr_url.strip()
+    submitted = feedback.submitted_at.strip() or feedback.received_at.strip()
+    lines = [
+        "Every Code received new PR feedback for this request.",
+        f"Feedback kind: {feedback.feedback_kind}",
+        f"Actor: {feedback.actor}",
+    ]
+    if submitted:
+        lines.append(f"Submitted at: {submitted}")
+    if source:
+        lines.append(f"Source: {source}")
+    lines.extend(
+        (
+            "",
+            "Feedback:",
+            feedback.body.strip(),
+            "",
+            "Read the PR context and existing discussion before changing files. "
+            "Apply the requested correction on the same branch/worktree, update the PR, "
+            "and then let the session exit when checks are complete.",
+        )
+    )
+    return "\n".join(lines)
+
+
 def render_every_code_command(
     record: EveryCodeWorkRequestRecord,
     *,
@@ -502,6 +605,40 @@ def build_every_code_session_command(
         "status=$?\n"
         f"{finish_shell}\n"
         "exit $status"
+    )
+
+
+def build_every_code_feedback_session_command(
+    *,
+    feedback: EveryCodePrFeedbackRecord,
+    state_dir: Path,
+    host: str,
+    database_url: str = "",
+    service_url: str = "",
+    worker_token_env: str = "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN",
+) -> str:
+    command = "code " + shlex.quote(every_code_pr_feedback_prompt(feedback))
+    return build_every_code_session_command(
+        record=EveryCodeWorkRequestRecord(
+            request_id=feedback.request_id,
+            source="manual",
+            state="running",
+            repository=feedback.repository,
+            issue_number=1,
+            issue_url=feedback.pr_url,
+            trigger_label="every-code",
+            queued_at=feedback.received_at,
+            updated_at=feedback.received_at,
+            claimed_at=feedback.received_at,
+            claimed_by_host=host.strip() or "Every Code worker",
+            started_at=feedback.received_at,
+        ),
+        command=command,
+        state_dir=state_dir,
+        host=host,
+        database_url=database_url,
+        service_url=service_url,
+        worker_token_env=worker_token_env,
     )
 
 
@@ -780,6 +917,54 @@ def run_every_code_worker_once(
     )
 
 
+def apply_every_code_pr_feedback_for_host(
+    *,
+    record_store: EveryCodeWorkerStore,
+    host: str,
+    state_dir: Path | None,
+    database_url: str = "",
+    service_url: str = "",
+    worker_token_env: str = "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN",
+    tmux_binary: str = "tmux",
+    runner: Runner | None = None,
+) -> EveryCodePrFeedbackApplyResult:
+    if state_dir is None:
+        return EveryCodePrFeedbackApplyResult(
+            status="empty",
+            detail="Every Code PR feedback requires a worker state directory.",
+        )
+    normalized_host = host.strip()
+    if not normalized_host:
+        raise ValueError("Every Code worker requires a host name")
+    feedback_records = record_store.list_every_code_pr_feedback_records(
+        status="pending",
+        limit=25,
+    )
+    if not feedback_records:
+        return EveryCodePrFeedbackApplyResult(
+            status="empty", detail="No pending Every Code PR feedback."
+        )
+    run = runner or _run_subprocess
+    for feedback in feedback_records:
+        result = _apply_every_code_pr_feedback_record(
+            record_store=record_store,
+            feedback=feedback,
+            host=normalized_host,
+            state_dir=state_dir,
+            database_url=database_url,
+            service_url=service_url,
+            worker_token_env=worker_token_env,
+            tmux_binary=tmux_binary,
+            runner=run,
+        )
+        if result.status != "empty":
+            return result
+    return EveryCodePrFeedbackApplyResult(
+        status="empty",
+        detail="No pending Every Code PR feedback belongs to this host.",
+    )
+
+
 def run_every_code_worker_loop(
     *,
     record_store: EveryCodeWorkerStore,
@@ -818,6 +1003,16 @@ def run_every_code_worker_loop(
             record_store=record_store,
             host=host,
             state_dir=state_dir,
+            tmux_binary=tmux_binary,
+            runner=runner,
+        )
+        apply_every_code_pr_feedback_for_host(
+            record_store=record_store,
+            host=host,
+            state_dir=state_dir,
+            database_url=database_url,
+            service_url=service_url,
+            worker_token_env=worker_token_env,
             tmux_binary=tmux_binary,
             runner=runner,
         )
@@ -927,6 +1122,163 @@ def close_terminal_every_code_sessions(
             continue
         closed += 1
     return closed
+
+
+def _apply_every_code_pr_feedback_record(
+    *,
+    record_store: EveryCodeWorkerStore,
+    feedback: EveryCodePrFeedbackRecord,
+    host: str,
+    state_dir: Path,
+    database_url: str,
+    service_url: str,
+    worker_token_env: str,
+    tmux_binary: str,
+    runner: Runner,
+) -> EveryCodePrFeedbackApplyResult:
+    try:
+        record = record_store.read_every_code_work_request_record(feedback.request_id)
+    except Exception:
+        _mark_every_code_pr_feedback(record_store, feedback=feedback, status="ignored")
+        return EveryCodePrFeedbackApplyResult(
+            status="ignored",
+            detail="Every Code work request for PR feedback was not found.",
+            feedback_id=feedback.feedback_id,
+            request_id=feedback.request_id,
+        )
+    if record.claimed_by_host.strip() != host:
+        return EveryCodePrFeedbackApplyResult(
+            status="empty",
+            detail="Every Code PR feedback belongs to another host.",
+            feedback_id=feedback.feedback_id,
+            request_id=feedback.request_id,
+        )
+    if _terminal_every_code_request_closed_by_linked_pr(record):
+        _mark_every_code_pr_feedback(record_store, feedback=feedback, status="ignored")
+        return EveryCodePrFeedbackApplyResult(
+            status="ignored",
+            detail="Every Code PR feedback belongs to a closed linked pull request.",
+            feedback_id=feedback.feedback_id,
+            request_id=feedback.request_id,
+        )
+    state_path = every_code_session_state_path(state_dir=state_dir, request_id=record.request_id)
+    session_state = read_every_code_session_state(state_path)
+    if session_state is None:
+        _mark_every_code_pr_feedback(record_store, feedback=feedback, status="ignored")
+        return EveryCodePrFeedbackApplyResult(
+            status="ignored",
+            detail="Every Code PR feedback has no local session state on this host.",
+            feedback_id=feedback.feedback_id,
+            request_id=feedback.request_id,
+        )
+    if session_state.get("host", host) != host:
+        return EveryCodePrFeedbackApplyResult(
+            status="empty",
+            detail="Every Code PR feedback session state belongs to another host.",
+            feedback_id=feedback.feedback_id,
+            request_id=feedback.request_id,
+        )
+    session_name = session_state["session_name"]
+    existing_session = _tmux_session_exists(
+        tmux_binary=tmux_binary,
+        session_name=session_name,
+        runner=runner,
+    )
+    if existing_session is None:
+        return EveryCodePrFeedbackApplyResult(
+            status="blocked",
+            detail=f"Could not inspect tmux session {session_name!r}.",
+            feedback_id=feedback.feedback_id,
+            request_id=feedback.request_id,
+            session_name=session_name,
+        )
+    if existing_session:
+        if not _send_every_code_pr_feedback_to_session(
+            feedback=feedback,
+            session_name=session_name,
+            tmux_binary=tmux_binary,
+            runner=runner,
+        ):
+            return EveryCodePrFeedbackApplyResult(
+                status="blocked",
+                detail=f"Could not send PR feedback to tmux session {session_name!r}.",
+                feedback_id=feedback.feedback_id,
+                request_id=feedback.request_id,
+                session_name=session_name,
+            )
+        _mark_every_code_pr_feedback(record_store, feedback=feedback, status="applied")
+        return EveryCodePrFeedbackApplyResult(
+            status="applied",
+            detail="Every Code PR feedback was sent to the running session.",
+            feedback_id=feedback.feedback_id,
+            request_id=feedback.request_id,
+            session_name=session_name,
+        )
+
+    launch_root = Path(session_state.get("launch_root", "")).expanduser()
+    if not launch_root.is_dir():
+        _mark_every_code_pr_feedback(record_store, feedback=feedback, status="ignored")
+        state_path.unlink(missing_ok=True)
+        return EveryCodePrFeedbackApplyResult(
+            status="ignored",
+            detail="Every Code PR feedback worktree is no longer available on this host.",
+            feedback_id=feedback.feedback_id,
+            request_id=feedback.request_id,
+            session_name=session_name,
+        )
+    if record.state in TERMINAL_EVERY_CODE_STATES:
+        resumed = resume_every_code_work_request(
+            record,
+            host=host,
+            resumed_at=utc_now_timestamp(),
+            result_summary=f"Resumed for PR feedback: {feedback.html_url or feedback.pr_url}",
+        )
+        record_store.write_every_code_work_request_record(resumed)
+    command = build_every_code_feedback_session_command(
+        feedback=feedback,
+        state_dir=state_dir,
+        host=host,
+        database_url=database_url,
+        service_url=service_url,
+        worker_token_env=worker_token_env,
+    )
+    try:
+        launch_result = runner(
+            (
+                tmux_binary,
+                "new-session",
+                "-d",
+                "-s",
+                session_name,
+                "-c",
+                str(launch_root),
+                command,
+            )
+        )
+    except OSError:
+        return EveryCodePrFeedbackApplyResult(
+            status="blocked",
+            detail=f"Could not relaunch tmux session {session_name!r} for PR feedback.",
+            feedback_id=feedback.feedback_id,
+            request_id=feedback.request_id,
+            session_name=session_name,
+        )
+    if launch_result.returncode != 0:
+        return EveryCodePrFeedbackApplyResult(
+            status="blocked",
+            detail=f"tmux relaunch failed: {launch_result.stderr.strip()}",
+            feedback_id=feedback.feedback_id,
+            request_id=feedback.request_id,
+            session_name=session_name,
+        )
+    _mark_every_code_pr_feedback(record_store, feedback=feedback, status="applied")
+    return EveryCodePrFeedbackApplyResult(
+        status="applied",
+        detail="Every Code PR feedback resumed the local session.",
+        feedback_id=feedback.feedback_id,
+        request_id=feedback.request_id,
+        session_name=session_name,
+    )
 
 
 def build_every_code_worker_daemon_spec(
@@ -1186,6 +1538,43 @@ def request_every_code_pr_preview_label(
         detail = result.stderr.strip() or result.stdout.strip() or "gh pr edit failed"
         return f"Could not request Launchplane preview: {detail}"
     return f"Requested Launchplane preview with `{LAUNCHPLANE_PREVIEW_ENABLE_LABEL}`."
+
+
+def _mark_every_code_pr_feedback(
+    record_store: EveryCodeWorkerStore,
+    *,
+    feedback: EveryCodePrFeedbackRecord,
+    status: EveryCodePrFeedbackStatus,
+) -> EveryCodePrFeedbackRecord | None:
+    if feedback.status != "pending":
+        return None
+    updated_feedback = feedback.model_copy(update={"status": status})
+    record_store.write_every_code_pr_feedback_record(updated_feedback)
+    return updated_feedback
+
+
+def _terminal_every_code_request_closed_by_linked_pr(record: EveryCodeWorkRequestRecord) -> bool:
+    if record.state not in TERMINAL_EVERY_CODE_STATES:
+        return False
+    summary = record.result_summary.strip()
+    return summary.startswith("Linked pull request merged:") or summary.startswith(
+        "Linked pull request closed without merge:"
+    )
+
+
+def _send_every_code_pr_feedback_to_session(
+    *,
+    feedback: EveryCodePrFeedbackRecord,
+    session_name: str,
+    tmux_binary: str,
+    runner: Runner,
+) -> bool:
+    prompt = every_code_pr_feedback_prompt(feedback)
+    try:
+        result = runner((tmux_binary, "send-keys", "-t", session_name, prompt, "Enter"))
+    except OSError:
+        return False
+    return result.returncode == 0
 
 
 def _run_subprocess(args: Sequence[str]) -> subprocess.CompletedProcess[str]:

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -44,6 +44,8 @@ from control_plane.contracts.every_code_work_request import (
 from control_plane.contracts.every_code_pr_feedback_record import (
     EveryCodePrFeedbackKind,
     EveryCodePrFeedbackRecord,
+    EveryCodePrFeedbackStatus,
+    apply_every_code_pr_feedback_status,
     build_every_code_pr_feedback_id,
 )
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
@@ -1264,6 +1266,22 @@ class EveryCodeWorkRequestStatusEnvelope(BaseModel):
     updated_at: str = ""
 
 
+class EveryCodePrFeedbackStatusEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    feedback_id: str
+    request_id: str
+    status: EveryCodePrFeedbackStatus
+
+    @model_validator(mode="after")
+    def _validate_status(self) -> "EveryCodePrFeedbackStatusEnvelope":
+        if not self.feedback_id.strip():
+            raise ValueError("Every Code PR feedback status requires feedback_id")
+        if not self.request_id.strip():
+            raise ValueError("Every Code PR feedback status requires request_id")
+        return self
+
+
 class WorkGraphRankEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -1717,6 +1735,8 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
     segments = [segment for segment in path.split("/") if segment]
     if len(segments) == 3 and segments == ["v1", "every-code", "work-requests"]:
         return "every_code_work_request.read", {}
+    if len(segments) == 3 and segments == ["v1", "every-code", "pr-feedback"]:
+        return "every_code_pr_feedback.read", {}
     if len(segments) == 4 and segments[:3] == ["v1", "every-code", "work-requests"]:
         return "every_code_work_request.read", {"request_id": segments[3]}
     if len(segments) == 2 and segments == ["v1", "drivers"]:
@@ -1835,6 +1855,7 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/every-code/work-requests/create",
         "/v1/every-code/work-requests/claim",
         "/v1/every-code/work-requests/status",
+        "/v1/every-code/pr-feedback/status",
         "/v1/work-graph/rank",
         "/v1/evidence/deployments",
         "/v1/evidence/backup-gates",
@@ -2676,11 +2697,14 @@ def _every_code_worker_token_from_env() -> str:
 def _is_every_code_worker_route(*, method: str, path: str) -> bool:
     if method == "GET" and path == "/v1/every-code/work-requests":
         return True
+    if method == "GET" and path == "/v1/every-code/pr-feedback":
+        return True
     if method == "GET" and path.startswith("/v1/every-code/work-requests/"):
         return True
     return method == "POST" and path in {
         "/v1/every-code/work-requests/claim",
         "/v1/every-code/work-requests/status",
+        "/v1/every-code/pr-feedback/status",
     }
 
 
@@ -2707,13 +2731,33 @@ def _every_code_read_payload(
 ) -> dict[str, object]:
     every_code_store = _every_code_work_request_store(record_store)
     segments = [segment for segment in path.split("/") if segment]
+    if path == "/v1/every-code/pr-feedback":
+        request_id_filter = str((query.get("request_id") or [""])[0] or "").strip()
+        repository_filter = str((query.get("repository") or [""])[0] or "").strip()
+        status_filter = str((query.get("status") or [""])[0] or "").strip()
+        pr_number_value = str((query.get("pr_number") or [""])[0] or "").strip()
+        pr_number_filter = int(pr_number_value) if pr_number_value else None
+        limit = int(str((query.get("limit") or ["50"])[0] or "50"))
+        feedback_records = every_code_store.list_every_code_pr_feedback_records(
+            request_id=request_id_filter,
+            repository=repository_filter,
+            pr_number=pr_number_filter,
+            status=status_filter,
+            limit=limit,
+        )
+        return {
+            "request_id": request_id_filter,
+            "repository": repository_filter,
+            "status_filter": status_filter,
+            "feedback": [record.model_dump(mode="json") for record in feedback_records],
+        }
     if len(segments) == 4 and segments[:3] == ["v1", "every-code", "work-requests"]:
         record = every_code_store.read_every_code_work_request_record(segments[3])
         return {"request": record.model_dump(mode="json")}
     state_filter = str((query.get("state") or [""])[0] or "").strip()
     repository_filter = str((query.get("repository") or [""])[0] or "").strip()
     limit = int(str((query.get("limit") or ["50"])[0] or "50"))
-    records = every_code_store.list_every_code_work_request_records(
+    work_request_records = every_code_store.list_every_code_work_request_records(
         state=state_filter,
         repository=repository_filter,
         limit=limit,
@@ -2721,7 +2765,7 @@ def _every_code_read_payload(
     return {
         "state": state_filter,
         "repository": repository_filter,
-        "requests": [record.model_dump(mode="json") for record in records],
+        "requests": [record.model_dump(mode="json") for record in work_request_records],
     }
 
 
@@ -2753,6 +2797,64 @@ def _handle_every_code_worker_write(
     payload: dict[str, object],
 ) -> list[bytes]:
     every_code_store = _every_code_work_request_store(record_store)
+    if path == "/v1/every-code/pr-feedback/status":
+        feedback_status_request = EveryCodePrFeedbackStatusEnvelope.model_validate(payload)
+        feedback_matches = every_code_store.list_every_code_pr_feedback_records(
+            request_id=feedback_status_request.request_id.strip(),
+            limit=100,
+        )
+        existing_feedback_record = next(
+            (
+                record
+                for record in feedback_matches
+                if record.feedback_id == feedback_status_request.feedback_id.strip()
+            ),
+            None,
+        )
+        if existing_feedback_record is None:
+            return _json_response(
+                start_response=start_response,
+                status_code=404,
+                payload={
+                    "status": "rejected",
+                    "trace_id": trace_id,
+                    "error": {
+                        "code": "not_found",
+                        "message": "Every Code PR feedback record was not found.",
+                    },
+                },
+            )
+        updated_feedback_record = apply_every_code_pr_feedback_status(
+            existing_feedback_record,
+            status=feedback_status_request.status,
+        )
+        if updated_feedback_record is None:
+            return _json_response(
+                start_response=start_response,
+                status_code=409,
+                payload={
+                    "status": "rejected",
+                    "trace_id": trace_id,
+                    "error": {
+                        "code": "feedback_already_final",
+                        "message": "Every Code PR feedback is already applied or ignored.",
+                    },
+                },
+            )
+        every_code_store.write_every_code_pr_feedback_record(updated_feedback_record)
+        return _json_response(
+            start_response=start_response,
+            status_code=202,
+            payload=_accepted_payload(
+                trace_id=trace_id,
+                result={
+                    "request_id": updated_feedback_record.request_id,
+                    "feedback_id": updated_feedback_record.feedback_id,
+                    "status": updated_feedback_record.status,
+                },
+                driver_result={"feedback": updated_feedback_record.model_dump(mode="json")},
+            ),
+        )
     if path == "/v1/every-code/work-requests/claim":
         claim_request = EveryCodeWorkRequestClaimEnvelope.model_validate(payload)
         claimed_record = every_code_store.claim_every_code_work_request_record(
@@ -2782,29 +2884,32 @@ def _handle_every_code_worker_write(
                 driver_result={"request": claimed_record.model_dump(mode="json")},
             ),
         )
-    status_request = EveryCodeWorkRequestStatusEnvelope.model_validate(payload)
-    existing_record = every_code_store.read_every_code_work_request_record(
-        status_request.request_id.strip()
+    work_request_status_request = EveryCodeWorkRequestStatusEnvelope.model_validate(payload)
+    existing_work_request_record = every_code_store.read_every_code_work_request_record(
+        work_request_status_request.request_id.strip()
     )
-    updated_record = apply_every_code_work_request_status(
-        existing_record,
+    updated_work_request_record = apply_every_code_work_request_status(
+        existing_work_request_record,
         EveryCodeWorkRequestStatusUpdate(
-            state=status_request.state,
-            host=status_request.host,
-            updated_at=status_request.updated_at.strip() or _utc_now_timestamp(),
-            result_pr_url=status_request.result_pr_url,
-            result_summary=status_request.result_summary,
-            error_message=status_request.error_message,
+            state=work_request_status_request.state,
+            host=work_request_status_request.host,
+            updated_at=work_request_status_request.updated_at.strip() or _utc_now_timestamp(),
+            result_pr_url=work_request_status_request.result_pr_url,
+            result_summary=work_request_status_request.result_summary,
+            error_message=work_request_status_request.error_message,
         ),
     )
-    every_code_store.write_every_code_work_request_record(updated_record)
+    every_code_store.write_every_code_work_request_record(updated_work_request_record)
     return _json_response(
         start_response=start_response,
         status_code=202,
         payload=_accepted_payload(
             trace_id=trace_id,
-            result={"request_id": updated_record.request_id, "state": updated_record.state},
-            driver_result={"request": updated_record.model_dump(mode="json")},
+            result={
+                "request_id": updated_work_request_record.request_id,
+                "state": updated_work_request_record.state,
+            },
+            driver_result={"request": updated_work_request_record.model_dump(mode="json")},
         ),
     )
 

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -8,13 +8,16 @@ import signal
 import threading
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
 
 from click.testing import CliRunner
 
 from control_plane.cli import main
+from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
 from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
 from control_plane.every_code_worker import (
     EveryCodeWorkerApiStore,
+    apply_every_code_pr_feedback_for_host,
     build_every_code_worker_daemon_spec,
     build_every_code_session_command,
     close_terminal_every_code_sessions,
@@ -60,6 +63,24 @@ def _queued_preview_record() -> EveryCodeWorkRequestRecord:
             "repository": "every/tenant-opw",
             "issue_url": "https://github.com/every/tenant-opw/issues/123",
         }
+    )
+
+
+def _feedback_record(*, status: str = "pending") -> EveryCodePrFeedbackRecord:
+    return EveryCodePrFeedbackRecord(
+        feedback_id="every-code-pr-feedback-cbusillo-code-26-ic-1001",
+        request_id="every-code-cbusillo-code-123-test",
+        repository="cbusillo/code",
+        pr_number=26,
+        pr_url="https://github.com/cbusillo/code/pull/26",
+        feedback_kind="issue_comment",
+        github_delivery_id="delivery-comment",
+        github_node_id="IC_kwDO_test_1001",
+        actor="cbusillo",
+        body="Please tighten the README wording before merge.",
+        html_url="https://github.com/cbusillo/code/pull/26#issuecomment-1001",
+        received_at="2026-05-06T19:00:00Z",
+        status=status,  # type: ignore[arg-type]
     )
 
 
@@ -110,6 +131,16 @@ class _ExistingSessionRunner(_Runner):
         return subprocess.CompletedProcess(args, 0, "", "")
 
 
+class _GoneSessionRunner(_Runner):
+    def __call__(self, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        self.calls.append(tuple(args))
+        if args[1] == "has-session":
+            return subprocess.CompletedProcess(args, 1, "", "no session")
+        if args[0] == "tmux" and args[1] == "new-session":
+            return subprocess.CompletedProcess(args, 0, "", "")
+        return super().__call__(args)
+
+
 class _Process:
     def __init__(self, pid: int) -> None:
         self.pid = pid
@@ -126,11 +157,34 @@ class _EveryCodeApiHandler(BaseHTTPRequestHandler):
         if self.headers.get("Authorization") != f"Bearer {self.token}":
             self._write_json(401, {"status": "rejected"})
             return
-        if self.path.startswith("/v1/every-code/work-requests?"):
-            records = self.store.list_every_code_work_request_records(state="queued", limit=1)
+        if self.path.startswith("/v1/every-code/pr-feedback"):
+            query = parse_qs(urlparse(self.path).query)
+            feedback_records = self.store.list_every_code_pr_feedback_records(
+                status=str((query.get("status") or [""])[0]),
+                limit=10,
+            )
             self._write_json(
                 200,
-                {"status": "ok", "requests": [record.model_dump(mode="json") for record in records]},
+                {
+                    "status": "ok",
+                    "feedback": [
+                        record.model_dump(mode="json") for record in feedback_records
+                    ],
+                },
+            )
+            return
+        if self.path.startswith("/v1/every-code/work-requests?"):
+            work_request_records = self.store.list_every_code_work_request_records(
+                state="queued", limit=1
+            )
+            self._write_json(
+                200,
+                {
+                    "status": "ok",
+                    "requests": [
+                        record.model_dump(mode="json") for record in work_request_records
+                    ],
+                },
             )
             return
         request_id = self.path.rsplit("/", 1)[-1]
@@ -143,26 +197,56 @@ class _EveryCodeApiHandler(BaseHTTPRequestHandler):
             return
         content_length = int(self.headers.get("Content-Length", "0"))
         payload = json.loads(self.rfile.read(content_length).decode("utf-8"))
+        if self.path == "/v1/every-code/pr-feedback/status":
+            feedback_records = self.store.list_every_code_pr_feedback_records(
+                request_id=str(payload["request_id"]),
+                limit=10,
+            )
+            feedback_record = next(
+                record
+                for record in feedback_records
+                if record.feedback_id == payload["feedback_id"]
+            )
+            updated_feedback_record = feedback_record.model_copy(update={"status": payload["status"]})
+            self.store.write_every_code_pr_feedback_record(updated_feedback_record)
+            self._write_json(
+                202,
+                {
+                    "status": "accepted",
+                    "records": {
+                        "request_id": updated_feedback_record.request_id,
+                        "feedback_id": updated_feedback_record.feedback_id,
+                        "status": updated_feedback_record.status,
+                    },
+                    "result": {"feedback": updated_feedback_record.model_dump(mode="json")},
+                },
+            )
+            return
         if self.path == "/v1/every-code/work-requests/claim":
-            record = self.store.claim_every_code_work_request_record(
+            claimed_record = self.store.claim_every_code_work_request_record(
                 request_id=str(payload["request_id"]),
                 host=str(payload["host"]),
                 claimed_at="2026-05-06T00:00:00Z",
             )
-            if record is None:
+            if claimed_record is None:
                 self._write_json(409, {"status": "rejected"})
                 return
             self._write_json(
                 202,
                 {
                     "status": "accepted",
-                    "records": {"request_id": record.request_id, "state": record.state},
-                    "result": {"request": record.model_dump(mode="json")},
+                    "records": {
+                        "request_id": claimed_record.request_id,
+                        "state": claimed_record.state,
+                    },
+                    "result": {"request": claimed_record.model_dump(mode="json")},
                 },
             )
             return
-        record = self.store.read_every_code_work_request_record(str(payload["request_id"]))
-        updated_record = record.model_copy(
+        work_request_record = self.store.read_every_code_work_request_record(
+            str(payload["request_id"])
+        )
+        updated_work_request_record = work_request_record.model_copy(
             update={
                 "state": payload["state"],
                 "updated_at": payload["updated_at"],
@@ -173,16 +257,16 @@ class _EveryCodeApiHandler(BaseHTTPRequestHandler):
                 "error_message": payload.get("error_message", ""),
             }
         )
-        self.store.write_every_code_work_request_record(updated_record)
+        self.store.write_every_code_work_request_record(updated_work_request_record)
         self._write_json(
             202,
             {
                 "status": "accepted",
                 "records": {
-                    "request_id": updated_record.request_id,
-                    "state": updated_record.state,
+                    "request_id": updated_work_request_record.request_id,
+                    "state": updated_work_request_record.state,
                 },
-                "result": {"request": updated_record.model_dump(mode="json")},
+                "result": {"request": updated_work_request_record.model_dump(mode="json")},
             },
         )
 
@@ -237,6 +321,35 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(claimed_record.claimed_by_host, "Chris-Studio")
         self.assertEqual(read_record.state, "running")
         self.assertEqual(read_record.result_summary, "Visible tmux session: every-code-test")
+
+    def test_api_store_lists_and_updates_pr_feedback_via_service(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            _EveryCodeApiHandler.store = FilesystemRecordStore(
+                state_dir=temporary_root / "state"
+            )
+            _EveryCodeApiHandler.store.write_every_code_pr_feedback_record(_feedback_record())
+            server = ThreadingHTTPServer(("127.0.0.1", 0), _EveryCodeApiHandler)
+            server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+            server_thread.start()
+            try:
+                store = EveryCodeWorkerApiStore(
+                    service_url=f"http://127.0.0.1:{server.server_port}",
+                    worker_token="worker-token",
+                )
+
+                feedback_records = store.list_every_code_pr_feedback_records(status="pending")
+                applied_record = feedback_records[0].model_copy(update={"status": "applied"})
+                store.write_every_code_pr_feedback_record(applied_record)
+                listed_after_update = store.list_every_code_pr_feedback_records(status="applied")
+            finally:
+                server.shutdown()
+                server.server_close()
+                server_thread.join(timeout=5)
+
+        self.assertEqual(len(feedback_records), 1)
+        self.assertEqual(feedback_records[0].feedback_id, _feedback_record().feedback_id)
+        self.assertEqual(listed_after_update[0].status, "applied")
 
     def test_session_name_is_stable_and_tmux_safe(self) -> None:
         session_name = every_code_tmux_session_name("every code/cbusillo/code#123 !")
@@ -475,6 +588,131 @@ class EveryCodeWorkerTests(unittest.TestCase):
         )
         self.assertIn("every-code finish", launch_call[-1])
         self.assertTrue(any(call[:3] == ("gh", "issue", "comment") for call in runner.calls))
+
+    def test_apply_feedback_sends_prompt_to_active_session(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "state",
+                runner=_Runner(),
+            )
+            store.write_every_code_pr_feedback_record(_feedback_record())
+            runner = _ExistingSessionRunner()
+
+            result = apply_every_code_pr_feedback_for_host(
+                record_store=store,
+                host="Chris-Studio",
+                state_dir=temporary_root / "state",
+                runner=runner,
+            )
+            feedback = store.list_every_code_pr_feedback_records(limit=1)[0]
+
+        self.assertEqual(result.status, "applied")
+        self.assertEqual(feedback.status, "applied")
+        send_call = next(call for call in runner.calls if call[1] == "send-keys")
+        self.assertIn("Please tighten the README wording", send_call[4])
+
+    def test_apply_feedback_relaunches_terminal_session_in_saved_worktree(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "state",
+                runner=_Runner(),
+            )
+            finished_record = store.read_every_code_work_request_record(
+                "every-code-cbusillo-code-123-test"
+            ).model_copy(
+                update={
+                    "state": "done",
+                    "finished_at": "2026-05-06T19:05:00Z",
+                    "updated_at": "2026-05-06T19:05:00Z",
+                    "result_pr_url": "https://github.com/cbusillo/code/pull/26",
+                    "result_summary": "Opened PR.",
+                }
+            )
+            store.write_every_code_work_request_record(finished_record)
+            store.write_every_code_pr_feedback_record(_feedback_record())
+            runner = _GoneSessionRunner()
+
+            result = apply_every_code_pr_feedback_for_host(
+                record_store=store,
+                host="Chris-Studio",
+                state_dir=temporary_root / "state",
+                runner=runner,
+            )
+            feedback = store.list_every_code_pr_feedback_records(limit=1)[0]
+            resumed_record = store.read_every_code_work_request_record(
+                "every-code-cbusillo-code-123-test"
+            )
+
+        self.assertEqual(result.status, "applied")
+        self.assertEqual(feedback.status, "applied")
+        self.assertEqual(resumed_record.state, "running")
+        self.assertEqual(resumed_record.finished_at, "")
+        launch_call = next(call for call in runner.calls if call[1] == "new-session")
+        self.assertEqual(
+            launch_call[6],
+            str(every_code_worktree_root(_queued_record(), state_dir=temporary_root / "state")),
+        )
+        self.assertIn("Every Code received new PR feedback", launch_call[-1])
+
+    def test_apply_feedback_ignores_request_closed_by_linked_pr(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "state",
+                runner=_Runner(),
+            )
+            closed_record = store.read_every_code_work_request_record(
+                "every-code-cbusillo-code-123-test"
+            ).model_copy(
+                update={
+                    "state": "done",
+                    "finished_at": "2026-05-06T19:05:00Z",
+                    "updated_at": "2026-05-06T19:05:00Z",
+                    "result_pr_url": "https://github.com/cbusillo/code/pull/26",
+                    "result_summary": "Linked pull request merged: https://github.com/cbusillo/code/pull/26",
+                }
+            )
+            store.write_every_code_work_request_record(closed_record)
+            store.write_every_code_pr_feedback_record(_feedback_record())
+            runner = _GoneSessionRunner()
+
+            result = apply_every_code_pr_feedback_for_host(
+                record_store=store,
+                host="Chris-Studio",
+                state_dir=temporary_root / "state",
+                runner=runner,
+            )
+            feedback = store.list_every_code_pr_feedback_records(limit=1)[0]
+
+        self.assertEqual(result.status, "ignored")
+        self.assertEqual(feedback.status, "ignored")
+        self.assertFalse(any(call[1] == "new-session" for call in runner.calls))
 
     def test_terminal_host_request_sends_sigterm_to_session_process_group(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1538,6 +1538,111 @@ class LaunchplaneServiceTests(unittest.TestCase):
         )
         self.assertTrue(second_response["deduped"])
 
+    def test_every_code_worker_token_lists_and_marks_pr_feedback(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        issue_payload = _every_code_github_issue_labeled_payload()
+        comment_payload = _every_code_github_pr_comment_payload(comment_id=3003)
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            _issue_status, issue_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=issue_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-issue",
+                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                },
+            )
+            request_id = issue_response["records"]["request_id"]
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/claim",
+                payload={"request_id": request_id, "host": "Chris-Studio"},
+                authorization="Bearer dev-worker-token",
+            )
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/status",
+                payload={
+                    "request_id": request_id,
+                    "host": "Chris-Studio",
+                    "state": "done",
+                    "result_pr_url": "https://github.com/cbusillo/code/pull/26",
+                    "result_summary": "Opened PR.",
+                    "updated_at": "2026-05-06T16:00:00Z",
+                },
+                authorization="Bearer dev-worker-token",
+            )
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=comment_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issue_comment",
+                    "X-GitHub-Delivery": "delivery-comment",
+                    "X-Hub-Signature-256": _github_webhook_signature(comment_payload, secret),
+                },
+            )
+            list_status, list_response = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/every-code/pr-feedback",
+                query_string=f"request_id={request_id}&status=pending",
+                authorization="Bearer dev-worker-token",
+            )
+            self.assertEqual(list_status, 200, list_response)
+            feedback_id = list_response["feedback"][0]["feedback_id"]
+            status_status, status_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/pr-feedback/status",
+                payload={
+                    "feedback_id": feedback_id,
+                    "request_id": request_id,
+                    "status": "applied",
+                },
+                authorization="Bearer dev-worker-token",
+            )
+            second_status, second_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/pr-feedback/status",
+                payload={
+                    "feedback_id": feedback_id,
+                    "request_id": request_id,
+                    "status": "ignored",
+                },
+                authorization="Bearer dev-worker-token",
+            )
+
+        self.assertEqual(list_status, 200)
+        self.assertEqual(len(list_response["feedback"]), 1)
+        self.assertEqual(status_status, 202)
+        self.assertEqual(status_response["result"]["feedback"]["status"], "applied")
+        self.assertEqual(second_status, 409)
+        self.assertEqual(second_response["error"]["code"], "feedback_already_final")
+
     def test_every_code_github_webhook_rejects_invalid_signature(self) -> None:
         secret = "launchplane-every-code-webhook-secret"
         webhook_payload = _every_code_github_issue_labeled_payload()


### PR DESCRIPTION
## Summary
- add worker-token APIs for listing pending Every Code PR feedback and marking feedback applied/ignored
- have the local Every Code worker apply pending PR feedback to live tmux sessions or relaunch the saved worktree when the original session exited after opening a PR
- keep truly terminal linked-PR closures from being resurrected by late feedback

Refs #332

## Validation
- `uv run python -m unittest tests.test_every_code_worker`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`
