### PR TITLE
feat(every-code): sync PR feedback webhook events

### DIFF
--- a/control_plane/every_code_webhooks.py
+++ b/control_plane/every_code_webhooks.py
@@ -6,7 +6,13 @@ import subprocess
 from typing import Callable, Sequence
 
 
-EVERY_CODE_WEBHOOK_EVENTS = ("issues", "pull_request")
+EVERY_CODE_WEBHOOK_EVENTS = (
+    "issues",
+    "pull_request",
+    "issue_comment",
+    "pull_request_review",
+    "pull_request_review_comment",
+)
 EVERY_CODE_WEBHOOK_URL = "https://launchplane.shinycomputers.com/v1/every-code/github-webhook"
 
 Runner = Callable[[Sequence[str], str | None], subprocess.CompletedProcess[str]]

--- a/tests/test_every_code_webhooks.py
+++ b/tests/test_every_code_webhooks.py
@@ -68,8 +68,15 @@ class EveryCodeWebhookSyncTests(unittest.TestCase):
         }
         patch_payload = payloads["PATCH"]
         post_payload = payloads["POST"]
-        self.assertEqual(patch_payload["events"], ["issues", "pull_request"])
-        self.assertEqual(post_payload["events"], ["issues", "pull_request"])
+        expected_events = [
+            "issues",
+            "pull_request",
+            "issue_comment",
+            "pull_request_review",
+            "pull_request_review_comment",
+        ]
+        self.assertEqual(patch_payload["events"], expected_events)
+        self.assertEqual(post_payload["events"], expected_events)
         self.assertEqual(patch_payload["config"]["secret"], "secret")
 
 


### PR DESCRIPTION
## Summary
- expand Every Code webhook sync to include PR feedback events
- keep hook create/update behavior idempotent while requesting issue, PR lifecycle, and PR feedback deliveries

Refs #333

## Validation
- `uv run python -m unittest tests.test_every_code_webhooks`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`
