### PR TITLE
Use repo preview label for Every Code PRs

### DIFF
--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -25,9 +25,8 @@ from control_plane.contracts.every_code_work_request import (
     resume_every_code_work_request,
 )
 from control_plane.workflows.launchplane import (
-    LAUNCHPLANE_PREVIEW_ENABLE_LABEL,
     github_pull_request_reference,
-    launchplane_anchor_repo_eligible,
+    launchplane_anchor_repo_preview_label,
 )
 from control_plane.workflows.ship import utc_now_timestamp
 
@@ -72,9 +71,7 @@ class EveryCodeWorkerStore(Protocol):
         limit: int | None = None,
     ) -> tuple[EveryCodePrFeedbackRecord, ...]: ...
 
-    def write_every_code_pr_feedback_record(
-        self, record: EveryCodePrFeedbackRecord
-    ) -> object: ...
+    def write_every_code_pr_feedback_record(self, record: EveryCodePrFeedbackRecord) -> object: ...
 
 
 Runner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
@@ -1517,7 +1514,8 @@ def request_every_code_pr_preview_label(
     reference = github_pull_request_reference(pr_url=result_pr_url.strip())
     if reference is None:
         return ""
-    if not launchplane_anchor_repo_eligible(repo=reference["repo"]):
+    preview_label = launchplane_anchor_repo_preview_label(repo=reference["repo"])
+    if not preview_label:
         return ""
     run = runner or _run_subprocess
     repo = f"{reference['owner']}/{reference['repo']}"
@@ -1531,7 +1529,7 @@ def request_every_code_pr_preview_label(
                 "--repo",
                 repo,
                 "--add-label",
-                LAUNCHPLANE_PREVIEW_ENABLE_LABEL,
+                preview_label,
             )
         )
     except OSError as exc:
@@ -1539,7 +1537,7 @@ def request_every_code_pr_preview_label(
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or "gh pr edit failed"
         return f"Could not request Launchplane preview: {detail}"
-    return f"Requested Launchplane preview with `{LAUNCHPLANE_PREVIEW_ENABLE_LABEL}`."
+    return f"Requested Launchplane preview with `{preview_label}`."
 
 
 def _mark_every_code_pr_feedback(

--- a/control_plane/workflows/launchplane.py
+++ b/control_plane/workflows/launchplane.py
@@ -54,6 +54,9 @@ LAUNCHPLANE_TENANT_ANCHOR_CONTEXTS: dict[str, str] = {
     "tenant-cm": "cm",
     "tenant-opw": "opw",
 }
+LAUNCHPLANE_TENANT_ANCHOR_PREVIEW_LABELS: dict[str, str] = {
+    "sellyouroutboard": "preview",
+}
 LAUNCHPLANE_PREVIEW_REQUEST_BLOCK_PATTERN = re.compile(
     rf"```{re.escape(LAUNCHPLANE_PREVIEW_REQUEST_BLOCK_INFO_STRING)}[ \t]*\r?\n(?P<body>.*?)\r?\n```",
     flags=re.IGNORECASE | re.DOTALL,
@@ -113,6 +116,13 @@ def launchplane_anchor_repo_context(*, repo: str) -> str:
 
 def launchplane_anchor_repo_eligible(*, repo: str) -> bool:
     return bool(launchplane_anchor_repo_context(repo=repo))
+
+
+def launchplane_anchor_repo_preview_label(*, repo: str) -> str:
+    repo_name = repo.strip()
+    if not launchplane_anchor_repo_eligible(repo=repo_name):
+        return ""
+    return LAUNCHPLANE_TENANT_ANCHOR_PREVIEW_LABELS.get(repo_name, LAUNCHPLANE_PREVIEW_ENABLE_LABEL)
 
 
 def classify_pull_request_event_for_launchplane(

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -1030,7 +1030,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
                 "--repo",
                 "cbusillo/sellyouroutboard",
                 "--add-label",
-                "launchplane-preview",
+                "preview",
             ),
             runner.calls,
         )

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -173,9 +173,7 @@ class _EveryCodeApiHandler(BaseHTTPRequestHandler):
                 200,
                 {
                     "status": "ok",
-                    "feedback": [
-                        record.model_dump(mode="json") for record in feedback_records
-                    ],
+                    "feedback": [record.model_dump(mode="json") for record in feedback_records],
                 },
             )
             return
@@ -187,9 +185,7 @@ class _EveryCodeApiHandler(BaseHTTPRequestHandler):
                 200,
                 {
                     "status": "ok",
-                    "requests": [
-                        record.model_dump(mode="json") for record in work_request_records
-                    ],
+                    "requests": [record.model_dump(mode="json") for record in work_request_records],
                 },
             )
             return
@@ -213,7 +209,9 @@ class _EveryCodeApiHandler(BaseHTTPRequestHandler):
                 for record in feedback_records
                 if record.feedback_id == payload["feedback_id"]
             )
-            updated_feedback_record = feedback_record.model_copy(update={"status": payload["status"]})
+            updated_feedback_record = feedback_record.model_copy(
+                update={"status": payload["status"]}
+            )
             self.store.write_every_code_pr_feedback_record(updated_feedback_record)
             self._write_json(
                 202,
@@ -329,9 +327,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
     def test_api_store_lists_and_updates_pr_feedback_via_service(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             temporary_root = Path(temporary_directory_name)
-            _EveryCodeApiHandler.store = FilesystemRecordStore(
-                state_dir=temporary_root / "state"
-            )
+            _EveryCodeApiHandler.store = FilesystemRecordStore(state_dir=temporary_root / "state")
             _EveryCodeApiHandler.store.write_every_code_pr_feedback_record(_feedback_record())
             server = ThreadingHTTPServer(("127.0.0.1", 0), _EveryCodeApiHandler)
             server_thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -461,7 +457,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
                 "--repo",
                 "cbusillo/sellyouroutboard",
                 "--add-label",
-                "launchplane-preview",
+                "preview",
             ),
             runner.calls,
         )


### PR DESCRIPTION
## Summary
- add a preview label map for preview-capable anchor repos
- request SYO previews with the product repo's existing `preview` label
- keep existing tenant repos on `launchplane-preview`

Refs #331

## Verification
- uv run python -m unittest tests.test_every_code_worker.EveryCodeWorkerTests.test_preview_label_request_labels_sellyouroutboard_pull_request tests.test_every_code_worker.EveryCodeWorkerTests.test_preview_label_request_labels_eligible_pull_request tests.test_every_code_worker.EveryCodeWorkerTests.test_preview_label_request_skips_ineligible_pull_request
- git diff --check
- uv run --extra dev ruff check --diff control_plane/workflows/launchplane.py control_plane/every_code_worker.py tests/test_every_code_worker.py
- uv run --extra dev ruff check control_plane/workflows/launchplane.py control_plane/every_code_worker.py tests/test_every_code_worker.py
- uv run --extra dev ruff format --check control_plane/workflows/launchplane.py control_plane/every_code_worker.py tests/test_every_code_worker.py
- uv run --extra dev mypy control_plane/workflows/launchplane.py control_plane/every_code_worker.py tests/test_every_code_worker.py

Live smoke context: cbusillo/sellyouroutboard already has a `preview` label and its preview-control-plane workflow keys on that label; it does not have `launchplane-preview`.