### PR TITLE
Normalize generic-web promotion artifact tags

### DIFF
--- a/control_plane/workflows/generic_web_deploy.py
+++ b/control_plane/workflows/generic_web_deploy.py
@@ -92,11 +92,35 @@ def _fallback_target_name(*, profile: LaunchplaneProductProfileRecord, lane: Pro
     return f"{profile.product}-{lane.instance}"
 
 
+def normalize_generic_web_artifact_id(
+    *, profile: LaunchplaneProductProfileRecord, artifact_id: str
+) -> str:
+    normalized_artifact_id = artifact_id.strip()
+    image_repository = profile.image.repository.strip().rstrip("/")
+    if not normalized_artifact_id:
+        raise click.ClickException("Generic web deploy requires artifact_id.")
+    if normalized_artifact_id.startswith(f"{image_repository}@") or normalized_artifact_id.startswith(
+        f"{image_repository}:"
+    ):
+        return normalized_artifact_id
+    if normalized_artifact_id.startswith("sha256:"):
+        return f"{image_repository}@{normalized_artifact_id}"
+    if "/" in normalized_artifact_id or "@" in normalized_artifact_id:
+        raise click.ClickException(
+            "Generic web artifact_id must use the product image repository "
+            f"{image_repository!r}, or be a bare image tag."
+        )
+    return f"{image_repository}:{normalized_artifact_id}"
+
+
 def _fallback_ship_request(
     *, request: GenericWebDeployRequest, profile: LaunchplaneProductProfileRecord, lane: ProductLaneProfile
 ) -> ShipRequest:
     return ShipRequest(
-        artifact_id=request.artifact_id,
+        artifact_id=normalize_generic_web_artifact_id(
+            profile=profile,
+            artifact_id=request.artifact_id,
+        ),
         context=lane.context,
         instance=lane.instance,
         source_git_ref=request.source_git_ref,
@@ -148,7 +172,10 @@ def _resolve_ship_request(
         profile=profile, lane=lane
     )
     ship_request = ShipRequest(
-        artifact_id=request.artifact_id,
+        artifact_id=normalize_generic_web_artifact_id(
+            profile=profile,
+            artifact_id=request.artifact_id,
+        ),
         context=lane.context,
         instance=lane.instance,
         source_git_ref=request.source_git_ref,

--- a/control_plane/workflows/generic_web_promotion.py
+++ b/control_plane/workflows/generic_web_promotion.py
@@ -29,6 +29,7 @@ from control_plane.workflows.generic_web_deploy import (
     GenericWebDeployStore,
     GenericWebDeployRequest,
     execute_generic_web_deploy,
+    normalize_generic_web_artifact_id,
     resolve_generic_web_profile_lane,
 )
 from control_plane.workflows.inventory import build_environment_inventory
@@ -157,6 +158,14 @@ def execute_generic_web_prod_promotion(
     profile, source_lane, destination_lane = resolve_generic_web_promotion_lanes(
         record_store=record_store,
         request=request,
+    )
+    request = request.model_copy(
+        update={
+            "artifact_id": normalize_generic_web_artifact_id(
+                profile=profile,
+                artifact_id=request.artifact_id,
+            )
+        }
     )
     promotion_record_id = generate_promotion_record_id(
         context_name=destination_lane.context,

--- a/tests/test_generic_web_deploy.py
+++ b/tests/test_generic_web_deploy.py
@@ -15,6 +15,7 @@ from control_plane.dokploy import DokploySourceOfTruth, DokployTargetDefinition
 from control_plane.workflows.generic_web_deploy import (
     GenericWebDeployRequest,
     execute_generic_web_deploy,
+    normalize_generic_web_artifact_id,
     resolve_generic_web_profile_lane,
 )
 
@@ -85,6 +86,24 @@ def _source_of_truth() -> DokploySourceOfTruth:
 
 
 class GenericWebDeployTests(unittest.TestCase):
+    def test_normalize_generic_web_artifact_id_qualifies_bare_release_tag(self) -> None:
+        artifact_id = normalize_generic_web_artifact_id(
+            profile=_profile(),
+            artifact_id="sha-2da6435e10cade0870ed5cbdf40c8048594f8b1c",
+        )
+
+        self.assertEqual(
+            artifact_id,
+            "ghcr.io/cbusillo/sellyouroutboard:sha-2da6435e10cade0870ed5cbdf40c8048594f8b1c",
+        )
+
+    def test_normalize_generic_web_artifact_id_rejects_other_repositories(self) -> None:
+        with self.assertRaises(click.ClickException):
+            normalize_generic_web_artifact_id(
+                profile=_profile(),
+                artifact_id="ghcr.io/cbusillo/other-app:sha-abc123",
+            )
+
     def test_execute_generic_web_deploy_writes_pass_record_for_profile_lane(self) -> None:
         store = _GenericWebDeployStore(_profile())
 
@@ -114,11 +133,51 @@ class GenericWebDeployTests(unittest.TestCase):
         self.assertEqual(result.target_id, "target-123")
         self.assertEqual(len(store.deployments), 1)
         self.assertEqual(store.deployments[0].deploy.status, "pass")
+        self.assertEqual(
+            store.deployments[0].artifact_identity.artifact_id,
+            "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+        )
         self.assertIsNotNone(store.deployments[0].resolved_target)
         resolved_target = store.deployments[0].resolved_target
         assert resolved_target is not None
         self.assertEqual(resolved_target.target_name, "sellyouroutboard-testing-app")
         deploy.assert_called_once()
+
+    def test_execute_generic_web_deploy_uses_qualified_bare_tag(self) -> None:
+        store = _GenericWebDeployStore(_profile())
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                return_value=_source_of_truth(),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_deploy.control_plane_runtime_environments.resolve_runtime_environment_values",
+                return_value={},
+            ),
+            patch(
+                "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch("control_plane.workflows.generic_web_deploy.execute_dokploy_artifact_deploy") as deploy,
+        ):
+            execute_generic_web_deploy(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebDeployRequest(
+                    product="sellyouroutboard",
+                    instance="testing",
+                    artifact_id="sha-2da6435e10cade0870ed5cbdf40c8048594f8b1c",
+                    source_git_ref="2da6435e10cade0870ed5cbdf40c8048594f8b1c",
+                ),
+            )
+
+        deploy_request = deploy.call_args.kwargs["ship_request"]
+        expected_artifact_id = (
+            "ghcr.io/cbusillo/sellyouroutboard:sha-2da6435e10cade0870ed5cbdf40c8048594f8b1c"
+        )
+        self.assertEqual(deploy_request.artifact_id, expected_artifact_id)
+        self.assertEqual(store.deployments[0].artifact_identity.artifact_id, expected_artifact_id)
 
     def test_execute_generic_web_deploy_records_failure_when_provider_fails(self) -> None:
         store = _GenericWebDeployStore(_profile())

--- a/tests/test_generic_web_promotion.py
+++ b/tests/test_generic_web_promotion.py
@@ -17,9 +17,13 @@ from control_plane.contracts.product_profile_record import (
     ProductPromotionWorkflowProfile,
     ProductPreviewProfile,
 )
-from control_plane.contracts.promotion_record import HealthcheckEvidence, PromotionRecord
+from control_plane.contracts.promotion_record import (
+    ArtifactIdentityReference,
+    HealthcheckEvidence,
+    PromotionRecord,
+)
 from control_plane.contracts.ship_request import ShipRequest
-from control_plane.workflows.generic_web_deploy import GenericWebDeployResult
+from control_plane.workflows.generic_web_deploy import GenericWebDeployRequest, GenericWebDeployResult
 from control_plane.workflows.generic_web_promotion import (
     GenericWebProdPromotionRequest,
     execute_generic_web_prod_promotion,
@@ -193,6 +197,52 @@ class GenericWebProdPromotionTests(unittest.TestCase):
         self.assertEqual(deployment.destination_health.status, "pass")
         self.assertIn(("sellyouroutboard-testing", "prod"), store.inventories)
         self.assertEqual(healthcheck.call_count, 2)
+
+    def test_execute_prod_promotion_qualifies_bare_release_tag(self) -> None:
+        store = _GenericWebPromotionStore(_profile())
+        seen_artifact_ids: list[str] = []
+
+        def fake_deploy(**kwargs: object) -> GenericWebDeployResult:
+            deploy_request = kwargs["request"]
+            self.assertIsInstance(deploy_request, GenericWebDeployRequest)
+            seen_artifact_ids.append(deploy_request.artifact_id)
+            store.write_deployment_record(
+                _deployment_record().model_copy(
+                    update={
+                        "artifact_identity": ArtifactIdentityReference(
+                            artifact_id=deploy_request.artifact_id
+                        )
+                    }
+                )
+            )
+            return _deploy_result()
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_promotion.execute_generic_web_deploy",
+                side_effect=fake_deploy,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_promotion._wait_for_healthcheck",
+                return_value=None,
+            ),
+        ):
+            result = execute_generic_web_prod_promotion(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=_request(
+                    artifact_id="sha-2da6435e10cade0870ed5cbdf40c8048594f8b1c",
+                    source_git_ref="2da6435e10cade0870ed5cbdf40c8048594f8b1c",
+                ),
+            )
+
+        expected_artifact_id = (
+            "ghcr.io/cbusillo/sellyouroutboard:sha-2da6435e10cade0870ed5cbdf40c8048594f8b1c"
+        )
+        self.assertEqual(seen_artifact_ids, [expected_artifact_id])
+        self.assertEqual(result.artifact_id, expected_artifact_id)
+        promotion = next(iter(store.promotions.values()))
+        self.assertEqual(promotion.artifact_identity.artifact_id, expected_artifact_id)
 
     def test_dry_run_returns_pending_evidence_without_mutation(self) -> None:
         store = _GenericWebPromotionStore(_profile())


### PR DESCRIPTION
## Summary
- qualify bare generic-web artifact tags with the product profile image repository before Dokploy mutation
- preserve canonical artifact identity in deployment and promotion records
- reject artifact references that point at a different image repository

Refs #344

## Validation
- uv run python -m unittest tests.test_generic_web_deploy tests.test_generic_web_promotion
- uv run --extra dev ruff check control_plane/workflows/generic_web_deploy.py control_plane/workflows/generic_web_promotion.py tests/test_generic_web_deploy.py tests/test_generic_web_promotion.py

## Live Evidence
- Root cause: SYO prod promotion sent bare artifact_id `sha-2da6435e10cade0870ed5cbdf40c8048594f8b1c`, leaving Dokploy prod target `dockerImage` set to that non-pullable value.
- Supported retry run succeeded with explicit image `ghcr.io/cbusillo/sellyouroutboard:sha-2da6435e10cade0870ed5cbdf40c8048594f8b1c`: https://github.com/cbusillo/sellyouroutboard/actions/runs/25457336793
- Production health now reports revision `2da6435e10cade0870ed5cbdf40c8048594f8b1c`.
