### PR TITLE
Fix Every Code PR close lookup

### DIFF
--- a/control_plane/contracts/every_code_work_request.py
+++ b/control_plane/contracts/every_code_work_request.py
@@ -93,7 +93,9 @@ def build_every_code_work_request_id(
     normalized_repository = repository.strip().lower()
     normalized_label = trigger_label.strip().lower()
     if not normalized_repository or issue_number < 1 or not normalized_label:
-        raise ValueError("Every Code work request id requires repository, issue_number, and trigger_label")
+        raise ValueError(
+            "Every Code work request id requires repository, issue_number, and trigger_label"
+        )
     digest = hashlib.sha256(
         f"{normalized_repository}#{issue_number}:{normalized_label}".encode("utf-8")
     ).hexdigest()[:16]
@@ -185,7 +187,7 @@ def close_every_code_work_request_for_pull_request(
         raise ValueError("Every Code PR close update requires pr_url")
     if not closed_at.strip():
         raise ValueError("Every Code PR close update requires closed_at")
-    if record.result_pr_url.strip() != normalized_pr_url:
+    if record.result_pr_url.strip() and record.result_pr_url.strip() != normalized_pr_url:
         return None
     if record.state in {"queued", "done", "blocked"}:
         return None

--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -47,6 +47,7 @@ class EveryCodeWorkerStore(Protocol):
         state: str = "",
         repository: str = "",
         limit: int | None = None,
+        offset: int = 0,
     ) -> tuple[EveryCodeWorkRequestRecord, ...]: ...
 
     def claim_every_code_work_request_record(
@@ -69,6 +70,7 @@ class EveryCodeWorkerStore(Protocol):
         pr_number: int | None = None,
         status: str = "",
         limit: int | None = None,
+        offset: int = 0,
     ) -> tuple[EveryCodePrFeedbackRecord, ...]: ...
 
     def write_every_code_pr_feedback_record(self, record: EveryCodePrFeedbackRecord) -> object: ...
@@ -110,6 +112,7 @@ class EveryCodeWorkerApiStore:
         state: str = "",
         repository: str = "",
         limit: int | None = None,
+        offset: int = 0,
     ) -> tuple[EveryCodeWorkRequestRecord, ...]:
         query: dict[str, object] = {}
         if state.strip():
@@ -118,6 +121,8 @@ class EveryCodeWorkerApiStore:
             query["repository"] = repository.strip()
         if limit is not None:
             query["limit"] = limit
+        if offset > 0:
+            query["offset"] = offset
         suffix = f"?{urlencode(query)}" if query else ""
         payload = self._request("GET", f"/v1/every-code/work-requests{suffix}")
         requests = payload.get("requests", [])
@@ -179,6 +184,7 @@ class EveryCodeWorkerApiStore:
         pr_number: int | None = None,
         status: str = "",
         limit: int | None = None,
+        offset: int = 0,
     ) -> tuple[EveryCodePrFeedbackRecord, ...]:
         query: dict[str, object] = {}
         if request_id.strip():
@@ -191,6 +197,8 @@ class EveryCodeWorkerApiStore:
             query["status"] = status.strip()
         if limit is not None:
             query["limit"] = limit
+        if offset > 0:
+            query["offset"] = offset
         suffix = f"?{urlencode(query)}" if query else ""
         payload = self._request("GET", f"/v1/every-code/pr-feedback{suffix}")
         feedback = payload.get("feedback", [])

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -12,7 +12,7 @@ import secrets
 from socketserver import ThreadingMixIn
 import uuid
 from pathlib import Path
-from typing import BinaryIO, Callable, Generic, Literal, Protocol, TypeVar, cast
+from typing import BinaryIO, Callable, Generic, Iterable, Literal, Protocol, TypeVar, cast
 from urllib.parse import parse_qs, unquote
 from wsgiref.simple_server import WSGIServer, make_server
 from wsgiref.types import WSGIApplication
@@ -1904,6 +1904,7 @@ class _EveryCodeWorkRequestStore(Protocol):
         state: str = "",
         repository: str = "",
         limit: int | None = None,
+        offset: int = 0,
     ) -> tuple[EveryCodeWorkRequestRecord, ...]: ...
 
     def claim_every_code_work_request_record(
@@ -1914,9 +1915,7 @@ class _EveryCodeWorkRequestStore(Protocol):
         claimed_at: str,
     ) -> EveryCodeWorkRequestRecord | None: ...
 
-    def write_every_code_pr_feedback_record(
-        self, record: EveryCodePrFeedbackRecord
-    ) -> object: ...
+    def write_every_code_pr_feedback_record(self, record: EveryCodePrFeedbackRecord) -> object: ...
 
     def list_every_code_pr_feedback_records(
         self,
@@ -1926,6 +1925,7 @@ class _EveryCodeWorkRequestStore(Protocol):
         pr_number: int | None = None,
         status: str = "",
         limit: int | None = None,
+        offset: int = 0,
     ) -> tuple[EveryCodePrFeedbackRecord, ...]: ...
 
 
@@ -2145,26 +2145,62 @@ def _handle_every_code_pull_request_webhook(
     merged = bool(pull_request_payload.get("merged")) if pull_request_payload else False
     closed_at = _github_webhook_string(pull_request_payload, "closed_at") or _utc_now_timestamp()
     every_code_store = _every_code_work_request_store(record_store)
-    matched_record: EveryCodeWorkRequestRecord | None = None
-    updated_record: EveryCodeWorkRequestRecord | None = None
-    for record in every_code_store.list_every_code_work_request_records(
+    matched_record = _find_every_code_work_request_for_pull_request(
+        every_code_store,
         repository=repository,
-        limit=100,
-    ):
-        if record.result_pr_url.strip() != pr_url:
-            continue
-        matched_record = record
+        pr_url=pr_url,
+    )
+    updated_record: EveryCodeWorkRequestRecord | None = None
+    if matched_record is not None:
         closed_record = close_every_code_work_request_for_pull_request(
-            record,
+            matched_record,
             pr_url=pr_url,
             merged=merged,
             closed_at=closed_at,
         )
-        if closed_record is None:
+        if closed_record is not None:
+            every_code_store.write_every_code_work_request_record(closed_record)
+            updated_record = closed_record
+
+    if updated_record is None and matched_record is None:
+        feedback_record = _find_every_code_pr_feedback_for_pull_request(
+            every_code_store,
+            repository=repository,
+            pr_url=pr_url,
+        )
+        if feedback_record is not None:
+            matched_record = every_code_store.read_every_code_work_request_record(
+                feedback_record.request_id
+            )
+            closed_record = close_every_code_work_request_for_pull_request(
+                matched_record,
+                pr_url=pr_url,
+                merged=merged,
+                closed_at=closed_at,
+            )
+            if closed_record is not None:
+                every_code_store.write_every_code_work_request_record(closed_record)
+                updated_record = closed_record
+
+    if updated_record is None and matched_record is None:
+        for record in _iter_every_code_work_request_records(
+            every_code_store,
+            repository=repository,
+        ):
+            if record.issue_url.strip() != pr_url:
+                continue
+            matched_record = record
+            closed_record = close_every_code_work_request_for_pull_request(
+                record,
+                pr_url=pr_url,
+                merged=merged,
+                closed_at=closed_at,
+            )
+            if closed_record is None:
+                break
+            every_code_store.write_every_code_work_request_record(closed_record)
+            updated_record = closed_record
             break
-        every_code_store.write_every_code_work_request_record(closed_record)
-        updated_record = closed_record
-        break
 
     if matched_record is None:
         return _json_response(
@@ -2202,6 +2238,78 @@ def _handle_every_code_pull_request_webhook(
     )
     accepted_payload["github_delivery_id"] = delivery_id
     return _json_response(start_response=start_response, status_code=202, payload=accepted_payload)
+
+
+def _find_every_code_work_request_for_pull_request(
+    every_code_store: _EveryCodeWorkRequestStore,
+    *,
+    repository: str,
+    pr_url: str,
+) -> EveryCodeWorkRequestRecord | None:
+    for record in _iter_every_code_work_request_records(
+        every_code_store,
+        repository=repository,
+    ):
+        if record.result_pr_url.strip() == pr_url:
+            return record
+    return None
+
+
+def _find_every_code_pr_feedback_for_pull_request(
+    every_code_store: _EveryCodeWorkRequestStore,
+    *,
+    repository: str,
+    pr_url: str,
+) -> EveryCodePrFeedbackRecord | None:
+    for record in _iter_every_code_pr_feedback_records(
+        every_code_store,
+        repository=repository,
+    ):
+        if record.pr_url.strip() == pr_url:
+            return record
+    return None
+
+
+def _iter_every_code_work_request_records(
+    every_code_store: _EveryCodeWorkRequestStore,
+    *,
+    repository: str,
+) -> Iterable[EveryCodeWorkRequestRecord]:
+    page_size = 100
+    offset = 0
+    while True:
+        records = every_code_store.list_every_code_work_request_records(
+            repository=repository,
+            limit=page_size,
+            offset=offset,
+        )
+        if not records:
+            break
+        yield from records
+        if len(records) < page_size:
+            break
+        offset += page_size
+
+
+def _iter_every_code_pr_feedback_records(
+    every_code_store: _EveryCodeWorkRequestStore,
+    *,
+    repository: str,
+) -> Iterable[EveryCodePrFeedbackRecord]:
+    page_size = 100
+    offset = 0
+    while True:
+        records = every_code_store.list_every_code_pr_feedback_records(
+            repository=repository,
+            limit=page_size,
+            offset=offset,
+        )
+        if not records:
+            break
+        yield from records
+        if len(records) < page_size:
+            break
+        offset += page_size
 
 
 def _handle_every_code_pr_feedback_webhook(
@@ -2738,12 +2846,14 @@ def _every_code_read_payload(
         pr_number_value = str((query.get("pr_number") or [""])[0] or "").strip()
         pr_number_filter = int(pr_number_value) if pr_number_value else None
         limit = int(str((query.get("limit") or ["50"])[0] or "50"))
+        offset = int(str((query.get("offset") or ["0"])[0] or "0"))
         feedback_records = every_code_store.list_every_code_pr_feedback_records(
             request_id=request_id_filter,
             repository=repository_filter,
             pr_number=pr_number_filter,
             status=status_filter,
             limit=limit,
+            offset=offset,
         )
         return {
             "request_id": request_id_filter,
@@ -2757,10 +2867,12 @@ def _every_code_read_payload(
     state_filter = str((query.get("state") or [""])[0] or "").strip()
     repository_filter = str((query.get("repository") or [""])[0] or "").strip()
     limit = int(str((query.get("limit") or ["50"])[0] or "50"))
+    offset = int(str((query.get("offset") or ["0"])[0] or "0"))
     work_request_records = every_code_store.list_every_code_work_request_records(
         state=state_filter,
         repository=repository_filter,
         limit=limit,
+        offset=offset,
     )
     return {
         "state": state_filter,

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -48,9 +48,7 @@ class FilesystemRecordStore:
         )
         return record_path
 
-    def _create_model_if_absent(
-        self, record_type: str, record_id: str, model: BaseModel
-    ) -> bool:
+    def _create_model_if_absent(self, record_type: str, record_id: str, model: BaseModel) -> bool:
         record_path = self._record_path(record_type, record_id)
         record_path.parent.mkdir(parents=True, exist_ok=True)
         try:
@@ -168,6 +166,7 @@ class FilesystemRecordStore:
         state: str = "",
         repository: str = "",
         limit: int | None = None,
+        offset: int = 0,
     ) -> tuple[EveryCodeWorkRequestRecord, ...]:
         records = [
             record
@@ -179,6 +178,8 @@ class FilesystemRecordStore:
             and (not repository or record.repository == repository)
         ]
         records.sort(key=lambda record: (record.updated_at, record.request_id), reverse=True)
+        if offset > 0:
+            records = records[offset:]
         if limit is not None:
             records = records[:limit]
         return tuple(records)
@@ -208,6 +209,7 @@ class FilesystemRecordStore:
         pr_number: int | None = None,
         status: str = "",
         limit: int | None = None,
+        offset: int = 0,
     ) -> tuple[EveryCodePrFeedbackRecord, ...]:
         records = [
             record
@@ -221,6 +223,8 @@ class FilesystemRecordStore:
             and (not status or record.status == status)
         ]
         records.sort(key=lambda record: (record.received_at, record.feedback_id), reverse=True)
+        if offset > 0:
+            records = records[offset:]
         if limit is not None:
             records = records[:limit]
         return tuple(records)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -750,11 +750,14 @@ class PostgresRecordStore(HumanSessionStore):
         filters: Sequence[object] = (),
         order_by: Sequence[object],
         limit: int | None = None,
+        offset: int = 0,
     ) -> tuple[RecordModel, ...]:
         statement = select(orm_model)
         if filters:
             statement = statement.where(*cast(Sequence[_SqlFilter], filters))
         statement = statement.order_by(*cast(Sequence[_SqlOrderBy], order_by))
+        if offset > 0:
+            statement = statement.offset(offset)
         if limit is not None:
             statement = statement.limit(limit)
         with self._session_factory() as session:
@@ -1248,6 +1251,7 @@ class PostgresRecordStore(HumanSessionStore):
         state: str = "",
         repository: str = "",
         limit: int | None = None,
+        offset: int = 0,
     ) -> tuple[EveryCodeWorkRequestRecord, ...]:
         filters: list[_SqlFilter] = []
         if state:
@@ -1263,6 +1267,7 @@ class PostgresRecordStore(HumanSessionStore):
                 LaunchplaneEveryCodeWorkRequestRow.request_id.desc(),
             ),
             limit=limit,
+            offset=offset,
         )
 
     def claim_every_code_work_request_record(
@@ -1322,6 +1327,7 @@ class PostgresRecordStore(HumanSessionStore):
         pr_number: int | None = None,
         status: str = "",
         limit: int | None = None,
+        offset: int = 0,
     ) -> tuple[EveryCodePrFeedbackRecord, ...]:
         filters: list[object] = []
         if request_id:
@@ -1341,6 +1347,7 @@ class PostgresRecordStore(HumanSessionStore):
                 LaunchplaneEveryCodePrFeedbackRow.feedback_id.desc(),
             ),
             limit=limit,
+            offset=offset,
         )
 
     def write_preview_lifecycle_plan_record(self, record: PreviewLifecyclePlanRecord) -> None:

--- a/tests/test_every_code_work_request.py
+++ b/tests/test_every_code_work_request.py
@@ -139,6 +139,60 @@ class EveryCodeWorkRequestRecordTests(unittest.TestCase):
             )
         )
 
+    def test_pr_close_marks_running_request_done_without_stored_pr_url(self) -> None:
+        claimed_record = claim_every_code_work_request(
+            _queued_record(),
+            host="Chris-Studio",
+            claimed_at="2026-05-05T22:01:00Z",
+        )
+        assert claimed_record is not None
+        running_record = apply_every_code_work_request_status(
+            claimed_record,
+            EveryCodeWorkRequestStatusUpdate(
+                state="running",
+                host="Chris-Studio",
+                updated_at="2026-05-05T22:03:00Z",
+            ),
+        )
+
+        done_record = close_every_code_work_request_for_pull_request(
+            running_record,
+            pr_url="https://github.com/cbusillo/code/pull/99",
+            merged=True,
+            closed_at="2026-05-05T22:05:00Z",
+        )
+
+        self.assertIsNotNone(done_record)
+        assert done_record is not None
+        self.assertEqual(done_record.state, "done")
+        self.assertEqual(done_record.result_pr_url, "https://github.com/cbusillo/code/pull/99")
+
+    def test_pr_close_does_not_match_different_stored_pr_url(self) -> None:
+        claimed_record = claim_every_code_work_request(
+            _queued_record(),
+            host="Chris-Studio",
+            claimed_at="2026-05-05T22:01:00Z",
+        )
+        assert claimed_record is not None
+        running_record = apply_every_code_work_request_status(
+            claimed_record,
+            EveryCodeWorkRequestStatusUpdate(
+                state="running",
+                host="Chris-Studio",
+                updated_at="2026-05-05T22:03:00Z",
+                result_pr_url="https://github.com/cbusillo/code/pull/88",
+            ),
+        )
+
+        self.assertIsNone(
+            close_every_code_work_request_for_pull_request(
+                running_record,
+                pr_url="https://github.com/cbusillo/code/pull/99",
+                merged=True,
+                closed_at="2026-05-05T22:05:00Z",
+            )
+        )
+
     def test_blocked_requires_error_message(self) -> None:
         with self.assertRaises(ValueError):
             EveryCodeWorkRequestRecord(

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -102,11 +102,20 @@ class FilesystemRecordStoreTests(unittest.TestCase):
                 request_id="every-code-cbusillo-code-123-test",
                 status="pending",
             )
+            offset_records = store.list_every_code_pr_feedback_records(
+                request_id="every-code-cbusillo-code-123-test",
+                status="pending",
+                limit=1,
+                offset=1,
+            )
             self.assertTrue(written_path.exists())
 
         self.assertEqual(
             [record.feedback_id for record in listed_records],
             [newer_record.feedback_id, older_record.feedback_id],
+        )
+        self.assertEqual(
+            [record.feedback_id for record in offset_records], [older_record.feedback_id]
         )
 
     def test_write_and_read_product_profile_record(self) -> None:

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -576,6 +576,11 @@ class PostgresRecordStoreTests(unittest.TestCase):
             )
 
             listed = store.list_every_code_work_request_records(state="queued")
+            offset_listed = store.list_every_code_work_request_records(
+                state="queued",
+                limit=1,
+                offset=1,
+            )
             claimed = store.claim_every_code_work_request_record(
                 request_id=newer_record.request_id,
                 host="Chris-Studio",
@@ -588,7 +593,11 @@ class PostgresRecordStoreTests(unittest.TestCase):
             )
             loaded = store.read_every_code_work_request_record(newer_record.request_id)
 
-        self.assertEqual([record.request_id for record in listed], [newer_record.request_id, older_record.request_id])
+        self.assertEqual(
+            [record.request_id for record in listed],
+            [newer_record.request_id, older_record.request_id],
+        )
+        self.assertEqual([record.request_id for record in offset_listed], [older_record.request_id])
         self.assertFalse(duplicate_created)
         self.assertEqual(created_duplicate.updated_at, newer_record.updated_at)
         self.assertIsNotNone(claimed)
@@ -632,10 +641,20 @@ class PostgresRecordStoreTests(unittest.TestCase):
                 pr_number=26,
                 status="pending",
             )
+            offset_listed = store.list_every_code_pr_feedback_records(
+                repository="cbusillo/code",
+                pr_number=26,
+                status="pending",
+                limit=1,
+                offset=1,
+            )
 
         self.assertEqual(
             [record.feedback_id for record in listed],
             [newer_record.feedback_id, older_record.feedback_id],
+        )
+        self.assertEqual(
+            [record.feedback_id for record in offset_listed], [older_record.feedback_id]
         )
 
     def test_human_sessions_round_trip_and_delete(self) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -426,14 +426,18 @@ def _every_code_github_issue_labeled_payload(
     action: str = "labeled",
     repository: str = "cbusillo/code",
     issue_number: int = 123,
+    issue_url: str = "",
 ) -> dict[str, object]:
+    resolved_issue_url = (
+        issue_url.strip() or f"https://github.com/{repository}/issues/{issue_number}"
+    )
     return {
         "action": action,
         "label": {"name": label},
         "repository": {"full_name": repository},
         "issue": {
             "number": issue_number,
-            "html_url": f"https://github.com/{repository}/issues/{issue_number}",
+            "html_url": resolved_issue_url,
             "title": "Wire local automation",
         },
         "sender": {"login": "cbusillo"},
@@ -1333,6 +1337,199 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(close_status, 202)
         self.assertEqual(close_payload["records"]["state"], "blocked")
         self.assertIn("closed without merge", close_payload["result"]["request"]["error_message"])
+
+    def test_every_code_pull_request_close_matches_pr_issue_url_without_result_pr_url(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main"
+                        ],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": [
+                            "every_code_work_request.read",
+                            "every_code_work_request.claim",
+                            "every_code_work_request.update",
+                        ],
+                    }
+                ]
+            }
+        )
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
+            event_name="workflow_dispatch",
+        )
+        issue_payload = _every_code_github_issue_labeled_payload(
+            issue_number=26,
+            issue_url="https://github.com/cbusillo/code/pull/26",
+        )
+        pr_payload = _every_code_github_pull_request_closed_payload()
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(identity),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            create_status, create_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=issue_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-feedback-close-issue",
+                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                },
+            )
+            request_id = str(create_payload["records"]["request_id"])
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/claim",
+                payload={"request_id": request_id, "host": "Chris-Studio"},
+                headers={"Idempotency-Key": "every-code-feedback-close-claim"},
+            )
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/status",
+                payload={
+                    "request_id": request_id,
+                    "host": "Chris-Studio",
+                    "state": "running",
+                },
+                headers={"Idempotency-Key": "every-code-feedback-close-running"},
+            )
+            close_status, close_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=pr_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "pull_request",
+                    "X-GitHub-Delivery": "delivery-feedback-close-pr",
+                    "X-Hub-Signature-256": _github_webhook_signature(pr_payload, secret),
+                },
+            )
+
+        self.assertEqual(create_status, 202)
+        self.assertEqual(close_status, 202)
+        self.assertEqual(close_payload["records"]["state"], "done")
+        self.assertEqual(
+            close_payload["result"]["request"]["result_pr_url"],
+            "https://github.com/cbusillo/code/pull/26",
+        )
+
+    def test_every_code_pull_request_close_pages_beyond_newest_requests(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main"
+                        ],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": [
+                            "every_code_work_request.read",
+                            "every_code_work_request.claim",
+                            "every_code_work_request.update",
+                        ],
+                    }
+                ]
+            }
+        )
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
+            event_name="workflow_dispatch",
+        )
+        target_pr_payload = _every_code_github_pull_request_closed_payload(pr_number=26)
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(identity),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            for issue_number in range(1, 103):
+                issue_payload = _every_code_github_issue_labeled_payload(issue_number=issue_number)
+                _create_status, create_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/every-code/github-webhook",
+                    payload=issue_payload,
+                    authorization="",
+                    headers={
+                        "X-GitHub-Event": "issues",
+                        "X-GitHub-Delivery": f"delivery-page-issue-{issue_number}",
+                        "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                    },
+                )
+                request_id = str(create_payload["records"]["request_id"])
+                _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/every-code/work-requests/claim",
+                    payload={"request_id": request_id, "host": "Chris-Studio"},
+                    headers={"Idempotency-Key": f"every-code-page-claim-{issue_number}"},
+                )
+                _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/every-code/work-requests/status",
+                    payload={
+                        "request_id": request_id,
+                        "host": "Chris-Studio",
+                        "state": "running",
+                        "result_pr_url": f"https://github.com/cbusillo/code/pull/{issue_number}",
+                    },
+                    headers={"Idempotency-Key": f"every-code-page-running-{issue_number}"},
+                )
+
+            close_status, close_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=target_pr_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "pull_request",
+                    "X-GitHub-Delivery": "delivery-page-pr-close",
+                    "X-Hub-Signature-256": _github_webhook_signature(target_pr_payload, secret),
+                },
+            )
+
+        self.assertEqual(close_status, 202)
+        self.assertEqual(close_payload["records"]["state"], "done")
+        self.assertEqual(
+            close_payload["result"]["request"]["result_pr_url"],
+            "https://github.com/cbusillo/code/pull/26",
+        )
 
     def test_every_code_pull_request_close_ignores_unlinked_pr(self) -> None:
         secret = "launchplane-every-code-webhook-secret"


### PR DESCRIPTION
## Summary
- page Every Code work-request and PR-feedback lookups instead of checking only the newest 100 records
- let PR-close handling recover matches from stored PR feedback or PR issue URLs when result_pr_url was never recorded
- preserve stored PR URL mismatch protection and add pagination support to filesystem/Postgres/API store paths

## Verification
- uv run python -m unittest tests.test_every_code_work_request tests.test_filesystem_store tests.test_postgres_store tests.test_service.LaunchplaneServiceTests.test_every_code_pull_request_close_marks_linked_request_done tests.test_service.LaunchplaneServiceTests.test_every_code_pull_request_close_blocks_unmerged_linked_request tests.test_service.LaunchplaneServiceTests.test_every_code_pull_request_close_matches_pr_issue_url_without_result_pr_url tests.test_service.LaunchplaneServiceTests.test_every_code_pull_request_close_pages_beyond_newest_requests tests.test_service.LaunchplaneServiceTests.test_every_code_pull_request_close_ignores_unlinked_pr
- uv run python -m unittest tests.test_service
- uv run --extra dev ruff check control_plane/contracts/every_code_work_request.py control_plane/every_code_worker.py control_plane/service.py control_plane/storage/filesystem.py control_plane/storage/postgres.py tests/test_every_code_work_request.py tests/test_filesystem_store.py tests/test_postgres_store.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/contracts/every_code_work_request.py control_plane/every_code_worker.py control_plane/service.py control_plane/storage/filesystem.py control_plane/storage/postgres.py tests/test_every_code_work_request.py tests/test_filesystem_store.py tests/test_postgres_store.py tests/test_service.py