### PR TITLE
fix(every-code): requeue stale issue requests

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -38,6 +38,7 @@ from control_plane.contracts.deployment_record import ResolvedTargetEvidence
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.every_code_work_request import build_every_code_work_request_id
 from control_plane.contracts.github_pull_request_event import GitHubPullRequestEvent
 from control_plane.contracts.github_webhook_replay_envelope import GitHubWebhookReplayEnvelope
 from control_plane.contracts.odoo_instance_override_record import OdooAddonSettingOverride
@@ -9715,6 +9716,87 @@ def every_code_finish(
             result_pr_url=result_pr_url,
             result_summary=result_summary,
         )
+    finally:
+        _close_store(record_store)
+    click.echo(json.dumps(result.as_payload(), indent=2, sort_keys=True))
+
+
+@every_code.command("rerun-issue")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    default="",
+    show_default=False,
+    help="Optional Postgres connection string for Launchplane work-request records.",
+)
+@click.option(
+    "--service-url",
+    default="",
+    help="Launchplane service base URL for API-backed worker mode.",
+)
+@click.option(
+    "--worker-token-env",
+    default=_EVERY_CODE_WORKER_TOKEN_ENV_KEY,
+    show_default=True,
+    help="Environment variable containing the Every Code worker token.",
+)
+@click.option(
+    "--state-dir",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    default=Path("state"),
+    show_default=True,
+    help="Filesystem state directory used when --database-url is not set.",
+)
+@click.option("--repository", required=True, help="GitHub owner/repo name.")
+@click.option("--issue-number", type=int, required=True, help="GitHub issue number.")
+@click.option("--trigger-label", default="every-code", show_default=True)
+@click.option("--actor", default="rerun", show_default=True)
+def every_code_rerun_issue(
+    database_url: str,
+    service_url: str,
+    worker_token_env: str,
+    state_dir: Path,
+    repository: str,
+    issue_number: int,
+    trigger_label: str,
+    actor: str,
+) -> None:
+    if service_url.strip():
+        record_store = _every_code_worker_store(
+            state_dir=state_dir,
+            database_url=database_url,
+            service_url=service_url,
+            worker_token_env=worker_token_env,
+        )
+        try:
+            request_id = build_every_code_work_request_id(
+                repository=repository,
+                issue_number=issue_number,
+                trigger_label=trigger_label,
+            )
+            rerun = getattr(record_store, "rerun_every_code_work_request_record")
+            request = rerun(request_id=request_id, trigger_actor=actor)
+            payload = {
+                "status": "queued",
+                "detail": "Requeued terminal Every Code work request for this issue.",
+                "request": request.model_dump(mode="json"),
+            }
+        finally:
+            _close_store(record_store)
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    record_store = _store(state_dir=state_dir, database_url=database_url)
+    try:
+        result = control_plane_every_code_reconciliation.rerun_every_code_issue(
+            record_store=record_store,
+            repository=repository,
+            issue_number=issue_number,
+            trigger_label=trigger_label,
+            actor=actor,
+        )
+    except (FileNotFoundError, ValueError) as error:
+        raise click.ClickException(str(error)) from error
     finally:
         _close_store(record_store)
     click.echo(json.dumps(result.as_payload(), indent=2, sort_keys=True))

--- a/control_plane/contracts/every_code_work_request.py
+++ b/control_plane/contracts/every_code_work_request.py
@@ -175,6 +175,34 @@ def resume_every_code_work_request(
     )
 
 
+def requeue_every_code_work_request(
+    record: EveryCodeWorkRequestRecord,
+    *,
+    queued_at: str,
+    trigger_actor: str = "",
+) -> EveryCodeWorkRequestRecord:
+    if not queued_at.strip():
+        raise ValueError("Every Code requeue requires queued_at")
+    if record.state not in {"done", "blocked"}:
+        raise ValueError("Every Code requeue requires a terminal work request")
+
+    return record.model_copy(
+        update={
+            "state": "queued",
+            "trigger_actor": trigger_actor.strip() or record.trigger_actor,
+            "queued_at": queued_at,
+            "updated_at": queued_at,
+            "claimed_at": "",
+            "claimed_by_host": "",
+            "started_at": "",
+            "finished_at": "",
+            "result_pr_url": "",
+            "result_summary": "",
+            "error_message": "",
+        }
+    )
+
+
 def close_every_code_work_request_for_pull_request(
     record: EveryCodeWorkRequestRecord,
     *,

--- a/control_plane/every_code_reconciliation.py
+++ b/control_plane/every_code_reconciliation.py
@@ -29,6 +29,7 @@ class EveryCodeRerunStore(Protocol):
         self, record: EveryCodeWorkRequestRecord
     ) -> object: ...
 
+
 @dataclass(frozen=True)
 class EveryCodeIssueReconciliationResult:
     status: EveryCodeReconciliationStatus

--- a/control_plane/every_code_reconciliation.py
+++ b/control_plane/every_code_reconciliation.py
@@ -6,6 +6,7 @@ from typing import Literal, Protocol, Sequence
 from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestRecord,
     build_every_code_work_request_id,
+    requeue_every_code_work_request,
 )
 from control_plane.workflows.ship import utc_now_timestamp
 
@@ -19,6 +20,15 @@ class EveryCodeReconciliationStore(Protocol):
     ) -> tuple[EveryCodeWorkRequestRecord, bool]: ...
 
 
+class EveryCodeRerunStore(Protocol):
+    def read_every_code_work_request_record(
+        self, request_id: str
+    ) -> EveryCodeWorkRequestRecord: ...
+
+    def write_every_code_work_request_record(
+        self, record: EveryCodeWorkRequestRecord
+    ) -> object: ...
+
 @dataclass(frozen=True)
 class EveryCodeIssueReconciliationResult:
     status: EveryCodeReconciliationStatus
@@ -27,6 +37,22 @@ class EveryCodeIssueReconciliationResult:
 
     def as_payload(self) -> dict[str, object]:
         payload: dict[str, object] = {"status": self.status, "detail": self.detail}
+        if self.request is not None:
+            payload["request"] = self.request.model_dump(mode="json")
+        return payload
+
+
+@dataclass(frozen=True)
+class EveryCodeIssueRerunResult:
+    status: str
+    detail: str
+    request: EveryCodeWorkRequestRecord | None = None
+
+    def as_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "status": self.status,
+            "detail": self.detail,
+        }
         if self.request is not None:
             payload["request"] = self.request.model_dump(mode="json")
         return payload
@@ -92,4 +118,32 @@ def reconcile_every_code_issue(
         status="deduped",
         detail="Every Code work request already exists for this issue and label.",
         request=stored_record,
+    )
+
+
+def rerun_every_code_issue(
+    *,
+    record_store: EveryCodeRerunStore,
+    repository: str,
+    issue_number: int,
+    trigger_label: str = "every-code",
+    actor: str = "requeue",
+) -> EveryCodeIssueRerunResult:
+    request_id = build_every_code_work_request_id(
+        repository=repository,
+        issue_number=issue_number,
+        trigger_label=trigger_label,
+    )
+    record = record_store.read_every_code_work_request_record(request_id)
+    now = utc_now_timestamp()
+    requeued_record = requeue_every_code_work_request(
+        record,
+        queued_at=now,
+        trigger_actor=actor,
+    )
+    record_store.write_every_code_work_request_record(requeued_record)
+    return EveryCodeIssueRerunResult(
+        status="queued",
+        detail="Requeued terminal Every Code work request for this issue.",
+        request=requeued_record,
     )

--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -176,6 +176,23 @@ class EveryCodeWorkerApiStore:
         )
         return payload
 
+    def rerun_every_code_work_request_record(
+        self, *, request_id: str, trigger_actor: str = ""
+    ) -> EveryCodeWorkRequestRecord:
+        payload = self._request(
+            "POST",
+            "/v1/every-code/work-requests/rerun",
+            body={"request_id": request_id.strip(), "trigger_actor": trigger_actor.strip()},
+            idempotency_key=f"every-code-rerun-{request_id.strip()}-{trigger_actor.strip()}",
+        )
+        request_payload = payload.get("request")
+        result_payload = payload.get("result")
+        if request_payload is None and isinstance(result_payload, dict):
+            request_payload = result_payload.get("request")
+        if not isinstance(request_payload, dict):
+            raise EveryCodeWorkerApiError("Launchplane rerun response is invalid")
+        return EveryCodeWorkRequestRecord.model_validate(request_payload)
+
     def list_every_code_pr_feedback_records(
         self,
         *,

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -40,6 +40,7 @@ from control_plane.contracts.every_code_work_request import (
     apply_every_code_work_request_status,
     build_every_code_work_request_id,
     close_every_code_work_request_for_pull_request,
+    requeue_every_code_work_request,
 )
 from control_plane.contracts.every_code_pr_feedback_record import (
     EveryCodePrFeedbackKind,
@@ -1266,6 +1267,19 @@ class EveryCodeWorkRequestStatusEnvelope(BaseModel):
     updated_at: str = ""
 
 
+class EveryCodeWorkRequestRerunEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    request_id: str
+    trigger_actor: str = ""
+
+    @model_validator(mode="after")
+    def _validate_rerun(self) -> "EveryCodeWorkRequestRerunEnvelope":
+        if not self.request_id.strip():
+            raise ValueError("Every Code work request rerun requires request_id")
+        return self
+
+
 class EveryCodePrFeedbackStatusEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -1854,6 +1868,7 @@ def _build_write_routes() -> frozenset[str]:
         _EVERY_CODE_GITHUB_WEBHOOK_ROUTE,
         "/v1/every-code/work-requests/create",
         "/v1/every-code/work-requests/claim",
+        "/v1/every-code/work-requests/rerun",
         "/v1/every-code/work-requests/status",
         "/v1/every-code/pr-feedback/status",
         "/v1/work-graph/rank",
@@ -2811,6 +2826,7 @@ def _is_every_code_worker_route(*, method: str, path: str) -> bool:
         return True
     return method == "POST" and path in {
         "/v1/every-code/work-requests/claim",
+        "/v1/every-code/work-requests/rerun",
         "/v1/every-code/work-requests/status",
         "/v1/every-code/pr-feedback/status",
     }
@@ -2994,6 +3010,26 @@ def _handle_every_code_worker_write(
                 trace_id=trace_id,
                 result={"request_id": claimed_record.request_id, "state": claimed_record.state},
                 driver_result={"request": claimed_record.model_dump(mode="json")},
+            ),
+        )
+    if path == "/v1/every-code/work-requests/rerun":
+        rerun_request = EveryCodeWorkRequestRerunEnvelope.model_validate(payload)
+        existing_record = every_code_store.read_every_code_work_request_record(
+            rerun_request.request_id.strip()
+        )
+        requeued_record = requeue_every_code_work_request(
+            existing_record,
+            queued_at=_utc_now_timestamp(),
+            trigger_actor=rerun_request.trigger_actor,
+        )
+        every_code_store.write_every_code_work_request_record(requeued_record)
+        return _json_response(
+            start_response=start_response,
+            status_code=202,
+            payload=_accepted_payload(
+                trace_id=trace_id,
+                result={"request_id": requeued_record.request_id, "state": requeued_record.state},
+                driver_result={"request": requeued_record.model_dump(mode="json")},
             ),
         )
     work_request_status_request = EveryCodeWorkRequestStatusEnvelope.model_validate(payload)
@@ -5199,6 +5235,43 @@ def create_launchplane_service_app(
                             "error": {
                                 "code": "authorization_denied",
                                 "message": "Workflow cannot claim Every Code work requests.",
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                return _handle_every_code_worker_write(
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                    record_store=record_store,
+                    path=path,
+                    payload=payload,
+                )
+            elif path == "/v1/every-code/work-requests/rerun":
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="every_code_work_request.write",
+                    product="launchplane",
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot rerun Every Code work requests.",
                             },
                         },
                     )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -4337,13 +4337,27 @@ def create_launchplane_service_app(
                     query=query,
                 )
             payload = _read_json_request(environ)
-            return _handle_every_code_worker_write(
-                start_response=start_response,
-                trace_id=request_trace_id,
-                record_store=record_store,
-                path=path,
-                payload=payload,
-            )
+            try:
+                return _handle_every_code_worker_write(
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                    record_store=record_store,
+                    path=path,
+                    payload=payload,
+                )
+            except ValueError as error:
+                return _json_response(
+                    start_response=start_response,
+                    status_code=400,
+                    payload={
+                        "status": "rejected",
+                        "trace_id": request_trace_id,
+                        "error": {
+                            "code": "invalid_payload",
+                            "message": str(error),
+                        },
+                    },
+                )
         try:
             if method == "GET":
                 identity = _read_identity(

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -58,6 +58,7 @@ VeriReel product paths:
   - `GET /v1/every-code/work-requests/{request_id}`
   - `POST /v1/every-code/work-requests/create`
   - `POST /v1/every-code/work-requests/claim`
+  - `POST /v1/every-code/work-requests/rerun`
   - `POST /v1/every-code/work-requests/status`
 - work graph chooser route:
   - `GET /v1/work-graph/snapshot`
@@ -117,11 +118,12 @@ the Launchplane service and on the Mac worker host, then run the worker with
 `uv run launchplane every-code start --service-url https://...`. That token is
 scoped in code to `GET /v1/every-code/work-requests`,
 `GET /v1/every-code/work-requests/{request_id}`,
-`POST /v1/every-code/work-requests/claim`, and
+`POST /v1/every-code/work-requests/claim`,
+`POST /v1/every-code/work-requests/rerun`, and
 `POST /v1/every-code/work-requests/status`. It cannot create webhook requests,
 write product records, or access other Launchplane service routes. This keeps
 remote DB credentials on the Launchplane host while still allowing visible local
-Code/tmux work sessions to claim and report progress.
+Code/tmux work sessions to claim, rerun terminal requests, and report progress.
 
 `POST /v1/work-graph/rank` ranks a caller-supplied work graph snapshot and
 returns the queue payload under `result.queue`. The route requires the

--- a/tests/test_every_code_reconciliation.py
+++ b/tests/test_every_code_reconciliation.py
@@ -6,7 +6,14 @@ import unittest
 from click.testing import CliRunner
 
 from control_plane.cli import main
-from control_plane.every_code_reconciliation import reconcile_every_code_issue
+from control_plane.contracts.every_code_work_request import (
+    EveryCodeWorkRequestStatusUpdate,
+    apply_every_code_work_request_status,
+)
+from control_plane.every_code_reconciliation import (
+    reconcile_every_code_issue,
+    rerun_every_code_issue,
+)
 from control_plane.storage.filesystem import FilesystemRecordStore
 
 
@@ -123,6 +130,116 @@ class EveryCodeIssueReconciliationTests(unittest.TestCase):
             self.assertEqual(payload["status"], "created")
             self.assertEqual(payload["request"]["source"], "reconciliation")
             self.assertEqual(payload["request"]["state"], "queued")
+
+    def test_rerun_issue_requeues_terminal_request(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            store = FilesystemRecordStore(state_dir=Path(tempdir))
+            created = reconcile_every_code_issue(
+                record_store=store,
+                repository="cbusillo/launchplane",
+                issue_number=278,
+                issue_url="https://github.com/cbusillo/launchplane/issues/278",
+                issue_title="Build Launchplane-backed Every Code automation",
+                labels=("every-code",),
+                actor="first",
+            )
+            assert created.request is not None
+            claimed = store.claim_every_code_work_request_record(
+                request_id=created.request.request_id,
+                host="worker-host",
+                claimed_at="2026-05-06T00:00:00Z",
+            )
+            assert claimed is not None
+            blocked = apply_every_code_work_request_status(
+                claimed,
+                EveryCodeWorkRequestStatusUpdate(
+                    state="blocked",
+                    host="worker-host",
+                    updated_at="2026-05-06T00:01:00Z",
+                    error_message="Needs another pass.",
+                ),
+            )
+            store.write_every_code_work_request_record(blocked)
+
+            result = rerun_every_code_issue(
+                record_store=store,
+                repository="cbusillo/launchplane",
+                issue_number=278,
+                actor="ops",
+            )
+
+            self.assertEqual(result.status, "queued")
+            self.assertIsNotNone(result.request)
+            assert result.request is not None
+            self.assertEqual(result.request.state, "queued")
+            self.assertEqual(result.request.trigger_actor, "ops")
+            self.assertEqual(result.request.claimed_by_host, "")
+            self.assertEqual(result.request.error_message, "")
+
+    def test_cli_rerun_issue_writes_json_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            runner = CliRunner()
+            create_result = runner.invoke(
+                main,
+                [
+                    "every-code",
+                    "reconcile-issue",
+                    "--state-dir",
+                    tempdir,
+                    "--repository",
+                    "cbusillo/launchplane",
+                    "--issue-number",
+                    "278",
+                    "--issue-url",
+                    "https://github.com/cbusillo/launchplane/issues/278",
+                    "--issue-title",
+                    "Build Launchplane-backed Every Code automation",
+                    "--label",
+                    "every-code",
+                ],
+            )
+            create_payload = json.loads(create_result.output)
+            store = FilesystemRecordStore(state_dir=Path(tempdir))
+            claimed = store.claim_every_code_work_request_record(
+                request_id=create_payload["request"]["request_id"],
+                host="worker-host",
+                claimed_at="2026-05-06T00:00:00Z",
+            )
+            assert claimed is not None
+            done = apply_every_code_work_request_status(
+                claimed,
+                EveryCodeWorkRequestStatusUpdate(
+                    state="done",
+                    host="worker-host",
+                    updated_at="2026-05-06T00:01:00Z",
+                    result_pr_url="https://github.com/cbusillo/launchplane/pull/351",
+                ),
+            )
+            store.write_every_code_work_request_record(done)
+
+            rerun_result = runner.invoke(
+                main,
+                [
+                    "every-code",
+                    "rerun-issue",
+                    "--state-dir",
+                    tempdir,
+                    "--repository",
+                    "cbusillo/launchplane",
+                    "--issue-number",
+                    "278",
+                    "--actor",
+                    "ops",
+                ],
+            )
+
+            self.assertEqual(create_result.exit_code, 0, create_result.output)
+            self.assertEqual(rerun_result.exit_code, 0, rerun_result.output)
+            rerun_payload = json.loads(rerun_result.output)
+            self.assertEqual(rerun_payload["status"], "queued")
+            self.assertEqual(rerun_payload["request"]["state"], "queued")
+            self.assertEqual(rerun_payload["request"]["trigger_actor"], "ops")
+            self.assertEqual(rerun_payload["request"]["result_pr_url"], "")
 
 
 if __name__ == "__main__":

--- a/tests/test_every_code_work_request.py
+++ b/tests/test_every_code_work_request.py
@@ -7,6 +7,7 @@ from control_plane.contracts.every_code_work_request import (
     build_every_code_work_request_id,
     claim_every_code_work_request,
     close_every_code_work_request_for_pull_request,
+    requeue_every_code_work_request,
 )
 
 
@@ -208,6 +209,50 @@ class EveryCodeWorkRequestRecordTests(unittest.TestCase):
                 claimed_at="2026-05-05T22:01:00Z",
                 claimed_by_host="Chris-Studio",
                 finished_at="2026-05-05T22:03:00Z",
+            )
+
+    def test_requeue_terminal_request_clears_worker_state(self) -> None:
+        claimed_record = claim_every_code_work_request(
+            _queued_record(),
+            host="Chris-Studio",
+            claimed_at="2026-05-05T22:01:00Z",
+        )
+        assert claimed_record is not None
+        blocked_record = apply_every_code_work_request_status(
+            claimed_record,
+            EveryCodeWorkRequestStatusUpdate(
+                state="blocked",
+                host="Chris-Studio",
+                updated_at="2026-05-05T22:03:00Z",
+                result_pr_url="https://github.com/cbusillo/code/pull/99",
+                result_summary="Old session went stale.",
+                error_message="Old session went stale.",
+            ),
+        )
+
+        requeued_record = requeue_every_code_work_request(
+            blocked_record,
+            queued_at="2026-05-05T22:07:00Z",
+            trigger_actor="cbusillo",
+        )
+
+        self.assertEqual(requeued_record.state, "queued")
+        self.assertEqual(requeued_record.trigger_actor, "cbusillo")
+        self.assertEqual(requeued_record.queued_at, "2026-05-05T22:07:00Z")
+        self.assertEqual(requeued_record.updated_at, "2026-05-05T22:07:00Z")
+        self.assertEqual(requeued_record.claimed_at, "")
+        self.assertEqual(requeued_record.claimed_by_host, "")
+        self.assertEqual(requeued_record.started_at, "")
+        self.assertEqual(requeued_record.finished_at, "")
+        self.assertEqual(requeued_record.result_pr_url, "")
+        self.assertEqual(requeued_record.result_summary, "")
+        self.assertEqual(requeued_record.error_message, "")
+
+    def test_requeue_requires_terminal_request(self) -> None:
+        with self.assertRaises(ValueError):
+            requeue_every_code_work_request(
+                _queued_record(),
+                queued_at="2026-05-05T22:07:00Z",
             )
 
 

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -15,6 +15,7 @@ from click.testing import CliRunner
 from control_plane.cli import main
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
 from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
+from control_plane.contracts.every_code_work_request import requeue_every_code_work_request
 from control_plane.every_code_worker import (
     EveryCodeWorkerApiStore,
     apply_every_code_pr_feedback_for_host,
@@ -247,6 +248,28 @@ class _EveryCodeApiHandler(BaseHTTPRequestHandler):
                 },
             )
             return
+        if self.path == "/v1/every-code/work-requests/rerun":
+            work_request_record = self.store.read_every_code_work_request_record(
+                str(payload["request_id"])
+            )
+            requeued_work_request_record = requeue_every_code_work_request(
+                work_request_record,
+                queued_at="2026-05-06T00:02:00Z",
+                trigger_actor=str(payload.get("trigger_actor") or ""),
+            )
+            self.store.write_every_code_work_request_record(requeued_work_request_record)
+            self._write_json(
+                202,
+                {
+                    "status": "accepted",
+                    "records": {
+                        "request_id": requeued_work_request_record.request_id,
+                        "state": requeued_work_request_record.state,
+                    },
+                    "result": {"request": requeued_work_request_record.model_dump(mode="json")},
+                },
+            )
+            return
         work_request_record = self.store.read_every_code_work_request_record(
             str(payload["request_id"])
         )
@@ -350,6 +373,49 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(len(feedback_records), 1)
         self.assertEqual(feedback_records[0].feedback_id, _feedback_record().feedback_id)
         self.assertEqual(listed_after_update[0].status, "applied")
+
+    def test_api_store_reruns_terminal_request_via_service(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            _EveryCodeApiHandler.store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            _EveryCodeApiHandler.store.write_every_code_work_request_record(
+                _queued_record().model_copy(
+                    update={
+                        "state": "blocked",
+                        "claimed_at": "2026-05-06T00:00:00Z",
+                        "claimed_by_host": "Chris-Studio",
+                        "started_at": "2026-05-06T00:01:00Z",
+                        "finished_at": "2026-05-06T00:02:00Z",
+                        "updated_at": "2026-05-06T00:02:00Z",
+                        "result_pr_url": "https://github.com/cbusillo/code/pull/26",
+                        "result_summary": "Detached session went stale.",
+                        "error_message": "Detached session went stale.",
+                    }
+                )
+            )
+            server = ThreadingHTTPServer(("127.0.0.1", 0), _EveryCodeApiHandler)
+            server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+            server_thread.start()
+            try:
+                store = EveryCodeWorkerApiStore(
+                    service_url=f"http://127.0.0.1:{server.server_port}",
+                    worker_token="worker-token",
+                )
+
+                requeued_record = store.rerun_every_code_work_request_record(
+                    request_id=_queued_record().request_id,
+                    trigger_actor="cbusillo",
+                )
+            finally:
+                server.shutdown()
+                server.server_close()
+                server_thread.join(timeout=5)
+
+        self.assertEqual(requeued_record.state, "queued")
+        self.assertEqual(requeued_record.trigger_actor, "cbusillo")
+        self.assertEqual(requeued_record.claimed_by_host, "")
+        self.assertEqual(requeued_record.result_pr_url, "")
+        self.assertEqual(requeued_record.error_message, "")
 
     def test_session_name_is_stable_and_tmux_safe(self) -> None:
         session_name = every_code_tmux_session_name("every code/cbusillo/code#123 !")

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -227,6 +227,34 @@ class _EveryCodeApiHandler(BaseHTTPRequestHandler):
                 },
             )
             return
+        if self.path == "/v1/every-code/work-requests/rerun":
+            work_request_record = self.store.read_every_code_work_request_record(
+                str(payload["request_id"])
+            )
+            requeued_record = work_request_record.model_copy(
+                update={
+                    "state": "queued",
+                    "trigger_actor": str(payload.get("trigger_actor") or "rerun"),
+                    "updated_at": "2026-05-06T00:02:00Z",
+                    "queued_at": "2026-05-06T00:02:00Z",
+                    "claimed_at": "",
+                    "claimed_by_host": "",
+                    "started_at": "",
+                    "finished_at": "",
+                    "result_pr_url": "",
+                    "result_summary": "",
+                    "error_message": "",
+                }
+            )
+            self.store.write_every_code_work_request_record(requeued_record)
+            self._write_json(
+                202,
+                {
+                    "status": "accepted",
+                    "result": {"request": requeued_record.model_dump(mode="json")},
+                },
+            )
+            return
         if self.path == "/v1/every-code/work-requests/claim":
             claimed_record = self.store.claim_every_code_work_request_record(
                 request_id=str(payload["request_id"]),

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1840,6 +1840,118 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(second_status, 409)
         self.assertEqual(second_response["error"]["code"], "feedback_already_final")
 
+    def test_every_code_worker_token_reruns_terminal_request(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        issue_payload = _every_code_github_issue_labeled_payload()
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            _issue_status, issue_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=issue_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-issue",
+                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                },
+            )
+            request_id = issue_response["records"]["request_id"]
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/claim",
+                payload={"request_id": request_id, "host": "Chris-Studio"},
+                authorization="Bearer dev-worker-token",
+            )
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/status",
+                payload={
+                    "request_id": request_id,
+                    "host": "Chris-Studio",
+                    "state": "blocked",
+                    "error_message": "Needs another pass.",
+                    "updated_at": "2026-05-06T16:00:00Z",
+                },
+                authorization="Bearer dev-worker-token",
+            )
+
+            rerun_status, rerun_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/rerun",
+                payload={"request_id": request_id, "trigger_actor": "ops"},
+                authorization="Bearer dev-worker-token",
+            )
+
+        self.assertEqual(rerun_status, 202)
+        request = rerun_response["result"]["request"]
+        self.assertEqual(request["state"], "queued")
+        self.assertEqual(request["trigger_actor"], "ops")
+        self.assertEqual(request["claimed_by_host"], "")
+        self.assertEqual(request["error_message"], "")
+
+    def test_every_code_worker_token_cannot_rerun_active_request(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        issue_payload = _every_code_github_issue_labeled_payload()
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            _issue_status, issue_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=issue_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-issue",
+                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                },
+            )
+            request_id = issue_response["records"]["request_id"]
+
+            rerun_status, rerun_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/rerun",
+                payload={"request_id": request_id, "trigger_actor": "ops"},
+                authorization="Bearer dev-worker-token",
+            )
+
+        self.assertEqual(rerun_status, 400)
+        self.assertEqual(rerun_response["error"]["code"], "invalid_payload")
+
     def test_every_code_github_webhook_rejects_invalid_signature(self) -> None:
         secret = "launchplane-every-code-webhook-secret"
         webhook_payload = _every_code_github_issue_labeled_payload()
@@ -2131,6 +2243,95 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(claim_payload["result"]["request"]["claimed_by_host"], "Chris-Studio")
         self.assertEqual(status_status, 202)
         self.assertEqual(status_payload["result"]["request"]["state"], "done")
+
+    def test_every_code_worker_token_can_rerun_terminal_request(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main"
+                        ],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["every_code_work_request.write"],
+                    }
+                ]
+            }
+        )
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
+            event_name="workflow_dispatch",
+        )
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "worker-token"},
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(identity),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            create_status, create_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/create",
+                payload={
+                    "repository": "cbusillo/code",
+                    "issue_number": 123,
+                    "issue_url": "https://github.com/cbusillo/code/issues/123",
+                    "issue_title": "Wire local automation",
+                    "trigger_label": "every-code",
+                    "trigger_actor": "cbusillo",
+                    "source": "manual",
+                    "queued_at": "2026-05-05T22:00:00Z",
+                },
+            )
+            request_id = str(create_payload["records"]["request_id"])
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/claim",
+                payload={"request_id": request_id, "host": "Chris-Studio"},
+                authorization="Bearer worker-token",
+            )
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/status",
+                payload={
+                    "request_id": request_id,
+                    "host": "Chris-Studio",
+                    "state": "blocked",
+                    "result_pr_url": "https://github.com/cbusillo/code/pull/26",
+                    "result_summary": "Detached session went stale.",
+                    "error_message": "Detached session went stale.",
+                    "updated_at": "2026-05-05T22:05:00Z",
+                },
+                authorization="Bearer worker-token",
+            )
+            rerun_status, rerun_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/rerun",
+                payload={"request_id": request_id, "trigger_actor": "cbusillo"},
+                authorization="Bearer worker-token",
+            )
+
+        self.assertEqual(create_status, 202)
+        self.assertEqual(rerun_status, 202)
+        self.assertEqual(rerun_payload["records"]["state"], "queued")
+        self.assertEqual(rerun_payload["result"]["request"]["trigger_actor"], "cbusillo")
+        self.assertEqual(rerun_payload["result"]["request"]["claimed_by_host"], "")
+        self.assertEqual(rerun_payload["result"]["request"]["result_pr_url"], "")
+        self.assertEqual(rerun_payload["result"]["request"]["error_message"], "")
 
     def test_every_code_worker_token_is_required_for_unauthenticated_request(self) -> None:
         with (


### PR DESCRIPTION
## Summary
- add an explicit Every Code rerun/requeue path for terminal issue requests
- expose a worker-token API endpoint and CLI command for rerunning an issue
- reset stale claim/session/result fields so the worker can claim the deterministic request again
- harden the worker-token rerun route so active requests return a JSON rejection instead of bubbling an exception
- document the rerun route and worker-token scope

## Validation
- uv run python -m unittest tests.test_every_code_work_request tests.test_every_code_reconciliation tests.test_every_code_worker tests.test_service.LaunchplaneServiceTests.test_every_code_worker_token_reruns_terminal_request tests.test_service.LaunchplaneServiceTests.test_every_code_worker_token_cannot_rerun_active_request
- uv run python -m unittest tests.test_service
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_every_code_worker.py
- uv run --extra dev ruff check control_plane/service.py tests/test_every_code_worker.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_every_code_worker.py

Fixes stale Every Code issue relabel loops like cbusillo/sellyouroutboard#67.
