### PR TITLE
Fix Every Code PR close issue URL fallback

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2157,6 +2157,8 @@ def _handle_every_code_pull_request_webhook(
     pull_request_payload = _github_webhook_mapping(payload, "pull_request")
     repository = _github_webhook_string(repository_payload, "full_name")
     pr_url = _github_webhook_string(pull_request_payload, "html_url")
+    pr_number_value = pull_request_payload.get("number") if pull_request_payload else None
+    pr_number = pr_number_value if isinstance(pr_number_value, int) else None
     merged = bool(pull_request_payload.get("merged")) if pull_request_payload else False
     closed_at = _github_webhook_string(pull_request_payload, "closed_at") or _utc_now_timestamp()
     every_code_store = _every_code_work_request_store(record_store)
@@ -2202,7 +2204,12 @@ def _handle_every_code_pull_request_webhook(
             every_code_store,
             repository=repository,
         ):
-            if record.issue_url.strip() != pr_url:
+            if not _every_code_issue_url_matches_pull_request(
+                issue_url=record.issue_url,
+                repository=repository,
+                pr_url=pr_url,
+                pr_number=pr_number,
+            ):
                 continue
             matched_record = record
             closed_record = close_every_code_work_request_for_pull_request(
@@ -2253,6 +2260,27 @@ def _handle_every_code_pull_request_webhook(
     )
     accepted_payload["github_delivery_id"] = delivery_id
     return _json_response(start_response=start_response, status_code=202, payload=accepted_payload)
+
+
+def _every_code_issue_url_matches_pull_request(
+    *,
+    issue_url: str,
+    repository: str,
+    pr_url: str,
+    pr_number: int | None,
+) -> bool:
+    normalized_issue_url = issue_url.strip().rstrip("/")
+    normalized_pr_url = pr_url.strip().rstrip("/")
+    if not normalized_issue_url or not normalized_pr_url:
+        return False
+    if normalized_issue_url == normalized_pr_url:
+        return True
+    if pr_number is None:
+        return False
+    normalized_repository = repository.strip().strip("/")
+    if not normalized_repository:
+        return False
+    return normalized_issue_url == f"https://github.com/{normalized_repository}/issues/{pr_number}"
 
 
 def _find_every_code_work_request_for_pull_request(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1338,7 +1338,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(close_payload["records"]["state"], "blocked")
         self.assertIn("closed without merge", close_payload["result"]["request"]["error_message"])
 
-    def test_every_code_pull_request_close_matches_pr_issue_url_without_result_pr_url(self) -> None:
+    def test_every_code_pull_request_close_matches_issue_url_without_result_pr_url(self) -> None:
         secret = "launchplane-every-code-webhook-secret"
         policy = LaunchplaneAuthzPolicy.model_validate(
             {
@@ -1365,10 +1365,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
             event_name="workflow_dispatch",
         )
-        issue_payload = _every_code_github_issue_labeled_payload(
-            issue_number=26,
-            issue_url="https://github.com/cbusillo/code/pull/26",
-        )
+        issue_payload = _every_code_github_issue_labeled_payload(issue_number=26)
         pr_payload = _every_code_github_pull_request_closed_payload()
         with (
             TemporaryDirectory() as temporary_directory_name,


### PR DESCRIPTION
## Summary
- match PR close events against the normal GitHub issue-side URL shape (`/issues/{number}`) when `result_pr_url` is missing
- keep the direct PR URL fallback for existing PR-shaped issue URLs
- update the regression test to use the normal issues webhook URL instead of a synthetic pull URL

## Verification
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_every_code_pull_request_close_matches_issue_url_without_result_pr_url tests.test_service.LaunchplaneServiceTests.test_every_code_pull_request_close_marks_linked_request_done tests.test_service.LaunchplaneServiceTests.test_every_code_pull_request_close_pages_beyond_newest_requests tests.test_service.LaunchplaneServiceTests.test_every_code_pull_request_close_ignores_unlinked_pr
- uv run python -m unittest tests.test_service
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_service.py
- uv run --extra dev ruff check control_plane/service.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_service.py
