### PR TITLE
fix(every-code): match PR feedback by linked issue

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2450,14 +2450,33 @@ def _handle_every_code_pr_feedback_webhook(
         )
 
     every_code_store = _every_code_work_request_store(record_store)
-    matched_record: EveryCodeWorkRequestRecord | None = None
-    for record in every_code_store.list_every_code_work_request_records(
+    matched_record = _find_every_code_work_request_for_pull_request(
+        every_code_store,
         repository=repository,
-        limit=100,
-    ):
-        if record.result_pr_url.strip() == pr_url:
-            matched_record = record
-            break
+        pr_url=pr_url,
+    )
+    if matched_record is None:
+        pull_request_payload = _github_webhook_mapping(payload, "pull_request")
+        linked_issue_numbers = (
+            _github_issue_numbers_referenced_by_pull_request(
+                pull_request_payload,
+                repository=repository,
+            )
+            if pull_request_payload is not None
+            else frozenset()
+        )
+        for record in _iter_every_code_work_request_records(
+            every_code_store,
+            repository=repository,
+        ):
+            if _every_code_issue_url_matches_pull_request(
+                issue_url=record.issue_url,
+                repository=repository,
+                pr_url=pr_url,
+                linked_issue_numbers=linked_issue_numbers,
+            ):
+                matched_record = record
+                break
     if matched_record is None:
         return _json_response(
             start_response=start_response,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -472,6 +472,7 @@ def _every_code_github_pr_comment_payload(
     pr_number: int = 26,
     body: str = "Please tighten this wording before merge.",
     comment_id: int = 1001,
+    pull_request_body: str = "",
 ) -> dict[str, object]:
     return {
         "action": "created",
@@ -487,6 +488,11 @@ def _every_code_github_pr_comment_payload(
             "html_url": f"https://github.com/{repository}/pull/{pr_number}#issuecomment-{comment_id}",
             "body": body,
             "author_association": "OWNER",
+        },
+        "pull_request": {
+            "number": pr_number,
+            "html_url": f"https://github.com/{repository}/pull/{pr_number}",
+            "body": pull_request_body,
         },
         "sender": {"login": "cbusillo"},
     }
@@ -1739,6 +1745,85 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(feedback["request_id"], request_id)
         self.assertEqual(feedback["feedback_kind"], "issue_comment")
         self.assertEqual(feedback["body"], "Please tighten this wording before merge.")
+
+    def test_every_code_pr_comment_webhook_matches_linked_issue(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        issue_payload = _every_code_github_issue_labeled_payload(issue_number=67)
+        comment_payload = _every_code_github_pr_comment_payload(
+            pr_number=75,
+            pull_request_body="Closes #67",
+        )
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            issue_status, issue_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=issue_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-issue",
+                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                },
+            )
+            request_id = issue_response["records"]["request_id"]
+            claim_status, _claim_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/claim",
+                payload={"request_id": request_id, "host": "Chris-Studio"},
+                authorization="Bearer dev-worker-token",
+            )
+            running_status, _running_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/status",
+                payload={
+                    "request_id": request_id,
+                    "host": "Chris-Studio",
+                    "state": "running",
+                    "result_summary": "Visible tmux session.",
+                    "updated_at": "2026-05-06T16:00:00Z",
+                },
+                authorization="Bearer dev-worker-token",
+            )
+            feedback_status, feedback_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=comment_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issue_comment",
+                    "X-GitHub-Delivery": "delivery-comment",
+                    "X-Hub-Signature-256": _github_webhook_signature(comment_payload, secret),
+                },
+            )
+
+        self.assertEqual(issue_status, 202)
+        self.assertEqual(claim_status, 202)
+        self.assertEqual(running_status, 202)
+        self.assertEqual(feedback_status, 202)
+        self.assertEqual(feedback_response["records"]["request_id"], request_id)
+        feedback = feedback_response["result"]["feedback"]
+        self.assertEqual(feedback["request_id"], request_id)
+        self.assertEqual(feedback["pr_number"], 75)
+        self.assertEqual(feedback["pr_url"], "https://github.com/cbusillo/code/pull/75")
 
     def test_every_code_pr_comment_webhook_dedupes_feedback(self) -> None:
         secret = "launchplane-every-code-webhook-secret"


### PR DESCRIPTION
## Summary
- match Every Code PR feedback to running work requests via PR closing references when `result_pr_url` is not set yet
- keep direct `result_pr_url` matching for completed/finished requests
- add regression coverage for comments on a live PR that closes the source issue

## Validation
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_every_code_pr_comment_webhook_matches_linked_issue tests.test_service.LaunchplaneServiceTests.test_every_code_pr_comment_webhook_records_feedback
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest