### PR TITLE
Fix Every Code rerun and queued PR close regressions

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -101,6 +101,7 @@ from control_plane.contracts.work_graph_read_model import (
 )
 from control_plane.drivers.registry import build_driver_context_view
 from control_plane.every_code_worker import (
+    EveryCodeWorkerApiError,
     EveryCodeWorkerApiStore,
     EveryCodeWorkerStore,
     build_every_code_worker_daemon_spec,
@@ -9781,6 +9782,8 @@ def every_code_rerun_issue(
                 "detail": "Requeued terminal Every Code work request for this issue.",
                 "request": request.model_dump(mode="json"),
             }
+        except EveryCodeWorkerApiError as error:
+            raise click.ClickException(str(error)) from error
         finally:
             _close_store(record_store)
         click.echo(json.dumps(payload, indent=2, sort_keys=True))

--- a/control_plane/contracts/every_code_work_request.py
+++ b/control_plane/contracts/every_code_work_request.py
@@ -217,7 +217,7 @@ def close_every_code_work_request_for_pull_request(
         raise ValueError("Every Code PR close update requires closed_at")
     if record.result_pr_url.strip() and record.result_pr_url.strip() != normalized_pr_url:
         return None
-    if record.state in {"queued", "done", "blocked"}:
+    if record.state in {"done", "blocked"}:
         return None
 
     state: EveryCodeWorkRequestState = "done" if merged else "blocked"

--- a/tests/test_every_code_reconciliation.py
+++ b/tests/test_every_code_reconciliation.py
@@ -1,7 +1,9 @@
 import json
+import os
 from pathlib import Path
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
@@ -240,6 +242,30 @@ class EveryCodeIssueReconciliationTests(unittest.TestCase):
             self.assertEqual(rerun_payload["request"]["state"], "queued")
             self.assertEqual(rerun_payload["request"]["trigger_actor"], "ops")
             self.assertEqual(rerun_payload["request"]["result_pr_url"], "")
+
+    def test_cli_rerun_issue_reports_service_failure_without_traceback(self) -> None:
+        runner = CliRunner()
+
+        with patch.dict(os.environ, {"LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-token"}):
+            result = runner.invoke(
+                main,
+                [
+                    "every-code",
+                    "rerun-issue",
+                    "--service-url",
+                    "http://127.0.0.1:1",
+                    "--repository",
+                    "cbusillo/launchplane",
+                    "--issue-number",
+                    "278",
+                    "--actor",
+                    "ops",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("Error: Launchplane API request failed", result.output)
+        self.assertNotIn("Traceback", result.output)
 
 
 if __name__ == "__main__":

--- a/tests/test_every_code_work_request.py
+++ b/tests/test_every_code_work_request.py
@@ -168,6 +168,24 @@ class EveryCodeWorkRequestRecordTests(unittest.TestCase):
         self.assertEqual(done_record.state, "done")
         self.assertEqual(done_record.result_pr_url, "https://github.com/cbusillo/code/pull/99")
 
+    def test_pr_close_marks_matching_queued_request_done(self) -> None:
+        done_record = close_every_code_work_request_for_pull_request(
+            _queued_record(),
+            pr_url="https://github.com/cbusillo/code/pull/99",
+            merged=True,
+            closed_at="2026-05-05T22:05:00Z",
+        )
+
+        self.assertIsNotNone(done_record)
+        assert done_record is not None
+        self.assertEqual(done_record.state, "done")
+        self.assertEqual(done_record.finished_at, "2026-05-05T22:05:00Z")
+        self.assertEqual(done_record.result_pr_url, "https://github.com/cbusillo/code/pull/99")
+        self.assertEqual(
+            done_record.result_summary,
+            "Linked pull request merged: https://github.com/cbusillo/code/pull/99",
+        )
+
     def test_pr_close_does_not_match_different_stored_pr_url(self) -> None:
         claimed_record = claim_every_code_work_request(
             _queued_record(),


### PR DESCRIPTION
## Summary
- report service-backed every-code rerun API failures as ClickException messages
- allow linked PR close events to finish queued work requests instead of selecting them and leaving them open
- add regression coverage for both paths

## Validation
- uv run python -m unittest tests.test_every_code_work_request tests.test_every_code_reconciliation tests.test_service.LaunchplaneServiceTests.test_every_code_pull_request_close_matches_issue_url_without_result_pr_url
- uv run python -m unittest tests.test_every_code_work_request tests.test_every_code_reconciliation tests.test_every_code_worker tests.test_service
- uv run --extra dev ruff check --diff control_plane/cli.py control_plane/contracts/every_code_work_request.py tests/test_every_code_reconciliation.py tests/test_every_code_work_request.py
- uv run --extra dev ruff check control_plane/cli.py control_plane/contracts/every_code_work_request.py tests/test_every_code_reconciliation.py tests/test_every_code_work_request.py
- uv run --extra dev ruff format --check control_plane/cli.py control_plane/contracts/every_code_work_request.py tests/test_every_code_reconciliation.py tests/test_every_code_work_request.py
