### PR TITLE
fix(every-code): read PR issue body for comment feedback

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2457,14 +2457,17 @@ def _handle_every_code_pr_feedback_webhook(
     )
     if matched_record is None:
         pull_request_payload = _github_webhook_mapping(payload, "pull_request")
-        linked_issue_numbers = (
-            _github_issue_numbers_referenced_by_pull_request(
-                pull_request_payload,
-                repository=repository,
+        linked_issue_numbers: frozenset[int] = frozenset()
+        if pull_request_payload is not None:
+            linked_issue_numbers = _github_issue_numbers_referenced_by_pull_request(
+                pull_request_payload, repository=repository
             )
-            if pull_request_payload is not None
-            else frozenset()
-        )
+        if event_name == "issue_comment":
+            issue_payload = _github_webhook_mapping(payload, "issue")
+            if issue_payload is not None:
+                linked_issue_numbers = linked_issue_numbers | _github_issue_numbers_referenced_by_pull_request(
+                    issue_payload, repository=repository
+                )
         for record in _iter_every_code_work_request_records(
             every_code_store,
             repository=repository,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -472,7 +472,7 @@ def _every_code_github_pr_comment_payload(
     pr_number: int = 26,
     body: str = "Please tighten this wording before merge.",
     comment_id: int = 1001,
-    pull_request_body: str = "",
+    issue_body: str = "",
 ) -> dict[str, object]:
     return {
         "action": "created",
@@ -480,6 +480,7 @@ def _every_code_github_pr_comment_payload(
         "issue": {
             "number": pr_number,
             "html_url": f"https://github.com/{repository}/pull/{pr_number}",
+            "body": issue_body,
             "pull_request": {"url": f"https://api.github.com/repos/{repository}/pulls/{pr_number}"},
         },
         "comment": {
@@ -488,11 +489,6 @@ def _every_code_github_pr_comment_payload(
             "html_url": f"https://github.com/{repository}/pull/{pr_number}#issuecomment-{comment_id}",
             "body": body,
             "author_association": "OWNER",
-        },
-        "pull_request": {
-            "number": pr_number,
-            "html_url": f"https://github.com/{repository}/pull/{pr_number}",
-            "body": pull_request_body,
         },
         "sender": {"login": "cbusillo"},
     }
@@ -1751,7 +1747,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         issue_payload = _every_code_github_issue_labeled_payload(issue_number=67)
         comment_payload = _every_code_github_pr_comment_payload(
             pr_number=75,
-            pull_request_body="Closes #67",
+            issue_body="Closes #67",
         )
         with (
             TemporaryDirectory() as temporary_directory_name,
@@ -1818,7 +1814,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(issue_status, 202)
         self.assertEqual(claim_status, 202)
         self.assertEqual(running_status, 202)
-        self.assertEqual(feedback_status, 202)
+        self.assertIn("records", feedback_response)
+        self.assertEqual(feedback_status, 202, feedback_response)
         self.assertEqual(feedback_response["records"]["request_id"], request_id)
         feedback = feedback_response["result"]["feedback"]
         self.assertEqual(feedback["request_id"], request_id)


### PR DESCRIPTION
## Summary
- include the GitHub issue-comment payload's PR-as-issue body when matching PR feedback to Every Code requests
- preserve direct PR payload matching for review/review-comment events
- update regression coverage to match the real issue_comment payload shape

## Validation
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_every_code_pr_comment_webhook_matches_linked_issue tests.test_service.LaunchplaneServiceTests.test_every_code_pr_comment_webhook_records_feedback
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest