### PR TITLE
fix(every-code): submit delivered PR feedback

### DIFF
--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -1596,7 +1596,7 @@ def _send_every_code_pr_feedback_to_session(
 ) -> bool:
     prompt = every_code_pr_feedback_prompt(feedback)
     try:
-        result = runner((tmux_binary, "send-keys", "-t", session_name, prompt, "Enter"))
+        result = runner((tmux_binary, "send-keys", "-t", session_name, prompt, "C-m"))
     except OSError:
         return False
     return result.returncode == 0

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -740,6 +740,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(feedback.status, "applied")
         send_call = next(call for call in runner.calls if call[1] == "send-keys")
         self.assertIn("Please tighten the README wording", send_call[4])
+        self.assertEqual(send_call[-1], "C-m")
 
     def test_apply_feedback_relaunches_terminal_session_in_saved_worktree(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- send `C-m` after injecting PR feedback into an active tmux session
- keep feedback delivery from leaving text idle in the composer
- add regression coverage for the submit key

## Validation
- uv run python -m unittest tests.test_every_code_worker.EveryCodeWorkerTests.test_apply_feedback_sends_prompt_to_active_session
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest