### PR TITLE
Apply Ruff formatting

### DIFF
--- a/control_plane/contracts/authz_policy_record.py
+++ b/control_plane/contracts/authz_policy_record.py
@@ -47,4 +47,3 @@ class LaunchplaneAuthzPolicyRecord(BaseModel):
         if self.policy_sha256 != computed_sha256:
             raise ValueError("authz policy record policy_sha256 does not match policy payload")
         return self
-

--- a/control_plane/contracts/dokploy_target_id_record.py
+++ b/control_plane/contracts/dokploy_target_id_record.py
@@ -17,4 +17,3 @@ class DokployTargetIdRecord(BaseModel):
         if not value.strip():
             raise ValueError("Dokploy target-id record requires non-empty string fields")
         return value.strip()
-

--- a/control_plane/contracts/environment_inventory.py
+++ b/control_plane/contracts/environment_inventory.py
@@ -1,6 +1,10 @@
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from control_plane.contracts.promotion_record import ArtifactIdentityReference, DeploymentEvidence, HealthcheckEvidence
+from control_plane.contracts.promotion_record import (
+    ArtifactIdentityReference,
+    DeploymentEvidence,
+    HealthcheckEvidence,
+)
 from control_plane.contracts.promotion_record import PostDeployUpdateEvidence
 
 
@@ -33,5 +37,7 @@ class EnvironmentInventory(BaseModel):
         if not self.deployment_record_id.strip():
             raise ValueError("environment inventory requires deployment_record_id")
         if self.promotion_record_id.strip() and not self.promoted_from_instance.strip():
-            raise ValueError("environment inventory with promotion_record_id requires promoted_from_instance")
+            raise ValueError(
+                "environment inventory with promotion_record_id requires promoted_from_instance"
+            )
         return self

--- a/control_plane/contracts/github_webhook_replay_envelope.py
+++ b/control_plane/contracts/github_webhook_replay_envelope.py
@@ -87,17 +87,29 @@ class GitHubWebhookReplayEnvelope(BaseModel):
             raise ValueError("GitHub webhook replay envelope delivery_source must not be blank")
         if self.capture is not None:
             capture_event_name = self._capture_header_value("X-GitHub-Event")
-            if self.event_name.strip() and capture_event_name and self.event_name.strip() != capture_event_name:
+            if (
+                self.event_name.strip()
+                and capture_event_name
+                and self.event_name.strip() != capture_event_name
+            ):
                 raise ValueError(
                     "GitHub webhook replay envelope event_name conflicts with capture header X-GitHub-Event"
                 )
             capture_signature = self._capture_header_value("X-Hub-Signature-256")
-            if self.signature_256.strip() and capture_signature and self.signature_256.strip() != capture_signature:
+            if (
+                self.signature_256.strip()
+                and capture_signature
+                and self.signature_256.strip() != capture_signature
+            ):
                 raise ValueError(
                     "GitHub webhook replay envelope signature_256 conflicts with capture header X-Hub-Signature-256"
                 )
             capture_delivery_id = self._capture_header_value("X-GitHub-Delivery")
-            if self.delivery_id.strip() and capture_delivery_id and self.delivery_id.strip() != capture_delivery_id:
+            if (
+                self.delivery_id.strip()
+                and capture_delivery_id
+                and self.delivery_id.strip() != capture_delivery_id
+            ):
                 raise ValueError(
                     "GitHub webhook replay envelope delivery_id conflicts with capture header X-GitHub-Delivery"
                 )

--- a/control_plane/contracts/odoo_instance_override_record.py
+++ b/control_plane/contracts/odoo_instance_override_record.py
@@ -90,7 +90,9 @@ class OdooOverrideApplyResult(BaseModel):
         if not self.attempted and self.status != "skipped":
             raise ValueError("non-attempted Odoo override apply result must use skipped status")
         if self.attempted and self.status not in {"pending", "pass", "fail"}:
-            raise ValueError("attempted Odoo override apply result must use pending/pass/fail status")
+            raise ValueError(
+                "attempted Odoo override apply result must use pending/pass/fail status"
+            )
         if self.status in {"pass", "fail"} and not self.applied_at:
             raise ValueError("completed Odoo override apply result requires applied_at")
         return self

--- a/control_plane/contracts/preview_enablement_record.py
+++ b/control_plane/contracts/preview_enablement_record.py
@@ -46,18 +46,22 @@ class PreviewEnablementRecord(BaseModel):
         if not self.updated_at.strip():
             raise ValueError("preview enablement record requires updated_at")
         if self.request_metadata_status == "invalid" and not self.request_metadata_error.strip():
-            raise ValueError(
-                "invalid preview enablement record requires request_metadata_error"
-            )
+            raise ValueError("invalid preview enablement record requires request_metadata_error")
         if self.request_metadata_status != "invalid" and self.request_metadata_error.strip():
             raise ValueError(
                 "preview enablement record can only include request_metadata_error when status is invalid"
             )
-        if self.request_metadata_status == "valid" and not self.request_metadata_baseline_channel.strip():
+        if (
+            self.request_metadata_status == "valid"
+            and not self.request_metadata_baseline_channel.strip()
+        ):
             raise ValueError(
                 "valid preview enablement record requires request_metadata_baseline_channel"
             )
-        if self.request_metadata_status != "valid" and self.request_metadata_baseline_channel.strip():
+        if (
+            self.request_metadata_status != "valid"
+            and self.request_metadata_baseline_channel.strip()
+        ):
             raise ValueError(
                 "preview enablement record can only include request_metadata_baseline_channel when status is valid"
             )

--- a/control_plane/contracts/preview_manifest.py
+++ b/control_plane/contracts/preview_manifest.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from control_plane.contracts.preview_generation_record import PreviewPullRequestSummary, PreviewSourceRecord
+from control_plane.contracts.preview_generation_record import (
+    PreviewPullRequestSummary,
+    PreviewSourceRecord,
+)
 
 
 class LaunchplaneResolvedPreviewManifest(BaseModel):
@@ -23,9 +26,13 @@ class LaunchplaneResolvedPreviewManifest(BaseModel):
         if not self.baseline_channel.strip():
             raise ValueError("resolved Launchplane preview manifest requires baseline_channel")
         if not self.baseline_release_tuple_id.strip():
-            raise ValueError("resolved Launchplane preview manifest requires baseline_release_tuple_id")
+            raise ValueError(
+                "resolved Launchplane preview manifest requires baseline_release_tuple_id"
+            )
         if not self.resolved_manifest_fingerprint.strip():
-            raise ValueError("resolved Launchplane preview manifest requires resolved_manifest_fingerprint")
+            raise ValueError(
+                "resolved Launchplane preview manifest requires resolved_manifest_fingerprint"
+            )
         if not self.source_map:
             raise ValueError("resolved Launchplane preview manifest requires source_map")
         return self

--- a/control_plane/contracts/preview_mutation_request.py
+++ b/control_plane/contracts/preview_mutation_request.py
@@ -169,9 +169,13 @@ class LaunchplanePullRequestMutationIntent(BaseModel):
     def _validate_intent(self) -> "LaunchplanePullRequestMutationIntent":
         if self.command == "request-generation":
             if self.preview_request is None:
-                raise ValueError("request-generation Launchplane mutation intent requires preview_request")
+                raise ValueError(
+                    "request-generation Launchplane mutation intent requires preview_request"
+                )
             if self.destroy_request is not None:
-                raise ValueError("request-generation Launchplane mutation intent cannot include destroy_request")
+                raise ValueError(
+                    "request-generation Launchplane mutation intent cannot include destroy_request"
+                )
             if self.generation_request is None and self.generation_request_seed is None:
                 raise ValueError(
                     "request-generation Launchplane mutation intent requires generation_request or generation_request_seed"
@@ -187,11 +191,17 @@ class LaunchplanePullRequestMutationIntent(BaseModel):
             return self
 
         if self.preview_request is not None:
-            raise ValueError("destroy-preview Launchplane mutation intent cannot include preview_request")
+            raise ValueError(
+                "destroy-preview Launchplane mutation intent cannot include preview_request"
+            )
         if self.generation_request is not None or self.generation_request_seed is not None:
-            raise ValueError("destroy-preview Launchplane mutation intent cannot include generation payload")
+            raise ValueError(
+                "destroy-preview Launchplane mutation intent cannot include generation payload"
+            )
         if self.destroy_request is None:
             raise ValueError("destroy-preview Launchplane mutation intent requires destroy_request")
         if self.manifest_resolution_required:
-            raise ValueError("destroy-preview Launchplane mutation intent cannot require manifest resolution")
+            raise ValueError(
+                "destroy-preview Launchplane mutation intent cannot require manifest resolution"
+            )
         return self

--- a/control_plane/contracts/preview_pr_feedback_record.py
+++ b/control_plane/contracts/preview_pr_feedback_record.py
@@ -68,7 +68,9 @@ class PreviewPrFeedbackRecord(BaseModel):
         return self
 
 
-def build_preview_pr_feedback_id(*, context_name: str, anchor_pr_number: int, requested_at: str) -> str:
+def build_preview_pr_feedback_id(
+    *, context_name: str, anchor_pr_number: int, requested_at: str
+) -> str:
     normalized_timestamp = (
         requested_at.strip()
         .replace(":", "")

--- a/control_plane/contracts/preview_request_metadata.py
+++ b/control_plane/contracts/preview_request_metadata.py
@@ -63,16 +63,24 @@ class LaunchplanePreviewRequestParseResult(BaseModel):
             if self.metadata is None:
                 raise ValueError("valid Launchplane preview request parse result requires metadata")
             if self.error.strip():
-                raise ValueError("valid Launchplane preview request parse result cannot include error")
+                raise ValueError(
+                    "valid Launchplane preview request parse result cannot include error"
+                )
             return self
         if self.status == "missing":
             if self.metadata is not None:
-                raise ValueError("missing Launchplane preview request parse result cannot include metadata")
+                raise ValueError(
+                    "missing Launchplane preview request parse result cannot include metadata"
+                )
             if self.error.strip():
-                raise ValueError("missing Launchplane preview request parse result cannot include error")
+                raise ValueError(
+                    "missing Launchplane preview request parse result cannot include error"
+                )
             return self
         if self.metadata is not None:
-            raise ValueError("invalid Launchplane preview request parse result cannot include metadata")
+            raise ValueError(
+                "invalid Launchplane preview request parse result cannot include metadata"
+            )
         if not self.error.strip():
             raise ValueError("invalid Launchplane preview request parse result requires error")
         return self

--- a/control_plane/contracts/promotion_record.py
+++ b/control_plane/contracts/promotion_record.py
@@ -111,7 +111,11 @@ class PromotionRecord(BaseModel):
     def _validate_promotion_path(self) -> "PromotionRecord":
         if self.from_instance == self.to_instance:
             raise ValueError("promotion source and destination instances must differ")
-        if self.backup_gate.required and self.backup_gate.status == "pass" and not self.backup_record_id.strip():
+        if (
+            self.backup_gate.required
+            and self.backup_gate.status == "pass"
+            and not self.backup_record_id.strip()
+        ):
             raise ValueError("promotion record with passing backup gate requires backup_record_id")
         return self
 

--- a/control_plane/every_code_webhooks.py
+++ b/control_plane/every_code_webhooks.py
@@ -76,7 +76,7 @@ def sync_every_code_webhooks(
 
 def _topic_repositories(*, owner: str, topic: str, runner: Runner) -> tuple[str, ...]:
     query = (
-        f'.[] | select(.isArchived == false) | '
+        f".[] | select(.isArchived == false) | "
         f'select([(.repositoryTopics // [])[].name] | index("{topic}")) | .nameWithOwner'
     )
     result = runner(
@@ -126,9 +126,14 @@ def _sync_repo_webhook(
     if existing_hook is not None:
         hook_id_value = existing_hook.get("id")
         hook_id = int(hook_id_value) if isinstance(hook_id_value, int | str) else 0
-        runner(("gh", "api", "-X", "PATCH", f"repos/{repo}/hooks/{hook_id}", "--input", "-"), hook_payload)
+        runner(
+            ("gh", "api", "-X", "PATCH", f"repos/{repo}/hooks/{hook_id}", "--input", "-"),
+            hook_payload,
+        )
         return EveryCodeWebhookSyncResult(repo=repo, status="updated", hook_id=hook_id)
-    result = runner(("gh", "api", "-X", "POST", f"repos/{repo}/hooks", "--input", "-"), hook_payload)
+    result = runner(
+        ("gh", "api", "-X", "POST", f"repos/{repo}/hooks", "--input", "-"), hook_payload
+    )
     created_hook = json.loads(result.stdout)
     hook_id = int(created_hook.get("id", 0)) if isinstance(created_hook, dict) else 0
     return EveryCodeWebhookSyncResult(repo=repo, status="created", hook_id=hook_id)

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2465,8 +2465,11 @@ def _handle_every_code_pr_feedback_webhook(
         if event_name == "issue_comment":
             issue_payload = _github_webhook_mapping(payload, "issue")
             if issue_payload is not None:
-                linked_issue_numbers = linked_issue_numbers | _github_issue_numbers_referenced_by_pull_request(
-                    issue_payload, repository=repository
+                linked_issue_numbers = (
+                    linked_issue_numbers
+                    | _github_issue_numbers_referenced_by_pull_request(
+                        issue_payload, repository=repository
+                    )
                 )
         for record in _iter_every_code_work_request_records(
             every_code_store,

--- a/control_plane/storage/factory.py
+++ b/control_plane/storage/factory.py
@@ -19,7 +19,9 @@ def resolve_database_url(database_url: str | None = None) -> str | None:
     return None
 
 
-def build_record_store(*, state_dir: Path, database_url: str | None = None) -> FilesystemRecordStore | PostgresRecordStore:
+def build_record_store(
+    *, state_dir: Path, database_url: str | None = None
+) -> FilesystemRecordStore | PostgresRecordStore:
     resolved_database_url = resolve_database_url(database_url)
     if resolved_database_url is None:
         return FilesystemRecordStore(state_dir=state_dir)

--- a/control_plane/storage/migrations/versions/a8b0c2d4e6f8_add_authz_policy_records.py
+++ b/control_plane/storage/migrations/versions/a8b0c2d4e6f8_add_authz_policy_records.py
@@ -44,4 +44,3 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_index("launchplane_authz_policies_updated_idx", table_name="launchplane_authz_policies")
     op.drop_table("launchplane_authz_policies")
-

--- a/control_plane/storage/migrations/versions/b9c1d3e5f7a9_add_product_profiles.py
+++ b/control_plane/storage/migrations/versions/b9c1d3e5f7a9_add_product_profiles.py
@@ -42,5 +42,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_index("launchplane_product_profiles_driver_idx", table_name="launchplane_product_profiles")
+    op.drop_index(
+        "launchplane_product_profiles_driver_idx", table_name="launchplane_product_profiles"
+    )
     op.drop_table("launchplane_product_profiles")

--- a/control_plane/workflows/generic_web_deploy.py
+++ b/control_plane/workflows/generic_web_deploy.py
@@ -17,7 +17,11 @@ from control_plane.contracts.product_profile_record import (
 from control_plane.contracts.promotion_record import HealthcheckEvidence
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.workflows.dokploy_deploy import execute_dokploy_artifact_deploy
-from control_plane.workflows.ship import build_deployment_record, generate_deployment_record_id, utc_now_timestamp
+from control_plane.workflows.ship import (
+    build_deployment_record,
+    generate_deployment_record_id,
+    utc_now_timestamp,
+)
 
 
 class GenericWebDeployStore(Protocol):
@@ -88,7 +92,9 @@ def _resolve_deploy_mode(*, configured_ship_mode: str, target_type: DokployTarge
     return f"dokploy-{configured_ship_mode}-api"
 
 
-def _fallback_target_name(*, profile: LaunchplaneProductProfileRecord, lane: ProductLaneProfile) -> str:
+def _fallback_target_name(
+    *, profile: LaunchplaneProductProfileRecord, lane: ProductLaneProfile
+) -> str:
     return f"{profile.product}-{lane.instance}"
 
 
@@ -99,9 +105,9 @@ def normalize_generic_web_artifact_id(
     image_repository = profile.image.repository.strip().rstrip("/")
     if not normalized_artifact_id:
         raise click.ClickException("Generic web deploy requires artifact_id.")
-    if normalized_artifact_id.startswith(f"{image_repository}@") or normalized_artifact_id.startswith(
-        f"{image_repository}:"
-    ):
+    if normalized_artifact_id.startswith(
+        f"{image_repository}@"
+    ) or normalized_artifact_id.startswith(f"{image_repository}:"):
         return normalized_artifact_id
     if normalized_artifact_id.startswith("sha256:"):
         return f"{image_repository}@{normalized_artifact_id}"
@@ -114,7 +120,10 @@ def normalize_generic_web_artifact_id(
 
 
 def _fallback_ship_request(
-    *, request: GenericWebDeployRequest, profile: LaunchplaneProductProfileRecord, lane: ProductLaneProfile
+    *,
+    request: GenericWebDeployRequest,
+    profile: LaunchplaneProductProfileRecord,
+    lane: ProductLaneProfile,
 ) -> ShipRequest:
     return ShipRequest(
         artifact_id=normalize_generic_web_artifact_id(
@@ -258,7 +267,9 @@ def execute_generic_web_deploy(
         )
 
     try:
-        host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
+        host, token = control_plane_dokploy.read_dokploy_config(
+            control_plane_root=control_plane_root
+        )
         execute_dokploy_artifact_deploy(
             host=host,
             token=token,

--- a/control_plane/workflows/preview_pr_feedback.py
+++ b/control_plane/workflows/preview_pr_feedback.py
@@ -215,7 +215,9 @@ def build_preview_pr_feedback_record(
             if existing_comment is not None:
                 existing_comment_id = existing_comment.get("id")
                 if not isinstance(existing_comment_id, int):
-                    raise click.ClickException("Existing preview feedback comment is missing a numeric id.")
+                    raise click.ClickException(
+                        "Existing preview feedback comment is missing a numeric id."
+                    )
                 if status == "cleared":
                     delete_github_issue_comment(
                         owner=github_reference["owner"],

--- a/control_plane/workflows/promote.py
+++ b/control_plane/workflows/promote.py
@@ -51,7 +51,9 @@ def build_promotion_record(
     )
 
 
-def generate_promotion_record_id(*, context_name: str, from_instance_name: str, to_instance_name: str) -> str:
+def generate_promotion_record_id(
+    *, context_name: str, from_instance_name: str, to_instance_name: str
+) -> str:
     timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
     return f"promotion-{timestamp}-{context_name}-{from_instance_name}-to-{to_instance_name}"
 
@@ -88,8 +90,11 @@ def _resolve_destination_health(
     if destination_health.status == "skipped":
         return destination_health
     if not wait:
-        return HealthcheckEvidence(urls=destination_health.urls, timeout_seconds=destination_health.timeout_seconds,
-                                   status="pending")
+        return HealthcheckEvidence(
+            urls=destination_health.urls,
+            timeout_seconds=destination_health.timeout_seconds,
+            status="pending",
+        )
     if deployment_status == "pass":
         return HealthcheckEvidence(
             verified=True,
@@ -97,8 +102,11 @@ def _resolve_destination_health(
             timeout_seconds=destination_health.timeout_seconds,
             status="pass",
         )
-    return HealthcheckEvidence(urls=destination_health.urls, timeout_seconds=destination_health.timeout_seconds,
-                               status="fail")
+    return HealthcheckEvidence(
+        urls=destination_health.urls,
+        timeout_seconds=destination_health.timeout_seconds,
+        status="fail",
+    )
 
 
 def build_executed_promotion_record(

--- a/control_plane/workflows/verireel_prod_backup_gate_worker.py
+++ b/control_plane/workflows/verireel_prod_backup_gate_worker.py
@@ -73,9 +73,7 @@ def _parse_non_negative_int(name: str, default: int) -> int:
 
 def _normalize_backup_modes(raw_value: str) -> tuple[str, ...]:
     tokens = {
-        token.strip().lower()
-        for token in raw_value.replace(":", ",").split(",")
-        if token.strip()
+        token.strip().lower() for token in raw_value.replace(":", ",").split(",") if token.strip()
     }
     if "none" in tokens:
         return ()
@@ -248,7 +246,9 @@ def _fetch_health_summary(base_url: str) -> dict[str, str]:
     return summary
 
 
-def _prune_snapshots(*, ctid: str, prefix: str, keep: int, timeout_seconds: int, preserve_name: str) -> None:
+def _prune_snapshots(
+    *, ctid: str, prefix: str, keep: int, timeout_seconds: int, preserve_name: str
+) -> None:
     if keep < 0:
         return
     output = _run_proxmox_command(
@@ -272,9 +272,13 @@ def _prune_snapshots(*, ctid: str, prefix: str, keep: int, timeout_seconds: int,
         )
 
 
-def execute_worker(request: VeriReelProdBackupGateWorkerRequest) -> VeriReelProdBackupGateWorkerResult:
+def execute_worker(
+    request: VeriReelProdBackupGateWorkerRequest,
+) -> VeriReelProdBackupGateWorkerResult:
     ctid = _required_env("VERIREEL_PROD_CT_ID")
-    backup_mode = _normalize_backup_modes(_optional_env("VERIREEL_PROD_BACKUP_MODE", DEFAULT_BACKUP_MODE))
+    backup_mode = _normalize_backup_modes(
+        _optional_env("VERIREEL_PROD_BACKUP_MODE", DEFAULT_BACKUP_MODE)
+    )
     storage = _optional_env("VERIREEL_PROD_BACKUP_STORAGE")
     if "vzdump" in backup_mode and not storage:
         raise click.ClickException(
@@ -282,8 +286,12 @@ def execute_worker(request: VeriReelProdBackupGateWorkerRequest) -> VeriReelProd
         )
     snapshot_prefix = _optional_env("VERIREEL_PROD_SNAPSHOT_PREFIX", DEFAULT_SNAPSHOT_PREFIX)
     snapshot_keep = _parse_non_negative_int("VERIREEL_PROD_SNAPSHOT_KEEP", 5)
-    testing_base_url = _optional_env("VERIREEL_TESTING_BASE_URL", "https://ver-testing.shinycomputers.com")
-    prod_base_url = _optional_env("VERIREEL_PROD_OPERATOR_BASE_URL", "https://ver-prod.shinycomputers.com")
+    testing_base_url = _optional_env(
+        "VERIREEL_TESTING_BASE_URL", "https://ver-testing.shinycomputers.com"
+    )
+    prod_base_url = _optional_env(
+        "VERIREEL_PROD_OPERATOR_BASE_URL", "https://ver-prod.shinycomputers.com"
+    )
 
     started_at = utc_now_timestamp()
     snapshot_name = _format_snapshot_name(snapshot_prefix) if "snapshot" in backup_mode else ""

--- a/tests/test_every_code_webhooks.py
+++ b/tests/test_every_code_webhooks.py
@@ -24,7 +24,9 @@ class _WebhookRunner:
                 "",
             )
         if command[:3] == ("gh", "api", "repos/cbusillo/code/hooks"):
-            return subprocess.CompletedProcess(command, 0, json.dumps(self.hooks["cbusillo/code"]), "")
+            return subprocess.CompletedProcess(
+                command, 0, json.dumps(self.hooks["cbusillo/code"]), ""
+            )
         if command[:3] == ("gh", "api", "repos/cbusillo/launchplane/hooks"):
             return subprocess.CompletedProcess(
                 command, 0, json.dumps(self.hooks["cbusillo/launchplane"]), ""

--- a/tests/test_generic_web_deploy.py
+++ b/tests/test_generic_web_deploy.py
@@ -120,7 +120,9 @@ class GenericWebDeployTests(unittest.TestCase):
                 "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_dokploy_config",
                 return_value=("https://dokploy.example", "token"),
             ),
-            patch("control_plane.workflows.generic_web_deploy.execute_dokploy_artifact_deploy") as deploy,
+            patch(
+                "control_plane.workflows.generic_web_deploy.execute_dokploy_artifact_deploy"
+            ) as deploy,
         ):
             result = execute_generic_web_deploy(
                 control_plane_root=Path("."),
@@ -161,7 +163,9 @@ class GenericWebDeployTests(unittest.TestCase):
                 "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_dokploy_config",
                 return_value=("https://dokploy.example", "token"),
             ),
-            patch("control_plane.workflows.generic_web_deploy.execute_dokploy_artifact_deploy") as deploy,
+            patch(
+                "control_plane.workflows.generic_web_deploy.execute_dokploy_artifact_deploy"
+            ) as deploy,
         ):
             execute_generic_web_deploy(
                 control_plane_root=Path("."),

--- a/tests/test_generic_web_promotion.py
+++ b/tests/test_generic_web_promotion.py
@@ -23,7 +23,10 @@ from control_plane.contracts.promotion_record import (
     PromotionRecord,
 )
 from control_plane.contracts.ship_request import ShipRequest
-from control_plane.workflows.generic_web_deploy import GenericWebDeployRequest, GenericWebDeployResult
+from control_plane.workflows.generic_web_deploy import (
+    GenericWebDeployRequest,
+    GenericWebDeployResult,
+)
 from control_plane.workflows.generic_web_promotion import (
     GenericWebProdPromotionRequest,
     execute_generic_web_prod_promotion,
@@ -160,6 +163,8 @@ def _deploy_result(*, deploy_status: Literal["pass", "fail"] = "pass") -> Generi
         target_id="app-123",
         error_message="provider failed" if deploy_status == "fail" else "",
     )
+
+
 class GenericWebProdPromotionTests(unittest.TestCase):
     def test_execute_records_source_destination_health_promotion_and_inventory(self) -> None:
         store = _GenericWebPromotionStore(_profile())

--- a/tests/test_launchplane_previews.py
+++ b/tests/test_launchplane_previews.py
@@ -246,7 +246,9 @@ def _backup_gate_record(
     status: ReleaseStatus = "pass",
     evidence: dict[str, str] | None = None,
 ) -> BackupGateRecord:
-    resolved_evidence = evidence if evidence is not None else {"snapshot": "s3://launchplane/opw/prod/2026-04-14"}
+    resolved_evidence = (
+        evidence if evidence is not None else {"snapshot": "s3://launchplane/opw/prod/2026-04-14"}
+    )
     return BackupGateRecord(
         record_id=record_id,
         context=context,
@@ -292,7 +294,9 @@ def _promotion_record(
             started_at="2026-04-13T08:56:00Z",
             finished_at="2026-04-13T09:00:00Z",
         ),
-        post_deploy_update=PostDeployUpdateEvidence(attempted=True, status="pass", detail="Updated"),
+        post_deploy_update=PostDeployUpdateEvidence(
+            attempted=True, status="pass", detail="Updated"
+        ),
         destination_health=HealthcheckEvidence(status=destination_health_status),
     )
 
@@ -353,7 +357,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
     store = PostgresRecordStore(database_url=database_url)
     store.ensure_schema()
     try:
-        for record in control_plane_runtime_environments.build_runtime_environment_records_from_definition(
+        for (
+            record
+        ) in control_plane_runtime_environments.build_runtime_environment_records_from_definition(
             control_plane_runtime_environments._parse_runtime_environment_definition(
                 tomllib.loads(payload),
                 source_file=control_plane_root / "config" / "runtime-environments.toml",
@@ -380,12 +386,7 @@ def _github_pull_request_webhook_payload(
     repo: str = "tenant-opw",
     pr_number: int = 123,
     pr_url: str = "https://github.com/every/tenant-opw/pull/123",
-    body: str = (
-        "```launchplane-preview\n"
-        "schema_version = 1\n"
-        'baseline_channel = "testing"\n'
-        "```\n"
-    ),
+    body: str = ('```launchplane-preview\nschema_version = 1\nbaseline_channel = "testing"\n```\n'),
     state: str = "open",
     merged: bool = False,
     head_sha: str = "aaaa1111",
@@ -418,7 +419,9 @@ def _github_pull_request_webhook_payload(
     return payload
 
 
-def _github_webhook_signature(payload: dict[str, object], secret: str = "launchplane-webhook-secret") -> str:
+def _github_webhook_signature(
+    payload: dict[str, object], secret: str = "launchplane-webhook-secret"
+) -> str:
     payload_bytes = json.dumps(payload).encode("utf-8")
     digest = hmac.new(secret.encode("utf-8"), payload_bytes, hashlib.sha256).hexdigest()
     return f"sha256={digest}"
@@ -534,7 +537,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
 
 [contexts.opw.instances.local.env]
 ODOO_DB_PASSWORD = "local-secret"
-""".strip()
+""".strip(),
             )
 
             with patch.dict(os.environ, _runtime_environments_env(control_plane_root), clear=True):
@@ -555,7 +558,7 @@ schema_version = 1
 
 [contexts.opw.instances.local.env]
 ODOO_DB_PASSWORD = "local-secret"
-""".strip()
+""".strip(),
             )
 
             with patch.dict(os.environ, _runtime_environments_env(control_plane_root), clear=True):
@@ -670,7 +673,9 @@ ODOO_DB_PASSWORD = "local-secret"
         self.assertEqual(transitioned.latest_generation_id, "hgen_01jabc_2")
         self.assertEqual(transitioned.serving_generation_id, "hgen_01jabc_1")
 
-    def test_apply_preview_destroyed_transition_clears_runtime_links_and_keeps_evidence(self) -> None:
+    def test_apply_preview_destroyed_transition_clears_runtime_links_and_keeps_evidence(
+        self,
+    ) -> None:
         preview = _preview_record(
             state="teardown_pending",
             active_generation_id="hgen_01jabc_2",
@@ -691,7 +696,9 @@ ODOO_DB_PASSWORD = "local-secret"
         self.assertEqual(transitioned.destroy_reason, "merged_after_grace_window")
 
     def test_launchplane_preview_label_enabled_matches_configured_label(self) -> None:
-        self.assertTrue(launchplane_preview_label_enabled(label_names=("bug", "launchplane-preview")))
+        self.assertTrue(
+            launchplane_preview_label_enabled(label_names=("bug", "launchplane-preview"))
+        )
         self.assertFalse(launchplane_preview_label_enabled(label_names=("bug", "needs-review")))
 
     def test_launchplane_anchor_repo_resolution_accepts_tenant_repos_only(self) -> None:
@@ -702,7 +709,9 @@ ODOO_DB_PASSWORD = "local-secret"
         self.assertFalse(launchplane_anchor_repo_eligible(repo="shared-addons"))
         self.assertFalse(launchplane_anchor_repo_eligible(repo="control-plane"))
 
-    def test_classify_pull_request_event_for_launchplane_enables_preview_when_label_added(self) -> None:
+    def test_classify_pull_request_event_for_launchplane_enables_preview_when_label_added(
+        self,
+    ) -> None:
         event = GitHubPullRequestEvent(
             action="labeled",
             repo="tenant-opw",
@@ -718,7 +727,9 @@ ODOO_DB_PASSWORD = "local-secret"
 
         self.assertEqual(action, "enable_preview")
 
-    def test_classify_pull_request_event_for_launchplane_refreshes_enabled_preview_on_sync(self) -> None:
+    def test_classify_pull_request_event_for_launchplane_refreshes_enabled_preview_on_sync(
+        self,
+    ) -> None:
         event = GitHubPullRequestEvent(
             action="synchronize",
             repo="tenant-opw",
@@ -755,7 +766,9 @@ ODOO_DB_PASSWORD = "local-secret"
 
         self.assertEqual(action, "destroy_preview")
 
-    def test_classify_pull_request_event_for_launchplane_reenables_destroyed_preview_on_reopen(self) -> None:
+    def test_classify_pull_request_event_for_launchplane_reenables_destroyed_preview_on_reopen(
+        self,
+    ) -> None:
         event = GitHubPullRequestEvent(
             action="reopened",
             repo="tenant-opw",
@@ -810,7 +823,9 @@ ODOO_DB_PASSWORD = "local-secret"
         self.assertEqual(result.metadata.companions[0].pr_number, 456)
 
     def test_parse_preview_request_metadata_is_missing_without_launchplane_block(self) -> None:
-        result = parse_preview_request_metadata(pr_body="Regular PR body without Launchplane metadata.")
+        result = parse_preview_request_metadata(
+            pr_body="Regular PR body without Launchplane metadata."
+        )
 
         self.assertEqual(result.status, "missing")
         self.assertIsNone(result.metadata)
@@ -864,10 +879,13 @@ ODOO_DB_PASSWORD = "local-secret"
 
             self.assertEqual(len(previews), 1)
             self.assertEqual(previews[0].preview_label, "opw/tenant-opw/pr-123")
-            self.assertEqual([record.generation_id for record in generations], [
-                "hgen_01jabc_2",
-                "hgen_01jabc_1",
-            ])
+            self.assertEqual(
+                [record.generation_id for record in generations],
+                [
+                    "hgen_01jabc_2",
+                    "hgen_01jabc_1",
+                ],
+            )
 
     def test_launchplane_previews_show_active_preview(self) -> None:
         runner = CliRunner()
@@ -1022,7 +1040,9 @@ ODOO_DB_PASSWORD = "local-secret"
             self.assertIn('class="preview-detail-grid"', rendered_html)
             self.assertIn("tenant-opw PR 123", rendered_html)
             self.assertIn("opw/tenant-opw/pr-123", rendered_html)
-            self.assertIn("https://launchplane.example/previews/opw/tenant-opw/pr-123", rendered_html)
+            self.assertIn(
+                "https://launchplane.example/previews/opw/tenant-opw/pr-123", rendered_html
+            )
             self.assertIn("artifact-opw-123", rendered_html)
             self.assertIn("launchplane-manifest-001", rendered_html)
             self.assertIn("Serving the latest requested generation.", rendered_html)
@@ -1161,17 +1181,30 @@ ODOO_DB_PASSWORD = "local-secret"
             self.assertEqual(payload["preview_enablement_counts"]["candidate"], 1)
             self.assertEqual(payload["preview_enablement_counts"]["requested"], 1)
             self.assertEqual(payload["preview_enablement_counts"]["running"], 2)
-            self.assertEqual(payload["environments"]["testing"]["live"]["artifact_id"], "artifact-testing")
-            self.assertEqual(payload["environments"]["prod"]["live"]["artifact_id"], "artifact-prod")
+            self.assertEqual(
+                payload["environments"]["testing"]["live"]["artifact_id"], "artifact-testing"
+            )
+            self.assertEqual(
+                payload["environments"]["prod"]["live"]["artifact_id"], "artifact-prod"
+            )
             self.assertEqual(payload["promotion_summary"]["status"], "candidate")
             self.assertEqual(payload["promotion_action"]["status"], "blocked")
             self.assertEqual(payload["environment_actions"]["testing"]["status"], "actionable")
             self.assertEqual(payload["environment_actions"]["prod"]["status"], "actionable")
             self.assertIn("ship resolve", payload["environment_actions"]["testing"]["recipe"])
-            self.assertEqual(payload["promotion_action"]["candidate_artifact_id"], "artifact-testing")
-            self.assertEqual(payload["promotion_action"]["current_prod_artifact_id"], "artifact-prod")
-            self.assertEqual(payload["promotion_action"]["evidence_checks"][3]["label"], "Prod backup gate")
-            self.assertIn("no prod backup-gate evidence", payload["promotion_action"]["evidence_checks"][3]["detail"].lower())
+            self.assertEqual(
+                payload["promotion_action"]["candidate_artifact_id"], "artifact-testing"
+            )
+            self.assertEqual(
+                payload["promotion_action"]["current_prod_artifact_id"], "artifact-prod"
+            )
+            self.assertEqual(
+                payload["promotion_action"]["evidence_checks"][3]["label"], "Prod backup gate"
+            )
+            self.assertIn(
+                "no prod backup-gate evidence",
+                payload["promotion_action"]["evidence_checks"][3]["detail"].lower(),
+            )
             self.assertIn("backup-gates write", payload["promotion_action"]["backup_gate_recipe"])
             self.assertEqual(payload["promotion_action"]["resolve_recipe"], "")
             self.assertEqual(payload["promotion_action"]["execute_recipe"], "")
@@ -1282,7 +1315,9 @@ ODOO_DB_PASSWORD = "local-secret"
             self.assertEqual(record.request_metadata_status, "valid")
             self.assertEqual(record.request_metadata_baseline_channel, "testing")
 
-    def test_launchplane_previews_ingest_pr_event_persists_valid_preview_metadata_snapshot(self) -> None:
+    def test_launchplane_previews_ingest_pr_event_persists_valid_preview_metadata_snapshot(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -1333,7 +1368,9 @@ ODOO_DB_PASSWORD = "local-secret"
             self.assertEqual(record.request_metadata_companions[0].repo, "shared-addons")
             self.assertEqual(record.request_metadata_companions[0].pr_number, 456)
 
-    def test_launchplane_previews_show_tenant_uses_valid_metadata_snapshot_for_enablement_actions(self) -> None:
+    def test_launchplane_previews_show_tenant_uses_valid_metadata_snapshot_for_enablement_actions(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -1371,7 +1408,9 @@ ODOO_DB_PASSWORD = "local-secret"
             self.assertEqual(enablement_by_pr[129]["request_metadata_status"], "valid")
             self.assertEqual(enablement_by_pr[129]["action"]["status"], "actionable")
 
-    def test_launchplane_previews_render_site_release_tuple_records_resolve_enablement_recipe(self) -> None:
+    def test_launchplane_previews_render_site_release_tuple_records_resolve_enablement_recipe(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             temporary_directory = Path(temporary_directory_name)
@@ -1414,7 +1453,9 @@ ODOO_DB_PASSWORD = "local-secret"
             self.assertNotIn("&lt;resolved-baseline-tuple-id&gt;", index_html)
             self.assertNotIn("&lt;resolved-manifest-fingerprint&gt;", index_html)
 
-    def test_launchplane_previews_render_index_page_leads_with_tenant_environment_when_scoped(self) -> None:
+    def test_launchplane_previews_render_index_page_leads_with_tenant_environment_when_scoped(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -1511,19 +1552,28 @@ ODOO_DB_PASSWORD = "local-secret"
             self.assertIn("Testing lane", rendered_html)
             self.assertIn("Prod lane", rendered_html)
             self.assertIn("Main feeds testing.", rendered_html)
-            self.assertIn("Testing is carrying a newer artifact than prod and is the current promotion candidate.", rendered_html)
+            self.assertIn(
+                "Testing is carrying a newer artifact than prod and is the current promotion candidate.",
+                rendered_html,
+            )
             self.assertIn("Testing is ready to promote into prod.", rendered_html)
             self.assertIn("Rebuild long-lived lanes", rendered_html)
             self.assertIn("Re-ship current testing artifact", rendered_html)
             self.assertIn("ship resolve -&gt; ship execute", rendered_html)
             self.assertIn("Promotion candidate", rendered_html)
-            self.assertIn("Latest prod backup gate backup-opw-prod-20260414T111500Z passed and can authorize promotion.", rendered_html)
+            self.assertIn(
+                "Latest prod backup gate backup-opw-prod-20260414T111500Z passed and can authorize promotion.",
+                rendered_html,
+            )
             self.assertIn("promote resolve", rendered_html)
             self.assertIn("promote execute", rendered_html)
             self.assertNotIn("backup-gates write", rendered_html)
             self.assertIn("Why each PR does or does not have a preview", rendered_html)
             self.assertIn("Eligible tenant PR. No preview request is active yet.", rendered_html)
-            self.assertIn("GitHub label launchplane-preview requested a preview, but Launchplane has not created the preview record yet.", rendered_html)
+            self.assertIn(
+                "GitHub label launchplane-preview requested a preview, but Launchplane has not created the preview record yet.",
+                rendered_html,
+            )
             self.assertIn("Request Launchplane preview", rendered_html)
             self.assertIn("Show Launchplane request recipe", rendered_html)
             self.assertIn("request-generation", rendered_html)
@@ -1531,7 +1581,9 @@ ODOO_DB_PASSWORD = "local-secret"
             self.assertIn("artifact-prod", rendered_html)
             self.assertIn("Pull request previews", rendered_html)
 
-    def test_launchplane_previews_render_index_page_surfaces_backup_gate_recipe_when_promotion_blocked(self) -> None:
+    def test_launchplane_previews_render_index_page_surfaces_backup_gate_recipe_when_promotion_blocked(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -1573,11 +1625,16 @@ ODOO_DB_PASSWORD = "local-secret"
 
             self.assertEqual(result.exit_code, 0, msg=result.output)
             rendered_html = output_file.read_text(encoding="utf-8")
-            self.assertIn("A newer testing artifact exists, but Launchplane cannot promote it yet.", rendered_html)
+            self.assertIn(
+                "A newer testing artifact exists, but Launchplane cannot promote it yet.",
+                rendered_html,
+            )
             self.assertIn("backup-gates write", rendered_html)
             self.assertNotIn("promote resolve", rendered_html)
 
-    def test_launchplane_previews_render_index_page_leads_with_enablement_when_no_lane_evidence_exists(self) -> None:
+    def test_launchplane_previews_render_index_page_leads_with_enablement_when_no_lane_evidence_exists(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -1612,13 +1669,17 @@ ODOO_DB_PASSWORD = "local-secret"
 
             self.assertEqual(result.exit_code, 0, msg=result.output)
             rendered_html = output_file.read_text(encoding="utf-8")
-            self.assertIn("Preview enablement is the first meaningful control surface", rendered_html)
+            self.assertIn(
+                "Preview enablement is the first meaningful control surface", rendered_html
+            )
             self.assertIn("Why each PR does or does not have a preview", rendered_html)
             self.assertIn("Materialize requested Launchplane preview", rendered_html)
             self.assertNotIn("Rebuild long-lived lanes", rendered_html)
             self.assertNotIn("Launchplane cannot plan the next promotion yet.", rendered_html)
 
-    def test_launchplane_previews_render_index_page_marks_missing_lane_action_evidence(self) -> None:
+    def test_launchplane_previews_render_index_page_marks_missing_lane_action_evidence(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -1841,14 +1902,16 @@ ODOO_DB_PASSWORD = "local-secret"
             self.assertIn("Retained evidence", rendered_html)
             self.assertIn("Policy snapshot", rendered_html)
             self.assertIn('data-filter-control="attention"', rendered_html)
-            self.assertIn('data-preview-row', rendered_html)
+            self.assertIn("data-preview-row", rendered_html)
             self.assertIn("Serving older generation", rendered_html)
             self.assertIn("Evidence only", rendered_html)
             self.assertIn("opw/tenant-opw/pr-123", rendered_html)
             self.assertIn("opw/tenant-opw/pr-124", rendered_html)
             self.assertIn("opw/tenant-opw/pr-125", rendered_html)
 
-    def test_launchplane_previews_render_index_page_surfaces_scope_controls_for_multi_context_inventory(self) -> None:
+    def test_launchplane_previews_render_index_page_surfaces_scope_controls_for_multi_context_inventory(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -1975,7 +2038,9 @@ ODOO_DB_PASSWORD = "local-secret"
             self.assertIn("tenant-cm", rendered_html)
             self.assertIn("testing", rendered_html)
 
-    def test_launchplane_previews_render_policy_page_shows_context_distribution_for_multi_context_inventory(self) -> None:
+    def test_launchplane_previews_render_policy_page_shows_context_distribution_for_multi_context_inventory(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -2100,13 +2165,15 @@ ODOO_DB_PASSWORD = "local-secret"
             policy_html = policy_file.read_text(encoding="utf-8")
             detail_html = detail_file.read_text(encoding="utf-8")
             self.assertIn('href="previews/opw/tenant-opw/pr-123.html"', index_html)
-            self.assertIn('#operator-actions', index_html)
+            self.assertIn("#operator-actions", index_html)
             self.assertIn('href="policy.html"', index_html)
             self.assertIn('href="../../../index.html"', detail_html)
             self.assertIn('href="../../../policy.html"', detail_html)
             self.assertIn('href="previews/opw/tenant-opw/pr-123.html"', policy_html)
 
-    def test_launchplane_previews_render_site_enablement_row_links_to_existing_preview_detail(self) -> None:
+    def test_launchplane_previews_render_site_enablement_row_links_to_existing_preview_detail(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -2157,7 +2224,9 @@ ODOO_DB_PASSWORD = "local-secret"
                 index_html,
             )
 
-    def test_launchplane_previews_render_site_writes_environment_detail_pages_and_links_from_overview(self) -> None:
+    def test_launchplane_previews_render_site_writes_environment_detail_pages_and_links_from_overview(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -2231,7 +2300,9 @@ ODOO_DB_PASSWORD = "local-secret"
             self.assertIn("Recent promotions into this lane", prod_detail_html)
             self.assertIn("promotion-2026-04-14T11:10:00Z-opw-testing-to-prod", prod_detail_html)
 
-    def test_launchplane_previews_render_site_environment_detail_marks_partial_evidence_cleanly(self) -> None:
+    def test_launchplane_previews_render_site_environment_detail_marks_partial_evidence_cleanly(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -2266,12 +2337,18 @@ ODOO_DB_PASSWORD = "local-secret"
             self.assertTrue(testing_detail_file.exists())
 
             testing_detail_html = testing_detail_file.read_text(encoding="utf-8")
-            self.assertIn("No live promotion record is attached to this lane inventory.", testing_detail_html)
-            self.assertIn("No authorized backup gate is attached to this lane yet.", testing_detail_html)
+            self.assertIn(
+                "No live promotion record is attached to this lane inventory.", testing_detail_html
+            )
+            self.assertIn(
+                "No authorized backup gate is attached to this lane yet.", testing_detail_html
+            )
             self.assertIn("No deployment history recorded for this lane yet.", testing_detail_html)
             self.assertIn("No promotion history recorded into this lane yet.", testing_detail_html)
 
-    def test_launchplane_previews_render_site_writes_promotion_detail_page_and_link_from_overview(self) -> None:
+    def test_launchplane_previews_render_site_writes_promotion_detail_page_and_link_from_overview(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -2338,9 +2415,13 @@ ODOO_DB_PASSWORD = "local-secret"
             self.assertIn('href="../../policy.html"', promotion_detail_html)
             self.assertIn("Recent promotions into prod", promotion_detail_html)
             self.assertIn("Recent prod backup authorization", promotion_detail_html)
-            self.assertIn("promotion-2026-04-14T11:10:00Z-opw-testing-to-prod", promotion_detail_html)
+            self.assertIn(
+                "promotion-2026-04-14T11:10:00Z-opw-testing-to-prod", promotion_detail_html
+            )
 
-    def test_launchplane_previews_render_status_page_calls_out_failed_latest_replacement(self) -> None:
+    def test_launchplane_previews_render_status_page_calls_out_failed_latest_replacement(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -2401,12 +2482,17 @@ ODOO_DB_PASSWORD = "local-secret"
 
             self.assertEqual(result.exit_code, 0, msg=result.output)
             rendered_html = output_file.read_text(encoding="utf-8")
-            self.assertIn("Latest replacement failed. Launchplane is still serving the older preview.", rendered_html)
+            self.assertIn(
+                "Latest replacement failed. Launchplane is still serving the older preview.",
+                rendered_html,
+            )
             self.assertIn("Replacement generation failed during deploy.", rendered_html)
             self.assertIn("hgen_01jabc_1", rendered_html)
             self.assertIn("hgen_01jabc_2", rendered_html)
 
-    def test_launchplane_previews_render_status_page_preserves_destroyed_preview_evidence(self) -> None:
+    def test_launchplane_previews_render_status_page_preserves_destroyed_preview_evidence(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -2586,7 +2672,9 @@ ODOO_DB_PASSWORD = "local-secret"
                 rendered_html,
             )
 
-    def test_launchplane_previews_render_status_page_calls_out_in_progress_replacement(self) -> None:
+    def test_launchplane_previews_render_status_page_calls_out_in_progress_replacement(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -2892,7 +2980,7 @@ LAUNCHPLANE_PREVIEW_BASE_URL = "https://launchplane.example"
 
 [contexts.opw.shared_env]
 ENV_OVERRIDE_DISABLE_CRON = true
-""".strip()
+""".strip(),
             )
             input_file = control_plane_root / "preview-request.json"
             input_file.write_text(
@@ -2933,7 +3021,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
                 "https://launchplane.example/previews/opw/tenant-opw/pr-123",
             )
 
-    def test_launchplane_previews_write_preview_reuses_existing_identity_and_created_at(self) -> None:
+    def test_launchplane_previews_write_preview_reuses_existing_identity_and_created_at(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -2948,7 +3038,7 @@ LAUNCHPLANE_PREVIEW_BASE_URL = "https://launchplane.example"
 
 [contexts.opw.shared_env]
 ENV_OVERRIDE_DISABLE_CRON = true
-""".strip()
+""".strip(),
             )
             store = FilesystemRecordStore(state_dir=state_dir)
             store.write_preview_record(
@@ -3006,7 +3096,7 @@ schema_version = 1
 
 [contexts.opw.shared_env]
 ENV_OVERRIDE_DISABLE_CRON = true
-""".strip()
+""".strip(),
             )
             input_file = control_plane_root / "preview-request.json"
             input_file.write_text(
@@ -3040,7 +3130,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertNotEqual(result.exit_code, 0)
             self.assertIn("LAUNCHPLANE_PREVIEW_BASE_URL", result.output)
 
-    def test_launchplane_previews_write_preview_accepts_explicit_canonical_url_without_base_url(self) -> None:
+    def test_launchplane_previews_write_preview_accepts_explicit_canonical_url_without_base_url(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -3172,7 +3264,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertNotEqual(result.exit_code, 0)
             self.assertIn("No Launchplane preview found", result.output)
 
-    def test_launchplane_previews_request_generation_updates_preview_and_generation_together(self) -> None:
+    def test_launchplane_previews_request_generation_updates_preview_and_generation_together(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -3187,7 +3281,7 @@ LAUNCHPLANE_PREVIEW_BASE_URL = "https://launchplane.example"
 
 [contexts.opw.shared_env]
 ENV_OVERRIDE_DISABLE_CRON = true
-""".strip()
+""".strip(),
             )
             store = FilesystemRecordStore(state_dir=state_dir)
             store.write_preview_record(
@@ -3263,7 +3357,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertEqual(preview.serving_generation_id, "hgen_01jabc_1")
             self.assertEqual(generation.sequence, 2)
 
-    def test_launchplane_previews_write_from_generation_accepts_external_preview_evidence(self) -> None:
+    def test_launchplane_previews_write_from_generation_accepts_external_preview_evidence(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -3417,7 +3513,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertEqual(preview.serving_generation_id, "hpr_01jabc-generation-0002")
             self.assertEqual(preview.active_generation_id, "hpr_01jabc-generation-0002")
 
-    def test_launchplane_previews_mark_generation_failed_keeps_existing_serving_generation(self) -> None:
+    def test_launchplane_previews_mark_generation_failed_keeps_existing_serving_generation(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -3599,7 +3697,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertEqual(preview.destroy_reason, "external_preview_cleanup_completed")
             self.assertEqual(preview.active_generation_id, "")
             self.assertEqual(preview.serving_generation_id, "")
-            self.assertEqual(preview.latest_generation_id, "preview-verireel-pr-123-generation-0003")
+            self.assertEqual(
+                preview.latest_generation_id, "preview-verireel-pr-123-generation-0003"
+            )
 
     def test_launchplane_previews_ingest_pr_event_enables_preview_when_label_added(self) -> None:
         runner = CliRunner()
@@ -3657,9 +3757,16 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertEqual(payload["mutation"]["command"], "request-generation")
             self.assertFalse(payload["mutation"]["manifest_resolution_required"])
             self.assertEqual(payload["mutation"]["preview_request"]["context"], "opw")
-            self.assertEqual(payload["mutation"]["preview_request"]["created_at"], "2026-04-13T12:15:00Z")
-            self.assertEqual(payload["mutation"]["generation_request"]["baseline_release_tuple_id"], "opw-testing-2026-04-13")
-            self.assertEqual(payload["mutation"]["generation_request"]["source_map"][0]["git_sha"], "aaaa1111")
+            self.assertEqual(
+                payload["mutation"]["preview_request"]["created_at"], "2026-04-13T12:15:00Z"
+            )
+            self.assertEqual(
+                payload["mutation"]["generation_request"]["baseline_release_tuple_id"],
+                "opw-testing-2026-04-13",
+            )
+            self.assertEqual(
+                payload["mutation"]["generation_request"]["source_map"][0]["git_sha"], "aaaa1111"
+            )
             self.assertEqual(
                 payload["mutation"]["generation_request"]["requested_reason"],
                 "github_pr_event_enable_preview",
@@ -3668,7 +3775,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
                 payload["mutation"]["generation_request"]["requested_at"],
                 "2026-04-13T12:15:00Z",
             )
-            self.assertEqual(payload["manifest"]["baseline_release_tuple_id"], "opw-testing-2026-04-13")
+            self.assertEqual(
+                payload["manifest"]["baseline_release_tuple_id"], "opw-testing-2026-04-13"
+            )
             self.assertIsNone(payload["preview"])
 
     def test_launchplane_previews_ingest_pr_event_refreshes_existing_preview(self) -> None:
@@ -3732,7 +3841,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertEqual(payload["request_metadata"]["status"], "missing")
             self.assertEqual(payload["mutation"]["command"], "request-generation")
             self.assertEqual(payload["mutation"]["preview_request"]["created_at"], "")
-            self.assertEqual(payload["mutation"]["preview_request"]["updated_at"], "2026-04-13T12:16:00Z")
+            self.assertEqual(
+                payload["mutation"]["preview_request"]["updated_at"], "2026-04-13T12:16:00Z"
+            )
             self.assertEqual(
                 payload["mutation"]["generation_request"]["requested_reason"],
                 "github_pr_event_refresh_preview",
@@ -3803,7 +3914,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertTrue(payload["mutation"]["manifest_resolution_required"])
             self.assertIn("generation_request_seed", payload["mutation"])
 
-    def test_launchplane_previews_ingest_pr_event_resolves_allowlisted_companion_when_lookup_succeeds(self) -> None:
+    def test_launchplane_previews_ingest_pr_event_resolves_allowlisted_companion_when_lookup_succeeds(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -3838,7 +3951,10 @@ ENV_OVERRIDE_DISABLE_CRON = true
 
             with (
                 patch("control_plane.cli._control_plane_root", return_value=control_plane_root),
-                patch("control_plane.workflows.launchplane.resolve_launchplane_github_token", return_value="token"),
+                patch(
+                    "control_plane.workflows.launchplane.resolve_launchplane_github_token",
+                    return_value="token",
+                ),
                 patch(
                     "control_plane.workflows.launchplane.fetch_github_pull_request_head",
                     return_value=(
@@ -3869,9 +3985,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                 "shared-addons",
             )
             self.assertEqual(
-                payload["enablement_record"]["request_metadata_companion_summaries"][0][
-                    "head_sha"
-                ],
+                payload["enablement_record"]["request_metadata_companion_summaries"][0]["head_sha"],
                 "bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222",
             )
             record = FilesystemRecordStore(state_dir=state_dir).read_preview_enablement_record(
@@ -4069,12 +4183,19 @@ ENV_OVERRIDE_DISABLE_CRON = true
             )
             store = FilesystemRecordStore(state_dir=state_dir)
             preview = store.read_preview_record(payload["apply"]["result"]["preview_id"])
-            generation = store.read_preview_generation_record(payload["apply"]["result"]["generation_id"])
+            generation = store.read_preview_generation_record(
+                payload["apply"]["result"]["generation_id"]
+            )
             self.assertEqual(preview.state, "pending")
             self.assertEqual(preview.active_generation_id, generation.generation_id)
-            self.assertEqual(generation.resolved_manifest_fingerprint, payload["manifest"]["resolved_manifest_fingerprint"])
+            self.assertEqual(
+                generation.resolved_manifest_fingerprint,
+                payload["manifest"]["resolved_manifest_fingerprint"],
+            )
 
-    def test_launchplane_previews_ingest_pr_event_apply_reports_noop_when_manifest_unresolved(self) -> None:
+    def test_launchplane_previews_ingest_pr_event_apply_reports_noop_when_manifest_unresolved(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -4133,7 +4254,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             store = FilesystemRecordStore(state_dir=state_dir)
             self.assertEqual(store.list_preview_records(), ())
 
-    def test_launchplane_previews_ingest_pr_event_emits_destroy_intent_for_closed_preview(self) -> None:
+    def test_launchplane_previews_ingest_pr_event_emits_destroy_intent_for_closed_preview(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -4232,7 +4355,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertEqual(preview.state, "destroyed")
             self.assertEqual(preview.destroy_reason, "pull_request_closed")
 
-    def test_launchplane_previews_ingest_pr_event_delivers_feedback_by_creating_comment(self) -> None:
+    def test_launchplane_previews_ingest_pr_event_delivers_feedback_by_creating_comment(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -4259,8 +4384,14 @@ ENV_OVERRIDE_DISABLE_CRON = true
 
             with (
                 patch("control_plane.cli._control_plane_root", return_value=control_plane_root),
-                patch("control_plane.workflows.launchplane.resolve_launchplane_github_token", return_value="token"),
-                patch("control_plane.workflows.launchplane.find_github_issue_comment_by_marker", return_value=None),
+                patch(
+                    "control_plane.workflows.launchplane.resolve_launchplane_github_token",
+                    return_value="token",
+                ),
+                patch(
+                    "control_plane.workflows.launchplane.find_github_issue_comment_by_marker",
+                    return_value=None,
+                ),
                 patch(
                     "control_plane.workflows.launchplane.create_github_issue_comment",
                     return_value={
@@ -4291,7 +4422,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertIn("launchplane-control-plane:pr-feedback", create_kwargs["body"])
             self.assertIn("Launchplane resolved preview inputs", create_kwargs["body"])
 
-    def test_launchplane_previews_ingest_pr_event_delivers_feedback_by_updating_existing_comment(self) -> None:
+    def test_launchplane_previews_ingest_pr_event_delivers_feedback_by_updating_existing_comment(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -4318,10 +4451,16 @@ ENV_OVERRIDE_DISABLE_CRON = true
 
             with (
                 patch("control_plane.cli._control_plane_root", return_value=control_plane_root),
-                patch("control_plane.workflows.launchplane.resolve_launchplane_github_token", return_value="token"),
+                patch(
+                    "control_plane.workflows.launchplane.resolve_launchplane_github_token",
+                    return_value="token",
+                ),
                 patch(
                     "control_plane.workflows.launchplane.find_github_issue_comment_by_marker",
-                    return_value={"id": 321, "body": "<!-- launchplane-control-plane:pr-feedback -->\nold"},
+                    return_value={
+                        "id": 321,
+                        "body": "<!-- launchplane-control-plane:pr-feedback -->\nold",
+                    },
                 ),
                 patch(
                     "control_plane.workflows.launchplane.update_github_issue_comment",
@@ -4352,7 +4491,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             update_kwargs = update_comment.call_args.kwargs
             self.assertIn("launchplane-control-plane:pr-feedback", update_kwargs["body"])
 
-    def test_launchplane_previews_ingest_pr_event_feedback_delivery_fails_closed_without_token(self) -> None:
+    def test_launchplane_previews_ingest_pr_event_feedback_delivery_fails_closed_without_token(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -4396,7 +4537,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertFalse(payload["feedback_delivery"]["delivered"])
             self.assertEqual(payload["feedback_delivery"]["reason"], "github_token_missing")
 
-    def test_launchplane_previews_ingest_github_webhook_adapts_pull_request_event_and_reuses_apply_flow(self) -> None:
+    def test_launchplane_previews_ingest_github_webhook_adapts_pull_request_event_and_reuses_apply_flow(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -4437,7 +4580,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertEqual(payload["webhook"]["delivery"]["delivery_id"], "gh-delivery-123")
             self.assertEqual(payload["webhook"]["delivery"]["delivery_source"], "github-webhook")
 
-    def test_launchplane_previews_ingest_github_webhook_adapts_closed_pull_request_destroy_intent(self) -> None:
+    def test_launchplane_previews_ingest_github_webhook_adapts_closed_pull_request_destroy_intent(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -4483,7 +4628,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
                 "pull_request_merged",
             )
 
-    def test_launchplane_previews_ingest_github_webhook_fails_closed_for_unsupported_event_name(self) -> None:
+    def test_launchplane_previews_ingest_github_webhook_fails_closed_for_unsupported_event_name(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             input_file = Path(temporary_directory_name) / "github-webhook.json"
@@ -4508,7 +4655,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertNotEqual(result.exit_code, 0)
             self.assertIn("event_name='pull_request'", result.output)
 
-    def test_launchplane_previews_ingest_github_webhook_fails_closed_for_malformed_payload(self) -> None:
+    def test_launchplane_previews_ingest_github_webhook_fails_closed_for_malformed_payload(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             input_file = Path(temporary_directory_name) / "github-webhook.json"
@@ -4557,7 +4706,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertNotEqual(result.exit_code, 0)
             self.assertIn("signature verification failed", result.output)
 
-    def test_launchplane_previews_ingest_github_webhook_allows_explicit_unsigned_bypass(self) -> None:
+    def test_launchplane_previews_ingest_github_webhook_allows_explicit_unsigned_bypass(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -4635,7 +4786,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertEqual(payload["webhook"]["delivery"]["delivery_id"], "replay-456")
             self.assertEqual(payload["webhook"]["delivery"]["delivery_source"], "local-capture")
 
-    def test_launchplane_previews_build_github_webhook_replay_envelope_emits_minimal_envelope(self) -> None:
+    def test_launchplane_previews_build_github_webhook_replay_envelope_emits_minimal_envelope(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             payload_file = Path(temporary_directory_name) / "github-webhook.json"
@@ -4661,7 +4814,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertEqual(envelope["payload_text"], json.dumps(webhook_payload))
             self.assertNotIn("capture", envelope)
 
-    def test_launchplane_previews_build_github_webhook_replay_envelope_round_trips_into_replay(self) -> None:
+    def test_launchplane_previews_build_github_webhook_replay_envelope_round_trips_into_replay(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -4749,13 +4904,17 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertEqual(replay_payload["decision"]["action"], "enable_preview")
             self.assertTrue(replay_payload["apply"]["applied"])
             self.assertTrue(replay_payload["webhook"]["signature_verification"]["verified"])
-            self.assertEqual(replay_payload["webhook"]["delivery"]["delivery_id"], "replay-builder-123")
+            self.assertEqual(
+                replay_payload["webhook"]["delivery"]["delivery_id"], "replay-builder-123"
+            )
             self.assertEqual(
                 replay_payload["webhook_replay"]["capture"]["source"],
                 "local-http-capture",
             )
 
-    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_non_string_headers(self) -> None:
+    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_non_string_headers(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             payload_file = Path(temporary_directory_name) / "github-webhook.json"
@@ -4879,7 +5038,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
                 "1.1 proxy.example",
             )
 
-    def test_launchplane_previews_build_github_webhook_replay_envelope_accepts_http_capture_file(self) -> None:
+    def test_launchplane_previews_build_github_webhook_replay_envelope_accepts_http_capture_file(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -4959,10 +5120,16 @@ ENV_OVERRIDE_DISABLE_CRON = true
             replay_payload = json.loads(replay_result.output)
             self.assertEqual(replay_payload["decision"]["action"], "enable_preview")
             self.assertTrue(replay_payload["webhook"]["signature_verification"]["verified"])
-            self.assertEqual(replay_payload["webhook"]["delivery"]["delivery_id"], "http-capture-123")
-            self.assertEqual(replay_payload["webhook_replay"]["capture"]["source"], "saved-http-capture")
             self.assertEqual(
-                replay_payload["webhook_replay"]["capture"]["evidence"]["http_request"]["request_line"],
+                replay_payload["webhook"]["delivery"]["delivery_id"], "http-capture-123"
+            )
+            self.assertEqual(
+                replay_payload["webhook_replay"]["capture"]["source"], "saved-http-capture"
+            )
+            self.assertEqual(
+                replay_payload["webhook_replay"]["capture"]["evidence"]["http_request"][
+                    "request_line"
+                ],
                 "POST /github/webhook HTTP/1.1",
             )
 
@@ -5621,7 +5788,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
                 result.output,
             )
 
-    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_conflicting_http_request_evidence(self) -> None:
+    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_conflicting_http_request_evidence(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             http_capture_file = Path(temporary_directory_name) / "github-webhook.http"
@@ -5665,7 +5834,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertNotEqual(result.exit_code, 0)
             self.assertIn("request_line conflicts", result.output)
 
-    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_mismatched_http_capture_content_length(self) -> None:
+    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_mismatched_http_capture_content_length(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             http_capture_file = Path(temporary_directory_name) / "github-webhook.http"
@@ -5697,7 +5868,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertNotEqual(result.exit_code, 0)
             self.assertIn("Content-Length does not match", result.output)
 
-    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_non_integer_http_capture_content_length(self) -> None:
+    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_non_integer_http_capture_content_length(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             http_capture_file = Path(temporary_directory_name) / "github-webhook.http"
@@ -5729,7 +5902,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertNotEqual(result.exit_code, 0)
             self.assertIn("Content-Length header must be an integer", result.output)
 
-    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_non_json_http_capture_content_type(self) -> None:
+    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_non_json_http_capture_content_type(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             http_capture_file = Path(temporary_directory_name) / "github-webhook.http"
@@ -5761,7 +5936,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertNotEqual(result.exit_code, 0)
             self.assertIn("Content-Type must be JSON", result.output)
 
-    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_conflicting_http_method_override(self) -> None:
+    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_conflicting_http_method_override(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             http_capture_file = Path(temporary_directory_name) / "github-webhook.http"
@@ -5793,7 +5970,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertNotEqual(result.exit_code, 0)
             self.assertIn("X-HTTP-Method-Override must not conflict", result.output)
 
-    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_unsupported_transfer_encoding(self) -> None:
+    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_unsupported_transfer_encoding(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             http_capture_file = Path(temporary_directory_name) / "github-webhook.http"
@@ -5825,7 +6004,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertNotEqual(result.exit_code, 0)
             self.assertIn("Transfer-Encoding is unsupported", result.output)
 
-    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_unsupported_content_encoding(self) -> None:
+    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_unsupported_content_encoding(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             http_capture_file = Path(temporary_directory_name) / "github-webhook.http"
@@ -5857,7 +6038,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertNotEqual(result.exit_code, 0)
             self.assertIn("Content-Encoding is unsupported", result.output)
 
-    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_trailer_declarations(self) -> None:
+    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_trailer_declarations(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             http_capture_file = Path(temporary_directory_name) / "github-webhook.http"
@@ -5889,7 +6072,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertNotEqual(result.exit_code, 0)
             self.assertIn("Trailer declarations are unsupported", result.output)
 
-    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_expect_declarations(self) -> None:
+    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_expect_declarations(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             http_capture_file = Path(temporary_directory_name) / "github-webhook.http"
@@ -5921,7 +6106,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertNotEqual(result.exit_code, 0)
             self.assertIn("Expect declarations are unsupported", result.output)
 
-    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_connection_declarations(self) -> None:
+    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_connection_declarations(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             http_capture_file = Path(temporary_directory_name) / "github-webhook.http"
@@ -5953,7 +6140,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertNotEqual(result.exit_code, 0)
             self.assertIn("Connection declarations are unsupported", result.output)
 
-    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_pragma_declarations(self) -> None:
+    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_pragma_declarations(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             http_capture_file = Path(temporary_directory_name) / "github-webhook.http"
@@ -5985,7 +6174,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertNotEqual(result.exit_code, 0)
             self.assertIn("Pragma declarations are unsupported", result.output)
 
-    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_malformed_http_capture(self) -> None:
+    def test_launchplane_previews_build_github_webhook_replay_envelope_rejects_malformed_http_capture(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             http_capture_file = Path(temporary_directory_name) / "github-webhook.http"
@@ -6067,9 +6258,13 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertTrue(payload["apply"]["applied"])
             self.assertTrue(payload["webhook"]["signature_verification"]["verified"])
             self.assertEqual(payload["webhook"]["delivery"]["delivery_id"], "replay-789")
-            self.assertEqual(payload["webhook"]["delivery"]["delivery_source"], "captured-http-request")
+            self.assertEqual(
+                payload["webhook"]["delivery"]["delivery_source"], "captured-http-request"
+            )
             self.assertEqual(payload["webhook_replay"]["event_name"], "pull_request")
-            self.assertEqual(payload["webhook_replay"]["capture"]["recorded_at"], "2026-04-13T12:20:00Z")
+            self.assertEqual(
+                payload["webhook_replay"]["capture"]["recorded_at"], "2026-04-13T12:20:00Z"
+            )
             self.assertEqual(
                 payload["webhook_replay"]["capture"]["headers"]["X-GitHub-Hook-ID"],
                 "hook-42",
@@ -6079,7 +6274,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
                 "fixtures/github/replay-789.json",
             )
 
-    def test_launchplane_previews_replay_github_webhook_fails_closed_for_conflicting_capture_headers(self) -> None:
+    def test_launchplane_previews_replay_github_webhook_fails_closed_for_conflicting_capture_headers(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             input_file = Path(temporary_directory_name) / "github-webhook-replay.json"
@@ -6111,7 +6308,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertNotEqual(result.exit_code, 0)
             self.assertIn("conflicts with capture header X-GitHub-Event", result.output)
 
-    def test_launchplane_previews_replay_github_webhook_fails_closed_for_signed_envelope_without_payload_text(self) -> None:
+    def test_launchplane_previews_replay_github_webhook_fails_closed_for_signed_envelope_without_payload_text(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             input_file = Path(temporary_directory_name) / "github-webhook-replay.json"
@@ -6192,7 +6391,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertEqual(payload["request_metadata"]["status"], "invalid")
             self.assertIsNone(payload["mutation"])
 
-    def test_launchplane_previews_list_keeps_destroyed_previews_visible_and_filters_by_context(self) -> None:
+    def test_launchplane_previews_list_keeps_destroyed_previews_visible_and_filters_by_context(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -173,7 +173,9 @@ def _write_runtime_environments_file(repo_root: Path, payload: str) -> Path:
     store = PostgresRecordStore(database_url=_runtime_environments_database_url(repo_root))
     store.ensure_schema()
     try:
-        for record in control_plane_runtime_environments.build_runtime_environment_records_from_definition(
+        for (
+            record
+        ) in control_plane_runtime_environments.build_runtime_environment_records_from_definition(
             definition,
             updated_at="2026-04-22T00:00:00Z",
             source_label="test",
@@ -213,7 +215,9 @@ def _write_runtime_secret_and_safety_policy(
                 scope="instance",
                 context=context,
                 instance=instance,
-                env={"ODOO_ADDONS_PATH": "/odoo/addons,/opt/project/addons,/opt/project/addons/shared"},
+                env={
+                    "ODOO_ADDONS_PATH": "/odoo/addons,/opt/project/addons,/opt/project/addons/shared"
+                },
                 updated_at="2026-05-05T21:00:00Z",
                 source_label="test",
             )
@@ -316,10 +320,16 @@ def _post_deploy_update_evidence(
 
 class PromoteWorkflowTests(unittest.TestCase):
     def test_build_promotion_record_returns_pending_record(self) -> None:
-        record = build_promotion_record(record_id="promotion-20260410-182231-opw-testing-prod",
-                                        artifact_id="artifact-20260410-f45db648", context_name="opw",
-                                        from_instance_name="testing", to_instance_name="prod", target_name="opw-prod",
-                                        target_type="compose", deploy_mode="dokploy-compose-api")
+        record = build_promotion_record(
+            record_id="promotion-20260410-182231-opw-testing-prod",
+            artifact_id="artifact-20260410-f45db648",
+            context_name="opw",
+            from_instance_name="testing",
+            to_instance_name="prod",
+            target_name="opw-prod",
+            target_type="compose",
+            deploy_mode="dokploy-compose-api",
+        )
 
         self.assertEqual(record.artifact_identity.artifact_id, "artifact-20260410-f45db648")
         self.assertEqual(record.deploy.status, "pending")
@@ -327,18 +337,25 @@ class PromoteWorkflowTests(unittest.TestCase):
         self.assertEqual(record.from_instance, "testing")
 
     def test_build_executed_promotion_record_marks_success_after_waited_ship(self) -> None:
-        request = PromotionRequest(artifact_id="artifact-sha256-image456",
-                                   backup_record_id="backup-opw-prod-20260410T182231Z", source_git_ref="abc123",
-                                   context="opw", from_instance="testing", to_instance="prod", target_name="opw-prod",
-                                   target_type="compose", deploy_mode="dokploy-compose-api",
-                                   destination_health=_healthcheck_evidence(),
-                                   source_health=_healthcheck_evidence(
-                                       verified=True,
-                                       urls=("https://testing.example.com/web/health",),
-                                       timeout_seconds=30,
-                                       status="pass",
-                                   ),
-                                   backup_gate=_backup_gate_evidence())
+        request = PromotionRequest(
+            artifact_id="artifact-sha256-image456",
+            backup_record_id="backup-opw-prod-20260410T182231Z",
+            source_git_ref="abc123",
+            context="opw",
+            from_instance="testing",
+            to_instance="prod",
+            target_name="opw-prod",
+            target_type="compose",
+            deploy_mode="dokploy-compose-api",
+            destination_health=_healthcheck_evidence(),
+            source_health=_healthcheck_evidence(
+                verified=True,
+                urls=("https://testing.example.com/web/health",),
+                timeout_seconds=30,
+                status="pass",
+            ),
+            backup_gate=_backup_gate_evidence(),
+        )
 
         record = build_executed_promotion_record(
             request=request,
@@ -373,10 +390,17 @@ class PromoteWorkflowTests(unittest.TestCase):
             )
 
     def test_build_deployment_record_marks_pending_health_for_async_ship(self) -> None:
-        request = ShipRequest(context="opw", instance="prod", source_git_ref="abc123", target_name="opw-prod",
-                              target_type="compose", deploy_mode="dokploy-compose-api",
-                              artifact_id="artifact-sha256-image456", wait=False,
-                              destination_health=_healthcheck_evidence())
+        request = ShipRequest(
+            context="opw",
+            instance="prod",
+            source_git_ref="abc123",
+            target_name="opw-prod",
+            target_type="compose",
+            deploy_mode="dokploy-compose-api",
+            artifact_id="artifact-sha256-image456",
+            wait=False,
+            destination_health=_healthcheck_evidence(),
+        )
 
         record = build_deployment_record(
             request=request,
@@ -396,10 +420,19 @@ class PromoteWorkflowTests(unittest.TestCase):
         self.assertEqual(record.destination_health.status, "pending")
         self.assertFalse(record.destination_health.verified)
 
-    def test_build_deployment_record_marks_post_deploy_update_success_for_waited_compose_ship(self) -> None:
-        request = ShipRequest(context="opw", instance="prod", source_git_ref="abc123",
-                              artifact_id="artifact-sha256-image456", target_name="opw-prod", target_type="compose",
-                              deploy_mode="dokploy-compose-api", destination_health=_healthcheck_evidence())
+    def test_build_deployment_record_marks_post_deploy_update_success_for_waited_compose_ship(
+        self,
+    ) -> None:
+        request = ShipRequest(
+            context="opw",
+            instance="prod",
+            source_git_ref="abc123",
+            artifact_id="artifact-sha256-image456",
+            target_name="opw-prod",
+            target_type="compose",
+            deploy_mode="dokploy-compose-api",
+            destination_health=_healthcheck_evidence(),
+        )
 
         record = build_deployment_record(
             request=request,
@@ -412,12 +445,16 @@ class PromoteWorkflowTests(unittest.TestCase):
 
         self.assertTrue(record.post_deploy_update.attempted)
         self.assertEqual(record.post_deploy_update.status, "pass")
-        self.assertIn("native control-plane Dokploy schedule workflow", record.post_deploy_update.detail)
+        self.assertIn(
+            "native control-plane Dokploy schedule workflow", record.post_deploy_update.detail
+        )
 
 
 class ArtifactImageOverrideTests(unittest.TestCase):
     def test_sync_artifact_image_reference_sets_exact_image_reference(self) -> None:
-        resolved_target = ResolvedTargetEvidence(target_type="compose", target_id="compose-123", target_name="opw-prod")
+        resolved_target = ResolvedTargetEvidence(
+            target_type="compose", target_id="compose-123", target_name="opw-prod"
+        )
         artifact_manifest = ArtifactIdentityManifest.model_validate(
             {
                 "artifact_id": "artifact-sha256-image456",
@@ -432,31 +469,37 @@ class ArtifactImageOverrideTests(unittest.TestCase):
         )
         captured_update: dict[str, object] = {}
 
-        with patch(
-            "control_plane.dokploy.read_dokploy_config",
-            return_value=("https://dokploy.example.com", "token-123"),
-        ), patch(
-            "control_plane.runtime_environments.resolve_runtime_environment_values",
-            return_value={"ODOO_ADDONS_PATH": "/odoo/addons,/opt/project/addons/shared"},
-        ), patch(
-            "control_plane.dokploy.fetch_dokploy_target_payload",
-            side_effect=[
-                {"env": "DOCKER_IMAGE=odoo-runtime\nDOCKER_IMAGE_TAG=latest"},
-                {
-                    "env": (
-                        "DOCKER_IMAGE=odoo-runtime\n"
-                        "DOCKER_IMAGE_TAG=latest\n"
-                        "DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/odoo-private@sha256:image456\n"
-                        "ODOO_ADDONS_PATH=/odoo/addons,/opt/project/addons/shared"
-                    )
-                },
-            ],
-        ), patch(
-            "control_plane.dokploy.sync_dokploy_compose_raw_source",
-            return_value={"source_type": "raw", "compose_sha256": "abc123"},
-        ) as raw_compose_sync, patch(
-            "control_plane.dokploy.update_dokploy_target_env",
-            side_effect=lambda **kwargs: captured_update.update(kwargs),
+        with (
+            patch(
+                "control_plane.dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example.com", "token-123"),
+            ),
+            patch(
+                "control_plane.runtime_environments.resolve_runtime_environment_values",
+                return_value={"ODOO_ADDONS_PATH": "/odoo/addons,/opt/project/addons/shared"},
+            ),
+            patch(
+                "control_plane.dokploy.fetch_dokploy_target_payload",
+                side_effect=[
+                    {"env": "DOCKER_IMAGE=odoo-runtime\nDOCKER_IMAGE_TAG=latest"},
+                    {
+                        "env": (
+                            "DOCKER_IMAGE=odoo-runtime\n"
+                            "DOCKER_IMAGE_TAG=latest\n"
+                            "DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/odoo-private@sha256:image456\n"
+                            "ODOO_ADDONS_PATH=/odoo/addons,/opt/project/addons/shared"
+                        )
+                    },
+                ],
+            ),
+            patch(
+                "control_plane.dokploy.sync_dokploy_compose_raw_source",
+                return_value={"source_type": "raw", "compose_sha256": "abc123"},
+            ) as raw_compose_sync,
+            patch(
+                "control_plane.dokploy.update_dokploy_target_env",
+                side_effect=lambda **kwargs: captured_update.update(kwargs),
+            ),
         ):
             _sync_artifact_image_reference_for_target(
                 context_name="opw",
@@ -478,7 +521,9 @@ class ArtifactImageOverrideTests(unittest.TestCase):
         )
 
     def test_sync_artifact_image_reference_updates_stale_env_even_when_image_matches(self) -> None:
-        resolved_target = ResolvedTargetEvidence(target_type="compose", target_id="compose-123", target_name="cm-testing")
+        resolved_target = ResolvedTargetEvidence(
+            target_type="compose", target_id="compose-123", target_name="cm-testing"
+        )
         artifact_manifest = ArtifactIdentityManifest.model_validate(
             {
                 "artifact_id": "artifact-sha256-image456",
@@ -505,34 +550,40 @@ class ArtifactImageOverrideTests(unittest.TestCase):
                 context="cm",
                 instance="testing",
             )
-            with patch(
-                "control_plane.dokploy.read_dokploy_config",
-                return_value=("https://dokploy.example.com", "token-123"),
-            ), patch(
-                "control_plane.dokploy.fetch_dokploy_target_payload",
-                side_effect=[
-                    {"env": stale_env},
+            with (
+                patch(
+                    "control_plane.dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "token-123"),
+                ),
+                patch(
+                    "control_plane.dokploy.fetch_dokploy_target_payload",
+                    side_effect=[
+                        {"env": stale_env},
+                        {
+                            "env": (
+                                "DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/odoo-private@sha256:image456\n"
+                                "ODOO_ADDONS_PATH=/odoo/addons,/opt/project/addons,/opt/project/addons/shared\n"
+                                "SMTP_PASSWORD=managed-secret-value"
+                            )
+                        },
+                    ],
+                ),
+                patch(
+                    "control_plane.dokploy.sync_dokploy_compose_raw_source",
+                    return_value={"source_type": "raw", "compose_sha256": "abc123"},
+                ),
+                patch(
+                    "control_plane.dokploy.update_dokploy_target_env",
+                    side_effect=lambda **kwargs: captured_update.update(kwargs),
+                ),
+                patch.dict(
+                    os.environ,
                     {
-                        "env": (
-                            "DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/odoo-private@sha256:image456\n"
-                            "ODOO_ADDONS_PATH=/odoo/addons,/opt/project/addons,/opt/project/addons/shared\n"
-                            "SMTP_PASSWORD=managed-secret-value"
-                        )
+                        "LAUNCHPLANE_DATABASE_URL": database_url,
+                        "LAUNCHPLANE_MASTER_ENCRYPTION_KEY": "test-master-key",
                     },
-                ],
-            ), patch(
-                "control_plane.dokploy.sync_dokploy_compose_raw_source",
-                return_value={"source_type": "raw", "compose_sha256": "abc123"},
-            ), patch(
-                "control_plane.dokploy.update_dokploy_target_env",
-                side_effect=lambda **kwargs: captured_update.update(kwargs),
-            ), patch.dict(
-                os.environ,
-                {
-                    "LAUNCHPLANE_DATABASE_URL": database_url,
-                    "LAUNCHPLANE_MASTER_ENCRYPTION_KEY": "test-master-key",
-                },
-                clear=True,
+                    clear=True,
+                ),
             ):
                 runtime_source = _sync_artifact_image_reference_for_target(
                     context_name="cm",
@@ -553,7 +604,9 @@ class ArtifactImageOverrideTests(unittest.TestCase):
         self.assertEqual(runtime_source["runtime_env_verified"], "true")
 
     def test_sync_artifact_image_reference_blocks_unsafe_runtime_secret_binding(self) -> None:
-        resolved_target = ResolvedTargetEvidence(target_type="compose", target_id="compose-123", target_name="cm-prod")
+        resolved_target = ResolvedTargetEvidence(
+            target_type="compose", target_id="compose-123", target_name="cm-prod"
+        )
         artifact_manifest = ArtifactIdentityManifest.model_validate(
             {
                 "artifact_id": "artifact-sha256-image456",
@@ -575,19 +628,23 @@ class ArtifactImageOverrideTests(unittest.TestCase):
                 instance="prod",
                 secret_class="testing",
             )
-            with patch(
-                "control_plane.dokploy.read_dokploy_config",
-                return_value=("https://dokploy.example.com", "token-123"),
-            ), patch(
-                "control_plane.runtime_environments.resolve_runtime_environment_values",
-                return_value={"SMTP_PASSWORD": "managed-secret-value"},
-            ), patch(
-                "control_plane.dokploy.fetch_dokploy_target_payload",
-                return_value={"env": "DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/odoo-private@sha256:old"},
-            ), patch(
-                "control_plane.dokploy.update_dokploy_target_env"
-            ) as update_target_env, patch.dict(
-                os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True
+            with (
+                patch(
+                    "control_plane.dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "token-123"),
+                ),
+                patch(
+                    "control_plane.runtime_environments.resolve_runtime_environment_values",
+                    return_value={"SMTP_PASSWORD": "managed-secret-value"},
+                ),
+                patch(
+                    "control_plane.dokploy.fetch_dokploy_target_payload",
+                    return_value={
+                        "env": "DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/odoo-private@sha256:old"
+                    },
+                ),
+                patch("control_plane.dokploy.update_dokploy_target_env") as update_target_env,
+                patch.dict(os.environ, {"LAUNCHPLANE_DATABASE_URL": database_url}, clear=True),
             ):
                 with self.assertRaises(click.ClickException) as error_context:
                     _sync_artifact_image_reference_for_target(
@@ -602,7 +659,9 @@ class ArtifactImageOverrideTests(unittest.TestCase):
         update_target_env.assert_not_called()
 
     def test_sync_artifact_image_reference_rejects_legacy_monorepo_target_source(self) -> None:
-        resolved_target = ResolvedTargetEvidence(target_type="compose", target_id="compose-123", target_name="opw-testing")
+        resolved_target = ResolvedTargetEvidence(
+            target_type="compose", target_id="compose-123", target_name="opw-testing"
+        )
         artifact_manifest = ArtifactIdentityManifest.model_validate(
             {
                 "artifact_id": "artifact-sha256-image456",
@@ -616,20 +675,24 @@ class ArtifactImageOverrideTests(unittest.TestCase):
             }
         )
 
-        with patch(
-            "control_plane.dokploy.read_dokploy_config",
-            return_value=("https://dokploy.example.com", "token-123"),
-        ), patch(
-            "control_plane.runtime_environments.resolve_runtime_environment_values",
-            return_value={},
-        ), patch(
-            "control_plane.dokploy.fetch_dokploy_target_payload",
-            return_value={
-                "sourceType": "git",
-                "customGitUrl": "git@github.com:cbusillo/odoo-ai.git",
-                "customGitBranch": "opw-testing",
-                "env": "DOCKER_IMAGE=odoo-runtime\nDOCKER_IMAGE_TAG=latest",
-            },
+        with (
+            patch(
+                "control_plane.dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example.com", "token-123"),
+            ),
+            patch(
+                "control_plane.runtime_environments.resolve_runtime_environment_values",
+                return_value={},
+            ),
+            patch(
+                "control_plane.dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "sourceType": "git",
+                    "customGitUrl": "git@github.com:cbusillo/odoo-ai.git",
+                    "customGitBranch": "opw-testing",
+                    "env": "DOCKER_IMAGE=odoo-runtime\nDOCKER_IMAGE_TAG=latest",
+                },
+            ),
         ):
             with self.assertRaises(click.ClickException) as error_context:
                 _sync_artifact_image_reference_for_target(
@@ -643,7 +706,9 @@ class ArtifactImageOverrideTests(unittest.TestCase):
         self.assertIn("odoo-ai", str(error_context.exception))
 
     def test_sync_artifact_image_reference_rejects_mutable_addon_refs(self) -> None:
-        resolved_target = ResolvedTargetEvidence(target_type="compose", target_id="compose-123", target_name="opw-testing")
+        resolved_target = ResolvedTargetEvidence(
+            target_type="compose", target_id="compose-123", target_name="opw-testing"
+        )
         artifact_manifest = ArtifactIdentityManifest.model_validate(
             {
                 "artifact_id": "artifact-sha256-image456",
@@ -657,21 +722,25 @@ class ArtifactImageOverrideTests(unittest.TestCase):
             }
         )
 
-        with patch(
-            "control_plane.dokploy.read_dokploy_config",
-            return_value=("https://dokploy.example.com", "token-123"),
-        ), patch(
-            "control_plane.runtime_environments.resolve_runtime_environment_values",
-            return_value={},
-        ), patch(
-            "control_plane.dokploy.fetch_dokploy_target_payload",
-            return_value={
-                "env": (
-                    "DOCKER_IMAGE=odoo-runtime\n"
-                    "DOCKER_IMAGE_TAG=latest\n"
-                    "ODOO_ADDON_REPOSITORIES=cbusillo/disable_odoo_online@main,OCA/OpenUpgrade@89e649728027a8ab656b3aa4be18f4bd364db417"
-                )
-            },
+        with (
+            patch(
+                "control_plane.dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example.com", "token-123"),
+            ),
+            patch(
+                "control_plane.runtime_environments.resolve_runtime_environment_values",
+                return_value={},
+            ),
+            patch(
+                "control_plane.dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "env": (
+                        "DOCKER_IMAGE=odoo-runtime\n"
+                        "DOCKER_IMAGE_TAG=latest\n"
+                        "ODOO_ADDON_REPOSITORIES=cbusillo/disable_odoo_online@main,OCA/OpenUpgrade@89e649728027a8ab656b3aa4be18f4bd364db417"
+                    )
+                },
+            ),
         ):
             with self.assertRaises(click.ClickException) as error_context:
                 _sync_artifact_image_reference_for_target(
@@ -685,30 +754,37 @@ class ArtifactImageOverrideTests(unittest.TestCase):
         self.assertIn("disable_odoo_online@main", str(error_context.exception))
 
     def test_sync_artifact_image_reference_clears_stale_override_without_manifest(self) -> None:
-        resolved_target = ResolvedTargetEvidence(target_type="compose", target_id="compose-123", target_name="opw-prod")
+        resolved_target = ResolvedTargetEvidence(
+            target_type="compose", target_id="compose-123", target_name="opw-prod"
+        )
         captured_update: dict[str, object] = {}
 
-        with patch(
-            "control_plane.dokploy.read_dokploy_config",
-            return_value=("https://dokploy.example.com", "token-123"),
-        ), patch(
-            "control_plane.runtime_environments.resolve_runtime_environment_values",
-            return_value={},
-        ), patch(
-            "control_plane.dokploy.fetch_dokploy_target_payload",
-            side_effect=[
-                {
-                    "env": (
-                        "DOCKER_IMAGE=odoo-runtime\n"
-                        "DOCKER_IMAGE_TAG=latest\n"
-                        "DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/odoo-private@sha256:stale"
-                    )
-                },
-                {"env": "DOCKER_IMAGE=odoo-runtime\nDOCKER_IMAGE_TAG=latest"},
-            ],
-        ), patch(
-            "control_plane.dokploy.update_dokploy_target_env",
-            side_effect=lambda **kwargs: captured_update.update(kwargs),
+        with (
+            patch(
+                "control_plane.dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example.com", "token-123"),
+            ),
+            patch(
+                "control_plane.runtime_environments.resolve_runtime_environment_values",
+                return_value={},
+            ),
+            patch(
+                "control_plane.dokploy.fetch_dokploy_target_payload",
+                side_effect=[
+                    {
+                        "env": (
+                            "DOCKER_IMAGE=odoo-runtime\n"
+                            "DOCKER_IMAGE_TAG=latest\n"
+                            "DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/odoo-private@sha256:stale"
+                        )
+                    },
+                    {"env": "DOCKER_IMAGE=odoo-runtime\nDOCKER_IMAGE_TAG=latest"},
+                ],
+            ),
+            patch(
+                "control_plane.dokploy.update_dokploy_target_env",
+                side_effect=lambda **kwargs: captured_update.update(kwargs),
+            ),
         ):
             _sync_artifact_image_reference_for_target(
                 context_name="opw",
@@ -759,27 +835,39 @@ target_id = "compose-123"
             )
             input_file = repo_root / "ship-request.json"
             input_file.write_text(
-                ShipRequest(artifact_id="artifact-sha256-image456", context="opw", instance="prod",
-                            source_git_ref="abc123", target_name="opw-prod", target_type="compose",
-                            deploy_mode="dokploy-compose-api", verify_health=False).model_dump_json(indent=2),
+                ShipRequest(
+                    artifact_id="artifact-sha256-image456",
+                    context="opw",
+                    instance="prod",
+                    source_git_ref="abc123",
+                    target_name="opw-prod",
+                    target_type="compose",
+                    deploy_mode="dokploy-compose-api",
+                    verify_health=False,
+                ).model_dump_json(indent=2),
                 encoding="utf-8",
             )
             post_deploy_updates: list[dict[str, object]] = []
 
-            with patch.dict(
-                os.environ,
-                {
-                    "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
-                },
-            ), patch(
-                "control_plane.cli._run_compose_post_deploy_update",
-                side_effect=lambda **kwargs: post_deploy_updates.append(kwargs),
-            ), patch(
-                "control_plane.cli._sync_artifact_image_reference_for_target",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._execute_dokploy_deploy",
-                side_effect=lambda **_kwargs: None,
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
+                    },
+                ),
+                patch(
+                    "control_plane.cli._run_compose_post_deploy_update",
+                    side_effect=lambda **kwargs: post_deploy_updates.append(kwargs),
+                ),
+                patch(
+                    "control_plane.cli._sync_artifact_image_reference_for_target",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._execute_dokploy_deploy",
+                    side_effect=lambda **_kwargs: None,
+                ),
             ):
                 result = runner.invoke(
                     main,
@@ -813,37 +901,58 @@ class PromoteCliTests(unittest.TestCase):
             _write_release_tuple_record(state_dir)
             input_file = repo_root / "promotion-request.json"
             input_file.write_text(
-                PromotionRequest(artifact_id="artifact-sha256-image456",
-                                 backup_record_id="backup-opw-prod-20260410T182231Z", source_git_ref="abc123",
-                                 context="opw", from_instance="testing", to_instance="prod", target_name="opw-prod",
-                                 target_type="compose", deploy_mode="dokploy-compose-api", health_timeout_seconds=45,
-                                 source_health=_healthcheck_evidence(
-                                     verified=True,
-                                     urls=("https://testing.example.com/web/health",),
-                                     timeout_seconds=30,
-                                     status="pass",
-                                 ),
-                                 backup_gate=_backup_gate_evidence(),
-                                 destination_health=_healthcheck_evidence()).model_dump_json(indent=2),
+                PromotionRequest(
+                    artifact_id="artifact-sha256-image456",
+                    backup_record_id="backup-opw-prod-20260410T182231Z",
+                    source_git_ref="abc123",
+                    context="opw",
+                    from_instance="testing",
+                    to_instance="prod",
+                    target_name="opw-prod",
+                    target_type="compose",
+                    deploy_mode="dokploy-compose-api",
+                    health_timeout_seconds=45,
+                    source_health=_healthcheck_evidence(
+                        verified=True,
+                        urls=("https://testing.example.com/web/health",),
+                        timeout_seconds=30,
+                        status="pass",
+                    ),
+                    backup_gate=_backup_gate_evidence(),
+                    destination_health=_healthcheck_evidence(),
+                ).model_dump_json(indent=2),
                 encoding="utf-8",
             )
-            with patch(
-                "control_plane.cli._resolve_ship_request_for_promotion",
-                return_value=ShipRequest(artifact_id="artifact-sha256-image456", context="opw", instance="prod",
-                                         source_git_ref="abc123", target_name="opw-prod", target_type="compose",
-                                         deploy_mode="dokploy-compose-api",
-                                         destination_health=_healthcheck_evidence()),
-            ), patch(
-                "control_plane.cli._execute_ship",
-                return_value=(
-                    state_dir / "deployments" / "deployment-1.json",
-                    DeploymentRecord(record_id="deployment-1",
-                                     artifact_identity=_artifact_identity_reference(), context="opw",
-                                     instance="prod", source_git_ref="abc123",
-                                     deploy=_deploy_evidence(
-                                         started_at="2026-04-10T18:22:31Z",
-                                         finished_at="2026-04-10T18:24:00Z",
-                                     )),
+            with (
+                patch(
+                    "control_plane.cli._resolve_ship_request_for_promotion",
+                    return_value=ShipRequest(
+                        artifact_id="artifact-sha256-image456",
+                        context="opw",
+                        instance="prod",
+                        source_git_ref="abc123",
+                        target_name="opw-prod",
+                        target_type="compose",
+                        deploy_mode="dokploy-compose-api",
+                        destination_health=_healthcheck_evidence(),
+                    ),
+                ),
+                patch(
+                    "control_plane.cli._execute_ship",
+                    return_value=(
+                        state_dir / "deployments" / "deployment-1.json",
+                        DeploymentRecord(
+                            record_id="deployment-1",
+                            artifact_identity=_artifact_identity_reference(),
+                            context="opw",
+                            instance="prod",
+                            source_git_ref="abc123",
+                            deploy=_deploy_evidence(
+                                started_at="2026-04-10T18:22:31Z",
+                                finished_at="2026-04-10T18:24:00Z",
+                            ),
+                        ),
+                    ),
                 ),
             ):
                 result = runner.invoke(
@@ -864,7 +973,9 @@ class PromoteCliTests(unittest.TestCase):
             persisted_payload = promotion_files[0].read_text(encoding="utf-8")
             self.assertIn('"status": "pass"', persisted_payload)
             self.assertIn('"artifact_id": "artifact-sha256-image456"', persisted_payload)
-            self.assertIn('"backup_record_id": "backup-opw-prod-20260410T182231Z"', persisted_payload)
+            self.assertIn(
+                '"backup_record_id": "backup-opw-prod-20260410T182231Z"', persisted_payload
+            )
             self.assertIn('"deployment_id": "control-plane-dokploy"', persisted_payload)
             self.assertIn('"snapshot": "opw-predeploy-20260410-182231"', persisted_payload)
 
@@ -881,7 +992,10 @@ class PromoteCliTests(unittest.TestCase):
                         "schema_version": 1,
                         "context": "opw",
                         "instance": "prod",
-                        "artifact_identity": {"artifact_id": "artifact-sha256-image456", "manifest_version": 1},
+                        "artifact_identity": {
+                            "artifact_id": "artifact-sha256-image456",
+                            "manifest_version": 1,
+                        },
                         "source_git_ref": "abc123",
                         "deploy": {
                             "target_name": "opw-prod",
@@ -946,7 +1060,10 @@ class PromoteCliTests(unittest.TestCase):
                     {
                         "schema_version": 1,
                         "record_id": "promotion-1",
-                        "artifact_identity": {"artifact_id": "artifact-sha256-image456", "manifest_version": 1},
+                        "artifact_identity": {
+                            "artifact_id": "artifact-sha256-image456",
+                            "manifest_version": 1,
+                        },
                         "backup_record_id": "backup-opw-prod-20260410T182231Z",
                         "context": "opw",
                         "from_instance": "testing",
@@ -976,7 +1093,10 @@ class PromoteCliTests(unittest.TestCase):
                         "schema_version": 1,
                         "context": "opw",
                         "instance": "prod",
-                        "artifact_identity": {"artifact_id": "artifact-sha256-image456", "manifest_version": 1},
+                        "artifact_identity": {
+                            "artifact_id": "artifact-sha256-image456",
+                            "manifest_version": 1,
+                        },
                         "source_git_ref": "abc123",
                         "deploy": {
                             "target_name": "opw-prod",
@@ -1014,7 +1134,10 @@ class PromoteCliTests(unittest.TestCase):
                     {
                         "schema_version": 1,
                         "record_id": "deployment-1",
-                        "artifact_identity": {"artifact_id": "artifact-sha256-image456", "manifest_version": 1},
+                        "artifact_identity": {
+                            "artifact_id": "artifact-sha256-image456",
+                            "manifest_version": 1,
+                        },
                         "context": "opw",
                         "instance": "prod",
                         "source_git_ref": "abc123",
@@ -1072,7 +1195,10 @@ class PromoteCliTests(unittest.TestCase):
                         "schema_version": 1,
                         "context": "zeta",
                         "instance": "testing",
-                        "artifact_identity": {"artifact_id": "artifact-zeta", "manifest_version": 1},
+                        "artifact_identity": {
+                            "artifact_id": "artifact-zeta",
+                            "manifest_version": 1,
+                        },
                         "source_git_ref": "zeta-ref",
                         "deploy": {
                             "target_name": "zeta-testing",
@@ -1107,7 +1233,10 @@ class PromoteCliTests(unittest.TestCase):
                         "schema_version": 1,
                         "context": "acme",
                         "instance": "prod",
-                        "artifact_identity": {"artifact_id": "artifact-acme", "manifest_version": 1},
+                        "artifact_identity": {
+                            "artifact_id": "artifact-acme",
+                            "manifest_version": 1,
+                        },
                         "source_git_ref": "acme-ref",
                         "deploy": {
                             "target_name": "acme-prod",
@@ -1141,7 +1270,10 @@ class PromoteCliTests(unittest.TestCase):
                     {
                         "schema_version": 1,
                         "record_id": "deployment-zeta",
-                        "artifact_identity": {"artifact_id": "artifact-zeta", "manifest_version": 1},
+                        "artifact_identity": {
+                            "artifact_id": "artifact-zeta",
+                            "manifest_version": 1,
+                        },
                         "context": "zeta",
                         "instance": "testing",
                         "source_git_ref": "zeta-ref",
@@ -1167,7 +1299,10 @@ class PromoteCliTests(unittest.TestCase):
                     {
                         "schema_version": 1,
                         "record_id": "deployment-acme",
-                        "artifact_identity": {"artifact_id": "artifact-acme", "manifest_version": 1},
+                        "artifact_identity": {
+                            "artifact_id": "artifact-acme",
+                            "manifest_version": 1,
+                        },
                         "context": "acme",
                         "instance": "prod",
                         "source_git_ref": "acme-ref",
@@ -1201,7 +1336,10 @@ class PromoteCliTests(unittest.TestCase):
 
             self.assertEqual(result.exit_code, 0, msg=result.output)
             payload = json.loads(result.output)
-            self.assertEqual([(entry["context"], entry["instance"]) for entry in payload], [("acme", "prod"), ("zeta", "testing")])
+            self.assertEqual(
+                [(entry["context"], entry["instance"]) for entry in payload],
+                [("acme", "prod"), ("zeta", "testing")],
+            )
             self.assertEqual(payload[0]["live"]["artifact_id"], "artifact-acme")
             self.assertEqual(payload[1]["latest_deployment"]["record_id"], "deployment-zeta")
 
@@ -1366,10 +1504,12 @@ DOKPLOY_SHIP_MODE = "auto"
                 encoding="utf-8",
             )
 
-            with patch.dict(os.environ,
-                            {
-                                "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
-                            }):
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
+                },
+            ):
                 result = runner.invoke(
                     main,
                     [
@@ -1420,8 +1560,12 @@ DOKPLOY_SHIP_MODE = "auto"
             )
 
             self.assertEqual(result.exit_code, 0, msg=result.output)
-            persisted_payload = (state_dir / "promotions" / "promotion-1.json").read_text(encoding="utf-8")
-            self.assertIn('"backup_record_id": "backup-opw-prod-20260410T182231Z"', persisted_payload)
+            persisted_payload = (state_dir / "promotions" / "promotion-1.json").read_text(
+                encoding="utf-8"
+            )
+            self.assertIn(
+                '"backup_record_id": "backup-opw-prod-20260410T182231Z"', persisted_payload
+            )
 
     def test_backup_gates_list_returns_latest_first(self) -> None:
         runner = CliRunner()
@@ -1477,7 +1621,10 @@ DOKPLOY_SHIP_MODE = "auto"
                         {
                             "schema_version": 1,
                             "record_id": record_id,
-                            "artifact_identity": {"artifact_id": artifact_id, "manifest_version": 1},
+                            "artifact_identity": {
+                                "artifact_id": artifact_id,
+                                "manifest_version": 1,
+                            },
                             "backup_record_id": backup_record_id,
                             "context": "opw",
                             "from_instance": "testing",
@@ -1547,7 +1694,10 @@ DOKPLOY_SHIP_MODE = "auto"
                         {
                             "schema_version": 1,
                             "record_id": record_id,
-                            "artifact_identity": {"artifact_id": artifact_id, "manifest_version": 1},
+                            "artifact_identity": {
+                                "artifact_id": artifact_id,
+                                "manifest_version": 1,
+                            },
                             "context": "opw",
                             "instance": "prod",
                             "source_git_ref": source_git_ref,
@@ -1636,7 +1786,9 @@ DOKPLOY_SHIP_MODE = "auto"
             written_path = state_dir / "deployments" / "deployment-20260411T182231Z-opw-prod.json"
             self.assertEqual(Path(result.output.strip()), written_path)
             self.assertEqual(
-                DeploymentRecord.model_validate(json.loads(written_path.read_text(encoding="utf-8"))),
+                DeploymentRecord.model_validate(
+                    json.loads(written_path.read_text(encoding="utf-8"))
+                ),
                 record,
             )
 
@@ -1673,10 +1825,14 @@ DOKPLOY_SHIP_MODE = "auto"
             )
 
             self.assertEqual(result.exit_code, 0, msg=result.output)
-            written_path = state_dir / "promotions" / "promotion-20260411T182231Z-opw-testing-to-prod.json"
+            written_path = (
+                state_dir / "promotions" / "promotion-20260411T182231Z-opw-testing-to-prod.json"
+            )
             self.assertEqual(Path(result.output.strip()), written_path)
             self.assertEqual(
-                PromotionRecord.model_validate(json.loads(written_path.read_text(encoding="utf-8"))),
+                PromotionRecord.model_validate(
+                    json.loads(written_path.read_text(encoding="utf-8"))
+                ),
                 record,
             )
 
@@ -2120,31 +2276,45 @@ DOKPLOY_SHIP_MODE = "auto"
             _write_artifact_manifest(state_dir)
             input_file = repo_root / "ship-request.json"
             input_file.write_text(
-                ShipRequest(artifact_id="artifact-sha256-image456", context="opw", instance="prod",
-                            source_git_ref="abc123", target_name="opw-prod", target_type="compose",
-                            deploy_mode="dokploy-compose-api",
-                            destination_health=_healthcheck_evidence()).model_dump_json(indent=2),
+                ShipRequest(
+                    artifact_id="artifact-sha256-image456",
+                    context="opw",
+                    instance="prod",
+                    source_git_ref="abc123",
+                    target_name="opw-prod",
+                    target_type="compose",
+                    deploy_mode="dokploy-compose-api",
+                    destination_health=_healthcheck_evidence(),
+                ).model_dump_json(indent=2),
                 encoding="utf-8",
             )
 
-            with patch(
-                "control_plane.cli._resolve_dokploy_target",
-                return_value=(
-                    ResolvedTargetEvidence(target_type="compose", target_id="compose-123", target_name="opw-prod"),
-                    600,
+            with (
+                patch(
+                    "control_plane.cli._resolve_dokploy_target",
+                    return_value=(
+                        ResolvedTargetEvidence(
+                            target_type="compose", target_id="compose-123", target_name="opw-prod"
+                        ),
+                        600,
+                    ),
                 ),
-            ), patch(
-                "control_plane.cli._sync_artifact_image_reference_for_target",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._execute_dokploy_deploy",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._run_compose_post_deploy_update",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._wait_for_ship_healthcheck",
-                side_effect=lambda **_kwargs: None,
+                patch(
+                    "control_plane.cli._sync_artifact_image_reference_for_target",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._execute_dokploy_deploy",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._run_compose_post_deploy_update",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._wait_for_ship_healthcheck",
+                    side_effect=lambda **_kwargs: None,
+                ),
             ):
                 result = runner.invoke(
                     main,
@@ -2164,7 +2334,7 @@ DOKPLOY_SHIP_MODE = "auto"
             persisted_payload = inventory_file.read_text(encoding="utf-8")
             self.assertIn('"artifact_id": "artifact-sha256-image456"', persisted_payload)
             self.assertIn('"deployment_record_id": "deployment-', persisted_payload)
-            self.assertIn('native control-plane Dokploy schedule workflow', persisted_payload)
+            self.assertIn("native control-plane Dokploy schedule workflow", persisted_payload)
             tuple_file = state_dir / "release_tuples" / "opw-prod.json"
             self.assertTrue(tuple_file.exists())
             tuple_payload = tuple_file.read_text(encoding="utf-8")
@@ -2181,40 +2351,61 @@ DOKPLOY_SHIP_MODE = "auto"
             _write_release_tuple_record(state_dir)
             input_file = repo_root / "promotion-request.json"
             input_file.write_text(
-                PromotionRequest(artifact_id="artifact-sha256-image456",
-                                 backup_record_id="backup-opw-prod-20260410T182231Z", source_git_ref="abc123",
-                                 context="opw", from_instance="testing", to_instance="prod", target_name="opw-prod",
-                                 target_type="compose", deploy_mode="dokploy-compose-api", health_timeout_seconds=45,
-                                 source_health=_healthcheck_evidence(
-                                     verified=True,
-                                     urls=("https://testing.example.com/web/health",),
-                                     timeout_seconds=30,
-                                     status="pass",
-                                 ),
-                                 backup_gate=_backup_gate_evidence(),
-                                 destination_health=_healthcheck_evidence()).model_dump_json(indent=2),
+                PromotionRequest(
+                    artifact_id="artifact-sha256-image456",
+                    backup_record_id="backup-opw-prod-20260410T182231Z",
+                    source_git_ref="abc123",
+                    context="opw",
+                    from_instance="testing",
+                    to_instance="prod",
+                    target_name="opw-prod",
+                    target_type="compose",
+                    deploy_mode="dokploy-compose-api",
+                    health_timeout_seconds=45,
+                    source_health=_healthcheck_evidence(
+                        verified=True,
+                        urls=("https://testing.example.com/web/health",),
+                        timeout_seconds=30,
+                        status="pass",
+                    ),
+                    backup_gate=_backup_gate_evidence(),
+                    destination_health=_healthcheck_evidence(),
+                ).model_dump_json(indent=2),
                 encoding="utf-8",
             )
 
-            with patch(
-                "control_plane.cli._resolve_ship_request_for_promotion",
-                return_value=ShipRequest(context="opw", instance="prod", source_git_ref="abc123",
-                                         target_name="opw-prod", target_type="compose",
-                                         deploy_mode="dokploy-compose-api", artifact_id="artifact-sha256-image456",
-                                         destination_health=_healthcheck_evidence()),
-            ), patch(
-                "control_plane.cli._execute_ship",
-                return_value=(
-                    state_dir / "deployments" / "deployment-1.json",
-                    DeploymentRecord(record_id="deployment-1",
-                                     artifact_identity=_artifact_identity_reference(), context="opw",
-                                     instance="prod", source_git_ref="abc123",
-                                     deploy=_deploy_evidence(
-                                         started_at="2026-04-10T18:22:31Z",
-                                         finished_at="2026-04-10T18:24:00Z",
-                                     ),
-                                     post_deploy_update=_post_deploy_update_evidence(),
-                                     destination_health=_healthcheck_evidence(verified=True, status="pass")),
+            with (
+                patch(
+                    "control_plane.cli._resolve_ship_request_for_promotion",
+                    return_value=ShipRequest(
+                        context="opw",
+                        instance="prod",
+                        source_git_ref="abc123",
+                        target_name="opw-prod",
+                        target_type="compose",
+                        deploy_mode="dokploy-compose-api",
+                        artifact_id="artifact-sha256-image456",
+                        destination_health=_healthcheck_evidence(),
+                    ),
+                ),
+                patch(
+                    "control_plane.cli._execute_ship",
+                    return_value=(
+                        state_dir / "deployments" / "deployment-1.json",
+                        DeploymentRecord(
+                            record_id="deployment-1",
+                            artifact_identity=_artifact_identity_reference(),
+                            context="opw",
+                            instance="prod",
+                            source_git_ref="abc123",
+                            deploy=_deploy_evidence(
+                                started_at="2026-04-10T18:22:31Z",
+                                finished_at="2026-04-10T18:24:00Z",
+                            ),
+                            post_deploy_update=_post_deploy_update_evidence(),
+                            destination_health=_healthcheck_evidence(verified=True, status="pass"),
+                        ),
+                    ),
                 ),
             ):
                 result = runner.invoke(
@@ -2349,27 +2540,39 @@ target_id = "compose-123"
             )
             input_file = repo_root / "ship-request.json"
             input_file.write_text(
-                ShipRequest(artifact_id="artifact-sha256-image456", context="opw", instance="prod",
-                            source_git_ref="abc123", target_name="opw-prod", target_type="compose",
-                            deploy_mode="dokploy-compose-api", verify_health=False).model_dump_json(indent=2),
+                ShipRequest(
+                    artifact_id="artifact-sha256-image456",
+                    context="opw",
+                    instance="prod",
+                    source_git_ref="abc123",
+                    target_name="opw-prod",
+                    target_type="compose",
+                    deploy_mode="dokploy-compose-api",
+                    verify_health=False,
+                ).model_dump_json(indent=2),
                 encoding="utf-8",
             )
             post_deploy_updates: list[dict[str, object]] = []
 
-            with patch.dict(
-                os.environ,
-                {
-                    "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
-                },
-            ), patch(
-                "control_plane.cli._run_compose_post_deploy_update",
-                side_effect=lambda **kwargs: post_deploy_updates.append(kwargs),
-            ), patch(
-                "control_plane.cli._sync_artifact_image_reference_for_target",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._execute_dokploy_deploy",
-                side_effect=lambda **_kwargs: None,
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
+                    },
+                ),
+                patch(
+                    "control_plane.cli._run_compose_post_deploy_update",
+                    side_effect=lambda **kwargs: post_deploy_updates.append(kwargs),
+                ),
+                patch(
+                    "control_plane.cli._sync_artifact_image_reference_for_target",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._execute_dokploy_deploy",
+                    side_effect=lambda **_kwargs: None,
+                ),
             ):
                 result = runner.invoke(
                     main,
@@ -2433,28 +2636,40 @@ target_id = "compose-123"
             )
             input_file = repo_root / "ship-request.json"
             input_file.write_text(
-                ShipRequest(artifact_id="artifact-sha256-image456", context="opw", instance="prod",
-                            source_git_ref="abc123", target_name="opw-prod", target_type="compose",
-                            deploy_mode="dokploy-compose-api", verify_health=False).model_dump_json(indent=2),
+                ShipRequest(
+                    artifact_id="artifact-sha256-image456",
+                    context="opw",
+                    instance="prod",
+                    source_git_ref="abc123",
+                    target_name="opw-prod",
+                    target_type="compose",
+                    deploy_mode="dokploy-compose-api",
+                    verify_health=False,
+                ).model_dump_json(indent=2),
                 encoding="utf-8",
             )
 
             captured_sync_calls: list[dict[str, object]] = []
 
-            with patch.dict(
-                os.environ,
-                {
-                    "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
-                },
-            ), patch(
-                "control_plane.cli._sync_artifact_image_reference_for_target",
-                side_effect=lambda **kwargs: captured_sync_calls.append(kwargs),
-            ), patch(
-                "control_plane.cli._execute_dokploy_deploy",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._run_compose_post_deploy_update",
-                side_effect=lambda **_kwargs: None,
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
+                    },
+                ),
+                patch(
+                    "control_plane.cli._sync_artifact_image_reference_for_target",
+                    side_effect=lambda **kwargs: captured_sync_calls.append(kwargs),
+                ),
+                patch(
+                    "control_plane.cli._execute_dokploy_deploy",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._run_compose_post_deploy_update",
+                    side_effect=lambda **_kwargs: None,
+                ),
             ):
                 result = runner.invoke(
                     main,
@@ -2503,32 +2718,44 @@ target_id = "compose-123"
             )
             input_file = repo_root / "ship-request.json"
             input_file.write_text(
-                ShipRequest(artifact_id="artifact-sha256-image456", context="opw", instance="prod",
-                            source_git_ref="abc123", target_name="opw-prod", target_type="compose",
-                            deploy_mode="dokploy-compose-api",
-                            destination_health=_healthcheck_evidence()).model_dump_json(indent=2),
+                ShipRequest(
+                    artifact_id="artifact-sha256-image456",
+                    context="opw",
+                    instance="prod",
+                    source_git_ref="abc123",
+                    target_name="opw-prod",
+                    target_type="compose",
+                    deploy_mode="dokploy-compose-api",
+                    destination_health=_healthcheck_evidence(),
+                ).model_dump_json(indent=2),
                 encoding="utf-8",
             )
             post_deploy_updates: list[dict[str, object]] = []
             captured_health_urls: list[str] = []
 
-            with patch.dict(
-                os.environ,
-                {
-                    "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
-                },
-            ), patch(
-                "control_plane.cli._run_compose_post_deploy_update",
-                side_effect=lambda **kwargs: post_deploy_updates.append(kwargs),
-            ), patch(
-                "control_plane.cli._sync_artifact_image_reference_for_target",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._execute_dokploy_deploy",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._wait_for_ship_healthcheck",
-                side_effect=lambda url, timeout_seconds: captured_health_urls.append(url),
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
+                    },
+                ),
+                patch(
+                    "control_plane.cli._run_compose_post_deploy_update",
+                    side_effect=lambda **kwargs: post_deploy_updates.append(kwargs),
+                ),
+                patch(
+                    "control_plane.cli._sync_artifact_image_reference_for_target",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._execute_dokploy_deploy",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._wait_for_ship_healthcheck",
+                    side_effect=lambda url, timeout_seconds: captured_health_urls.append(url),
+                ),
             ):
                 result = runner.invoke(
                     main,
@@ -2554,31 +2781,45 @@ target_id = "compose-123"
             _write_artifact_manifest(state_dir)
             input_file = repo_root / "ship-request.json"
             input_file.write_text(
-                ShipRequest(artifact_id="artifact-sha256-image456", context="opw", instance="prod",
-                            source_git_ref="abc123", target_name="opw-prod", target_type="compose",
-                            deploy_mode="dokploy-compose-api",
-                            destination_health=_healthcheck_evidence()).model_dump_json(indent=2),
+                ShipRequest(
+                    artifact_id="artifact-sha256-image456",
+                    context="opw",
+                    instance="prod",
+                    source_git_ref="abc123",
+                    target_name="opw-prod",
+                    target_type="compose",
+                    deploy_mode="dokploy-compose-api",
+                    destination_health=_healthcheck_evidence(),
+                ).model_dump_json(indent=2),
                 encoding="utf-8",
             )
 
-            with patch(
-                "control_plane.cli._resolve_dokploy_target",
-                return_value=(
-                    ResolvedTargetEvidence(target_type="compose", target_id="compose-123", target_name="opw-prod"),
-                    600,
+            with (
+                patch(
+                    "control_plane.cli._resolve_dokploy_target",
+                    return_value=(
+                        ResolvedTargetEvidence(
+                            target_type="compose", target_id="compose-123", target_name="opw-prod"
+                        ),
+                        600,
+                    ),
                 ),
-            ), patch(
-                "control_plane.cli._sync_artifact_image_reference_for_target",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._execute_dokploy_deploy",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._run_compose_post_deploy_update",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._wait_for_ship_healthcheck",
-                side_effect=click.ClickException("Healthcheck failed"),
+                patch(
+                    "control_plane.cli._sync_artifact_image_reference_for_target",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._execute_dokploy_deploy",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._run_compose_post_deploy_update",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._wait_for_ship_healthcheck",
+                    side_effect=click.ClickException("Healthcheck failed"),
+                ),
             ):
                 result = runner.invoke(
                     main,
@@ -2600,7 +2841,9 @@ target_id = "compose-123"
             self.assertIn('"post_deploy_update": {', persisted_payload)
             self.assertIn('"attempted": true', persisted_payload)
 
-    def test_ship_execute_accepts_first_passing_health_url_when_multiple_are_available(self) -> None:
+    def test_ship_execute_accepts_first_passing_health_url_when_multiple_are_available(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             repo_root = Path(temporary_directory_name)
@@ -2632,26 +2875,36 @@ target_id = "compose-123"
                 self.assertEqual(timeout_seconds, 45)
                 captured_health_urls.append(url)
                 if url == "https://prod-alt.example.com/web/health":
-                    raise click.ClickException("Healthcheck failed for https://prod-alt.example.com/web/health: http 401")
+                    raise click.ClickException(
+                        "Healthcheck failed for https://prod-alt.example.com/web/health: http 401"
+                    )
 
-            with patch(
-                "control_plane.cli._resolve_dokploy_target",
-                return_value=(
-                    ResolvedTargetEvidence(target_type="compose", target_id="compose-123", target_name="opw-prod"),
-                    600,
+            with (
+                patch(
+                    "control_plane.cli._resolve_dokploy_target",
+                    return_value=(
+                        ResolvedTargetEvidence(
+                            target_type="compose", target_id="compose-123", target_name="opw-prod"
+                        ),
+                        600,
+                    ),
                 ),
-            ), patch(
-                "control_plane.cli._sync_artifact_image_reference_for_target",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._execute_dokploy_deploy",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._run_compose_post_deploy_update",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._wait_for_ship_healthcheck",
-                side_effect=_health_side_effect,
+                patch(
+                    "control_plane.cli._sync_artifact_image_reference_for_target",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._execute_dokploy_deploy",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._run_compose_post_deploy_update",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._wait_for_ship_healthcheck",
+                    side_effect=_health_side_effect,
+                ),
             ):
                 result = runner.invoke(
                     main,
@@ -2704,24 +2957,32 @@ target_id = "compose-123"
                 self.assertEqual(timeout_seconds, 45)
                 raise click.ClickException(f"Healthcheck failed for {url}: http 401")
 
-            with patch(
-                "control_plane.cli._resolve_dokploy_target",
-                return_value=(
-                    ResolvedTargetEvidence(target_type="compose", target_id="compose-123", target_name="opw-prod"),
-                    600,
+            with (
+                patch(
+                    "control_plane.cli._resolve_dokploy_target",
+                    return_value=(
+                        ResolvedTargetEvidence(
+                            target_type="compose", target_id="compose-123", target_name="opw-prod"
+                        ),
+                        600,
+                    ),
                 ),
-            ), patch(
-                "control_plane.cli._sync_artifact_image_reference_for_target",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._execute_dokploy_deploy",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._run_compose_post_deploy_update",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._wait_for_ship_healthcheck",
-                side_effect=_health_side_effect,
+                patch(
+                    "control_plane.cli._sync_artifact_image_reference_for_target",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._execute_dokploy_deploy",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._run_compose_post_deploy_update",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._wait_for_ship_healthcheck",
+                    side_effect=_health_side_effect,
+                ),
             ):
                 result = runner.invoke(
                     main,
@@ -2743,7 +3004,7 @@ target_id = "compose-123"
             self.assertEqual(len(deployment_files), 1)
             persisted_payload = deployment_files[0].read_text(encoding="utf-8")
             self.assertIn('"status": "fail"', persisted_payload)
-            self.assertIn('native control-plane Dokploy schedule workflow', persisted_payload)
+            self.assertIn("native control-plane Dokploy schedule workflow", persisted_payload)
 
     def test_ship_execute_marks_post_deploy_update_failed_when_native_update_fails(self) -> None:
         runner = CliRunner()
@@ -2753,28 +3014,41 @@ target_id = "compose-123"
             _write_artifact_manifest(state_dir)
             input_file = repo_root / "ship-request.json"
             input_file.write_text(
-                ShipRequest(artifact_id="artifact-sha256-image456", context="opw", instance="prod",
-                            source_git_ref="abc123", target_name="opw-prod", target_type="compose",
-                            deploy_mode="dokploy-compose-api",
-                            destination_health=_healthcheck_evidence()).model_dump_json(indent=2),
+                ShipRequest(
+                    artifact_id="artifact-sha256-image456",
+                    context="opw",
+                    instance="prod",
+                    source_git_ref="abc123",
+                    target_name="opw-prod",
+                    target_type="compose",
+                    deploy_mode="dokploy-compose-api",
+                    destination_health=_healthcheck_evidence(),
+                ).model_dump_json(indent=2),
                 encoding="utf-8",
             )
 
-            with patch(
-                "control_plane.cli._resolve_dokploy_target",
-                return_value=(
-                    ResolvedTargetEvidence(target_type="compose", target_id="compose-123", target_name="opw-prod"),
-                    600,
+            with (
+                patch(
+                    "control_plane.cli._resolve_dokploy_target",
+                    return_value=(
+                        ResolvedTargetEvidence(
+                            target_type="compose", target_id="compose-123", target_name="opw-prod"
+                        ),
+                        600,
+                    ),
                 ),
-            ), patch(
-                "control_plane.cli._sync_artifact_image_reference_for_target",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._execute_dokploy_deploy",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._run_compose_post_deploy_update",
-                side_effect=click.ClickException("Native post-deploy update failed"),
+                patch(
+                    "control_plane.cli._sync_artifact_image_reference_for_target",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._execute_dokploy_deploy",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._run_compose_post_deploy_update",
+                    side_effect=click.ClickException("Native post-deploy update failed"),
+                ),
             ):
                 result = runner.invoke(
                     main,
@@ -2796,7 +3070,7 @@ target_id = "compose-123"
             self.assertIn('"status": "pass"', persisted_payload)
             self.assertIn('"post_deploy_update": {', persisted_payload)
             self.assertIn('"attempted": true', persisted_payload)
-            self.assertIn('native control-plane Dokploy schedule workflow', persisted_payload)
+            self.assertIn("native control-plane Dokploy schedule workflow", persisted_payload)
             self.assertIn('"destination_health": {', persisted_payload)
             self.assertIn('"verified": false', persisted_payload)
 
@@ -2808,25 +3082,37 @@ target_id = "compose-123"
             _write_artifact_manifest(state_dir)
             input_file = repo_root / "ship-request.json"
             input_file.write_text(
-                ShipRequest(artifact_id="artifact-sha256-image456", context="opw", instance="prod",
-                            source_git_ref="abc123", target_name="opw-prod", target_type="compose",
-                            deploy_mode="dokploy-compose-api",
-                            destination_health=_healthcheck_evidence()).model_dump_json(indent=2),
+                ShipRequest(
+                    artifact_id="artifact-sha256-image456",
+                    context="opw",
+                    instance="prod",
+                    source_git_ref="abc123",
+                    target_name="opw-prod",
+                    target_type="compose",
+                    deploy_mode="dokploy-compose-api",
+                    destination_health=_healthcheck_evidence(),
+                ).model_dump_json(indent=2),
                 encoding="utf-8",
             )
 
-            with patch(
-                "control_plane.cli._resolve_dokploy_target",
-                return_value=(
-                    ResolvedTargetEvidence(target_type="compose", target_id="compose-123", target_name="opw-prod"),
-                    600,
+            with (
+                patch(
+                    "control_plane.cli._resolve_dokploy_target",
+                    return_value=(
+                        ResolvedTargetEvidence(
+                            target_type="compose", target_id="compose-123", target_name="opw-prod"
+                        ),
+                        600,
+                    ),
                 ),
-            ), patch(
-                "control_plane.cli._sync_artifact_image_reference_for_target",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._execute_dokploy_deploy",
-                side_effect=subprocess.CalledProcessError(1, ["uv", "run"]),
+                patch(
+                    "control_plane.cli._sync_artifact_image_reference_for_target",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._execute_dokploy_deploy",
+                    side_effect=subprocess.CalledProcessError(1, ["uv", "run"]),
+                ),
             ):
                 result = runner.invoke(
                     main,
@@ -2890,29 +3176,43 @@ target_id = "compose-123"
             _write_artifact_manifest(state_dir)
             input_file = repo_root / "ship-request.json"
             input_file.write_text(
-                ShipRequest(artifact_id="artifact-sha256-image456", context="opw", instance="prod",
-                            source_git_ref="abc123", target_name="opw-prod", target_type="compose",
-                            deploy_mode="dokploy-compose-api", verify_health=False).model_dump_json(indent=2),
+                ShipRequest(
+                    artifact_id="artifact-sha256-image456",
+                    context="opw",
+                    instance="prod",
+                    source_git_ref="abc123",
+                    target_name="opw-prod",
+                    target_type="compose",
+                    deploy_mode="dokploy-compose-api",
+                    verify_health=False,
+                ).model_dump_json(indent=2),
                 encoding="utf-8",
             )
 
             post_deploy_updates: list[dict[str, object]] = []
 
-            with patch(
-                "control_plane.cli._resolve_dokploy_target",
-                return_value=(
-                    ResolvedTargetEvidence(target_type="compose", target_id="compose-123", target_name="opw-prod"),
-                    600,
+            with (
+                patch(
+                    "control_plane.cli._resolve_dokploy_target",
+                    return_value=(
+                        ResolvedTargetEvidence(
+                            target_type="compose", target_id="compose-123", target_name="opw-prod"
+                        ),
+                        600,
+                    ),
                 ),
-            ), patch(
-                "control_plane.cli._sync_artifact_image_reference_for_target",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._execute_dokploy_deploy",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._run_compose_post_deploy_update",
-                side_effect=lambda **kwargs: post_deploy_updates.append(kwargs),
+                patch(
+                    "control_plane.cli._sync_artifact_image_reference_for_target",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._execute_dokploy_deploy",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._run_compose_post_deploy_update",
+                    side_effect=lambda **kwargs: post_deploy_updates.append(kwargs),
+                ),
             ):
                 result = runner.invoke(
                     main,
@@ -2940,27 +3240,45 @@ target_id = "compose-123"
             _write_artifact_manifest(state_dir)
             input_file = repo_root / "ship-request.json"
             input_file.write_text(
-                ShipRequest(artifact_id="artifact-sha256-image456", context="opw", instance="prod",
-                            source_git_ref="abc123", target_name="opw-prod", target_type="application",
-                            deploy_mode="dokploy-application-api", verify_health=False).model_dump_json(indent=2),
+                ShipRequest(
+                    artifact_id="artifact-sha256-image456",
+                    context="opw",
+                    instance="prod",
+                    source_git_ref="abc123",
+                    target_name="opw-prod",
+                    target_type="application",
+                    deploy_mode="dokploy-application-api",
+                    verify_health=False,
+                ).model_dump_json(indent=2),
                 encoding="utf-8",
             )
 
-            with patch(
-                "control_plane.cli._resolve_dokploy_target",
-                return_value=(
-                    ResolvedTargetEvidence(target_type="application", target_id="application-123", target_name="opw-prod"),
-                    600,
+            with (
+                patch(
+                    "control_plane.cli._resolve_dokploy_target",
+                    return_value=(
+                        ResolvedTargetEvidence(
+                            target_type="application",
+                            target_id="application-123",
+                            target_name="opw-prod",
+                        ),
+                        600,
+                    ),
                 ),
-            ), patch(
-                "control_plane.cli._sync_artifact_image_reference_for_target",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._execute_dokploy_deploy",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._run_compose_post_deploy_update",
-                side_effect=AssertionError("application deploys must not run compose post-deploy update"),
+                patch(
+                    "control_plane.cli._sync_artifact_image_reference_for_target",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._execute_dokploy_deploy",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._run_compose_post_deploy_update",
+                    side_effect=AssertionError(
+                        "application deploys must not run compose post-deploy update"
+                    ),
+                ),
             ):
                 result = runner.invoke(
                     main,
@@ -3004,21 +3322,30 @@ target_id = "compose-123"
                 encoding="utf-8",
             )
 
-            with patch(
-                "control_plane.cli._resolve_dokploy_target",
-                return_value=(
-                    ResolvedTargetEvidence(target_type="compose", target_id="compose-123", target_name="opw-prod"),
-                    600,
+            with (
+                patch(
+                    "control_plane.cli._resolve_dokploy_target",
+                    return_value=(
+                        ResolvedTargetEvidence(
+                            target_type="compose", target_id="compose-123", target_name="opw-prod"
+                        ),
+                        600,
+                    ),
                 ),
-            ), patch(
-                "control_plane.cli._sync_artifact_image_reference_for_target",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._execute_dokploy_deploy",
-                side_effect=lambda **_kwargs: None,
-            ), patch(
-                "control_plane.cli._run_compose_post_deploy_update",
-                side_effect=AssertionError("async compose deploys must not run compose post-deploy update"),
+                patch(
+                    "control_plane.cli._sync_artifact_image_reference_for_target",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._execute_dokploy_deploy",
+                    side_effect=lambda **_kwargs: None,
+                ),
+                patch(
+                    "control_plane.cli._run_compose_post_deploy_update",
+                    side_effect=AssertionError(
+                        "async compose deploys must not run compose post-deploy update"
+                    ),
+                ),
             ):
                 result = runner.invoke(
                     main,
@@ -3124,7 +3451,9 @@ target_id = "compose-123"
         self.assertEqual(resolved_target.target_name, "opw-prod")
         self.assertEqual(deploy_timeout_seconds, 7200)
 
-    def test_resolve_native_ship_request_reads_source_of_truth_and_target_domain_healthcheck(self) -> None:
+    def test_resolve_native_ship_request_reads_source_of_truth_and_target_domain_healthcheck(
+        self,
+    ) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             repo_root = Path(temporary_directory_name)
             _write_control_plane_dokploy_source_of_truth(
@@ -3149,12 +3478,15 @@ schema_version = 1
 
 [contexts.opw.instances.prod.env]
 DOKPLOY_SHIP_MODE = "auto"
-""".strip()
+""".strip(),
             )
 
-            with patch.dict(os.environ, {
-                "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
-            }):
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
+                },
+            ):
                 ship_request = _resolve_native_ship_request(
                     context_name="opw",
                     instance_name="prod",
@@ -3173,7 +3505,9 @@ DOKPLOY_SHIP_MODE = "auto"
         self.assertEqual(ship_request.target_type, "compose")
         self.assertEqual(ship_request.deploy_mode, "dokploy-compose-api")
         self.assertEqual(ship_request.source_git_ref, "origin/main")
-        self.assertEqual(ship_request.destination_health.urls, ("https://prod.example.com/web/health",))
+        self.assertEqual(
+            ship_request.destination_health.urls, ("https://prod.example.com/web/health",)
+        )
         self.assertEqual(ship_request.destination_health.timeout_seconds, 55)
         self.assertEqual(ship_request.destination_health.status, "pending")
 
@@ -3205,10 +3539,12 @@ DOKPLOY_SHIP_MODE = "auto"
 """,
             )
 
-            with patch.dict(os.environ,
-                            {
-                                "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
-                            }):
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
+                },
+            ):
                 result = runner.invoke(
                     main,
                     [
@@ -3267,10 +3603,12 @@ DOKPLOY_SHIP_MODE = "auto"
 """,
             )
 
-            with patch.dict(os.environ,
-                            {
-                                "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
-                            }):
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
+                },
+            ):
                 promotion_request = _resolve_native_promotion_request(
                     context_name="opw",
                     from_instance_name="testing",
@@ -3291,10 +3629,14 @@ DOKPLOY_SHIP_MODE = "auto"
         self.assertEqual(promotion_request.target_name, "opw-prod")
         self.assertEqual(promotion_request.target_type, "compose")
         self.assertEqual(promotion_request.deploy_mode, "dokploy-compose-api")
-        self.assertEqual(promotion_request.source_health.urls, ("https://testing.example.com/web/health",))
+        self.assertEqual(
+            promotion_request.source_health.urls, ("https://testing.example.com/web/health",)
+        )
         self.assertEqual(promotion_request.source_health.timeout_seconds, 25)
         self.assertEqual(promotion_request.source_health.status, "pending")
-        self.assertEqual(promotion_request.destination_health.urls, ("https://prod.example.com/web/health",))
+        self.assertEqual(
+            promotion_request.destination_health.urls, ("https://prod.example.com/web/health",)
+        )
         self.assertEqual(promotion_request.destination_health.timeout_seconds, 55)
         self.assertEqual(promotion_request.destination_health.status, "pending")
         self.assertEqual(promotion_request.backup_record_id, "backup-opw-prod-20260410T182231Z")
@@ -3336,10 +3678,12 @@ DOKPLOY_SHIP_MODE = "auto"
 """,
             )
 
-            with patch.dict(os.environ,
-                            {
-                                "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
-                            }):
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
+                },
+            ):
                 result = runner.invoke(
                     main,
                     [
@@ -3398,17 +3742,26 @@ DOKPLOY_SHIP_MODE = "auto"
             )
             input_file = repo_root / "promotion-request.json"
             input_file.write_text(
-                PromotionRequest(artifact_id="artifact-sha256-image456",
-                                 backup_record_id="backup-opw-prod-20260410T182231Z", source_git_ref="abc123",
-                                 context="opw", from_instance="testing", to_instance="prod", target_name="opw-prod",
-                                 target_type="compose", deploy_mode="dokploy-compose-api").model_dump_json(indent=2),
+                PromotionRequest(
+                    artifact_id="artifact-sha256-image456",
+                    backup_record_id="backup-opw-prod-20260410T182231Z",
+                    source_git_ref="abc123",
+                    context="opw",
+                    from_instance="testing",
+                    to_instance="prod",
+                    target_name="opw-prod",
+                    target_type="compose",
+                    deploy_mode="dokploy-compose-api",
+                ).model_dump_json(indent=2),
                 encoding="utf-8",
             )
 
-            with patch.dict(os.environ,
-                            {
-                                "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
-                            }):
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
+                },
+            ):
                 result = runner.invoke(
                     main,
                     [
@@ -3422,9 +3775,13 @@ DOKPLOY_SHIP_MODE = "auto"
                 )
 
             self.assertNotEqual(result.exit_code, 0)
-            self.assertIn("target_type does not match control-plane Dokploy source-of-truth", result.output)
+            self.assertIn(
+                "target_type does not match control-plane Dokploy source-of-truth", result.output
+            )
 
-    def test_promote_execute_dry_run_rejects_target_metadata_drift_against_source_of_truth(self) -> None:
+    def test_promote_execute_dry_run_rejects_target_metadata_drift_against_source_of_truth(
+        self,
+    ) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             repo_root = Path(temporary_directory_name)
@@ -3472,10 +3829,12 @@ DOKPLOY_SHIP_MODE = "auto"
                 encoding="utf-8",
             )
 
-            with patch.dict(os.environ,
-                            {
-                                "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
-                            }):
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root),
+                },
+            ):
                 result = runner.invoke(
                     main,
                     [
@@ -3489,7 +3848,9 @@ DOKPLOY_SHIP_MODE = "auto"
                 )
 
             self.assertNotEqual(result.exit_code, 0)
-            self.assertIn("target_type does not match control-plane Dokploy source-of-truth", result.output)
+            self.assertIn(
+                "target_type does not match control-plane Dokploy source-of-truth", result.output
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_start_launchplane_service.py
+++ b/tests/test_start_launchplane_service.py
@@ -9,13 +9,14 @@ from tempfile import TemporaryDirectory
 
 class StartLaunchplaneServiceScriptTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.script_path = Path(__file__).resolve().parents[1] / "scripts" / "start-launchplane-service.sh"
+        self.script_path = (
+            Path(__file__).resolve().parents[1] / "scripts" / "start-launchplane-service.sh"
+        )
 
     def _write_fake_uv(self, bin_dir: Path) -> None:
         uv_path = bin_dir / "uv"
         uv_path.write_text(
-            "#!/bin/sh\n"
-            "printf '%s\\n' \"$@\" >\"$UV_CAPTURE_FILE\"\n",
+            '#!/bin/sh\nprintf \'%s\\n\' "$@" >"$UV_CAPTURE_FILE"\n',
             encoding="utf-8",
         )
         uv_path.chmod(uv_path.stat().st_mode | stat.S_IXUSR)
@@ -89,7 +90,9 @@ class StartLaunchplaneServiceScriptTests(unittest.TestCase):
                         "UV_CAPTURE_FILE": str(capture_file),
                         "LAUNCHPLANE_APP_ROOT": str(app_root),
                         "LAUNCHPLANE_STATE_DIR": str(temporary_directory / "state"),
-                        "LAUNCHPLANE_POLICY_B64": base64.b64encode(b"schema_version = 1\n").decode("ascii"),
+                        "LAUNCHPLANE_POLICY_B64": base64.b64encode(b"schema_version = 1\n").decode(
+                            "ascii"
+                        ),
                     },
                     check=False,
                 )

--- a/tests/test_verireel_prod_promotion.py
+++ b/tests/test_verireel_prod_promotion.py
@@ -74,36 +74,40 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                 }
             )
 
-            with patch(
-                "control_plane.workflows.verireel_prod_promotion.execute_verireel_stable_deploy",
-                return_value=VeriReelStableDeployResult(
-                    deployment_record_id="deployment-verireel-prod-run-12345-attempt-1",
-                    deploy_status="pass",
-                    deploy_started_at="2026-04-21T18:20:00Z",
-                    deploy_finished_at="2026-04-21T18:21:15Z",
-                    target_name="ver-prod-app",
-                    target_type="application",
-                    target_id="prod-app-123",
-                    rollout_status="pass",
-                    rollout_base_url="https://ver-prod.shinycomputers.com",
-                    rollout_health_urls=("https://ver-prod.shinycomputers.com/api/health",),
-                    rollout_started_at="2026-04-21T18:21:16Z",
-                    rollout_finished_at="2026-04-21T18:21:45Z",
-                ),
-            ), patch(
-                "control_plane.workflows.verireel_prod_promotion._run_prisma_migrations",
-                return_value=None,
-            ), patch(
-                "control_plane.workflows.verireel_prod_promotion._verify_rollout",
-                side_effect=[
-                    VeriReelRolloutVerificationResult(
-                        status="pass",
-                        base_url="https://ver-prod.shinycomputers.com",
-                        health_urls=("https://ver-prod.shinycomputers.com/api/health",),
-                        started_at="2026-04-21T18:21:46Z",
-                        finished_at="2026-04-21T18:22:15Z",
+            with (
+                patch(
+                    "control_plane.workflows.verireel_prod_promotion.execute_verireel_stable_deploy",
+                    return_value=VeriReelStableDeployResult(
+                        deployment_record_id="deployment-verireel-prod-run-12345-attempt-1",
+                        deploy_status="pass",
+                        deploy_started_at="2026-04-21T18:20:00Z",
+                        deploy_finished_at="2026-04-21T18:21:15Z",
+                        target_name="ver-prod-app",
+                        target_type="application",
+                        target_id="prod-app-123",
+                        rollout_status="pass",
+                        rollout_base_url="https://ver-prod.shinycomputers.com",
+                        rollout_health_urls=("https://ver-prod.shinycomputers.com/api/health",),
+                        rollout_started_at="2026-04-21T18:21:16Z",
+                        rollout_finished_at="2026-04-21T18:21:45Z",
                     ),
-                ],
+                ),
+                patch(
+                    "control_plane.workflows.verireel_prod_promotion._run_prisma_migrations",
+                    return_value=None,
+                ),
+                patch(
+                    "control_plane.workflows.verireel_prod_promotion._verify_rollout",
+                    side_effect=[
+                        VeriReelRolloutVerificationResult(
+                            status="pass",
+                            base_url="https://ver-prod.shinycomputers.com",
+                            health_urls=("https://ver-prod.shinycomputers.com/api/health",),
+                            started_at="2026-04-21T18:21:46Z",
+                            finished_at="2026-04-21T18:22:15Z",
+                        ),
+                    ],
+                ),
             ):
                 result = execute_verireel_prod_promotion(
                     control_plane_root=root,
@@ -126,7 +130,9 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
             promotion = store.read_promotion_record(
                 "promotion-verireel-testing-to-prod-run-12345-attempt-1"
             )
-            self.assertEqual(promotion.backup_record_id, "backup-gate-verireel-prod-run-12345-attempt-1")
+            self.assertEqual(
+                promotion.backup_record_id, "backup-gate-verireel-prod-run-12345-attempt-1"
+            )
             self.assertEqual(promotion.source_health.status, "pass")
             self.assertEqual(promotion.deploy.status, "pass")
             self.assertEqual(promotion.deploy.deployment_id, "prod-app-123")
@@ -164,34 +170,40 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                 expected_build_tag="sha-abcdef1234567890",
             )
 
-            with patch(
-                "control_plane.workflows.verireel_prod_promotion.execute_verireel_stable_deploy",
-                return_value=VeriReelStableDeployResult(
-                    deployment_record_id="deployment-verireel-prod-run-12345-attempt-1",
-                    deploy_status="pass",
-                    deploy_started_at="2026-04-21T18:20:00Z",
-                    deploy_finished_at="2026-04-21T18:21:15Z",
-                    target_name="ver-prod-app",
-                    target_type="application",
-                    target_id="prod-app-123",
-                    rollout_status="pass",
-                    rollout_base_url="https://ver-prod.shinycomputers.com",
-                    rollout_health_urls=("https://ver-prod.shinycomputers.com/api/health",),
-                    rollout_started_at="2026-04-21T18:21:16Z",
-                    rollout_finished_at="2026-04-21T18:21:45Z",
+            with (
+                patch(
+                    "control_plane.workflows.verireel_prod_promotion.execute_verireel_stable_deploy",
+                    return_value=VeriReelStableDeployResult(
+                        deployment_record_id="deployment-verireel-prod-run-12345-attempt-1",
+                        deploy_status="pass",
+                        deploy_started_at="2026-04-21T18:20:00Z",
+                        deploy_finished_at="2026-04-21T18:21:15Z",
+                        target_name="ver-prod-app",
+                        target_type="application",
+                        target_id="prod-app-123",
+                        rollout_status="pass",
+                        rollout_base_url="https://ver-prod.shinycomputers.com",
+                        rollout_health_urls=("https://ver-prod.shinycomputers.com/api/health",),
+                        rollout_started_at="2026-04-21T18:21:16Z",
+                        rollout_finished_at="2026-04-21T18:21:45Z",
+                    ),
                 ),
-            ), patch(
-                "control_plane.workflows.verireel_prod_promotion._verify_rollout",
-                return_value=VeriReelRolloutVerificationResult(
-                    status="pass",
-                    base_url="https://ver-prod.shinycomputers.com",
-                    health_urls=("https://ver-prod.shinycomputers.com/api/health",),
-                    started_at="2026-04-21T18:21:16Z",
-                    finished_at="2026-04-21T18:21:45Z",
+                patch(
+                    "control_plane.workflows.verireel_prod_promotion._verify_rollout",
+                    return_value=VeriReelRolloutVerificationResult(
+                        status="pass",
+                        base_url="https://ver-prod.shinycomputers.com",
+                        health_urls=("https://ver-prod.shinycomputers.com/api/health",),
+                        started_at="2026-04-21T18:21:16Z",
+                        finished_at="2026-04-21T18:21:45Z",
+                    ),
                 ),
-            ), patch(
-                "control_plane.workflows.verireel_prod_promotion._run_prisma_migrations",
-                side_effect=click.ClickException("Dokploy schedule deployment failed during Prisma migration."),
+                patch(
+                    "control_plane.workflows.verireel_prod_promotion._run_prisma_migrations",
+                    side_effect=click.ClickException(
+                        "Dokploy schedule deployment failed during Prisma migration."
+                    ),
+                ),
             ):
                 result = execute_verireel_prod_promotion(
                     control_plane_root=root,
@@ -237,33 +249,40 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                 expected_build_tag="sha-abcdef1234567890",
             )
 
-            with patch(
-                "control_plane.workflows.verireel_prod_promotion.execute_verireel_stable_deploy",
-                return_value=VeriReelStableDeployResult(
-                    deployment_record_id="deployment-verireel-prod-run-12345-attempt-1",
-                    deploy_status="pass",
-                    deploy_started_at="2026-04-21T18:20:00Z",
-                    deploy_finished_at="2026-04-21T18:21:15Z",
-                    target_name="ver-prod-app",
-                    target_type="application",
-                    target_id="prod-app-123",
-                    rollout_status="pass",
-                    rollout_base_url="https://ver-prod.shinycomputers.com",
-                    rollout_health_urls=("https://ver-prod.shinycomputers.com/api/health",),
-                    rollout_started_at="2026-04-21T18:21:16Z",
-                    rollout_finished_at="2026-04-21T18:21:45Z",
+            with (
+                patch(
+                    "control_plane.workflows.verireel_prod_promotion.execute_verireel_stable_deploy",
+                    return_value=VeriReelStableDeployResult(
+                        deployment_record_id="deployment-verireel-prod-run-12345-attempt-1",
+                        deploy_status="pass",
+                        deploy_started_at="2026-04-21T18:20:00Z",
+                        deploy_finished_at="2026-04-21T18:21:15Z",
+                        target_name="ver-prod-app",
+                        target_type="application",
+                        target_id="prod-app-123",
+                        rollout_status="pass",
+                        rollout_base_url="https://ver-prod.shinycomputers.com",
+                        rollout_health_urls=("https://ver-prod.shinycomputers.com/api/health",),
+                        rollout_started_at="2026-04-21T18:21:16Z",
+                        rollout_finished_at="2026-04-21T18:21:45Z",
+                    ),
                 ),
-            ), patch(
-                "control_plane.workflows.verireel_prod_promotion._run_prisma_migrations",
-                return_value=None,
-            ), patch(
-                "control_plane.workflows.verireel_prod_promotion._verify_rollout",
-                side_effect=[
-                    click.ClickException("VeriReel prod rollout verification timed out: health payload mismatch."),
-                ],
-            ), patch(
-                "control_plane.workflows.verireel_prod_promotion._resolve_rollout_base_urls",
-                return_value=("https://ver-prod.shinycomputers.com",),
+                patch(
+                    "control_plane.workflows.verireel_prod_promotion._run_prisma_migrations",
+                    return_value=None,
+                ),
+                patch(
+                    "control_plane.workflows.verireel_prod_promotion._verify_rollout",
+                    side_effect=[
+                        click.ClickException(
+                            "VeriReel prod rollout verification timed out: health payload mismatch."
+                        ),
+                    ],
+                ),
+                patch(
+                    "control_plane.workflows.verireel_prod_promotion._resolve_rollout_base_urls",
+                    return_value=("https://ver-prod.shinycomputers.com",),
+                ),
             ):
                 result = execute_verireel_prod_promotion(
                     control_plane_root=root,
@@ -306,27 +325,30 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                 expected_build_tag="sha-abcdef1234567890",
             )
 
-            with patch(
-                "control_plane.workflows.verireel_prod_promotion.execute_verireel_stable_deploy",
-                return_value=VeriReelStableDeployResult(
-                    deployment_record_id="deployment-verireel-prod-run-12345-attempt-1",
-                    deploy_status="pass",
-                    deploy_started_at="2026-04-21T18:20:00Z",
-                    deploy_finished_at="2026-04-21T18:21:15Z",
-                    target_name="ver-prod-app",
-                    target_type="application",
-                    target_id="prod-app-123",
-                    rollout_status="fail",
-                    rollout_base_url="https://ver-prod.shinycomputers.com",
-                    rollout_health_urls=("https://ver-prod.shinycomputers.com/api/health",),
-                    error_message=(
-                        "VeriReel prod rollout page verification expected "
-                        "https://ver-prod.shinycomputers.com/ to include \"VeriReel\"."
+            with (
+                patch(
+                    "control_plane.workflows.verireel_prod_promotion.execute_verireel_stable_deploy",
+                    return_value=VeriReelStableDeployResult(
+                        deployment_record_id="deployment-verireel-prod-run-12345-attempt-1",
+                        deploy_status="pass",
+                        deploy_started_at="2026-04-21T18:20:00Z",
+                        deploy_finished_at="2026-04-21T18:21:15Z",
+                        target_name="ver-prod-app",
+                        target_type="application",
+                        target_id="prod-app-123",
+                        rollout_status="fail",
+                        rollout_base_url="https://ver-prod.shinycomputers.com",
+                        rollout_health_urls=("https://ver-prod.shinycomputers.com/api/health",),
+                        error_message=(
+                            "VeriReel prod rollout page verification expected "
+                            'https://ver-prod.shinycomputers.com/ to include "VeriReel".'
+                        ),
                     ),
                 ),
-            ), patch(
-                "control_plane.workflows.verireel_prod_promotion._resolve_rollout_base_urls",
-                return_value=("https://ver-prod.shinycomputers.com",),
+                patch(
+                    "control_plane.workflows.verireel_prod_promotion._resolve_rollout_base_urls",
+                    return_value=("https://ver-prod.shinycomputers.com",),
+                ),
             ):
                 result = execute_verireel_prod_promotion(
                     control_plane_root=root,

--- a/tests/test_verireel_testing_deploy.py
+++ b/tests/test_verireel_testing_deploy.py
@@ -40,36 +40,40 @@ class VeriReelTestingDeployWorkflowTests(unittest.TestCase):
                 destination_health=HealthcheckEvidence(status="skipped"),
             )
 
-            with patch(
-                "control_plane.workflows.verireel_stable_deploy.generate_deployment_record_id",
-                return_value="deployment-verireel-testing-run-12345-attempt-1",
-            ), patch(
-                "control_plane.workflows.verireel_stable_deploy.utc_now_timestamp",
-                side_effect=[
-                    "2026-04-20T18:20:00Z",
-                    "2026-04-20T18:21:15Z",
-                ],
-            ), patch(
-                "control_plane.workflows.verireel_stable_deploy._resolve_ship_request",
-                return_value=(
-                    ship_request,
-                    ResolvedTargetEvidence(
-                        target_type="application",
-                        target_id="testing-app-123",
-                        target_name="ver-testing-app",
-                    ),
-                    300,
+            with (
+                patch(
+                    "control_plane.workflows.verireel_stable_deploy.generate_deployment_record_id",
+                    return_value="deployment-verireel-testing-run-12345-attempt-1",
                 ),
-            ), patch(
-                "control_plane.workflows.verireel_stable_deploy._execute_dokploy_deploy"
-            ), patch(
-                "control_plane.workflows.verireel_stable_deploy._verify_rollout",
-                return_value=VeriReelRolloutVerificationResult(
-                    status="pass",
-                    base_url="https://ver-testing.shinycomputers.com",
-                    health_urls=("https://ver-testing.shinycomputers.com/api/health",),
-                    started_at="2026-04-20T18:21:16Z",
-                    finished_at="2026-04-20T18:21:45Z",
+                patch(
+                    "control_plane.workflows.verireel_stable_deploy.utc_now_timestamp",
+                    side_effect=[
+                        "2026-04-20T18:20:00Z",
+                        "2026-04-20T18:21:15Z",
+                    ],
+                ),
+                patch(
+                    "control_plane.workflows.verireel_stable_deploy._resolve_ship_request",
+                    return_value=(
+                        ship_request,
+                        ResolvedTargetEvidence(
+                            target_type="application",
+                            target_id="testing-app-123",
+                            target_name="ver-testing-app",
+                        ),
+                        300,
+                    ),
+                ),
+                patch("control_plane.workflows.verireel_stable_deploy._execute_dokploy_deploy"),
+                patch(
+                    "control_plane.workflows.verireel_stable_deploy._verify_rollout",
+                    return_value=VeriReelRolloutVerificationResult(
+                        status="pass",
+                        base_url="https://ver-testing.shinycomputers.com",
+                        health_urls=("https://ver-testing.shinycomputers.com/api/health",),
+                        started_at="2026-04-20T18:21:16Z",
+                        finished_at="2026-04-20T18:21:45Z",
+                    ),
                 ),
             ):
                 result = execute_verireel_stable_deploy(
@@ -78,10 +82,14 @@ class VeriReelTestingDeployWorkflowTests(unittest.TestCase):
                     request=request,
                 )
 
-            self.assertEqual(result.deployment_record_id, "deployment-verireel-testing-run-12345-attempt-1")
+            self.assertEqual(
+                result.deployment_record_id, "deployment-verireel-testing-run-12345-attempt-1"
+            )
             self.assertEqual(result.deploy_status, "pass")
             self.assertEqual(result.target_id, "testing-app-123")
-            deployment = store.read_deployment_record("deployment-verireel-testing-run-12345-attempt-1")
+            deployment = store.read_deployment_record(
+                "deployment-verireel-testing-run-12345-attempt-1"
+            )
             self.assertEqual(deployment.deploy.status, "pass")
             self.assertEqual(deployment.deploy.started_at, "2026-04-20T18:20:00Z")
             self.assertEqual(deployment.deploy.finished_at, "2026-04-20T18:21:15Z")
@@ -110,29 +118,34 @@ class VeriReelTestingDeployWorkflowTests(unittest.TestCase):
                 destination_health=HealthcheckEvidence(status="skipped"),
             )
 
-            with patch(
-                "control_plane.workflows.verireel_stable_deploy.generate_deployment_record_id",
-                return_value="deployment-verireel-testing-run-12345-attempt-1",
-            ), patch(
-                "control_plane.workflows.verireel_stable_deploy.utc_now_timestamp",
-                side_effect=[
-                    "2026-04-20T18:20:00Z",
-                    "2026-04-20T18:21:15Z",
-                ],
-            ), patch(
-                "control_plane.workflows.verireel_stable_deploy._resolve_ship_request",
-                return_value=(
-                    ship_request,
-                    ResolvedTargetEvidence(
-                        target_type="application",
-                        target_id="testing-app-123",
-                        target_name="ver-testing-app",
-                    ),
-                    300,
+            with (
+                patch(
+                    "control_plane.workflows.verireel_stable_deploy.generate_deployment_record_id",
+                    return_value="deployment-verireel-testing-run-12345-attempt-1",
                 ),
-            ), patch(
-                "control_plane.workflows.verireel_stable_deploy._execute_dokploy_deploy",
-                side_effect=click.ClickException("deploy failed"),
+                patch(
+                    "control_plane.workflows.verireel_stable_deploy.utc_now_timestamp",
+                    side_effect=[
+                        "2026-04-20T18:20:00Z",
+                        "2026-04-20T18:21:15Z",
+                    ],
+                ),
+                patch(
+                    "control_plane.workflows.verireel_stable_deploy._resolve_ship_request",
+                    return_value=(
+                        ship_request,
+                        ResolvedTargetEvidence(
+                            target_type="application",
+                            target_id="testing-app-123",
+                            target_name="ver-testing-app",
+                        ),
+                        300,
+                    ),
+                ),
+                patch(
+                    "control_plane.workflows.verireel_stable_deploy._execute_dokploy_deploy",
+                    side_effect=click.ClickException("deploy failed"),
+                ),
             ):
                 result = execute_verireel_stable_deploy(
                     control_plane_root=root,
@@ -142,14 +155,18 @@ class VeriReelTestingDeployWorkflowTests(unittest.TestCase):
 
             self.assertEqual(result.deploy_status, "fail")
             self.assertEqual(result.error_message, "deploy failed")
-            deployment = store.read_deployment_record("deployment-verireel-testing-run-12345-attempt-1")
+            deployment = store.read_deployment_record(
+                "deployment-verireel-testing-run-12345-attempt-1"
+            )
             self.assertEqual(deployment.deploy.status, "fail")
             resolved_target = deployment.resolved_target
             self.assertIsNotNone(resolved_target)
             assert resolved_target is not None
             self.assertEqual(resolved_target.target_id, "testing-app-123")
 
-    def test_execute_dokploy_deploy_updates_application_image_before_triggering_deploy(self) -> None:
+    def test_execute_dokploy_deploy_updates_application_image_before_triggering_deploy(
+        self,
+    ) -> None:
         captured_dokploy_requests: list[dict[str, object]] = []
         captured_trigger_calls: list[dict[str, object]] = []
         with TemporaryDirectory() as temporary_directory_name:
@@ -167,30 +184,37 @@ class VeriReelTestingDeployWorkflowTests(unittest.TestCase):
                 destination_health=HealthcheckEvidence(status="skipped"),
             )
 
-            with patch(
-                "control_plane.workflows.verireel_stable_deploy.control_plane_dokploy.read_dokploy_config",
-                return_value=("https://dokploy.example.com", "token-123"),
-            ), patch(
-                "control_plane.workflows.verireel_stable_deploy.control_plane_dokploy.latest_deployment_for_target",
-                return_value={"deploymentId": "deploy-old"},
-            ), patch(
-                "control_plane.workflows.verireel_stable_deploy.control_plane_dokploy.fetch_dokploy_target_payload",
-                return_value={
-                    "applicationId": "testing-app-123",
-                    "dockerImage": "ghcr.io/every/verireel-app:prod",
-                    "username": "every",
-                    "password": "ghp_test",
-                    "registryUrl": "ghcr.io",
-                },
-            ), patch(
-                "control_plane.workflows.verireel_stable_deploy.control_plane_dokploy.dokploy_request",
-                side_effect=lambda **kwargs: captured_dokploy_requests.append(kwargs),
-            ), patch(
-                "control_plane.workflows.verireel_stable_deploy.control_plane_dokploy.trigger_deployment",
-                side_effect=lambda **kwargs: captured_trigger_calls.append(kwargs),
-            ), patch(
-                "control_plane.workflows.verireel_stable_deploy.control_plane_dokploy.wait_for_target_deployment",
-                return_value="deployment=deploy-new status=done",
+            with (
+                patch(
+                    "control_plane.workflows.verireel_stable_deploy.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "token-123"),
+                ),
+                patch(
+                    "control_plane.workflows.verireel_stable_deploy.control_plane_dokploy.latest_deployment_for_target",
+                    return_value={"deploymentId": "deploy-old"},
+                ),
+                patch(
+                    "control_plane.workflows.verireel_stable_deploy.control_plane_dokploy.fetch_dokploy_target_payload",
+                    return_value={
+                        "applicationId": "testing-app-123",
+                        "dockerImage": "ghcr.io/every/verireel-app:prod",
+                        "username": "every",
+                        "password": "ghp_test",
+                        "registryUrl": "ghcr.io",
+                    },
+                ),
+                patch(
+                    "control_plane.workflows.verireel_stable_deploy.control_plane_dokploy.dokploy_request",
+                    side_effect=lambda **kwargs: captured_dokploy_requests.append(kwargs),
+                ),
+                patch(
+                    "control_plane.workflows.verireel_stable_deploy.control_plane_dokploy.trigger_deployment",
+                    side_effect=lambda **kwargs: captured_trigger_calls.append(kwargs),
+                ),
+                patch(
+                    "control_plane.workflows.verireel_stable_deploy.control_plane_dokploy.wait_for_target_deployment",
+                    return_value="deployment=deploy-new status=done",
+                ),
             ):
                 _execute_dokploy_deploy(
                     control_plane_root=root,


### PR DESCRIPTION
## Summary
- apply Ruff formatting across the remaining Python files that failed the repo-wide format gate
- close the broad format-cleanup task now that `ruff format --check .` passes

Closes #166

## Validation
- uv run --extra dev ruff format --check .
- uv run python -m unittest
- uv run --extra dev ruff check .
