### PR TITLE
feat(every-code): react to PR feedback delivery

### DIFF
--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -1151,10 +1151,14 @@ def _apply_every_code_pr_feedback_record(
     tmux_binary: str,
     runner: Runner,
 ) -> EveryCodePrFeedbackApplyResult:
+    _acknowledge_every_code_pr_feedback(feedback=feedback, reaction="eyes", runner=runner)
     try:
         record = record_store.read_every_code_work_request_record(feedback.request_id)
     except Exception:
         _mark_every_code_pr_feedback(record_store, feedback=feedback, status="ignored")
+        _acknowledge_every_code_pr_feedback(
+            feedback=feedback, reaction="confused", runner=runner
+        )
         return EveryCodePrFeedbackApplyResult(
             status="ignored",
             detail="Every Code work request for PR feedback was not found.",
@@ -1170,6 +1174,9 @@ def _apply_every_code_pr_feedback_record(
         )
     if _terminal_every_code_request_closed_by_linked_pr(record):
         _mark_every_code_pr_feedback(record_store, feedback=feedback, status="ignored")
+        _acknowledge_every_code_pr_feedback(
+            feedback=feedback, reaction="confused", runner=runner
+        )
         return EveryCodePrFeedbackApplyResult(
             status="ignored",
             detail="Every Code PR feedback belongs to a closed linked pull request.",
@@ -1180,6 +1187,9 @@ def _apply_every_code_pr_feedback_record(
     session_state = read_every_code_session_state(state_path)
     if session_state is None:
         _mark_every_code_pr_feedback(record_store, feedback=feedback, status="ignored")
+        _acknowledge_every_code_pr_feedback(
+            feedback=feedback, reaction="confused", runner=runner
+        )
         return EveryCodePrFeedbackApplyResult(
             status="ignored",
             detail="Every Code PR feedback has no local session state on this host.",
@@ -1214,6 +1224,9 @@ def _apply_every_code_pr_feedback_record(
             tmux_binary=tmux_binary,
             runner=runner,
         ):
+            _acknowledge_every_code_pr_feedback(
+                feedback=feedback, reaction="confused", runner=runner
+            )
             return EveryCodePrFeedbackApplyResult(
                 status="blocked",
                 detail=f"Could not send PR feedback to tmux session {session_name!r}.",
@@ -1222,6 +1235,7 @@ def _apply_every_code_pr_feedback_record(
                 session_name=session_name,
             )
         _mark_every_code_pr_feedback(record_store, feedback=feedback, status="applied")
+        _acknowledge_every_code_pr_feedback(feedback=feedback, reaction="rocket", runner=runner)
         return EveryCodePrFeedbackApplyResult(
             status="applied",
             detail="Every Code PR feedback was sent to the running session.",
@@ -1233,6 +1247,9 @@ def _apply_every_code_pr_feedback_record(
     launch_root = Path(session_state.get("launch_root", "")).expanduser()
     if not launch_root.is_dir():
         _mark_every_code_pr_feedback(record_store, feedback=feedback, status="ignored")
+        _acknowledge_every_code_pr_feedback(
+            feedback=feedback, reaction="confused", runner=runner
+        )
         state_path.unlink(missing_ok=True)
         return EveryCodePrFeedbackApplyResult(
             status="ignored",
@@ -1271,6 +1288,9 @@ def _apply_every_code_pr_feedback_record(
             )
         )
     except OSError:
+        _acknowledge_every_code_pr_feedback(
+            feedback=feedback, reaction="confused", runner=runner
+        )
         return EveryCodePrFeedbackApplyResult(
             status="blocked",
             detail=f"Could not relaunch tmux session {session_name!r} for PR feedback.",
@@ -1279,6 +1299,9 @@ def _apply_every_code_pr_feedback_record(
             session_name=session_name,
         )
     if launch_result.returncode != 0:
+        _acknowledge_every_code_pr_feedback(
+            feedback=feedback, reaction="confused", runner=runner
+        )
         return EveryCodePrFeedbackApplyResult(
             status="blocked",
             detail=f"tmux relaunch failed: {launch_result.stderr.strip()}",
@@ -1287,6 +1310,7 @@ def _apply_every_code_pr_feedback_record(
             session_name=session_name,
         )
     _mark_every_code_pr_feedback(record_store, feedback=feedback, status="applied")
+    _acknowledge_every_code_pr_feedback(feedback=feedback, reaction="rocket", runner=runner)
     return EveryCodePrFeedbackApplyResult(
         status="applied",
         detail="Every Code PR feedback resumed the local session.",
@@ -1294,6 +1318,37 @@ def _apply_every_code_pr_feedback_record(
         request_id=feedback.request_id,
         session_name=session_name,
     )
+
+
+def _acknowledge_every_code_pr_feedback(
+    *,
+    feedback: EveryCodePrFeedbackRecord,
+    reaction: str,
+    runner: Runner,
+) -> None:
+    if feedback.feedback_kind != "issue_comment":
+        return
+    if not feedback.github_id.strip():
+        return
+    reference = github_pull_request_reference(pr_url=feedback.pr_url)
+    if reference is None:
+        return
+    try:
+        runner(
+            (
+                "gh",
+                "api",
+                "--method",
+                "POST",
+                f"repos/{reference['owner']}/{reference['repo']}/issues/comments/{feedback.github_id.strip()}/reactions",
+                "-H",
+                "Accept: application/vnd.github+json",
+                "-f",
+                f"content={reaction}",
+            )
+        )
+    except OSError:
+        return
 
 
 def build_every_code_worker_daemon_spec(

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -77,6 +77,7 @@ def _feedback_record(*, status: str = "pending") -> EveryCodePrFeedbackRecord:
         feedback_kind="issue_comment",
         github_delivery_id="delivery-comment",
         github_node_id="IC_kwDO_test_1001",
+        github_id="1001",
         actor="cbusillo",
         body="Please tighten the README wording before merge.",
         html_url="https://github.com/cbusillo/code/pull/26#issuecomment-1001",
@@ -135,6 +136,18 @@ class _ExistingSessionRunner(_Runner):
             return subprocess.CompletedProcess(args, 0, "", "")
         if args[1] == "display-message":
             return subprocess.CompletedProcess(args, 0, "4242\n", "")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+
+class _FailingFeedbackSendRunner(_ExistingSessionRunner):
+    def __call__(self, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        self.calls.append(tuple(args))
+        if args[1] == "has-session":
+            return subprocess.CompletedProcess(args, 0, "", "")
+        if args[1] == "display-message":
+            return subprocess.CompletedProcess(args, 0, "4242\n", "")
+        if args[1] == "send-keys":
+            return subprocess.CompletedProcess(args, 1, "", "send failed")
         return subprocess.CompletedProcess(args, 0, "", "")
 
 
@@ -741,6 +754,53 @@ class EveryCodeWorkerTests(unittest.TestCase):
         send_call = next(call for call in runner.calls if call[1] == "send-keys")
         self.assertIn("Please tighten the README wording", send_call[4])
         self.assertEqual(send_call[-1], "C-m")
+        reaction_calls = [
+            call
+            for call in runner.calls
+            if call[:4] == ("gh", "api", "--method", "POST")
+        ]
+        self.assertEqual(
+            [call[-1] for call in reaction_calls],
+            ["content=eyes", "content=rocket"],
+        )
+
+    def test_apply_feedback_reacts_when_active_session_send_fails(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "state",
+                runner=_Runner(),
+            )
+            store.write_every_code_pr_feedback_record(_feedback_record())
+            runner = _FailingFeedbackSendRunner()
+
+            result = apply_every_code_pr_feedback_for_host(
+                record_store=store,
+                host="Chris-Studio",
+                state_dir=temporary_root / "state",
+                runner=runner,
+            )
+            feedback = store.list_every_code_pr_feedback_records(limit=1)[0]
+
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(feedback.status, "pending")
+        reaction_calls = [
+            call
+            for call in runner.calls
+            if call[:4] == ("gh", "api", "--method", "POST")
+        ]
+        self.assertEqual(
+            [call[-1] for call in reaction_calls],
+            ["content=eyes", "content=confused"],
+        )
 
     def test_apply_feedback_relaunches_terminal_session_in_saved_worktree(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add best-effort GitHub reactions when the local worker starts and finishes applying PR feedback
- use eyes when feedback is picked up, rocket when delivered, and confused when delivery fails or is ignored
- keep reaction failures non-blocking so feedback processing remains the source of truth

Refs #359.

## Validation
- uv run python -m unittest tests.test_every_code_worker.EveryCodeWorkerTests.test_apply_feedback_sends_prompt_to_active_session tests.test_every_code_worker.EveryCodeWorkerTests.test_apply_feedback_reacts_when_active_session_send_fails
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest