### PR TITLE
Fix Every Code PR close follow-ups

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -9782,7 +9782,7 @@ def every_code_rerun_issue(
                 "detail": "Requeued terminal Every Code work request for this issue.",
                 "request": request.model_dump(mode="json"),
             }
-        except EveryCodeWorkerApiError as error:
+        except (EveryCodeWorkerApiError, ValueError) as error:
             raise click.ClickException(str(error)) from error
         finally:
             _close_store(record_store)

--- a/control_plane/contracts/every_code_work_request.py
+++ b/control_plane/contracts/every_code_work_request.py
@@ -235,6 +235,10 @@ def close_every_code_work_request_for_pull_request(
         "result_summary": summary,
         "error_message": error_message,
     }
+    if not record.claimed_at.strip():
+        updates["claimed_at"] = closed_at
+    if not record.claimed_by_host.strip():
+        updates["claimed_by_host"] = "github-pull-request-close"
     if not record.started_at.strip():
         updates["started_at"] = closed_at
     return record.model_copy(update=updates)

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2177,69 +2177,35 @@ def _handle_every_code_pull_request_webhook(
     merged = bool(pull_request_payload.get("merged")) if pull_request_payload else False
     closed_at = _github_webhook_string(pull_request_payload, "closed_at") or _utc_now_timestamp()
     every_code_store = _every_code_work_request_store(record_store)
-    matched_record = _find_every_code_work_request_for_pull_request(
+    candidate_records: dict[str, EveryCodeWorkRequestRecord] = {}
+    repository_records = tuple(
+        _iter_every_code_work_request_records(every_code_store, repository=repository)
+    )
+    for record in repository_records:
+        if record.result_pr_url.strip() == pr_url:
+            candidate_records[record.request_id] = record
+
+    feedback_record = _find_every_code_pr_feedback_for_pull_request(
         every_code_store,
         repository=repository,
         pr_url=pr_url,
     )
-    updated_record: EveryCodeWorkRequestRecord | None = None
-    if matched_record is not None:
-        closed_record = close_every_code_work_request_for_pull_request(
-            matched_record,
-            pr_url=pr_url,
-            merged=merged,
-            closed_at=closed_at,
+    if feedback_record is not None:
+        feedback_request_record = every_code_store.read_every_code_work_request_record(
+            feedback_record.request_id
         )
-        if closed_record is not None:
-            every_code_store.write_every_code_work_request_record(closed_record)
-            updated_record = closed_record
+        candidate_records[feedback_request_record.request_id] = feedback_request_record
 
-    if updated_record is None and matched_record is None:
-        feedback_record = _find_every_code_pr_feedback_for_pull_request(
-            every_code_store,
+    for record in repository_records:
+        if _every_code_issue_url_matches_pull_request(
+            issue_url=record.issue_url,
             repository=repository,
             pr_url=pr_url,
-        )
-        if feedback_record is not None:
-            matched_record = every_code_store.read_every_code_work_request_record(
-                feedback_record.request_id
-            )
-            closed_record = close_every_code_work_request_for_pull_request(
-                matched_record,
-                pr_url=pr_url,
-                merged=merged,
-                closed_at=closed_at,
-            )
-            if closed_record is not None:
-                every_code_store.write_every_code_work_request_record(closed_record)
-                updated_record = closed_record
-
-    if updated_record is None and matched_record is None:
-        for record in _iter_every_code_work_request_records(
-            every_code_store,
-            repository=repository,
+            linked_issue_numbers=linked_issue_numbers,
         ):
-            if not _every_code_issue_url_matches_pull_request(
-                issue_url=record.issue_url,
-                repository=repository,
-                pr_url=pr_url,
-                linked_issue_numbers=linked_issue_numbers,
-            ):
-                continue
-            matched_record = record
-            closed_record = close_every_code_work_request_for_pull_request(
-                record,
-                pr_url=pr_url,
-                merged=merged,
-                closed_at=closed_at,
-            )
-            if closed_record is None:
-                break
-            every_code_store.write_every_code_work_request_record(closed_record)
-            updated_record = closed_record
-            break
+            candidate_records[record.request_id] = record
 
-    if matched_record is None:
+    if not candidate_records:
         return _json_response(
             start_response=start_response,
             status_code=202,
@@ -2251,7 +2217,24 @@ def _handle_every_code_pull_request_webhook(
                 "github_delivery_id": delivery_id,
             },
         )
-    if updated_record is None:
+
+    updated_records: list[EveryCodeWorkRequestRecord] = []
+    terminal_records: list[EveryCodeWorkRequestRecord] = []
+    for record in candidate_records.values():
+        closed_record = close_every_code_work_request_for_pull_request(
+            record,
+            pr_url=pr_url,
+            merged=merged,
+            closed_at=closed_at,
+        )
+        if closed_record is None:
+            terminal_records.append(record)
+            continue
+        every_code_store.write_every_code_work_request_record(closed_record)
+        updated_records.append(closed_record)
+
+    if not updated_records:
+        terminal_record = terminal_records[0]
         return _json_response(
             start_response=start_response,
             status_code=202,
@@ -2261,17 +2244,26 @@ def _handle_every_code_pull_request_webhook(
                 "skipped": True,
                 "reason": "linked_every_code_request_already_terminal",
                 "result": {
-                    "request_id": matched_record.request_id,
-                    "state": matched_record.state,
+                    "request_id": terminal_record.request_id,
+                    "state": terminal_record.state,
                 },
                 "github_delivery_id": delivery_id,
             },
         )
 
+    updated_record = updated_records[0]
     accepted_payload = _accepted_payload(
         trace_id=trace_id,
-        result={"request_id": updated_record.request_id, "state": updated_record.state},
-        driver_result={"request": updated_record.model_dump(mode="json")},
+        result={
+            "request_id": updated_record.request_id,
+            "state": updated_record.state,
+            "closed_count": len(updated_records),
+        },
+        driver_result={
+            "request": updated_record.model_dump(mode="json"),
+            "closed_count": len(updated_records),
+            "requests": [record.model_dump(mode="json") for record in updated_records],
+        },
     )
     accepted_payload["github_delivery_id"] = delivery_id
     return _json_response(start_response=start_response, status_code=202, payload=accepted_payload)
@@ -2328,21 +2320,6 @@ def _github_issue_numbers_referenced_by_pull_request(
                 ) or issue_reference_match.group("number")
                 issue_numbers.add(int(issue_number))
     return frozenset(issue_numbers)
-
-
-def _find_every_code_work_request_for_pull_request(
-    every_code_store: _EveryCodeWorkRequestStore,
-    *,
-    repository: str,
-    pr_url: str,
-) -> EveryCodeWorkRequestRecord | None:
-    for record in _iter_every_code_work_request_records(
-        every_code_store,
-        repository=repository,
-    ):
-        if record.result_pr_url.strip() == pr_url:
-            return record
-    return None
 
 
 def _find_every_code_pr_feedback_for_pull_request(
@@ -2450,10 +2427,16 @@ def _handle_every_code_pr_feedback_webhook(
         )
 
     every_code_store = _every_code_work_request_store(record_store)
-    matched_record = _find_every_code_work_request_for_pull_request(
-        every_code_store,
-        repository=repository,
-        pr_url=pr_url,
+    matched_record = next(
+        (
+            record
+            for record in _iter_every_code_work_request_records(
+                every_code_store,
+                repository=repository,
+            )
+            if record.result_pr_url.strip() == pr_url
+        ),
+        None,
     )
     if matched_record is None:
         pull_request_payload = _github_webhook_mapping(payload, "pull_request")
@@ -2947,6 +2930,13 @@ def _every_code_worker_token_authorized(
     return secrets.compare_digest(provided_token, expected_token)
 
 
+def _every_code_pagination_value(query: dict[str, list[str]], *, key: str, default: int) -> int:
+    value = int(str((query.get(key) or [str(default)])[0] or str(default)))
+    if value < 0:
+        raise ValueError(f"Every Code pagination {key} must be non-negative")
+    return value
+
+
 def _every_code_read_payload(
     *,
     record_store: object,
@@ -2961,8 +2951,8 @@ def _every_code_read_payload(
         status_filter = str((query.get("status") or [""])[0] or "").strip()
         pr_number_value = str((query.get("pr_number") or [""])[0] or "").strip()
         pr_number_filter = int(pr_number_value) if pr_number_value else None
-        limit = int(str((query.get("limit") or ["50"])[0] or "50"))
-        offset = int(str((query.get("offset") or ["0"])[0] or "0"))
+        limit = _every_code_pagination_value(query, key="limit", default=50)
+        offset = _every_code_pagination_value(query, key="offset", default=0)
         feedback_records = every_code_store.list_every_code_pr_feedback_records(
             request_id=request_id_filter,
             repository=repository_filter,
@@ -2982,8 +2972,8 @@ def _every_code_read_payload(
         return {"request": record.model_dump(mode="json")}
     state_filter = str((query.get("state") or [""])[0] or "").strip()
     repository_filter = str((query.get("repository") or [""])[0] or "").strip()
-    limit = int(str((query.get("limit") or ["50"])[0] or "50"))
-    offset = int(str((query.get("offset") or ["0"])[0] or "0"))
+    limit = _every_code_pagination_value(query, key="limit", default=50)
+    offset = _every_code_pagination_value(query, key="offset", default=0)
     work_request_records = every_code_store.list_every_code_work_request_records(
         state=state_filter,
         repository=repository_filter,
@@ -4429,13 +4419,27 @@ def create_launchplane_service_app(
                 )
         if _every_code_worker_token_authorized(environ=environ, method=method, path=path):
             if method == "GET":
-                return _handle_every_code_work_request_read(
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                    record_store=record_store,
-                    path=path,
-                    query=query,
-                )
+                try:
+                    return _handle_every_code_work_request_read(
+                        start_response=start_response,
+                        trace_id=request_trace_id,
+                        record_store=record_store,
+                        path=path,
+                        query=query,
+                    )
+                except ValueError as error:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=400,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "invalid_payload",
+                                "message": str(error),
+                            },
+                        },
+                    )
             payload = _read_json_request(environ)
             try:
                 return _handle_every_code_worker_write(

--- a/docs/records.md
+++ b/docs/records.md
@@ -578,6 +578,12 @@ state/
   same label to the same issue returns the existing request; a fresh retry model
   should use a new trigger label or explicit retry record rather than mutating a
   terminal request in place.
+- The same webhook ingress accepts signed pull-request `closed` deliveries to
+  terminalize linked Every Code requests. The close handler matches records by a
+  stored result PR URL, by recorded PR feedback, or by GitHub closing references
+  to linked issues. A single pull request can close multiple Every Code requests;
+  queued matches are terminalized with service-owned claim metadata so terminal
+  records still satisfy the work-request contract.
 
 ## Inventory
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -106,11 +106,14 @@ Versioned API ingress remains under `/v1`.
 `POST /v1/every-code/github-webhook` is the only unauthenticated write route.
 It trusts the request body through GitHub webhook HMAC verification instead of
 OIDC. The route requires `X-Hub-Signature-256`, `X-GitHub-Delivery`, and
-`X-GitHub-Event`, supports only `issues` events with action `labeled`, and only
-queues work for the `every-code` label. Other signed events, actions, or labels
-return `202` with `skipped: true`. Matching deliveries create or return the
-durable Every Code work request and include `deduped` plus the delivery id in
-the response.
+`X-GitHub-Event`, supports `issues.labeled` events for the `every-code` label,
+and accepts pull-request `closed` events to terminalize linked Every Code work
+requests. Other signed events, actions, or labels return `202` with
+`skipped: true`. Matching issue-label deliveries create or return the durable
+Every Code work request and include `deduped` plus the delivery id in the
+response. Matching pull-request close deliveries can close every linked request
+referenced by the PR, including still-queued requests that never stored a result
+PR URL.
 
 The Every Code worker read, claim, and status routes also accept a dedicated
 local-worker bearer token. Configure `LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN` on

--- a/tests/test_every_code_reconciliation.py
+++ b/tests/test_every_code_reconciliation.py
@@ -267,6 +267,30 @@ class EveryCodeIssueReconciliationTests(unittest.TestCase):
         self.assertIn("Error: Launchplane API request failed", result.output)
         self.assertNotIn("Traceback", result.output)
 
+    def test_cli_rerun_issue_reports_invalid_service_input_without_traceback(self) -> None:
+        runner = CliRunner()
+
+        with patch.dict(os.environ, {"LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-token"}):
+            result = runner.invoke(
+                main,
+                [
+                    "every-code",
+                    "rerun-issue",
+                    "--service-url",
+                    "http://127.0.0.1:1",
+                    "--repository",
+                    " ",
+                    "--issue-number",
+                    "278",
+                    "--actor",
+                    "ops",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("Error: Every Code work request id requires", result.output)
+        self.assertNotIn("Traceback", result.output)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_every_code_work_request.py
+++ b/tests/test_every_code_work_request.py
@@ -179,6 +179,9 @@ class EveryCodeWorkRequestRecordTests(unittest.TestCase):
         self.assertIsNotNone(done_record)
         assert done_record is not None
         self.assertEqual(done_record.state, "done")
+        self.assertEqual(done_record.claimed_at, "2026-05-05T22:05:00Z")
+        self.assertEqual(done_record.claimed_by_host, "github-pull-request-close")
+        self.assertEqual(done_record.started_at, "2026-05-05T22:05:00Z")
         self.assertEqual(done_record.finished_at, "2026-05-05T22:05:00Z")
         self.assertEqual(done_record.result_pr_url, "https://github.com/cbusillo/code/pull/99")
         self.assertEqual(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1439,6 +1439,100 @@ class LaunchplaneServiceTests(unittest.TestCase):
             "https://github.com/cbusillo/code/pull/71",
         )
 
+    def test_every_code_pull_request_close_matches_all_linked_issue_urls(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main"
+                        ],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["every_code_work_request.read"],
+                    }
+                ]
+            }
+        )
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
+            event_name="workflow_dispatch",
+        )
+        pr_payload = _every_code_github_pull_request_closed_payload(
+            pr_number=71,
+            body="Closes #64, closes #65",
+        )
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(identity),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            for issue_number in (64, 65):
+                issue_payload = _every_code_github_issue_labeled_payload(issue_number=issue_number)
+                _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/every-code/github-webhook",
+                    payload=issue_payload,
+                    authorization="",
+                    headers={
+                        "X-GitHub-Event": "issues",
+                        "X-GitHub-Delivery": f"delivery-multi-close-{issue_number}",
+                        "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                    },
+                )
+
+            close_status, close_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=pr_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "pull_request",
+                    "X-GitHub-Delivery": "delivery-multi-close-pr",
+                    "X-Hub-Signature-256": _github_webhook_signature(pr_payload, secret),
+                },
+            )
+            list_status, list_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/every-code/work-requests",
+                authorization="Bearer dev-worker-token",
+            )
+
+        self.assertEqual(close_status, 202)
+        self.assertEqual(close_payload["result"]["closed_count"], 2)
+        closed_requests = close_payload["result"]["requests"]
+        self.assertEqual({request["issue_number"] for request in closed_requests}, {64, 65})
+        self.assertTrue(all(request["state"] == "done" for request in closed_requests))
+        self.assertTrue(
+            all(
+                request["claimed_by_host"] == "github-pull-request-close"
+                for request in closed_requests
+            )
+        )
+        self.assertEqual(list_status, 200)
+        self.assertEqual(
+            {request["state"] for request in list_payload["requests"]},
+            {"done"},
+        )
+
     def test_every_code_pull_request_close_does_not_match_issue_by_pr_number(self) -> None:
         secret = "launchplane-every-code-webhook-secret"
         policy = LaunchplaneAuthzPolicy.model_validate(
@@ -2531,6 +2625,42 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 401)
         self.assertEqual(payload["error"]["code"], "authentication_required")
+
+    def test_every_code_worker_reads_reject_negative_offsets(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "worker-token"},
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            work_status, work_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/every-code/work-requests",
+                query_string="offset=-1",
+                authorization="Bearer worker-token",
+            )
+            feedback_status, feedback_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/every-code/pr-feedback",
+                query_string="offset=-1",
+                authorization="Bearer worker-token",
+            )
+
+        self.assertEqual(work_status, 400)
+        self.assertEqual(work_payload["error"]["code"], "invalid_payload")
+        self.assertIn("offset must be non-negative", work_payload["error"]["message"])
+        self.assertEqual(feedback_status, 400)
+        self.assertEqual(feedback_payload["error"]["code"], "invalid_payload")
+        self.assertIn("offset must be non-negative", feedback_payload["error"]["message"])
 
     def test_every_code_work_request_create_rejects_unauthorized_identity(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- close every Every Code request linked by a pull-request close event instead of stopping at the first match
- terminalize still-queued PR-close matches with service-owned claim metadata so records satisfy the terminal-state contract
- reject negative Every Code worker pagination offsets and wrap API-backed rerun input failures as ClickExceptions
- document the pull-request close webhook semantics

## Validation
- `uv run --extra dev ruff format --check control_plane/contracts/every_code_work_request.py control_plane/service.py control_plane/cli.py tests/test_every_code_work_request.py tests/test_every_code_reconciliation.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/contracts/every_code_work_request.py control_plane/service.py control_plane/cli.py tests/test_every_code_work_request.py tests/test_every_code_reconciliation.py tests/test_service.py`
- `git diff --check`
- `uv run python -m unittest tests.test_every_code_work_request tests.test_every_code_reconciliation tests.test_service.LaunchplaneServiceTests.test_every_code_pull_request_close_matches_issue_url_without_result_pr_url tests.test_service.LaunchplaneServiceTests.test_every_code_pull_request_close_matches_all_linked_issue_urls tests.test_service.LaunchplaneServiceTests.test_every_code_worker_reads_reject_negative_offsets`
- `uv run python -m unittest tests.test_service tests.test_every_code_work_request tests.test_every_code_reconciliation`
- `uv run python -m unittest`
