### PR TITLE
feat(every-code): pass session origin to Code

### DIFF
--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -618,7 +618,18 @@ def build_every_code_session_command(
     finish_shell = " ".join(
         "$status" if part == "$status" else shlex.quote(part) for part in finish_command
     )
-    return f"{command}\nstatus=$?\n{finish_shell}\nexit $status"
+    session_env = {
+        "EVERY_CODE_SESSION_ORIGIN": "every_code",
+        "EVERY_CODE_REQUEST_ID": record.request_id,
+        "EVERY_CODE_REPOSITORY": record.repository,
+        "EVERY_CODE_ISSUE_NUMBER": str(record.issue_number),
+        "EVERY_CODE_ISSUE_URL": record.issue_url,
+    }
+    env_shell = " ".join(
+        f"{key}={shlex.quote(value)}" for key, value in session_env.items() if value
+    )
+    session_command = f"{env_shell} {command}" if env_shell else command
+    return f"{session_command}\nstatus=$?\n{finish_shell}\nexit $status"
 
 
 def build_every_code_feedback_session_command(
@@ -1651,7 +1662,10 @@ def _send_every_code_pr_feedback_to_session(
 ) -> bool:
     prompt = every_code_pr_feedback_prompt(feedback)
     try:
-        result = runner((tmux_binary, "send-keys", "-t", session_name, prompt, "C-m"))
+        result = runner((tmux_binary, "send-keys", "-t", session_name, prompt))
+        if result.returncode != 0:
+            return False
+        result = runner((tmux_binary, "send-keys", "-t", session_name, "C-m"))
     except OSError:
         return False
     return result.returncode == 0

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -522,6 +522,11 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertIn("--worker-token-env LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN", command)
         self.assertIn("--request-id every-code-cbusillo-code-123-test", command)
         self.assertIn("--exit-code $status", command)
+        self.assertIn("EVERY_CODE_SESSION_ORIGIN=every_code", command)
+        self.assertIn("EVERY_CODE_REQUEST_ID=every-code-cbusillo-code-123-test", command)
+        self.assertIn("EVERY_CODE_REPOSITORY=cbusillo/code", command)
+        self.assertIn("EVERY_CODE_ISSUE_NUMBER=123", command)
+        self.assertIn("EVERY_CODE_ISSUE_URL=https://github.com/cbusillo/code/issues/123", command)
 
     def test_preview_label_request_labels_eligible_pull_request(self) -> None:
         runner = _Runner()
@@ -751,9 +756,11 @@ class EveryCodeWorkerTests(unittest.TestCase):
 
         self.assertEqual(result.status, "applied")
         self.assertEqual(feedback.status, "applied")
-        send_call = next(call for call in runner.calls if call[1] == "send-keys")
-        self.assertIn("Please tighten the README wording", send_call[4])
-        self.assertEqual(send_call[-1], "C-m")
+        send_calls = [call for call in runner.calls if call[1] == "send-keys"]
+        self.assertEqual(len(send_calls), 2)
+        self.assertIn("Please tighten the README wording", send_calls[0][4])
+        self.assertEqual(send_calls[0][-1], send_calls[0][4])
+        self.assertEqual(send_calls[1][-1], "C-m")
         reaction_calls = [
             call
             for call in runner.calls


### PR DESCRIPTION
## Summary
- launch Every Code sessions with structured origin environment variables
- include request/repository/issue metadata for Code remote inbox hello payloads
- send PR feedback prompts and submit key as separate tmux events so feedback actually executes

Refs cbusillo/launchplane#327.

## Validation
- uv run python -m unittest tests.test_every_code_worker.EveryCodeWorkerTests.test_apply_feedback_sends_prompt_to_active_session tests.test_every_code_worker.EveryCodeWorkerTests.test_apply_feedback_reacts_when_active_session_send_fails
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest tests.test_every_code_worker