### PR TITLE
Add service-first authz grant workflow

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -375,6 +375,9 @@ jobs:
                 '{
                   schema_version: 1,
                   product: "launchplane",
+                  mode: "apply",
+                  reason: ("Deploy workflow ensuring authz grant " + $source_label),
+                  related_issue: "cbusillo/launchplane#83",
                   grant: {
                     repository: $repository,
                     workflow_refs: [$workflow_ref],

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -6199,6 +6199,59 @@ def _load_json_file(input_file: Path) -> dict[str, object]:
     return payload
 
 
+def _post_launchplane_service_json(
+    *,
+    service_url: str,
+    path: str,
+    payload: dict[str, object],
+    bearer_token: str = "",
+    session_cookie: str = "",
+    idempotency_key: str = "",
+) -> dict[str, object]:
+    if bool(bearer_token.strip()) == bool(session_cookie.strip()):
+        raise click.ClickException("Provide exactly one of bearer token or session cookie.")
+    normalized_service_url = service_url.strip().rstrip("/")
+    if not normalized_service_url:
+        raise click.ClickException("Launchplane service URL is required.")
+    body = json.dumps(payload).encode("utf-8")
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+    if bearer_token.strip():
+        headers["Authorization"] = f"Bearer {bearer_token.strip()}"
+    else:
+        headers["Cookie"] = session_cookie.strip()
+    if idempotency_key.strip():
+        headers["Idempotency-Key"] = idempotency_key.strip()
+    request = Request(
+        f"{normalized_service_url}{path}",
+        data=body,
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            response_payload = json.loads(response.read().decode("utf-8"))
+    except HTTPError as error:
+        response_text = error.read().decode("utf-8", errors="replace")
+        try:
+            error_payload = json.loads(response_text)
+        except JSONDecodeError:
+            error_payload = {"error": {"message": response_text.strip()}}
+        error_detail = error_payload.get("error") if isinstance(error_payload, dict) else None
+        error_message = error_detail.get("message", "") if isinstance(error_detail, dict) else ""
+        message = str(error_message or f"Launchplane service returned HTTP {error.code}.")
+        raise click.ClickException(message) from error
+    except (URLError, TimeoutError) as error:
+        raise click.ClickException(f"Launchplane service request failed: {error}") from error
+    except JSONDecodeError as error:
+        raise click.ClickException("Launchplane service response was not valid JSON.") from error
+    if not isinstance(response_payload, dict):
+        raise click.ClickException("Launchplane service response was not a JSON object.")
+    return cast(dict[str, object], response_payload)
+
+
 def _load_github_webhook_json_bytes(
     raw_payload_bytes: bytes,
     *,
@@ -12794,6 +12847,110 @@ def authz_policies_import_toml(database_url: str, policy_file: Path, source_labe
             sort_keys=True,
         )
     )
+
+
+@authz_policies.command("grant-workflow")
+@click.option(
+    "--service-url",
+    required=True,
+    help="Deployed Launchplane service base URL. Shared/prod grants go through the service API.",
+)
+@click.option(
+    "--bearer-token-env",
+    default="LAUNCHPLANE_SERVICE_TOKEN",
+    show_default=True,
+    help="Environment variable containing a short-lived bearer token for the service.",
+)
+@click.option(
+    "--session-cookie",
+    default="",
+    help="Launchplane browser session cookie. Use instead of --bearer-token-env.",
+)
+@click.option("--repository", required=True, help="GitHub owner/repo grant target.")
+@click.option(
+    "--workflow-ref", "workflow_refs", multiple=True, help="Allowed workflow_ref pattern."
+)
+@click.option(
+    "--job-workflow-ref",
+    "job_workflow_refs",
+    multiple=True,
+    help="Allowed job_workflow_ref pattern.",
+)
+@click.option("--event-name", "event_names", multiple=True, help="Allowed GitHub event name.")
+@click.option("--ref", "refs", multiple=True, help="Allowed Git ref.")
+@click.option("--environment", "environments", multiple=True, help="Allowed GitHub environment.")
+@click.option("--product", "products", multiple=True, required=True, help="Allowed product.")
+@click.option("--context", "contexts", multiple=True, help="Allowed Launchplane context.")
+@click.option(
+    "--action", "actions", multiple=True, required=True, help="Allowed Launchplane action."
+)
+@click.option("--reason", default="", help="Required audit reason when --apply is used.")
+@click.option(
+    "--related-issue",
+    default="",
+    help="Optional related GitHub issue, e.g. cbusillo/launchplane#83.",
+)
+@click.option("--source-label", default="cli:authz-grant-workflow", show_default=True)
+@click.option(
+    "--idempotency-key", default="", help="Optional explicit Idempotency-Key for apply requests."
+)
+@click.option("--dry-run", "mode", flag_value="dry_run", default="dry_run")
+@click.option("--apply", "mode", flag_value="apply")
+def authz_policies_grant_workflow(
+    service_url: str,
+    bearer_token_env: str,
+    session_cookie: str,
+    repository: str,
+    workflow_refs: tuple[str, ...],
+    job_workflow_refs: tuple[str, ...],
+    event_names: tuple[str, ...],
+    refs: tuple[str, ...],
+    environments: tuple[str, ...],
+    products: tuple[str, ...],
+    contexts: tuple[str, ...],
+    actions: tuple[str, ...],
+    reason: str,
+    related_issue: str,
+    source_label: str,
+    idempotency_key: str,
+    mode: str,
+) -> None:
+    bearer_token = ""
+    if not session_cookie.strip():
+        token_env_key = bearer_token_env.strip() or "LAUNCHPLANE_SERVICE_TOKEN"
+        bearer_token = os.environ.get(token_env_key, "").strip()
+        if not bearer_token:
+            raise click.ClickException(
+                f"{token_env_key} is required unless --session-cookie is provided."
+            )
+    payload = {
+        "schema_version": 1,
+        "product": "launchplane",
+        "mode": mode,
+        "reason": reason,
+        "related_issue": related_issue,
+        "grant": {
+            "repository": repository,
+            "workflow_refs": list(workflow_refs),
+            "job_workflow_refs": list(job_workflow_refs),
+            "event_names": list(event_names),
+            "refs": list(refs),
+            "environments": list(environments),
+            "products": list(products),
+            "contexts": list(contexts),
+            "actions": list(actions),
+            "source_label": source_label,
+        },
+    }
+    response_payload = _post_launchplane_service_json(
+        service_url=service_url,
+        path="/v1/authz-policies/github-actions/grants",
+        payload=payload,
+        bearer_token=bearer_token,
+        session_cookie=session_cookie,
+        idempotency_key=idempotency_key,
+    )
+    click.echo(json.dumps(response_payload, indent=2, sort_keys=True))
 
 
 @runtime_key_safety.command("list-policies")

--- a/control_plane/contracts/authz_policy_record.py
+++ b/control_plane/contracts/authz_policy_record.py
@@ -32,6 +32,7 @@ class LaunchplaneAuthzPolicyRecord(BaseModel):
     updated_at: str
     policy_sha256: str = Field(default="")
     policy: LaunchplaneAuthzPolicy
+    audit: dict[str, object] = Field(default_factory=dict)
 
     @model_validator(mode="after")
     def _validate_record(self) -> "LaunchplaneAuthzPolicyRecord":

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1156,6 +1156,7 @@ _HUMAN_IDENTITY_MUTATION_ROUTES = frozenset(
     {
         _GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path,
         _GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.route_path,
+        "/v1/authz-policies/github-actions/grants",
     }
 )
 _HUMAN_IDENTITY_READ_MODEL_POST_ROUTES = frozenset({"/v1/work-graph/rank"})
@@ -1368,6 +1369,9 @@ class AuthzPolicyGitHubActionsGrantEnvelope(BaseModel):
 
     schema_version: int = Field(default=1, ge=1)
     product: str
+    mode: Literal["dry_run", "apply"] = "apply"
+    reason: str = ""
+    related_issue: str = ""
     grant: AuthzPolicyGitHubActionsGrant
 
     @model_validator(mode="after")
@@ -1375,6 +1379,10 @@ class AuthzPolicyGitHubActionsGrantEnvelope(BaseModel):
         if self.product.strip() != "launchplane":
             raise ValueError("Authz policy grant writes require product 'launchplane'.")
         self.product = "launchplane"
+        self.reason = self.reason.strip()
+        self.related_issue = self.related_issue.strip()
+        if self.mode == "apply" and not self.reason:
+            raise ValueError("Authz policy grant apply requires reason.")
         return self
 
 
@@ -2852,6 +2860,12 @@ def _should_store_idempotency_record(
 ) -> bool:
     if path in _NON_IDEMPOTENT_DRIVER_RESULT_ROUTES:
         return False
+    if (
+        path == "/v1/authz-policies/github-actions/grants"
+        and isinstance(driver_result, dict)
+        and driver_result.get("mode") == "dry_run"
+    ):
+        return False
     if driver_result is None:
         return True
     if _driver_result_contains_status(driver_result, "blocked"):
@@ -3460,19 +3474,131 @@ def _summarize_authz_policy_record(record: LaunchplaneAuthzPolicyRecord) -> dict
     }
 
 
-def _write_github_actions_authz_policy_grant(
+def _authz_policy_operator_payload(identity: LaunchplaneIdentity) -> dict[str, object]:
+    if isinstance(identity, GitHubHumanIdentity):
+        return {
+            "type": "github_human",
+            "login": identity.login,
+            "role": identity.role,
+        }
+    return {
+        "type": "github_actions",
+        "repository": identity.repository,
+        "workflow_ref": identity.workflow_ref,
+        "event_name": identity.event_name,
+        "ref": identity.ref,
+        "sha": identity.sha,
+    }
+
+
+def _authz_policy_grant_diff(
+    *, current_policy: LaunchplaneAuthzPolicy, grant: AuthzPolicyGitHubActionsGrant
+) -> dict[str, object]:
+    desired_rule = grant.to_policy_rule()
+    changed = not any(rule == desired_rule for rule in current_policy.github_actions)
+    return {
+        "changed": changed,
+        "previous_github_actions_rule_count": len(current_policy.github_actions),
+        "new_github_actions_rule_count": len(current_policy.github_actions) + int(changed),
+    }
+
+
+def _authz_policy_grant_audit_payload(
+    *,
+    request: AuthzPolicyGitHubActionsGrantEnvelope,
+    identity: LaunchplaneIdentity,
+    previous_record: LaunchplaneAuthzPolicyRecord,
+    new_record: LaunchplaneAuthzPolicyRecord | None,
+    changed: bool,
+    trace_id: str,
+) -> dict[str, object]:
+    return {
+        "mode": request.mode,
+        "reason": request.reason,
+        "related_issue": request.related_issue,
+        "operator": _authz_policy_operator_payload(identity),
+        "requested_grant": request.grant.to_policy_rule().model_dump(mode="json"),
+        "previous_policy_record_id": previous_record.record_id,
+        "previous_policy_sha256": previous_record.policy_sha256,
+        "new_policy_record_id": new_record.record_id
+        if new_record is not None
+        else previous_record.record_id,
+        "new_policy_sha256": new_record.policy_sha256
+        if new_record is not None
+        else previous_record.policy_sha256,
+        "changed": changed,
+        "trace_id": trace_id,
+        "updated_at": new_record.updated_at if new_record is not None else _now_timestamp(),
+    }
+
+
+def _authz_policy_grant_response_audit_payload(
+    audit: dict[str, object],
+) -> dict[str, object]:
+    response_audit = dict(audit)
+    requested_grant = response_audit.pop("requested_grant", None)
+    if isinstance(requested_grant, dict):
+        response_audit["requested_grant_summary"] = {
+            "repository": requested_grant.get("repository", ""),
+            "workflow_ref_count": len(requested_grant.get("workflow_refs") or ()),
+            "job_workflow_ref_count": len(requested_grant.get("job_workflow_refs") or ()),
+            "event_names": requested_grant.get("event_names") or (),
+            "products": requested_grant.get("products") or (),
+            "contexts": requested_grant.get("contexts") or (),
+            "actions": requested_grant.get("actions") or (),
+        }
+    return response_audit
+
+
+def _plan_github_actions_authz_policy_grant(
     *,
     record_store: PostgresRecordStore,
     grant: AuthzPolicyGitHubActionsGrant,
-) -> tuple[LaunchplaneAuthzPolicy, LaunchplaneAuthzPolicyRecord, bool]:
+) -> tuple[LaunchplaneAuthzPolicy, LaunchplaneAuthzPolicyRecord, dict[str, object]]:
     active_records = record_store.list_authz_policy_records(status="active", limit=1)
     if not active_records:
         raise ValueError("No active Launchplane authz policy record found.")
-    current_policy = active_records[0].policy
-    desired_rule = grant.to_policy_rule()
-    changed = not any(rule == desired_rule for rule in current_policy.github_actions)
+    current_record = active_records[0]
+    current_policy = current_record.policy
+    return (
+        current_policy,
+        current_record,
+        _authz_policy_grant_diff(
+            current_policy=current_policy,
+            grant=grant,
+        ),
+    )
+
+
+def _write_github_actions_authz_policy_grant(
+    *,
+    record_store: PostgresRecordStore,
+    request: AuthzPolicyGitHubActionsGrantEnvelope,
+    identity: LaunchplaneIdentity,
+    trace_id: str,
+) -> tuple[
+    LaunchplaneAuthzPolicy,
+    LaunchplaneAuthzPolicyRecord,
+    bool,
+    dict[str, object],
+    dict[str, object],
+]:
+    current_policy, current_record, diff = _plan_github_actions_authz_policy_grant(
+        record_store=record_store,
+        grant=request.grant,
+    )
+    changed = bool(diff["changed"])
+    desired_rule = request.grant.to_policy_rule()
     if not changed:
-        return current_policy, active_records[0], False
+        audit = _authz_policy_grant_audit_payload(
+            request=request,
+            identity=identity,
+            previous_record=current_record,
+            new_record=None,
+            changed=False,
+            trace_id=trace_id,
+        )
+        return current_policy, current_record, False, diff, audit
 
     updated_policy = current_policy.model_copy(
         update={"github_actions": current_policy.github_actions + (desired_rule,)}
@@ -3485,13 +3611,29 @@ def _write_github_actions_authz_policy_grant(
             policy_sha256=policy_sha256,
         ),
         status="active",
-        source=grant.source_label,
+        source=request.grant.source_label,
         updated_at=updated_at,
         policy_sha256=policy_sha256,
         policy=updated_policy,
+        audit=_authz_policy_grant_audit_payload(
+            request=request,
+            identity=identity,
+            previous_record=current_record,
+            new_record=None,
+            changed=True,
+            trace_id=trace_id,
+        ),
+    )
+    record.audit = _authz_policy_grant_audit_payload(
+        request=request,
+        identity=identity,
+        previous_record=current_record,
+        new_record=record,
+        changed=True,
+        trace_id=trace_id,
     )
     record_store.write_authz_policy_record(record)
-    return updated_policy, record, changed
+    return updated_policy, record, changed, diff, record.audit
 
 
 def _summarize_runtime_key_safety_policy_record(
@@ -5672,24 +5814,57 @@ def create_launchplane_service_app(
                             },
                         },
                     )
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                try:
-                    updated_policy, authz_policy_record, changed = (
-                        _write_github_actions_authz_policy_grant(
-                            record_store=record_store,
-                            grant=authz_grant_request.grant,
-                        )
+                if authz_grant_request.mode == "apply":
+                    idempotent_response = _check_idempotent_request(
+                        record_store=record_store,
+                        scope=request_scope,
+                        route_path=path,
+                        idempotency_key=request_idempotency_key,
+                        request_fingerprint=request_fingerprint,
+                        start_response=start_response,
+                        trace_id=request_trace_id,
                     )
+                    if idempotent_response is not None:
+                        return idempotent_response
+                try:
+                    current_policy, current_record, diff = _plan_github_actions_authz_policy_grant(
+                        record_store=record_store,
+                        grant=authz_grant_request.grant,
+                    )
+                    audit = _authz_policy_grant_audit_payload(
+                        request=authz_grant_request,
+                        identity=identity,
+                        previous_record=current_record,
+                        new_record=None,
+                        changed=bool(diff["changed"]),
+                        trace_id=request_trace_id,
+                    )
+                    authz_policy_record = current_record
+                    changed = bool(diff["changed"])
+                    if authz_grant_request.mode == "apply":
+                        (
+                            updated_policy,
+                            authz_policy_record,
+                            changed,
+                            diff,
+                            audit,
+                        ) = _write_github_actions_authz_policy_grant(
+                            record_store=record_store,
+                            request=authz_grant_request,
+                            identity=identity,
+                            trace_id=request_trace_id,
+                        )
+                    else:
+                        updated_policy = current_policy
+                        authz_policy_record = LaunchplaneAuthzPolicyRecord(
+                            record_id=current_record.record_id,
+                            status=current_record.status,
+                            source=current_record.source,
+                            updated_at=current_record.updated_at,
+                            policy_sha256=current_record.policy_sha256,
+                            policy=current_record.policy,
+                            audit=audit,
+                        )
                 except ValueError:
                     return _json_response(
                         start_response=start_response,
@@ -5703,9 +5878,10 @@ def create_launchplane_service_app(
                             },
                         },
                     )
-                authz_policy = updated_policy
-                resolved_authz_policy_sha256 = authz_policy_record.policy_sha256
-                resolved_authz_policy_source = "db"
+                if authz_grant_request.mode == "apply":
+                    authz_policy = updated_policy
+                    resolved_authz_policy_sha256 = authz_policy_record.policy_sha256
+                    resolved_authz_policy_source = "db"
                 result = {
                     "authz_policy_record_id": authz_policy_record.record_id,
                     "authz_policy_changed": str(changed).lower(),
@@ -5713,6 +5889,9 @@ def create_launchplane_service_app(
                 driver_result = {
                     "authz_policy": _summarize_authz_policy_record(authz_policy_record),
                     "changed": changed,
+                    "mode": authz_grant_request.mode,
+                    "diff": diff,
+                    "audit": _authz_policy_grant_response_audit_payload(audit),
                 }
             elif path == "/v1/runtime-key-safety/policies/apply":
                 runtime_policy_request = RuntimeKeySafetyPolicyApplyEnvelope.model_validate(payload)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -114,6 +114,15 @@ The service uses GitHub OIDC bearer tokens and DB-backed authz policy records.
 Additional evidence routes should land against the same authn/authz boundary
 rather than creating separate ad hoc ingress patterns.
 
+Operators should mutate shared or production authz through the deployed service,
+not by running arbitrary local DB writes from a checkout. Use
+`uv run launchplane authz-policies grant-workflow --service-url ... --dry-run`
+to inspect the diff, then rerun with `--apply --reason ...` and an idempotency
+key when the grant is approved. The CLI is a thin service client: it sends a
+short-lived bearer token or a Launchplane browser session cookie, and the
+service validates the caller, writes any new active policy record, stores audit
+metadata, and reloads the current service worker's active policy.
+
 The deploy workflow maintains DB-backed grants for SellYourOutboard operational
 workflows, including product profile cutover reads/writes, production promotion,
 and generic-web preview refresh/destroy requests. The grant request returns only

--- a/docs/records.md
+++ b/docs/records.md
@@ -94,9 +94,13 @@ an ORM column/table or remains only in the evidence payload.
   `artifact_id`, `minted_at`, and `provenance`. Repo SHA maps and source
   provenance details stay payload-only.
 - Authz policy: modeled fields are `record_id`, `status`, `source`,
-  `updated_at`, and `policy_sha256`. The parsed GitHub Actions and human grant
-  policy stays payload-only until Launchplane needs per-rule filtering or
-  browser-side policy editing.
+  `updated_at`, `policy_sha256`, and optional service-owned `audit` metadata.
+  The parsed GitHub Actions and human grant policy stays payload-only until
+  Launchplane needs per-rule filtering or browser-side policy editing. Authz
+  grant audit metadata records the operator identity, reason, related issue,
+  previous/new policy ids and shas, trace id, mode, and requested grant details;
+  service responses redact that requested-grant detail to counts and scope
+  summaries.
 - Dokploy target id: modeled fields are `context`, `instance`, `target_id`, and
   `updated_at`. Provider lookup/import evidence stays payload-only.
 - Dokploy target: modeled fields are `context`, `instance`, and `updated_at`.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -94,9 +94,15 @@ Launchplane verifies GitHub OIDC, authorizes workflow identity claims, accepts
 deployment/promotion/preview lifecycle evidence over HTTP, and executes the
 current Odoo/VeriReel artifact, deploy, backup, promotion, rollback, maintenance,
 and preview mutations as authenticated Launchplane routes. The authz policy
-grant route is reserved for Launchplane-owned deployment workflows, requires the
-`launchplane_service_deploy.execute` action, writes DB-backed GitHub Actions
-policy rules, and returns only record metadata and rule counts.
+grant route accepts GitHub Actions OIDC callers and authenticated admin human
+sessions, requires the `launchplane_service_deploy.execute` action, and remains
+the service-owned write/reload boundary for DB-backed GitHub Actions policy
+rules. Grant requests support `dry_run` and `apply` modes. Apply requests must
+include an audit reason, write a new active policy record only when the grant is
+not already present, and immediately refresh the in-process policy used by the
+current service worker. Responses return record metadata, rule counts, a compact
+diff, and redacted audit metadata rather than echoing workflow refs or the full
+policy body.
 
 The service also serves the built operator UI shell at `/`, with `/ui` retained
 as a compatibility alias. Built assets live under `/ui/assets/...`, while

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -382,6 +382,7 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
                 {
                     control_plane_service._GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path,
                     control_plane_service._GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.route_path,
+                    "/v1/authz-policies/github-actions/grants",
                 }
             ),
         )

--- a/tests/test_every_code_reconciliation.py
+++ b/tests/test_every_code_reconciliation.py
@@ -20,6 +20,85 @@ from control_plane.storage.filesystem import FilesystemRecordStore
 
 
 class EveryCodeIssueReconciliationTests(unittest.TestCase):
+    def test_cli_authz_grant_workflow_posts_service_dry_run_request(self) -> None:
+        runner = CliRunner()
+        captured_request: dict[str, object] = {}
+
+        def fake_post(**kwargs: object) -> dict[str, object]:
+            captured_request.update(kwargs)
+            return {
+                "status": "accepted",
+                "result": {"mode": "dry_run", "changed": True},
+            }
+
+        with (
+            patch.dict(os.environ, {"LAUNCHPLANE_SERVICE_TOKEN": "service-token"}),
+            patch("control_plane.cli._post_launchplane_service_json", side_effect=fake_post),
+        ):
+            result = runner.invoke(
+                main,
+                [
+                    "authz-policies",
+                    "grant-workflow",
+                    "--service-url",
+                    "https://launchplane.example",
+                    "--repository",
+                    "cbusillo/launchplane",
+                    "--workflow-ref",
+                    "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main",
+                    "--event-name",
+                    "workflow_dispatch",
+                    "--product",
+                    "sellyouroutboard",
+                    "--context",
+                    "launchplane",
+                    "--action",
+                    "product_profile.read",
+                    "--reason",
+                    "Inspect grant before apply.",
+                    "--related-issue",
+                    "cbusillo/launchplane#83",
+                    "--dry-run",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(captured_request["bearer_token"], "service-token")
+        self.assertEqual(captured_request["session_cookie"], "")
+        self.assertEqual(captured_request["path"], "/v1/authz-policies/github-actions/grants")
+        payload = captured_request["payload"]
+        assert isinstance(payload, dict)
+        self.assertEqual(payload["mode"], "dry_run")
+        self.assertEqual(payload["reason"], "Inspect grant before apply.")
+        grant = payload["grant"]
+        assert isinstance(grant, dict)
+        self.assertEqual(grant["repository"], "cbusillo/launchplane")
+        self.assertEqual(grant["actions"], ["product_profile.read"])
+        response_payload = json.loads(result.output)
+        self.assertEqual(response_payload["result"]["mode"], "dry_run")
+
+    def test_cli_authz_grant_workflow_requires_one_auth_source(self) -> None:
+        runner = CliRunner()
+
+        result = runner.invoke(
+            main,
+            [
+                "authz-policies",
+                "grant-workflow",
+                "--service-url",
+                "https://launchplane.example",
+                "--repository",
+                "cbusillo/launchplane",
+                "--product",
+                "launchplane",
+                "--action",
+                "product_profile.read",
+            ],
+        )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("LAUNCHPLANE_SERVICE_TOKEN is required", result.output)
+
     def test_creates_queued_request_when_trigger_label_is_present(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             store = FilesystemRecordStore(state_dir=Path(tempdir))

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -7592,6 +7592,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 payload={
                     "schema_version": 1,
                     "product": "launchplane",
+                    "mode": "apply",
+                    "reason": "Grant product profile read for SYO promotion diagnostics.",
+                    "related_issue": "cbusillo/launchplane#83",
                     "grant": {
                         "repository": "cbusillo/launchplane",
                         "workflow_refs": [
@@ -7628,6 +7631,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 payload={
                     "schema_version": 1,
                     "product": "launchplane",
+                    "mode": "apply",
+                    "reason": "Grant product profile read for SYO promotion diagnostics.",
+                    "related_issue": "cbusillo/launchplane#83",
                     "grant": {
                         "repository": "cbusillo/launchplane",
                         "workflow_refs": [
@@ -7646,6 +7652,17 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 202)
         self.assertEqual(payload["records"]["authz_policy_record_id"], active_policy.record_id)
         self.assertEqual(payload["result"]["changed"], True)
+        self.assertEqual(payload["result"]["mode"], "apply")
+        self.assertEqual(payload["result"]["audit"]["related_issue"], "cbusillo/launchplane#83")
+        self.assertEqual(
+            active_policy.audit["reason"],
+            "Grant product profile read for SYO promotion diagnostics.",
+        )
+        self.assertIn("workflow_refs", json.dumps(active_policy.audit, sort_keys=True))
+        actions_operator = active_policy.audit["operator"]
+        self.assertIsInstance(actions_operator, dict)
+        assert isinstance(actions_operator, dict)
+        self.assertEqual(actions_operator["type"], "github_actions")
         self.assertNotIn("workflow_refs", json.dumps(payload, sort_keys=True))
         self.assertEqual(profile_status_code, 200)
         self.assertEqual(profile_payload["profile"]["product"], "sellyouroutboard")
@@ -7654,6 +7671,220 @@ class LaunchplaneServiceTests(unittest.TestCase):
             repeat_payload["records"]["authz_policy_record_id"], active_policy.record_id
         )
         self.assertEqual(repeat_payload["result"]["changed"], False)
+
+    def test_authz_policy_grant_endpoint_dry_run_does_not_write_or_reload(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["launchplane_service_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/authz-policies/github-actions/grants",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "mode": "dry_run",
+                    "reason": "Inspect whether product profile read grant is needed.",
+                    "related_issue": "cbusillo/launchplane#83",
+                    "grant": {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                        ],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["sellyouroutboard"],
+                        "contexts": ["launchplane"],
+                        "actions": ["product_profile.read"],
+                        "source_label": "test:dry-run-grant",
+                    },
+                },
+                headers={"Idempotency-Key": "authz-grant:dry-run"},
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                active_records = store.list_authz_policy_records(status="active")
+                dry_run_idempotency_record = store.read_idempotency_record(
+                    scope=(
+                        "cbusillo/launchplane|"
+                        "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main|"
+                        "repo:every/verireel:pull_request"
+                    ),
+                    route_path="/v1/authz-policies/github-actions/grants",
+                    idempotency_key="authz-grant:dry-run",
+                )
+                store.write_product_profile_record(
+                    LaunchplaneProductProfileRecord.model_validate(
+                        _product_profile_payload_with_prod()
+                    )
+                )
+            finally:
+                store.close()
+            profile_status_code, profile_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/product-profiles/sellyouroutboard",
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "dry_run")
+        self.assertEqual(payload["result"]["changed"], True)
+        self.assertEqual(payload["result"]["diff"]["new_github_actions_rule_count"], 2)
+        self.assertEqual(payload["result"]["audit"]["mode"], "dry_run")
+        self.assertNotIn("requested_grant", payload["result"]["audit"])
+        self.assertEqual(
+            payload["result"]["audit"]["requested_grant_summary"]["workflow_ref_count"],
+            1,
+        )
+        self.assertEqual(len(active_records), 1)
+        self.assertIsNone(dry_run_idempotency_record)
+        self.assertEqual(profile_status_code, 403)
+        self.assertEqual(profile_payload["error"]["code"], "authorization_denied")
+
+    def test_authz_policy_grant_endpoint_allows_admin_human_session(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_humans": [
+                        {
+                            "logins": ["alice"],
+                            "roles": ["admin"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["launchplane_service_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=_StubGitHubOAuthClient(_human_identity(role="admin")),  # type: ignore[arg-type]
+            )
+            cookie = _signed_in_cookie(app)
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/authz-policies/github-actions/grants",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "mode": "apply",
+                    "reason": "Allow product profile reads for operator diagnostics.",
+                    "related_issue": "cbusillo/launchplane#83",
+                    "grant": {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                        ],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["sellyouroutboard"],
+                        "contexts": ["launchplane"],
+                        "actions": ["product_profile.read"],
+                        "source_label": "test:human-grant",
+                    },
+                },
+                authorization="",
+                headers={
+                    "Cookie": cookie,
+                    "Idempotency-Key": "authz-grant:human-admin",
+                },
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                active_policy = store.list_authz_policy_records(status="active", limit=1)[0]
+            finally:
+                store.close()
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["changed"], True)
+        self.assertEqual(payload["result"]["audit"]["operator"]["type"], "github_human")
+        self.assertEqual(payload["result"]["audit"]["operator"]["login"], "alice")
+        human_operator = active_policy.audit["operator"]
+        self.assertIsInstance(human_operator, dict)
+        assert isinstance(human_operator, dict)
+        self.assertEqual(human_operator["type"], "github_human")
+
+    def test_authz_policy_grant_endpoint_apply_requires_reason(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "actions": ["launchplane_service_deploy.execute"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/authz-policies/github-actions/grants",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "mode": "apply",
+                    "grant": {
+                        "repository": "cbusillo/launchplane",
+                        "actions": ["product_profile.read"],
+                    },
+                },
+                headers={"Idempotency-Key": "authz-grant:no-reason"},
+            )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_request")
 
     def test_authz_policy_grant_endpoint_rejects_without_self_deploy_permission(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -7692,6 +7923,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 payload={
                     "schema_version": 1,
                     "product": "launchplane",
+                    "mode": "apply",
+                    "reason": "Attempt unauthorized grant.",
                     "grant": {
                         "repository": "cbusillo/launchplane",
                         "actions": ["product_profile.read"],


### PR DESCRIPTION
## Summary
- adds service-owned dry-run/apply semantics for GitHub Actions authz policy grants
- records audit metadata for applied authz policy records and redacts grant details from service responses
- allows authenticated admin human sessions to call the grant route, while preserving policy checks
- adds `authz-policies grant-workflow` as a thin service client for operator use
- updates deploy workflow grant calls to provide audit reasons and documents the service-first workflow

Refs #83

## Validation
- `uv run --extra dev ruff format --check control_plane/contracts/authz_policy_record.py control_plane/service.py control_plane/cli.py tests/test_service.py tests/test_every_code_reconciliation.py tests/test_driver_descriptors.py`
- `uv run --extra dev ruff check control_plane/contracts/authz_policy_record.py control_plane/service.py control_plane/cli.py tests/test_service.py tests/test_every_code_reconciliation.py tests/test_driver_descriptors.py`
- `git diff --check`
- `uv run python -m unittest tests.test_service tests.test_every_code_reconciliation tests.test_driver_descriptors tests.test_postgres_store tests.test_filesystem_store`
- `uv run python -m unittest`
