### PR TITLE
fix(every-code): close sessions when source issue closes

### DIFF
--- a/control_plane/contracts/every_code_work_request.py
+++ b/control_plane/contracts/every_code_work_request.py
@@ -242,3 +242,33 @@ def close_every_code_work_request_for_pull_request(
     if not record.started_at.strip():
         updates["started_at"] = closed_at
     return record.model_copy(update=updates)
+
+
+def close_every_code_work_request_for_issue(
+    record: EveryCodeWorkRequestRecord,
+    *,
+    closed_at: str,
+    reason: str = "",
+) -> EveryCodeWorkRequestRecord | None:
+    if not closed_at.strip():
+        raise ValueError("Every Code issue close update requires closed_at")
+    if record.state in {"done", "blocked"}:
+        return None
+
+    normalized_reason = reason.strip().lower()
+    suffix = f" ({normalized_reason})" if normalized_reason else ""
+    summary = f"Source issue closed{suffix}: {record.issue_url.strip()}"
+    updates: dict[str, object] = {
+        "state": "done",
+        "updated_at": closed_at,
+        "finished_at": closed_at,
+        "result_summary": summary,
+        "error_message": "",
+    }
+    if not record.claimed_at.strip():
+        updates["claimed_at"] = closed_at
+    if not record.claimed_by_host.strip():
+        updates["claimed_by_host"] = "github-issue-close"
+    if not record.started_at.strip():
+        updates["started_at"] = closed_at
+    return record.model_copy(update=updates)

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -40,6 +40,7 @@ from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestStatusUpdate,
     apply_every_code_work_request_status,
     build_every_code_work_request_id,
+    close_every_code_work_request_for_issue,
     close_every_code_work_request_for_pull_request,
     requeue_every_code_work_request,
 )
@@ -2081,6 +2082,14 @@ def _handle_every_code_github_webhook(
                 "reason": "unsupported_event",
             },
         )
+    if payload.get("action") == "closed":
+        return _handle_every_code_issue_closed_webhook(
+            start_response=start_response,
+            trace_id=trace_id,
+            delivery_id=delivery_id,
+            payload=payload,
+            record_store=record_store,
+        )
     if payload.get("action") != "labeled":
         return _json_response(
             start_response=start_response,
@@ -2138,6 +2147,85 @@ def _handle_every_code_github_webhook(
         driver_result={"request": stored_record.model_dump(mode="json")},
     )
     accepted_payload["deduped"] = deduped
+    accepted_payload["github_delivery_id"] = delivery_id
+    return _json_response(start_response=start_response, status_code=202, payload=accepted_payload)
+
+
+def _handle_every_code_issue_closed_webhook(
+    *,
+    start_response: _StartResponse,
+    trace_id: str,
+    delivery_id: str,
+    payload: dict[str, object],
+    record_store: object,
+) -> list[bytes]:
+    repository_payload = _github_webhook_mapping(payload, "repository")
+    issue_payload = _github_webhook_mapping(payload, "issue")
+    repository = _github_webhook_string(repository_payload, "full_name")
+    issue_number_value = issue_payload.get("number") if issue_payload is not None else None
+    if not isinstance(issue_number_value, int):
+        raise ValueError("GitHub issue webhook requires integer issue.number")
+    issue_url = _github_webhook_string(issue_payload, "html_url")
+    closed_at = _github_webhook_string(issue_payload, "closed_at") or _utc_now_timestamp()
+    state_reason = _github_webhook_string(issue_payload, "state_reason")
+
+    every_code_store = _every_code_work_request_store(record_store)
+    updated_records: list[EveryCodeWorkRequestRecord] = []
+    terminal_records: list[EveryCodeWorkRequestRecord] = []
+    for record in _iter_every_code_work_request_records(
+        every_code_store,
+        repository=repository,
+    ):
+        if record.issue_number != issue_number_value:
+            continue
+        if issue_url.strip() and record.issue_url.strip() != issue_url.strip():
+            continue
+        closed_record = close_every_code_work_request_for_issue(
+            record,
+            closed_at=closed_at,
+            reason=state_reason,
+        )
+        if closed_record is None:
+            terminal_records.append(record)
+            continue
+        every_code_store.write_every_code_work_request_record(closed_record)
+        updated_records.append(closed_record)
+
+    if not updated_records:
+        response_payload: dict[str, object] = {
+            "status": "accepted",
+            "trace_id": trace_id,
+            "skipped": True,
+            "reason": "linked_every_code_request_not_found",
+            "github_delivery_id": delivery_id,
+        }
+        if terminal_records:
+            terminal_record = terminal_records[0]
+            response_payload["reason"] = "linked_every_code_request_already_terminal"
+            response_payload["result"] = {
+                "request_id": terminal_record.request_id,
+                "state": terminal_record.state,
+            }
+        return _json_response(
+            start_response=start_response,
+            status_code=202,
+            payload=response_payload,
+        )
+
+    updated_record = updated_records[0]
+    accepted_payload = _accepted_payload(
+        trace_id=trace_id,
+        result={
+            "request_id": updated_record.request_id,
+            "state": updated_record.state,
+            "closed_count": len(updated_records),
+        },
+        driver_result={
+            "request": updated_record.model_dump(mode="json"),
+            "closed_count": len(updated_records),
+            "requests": [record.model_dump(mode="json") for record in updated_records],
+        },
+    )
     accepted_payload["github_delivery_id"] = delivery_id
     return _json_response(start_response=start_response, status_code=202, payload=accepted_payload)
 

--- a/tests/test_every_code_work_request.py
+++ b/tests/test_every_code_work_request.py
@@ -6,6 +6,7 @@ from control_plane.contracts.every_code_work_request import (
     apply_every_code_work_request_status,
     build_every_code_work_request_id,
     claim_every_code_work_request,
+    close_every_code_work_request_for_issue,
     close_every_code_work_request_for_pull_request,
     requeue_every_code_work_request,
 )
@@ -137,6 +138,45 @@ class EveryCodeWorkRequestRecordTests(unittest.TestCase):
                 pr_url="https://github.com/cbusillo/code/pull/99",
                 merged=True,
                 closed_at="2026-05-05T22:06:00Z",
+            )
+        )
+
+    def test_issue_close_marks_running_request_done(self) -> None:
+        claimed_record = claim_every_code_work_request(
+            _queued_record(),
+            host="Chris-Studio",
+            claimed_at="2026-05-05T22:01:00Z",
+        )
+        assert claimed_record is not None
+        running_record = apply_every_code_work_request_status(
+            claimed_record,
+            EveryCodeWorkRequestStatusUpdate(
+                state="running",
+                host="Chris-Studio",
+                updated_at="2026-05-05T22:03:00Z",
+            ),
+        )
+
+        done_record = close_every_code_work_request_for_issue(
+            running_record,
+            closed_at="2026-05-05T22:05:00Z",
+            reason="completed",
+        )
+
+        self.assertIsNotNone(done_record)
+        assert done_record is not None
+        self.assertEqual(done_record.state, "done")
+        self.assertEqual(done_record.finished_at, "2026-05-05T22:05:00Z")
+        self.assertEqual(done_record.error_message, "")
+        self.assertEqual(
+            done_record.result_summary,
+            "Source issue closed (completed): https://github.com/cbusillo/code/issues/123",
+        )
+        self.assertIsNone(
+            close_every_code_work_request_for_issue(
+                done_record,
+                closed_at="2026-05-05T22:06:00Z",
+                reason="completed",
             )
         )
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -427,19 +427,26 @@ def _every_code_github_issue_labeled_payload(
     repository: str = "cbusillo/code",
     issue_number: int = 123,
     issue_url: str = "",
+    closed_at: str = "",
+    state_reason: str = "",
 ) -> dict[str, object]:
     resolved_issue_url = (
         issue_url.strip() or f"https://github.com/{repository}/issues/{issue_number}"
     )
+    issue_payload = {
+        "number": issue_number,
+        "html_url": resolved_issue_url,
+        "title": "Wire local automation",
+    }
+    if closed_at.strip():
+        issue_payload["closed_at"] = closed_at
+    if state_reason.strip():
+        issue_payload["state_reason"] = state_reason
     return {
         "action": action,
         "label": {"name": label},
         "repository": {"full_name": repository},
-        "issue": {
-            "number": issue_number,
-            "html_url": resolved_issue_url,
-            "title": "Wire local automation",
-        },
+        "issue": issue_payload,
         "sender": {"login": "cbusillo"},
     }
 
@@ -1146,6 +1153,112 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(
             second_payload["result"]["request"]["result_pr_url"],
             "https://github.com/cbusillo/code/pull/26",
+        )
+
+    def test_every_code_issue_close_marks_linked_request_done(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main"
+                        ],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": [
+                            "every_code_work_request.read",
+                            "every_code_work_request.claim",
+                            "every_code_work_request.update",
+                        ],
+                    }
+                ]
+            }
+        )
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
+            event_name="workflow_dispatch",
+        )
+        issue_payload = _every_code_github_issue_labeled_payload()
+        close_payload = _every_code_github_issue_labeled_payload(
+            action="closed",
+            closed_at="2026-05-06T16:20:00Z",
+            state_reason="completed",
+        )
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(identity),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            create_status, create_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=issue_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-issue",
+                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                },
+            )
+            request_id = str(create_payload["records"]["request_id"])
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/claim",
+                payload={"request_id": request_id, "host": "Chris-Studio"},
+                headers={"Idempotency-Key": "every-code-issue-close-claim"},
+            )
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/status",
+                payload={
+                    "request_id": request_id,
+                    "host": "Chris-Studio",
+                    "state": "running",
+                },
+                headers={"Idempotency-Key": "every-code-issue-close-running"},
+            )
+
+            close_status, closed_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=close_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-issue-close",
+                    "X-Hub-Signature-256": _github_webhook_signature(close_payload, secret),
+                },
+            )
+
+        self.assertEqual(create_status, 202)
+        self.assertEqual(close_status, 202)
+        self.assertEqual(closed_response["records"]["state"], "done")
+        self.assertEqual(
+            closed_response["result"]["request"]["finished_at"],
+            "2026-05-06T16:20:00Z",
+        )
+        self.assertEqual(
+            closed_response["result"]["request"]["result_summary"],
+            "Source issue closed (completed): https://github.com/cbusillo/code/issues/123",
         )
 
     def test_every_code_pull_request_close_marks_linked_request_done(self) -> None:


### PR DESCRIPTION
## Summary
- handle Every Code source issue close webhooks as terminal lifecycle events
- mark linked requests done with source-issue close details so worker cleanup can stop local tmux/TUI sessions
- add contract and service coverage for issue-close shutdown behavior

## Validation
- uv run python -m unittest tests.test_every_code_work_request.EveryCodeWorkRequestRecordTests.test_pr_close_marks_matching_running_request_done tests.test_every_code_work_request.EveryCodeWorkRequestRecordTests.test_issue_close_marks_running_request_done tests.test_service.LaunchplaneServiceTests.test_every_code_issue_close_marks_linked_request_done
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest

## Live cleanup
- manually marked cbusillo/sellyouroutboard#81 request done and terminated its stale local tmux session after the original close webhook had already been missed
