### PR TITLE
Refactor work graph service routes

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -93,12 +93,6 @@ from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeKeySafetyPolicyRecord,
     RuntimeSecretSafetyRule,
 )
-from control_plane.contracts.work_graph_read_model import (
-    WorkGraphPlanningIssueFacts,
-    WorkGraphSnapshot,
-    build_work_graph_queue,
-    build_work_graph_snapshot_from_records,
-)
 from control_plane.drivers.registry import (
     build_driver_context_view,
     list_driver_descriptors,
@@ -136,6 +130,12 @@ from control_plane.tracked_target_logs import build_tracked_target_logs_payload
 from control_plane.work_graph_github_projects import (
     build_github_project_planning_facts,
     load_github_project_planning_facts_config_from_env,
+)
+from control_plane.work_graph_service import (
+    WorkGraphPlanningFactsProvider,
+    WorkGraphRankEnvelope,
+    build_work_graph_rank_result,
+    build_work_graph_snapshot_service_payload,
 )
 from control_plane.workflows.evidence_ingestion import (
     apply_deployment_evidence,
@@ -255,7 +255,6 @@ _GITHUB_ISSUE_REFERENCE_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _EVERY_CODE_TRIGGER_LABEL = "every-code"
-_WorkGraphPlanningFactsProvider = Callable[[], tuple[WorkGraphPlanningIssueFacts, ...]]
 
 
 @dataclass(frozen=True)
@@ -1305,14 +1304,6 @@ class EveryCodePrFeedbackStatusEnvelope(BaseModel):
         if not self.request_id.strip():
             raise ValueError("Every Code PR feedback status requires request_id")
         return self
-
-
-class WorkGraphRankEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    snapshot: WorkGraphSnapshot
-    limit: int = Field(default=25, ge=1, le=100)
 
 
 class AuthzPolicyGitHubActionsGrant(BaseModel):
@@ -4382,7 +4373,7 @@ def create_launchplane_service_app(
     github_oauth_config: GitHubOAuthConfig | None = None,
     github_oauth_client: GitHubOAuthClient | None = None,
     human_session_store: HumanSessionStore | None = None,
-    work_graph_planning_facts_provider: _WorkGraphPlanningFactsProvider | None = None,
+    work_graph_planning_facts_provider: WorkGraphPlanningFactsProvider | None = None,
 ) -> _WsgiApp:
     resolved_root = control_plane_root_path or control_plane_root()
     ui_static_root = resolved_root / "control_plane" / "ui_static"
@@ -5156,23 +5147,12 @@ def create_launchplane_service_app(
                             context=requested_context,
                         )
 
-                    work_requests = _every_code_work_request_store(
-                        record_store
-                    ).list_every_code_work_request_records(limit=100)
-                    product_overviews = build_product_site_overviews(
-                        record_store=record_store,
-                        action_allowed=work_graph_product_action_allowed,
-                    )
-                    planning_issue_facts = (
-                        work_graph_planning_facts_provider()
-                        if work_graph_planning_facts_provider is not None
-                        else ()
-                    )
-                    snapshot = build_work_graph_snapshot_from_records(
+                    work_graph_payload = build_work_graph_snapshot_service_payload(
                         generated_at=_utc_now_timestamp(),
-                        product_overviews=product_overviews,
-                        work_requests=work_requests,
-                        planning_issue_facts=planning_issue_facts,
+                        product_store=record_store,
+                        work_request_store=_every_code_work_request_store(record_store),
+                        action_allowed=work_graph_product_action_allowed,
+                        planning_facts_provider=work_graph_planning_facts_provider,
                     )
                     return _json_response(
                         start_response=start_response,
@@ -5180,12 +5160,7 @@ def create_launchplane_service_app(
                         payload={
                             "status": "ok",
                             "trace_id": request_trace_id,
-                            "snapshot": snapshot.model_dump(mode="json"),
-                            "source": {
-                                "product_count": len(product_overviews),
-                                "work_request_count": len(work_requests),
-                                "planning_fact_count": len(planning_issue_facts),
-                            },
+                            **work_graph_payload,
                         },
                     )
                 if action == "product_profile.read":
@@ -5698,12 +5673,7 @@ def create_launchplane_service_app(
                             },
                         },
                     )
-                queue = build_work_graph_queue(
-                    rank_request.snapshot,
-                    limit=rank_request.limit,
-                )
-                result = {"item_count": len(queue.items), "hidden_count": queue.hidden_count}
-                driver_result = {"queue": queue.model_dump(mode="json")}
+                result, driver_result = build_work_graph_rank_result(rank_request)
             elif path == "/v1/evidence/deployments":
                 deployment_request = DeploymentEvidenceEnvelope.model_validate(payload)
                 if not authz_policy.allows(

--- a/control_plane/work_graph_service.py
+++ b/control_plane/work_graph_service.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
+from control_plane.contracts.product_environment_read_model import (
+    ActionAllowed,
+    ProductReadModelStore,
+    build_product_site_overviews,
+)
+from control_plane.contracts.work_graph_read_model import (
+    WorkGraphPlanningIssueFacts,
+    WorkGraphSnapshot,
+    build_work_graph_queue,
+    build_work_graph_snapshot_from_records,
+)
+
+
+WorkGraphPlanningFactsProvider = Callable[[], tuple[WorkGraphPlanningIssueFacts, ...]]
+
+
+class WorkGraphWorkRequestStore(Protocol):
+    def list_every_code_work_request_records(
+        self,
+        *,
+        state: str = "",
+        repository: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[EveryCodeWorkRequestRecord, ...]: ...
+
+
+class WorkGraphRankEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    snapshot: WorkGraphSnapshot
+    limit: int = Field(default=25, ge=1, le=100)
+
+
+def build_work_graph_snapshot_service_payload(
+    *,
+    generated_at: str,
+    product_store: ProductReadModelStore,
+    work_request_store: WorkGraphWorkRequestStore,
+    action_allowed: ActionAllowed,
+    planning_facts_provider: WorkGraphPlanningFactsProvider | None,
+) -> dict[str, object]:
+    work_requests = work_request_store.list_every_code_work_request_records(limit=100)
+    product_overviews = build_product_site_overviews(
+        record_store=product_store,
+        action_allowed=action_allowed,
+    )
+    planning_issue_facts = planning_facts_provider() if planning_facts_provider is not None else ()
+    snapshot = build_work_graph_snapshot_from_records(
+        generated_at=generated_at,
+        product_overviews=product_overviews,
+        work_requests=work_requests,
+        planning_issue_facts=planning_issue_facts,
+    )
+    return {
+        "snapshot": snapshot.model_dump(mode="json"),
+        "source": {
+            "product_count": len(product_overviews),
+            "work_request_count": len(work_requests),
+            "planning_fact_count": len(planning_issue_facts),
+        },
+    }
+
+
+def build_work_graph_rank_result(
+    rank_request: WorkGraphRankEnvelope,
+) -> tuple[dict[str, object], dict[str, object]]:
+    queue = build_work_graph_queue(
+        rank_request.snapshot,
+        limit=rank_request.limit,
+    )
+    return (
+        {"item_count": len(queue.items), "hidden_count": queue.hidden_count},
+        {"queue": queue.model_dump(mode="json")},
+    )

--- a/tests/test_work_graph_service.py
+++ b/tests/test_work_graph_service.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import unittest
+from typing import cast
+
+from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.work_graph_read_model import WorkGraphPlanningIssueFacts
+from control_plane.work_graph_service import (
+    WorkGraphRankEnvelope,
+    build_work_graph_rank_result,
+    build_work_graph_snapshot_service_payload,
+)
+
+
+def _work_request(**overrides: object) -> EveryCodeWorkRequestRecord:
+    payload: dict[str, object] = {
+        "request_id": "every-code-cbusillo-launchplane-190",
+        "source": "github_issue_label",
+        "state": "queued",
+        "repository": "cbusillo/launchplane",
+        "issue_number": 190,
+        "issue_url": "https://github.com/cbusillo/launchplane/issues/190",
+        "issue_title": "Build What To Work On Next cockpit",
+        "trigger_label": "every-code",
+        "trigger_actor": "cbusillo",
+        "github_delivery_id": "delivery-190",
+        "queued_at": "2026-05-06T02:00:00Z",
+        "updated_at": "2026-05-06T02:00:00Z",
+    }
+    payload.update(overrides)
+    return EveryCodeWorkRequestRecord.model_validate(payload)
+
+
+class _EmptyProductStore:
+    def list_product_profile_records(
+        self,
+        *,
+        driver_id: str = "",
+    ) -> tuple[LaunchplaneProductProfileRecord, ...]:
+        return ()
+
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
+        raise AssertionError("empty product store should not read product profiles")
+
+
+class _WorkRequestStore:
+    def __init__(self, records: tuple[EveryCodeWorkRequestRecord, ...]) -> None:
+        self.records = records
+        self.seen_limit: int | None = None
+
+    def list_every_code_work_request_records(
+        self,
+        *,
+        state: str = "",
+        repository: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[EveryCodeWorkRequestRecord, ...]:
+        self.seen_limit = limit
+        return self.records
+
+
+class WorkGraphServiceTests(unittest.TestCase):
+    def test_snapshot_payload_builds_source_counts_and_applies_planning_facts(self) -> None:
+        work_request_store = _WorkRequestStore((_work_request(),))
+
+        payload = build_work_graph_snapshot_service_payload(
+            generated_at="2026-05-06T02:05:00Z",
+            product_store=_EmptyProductStore(),
+            work_request_store=work_request_store,
+            action_allowed=lambda _action, _product, _context: True,
+            planning_facts_provider=lambda: (
+                WorkGraphPlanningIssueFacts.model_validate(
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "number": 190,
+                        "focus": "Now",
+                        "manager": "@cellmechanic",
+                        "blocking": 2,
+                    }
+                ),
+            ),
+        )
+
+        self.assertEqual(work_request_store.seen_limit, 100)
+        self.assertEqual(
+            payload["source"],
+            {"product_count": 0, "work_request_count": 1, "planning_fact_count": 1},
+        )
+        snapshot = cast(dict[str, object], payload["snapshot"])
+        repos = cast(list[dict[str, object]], snapshot["repos"])
+        issues = cast(list[dict[str, object]], snapshot["issues"])
+        self.assertEqual(snapshot["generated_at"], "2026-05-06T02:05:00Z")
+        self.assertEqual(repos[0]["classification"], "active_awareness")
+        self.assertEqual(issues[0]["focus"], "Now")
+        self.assertEqual(issues[0]["manager"], "@cellmechanic")
+        self.assertEqual(issues[0]["blocking"], 2)
+
+    def test_rank_result_returns_summary_and_driver_queue(self) -> None:
+        snapshot_payload = build_work_graph_snapshot_service_payload(
+            generated_at="2026-05-06T02:05:00Z",
+            product_store=_EmptyProductStore(),
+            work_request_store=_WorkRequestStore((_work_request(),)),
+            action_allowed=lambda _action, _product, _context: True,
+            planning_facts_provider=None,
+        )
+        rank_request = WorkGraphRankEnvelope.model_validate(
+            {"snapshot": snapshot_payload["snapshot"], "limit": 5}
+        )
+
+        result, driver_result = build_work_graph_rank_result(rank_request)
+
+        self.assertEqual(result, {"item_count": 1, "hidden_count": 0})
+        queue = cast(dict[str, object], driver_result["queue"])
+        items = cast(list[dict[str, object]], queue["items"])
+        self.assertEqual(items[0]["number"], 190)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Extract work graph snapshot payload assembly and rank result construction from `control_plane/service.py` into `control_plane/work_graph_service.py`
- Preserve existing HTTP authorization/validation order in the service routes
- Add direct unit coverage for the extracted service helper payload and rank contracts

Refs #307

## Validation
- `uv run --extra dev ruff format --check control_plane/service.py control_plane/work_graph_service.py tests/test_work_graph_service.py`
- `uv run --extra dev ruff check control_plane/service.py control_plane/work_graph_service.py tests/test_work_graph_service.py`
- `uv run python -m unittest tests.test_work_graph_service tests.test_service.LaunchplaneServiceTests.test_work_graph_rank_returns_ranked_queue tests.test_service.LaunchplaneServiceTests.test_work_graph_rank_rejects_unauthorized_identity tests.test_service.LaunchplaneServiceTests.test_work_graph_rank_rejects_unclassified_issue tests.test_service.LaunchplaneServiceTests.test_human_session_can_rank_work_graph_snapshot tests.test_service.LaunchplaneServiceTests.test_work_graph_snapshot_returns_launchplane_assembled_snapshot tests.test_service.LaunchplaneServiceTests.test_work_graph_snapshot_uses_compact_planning_facts_when_available tests.test_service.LaunchplaneServiceTests.test_work_graph_snapshot_rejects_unauthorized_identity`
- `uv run python -m unittest tests.test_service tests.test_work_graph_service tests.test_work_graph_read_model tests.test_work_graph_github_projects`
- `uv run python -m unittest`
- `uv run --extra dev mypy control_plane tests`