### PR TITLE
Extract operator work graph queue component

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,6 @@
 import {
   AlertTriangle,
   Archive,
-  CheckCircle2,
   ChevronDown,
   Clock3,
   Command,
@@ -16,7 +15,6 @@ import {
   Play,
   Plus,
   RefreshCw,
-  Route,
   Save,
   ShieldAlert,
   ShieldCheck,
@@ -42,6 +40,8 @@ import {
   readWorkGraphSnapshot,
   rankWorkGraphSnapshot,
 } from "./api";
+import { formatTime, labelForStatus } from "./format";
+import { StatusIcon, StatusPill, StateBlock, SkeletonRows } from "./status-ui";
 import type {
   AuthIdentity,
   DataProvenance,
@@ -67,9 +67,12 @@ import type {
   Status,
   FreshnessStatus,
   WorkGraphQueueItem,
-  WorkGraphRecommendation,
-  WorkGraphState,
 } from "./types";
+import {
+  WorkGraphQueue,
+  type WorkGraphFilter,
+  type WorkGraphMode,
+} from "./WorkGraphQueue";
 
 type Theme = "dark" | "light";
 const assetUrl = (path: string) => `${import.meta.env.BASE_URL}${path}`;
@@ -128,9 +131,6 @@ type SecretConfigRow = {
   value: string;
   description: string;
 };
-type WorkGraphFilter = WorkGraphState | "all";
-type WorkGraphMode = WorkGraphRecommendation | "all";
-
 const THEME_STORAGE_KEY = "launchplane.theme";
 const DEFAULT_CHOICES: DriverChoice[] = [
   {
@@ -1069,162 +1069,6 @@ function ProductInventoryCockpit({
       />
       <EveryCodeQueue requests={activeWork} loading={loading} />
     </section>
-  );
-}
-
-function WorkGraphQueue({
-  items,
-  hiddenCount,
-  error,
-  filter,
-  mode,
-  loading,
-  onFilterChange,
-  onModeChange,
-}: {
-  items: WorkGraphQueueItem[];
-  hiddenCount: number;
-  error: string;
-  filter: WorkGraphFilter;
-  mode: WorkGraphMode;
-  loading: boolean;
-  onFilterChange: (filter: WorkGraphFilter) => void;
-  onModeChange: (mode: WorkGraphMode) => void;
-}) {
-  const filteredItems = items.filter((item) => {
-    const stateMatches = filter === "all" || item.state === filter;
-    const modeMatches = mode === "all" || item.recommendation === mode;
-    return stateMatches && modeMatches;
-  });
-  const readyCount = items.filter((item) => item.state === "ready").length;
-  const blockedCount = items.filter((item) => item.state === "blocked").length;
-  const status: Status | string = error
-    ? "fail"
-    : blockedCount
-      ? "blocked"
-      : readyCount
-        ? "pending"
-        : items.length
-          ? "unknown"
-          : "pass";
-
-  return (
-    <div className="work-graph-queue">
-      <div className="queue-head work-graph-head">
-        <span>What next</span>
-        <strong>{items.length ? `${items.length} ranked` : "clear"}</strong>
-        <StatusPill status={status} />
-      </div>
-      <div className="work-graph-controls" aria-label="Work graph filters">
-        <SegmentedControl<WorkGraphFilter>
-          ariaLabel="Work state"
-          value={filter}
-          options={[
-            { value: "all", label: "All" },
-            { value: "ready", label: "Ready" },
-            { value: "blocked", label: "Blocked" },
-            { value: "waiting", label: "Waiting" },
-          ]}
-          onChange={onFilterChange}
-        />
-        <SegmentedControl<WorkGraphMode>
-          ariaLabel="Recommendation"
-          value={mode}
-          options={[
-            { value: "all", label: "Any" },
-            { value: "quick_win", label: "Quick" },
-            { value: "deep_work", label: "Deep" },
-            { value: "switch_projects", label: "Switch" },
-            { value: "attention_needed", label: "Needs" },
-          ]}
-          onChange={onModeChange}
-        />
-      </div>
-      {error ? (
-        <StateBlock icon={<ShieldAlert size={18} />} title={error} />
-      ) : null}
-      {loading && !items.length ? <SkeletonRows /> : null}
-      {!loading && !error && !items.length ? (
-        <StateBlock icon={<Route size={18} />} title="No ranked work yet" />
-      ) : null}
-      {!loading && !error && items.length && !filteredItems.length ? (
-        <StateBlock icon={<Route size={18} />} title="No work matches filters" />
-      ) : null}
-      {filteredItems.slice(0, 5).map((item) => (
-        <a
-          className="work-graph-row"
-          href={item.url}
-          key={`${item.repository}:${item.number}`}
-          target="_blank"
-          rel="noreferrer"
-        >
-          <span className="work-graph-score">{item.score}</span>
-          <span className="work-graph-content">
-            <span className="work-graph-title">
-              <strong>{item.title}</strong>
-              <code>
-                {item.repository}#{item.number}
-              </code>
-            </span>
-            <span className="work-graph-meta">
-              <span>{item.focus}</span>
-              <span>{item.manager || "Unassigned"}</span>
-              <span>{formatTime(item.updated_at)}</span>
-              <span>
-                {item.product_display_name || item.product || item.repo_classification}
-              </span>
-            </span>
-            {item.finish_line ? (
-              <span className="work-graph-finish">{item.finish_line}</span>
-            ) : null}
-            <span className="work-graph-tags">
-              <span className="status-pill" data-status={workGraphStateStatus(item.state)}>
-                <StatusIcon status={workGraphStateStatus(item.state)} />
-                {item.state}
-              </span>
-              <span className="recommendation-chip">
-                {recommendationLabel(item.recommendation)}
-              </span>
-              {item.reasons.slice(0, 2).map((reason) => (
-                <span className="reason-chip" key={`${item.repository}:${item.number}:${reason.code}`}>
-                  {reasonLabel(reason.code)}
-                </span>
-              ))}
-            </span>
-          </span>
-        </a>
-      ))}
-      {hiddenCount ? (
-        <code className="work-graph-hidden">{hiddenCount} hidden by rank or state</code>
-      ) : null}
-    </div>
-  );
-}
-
-function SegmentedControl<T extends string>({
-  ariaLabel,
-  value,
-  options,
-  onChange,
-}: {
-  ariaLabel: string;
-  value: T;
-  options: Array<{ value: T; label: string }>;
-  onChange: (value: T) => void;
-}) {
-  return (
-    <div className="segmented-control" aria-label={ariaLabel}>
-      {options.map((option) => (
-        <button
-          type="button"
-          key={option.value}
-          data-selected={option.value === value}
-          onClick={() => onChange(option.value)}
-        >
-          {option.label}
-        </button>
-      ))}
-    </div>
   );
 }
 
@@ -3683,28 +3527,6 @@ function MetricTile({
   );
 }
 
-function StatusPill({ status }: { status: Status | string }) {
-  return (
-    <span className="status-pill" data-status={status}>
-      <StatusIcon status={status} />
-      {labelForStatus(status)}
-    </span>
-  );
-}
-
-function StatusIcon({ status }: { status: Status | string }) {
-  if (status === "pass" || status === "ready") {
-    return <CheckCircle2 size={15} aria-hidden="true" />;
-  }
-  if (status === "fail" || status === "blocked") {
-    return <XCircle size={15} aria-hidden="true" />;
-  }
-  if (status === "pending") {
-    return <Clock3 size={15} aria-hidden="true" />;
-  }
-  return <AlertTriangle size={15} aria-hidden="true" />;
-}
-
 function SafetyIcon({ safety }: { safety: Safety }) {
   if (safety === "destructive") {
     return <ShieldAlert size={15} aria-hidden="true" />;
@@ -3716,26 +3538,6 @@ function SafetyIcon({ safety }: { safety: Safety }) {
     return <ShieldCheck size={15} aria-hidden="true" />;
   }
   return <Eye size={15} aria-hidden="true" />;
-}
-
-function StateBlock({ icon, title }: { icon: ReactNode; title: string }) {
-  return (
-    <div className="state-block">
-      {icon}
-      <strong>{title}</strong>
-    </div>
-  );
-}
-
-function SkeletonRows() {
-  return (
-    <div className="skeleton-list" aria-hidden="true">
-      <span />
-      <span />
-      <span />
-      <span />
-    </div>
-  );
 }
 
 function EvidenceStrip({
@@ -4417,10 +4219,6 @@ function worstStatus(statuses: Array<Status | string>): Status | string {
   return "unknown";
 }
 
-function labelForStatus(status: Status | string): string {
-  return status.replace("_", " ") || "unknown";
-}
-
 function workRequestStatus(state: EveryCodeWorkRequestRecord["state"]): Status | string {
   if (state === "done") {
     return "pass";
@@ -4434,27 +4232,6 @@ function workRequestStatus(state: EveryCodeWorkRequestRecord["state"]): Status |
   return "unknown";
 }
 
-function workGraphStateStatus(state: WorkGraphState): Status | string {
-  if (state === "ready") {
-    return "pending";
-  }
-  if (state === "blocked") {
-    return "blocked";
-  }
-  if (state === "waiting") {
-    return "unknown";
-  }
-  return "pass";
-}
-
-function recommendationLabel(recommendation: WorkGraphRecommendation): string {
-  return recommendation.replaceAll("_", " ");
-}
-
-function reasonLabel(code: string): string {
-  return code.replaceAll("_", " ");
-}
-
 function safetyLabel(safety: Safety): string {
   return safety.replace("_", " ").toUpperCase();
 }
@@ -4464,20 +4241,4 @@ function shorten(value: string): string {
     return value;
   }
   return `${value.slice(0, 7)}...${value.slice(-4)}`;
-}
-
-function formatTime(value: string): string {
-  if (!value) {
-    return "unknown";
-  }
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-  return new Intl.DateTimeFormat(undefined, {
-    month: "short",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(date);
 }

--- a/frontend/src/WorkGraphQueue.tsx
+++ b/frontend/src/WorkGraphQueue.tsx
@@ -1,0 +1,190 @@
+import { Route, ShieldAlert } from "lucide-react";
+
+import { formatTime } from "./format";
+import { SkeletonRows, StateBlock, StatusIcon, StatusPill } from "./status-ui";
+import type {
+  Status,
+  WorkGraphQueueItem,
+  WorkGraphRecommendation,
+  WorkGraphState,
+} from "./types";
+
+export type WorkGraphFilter = WorkGraphState | "all";
+export type WorkGraphMode = WorkGraphRecommendation | "all";
+
+export function WorkGraphQueue({
+  items,
+  hiddenCount,
+  error,
+  filter,
+  mode,
+  loading,
+  onFilterChange,
+  onModeChange,
+}: {
+  items: WorkGraphQueueItem[];
+  hiddenCount: number;
+  error: string;
+  filter: WorkGraphFilter;
+  mode: WorkGraphMode;
+  loading: boolean;
+  onFilterChange: (filter: WorkGraphFilter) => void;
+  onModeChange: (mode: WorkGraphMode) => void;
+}) {
+  const filteredItems = items.filter((item) => {
+    const stateMatches = filter === "all" || item.state === filter;
+    const modeMatches = mode === "all" || item.recommendation === mode;
+    return stateMatches && modeMatches;
+  });
+  const readyCount = items.filter((item) => item.state === "ready").length;
+  const blockedCount = items.filter((item) => item.state === "blocked").length;
+  const status: Status | string = error
+    ? "fail"
+    : blockedCount
+      ? "blocked"
+      : readyCount
+        ? "pending"
+        : items.length
+          ? "unknown"
+          : "pass";
+
+  return (
+    <div className="work-graph-queue">
+      <div className="queue-head work-graph-head">
+        <span>What next</span>
+        <strong>{items.length ? `${items.length} ranked` : "clear"}</strong>
+        <StatusPill status={status} />
+      </div>
+      <div className="work-graph-controls" aria-label="Work graph filters">
+        <SegmentedControl<WorkGraphFilter>
+          ariaLabel="Work state"
+          value={filter}
+          options={[
+            { value: "all", label: "All" },
+            { value: "ready", label: "Ready" },
+            { value: "blocked", label: "Blocked" },
+            { value: "waiting", label: "Waiting" },
+          ]}
+          onChange={onFilterChange}
+        />
+        <SegmentedControl<WorkGraphMode>
+          ariaLabel="Recommendation"
+          value={mode}
+          options={[
+            { value: "all", label: "Any" },
+            { value: "quick_win", label: "Quick" },
+            { value: "deep_work", label: "Deep" },
+            { value: "switch_projects", label: "Switch" },
+            { value: "attention_needed", label: "Needs" },
+          ]}
+          onChange={onModeChange}
+        />
+      </div>
+      {error ? (
+        <StateBlock icon={<ShieldAlert size={18} />} title={error} />
+      ) : null}
+      {loading && !items.length ? <SkeletonRows /> : null}
+      {!loading && !error && !items.length ? (
+        <StateBlock icon={<Route size={18} />} title="No ranked work yet" />
+      ) : null}
+      {!loading && !error && items.length && !filteredItems.length ? (
+        <StateBlock icon={<Route size={18} />} title="No work matches filters" />
+      ) : null}
+      {filteredItems.slice(0, 5).map((item) => (
+        <a
+          className="work-graph-row"
+          href={item.url}
+          key={`${item.repository}:${item.number}`}
+          target="_blank"
+          rel="noreferrer"
+        >
+          <span className="work-graph-score">{item.score}</span>
+          <span className="work-graph-content">
+            <span className="work-graph-title">
+              <strong>{item.title}</strong>
+              <code>
+                {item.repository}#{item.number}
+              </code>
+            </span>
+            <span className="work-graph-meta">
+              <span>{item.focus}</span>
+              <span>{item.manager || "Unassigned"}</span>
+              <span>{formatTime(item.updated_at)}</span>
+              <span>
+                {item.product_display_name || item.product || item.repo_classification}
+              </span>
+            </span>
+            {item.finish_line ? (
+              <span className="work-graph-finish">{item.finish_line}</span>
+            ) : null}
+            <span className="work-graph-tags">
+              <span className="status-pill" data-status={workGraphStateStatus(item.state)}>
+                <StatusIcon status={workGraphStateStatus(item.state)} />
+                {item.state}
+              </span>
+              <span className="recommendation-chip">
+                {recommendationLabel(item.recommendation)}
+              </span>
+              {item.reasons.slice(0, 2).map((reason) => (
+                <span className="reason-chip" key={`${item.repository}:${item.number}:${reason.code}`}>
+                  {reasonLabel(reason.code)}
+                </span>
+              ))}
+            </span>
+          </span>
+        </a>
+      ))}
+      {hiddenCount ? (
+        <code className="work-graph-hidden">{hiddenCount} hidden by rank or state</code>
+      ) : null}
+    </div>
+  );
+}
+
+function SegmentedControl<T extends string>({
+  ariaLabel,
+  value,
+  options,
+  onChange,
+}: {
+  ariaLabel: string;
+  value: T;
+  options: Array<{ value: T; label: string }>;
+  onChange: (value: T) => void;
+}) {
+  return (
+    <div className="segmented-control" aria-label={ariaLabel}>
+      {options.map((option) => (
+        <button
+          type="button"
+          key={option.value}
+          data-selected={option.value === value}
+          onClick={() => onChange(option.value)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function workGraphStateStatus(state: WorkGraphState): Status | string {
+  if (state === "ready") {
+    return "pending";
+  }
+  if (state === "blocked") {
+    return "blocked";
+  }
+  if (state === "waiting") {
+    return "unknown";
+  }
+  return "pass";
+}
+
+function recommendationLabel(recommendation: WorkGraphRecommendation): string {
+  return recommendation.replaceAll("_", " ");
+}
+
+function reasonLabel(code: string): string {
+  return code.replaceAll("_", " ");
+}

--- a/frontend/src/format.ts
+++ b/frontend/src/format.ts
@@ -1,0 +1,19 @@
+export function formatTime(value: string): string {
+  if (!value) {
+    return "unknown";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+export function labelForStatus(status: string): string {
+  return status.replace("_", " ") || "unknown";
+}

--- a/frontend/src/status-ui.tsx
+++ b/frontend/src/status-ui.tsx
@@ -1,0 +1,47 @@
+import { AlertTriangle, CheckCircle2, Clock3, XCircle } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { labelForStatus } from "./format";
+import type { Status } from "./types";
+
+export function StatusPill({ status }: { status: Status | string }) {
+  return (
+    <span className="status-pill" data-status={status}>
+      <StatusIcon status={status} />
+      {labelForStatus(status)}
+    </span>
+  );
+}
+
+export function StatusIcon({ status }: { status: Status | string }) {
+  if (status === "pass" || status === "ready") {
+    return <CheckCircle2 size={15} aria-hidden="true" />;
+  }
+  if (status === "fail" || status === "blocked") {
+    return <XCircle size={15} aria-hidden="true" />;
+  }
+  if (status === "pending") {
+    return <Clock3 size={15} aria-hidden="true" />;
+  }
+  return <AlertTriangle size={15} aria-hidden="true" />;
+}
+
+export function StateBlock({ icon, title }: { icon: ReactNode; title: string }) {
+  return (
+    <div className="state-block">
+      {icon}
+      <strong>{title}</strong>
+    </div>
+  );
+}
+
+export function SkeletonRows() {
+  return (
+    <div className="skeleton-list" aria-hidden="true">
+      <span />
+      <span />
+      <span />
+      <span />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Move the operator UI work graph queue out of `frontend/src/App.tsx` into `frontend/src/WorkGraphQueue.tsx`
- Move shared status primitives and formatting helpers into small focused modules
- Preserve existing API/session behavior and fixture gallery markup for the work graph panel

Refs #307

## Validation
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend validate`
- Browser smoke: `http://127.0.0.1:5179/ui/?fixtures=1`, verified the fixture gallery renders the extracted work graph panel, interacted with state/recommendation segmented controls, and checked console output for runtime errors