### PR TITLE
Extract Every Code queue component

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,6 +40,7 @@ import {
   readWorkGraphSnapshot,
   rankWorkGraphSnapshot,
 } from "./api";
+import { EveryCodeQueue } from "./EveryCodeQueue";
 import { formatTime, labelForStatus } from "./format";
 import { StatusIcon, StatusPill, StateBlock, SkeletonRows } from "./status-ui";
 import type {
@@ -1069,50 +1070,6 @@ function ProductInventoryCockpit({
       />
       <EveryCodeQueue requests={activeWork} loading={loading} />
     </section>
-  );
-}
-
-function EveryCodeQueue({
-  requests,
-  loading,
-}: {
-  requests: EveryCodeWorkRequestRecord[];
-  loading: boolean;
-}) {
-  return (
-    <div className="every-code-queue">
-      <div className="queue-head">
-        <span>Every Code</span>
-        <strong>{requests.length ? `${requests.length} active` : "clear"}</strong>
-      </div>
-      {loading && !requests.length ? <SkeletonRows /> : null}
-      {!loading && !requests.length ? (
-        <StateBlock icon={<TerminalSquare size={18} />} title="No queued local work" />
-      ) : null}
-      {requests.slice(0, 4).map((request) => (
-        <a
-          className="queue-row"
-          href={request.issue_url}
-          key={request.request_id}
-          target="_blank"
-          rel="noreferrer"
-        >
-          <span>
-            <strong>{request.issue_title || `Issue #${request.issue_number}`}</strong>
-            <code>
-              {request.repository}#{request.issue_number}
-            </code>
-          </span>
-          <span
-            className="status-pill"
-            data-status={workRequestStatus(request.state)}
-          >
-            <StatusIcon status={workRequestStatus(request.state)} />
-            {request.state}
-          </span>
-        </a>
-      ))}
-    </div>
   );
 }
 
@@ -4215,19 +4172,6 @@ function worstStatus(statuses: Array<Status | string>): Status | string {
   }
   if (statuses.every((status) => status === "pass")) {
     return "pass";
-  }
-  return "unknown";
-}
-
-function workRequestStatus(state: EveryCodeWorkRequestRecord["state"]): Status | string {
-  if (state === "done") {
-    return "pass";
-  }
-  if (state === "blocked") {
-    return "blocked";
-  }
-  if (state === "queued" || state === "claimed" || state === "running") {
-    return "pending";
   }
   return "unknown";
 }

--- a/frontend/src/EveryCodeQueue.tsx
+++ b/frontend/src/EveryCodeQueue.tsx
@@ -1,0 +1,61 @@
+import { TerminalSquare } from "lucide-react";
+
+import { SkeletonRows, StateBlock, StatusIcon } from "./status-ui";
+import type { EveryCodeWorkRequestRecord, Status } from "./types";
+
+export function EveryCodeQueue({
+  requests,
+  loading,
+}: {
+  requests: EveryCodeWorkRequestRecord[];
+  loading: boolean;
+}) {
+  return (
+    <div className="every-code-queue">
+      <div className="queue-head">
+        <span>Every Code</span>
+        <strong>{requests.length ? `${requests.length} active` : "clear"}</strong>
+      </div>
+      {loading && !requests.length ? <SkeletonRows /> : null}
+      {!loading && !requests.length ? (
+        <StateBlock icon={<TerminalSquare size={18} />} title="No queued local work" />
+      ) : null}
+      {requests.slice(0, 4).map((request) => (
+        <a
+          className="queue-row"
+          href={request.issue_url}
+          key={request.request_id}
+          target="_blank"
+          rel="noreferrer"
+        >
+          <span>
+            <strong>{request.issue_title || `Issue #${request.issue_number}`}</strong>
+            <code>
+              {request.repository}#{request.issue_number}
+            </code>
+          </span>
+          <span
+            className="status-pill"
+            data-status={workRequestStatus(request.state)}
+          >
+            <StatusIcon status={workRequestStatus(request.state)} />
+            {request.state}
+          </span>
+        </a>
+      ))}
+    </div>
+  );
+}
+
+function workRequestStatus(state: EveryCodeWorkRequestRecord["state"]): Status | string {
+  if (state === "done") {
+    return "pass";
+  }
+  if (state === "blocked") {
+    return "blocked";
+  }
+  if (state === "queued" || state === "claimed" || state === "running") {
+    return "pending";
+  }
+  return "unknown";
+}


### PR DESCRIPTION
## Summary
- Move Every Code queue rendering from `frontend/src/App.tsx` into `frontend/src/EveryCodeQueue.tsx`
- Keep fetching/filtering/session state in the App shell
- Reuse the shared status primitives from the prior #307 UI slice

Refs #307

## Validation
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend validate`
- Browser smoke: `http://127.0.0.1:5180/ui/?fixtures=1`, confirmed fixture gallery includes the Every Code queue row and checked browser console for runtime errors