### PR TITLE
Extract operator auth panels

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,6 +40,7 @@ import {
   readWorkGraphSnapshot,
   rankWorkGraphSnapshot,
 } from "./api";
+import { ApiErrorPanel, AuthPanel } from "./AuthPanels";
 import { EveryCodeQueue } from "./EveryCodeQueue";
 import { formatTime, labelForStatus } from "./format";
 import { StatusIcon, StatusPill, StateBlock, SkeletonRows } from "./status-ui";
@@ -1179,58 +1180,6 @@ function ProductOverviewShell({
           ))}
         </div>
       ) : null}
-    </section>
-  );
-}
-
-function AuthPanel({ checking }: { checking: boolean }) {
-  const loginHref = `/auth/github/login?return_to=${encodeURIComponent(window.location.pathname || "/")}`;
-  return (
-    <section className="auth-panel" aria-labelledby="auth-heading">
-      <div className="section-heading">
-        <div>
-          <p className="eyebrow">Operator access</p>
-          <h1 id="auth-heading">Connect to Launchplane</h1>
-        </div>
-        <ShieldCheck size={22} aria-hidden="true" />
-      </div>
-      <div className="auth-form">
-        <a
-          className="button button-primary"
-          href={loginHref}
-          aria-disabled={checking}
-        >
-          {checking ? (
-            <Loader2 className="spin" size={15} />
-          ) : (
-            <KeyRound size={15} />
-          )}
-          <span>{checking ? "Checking session" : "Sign in with GitHub"}</span>
-        </a>
-      </div>
-    </section>
-  );
-}
-
-function ApiErrorPanel({
-  message,
-  traceId,
-  onClearToken,
-}: {
-  message: string;
-  traceId: string;
-  onClearToken: () => void;
-}) {
-  return (
-    <section className="alert-panel" role="alert">
-      <AlertTriangle size={18} aria-hidden="true" />
-      <div>
-        <strong>{message}</strong>
-        {traceId ? <code>{traceId}</code> : null}
-      </div>
-      <button className="button" type="button" onClick={onClearToken}>
-        Sign out
-      </button>
     </section>
   );
 }

--- a/frontend/src/AuthPanels.tsx
+++ b/frontend/src/AuthPanels.tsx
@@ -1,0 +1,53 @@
+import { AlertTriangle, KeyRound, Loader2, ShieldCheck } from "lucide-react";
+
+export function AuthPanel({ checking }: { checking: boolean }) {
+  const loginHref = `/auth/github/login?return_to=${encodeURIComponent(window.location.pathname || "/")}`;
+  return (
+    <section className="auth-panel" aria-labelledby="auth-heading">
+      <div className="section-heading">
+        <div>
+          <p className="eyebrow">Operator access</p>
+          <h1 id="auth-heading">Connect to Launchplane</h1>
+        </div>
+        <ShieldCheck size={22} aria-hidden="true" />
+      </div>
+      <div className="auth-form">
+        <a
+          className="button button-primary"
+          href={loginHref}
+          aria-disabled={checking}
+        >
+          {checking ? (
+            <Loader2 className="spin" size={15} />
+          ) : (
+            <KeyRound size={15} />
+          )}
+          <span>{checking ? "Checking session" : "Sign in with GitHub"}</span>
+        </a>
+      </div>
+    </section>
+  );
+}
+
+export function ApiErrorPanel({
+  message,
+  traceId,
+  onClearToken,
+}: {
+  message: string;
+  traceId: string;
+  onClearToken: () => void;
+}) {
+  return (
+    <section className="alert-panel" role="alert">
+      <AlertTriangle size={18} aria-hidden="true" />
+      <div>
+        <strong>{message}</strong>
+        {traceId ? <code>{traceId}</code> : null}
+      </div>
+      <button className="button" type="button" onClick={onClearToken}>
+        Sign out
+      </button>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Move unauthenticated auth and API error panel rendering from `frontend/src/App.tsx` into `frontend/src/AuthPanels.tsx`
- Keep session/auth state and sign-out behavior in the App shell
- Preserve login URL behavior, markup, and classes

Refs #307

## Validation
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend validate`
- Browser smoke: `http://127.0.0.1:5181/ui/`, verified unauthenticated sign-in panel renders correctly and browser console has no runtime errors