### PR TITLE
Move key value UI primitive

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,7 +43,7 @@ import {
 import { ApiErrorPanel, AuthPanel } from "./AuthPanels";
 import { EveryCodeQueue } from "./EveryCodeQueue";
 import { formatTime, labelForStatus } from "./format";
-import { MetricTile, PanelHead } from "./panel-ui";
+import { KeyValue, MetricTile, PanelHead } from "./panel-ui";
 import { StatusIcon, StatusPill, StateBlock, SkeletonRows } from "./status-ui";
 import type {
   AuthIdentity,
@@ -3367,32 +3367,6 @@ function ActionReviewDialog({
           </button>
         </div>
       </section>
-    </div>
-  );
-}
-
-function KeyValue({
-  label,
-  value,
-  mono = false,
-  muted = false,
-  status,
-}: {
-  label: string;
-  value: string;
-  mono?: boolean;
-  muted?: boolean;
-  status?: Status | string;
-}) {
-  return (
-    <div className="kv-row">
-      <span>{label}</span>
-      <strong
-        className={`${mono ? "mono" : ""} ${muted ? "muted" : ""}`}
-        data-status={status}
-      >
-        {value || "unknown"}
-      </strong>
     </div>
   );
 }

--- a/frontend/src/panel-ui.tsx
+++ b/frontend/src/panel-ui.tsx
@@ -38,3 +38,29 @@ export function MetricTile({
     </div>
   );
 }
+
+export function KeyValue({
+  label,
+  value,
+  mono = false,
+  muted = false,
+  status,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+  muted?: boolean;
+  status?: Status | string;
+}) {
+  return (
+    <div className="kv-row">
+      <span>{label}</span>
+      <strong
+        className={`${mono ? "mono" : ""} ${muted ? "muted" : ""}`}
+        data-status={status}
+      >
+        {value || "unknown"}
+      </strong>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Move the shared `KeyValue` display primitive from `frontend/src/App.tsx` into `frontend/src/panel-ui.tsx`
- Preserve all props, markup/classes, and status attributes
- Keep caller behavior unchanged

Refs #307

## Validation
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend validate`
- Browser smoke: `http://127.0.0.1:5183/ui/?fixtures=1`, confirmed fixture gallery includes KeyValue-driven details and browser console has no runtime errors