### PR TITLE
Extract product read service helpers

### DIFF
--- a/control_plane/product_read_service.py
+++ b/control_plane/product_read_service.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from control_plane.contracts.product_environment_read_model import (
+    ActionAllowed,
+    ProductReadModelStore,
+    build_product_activity_read_model,
+    build_product_environment_detail,
+    build_product_site_overview,
+    build_product_site_overviews,
+)
+
+
+@dataclass(frozen=True)
+class ProductEnvironmentReadServiceResult:
+    payload: dict[str, object]
+    authorization_product: str
+    authorization_context: str
+    denial_message: str
+
+
+def is_product_environment_detail_request(params: Mapping[str, str]) -> bool:
+    return any(key in params for key in ("activity", "environment", "product"))
+
+
+def build_product_profile_list_service_payload(
+    *, record_store: ProductReadModelStore, driver_id: str
+) -> dict[str, object]:
+    profiles = record_store.list_product_profile_records(driver_id=driver_id)
+    return {
+        "driver_id": driver_id,
+        "profiles": [profile.model_dump(mode="json") for profile in profiles],
+    }
+
+
+def build_product_environment_read_service_result(
+    *,
+    record_store: ProductReadModelStore,
+    params: Mapping[str, str],
+    action_allowed: ActionAllowed,
+) -> ProductEnvironmentReadServiceResult:
+    if params.get("activity") == "true":
+        activity = build_product_activity_read_model(
+            record_store=record_store,
+            product=params["product"],
+        )
+        return ProductEnvironmentReadServiceResult(
+            payload={"activity": activity.model_dump(mode="json")},
+            authorization_product=activity.product,
+            authorization_context="launchplane",
+            denial_message="Workflow cannot read the requested product activity.",
+        )
+
+    if "environment" in params:
+        detail = build_product_environment_detail(
+            record_store=record_store,
+            product=params["product"],
+            environment=params["environment"],
+            action_allowed=action_allowed,
+        )
+        return ProductEnvironmentReadServiceResult(
+            payload={"environment": detail.model_dump(mode="json")},
+            authorization_product=detail.product,
+            authorization_context=detail.context,
+            denial_message="Workflow cannot read the requested product environment.",
+        )
+
+    if "product" in params:
+        overview = build_product_site_overview(
+            record_store=record_store,
+            product=params["product"],
+            action_allowed=action_allowed,
+        )
+        return ProductEnvironmentReadServiceResult(
+            payload={"product": overview.model_dump(mode="json")},
+            authorization_product=overview.product,
+            authorization_context="launchplane",
+            denial_message="Workflow cannot read the requested product overview.",
+        )
+
+    raise ValueError("Product environment read result requires product parameters.")
+
+
+def build_product_environment_list_service_payload(
+    *,
+    record_store: ProductReadModelStore,
+    action_allowed: ActionAllowed,
+) -> dict[str, object]:
+
+    overviews = build_product_site_overviews(
+        record_store=record_store,
+        action_allowed=action_allowed,
+    )
+    return {
+        "products": [overview.model_dump(mode="json") for overview in overviews],
+    }

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -26,6 +26,7 @@ from control_plane import dokploy as control_plane_dokploy
 from control_plane import product_config as control_plane_product_config
 from control_plane import product_context_audit as control_plane_product_context_audit
 from control_plane import product_context_cutover as control_plane_product_context_cutover
+from control_plane import product_read_service as control_plane_product_read_service
 from control_plane import live_target_runtime as control_plane_live_target_runtime
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.authz_policy_record import (
@@ -77,12 +78,6 @@ from control_plane.contracts.product_profile_record import (
     ProductLaneProfile,
 )
 from control_plane.contracts.product_onboarding_manifest import ProductOnboardingManifest
-from control_plane.contracts.product_environment_read_model import (
-    build_product_activity_read_model,
-    build_product_environment_detail,
-    build_product_site_overview,
-    build_product_site_overviews,
-)
 from control_plane.contracts.promotion_record import (
     HealthcheckEvidence,
     PostDeployUpdateEvidence,
@@ -5293,15 +5288,17 @@ def create_launchplane_service_app(
                             },
                         )
                     driver_id_filter = str((query.get("driver_id") or [""])[0] or "").strip()
-                    profiles = record_store.list_product_profile_records(driver_id=driver_id_filter)
+                    product_profile_payload = control_plane_product_read_service.build_product_profile_list_service_payload(
+                        record_store=record_store,
+                        driver_id=driver_id_filter,
+                    )
                     return _json_response(
                         start_response=start_response,
                         status_code=200,
                         payload={
                             "status": "ok",
                             "trace_id": request_trace_id,
-                            "driver_id": driver_id_filter,
-                            "profiles": [profile.model_dump(mode="json") for profile in profiles],
+                            **product_profile_payload,
                         },
                     )
                 if action == "product_environment.read":
@@ -5316,48 +5313,18 @@ def create_launchplane_service_app(
                             context=requested_context,
                         )
 
-                    if params.get("activity") == "true":
-                        activity = build_product_activity_read_model(
+                    if control_plane_product_read_service.is_product_environment_detail_request(
+                        params
+                    ):
+                        product_read_result = control_plane_product_read_service.build_product_environment_read_service_result(
                             record_store=record_store,
-                            product=params["product"],
-                        )
-                        if not product_action_allowed(
-                            "product_environment.read",
-                            activity.product,
-                            "launchplane",
-                        ):
-                            return _json_response(
-                                start_response=start_response,
-                                status_code=403,
-                                payload={
-                                    "status": "rejected",
-                                    "trace_id": request_trace_id,
-                                    "error": {
-                                        "code": "authorization_denied",
-                                        "message": "Workflow cannot read the requested product activity.",
-                                    },
-                                },
-                            )
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=200,
-                            payload={
-                                "status": "ok",
-                                "trace_id": request_trace_id,
-                                "activity": activity.model_dump(mode="json"),
-                            },
-                        )
-                    if "environment" in params:
-                        detail = build_product_environment_detail(
-                            record_store=record_store,
-                            product=params["product"],
-                            environment=params["environment"],
+                            params=params,
                             action_allowed=product_action_allowed,
                         )
                         if not product_action_allowed(
                             "product_environment.read",
-                            detail.product,
-                            detail.context,
+                            product_read_result.authorization_product,
+                            product_read_result.authorization_context,
                         ):
                             return _json_response(
                                 start_response=start_response,
@@ -5367,9 +5334,7 @@ def create_launchplane_service_app(
                                     "trace_id": request_trace_id,
                                     "error": {
                                         "code": "authorization_denied",
-                                        "message": (
-                                            "Workflow cannot read the requested product environment."
-                                        ),
+                                        "message": product_read_result.denial_message,
                                     },
                                 },
                             )
@@ -5379,39 +5344,7 @@ def create_launchplane_service_app(
                             payload={
                                 "status": "ok",
                                 "trace_id": request_trace_id,
-                                "environment": detail.model_dump(mode="json"),
-                            },
-                        )
-                    if "product" in params:
-                        overview = build_product_site_overview(
-                            record_store=record_store,
-                            product=params["product"],
-                            action_allowed=product_action_allowed,
-                        )
-                        if not product_action_allowed(
-                            "product_environment.read",
-                            overview.product,
-                            "launchplane",
-                        ):
-                            return _json_response(
-                                start_response=start_response,
-                                status_code=403,
-                                payload={
-                                    "status": "rejected",
-                                    "trace_id": request_trace_id,
-                                    "error": {
-                                        "code": "authorization_denied",
-                                        "message": "Workflow cannot read the requested product overview.",
-                                    },
-                                },
-                            )
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=200,
-                            payload={
-                                "status": "ok",
-                                "trace_id": request_trace_id,
-                                "product": overview.model_dump(mode="json"),
+                                **product_read_result.payload,
                             },
                         )
                     if not product_action_allowed(
@@ -5431,7 +5364,7 @@ def create_launchplane_service_app(
                                 },
                             },
                         )
-                    overviews = build_product_site_overviews(
+                    product_list_payload = control_plane_product_read_service.build_product_environment_list_service_payload(
                         record_store=record_store,
                         action_allowed=product_action_allowed,
                     )
@@ -5441,9 +5374,7 @@ def create_launchplane_service_app(
                         payload={
                             "status": "ok",
                             "trace_id": request_trace_id,
-                            "products": [
-                                overview.model_dump(mode="json") for overview in overviews
-                            ],
+                            **product_list_payload,
                         },
                     )
                 context_name = params["context"]

--- a/tests/test_product_read_service.py
+++ b/tests/test_product_read_service.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import unittest
+from typing import cast
+
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.product_read_service import (
+    build_product_environment_list_service_payload,
+    build_product_environment_read_service_result,
+    build_product_profile_list_service_payload,
+)
+
+
+def _profile_payload(
+    *, product: str = "example-site", driver_id: str = "generic-web"
+) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "product": product,
+        "display_name": "Example Site",
+        "repository": f"every/{product}",
+        "driver_id": driver_id,
+        "image": {"repository": f"ghcr.io/every/{product}"},
+        "runtime_port": 3000,
+        "health_path": "/healthz",
+        "lanes": (
+            {
+                "instance": "testing",
+                "context": "example-site-testing",
+                "base_url": "https://testing.example.invalid",
+                "health_url": "https://testing.example.invalid/healthz",
+            },
+            {
+                "instance": "prod",
+                "context": "example-site-prod",
+                "base_url": "https://example.invalid",
+                "health_url": "https://example.invalid/healthz",
+            },
+        ),
+        "preview": {
+            "enabled": True,
+            "context": "shared-preview",
+            "slug_template": "pr-{number}",
+        },
+        "updated_at": "2026-05-02T22:30:00Z",
+        "source": "test",
+    }
+
+
+class _ProductReadStore:
+    def __init__(self, profile: LaunchplaneProductProfileRecord) -> None:
+        self.profile = profile
+
+    def list_product_profile_records(
+        self,
+        *,
+        driver_id: str = "",
+    ) -> tuple[LaunchplaneProductProfileRecord, ...]:
+        if driver_id and driver_id != self.profile.driver_id:
+            return ()
+        return (self.profile,)
+
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
+        if product != self.profile.product:
+            raise FileNotFoundError(product)
+        return self.profile
+
+    def list_preview_records(
+        self,
+        *,
+        context_name: str = "",
+        anchor_repo: str = "",
+        anchor_pr_number: int | None = None,
+        limit: int | None = None,
+    ) -> tuple[object, ...]:
+        return ()
+
+    def list_deployment_records(
+        self, *, context_name: str = "", instance_name: str = "", limit: int | None = None
+    ) -> tuple[object, ...]:
+        return ()
+
+    def list_promotion_records(
+        self,
+        *,
+        context_name: str = "",
+        from_instance_name: str = "",
+        to_instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[object, ...]:
+        return ()
+
+    def list_backup_gate_records(
+        self, *, context_name: str = "", instance_name: str = "", limit: int | None = None
+    ) -> tuple[object, ...]:
+        return ()
+
+    def list_preview_desired_state_records(
+        self, *, context_name: str = "", limit: int | None = None
+    ) -> tuple[object, ...]:
+        return ()
+
+    def list_preview_lifecycle_cleanup_records(
+        self, *, context_name: str = "", limit: int | None = None
+    ) -> tuple[object, ...]:
+        return ()
+
+    def list_preview_pr_feedback_records(
+        self, *, context_name: str = "", limit: int | None = None
+    ) -> tuple[object, ...]:
+        return ()
+
+    def list_authz_policy_records(
+        self, *, status: str = "", limit: int | None = None
+    ) -> tuple[object, ...]:
+        return ()
+
+    def list_runtime_environment_records(
+        self, *, context_name: str = "", scope: str = ""
+    ) -> tuple[object, ...]:
+        return ()
+
+    def list_secret_binding_records(
+        self, *, context_name: str = "", scope: str = ""
+    ) -> tuple[object, ...]:
+        return ()
+
+
+class ProductReadServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.profile = LaunchplaneProductProfileRecord.model_validate(_profile_payload())
+        self.store = _ProductReadStore(self.profile)
+
+    def test_product_profile_list_payload_preserves_driver_filter(self) -> None:
+        payload = build_product_profile_list_service_payload(
+            record_store=self.store,
+            driver_id="generic-web",
+        )
+
+        self.assertEqual(payload["driver_id"], "generic-web")
+        profiles = cast(list[dict[str, object]], payload["profiles"])
+        self.assertEqual(len(profiles), 1)
+
+    def test_product_environment_result_identifies_authorization_target(self) -> None:
+        result = build_product_environment_read_service_result(
+            record_store=self.store,
+            params={"product": "example-site", "environment": "prod"},
+            action_allowed=lambda _action, _product, _context: True,
+        )
+
+        self.assertEqual(result.authorization_product, "example-site")
+        self.assertEqual(result.authorization_context, "example-site-prod")
+        self.assertEqual(
+            result.denial_message,
+            "Workflow cannot read the requested product environment.",
+        )
+        self.assertIn("environment", result.payload)
+
+    def test_product_environment_list_payload_serializes_overviews(self) -> None:
+        payload = build_product_environment_list_service_payload(
+            record_store=self.store,
+            action_allowed=lambda _action, _product, _context: True,
+        )
+
+        products = cast(list[dict[str, object]], payload["products"])
+        self.assertEqual(len(products), 1)
+        self.assertEqual(products[0]["product"], "example-site")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Extract product profile list and product environment read payload assembly from `service.py` into `control_plane/product_read_service.py`
- Keep route-level authz, status codes, and response envelope wiring in `service.py`
- Add direct unit coverage for the extracted product read helper contracts

Part of #307.

## Validation
- `uv run --extra dev ruff format --check control_plane/service.py control_plane/product_read_service.py tests/test_product_read_service.py`
- `uv run --extra dev ruff check control_plane/service.py control_plane/product_read_service.py tests/test_product_read_service.py`
- `uv run python -m unittest tests.test_product_read_service tests.test_service.LaunchplaneServiceTests.test_product_profile_endpoints_round_trip_authorized_record tests.test_service.LaunchplaneServiceTests.test_product_overview_endpoint_is_generic_web_profile_driven tests.test_service.LaunchplaneServiceTests.test_product_activity_endpoint_returns_product_timeline tests.test_service.LaunchplaneServiceTests.test_product_environment_detail_redacts_runtime_and_secret_values tests.test_service.LaunchplaneServiceTests.test_product_profile_list_denial_includes_authz_diagnostics`
- `uv run python -m unittest tests.test_service tests.test_product_read_service`
- `uv run python -m unittest`