### PR TITLE
feat(every-code): gate preview labels on PR checks

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -107,6 +107,7 @@ from control_plane.every_code_worker import (
     build_every_code_worker_daemon_spec,
     every_code_worker_daemon_status,
     finish_every_code_work_request,
+    request_ready_every_code_pr_preview_labels,
     run_every_code_worker_loop,
     run_every_code_worker_once,
     start_every_code_worker_daemon,
@@ -9769,6 +9770,59 @@ def every_code_finish(
             exit_code=exit_code,
             result_pr_url=result_pr_url,
             result_summary=result_summary,
+        )
+    finally:
+        _close_store(record_store)
+    click.echo(json.dumps(result.as_payload(), indent=2, sort_keys=True))
+
+
+@every_code.command("reconcile-previews")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    default="",
+    show_default=False,
+    help="Optional Postgres connection string for Launchplane work-request records.",
+)
+@click.option(
+    "--service-url",
+    default="",
+    help="Launchplane service base URL for API-backed worker mode.",
+)
+@click.option(
+    "--worker-token-env",
+    default=_EVERY_CODE_WORKER_TOKEN_ENV_KEY,
+    show_default=True,
+    help="Environment variable containing the Every Code worker token.",
+)
+@click.option(
+    "--state-dir",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    default=Path("state"),
+    show_default=True,
+    help="Filesystem state directory used when --database-url is not set.",
+)
+@click.option("--repository", default="", help="Optional owner/repo filter.")
+@click.option("--limit", type=click.IntRange(min=1), default=50, show_default=True)
+def every_code_reconcile_previews(
+    database_url: str,
+    service_url: str,
+    worker_token_env: str,
+    state_dir: Path,
+    repository: str,
+    limit: int,
+) -> None:
+    record_store = _every_code_worker_store(
+        state_dir=state_dir,
+        database_url=database_url,
+        service_url=service_url,
+        worker_token_env=worker_token_env,
+    )
+    try:
+        result = request_ready_every_code_pr_preview_labels(
+            record_store=record_store,
+            repository=repository,
+            limit=limit,
         )
     finally:
         _close_store(record_store)

--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -412,6 +412,24 @@ class EveryCodePrFeedbackApplyResult:
         }
 
 
+@dataclass(frozen=True)
+class EveryCodePreviewGateResult:
+    checked: int = 0
+    labeled: int = 0
+    pending: int = 0
+    blocked: int = 0
+    skipped: int = 0
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "checked": self.checked,
+            "labeled": self.labeled,
+            "pending": self.pending,
+            "blocked": self.blocked,
+            "skipped": self.skipped,
+        }
+
+
 def every_code_tmux_session_name(request_id: str) -> str:
     normalized = re.sub(r"[^A-Za-z0-9_.:-]+", "-", request_id.strip()).strip("-._:")
     return f"every-code-{normalized or 'request'}"[:80]
@@ -1042,6 +1060,11 @@ def run_every_code_worker_loop(
             tmux_binary=tmux_binary,
             runner=runner,
         )
+        request_ready_every_code_pr_preview_labels(
+            record_store=record_store,
+            repository=repository,
+            runner=runner,
+        )
         last_result = run_every_code_worker_once(
             record_store=record_store,
             host=host,
@@ -1537,20 +1560,14 @@ def finish_every_code_work_request(
 ) -> EveryCodeWorkerFinishResult:
     record = record_store.read_every_code_work_request_record(request_id.strip())
     if record.state in TERMINAL_EVERY_CODE_STATES:
-        preview_label_summary = ""
         terminal_pr_url = result_pr_url.strip() or record.result_pr_url
-        if record.state == "done" and exit_code == 0 and terminal_pr_url:
-            preview_label_summary = request_every_code_pr_preview_label(
-                result_pr_url=terminal_pr_url,
-                runner=runner,
-            )
+        del runner
         detail_parts = [
             part
             for part in (
                 record.result_summary
                 or record.error_message
                 or "Every Code request is already terminal.",
-                preview_label_summary,
             )
             if part
         ]
@@ -1563,14 +1580,8 @@ def finish_every_code_work_request(
             result_pr_url=terminal_pr_url,
         )
     succeeded = exit_code == 0
-    preview_label_summary = ""
-    if succeeded and result_pr_url.strip():
-        preview_label_summary = request_every_code_pr_preview_label(
-            result_pr_url=result_pr_url,
-            runner=runner,
-        )
-    summary_parts = [part for part in (result_summary.strip(), preview_label_summary) if part]
-    summary = "; ".join(summary_parts) or (
+    del runner
+    summary = result_summary.strip() or (
         "Every Code session completed successfully."
         if succeeded
         else f"Every Code session exited with status {exit_code}."
@@ -1595,6 +1606,149 @@ def finish_every_code_work_request(
         issue_number=updated_record.issue_number,
         result_pr_url=updated_record.result_pr_url,
     )
+
+
+def request_ready_every_code_pr_preview_labels(
+    *,
+    record_store: EveryCodeWorkerStore,
+    repository: str = "",
+    limit: int = 50,
+    runner: Runner | None = None,
+) -> EveryCodePreviewGateResult:
+    records = record_store.list_every_code_work_request_records(
+        state="done",
+        repository=repository.strip(),
+        limit=limit,
+    )
+    if not records:
+        return EveryCodePreviewGateResult()
+
+    run = runner or _run_subprocess
+    checked = 0
+    labeled = 0
+    pending = 0
+    blocked = 0
+    skipped = 0
+    for record in records:
+        result_pr_url = record.result_pr_url.strip()
+        if not result_pr_url:
+            skipped += 1
+            continue
+        readiness = every_code_pr_preview_readiness(
+            result_pr_url=result_pr_url,
+            runner=run,
+        )
+        if readiness == "ready":
+            checked += 1
+            summary = request_every_code_pr_preview_label(
+                result_pr_url=result_pr_url,
+                runner=run,
+            )
+            if summary.startswith("Requested Launchplane preview"):
+                labeled += 1
+            elif summary:
+                blocked += 1
+            else:
+                skipped += 1
+        elif readiness == "pending":
+            checked += 1
+            pending += 1
+        elif readiness == "blocked":
+            checked += 1
+            blocked += 1
+        else:
+            skipped += 1
+    return EveryCodePreviewGateResult(
+        checked=checked,
+        labeled=labeled,
+        pending=pending,
+        blocked=blocked,
+        skipped=skipped,
+    )
+
+
+def every_code_pr_preview_readiness(
+    *,
+    result_pr_url: str,
+    runner: Runner | None = None,
+) -> Literal["ready", "pending", "blocked", "skipped"]:
+    reference = github_pull_request_reference(pr_url=result_pr_url.strip())
+    if reference is None:
+        return "skipped"
+    preview_label = launchplane_anchor_repo_preview_label(repo=reference["repo"])
+    if not preview_label:
+        return "skipped"
+    payload = _github_pr_view_payload(
+        owner=reference["owner"],
+        repo=reference["repo"],
+        pr_number=reference["pr_number"],
+        runner=runner or _run_subprocess,
+    )
+    if payload is None:
+        return "blocked"
+    if str(payload.get("state") or "").upper() != "OPEN":
+        return "skipped"
+    if _github_pr_payload_has_label(payload, preview_label):
+        return "skipped"
+    check_rollup = payload.get("statusCheckRollup")
+    if not isinstance(check_rollup, list):
+        return "pending"
+    relevant_checks = [
+        item
+        for item in check_rollup
+        if isinstance(item, dict)
+        and str(item.get("conclusion") or "").upper() != "SKIPPED"
+    ]
+    if not relevant_checks:
+        return "ready"
+    if any(str(item.get("status") or "").upper() != "COMPLETED" for item in relevant_checks):
+        return "pending"
+    if all(str(item.get("conclusion") or "").upper() == "SUCCESS" for item in relevant_checks):
+        return "ready"
+    return "blocked"
+
+
+def _github_pr_view_payload(
+    *,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    runner: Runner,
+) -> dict[str, object] | None:
+    try:
+        result = runner(
+            (
+                "gh",
+                "pr",
+                "view",
+                str(pr_number),
+                "--repo",
+                f"{owner}/{repo}",
+                "--json",
+                "state,labels,statusCheckRollup",
+            )
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def _github_pr_payload_has_label(payload: dict[str, object], label_name: str) -> bool:
+    labels = payload.get("labels")
+    if not isinstance(labels, list):
+        return False
+    for label in labels:
+        if isinstance(label, dict) and label.get("name") == label_name:
+            return True
+    return False
 
 
 def request_every_code_pr_preview_label(

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -31,6 +31,7 @@ from control_plane.every_code_worker import (
     every_code_worker_daemon_status,
     finish_every_code_work_request,
     prepare_every_code_checkout,
+    request_ready_every_code_pr_preview_labels,
     request_every_code_pr_preview_label,
     run_every_code_worker_loop,
     run_every_code_worker_once,
@@ -86,11 +87,32 @@ def _feedback_record(*, status: str = "pending") -> EveryCodePrFeedbackRecord:
     )
 
 
+def _done_record(*, repository: str, result_pr_url: str) -> EveryCodeWorkRequestRecord:
+    return _queued_record().model_copy(
+        update={
+            "state": "done",
+            "repository": repository,
+            "result_pr_url": result_pr_url,
+            "claimed_at": "2026-05-05T22:01:00Z",
+            "claimed_by_host": "Chris-Studio",
+            "started_at": "2026-05-05T22:02:00Z",
+            "finished_at": "2026-05-05T22:03:00Z",
+        }
+    )
+
+
 class _Runner:
-    def __init__(self, *, fail_issue_comment: bool = False, existing_branch: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        fail_issue_comment: bool = False,
+        existing_branch: bool = False,
+        pr_view_payload: dict[str, object] | None = None,
+    ) -> None:
         self.calls: list[tuple[str, ...]] = []
         self.fail_issue_comment = fail_issue_comment
         self.existing_branch = existing_branch
+        self.pr_view_payload = pr_view_payload
 
     def __call__(self, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
         self.calls.append(tuple(args))
@@ -122,6 +144,8 @@ class _Runner:
             if self.fail_issue_comment:
                 return subprocess.CompletedProcess(args, 1, "", "rate limited")
             return subprocess.CompletedProcess(args, 0, "", "")
+        if args[:3] == ("gh", "pr", "view") and self.pr_view_payload is not None:
+            return subprocess.CompletedProcess(args, 0, json.dumps(self.pr_view_payload), "")
         if args[1] == "display-message":
             return subprocess.CompletedProcess(args, 0, "4242\n", "")
         if args[1] == "has-session":
@@ -585,6 +609,125 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(summary, "")
         self.assertEqual(runner.calls, [])
 
+    def test_preview_gate_labels_done_pull_request_after_checks_pass(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_every_code_work_request_record(
+                _done_record(
+                    repository="cbusillo/sellyouroutboard",
+                    result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/86",
+                )
+            )
+            runner = _Runner(
+                pr_view_payload={
+                    "state": "OPEN",
+                    "labels": [],
+                    "statusCheckRollup": [
+                        {"name": "static_checks", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                        {"name": "preview", "status": "COMPLETED", "conclusion": "SKIPPED"},
+                    ],
+                }
+            )
+
+            result = request_ready_every_code_pr_preview_labels(
+                record_store=store,
+                runner=runner,
+            )
+
+        self.assertEqual(result.labeled, 1)
+        self.assertIn(
+            (
+                "gh",
+                "pr",
+                "edit",
+                "86",
+                "--repo",
+                "cbusillo/sellyouroutboard",
+                "--add-label",
+                "preview",
+            ),
+            runner.calls,
+        )
+
+    def test_preview_gate_waits_for_incomplete_checks(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_every_code_work_request_record(
+                _done_record(
+                    repository="cbusillo/sellyouroutboard",
+                    result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/86",
+                )
+            )
+            runner = _Runner(
+                pr_view_payload={
+                    "state": "OPEN",
+                    "labels": [],
+                    "statusCheckRollup": [
+                        {"name": "static_checks", "status": "IN_PROGRESS", "conclusion": ""},
+                    ],
+                }
+            )
+
+            result = request_ready_every_code_pr_preview_labels(
+                record_store=store,
+                runner=runner,
+            )
+
+        self.assertEqual(result.pending, 1)
+        self.assertFalse(any(call[:3] == ("gh", "pr", "edit") for call in runner.calls))
+
+    def test_preview_gate_blocks_failed_checks(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_every_code_work_request_record(
+                _done_record(
+                    repository="cbusillo/sellyouroutboard",
+                    result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/86",
+                )
+            )
+            runner = _Runner(
+                pr_view_payload={
+                    "state": "OPEN",
+                    "labels": [],
+                    "statusCheckRollup": [
+                        {"name": "static_checks", "status": "COMPLETED", "conclusion": "FAILURE"},
+                    ],
+                }
+            )
+
+            result = request_ready_every_code_pr_preview_labels(
+                record_store=store,
+                runner=runner,
+            )
+
+        self.assertEqual(result.blocked, 1)
+        self.assertFalse(any(call[:3] == ("gh", "pr", "edit") for call in runner.calls))
+
+    def test_preview_gate_skips_pull_request_with_preview_label(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_every_code_work_request_record(
+                _done_record(
+                    repository="cbusillo/sellyouroutboard",
+                    result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/86",
+                )
+            )
+            runner = _Runner(
+                pr_view_payload={
+                    "state": "OPEN",
+                    "labels": [{"name": "preview"}],
+                    "statusCheckRollup": [],
+                }
+            )
+
+            result = request_ready_every_code_pr_preview_labels(
+                record_store=store,
+                runner=runner,
+            )
+
+        self.assertEqual(result.skipped, 1)
+        self.assertFalse(any(call[:3] == ("gh", "pr", "edit") for call in runner.calls))
+
     def test_prepare_checkout_creates_worker_owned_worktree(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             temporary_root = Path(temporary_directory_name)
@@ -1040,7 +1183,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(record.result_pr_url, "https://github.com/cbusillo/code/pull/99")
         self.assertEqual(record.error_message, "")
 
-    def test_finish_requests_preview_label_for_eligible_pr(self) -> None:
+    def test_finish_defers_preview_label_until_gate_passes(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             temporary_root = Path(temporary_directory_name)
             checkout_root = temporary_root / "Developer" / "tenant-opw"
@@ -1070,8 +1213,8 @@ class EveryCodeWorkerTests(unittest.TestCase):
             )
 
         self.assertEqual(result.status, "done")
-        self.assertIn("Requested Launchplane preview", record.result_summary)
-        self.assertTrue(any(call[:3] == ("gh", "pr", "edit") for call in runner.calls))
+        self.assertNotIn("Requested Launchplane preview", record.result_summary)
+        self.assertFalse(any(call[:3] == ("gh", "pr", "edit") for call in runner.calls))
 
     def test_finish_marks_failed_session_blocked(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -1138,7 +1281,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(result.status, "done")
         self.assertEqual(result.detail, "Linked pull request merged.")
 
-    def test_finish_retries_preview_label_for_terminal_done_request(self) -> None:
+    def test_finish_does_not_retry_preview_label_for_terminal_done_request(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             temporary_root = Path(temporary_directory_name)
             checkout_root = temporary_root / "Developer" / "sellyouroutboard"
@@ -1182,20 +1325,8 @@ class EveryCodeWorkerTests(unittest.TestCase):
             result.result_pr_url,
             "https://github.com/cbusillo/sellyouroutboard/pull/71",
         )
-        self.assertIn("Requested Launchplane preview", result.detail)
-        self.assertIn(
-            (
-                "gh",
-                "pr",
-                "edit",
-                "71",
-                "--repo",
-                "cbusillo/sellyouroutboard",
-                "--add-label",
-                "preview",
-            ),
-            runner.calls,
-        )
+        self.assertEqual(result.detail, "Every Code opened PR #71.")
+        self.assertFalse(any(call[:3] == ("gh", "pr", "edit") for call in runner.calls))
 
     def test_run_once_marks_missing_checkout_blocked(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -1570,6 +1701,33 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         payload = json.loads(result.output)
         self.assertEqual(payload["status"], "done")
+
+    def test_cli_reconcile_previews_reports_gate_summary(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(
+                _done_record(
+                    repository="cbusillo/code",
+                    result_pr_url="https://github.com/cbusillo/code/pull/99",
+                )
+            )
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "every-code",
+                    "reconcile-previews",
+                    "--state-dir",
+                    str(temporary_root / "state"),
+                    "--repository",
+                    "cbusillo/code",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["skipped"], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- defer Every Code preview labels until the PR check rollup is green
- reconcile completed Every Code PRs from the worker loop so missed labels can recover
- add `every-code reconcile-previews` for one-shot backfills

Refs #373.

## Validation
- uv run python -m unittest tests.test_every_code_worker
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest