### PR TITLE
fix(every-code): reconcile previews for running sessions

### DIFF
--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -1615,10 +1615,18 @@ def request_ready_every_code_pr_preview_labels(
     limit: int = 50,
     runner: Runner | None = None,
 ) -> EveryCodePreviewGateResult:
-    records = record_store.list_every_code_work_request_records(
-        state="done",
-        repository=repository.strip(),
-        limit=limit,
+    normalized_repository = repository.strip()
+    records = (
+        *record_store.list_every_code_work_request_records(
+            state="running",
+            repository=normalized_repository,
+            limit=limit,
+        ),
+        *record_store.list_every_code_work_request_records(
+            state="done",
+            repository=normalized_repository,
+            limit=limit,
+        ),
     )
     if not records:
         return EveryCodePreviewGateResult()
@@ -1630,7 +1638,7 @@ def request_ready_every_code_pr_preview_labels(
     blocked = 0
     skipped = 0
     for record in records:
-        result_pr_url = record.result_pr_url.strip()
+        result_pr_url = _every_code_preview_pr_url_for_record(record, runner=run)
         if not result_pr_url:
             skipped += 1
             continue
@@ -1706,6 +1714,54 @@ def every_code_pr_preview_readiness(
     if all(str(item.get("conclusion") or "").upper() == "SUCCESS" for item in relevant_checks):
         return "ready"
     return "blocked"
+
+
+def _every_code_preview_pr_url_for_record(
+    record: EveryCodeWorkRequestRecord,
+    *,
+    runner: Runner,
+) -> str:
+    result_pr_url = record.result_pr_url.strip()
+    if result_pr_url:
+        return result_pr_url
+    if record.state != "running":
+        return ""
+    branch = every_code_worktree_branch(record)
+    try:
+        result = runner(
+            (
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                record.repository.strip(),
+                "--state",
+                "open",
+                "--head",
+                branch,
+                "--json",
+                "url",
+                "--limit",
+                "1",
+            )
+        )
+    except OSError:
+        return ""
+    if result.returncode != 0:
+        return ""
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return ""
+    if not isinstance(payload, list) or not payload:
+        return ""
+    first = payload[0]
+    if not isinstance(first, dict):
+        return ""
+    url = first.get("url")
+    if not isinstance(url, str):
+        return ""
+    return url.strip()
 
 
 def _github_pr_view_payload(

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -565,9 +565,6 @@ class EveryCodeWorkerTests(unittest.TestCase):
         )
 
         self.assertIn("Requested Launchplane preview", summary)
-        expected_record = _queued_record().model_copy(
-            update={"repository": "cbusillo/sellyouroutboard"}
-        )
         self.assertIn(
             (
                 "gh",

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -108,11 +108,13 @@ class _Runner:
         fail_issue_comment: bool = False,
         existing_branch: bool = False,
         pr_view_payload: dict[str, object] | None = None,
+        pr_list_payload: list[dict[str, object]] | None = None,
     ) -> None:
         self.calls: list[tuple[str, ...]] = []
         self.fail_issue_comment = fail_issue_comment
         self.existing_branch = existing_branch
         self.pr_view_payload = pr_view_payload
+        self.pr_list_payload = pr_list_payload
 
     def __call__(self, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
         self.calls.append(tuple(args))
@@ -146,6 +148,8 @@ class _Runner:
             return subprocess.CompletedProcess(args, 0, "", "")
         if args[:3] == ("gh", "pr", "view") and self.pr_view_payload is not None:
             return subprocess.CompletedProcess(args, 0, json.dumps(self.pr_view_payload), "")
+        if args[:3] == ("gh", "pr", "list") and self.pr_list_payload is not None:
+            return subprocess.CompletedProcess(args, 0, json.dumps(self.pr_list_payload), "")
         if args[1] == "display-message":
             return subprocess.CompletedProcess(args, 0, "4242\n", "")
         if args[1] == "has-session":
@@ -561,6 +565,9 @@ class EveryCodeWorkerTests(unittest.TestCase):
         )
 
         self.assertIn("Requested Launchplane preview", summary)
+        expected_record = _queued_record().model_copy(
+            update={"repository": "cbusillo/sellyouroutboard"}
+        )
         self.assertIn(
             (
                 "gh",
@@ -727,6 +734,57 @@ class EveryCodeWorkerTests(unittest.TestCase):
 
         self.assertEqual(result.skipped, 1)
         self.assertFalse(any(call[:3] == ("gh", "pr", "edit") for call in runner.calls))
+
+    def test_preview_gate_discovers_running_request_pull_request_by_branch(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            running_record = _queued_record().model_copy(
+                update={
+                    "state": "running",
+                    "repository": "cbusillo/sellyouroutboard",
+                    "claimed_at": "2026-05-05T22:01:00Z",
+                    "claimed_by_host": "Chris-Studio",
+                    "started_at": "2026-05-05T22:02:00Z",
+                }
+            )
+            store.write_every_code_work_request_record(
+                running_record
+            )
+            runner = _Runner(
+                pr_list_payload=[{"url": "https://github.com/cbusillo/sellyouroutboard/pull/86"}],
+                pr_view_payload={
+                    "state": "OPEN",
+                    "labels": [],
+                    "statusCheckRollup": [
+                        {"name": "static_checks", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                    ],
+                },
+            )
+
+            result = request_ready_every_code_pr_preview_labels(
+                record_store=store,
+                runner=runner,
+            )
+
+        self.assertEqual(result.labeled, 1)
+        self.assertIn(
+            (
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                "cbusillo/sellyouroutboard",
+                "--state",
+                "open",
+                "--head",
+                every_code_worktree_branch(running_record),
+                "--json",
+                "url",
+                "--limit",
+                "1",
+            ),
+            runner.calls,
+        )
 
     def test_prepare_checkout_creates_worker_owned_worktree(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- include running Every Code requests in preview reconciliation
- discover open PRs by the deterministic Every Code branch when result_pr_url is still empty
- keep the existing green-check gate before adding preview labels

Refs #373.

## Validation
- uv run python -m unittest tests.test_every_code_worker
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest