### PR TITLE
Extract product config service error handling

### DIFF
--- a/control_plane/product_config_service.py
+++ b/control_plane/product_config_service.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from control_plane import product_config as control_plane_product_config
+from control_plane.product_config import ProductConfigMode, ProductConfigStore
+
+
+@dataclass(frozen=True)
+class ProductConfigServiceError:
+    status_code: int
+    code: str
+    message: str
+
+
+def apply_product_config_service_request(
+    *,
+    record_store: ProductConfigStore,
+    payload: dict[str, object],
+    mode: ProductConfigMode,
+    actor: str,
+    source_label: str,
+) -> tuple[dict[str, object] | None, ProductConfigServiceError | None]:
+    try:
+        return (
+            control_plane_product_config.apply_product_config_bundle(
+                record_store=record_store,
+                payload=payload,
+                mode=mode,
+                actor=actor,
+                source_label=source_label,
+            ),
+            None,
+        )
+    except control_plane_product_config.ProductConfigError as error:
+        return None, product_config_service_error(error)
+
+
+def product_config_service_error(
+    error: control_plane_product_config.ProductConfigError,
+) -> ProductConfigServiceError:
+    error_code = error.code
+    error_message = "Product config request failed validation."
+    status_code = 400
+    if error_code == "secret_configuration_required":
+        status_code = 503
+        error_message = "Launchplane service is missing required secret write configuration."
+    if error_code == "runtime_key_safety_unavailable":
+        status_code = 503
+        error_message = "Launchplane runtime key-safety policy is unavailable."
+    if error_code == "runtime_key_safety_failed":
+        error_message = "Product config runtime key-safety gate failed."
+    return ProductConfigServiceError(
+        status_code=status_code,
+        code=error_code,
+        message=error_message,
+    )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -24,6 +24,7 @@ from jwt import InvalidTokenError
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import product_config as control_plane_product_config
+from control_plane import product_config_service as control_plane_product_config_service
 from control_plane import product_context_audit as control_plane_product_context_audit
 from control_plane import product_context_cutover as control_plane_product_context_cutover
 from control_plane import product_read_service as control_plane_product_read_service
@@ -5733,40 +5734,29 @@ def create_launchplane_service_app(
                             },
                         },
                     )
-                try:
-                    driver_result = control_plane_product_config.apply_product_config_bundle(
-                        record_store=record_store,
-                        payload=product_config_request.product_config_payload(),
-                        mode=cast(
-                            control_plane_product_config.ProductConfigMode,
-                            product_config_request.mode,
-                        ),
-                        actor=_identity_actor(identity),
-                        source_label=product_config_request.source_label,
-                    )
-                except control_plane_product_config.ProductConfigError as error:
-                    error_code = error.code
-                    error_message = "Product config request failed validation."
-                    status_code = 400
-                    if error_code == "secret_configuration_required":
-                        status_code = 503
-                        error_message = (
-                            "Launchplane service is missing required secret write configuration."
-                        )
-                    if error_code == "runtime_key_safety_unavailable":
-                        status_code = 503
-                        error_message = "Launchplane runtime key-safety policy is unavailable."
-                    if error_code == "runtime_key_safety_failed":
-                        error_message = "Product config runtime key-safety gate failed."
+                (
+                    driver_result,
+                    product_config_error,
+                ) = control_plane_product_config_service.apply_product_config_service_request(
+                    record_store=record_store,
+                    payload=product_config_request.product_config_payload(),
+                    mode=cast(
+                        control_plane_product_config.ProductConfigMode,
+                        product_config_request.mode,
+                    ),
+                    actor=_identity_actor(identity),
+                    source_label=product_config_request.source_label,
+                )
+                if product_config_error is not None:
                     return _json_response(
                         start_response=start_response,
-                        status_code=status_code,
+                        status_code=product_config_error.status_code,
                         payload={
                             "status": "rejected",
                             "trace_id": request_trace_id,
                             "error": {
-                                "code": error_code,
-                                "message": error_message,
+                                "code": product_config_error.code,
+                                "message": product_config_error.message,
                             },
                         },
                     )

--- a/tests/test_product_config_service.py
+++ b/tests/test_product_config_service.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import unittest
+
+from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
+from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyPolicyRecord
+from control_plane.contracts.secret_record import (
+    SecretAuditEvent,
+    SecretBinding,
+    SecretRecord,
+    SecretVersion,
+)
+from control_plane.product_config import ProductConfigError
+from control_plane.product_config_service import (
+    apply_product_config_service_request,
+    product_config_service_error,
+)
+
+
+class _FailingProductConfigStore:
+    def list_runtime_environment_records(
+        self, *, context_name: str = "", instance_name: str = ""
+    ) -> tuple[RuntimeEnvironmentRecord, ...]:
+        return ()
+
+    def write_runtime_environment_record(self, record: RuntimeEnvironmentRecord) -> None:
+        raise AssertionError("dry-run test should not write runtime environment records")
+
+    def list_runtime_key_safety_policy_records(
+        self,
+        *,
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[RuntimeKeySafetyPolicyRecord, ...]:
+        return ()
+
+    def read_secret_record(self, secret_id: str) -> SecretRecord:
+        raise FileNotFoundError(secret_id)
+
+    def list_secret_records(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[SecretRecord, ...]:
+        return ()
+
+    def read_secret_version(self, version_id: str) -> SecretVersion:
+        raise FileNotFoundError(version_id)
+
+    def list_secret_versions(self, *, secret_id: str) -> tuple[SecretVersion, ...]:
+        return ()
+
+    def list_secret_bindings(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[SecretBinding, ...]:
+        return ()
+
+    def list_secret_audit_events(self, *, secret_id: str) -> tuple[SecretAuditEvent, ...]:
+        return ()
+
+    def find_secret_record(
+        self,
+        *,
+        scope: str,
+        integration: str,
+        name: str,
+        context: str = "",
+        instance: str = "",
+    ) -> SecretRecord | None:
+        return None
+
+    def write_secret_record(self, record: SecretRecord) -> None:
+        raise AssertionError("dry-run test should not write secret records")
+
+    def write_secret_version(self, version: SecretVersion) -> None:
+        raise AssertionError("dry-run test should not write secret versions")
+
+    def write_secret_binding(self, binding: SecretBinding) -> None:
+        raise AssertionError("dry-run test should not write secret bindings")
+
+    def write_secret_audit_event(self, event: SecretAuditEvent) -> None:
+        raise AssertionError("dry-run test should not write secret audit events")
+
+
+class ProductConfigServiceTests(unittest.TestCase):
+    def test_service_request_maps_domain_error_without_raising(self) -> None:
+        driver_result, error = apply_product_config_service_request(
+            record_store=_FailingProductConfigStore(),
+            payload={
+                "schema_version": 1,
+                "product": "example-site",
+                "context": "example-site-prod",
+                "instance": "prod",
+                "runtime_env": {"env": {"API_TOKEN": "secret-shaped"}},
+            },
+            mode="dry-run",
+            actor="tester",
+            source_label="test",
+        )
+
+        self.assertIsNone(driver_result)
+        self.assertIsNotNone(error)
+        assert error is not None
+        self.assertEqual(error.status_code, 400)
+        self.assertEqual(error.code, "invalid_request")
+        self.assertEqual(
+            error.message,
+            "Product config request failed validation.",
+        )
+
+    def test_runtime_key_safety_unavailable_error_is_service_unavailable(self) -> None:
+        error = product_config_service_error(
+            ProductConfigError(
+                "runtime key safety unavailable", code="runtime_key_safety_unavailable"
+            )
+        )
+
+        self.assertEqual(error.status_code, 503)
+        self.assertEqual(error.code, "runtime_key_safety_unavailable")
+        self.assertEqual(
+            error.message,
+            "Launchplane runtime key-safety policy is unavailable.",
+        )
+
+    def test_runtime_key_safety_failed_error_is_bad_request(self) -> None:
+        error = product_config_service_error(
+            ProductConfigError("unsafe runtime key", code="runtime_key_safety_failed")
+        )
+
+        self.assertEqual(error.status_code, 400)
+        self.assertEqual(error.code, "runtime_key_safety_failed")
+        self.assertEqual(error.message, "Product config runtime key-safety gate failed.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Extract product-config API domain call/error mapping into `control_plane/product_config_service.py`
- Keep authz, idempotency, DB requirement, and response envelope handling in `service.py`
- Add direct tests for product-config service error normalization

Part of #307.

## Validation
- `uv run --extra dev ruff format --check control_plane/service.py control_plane/product_config_service.py tests/test_product_config_service.py`
- `uv run --extra dev ruff check control_plane/service.py control_plane/product_config_service.py tests/test_product_config_service.py`
- `uv run --extra dev mypy control_plane tests`
- focused product-config endpoint/service tests
- `uv run python -m unittest tests.test_service tests.test_product_config_service`
- `uv run python -m unittest`