### PR TITLE
Extract product onboarding service response helper

### DIFF
--- a/control_plane/product_onboarding_service.py
+++ b/control_plane/product_onboarding_service.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from control_plane.workflows.product_onboarding import ProductOnboardingApplyResult
+
+
+def build_product_onboarding_service_result(
+    onboarding_result: ProductOnboardingApplyResult,
+) -> tuple[dict[str, object], dict[str, object]]:
+    result: dict[str, object] = {
+        "product_profile": onboarding_result.product_profile.product,
+        "dokploy_target_count": len(onboarding_result.dokploy_targets),
+        "dokploy_target_id_count": len(onboarding_result.dokploy_target_ids),
+        "runtime_environment_record_count": len(onboarding_result.runtime_environments),
+        "secret_binding_count": len(onboarding_result.secret_bindings),
+    }
+    driver_result: dict[str, object] = {
+        "product": onboarding_result.product,
+        "product_profile": onboarding_result.product_profile.model_dump(mode="json"),
+        "dokploy_targets": [
+            record.model_dump(mode="json") for record in onboarding_result.dokploy_targets
+        ],
+        "dokploy_target_ids": [
+            {
+                "context": record.context,
+                "instance": record.instance,
+                "target_id_recorded": bool(record.target_id.strip()),
+                "updated_at": record.updated_at,
+                "source_label": record.source_label,
+            }
+            for record in onboarding_result.dokploy_target_ids
+        ],
+        "runtime_environment_records": [
+            {
+                "scope": record.scope,
+                "context": record.context,
+                "instance": record.instance,
+                "env_keys": sorted(record.env),
+                "updated_at": record.updated_at,
+                "source_label": record.source_label,
+            }
+            for record in onboarding_result.runtime_environments
+        ],
+        "secret_bindings": [
+            {
+                "binding_id": binding.binding_id,
+                "integration": binding.integration,
+                "binding_key": binding.binding_key,
+                "context": binding.context,
+                "instance": binding.instance,
+                "status": binding.status,
+                "updated_at": binding.updated_at,
+            }
+            for binding in onboarding_result.secret_bindings
+        ],
+    }
+    return result, driver_result

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -27,6 +27,7 @@ from control_plane import product_config as control_plane_product_config
 from control_plane import product_config_service as control_plane_product_config_service
 from control_plane import product_context_audit as control_plane_product_context_audit
 from control_plane import product_context_cutover as control_plane_product_context_cutover
+from control_plane import product_onboarding_service as control_plane_product_onboarding_service
 from control_plane import product_read_service as control_plane_product_read_service
 from control_plane import live_target_runtime as control_plane_live_target_runtime
 from control_plane import secrets as control_plane_secrets
@@ -6081,54 +6082,11 @@ def create_launchplane_service_app(
                     record_store=record_store,
                     manifest=onboarding_request.manifest,
                 )
-                result = {
-                    "product_profile": onboarding_result.product_profile.product,
-                    "dokploy_target_count": len(onboarding_result.dokploy_targets),
-                    "dokploy_target_id_count": len(onboarding_result.dokploy_target_ids),
-                    "runtime_environment_record_count": len(onboarding_result.runtime_environments),
-                    "secret_binding_count": len(onboarding_result.secret_bindings),
-                }
-                driver_result = {
-                    "product": onboarding_result.product,
-                    "product_profile": onboarding_result.product_profile.model_dump(mode="json"),
-                    "dokploy_targets": [
-                        record.model_dump(mode="json")
-                        for record in onboarding_result.dokploy_targets
-                    ],
-                    "dokploy_target_ids": [
-                        {
-                            "context": record.context,
-                            "instance": record.instance,
-                            "target_id_recorded": bool(record.target_id.strip()),
-                            "updated_at": record.updated_at,
-                            "source_label": record.source_label,
-                        }
-                        for record in onboarding_result.dokploy_target_ids
-                    ],
-                    "runtime_environment_records": [
-                        {
-                            "scope": record.scope,
-                            "context": record.context,
-                            "instance": record.instance,
-                            "env_keys": sorted(record.env),
-                            "updated_at": record.updated_at,
-                            "source_label": record.source_label,
-                        }
-                        for record in onboarding_result.runtime_environments
-                    ],
-                    "secret_bindings": [
-                        {
-                            "binding_id": binding.binding_id,
-                            "integration": binding.integration,
-                            "binding_key": binding.binding_key,
-                            "context": binding.context,
-                            "instance": binding.instance,
-                            "status": binding.status,
-                            "updated_at": binding.updated_at,
-                        }
-                        for binding in onboarding_result.secret_bindings
-                    ],
-                }
+                result, driver_result = (
+                    control_plane_product_onboarding_service.build_product_onboarding_service_result(
+                        onboarding_result
+                    )
+                )
             elif path == "/v1/drivers/launchplane/self-deploy":
                 self_deploy_request = LaunchplaneSelfDeployEnvelope.model_validate(payload)
                 if not authz_policy.allows(

--- a/tests/test_product_onboarding_service.py
+++ b/tests/test_product_onboarding_service.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import unittest
+
+from control_plane.contracts.product_onboarding_manifest import ProductOnboardingManifest
+from control_plane.product_onboarding_service import build_product_onboarding_service_result
+from control_plane.workflows.product_onboarding import apply_product_onboarding_manifest
+
+
+class _ProductOnboardingStore:
+    def __init__(self) -> None:
+        self.product_profiles: list[object] = []
+        self.dokploy_targets: list[object] = []
+        self.dokploy_target_ids: list[object] = []
+        self.runtime_environments: list[object] = []
+        self.secret_bindings: list[object] = []
+
+    def write_product_profile_record(self, record: object) -> None:
+        self.product_profiles.append(record)
+
+    def write_dokploy_target_record(self, record: object) -> None:
+        self.dokploy_targets.append(record)
+
+    def write_dokploy_target_id_record(self, record: object) -> None:
+        self.dokploy_target_ids.append(record)
+
+    def write_runtime_environment_record(self, record: object) -> None:
+        self.runtime_environments.append(record)
+
+    def write_secret_binding(self, binding: object) -> None:
+        self.secret_bindings.append(binding)
+
+
+class ProductOnboardingServiceTests(unittest.TestCase):
+    def test_service_result_summarizes_records_without_secret_ids(self) -> None:
+        manifest = ProductOnboardingManifest.model_validate(
+            {
+                "product": "discord-blue",
+                "display_name": "Discord Blue",
+                "repository": "cbusillo/discord-blue",
+                "driver_id": "generic-web",
+                "image_repository": "ghcr.io/cbusillo/discord-blue",
+                "runtime_port": 8787,
+                "health_path": "/health",
+                "lanes": [{"instance": "prod", "context": "discord-blue"}],
+                "dokploy_targets": [
+                    {
+                        "context": "discord-blue",
+                        "instance": "prod",
+                        "target_id": "app-discord-blue",
+                        "target_type": "application",
+                        "target_name": "discord-blue",
+                        "healthcheck_enabled": False,
+                    }
+                ],
+                "runtime_environments": [
+                    {
+                        "scope": "instance",
+                        "context": "discord-blue",
+                        "instance": "prod",
+                        "env": {"DISCORD_BLUE_STATE_DIR": "/var/lib/discord-blue"},
+                    }
+                ],
+                "secret_bindings": [
+                    {
+                        "binding_key": "DISCORD_TOKEN",
+                        "context": "discord-blue",
+                        "instance": "prod",
+                    }
+                ],
+                "updated_at": "2026-05-04T18:00:00Z",
+                "source_label": "test:discord-blue-onboarding",
+            }
+        )
+        onboarding_result = apply_product_onboarding_manifest(
+            record_store=_ProductOnboardingStore(), manifest=manifest
+        )
+
+        result, driver_result = build_product_onboarding_service_result(onboarding_result)
+
+        self.assertEqual(result["product_profile"], "discord-blue")
+        self.assertEqual(result["dokploy_target_count"], 1)
+        self.assertEqual(result["dokploy_target_id_count"], 1)
+        self.assertEqual(result["runtime_environment_record_count"], 1)
+        self.assertEqual(result["secret_binding_count"], 1)
+        self.assertEqual(driver_result["product"], "discord-blue")
+        self.assertNotIn("secret_id", str(driver_result))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Extract product onboarding API result/driver-result shaping into `control_plane/product_onboarding_service.py`
- Keep authorization, idempotency, DB requirement checks, and manifest application in `service.py`
- Add direct tests for the onboarding service response contract, including secret-id redaction

Part of #307.

## Validation
- `uv run --extra dev ruff format --check control_plane/service.py control_plane/product_onboarding_service.py tests/test_product_onboarding_service.py`
- `uv run --extra dev ruff check control_plane/service.py control_plane/product_onboarding_service.py tests/test_product_onboarding_service.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest tests.test_product_onboarding_service tests.test_service.LaunchplaneServiceTests.test_product_onboarding_endpoint_writes_full_launchplane_owned_bundle`
- `uv run python -m unittest tests.test_service tests.test_product_onboarding_service`
- `uv run python -m unittest`