### PR TITLE
feat(every-code): notify issue authors when previews are ready

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1964,6 +1964,10 @@ def _every_code_work_request_store(record_store: object) -> _EveryCodeWorkReques
     raise TypeError("record store does not support Every Code work requests")
 
 
+def _supports_every_code_work_requests(record_store: object) -> bool:
+    return hasattr(record_store, "list_every_code_work_request_records")
+
+
 def _github_webhook_header(environ: dict[str, object], name: str) -> str:
     return str(environ.get(f"HTTP_{name.upper().replace('-', '_')}", "")).strip()
 
@@ -7663,6 +7667,11 @@ def create_launchplane_service_app(
                     revision=preview_pr_feedback_request.revision,
                     run_url=preview_pr_feedback_request.run_url,
                     failure_summary=preview_pr_feedback_request.failure_summary,
+                    every_code_record_store=(
+                        record_store
+                        if _supports_every_code_work_requests(record_store)
+                        else None
+                    ),
                 )
                 preview_pr_feedback_id = _write_preview_pr_feedback_if_supported(
                     record_store=record_store,

--- a/control_plane/workflows/preview_pr_feedback.py
+++ b/control_plane/workflows/preview_pr_feedback.py
@@ -1,28 +1,298 @@
 from pathlib import Path
+from typing import Protocol
 
 import click
 
+from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
 from control_plane.contracts.preview_pr_feedback_record import (
     PreviewPrFeedbackDeliveryStatus,
     PreviewPrFeedbackRecord,
     PreviewPrFeedbackStatus,
     build_preview_pr_feedback_id,
 )
+from control_plane.every_code_worker import every_code_worktree_branch
 from control_plane.workflows.launchplane import (
     create_github_issue_comment,
     delete_github_issue_comment,
     find_github_issue_comment_by_marker,
+    github_api_request,
     github_pull_request_reference,
     resolve_launchplane_github_token,
     update_github_issue_comment,
 )
 
 DEFAULT_PREVIEW_FEEDBACK_MARKER = "<!-- verireel-preview-control -->"
+DEFAULT_EVERY_CODE_PREVIEW_READY_MARKER_PREFIX = "<!-- launchplane-every-code-preview-ready"
+
+
+class EveryCodeWorkRequestReadStore(Protocol):
+    def list_every_code_work_request_records(
+        self,
+        *,
+        state: str = "",
+        repository: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[EveryCodeWorkRequestRecord, ...]: ...
 
 
 def _comment_url(payload: dict[str, object]) -> str:
     html_url = payload.get("html_url")
     return html_url if isinstance(html_url, str) else ""
+
+
+def _find_every_code_work_request_for_preview(
+    *,
+    record_store: EveryCodeWorkRequestReadStore | None,
+    repository: str,
+    anchor_pr_url: str,
+    anchor_pr_head_branch: str = "",
+) -> EveryCodeWorkRequestRecord | None:
+    if record_store is None:
+        return None
+    normalized_repository = repository.strip()
+    normalized_pr_url = anchor_pr_url.strip()
+    if not normalized_repository or not normalized_pr_url:
+        return None
+
+    records: list[EveryCodeWorkRequestRecord] = []
+    for state in ("running", "done"):
+        records.extend(
+            record_store.list_every_code_work_request_records(
+                state=state,
+                repository=normalized_repository,
+                limit=100,
+            )
+        )
+    for record in records:
+        if record.result_pr_url.strip() == normalized_pr_url:
+            return record
+
+    normalized_head_branch = anchor_pr_head_branch.strip()
+    if not normalized_head_branch:
+        return None
+    for record in records:
+        if record.repository.strip().casefold() != normalized_repository.casefold():
+            continue
+        expected_branch = every_code_worktree_branch(record)
+        if expected_branch == normalized_head_branch:
+            return record
+    return None
+
+
+def _every_code_preview_ready_marker(*, repository: str, pr_number: int) -> str:
+    return f"{DEFAULT_EVERY_CODE_PREVIEW_READY_MARKER_PREFIX}:{repository}#{pr_number} -->"
+
+
+def _render_every_code_preview_ready_issue_comment(
+    *,
+    marker: str,
+    issue_author: str,
+    pr_number: int,
+    anchor_pr_url: str,
+    preview_url: str,
+    reviewer_action: str,
+) -> str:
+    lines = [
+        marker,
+        f"@{issue_author} your Every Code preview is ready for PR #{pr_number}.",
+        "",
+        f"- Preview URL: {preview_url}",
+        f"- Pull request: {anchor_pr_url}",
+    ]
+    if reviewer_action == "requested":
+        lines.append("- Review request: requested you as a reviewer on the pull request.")
+    elif reviewer_action == "already_requested":
+        lines.append("- Review request: you were already requested as a reviewer.")
+    elif reviewer_action == "skipped_pr_author":
+        lines.append("- Review request: skipped because you opened the pull request.")
+    elif reviewer_action.startswith("failed"):
+        lines.append(
+            "- Review request: GitHub did not accept the automatic reviewer request; "
+            "this comment is the fallback notification."
+        )
+    return "\n".join(lines)
+
+
+def _github_issue_author_login(
+    *, owner: str, repo: str, issue_number: int, token: str
+) -> str:
+    payload = github_api_request(
+        path=f"/repos/{owner}/{repo}/issues/{issue_number}",
+        token=token,
+    )
+    if not isinstance(payload, dict):
+        raise click.ClickException(
+            f"GitHub issue response for {owner}/{repo}#{issue_number} must be an object."
+        )
+    user = payload.get("user")
+    if not isinstance(user, dict):
+        return ""
+    login = user.get("login")
+    return login.strip() if isinstance(login, str) else ""
+
+
+def _github_pull_request_author_and_head_branch(
+    *, owner: str, repo: str, pr_number: int, token: str
+) -> tuple[str, str]:
+    payload = github_api_request(
+        path=f"/repos/{owner}/{repo}/pulls/{pr_number}",
+        token=token,
+    )
+    if not isinstance(payload, dict):
+        raise click.ClickException(
+            f"GitHub pull request response for {owner}/{repo}#{pr_number} must be an object."
+        )
+    user = payload.get("user")
+    pr_author = ""
+    if isinstance(user, dict):
+        login = user.get("login")
+        pr_author = login.strip() if isinstance(login, str) else ""
+    head = payload.get("head")
+    if not isinstance(head, dict):
+        return pr_author, ""
+    reference = head.get("ref")
+    return pr_author, reference.strip() if isinstance(reference, str) else ""
+
+
+def _github_requested_reviewer_logins(
+    *, owner: str, repo: str, pr_number: int, token: str
+) -> frozenset[str]:
+    payload = github_api_request(
+        path=f"/repos/{owner}/{repo}/pulls/{pr_number}/requested_reviewers",
+        token=token,
+    )
+    if not isinstance(payload, dict):
+        raise click.ClickException(
+            f"GitHub requested reviewers response for {owner}/{repo}#{pr_number} must be an object."
+        )
+    users = payload.get("users")
+    if not isinstance(users, list):
+        return frozenset()
+    logins: set[str] = set()
+    for item in users:
+        if not isinstance(item, dict):
+            continue
+        login = item.get("login")
+        if isinstance(login, str) and login.strip():
+            logins.add(login.strip().casefold())
+    return frozenset(logins)
+
+
+def _request_github_pull_request_reviewer(
+    *, owner: str, repo: str, pr_number: int, reviewer: str, token: str
+) -> None:
+    payload = github_api_request(
+        path=f"/repos/{owner}/{repo}/pulls/{pr_number}/requested_reviewers",
+        token=token,
+        method="POST",
+        body={"reviewers": [reviewer]},
+    )
+    if not isinstance(payload, dict):
+        raise click.ClickException(
+            f"GitHub reviewer request response for {owner}/{repo}#{pr_number} must be an object."
+        )
+
+
+def _notify_every_code_preview_ready_source_issue(
+    *,
+    record_store: EveryCodeWorkRequestReadStore | None,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    anchor_pr_url: str,
+    repository: str,
+    preview_url: str,
+    token: str,
+) -> str:
+    if not preview_url.strip():
+        return "skipped_no_preview_url"
+    pr_author, pr_head_branch = _github_pull_request_author_and_head_branch(
+        owner=owner,
+        repo=repo,
+        pr_number=pr_number,
+        token=token,
+    )
+    record = _find_every_code_work_request_for_preview(
+        record_store=record_store,
+        repository=repository,
+        anchor_pr_url=anchor_pr_url,
+        anchor_pr_head_branch=pr_head_branch,
+    )
+    if record is None:
+        return "skipped_no_every_code_request"
+
+    issue_author = _github_issue_author_login(
+        owner=owner,
+        repo=repo,
+        issue_number=record.issue_number,
+        token=token,
+    )
+    if not issue_author:
+        return "skipped_no_issue_author"
+
+    reviewer_action = "requested"
+    if pr_author.casefold() == issue_author.casefold():
+        reviewer_action = "skipped_pr_author"
+    else:
+        requested_reviewers = _github_requested_reviewer_logins(
+            owner=owner,
+            repo=repo,
+            pr_number=pr_number,
+            token=token,
+        )
+        if issue_author.casefold() in requested_reviewers:
+            reviewer_action = "already_requested"
+        else:
+            try:
+                _request_github_pull_request_reviewer(
+                    owner=owner,
+                    repo=repo,
+                    pr_number=pr_number,
+                    reviewer=issue_author,
+                    token=token,
+                )
+            except click.ClickException:
+                reviewer_action = "failed"
+
+    marker = _every_code_preview_ready_marker(repository=repository, pr_number=pr_number)
+    comment_markdown = _render_every_code_preview_ready_issue_comment(
+        marker=marker,
+        issue_author=issue_author,
+        pr_number=pr_number,
+        anchor_pr_url=anchor_pr_url,
+        preview_url=preview_url.strip(),
+        reviewer_action=reviewer_action,
+    )
+    existing_comment = find_github_issue_comment_by_marker(
+        owner=owner,
+        repo=repo,
+        issue_number=record.issue_number,
+        token=token,
+        marker=marker,
+    )
+    if existing_comment is not None:
+        existing_comment_id = existing_comment.get("id")
+        if not isinstance(existing_comment_id, int):
+            raise click.ClickException(
+                "Existing Every Code preview ready comment is missing a numeric id."
+            )
+        update_github_issue_comment(
+            owner=owner,
+            repo=repo,
+            comment_id=existing_comment_id,
+            token=token,
+            body=comment_markdown,
+        )
+        return f"updated_source_issue_comment:{reviewer_action}"
+    create_github_issue_comment(
+        owner=owner,
+        repo=repo,
+        issue_number=record.issue_number,
+        token=token,
+        body=comment_markdown,
+    )
+    return f"created_source_issue_comment:{reviewer_action}"
 
 
 def _render_preview_pr_feedback_markdown(
@@ -177,6 +447,7 @@ def build_preview_pr_feedback_record(
     revision: str = "",
     run_url: str = "",
     failure_summary: str = "",
+    every_code_record_store: EveryCodeWorkRequestReadStore | None = None,
 ) -> PreviewPrFeedbackRecord:
     comment_markdown = _render_preview_pr_feedback_markdown(
         marker=marker,
@@ -255,6 +526,19 @@ def build_preview_pr_feedback_record(
                 delivery_action = "created_comment"
                 comment_id = created_comment_id if isinstance(created_comment_id, int) else 0
                 comment_url = _comment_url(created_comment)
+            if status == "ready" and preview_url.strip():
+                source_issue_action = _notify_every_code_preview_ready_source_issue(
+                    record_store=every_code_record_store,
+                    owner=github_reference["owner"],
+                    repo=github_reference["repo"],
+                    pr_number=github_reference["pr_number"],
+                    anchor_pr_url=anchor_pr_url,
+                    repository=repository,
+                    preview_url=preview_url,
+                    token=github_token,
+                )
+                if not delivery_action:
+                    delivery_action = source_issue_action
         except click.ClickException as exc:
             delivery_status = "failed"
             error_message = str(exc)

--- a/tests/test_preview_pr_feedback.py
+++ b/tests/test_preview_pr_feedback.py
@@ -1,11 +1,173 @@
 import unittest
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
+from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
+from control_plane.every_code_worker import every_code_worktree_branch
+from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.preview_pr_feedback import build_preview_pr_feedback_record
 
 
+def _every_code_request(*, result_pr_url: str = "") -> EveryCodeWorkRequestRecord:
+    return EveryCodeWorkRequestRecord(
+        request_id="every-code-cbusillo-sellyouroutboard-82-test",
+        source="github_issue_label",
+        state="running",
+        repository="cbusillo/sellyouroutboard",
+        issue_number=82,
+        issue_url="https://github.com/cbusillo/sellyouroutboard/issues/82",
+        issue_title="Improve image previews",
+        trigger_label="every-code",
+        trigger_actor="Mbanks89",
+        github_delivery_id="delivery-82",
+        queued_at="2026-05-07T12:00:00Z",
+        updated_at="2026-05-07T12:10:00Z",
+        claimed_at="2026-05-07T12:01:00Z",
+        claimed_by_host="Chris-Studio",
+        started_at="2026-05-07T12:02:00Z",
+        result_pr_url=result_pr_url,
+    )
+
+
 class PreviewPrFeedbackWorkflowTests(unittest.TestCase):
+    def test_ready_feedback_notifies_issue_author_and_requests_review(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name))
+            request = _every_code_request(
+                result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/88"
+            )
+            store.write_every_code_work_request_record(request)
+
+            with (
+                patch(
+                    "control_plane.workflows.preview_pr_feedback.resolve_launchplane_github_token",
+                    return_value="github-token",
+                ),
+                patch(
+                    "control_plane.workflows.preview_pr_feedback.find_github_issue_comment_by_marker",
+                    side_effect=[None, None],
+                ) as find_comment,
+                patch(
+                    "control_plane.workflows.preview_pr_feedback.create_github_issue_comment",
+                    side_effect=[
+                        {
+                            "id": 123,
+                            "html_url": "https://github.com/cbusillo/sellyouroutboard/pull/88#issuecomment-123",
+                        },
+                        {
+                            "id": 456,
+                            "html_url": "https://github.com/cbusillo/sellyouroutboard/issues/82#issuecomment-456",
+                        },
+                    ],
+                ) as create_comment,
+                patch(
+                    "control_plane.workflows.preview_pr_feedback.github_api_request",
+                    side_effect=[
+                        {"user": {"login": "code-agent"}, "head": {"ref": "feature/preview"}},
+                        {"user": {"login": "Mbanks89"}},
+                        {"users": []},
+                        {"requested_reviewers": [{"login": "Mbanks89"}]},
+                    ],
+                ) as github_request,
+            ):
+                record = build_preview_pr_feedback_record(
+                    control_plane_root=Path("."),
+                    product="sellyouroutboard",
+                    context="sellyouroutboard-preview",
+                    source="preview-control-plane",
+                    requested_at="2026-05-07T12:20:00Z",
+                    repository="cbusillo/sellyouroutboard",
+                    anchor_repo="sellyouroutboard",
+                    anchor_pr_number=88,
+                    anchor_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/88",
+                    status="ready",
+                    preview_url="https://pr-88.sellyouroutboard.dev",
+                    every_code_record_store=store,
+                )
+
+        self.assertEqual(record.delivery_status, "delivered")
+        self.assertEqual(record.delivery_action, "created_comment")
+        self.assertEqual(find_comment.call_count, 2)
+        create_comment.assert_any_call(
+            owner="cbusillo",
+            repo="sellyouroutboard",
+            issue_number=88,
+            token="github-token",
+            body=record.comment_markdown,
+        )
+        source_issue_call = create_comment.call_args_list[1]
+        self.assertEqual(source_issue_call.kwargs["issue_number"], 82)
+        self.assertIn("@Mbanks89", source_issue_call.kwargs["body"])
+        self.assertIn("https://pr-88.sellyouroutboard.dev", source_issue_call.kwargs["body"])
+        self.assertIn("requested you as a reviewer", source_issue_call.kwargs["body"])
+        self.assertEqual(github_request.call_args_list[3].kwargs["method"], "POST")
+        self.assertEqual(github_request.call_args_list[3].kwargs["body"], {"reviewers": ["Mbanks89"]})
+
+    def test_ready_feedback_updates_issue_comment_and_skips_pr_author_review(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name))
+            request = _every_code_request()
+            store.write_every_code_work_request_record(request)
+
+            with (
+                patch(
+                    "control_plane.workflows.preview_pr_feedback.resolve_launchplane_github_token",
+                    return_value="github-token",
+                ),
+                patch(
+                    "control_plane.workflows.preview_pr_feedback.find_github_issue_comment_by_marker",
+                    side_effect=[
+                        {"id": 123, "body": "<!-- verireel-preview-control -->\nold"},
+                        {
+                            "id": 456,
+                            "body": "<!-- launchplane-every-code-preview-ready:cbusillo/sellyouroutboard#88 -->\nold",
+                        },
+                    ],
+                ),
+                patch(
+                    "control_plane.workflows.preview_pr_feedback.update_github_issue_comment",
+                    return_value={
+                        "id": 123,
+                        "html_url": "https://github.com/cbusillo/sellyouroutboard/pull/88#issuecomment-123",
+                    },
+                ) as update_comment,
+                patch(
+                    "control_plane.workflows.preview_pr_feedback.create_github_issue_comment"
+                ) as create_comment,
+                patch(
+                    "control_plane.workflows.preview_pr_feedback.github_api_request",
+                    side_effect=[
+                        {
+                            "user": {"login": "Mbanks89"},
+                            "head": {"ref": every_code_worktree_branch(request)},
+                        },
+                        {"user": {"login": "Mbanks89"}},
+                    ],
+                ) as github_request,
+            ):
+                record = build_preview_pr_feedback_record(
+                    control_plane_root=Path("."),
+                    product="sellyouroutboard",
+                    context="sellyouroutboard-preview",
+                    source="preview-control-plane",
+                    requested_at="2026-05-07T12:20:00Z",
+                    repository="cbusillo/sellyouroutboard",
+                    anchor_repo="sellyouroutboard",
+                    anchor_pr_number=88,
+                    anchor_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/88",
+                    status="ready",
+                    preview_url="https://pr-88.sellyouroutboard.dev",
+                    every_code_record_store=store,
+                )
+
+        self.assertEqual(record.delivery_status, "delivered")
+        create_comment.assert_not_called()
+        self.assertEqual(update_comment.call_count, 2)
+        self.assertEqual(update_comment.call_args_list[1].kwargs["comment_id"], 456)
+        self.assertIn("skipped because you opened the pull request", update_comment.call_args_list[1].kwargs["body"])
+        self.assertEqual(github_request.call_count, 2)
+
     def test_pending_feedback_renders_neutral_waiting_comment(self) -> None:
         with (
             patch(


### PR DESCRIPTION
## Summary
- notify the source issue author when an Every Code preview reaches the ready state
- request the issue author as a PR reviewer when GitHub allows it
- match running Every Code requests by result PR URL or deterministic Every Code branch

Closes #392.

## Validation
- uv run --extra dev ruff check .
- uv run python -m unittest tests.test_preview_pr_feedback
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest