### PR TITLE
Extract runtime key safety service helpers

### DIFF
--- a/control_plane/runtime_key_safety_service.py
+++ b/control_plane/runtime_key_safety_service.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol
+
+from control_plane.contracts.runtime_key_safety_policy import (
+    RuntimeKeySafetyPolicyRecord,
+    RuntimeSecretSafetyRule,
+)
+
+
+TimestampProvider = Callable[[], str]
+RecordSlugProvider = Callable[[str], str]
+
+
+class RuntimeKeySafetyPolicyStore(Protocol):
+    def list_runtime_key_safety_policy_records(
+        self,
+        *,
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[RuntimeKeySafetyPolicyRecord, ...]: ...
+
+    def write_runtime_key_safety_policy_record(
+        self, record: RuntimeKeySafetyPolicyRecord
+    ) -> None: ...
+
+
+def summarize_runtime_key_safety_policy_record(
+    record: RuntimeKeySafetyPolicyRecord,
+) -> dict[str, object]:
+    return {
+        "record_id": record.record_id,
+        "status": record.status,
+        "source": record.source,
+        "updated_at": record.updated_at,
+        "policy_sha256": record.policy_sha256,
+        "rule_count": len(record.rules),
+        "binding_keys": [rule.binding_key for rule in record.rules],
+    }
+
+
+def write_runtime_key_safety_policy(
+    *,
+    record_store: RuntimeKeySafetyPolicyStore,
+    rules: tuple[RuntimeSecretSafetyRule, ...],
+    source_label: str,
+    now_timestamp: TimestampProvider,
+    record_slug: RecordSlugProvider,
+) -> tuple[RuntimeKeySafetyPolicyRecord, bool]:
+    existing_records = record_store.list_runtime_key_safety_policy_records(status="active", limit=1)
+    existing_record = existing_records[0] if existing_records else None
+    merged_rules = merge_runtime_key_safety_rules(
+        existing_record.rules if existing_record is not None else (), rules
+    )
+    updated_at = now_timestamp()
+    pending_record = RuntimeKeySafetyPolicyRecord(
+        record_id="runtime-key-safety-policy-pending",
+        status="active",
+        source=source_label,
+        updated_at=updated_at,
+        rules=merged_rules,
+    )
+    if (
+        existing_record is not None
+        and existing_record.policy_sha256 == pending_record.policy_sha256
+    ):
+        return existing_record, False
+    record = pending_record.model_copy(
+        update={
+            "record_id": "runtime-key-safety-policy-"
+            f"{record_slug(updated_at)}-{pending_record.policy_sha256[:12]}",
+        }
+    )
+    record_store.write_runtime_key_safety_policy_record(record)
+    return record, True
+
+
+def merge_runtime_key_safety_rules(
+    existing_rules: tuple[RuntimeSecretSafetyRule, ...],
+    requested_rules: tuple[RuntimeSecretSafetyRule, ...],
+) -> tuple[RuntimeSecretSafetyRule, ...]:
+    rules_by_binding_key = {rule.binding_key: rule for rule in existing_rules}
+    for requested_rule in requested_rules:
+        existing_rule = rules_by_binding_key.get(requested_rule.binding_key)
+        if existing_rule is None or existing_rule.secret_class != requested_rule.secret_class:
+            rules_by_binding_key[requested_rule.binding_key] = requested_rule
+            continue
+        rules_by_binding_key[requested_rule.binding_key] = requested_rule.model_copy(
+            update={
+                "allowed_contexts": merge_runtime_key_safety_scope_values(
+                    existing_rule.allowed_contexts, requested_rule.allowed_contexts
+                ),
+                "allowed_instances": merge_runtime_key_safety_scope_values(
+                    existing_rule.allowed_instances, requested_rule.allowed_instances
+                ),
+                "description": requested_rule.description or existing_rule.description,
+            }
+        )
+    return tuple(rules_by_binding_key[key] for key in sorted(rules_by_binding_key))
+
+
+def merge_runtime_key_safety_scope_values(
+    existing_values: tuple[str, ...], requested_values: tuple[str, ...]
+) -> tuple[str, ...]:
+    if not existing_values or not requested_values:
+        return ()
+    return tuple(sorted({*existing_values, *requested_values}))

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -30,6 +30,7 @@ from control_plane import product_context_cutover as control_plane_product_conte
 from control_plane import product_onboarding_service as control_plane_product_onboarding_service
 from control_plane import product_read_service as control_plane_product_read_service
 from control_plane import live_target_runtime as control_plane_live_target_runtime
+from control_plane import runtime_key_safety_service as control_plane_runtime_key_safety_service
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.authz_policy_record import (
     LaunchplaneAuthzPolicyRecord,
@@ -86,10 +87,7 @@ from control_plane.contracts.promotion_record import (
     PromotionRecord,
     ReleaseStatus,
 )
-from control_plane.contracts.runtime_key_safety_policy import (
-    RuntimeKeySafetyPolicyRecord,
-    RuntimeSecretSafetyRule,
-)
+from control_plane.contracts.runtime_key_safety_policy import RuntimeSecretSafetyRule
 from control_plane.drivers.registry import (
     build_driver_context_view,
     list_driver_descriptors,
@@ -3716,85 +3714,6 @@ def _write_github_actions_authz_policy_grant(
     return updated_policy, record, changed, diff, record.audit
 
 
-def _summarize_runtime_key_safety_policy_record(
-    record: RuntimeKeySafetyPolicyRecord,
-) -> dict[str, object]:
-    return {
-        "record_id": record.record_id,
-        "status": record.status,
-        "source": record.source,
-        "updated_at": record.updated_at,
-        "policy_sha256": record.policy_sha256,
-        "rule_count": len(record.rules),
-        "binding_keys": [rule.binding_key for rule in record.rules],
-    }
-
-
-def _write_runtime_key_safety_policy(
-    *,
-    record_store: PostgresRecordStore,
-    request: RuntimeKeySafetyPolicyApplyEnvelope,
-) -> tuple[RuntimeKeySafetyPolicyRecord, bool]:
-    existing_records = record_store.list_runtime_key_safety_policy_records(status="active", limit=1)
-    existing_record = existing_records[0] if existing_records else None
-    rules = _merged_runtime_key_safety_rules(
-        existing_record.rules if existing_record is not None else (), request.rules
-    )
-    updated_at = _now_timestamp()
-    pending_record = RuntimeKeySafetyPolicyRecord(
-        record_id="runtime-key-safety-policy-pending",
-        status="active",
-        source=request.source_label,
-        updated_at=updated_at,
-        rules=rules,
-    )
-    if (
-        existing_record is not None
-        and existing_record.policy_sha256 == pending_record.policy_sha256
-    ):
-        return existing_record, False
-    record = pending_record.model_copy(
-        update={
-            "record_id": "runtime-key-safety-policy-"
-            f"{_record_slug(updated_at)}-{pending_record.policy_sha256[:12]}",
-        }
-    )
-    record_store.write_runtime_key_safety_policy_record(record)
-    return record, True
-
-
-def _merged_runtime_key_safety_rules(
-    existing_rules: tuple[RuntimeSecretSafetyRule, ...],
-    requested_rules: tuple[RuntimeSecretSafetyRule, ...],
-) -> tuple[RuntimeSecretSafetyRule, ...]:
-    rules_by_binding_key = {rule.binding_key: rule for rule in existing_rules}
-    for requested_rule in requested_rules:
-        existing_rule = rules_by_binding_key.get(requested_rule.binding_key)
-        if existing_rule is None or existing_rule.secret_class != requested_rule.secret_class:
-            rules_by_binding_key[requested_rule.binding_key] = requested_rule
-            continue
-        rules_by_binding_key[requested_rule.binding_key] = requested_rule.model_copy(
-            update={
-                "allowed_contexts": _merged_runtime_key_safety_scope_values(
-                    existing_rule.allowed_contexts, requested_rule.allowed_contexts
-                ),
-                "allowed_instances": _merged_runtime_key_safety_scope_values(
-                    existing_rule.allowed_instances, requested_rule.allowed_instances
-                ),
-                "description": requested_rule.description or existing_rule.description,
-            }
-        )
-    return tuple(rules_by_binding_key[key] for key in sorted(rules_by_binding_key))
-
-
-def _merged_runtime_key_safety_scope_values(
-    existing_values: tuple[str, ...], requested_values: tuple[str, ...]
-) -> tuple[str, ...]:
-    if not existing_values or not requested_values:
-        return ()
-    return tuple(sorted({*existing_values, *requested_values}))
-
-
 def _request_launchplane_self_deploy(
     *,
     control_plane_root_path: Path,
@@ -5929,16 +5848,22 @@ def create_launchplane_service_app(
                 )
                 if idempotent_response is not None:
                     return idempotent_response
-                runtime_policy_record, changed = _write_runtime_key_safety_policy(
+                (
+                    runtime_policy_record,
+                    changed,
+                ) = control_plane_runtime_key_safety_service.write_runtime_key_safety_policy(
                     record_store=record_store,
-                    request=runtime_policy_request,
+                    rules=runtime_policy_request.rules,
+                    source_label=runtime_policy_request.source_label,
+                    now_timestamp=_now_timestamp,
+                    record_slug=_record_slug,
                 )
                 result = {
                     "runtime_key_safety_policy_record_id": runtime_policy_record.record_id,
                     "runtime_key_safety_policy_changed": str(changed).lower(),
                 }
                 driver_result = {
-                    "runtime_key_safety_policy": _summarize_runtime_key_safety_policy_record(
+                    "runtime_key_safety_policy": control_plane_runtime_key_safety_service.summarize_runtime_key_safety_policy_record(
                         runtime_policy_record
                     ),
                     "changed": changed,
@@ -7626,9 +7551,7 @@ def create_launchplane_service_app(
                     run_url=preview_pr_feedback_request.run_url,
                     failure_summary=preview_pr_feedback_request.failure_summary,
                     every_code_record_store=(
-                        record_store
-                        if _supports_every_code_work_requests(record_store)
-                        else None
+                        record_store if _supports_every_code_work_requests(record_store) else None
                     ),
                 )
                 preview_pr_feedback_id = _write_preview_pr_feedback_if_supported(

--- a/tests/test_runtime_key_safety_service.py
+++ b/tests/test_runtime_key_safety_service.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import unittest
+
+from control_plane.contracts.runtime_key_safety_policy import (
+    RuntimeKeySafetyPolicyRecord,
+    RuntimeSecretSafetyRule,
+)
+from control_plane.runtime_key_safety_service import (
+    merge_runtime_key_safety_scope_values,
+    merge_runtime_key_safety_rules,
+    summarize_runtime_key_safety_policy_record,
+    write_runtime_key_safety_policy,
+)
+
+
+class _RuntimeKeySafetyPolicyStore:
+    def __init__(self, records: tuple[RuntimeKeySafetyPolicyRecord, ...] = ()) -> None:
+        self.records = records
+        self.written_records: list[RuntimeKeySafetyPolicyRecord] = []
+
+    def list_runtime_key_safety_policy_records(
+        self,
+        *,
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[RuntimeKeySafetyPolicyRecord, ...]:
+        records = tuple(record for record in self.records if not status or record.status == status)
+        if limit is not None:
+            return records[:limit]
+        return records
+
+    def write_runtime_key_safety_policy_record(self, record: RuntimeKeySafetyPolicyRecord) -> None:
+        self.written_records.append(record)
+        self.records = (record,) + self.records
+
+
+def _rule(
+    binding_key: str,
+    *,
+    secret_class: str = "prod_only",
+    contexts: tuple[str, ...] = (),
+    instances: tuple[str, ...] = (),
+    description: str = "",
+) -> RuntimeSecretSafetyRule:
+    return RuntimeSecretSafetyRule.model_validate(
+        {
+            "binding_key": binding_key,
+            "secret_class": secret_class,
+            "allowed_contexts": contexts,
+            "allowed_instances": instances,
+            "description": description,
+        }
+    )
+
+
+class RuntimeKeySafetyServiceTests(unittest.TestCase):
+    def test_scope_value_merge_preserves_open_scope(self) -> None:
+        self.assertEqual(merge_runtime_key_safety_scope_values((), ("prod",)), ())
+        self.assertEqual(merge_runtime_key_safety_scope_values(("prod",), ()), ())
+        self.assertEqual(
+            merge_runtime_key_safety_scope_values(("prod",), ("testing",)),
+            ("prod", "testing"),
+        )
+
+    def test_rule_merge_combines_matching_secret_class_and_sorts_by_binding(self) -> None:
+        merged_rules = merge_runtime_key_safety_rules(
+            (
+                _rule(
+                    "SMTP_PASSWORD",
+                    contexts=("sellyouroutboard",),
+                    instances=("prod",),
+                    description="existing",
+                ),
+            ),
+            (
+                _rule("RESEND_API_KEY", contexts=("sellyouroutboard",), instances=("prod",)),
+                _rule(
+                    "SMTP_PASSWORD",
+                    contexts=("verireel",),
+                    instances=("prod",),
+                    description="",
+                ),
+            ),
+        )
+
+        self.assertEqual(
+            [rule.binding_key for rule in merged_rules], ["RESEND_API_KEY", "SMTP_PASSWORD"]
+        )
+        smtp_rule = merged_rules[1]
+        self.assertEqual(smtp_rule.allowed_contexts, ("sellyouroutboard", "verireel"))
+        self.assertEqual(smtp_rule.allowed_instances, ("prod",))
+        self.assertEqual(smtp_rule.description, "existing")
+
+    def test_write_runtime_key_safety_policy_records_only_changed_policy(self) -> None:
+        store = _RuntimeKeySafetyPolicyStore()
+
+        record, changed = write_runtime_key_safety_policy(
+            record_store=store,
+            rules=(_rule("SMTP_PASSWORD", contexts=("sellyouroutboard",), instances=("prod",)),),
+            source_label="test:runtime-key-safety-policy",
+            now_timestamp=lambda: "2026-05-07T15:45:00Z",
+            record_slug=lambda value: value.lower().replace(":", "-"),
+        )
+
+        self.assertTrue(changed)
+        self.assertEqual(store.written_records, [record])
+        self.assertTrue(
+            record.record_id.startswith("runtime-key-safety-policy-2026-05-07t15-45-00z-")
+        )
+        summary = summarize_runtime_key_safety_policy_record(record)
+        self.assertEqual(summary["binding_keys"], ["SMTP_PASSWORD"])
+
+        repeated_record, repeated_changed = write_runtime_key_safety_policy(
+            record_store=store,
+            rules=(_rule("SMTP_PASSWORD", contexts=("sellyouroutboard",), instances=("prod",)),),
+            source_label="test:runtime-key-safety-policy",
+            now_timestamp=lambda: "2026-05-07T15:46:00Z",
+            record_slug=lambda value: value.lower().replace(":", "-"),
+        )
+
+        self.assertFalse(repeated_changed)
+        self.assertEqual(repeated_record.record_id, record.record_id)
+        self.assertEqual(store.written_records, [record])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Extract runtime-key-safety policy summary/write/merge helpers from `service.py` into `control_plane/runtime_key_safety_service.py`
- Keep route authorization, idempotency, DB requirement checks, and response envelopes in `service.py`
- Add direct coverage for scope merge behavior, rule reconciliation, summary shaping, and idempotent no-op writes

Part of #307.

## Validation
- `uv run --extra dev ruff format --check control_plane/service.py control_plane/runtime_key_safety_service.py tests/test_runtime_key_safety_service.py`
- `uv run --extra dev ruff check control_plane/service.py control_plane/runtime_key_safety_service.py tests/test_runtime_key_safety_service.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest tests.test_runtime_key_safety_service tests.test_service.LaunchplaneServiceTests.test_runtime_key_safety_policy_endpoint_reconciles_rules tests.test_service.LaunchplaneServiceTests.test_runtime_key_safety_policy_endpoint_rejects_without_permission`
- `uv run python -m unittest tests.test_service tests.test_runtime_key_safety_service`
- `uv run python -m unittest`