### PR TITLE
Extract authz grant service helpers

### DIFF
--- a/control_plane/authz_grant_service.py
+++ b/control_plane/authz_grant_service.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.authz_policy_record import (
+    LaunchplaneAuthzPolicyRecord,
+    authz_policy_sha256,
+    build_authz_policy_record_id,
+)
+from control_plane.service_auth import (
+    GitHubActionsPolicyRule,
+    GitHubHumanIdentity,
+    LaunchplaneAuthzPolicy,
+    LaunchplaneIdentity,
+)
+
+
+TimestampProvider = Callable[[], str]
+
+
+class AuthzPolicyRecordStore(Protocol):
+    def list_authz_policy_records(
+        self,
+        *,
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[LaunchplaneAuthzPolicyRecord, ...]: ...
+
+    def write_authz_policy_record(self, record: LaunchplaneAuthzPolicyRecord) -> None: ...
+
+
+class AuthzPolicyGitHubActionsGrant(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    repository: str
+    workflow_refs: tuple[str, ...] = ()
+    job_workflow_refs: tuple[str, ...] = ()
+    event_names: tuple[str, ...] = ()
+    refs: tuple[str, ...] = ()
+    environments: tuple[str, ...] = ()
+    products: tuple[str, ...] = ()
+    contexts: tuple[str, ...] = ()
+    actions: tuple[str, ...]
+    source_label: str = "service:authz-policy-grant"
+
+    @staticmethod
+    def _normalized_tuple(values: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(value.strip() for value in values if value.strip())
+
+    @model_validator(mode="after")
+    def _validate_grant(self) -> "AuthzPolicyGitHubActionsGrant":
+        self.repository = self.repository.strip()
+        if not self.repository:
+            raise ValueError("Authz policy grant requires repository.")
+        self.workflow_refs = self._normalized_tuple(self.workflow_refs)
+        self.job_workflow_refs = self._normalized_tuple(self.job_workflow_refs)
+        self.event_names = self._normalized_tuple(self.event_names)
+        self.refs = self._normalized_tuple(self.refs)
+        self.environments = self._normalized_tuple(self.environments)
+        self.products = self._normalized_tuple(self.products)
+        self.contexts = self._normalized_tuple(self.contexts)
+        self.actions = self._normalized_tuple(self.actions)
+        if not self.actions:
+            raise ValueError("Authz policy grant requires at least one action.")
+        self.source_label = self.source_label.strip() or "service:authz-policy-grant"
+        return self
+
+    def to_policy_rule(self) -> GitHubActionsPolicyRule:
+        return GitHubActionsPolicyRule(
+            repository=self.repository,
+            workflow_refs=self.workflow_refs,
+            job_workflow_refs=self.job_workflow_refs,
+            event_names=self.event_names,
+            refs=self.refs,
+            environments=self.environments,
+            products=self.products,
+            contexts=self.contexts,
+            actions=self.actions,
+        )
+
+
+class AuthzPolicyGitHubActionsGrantEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    mode: Literal["dry_run", "apply"] = "apply"
+    reason: str = ""
+    related_issue: str = ""
+    grant: AuthzPolicyGitHubActionsGrant
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "AuthzPolicyGitHubActionsGrantEnvelope":
+        if self.product.strip() != "launchplane":
+            raise ValueError("Authz policy grant writes require product 'launchplane'.")
+        self.product = "launchplane"
+        self.reason = self.reason.strip()
+        self.related_issue = self.related_issue.strip()
+        if self.mode == "apply" and not self.reason:
+            raise ValueError("Authz policy grant apply requires reason.")
+        return self
+
+
+def summarize_authz_policy_record(record: LaunchplaneAuthzPolicyRecord) -> dict[str, object]:
+    return {
+        "record_id": record.record_id,
+        "status": record.status,
+        "source": record.source,
+        "updated_at": record.updated_at,
+        "policy_sha256": record.policy_sha256,
+        "github_actions_rule_count": len(record.policy.github_actions),
+        "github_humans_rule_count": len(record.policy.github_humans),
+    }
+
+
+def authz_policy_operator_payload(identity: LaunchplaneIdentity) -> dict[str, object]:
+    if isinstance(identity, GitHubHumanIdentity):
+        return {
+            "type": "github_human",
+            "login": identity.login,
+            "role": identity.role,
+        }
+    return {
+        "type": "github_actions",
+        "repository": identity.repository,
+        "workflow_ref": identity.workflow_ref,
+        "event_name": identity.event_name,
+        "ref": identity.ref,
+        "sha": identity.sha,
+    }
+
+
+def authz_policy_grant_diff(
+    *, current_policy: LaunchplaneAuthzPolicy, grant: AuthzPolicyGitHubActionsGrant
+) -> dict[str, object]:
+    desired_rule = grant.to_policy_rule()
+    changed = not any(rule == desired_rule for rule in current_policy.github_actions)
+    return {
+        "changed": changed,
+        "previous_github_actions_rule_count": len(current_policy.github_actions),
+        "new_github_actions_rule_count": len(current_policy.github_actions) + int(changed),
+    }
+
+
+def authz_policy_grant_audit_payload(
+    *,
+    request: AuthzPolicyGitHubActionsGrantEnvelope,
+    identity: LaunchplaneIdentity,
+    previous_record: LaunchplaneAuthzPolicyRecord,
+    new_record: LaunchplaneAuthzPolicyRecord | None,
+    changed: bool,
+    trace_id: str,
+    now_timestamp: TimestampProvider,
+) -> dict[str, object]:
+    return {
+        "mode": request.mode,
+        "reason": request.reason,
+        "related_issue": request.related_issue,
+        "operator": authz_policy_operator_payload(identity),
+        "requested_grant": request.grant.to_policy_rule().model_dump(mode="json"),
+        "previous_policy_record_id": previous_record.record_id,
+        "previous_policy_sha256": previous_record.policy_sha256,
+        "new_policy_record_id": new_record.record_id
+        if new_record is not None
+        else previous_record.record_id,
+        "new_policy_sha256": new_record.policy_sha256
+        if new_record is not None
+        else previous_record.policy_sha256,
+        "changed": changed,
+        "trace_id": trace_id,
+        "updated_at": new_record.updated_at if new_record is not None else now_timestamp(),
+    }
+
+
+def authz_policy_grant_response_audit_payload(
+    audit: dict[str, object],
+) -> dict[str, object]:
+    response_audit = dict(audit)
+    requested_grant = response_audit.pop("requested_grant", None)
+    if isinstance(requested_grant, dict):
+        response_audit["requested_grant_summary"] = {
+            "repository": requested_grant.get("repository", ""),
+            "workflow_ref_count": len(requested_grant.get("workflow_refs") or ()),
+            "job_workflow_ref_count": len(requested_grant.get("job_workflow_refs") or ()),
+            "event_names": requested_grant.get("event_names") or (),
+            "products": requested_grant.get("products") or (),
+            "contexts": requested_grant.get("contexts") or (),
+            "actions": requested_grant.get("actions") or (),
+        }
+    return response_audit
+
+
+def plan_github_actions_authz_policy_grant(
+    *,
+    record_store: AuthzPolicyRecordStore,
+    grant: AuthzPolicyGitHubActionsGrant,
+) -> tuple[LaunchplaneAuthzPolicy, LaunchplaneAuthzPolicyRecord, dict[str, object]]:
+    active_records = record_store.list_authz_policy_records(status="active", limit=1)
+    if not active_records:
+        raise ValueError("No active Launchplane authz policy record found.")
+    current_record = active_records[0]
+    current_policy = current_record.policy
+    return (
+        current_policy,
+        current_record,
+        authz_policy_grant_diff(
+            current_policy=current_policy,
+            grant=grant,
+        ),
+    )
+
+
+def write_github_actions_authz_policy_grant(
+    *,
+    record_store: AuthzPolicyRecordStore,
+    request: AuthzPolicyGitHubActionsGrantEnvelope,
+    identity: LaunchplaneIdentity,
+    trace_id: str,
+    now_timestamp: TimestampProvider,
+) -> tuple[
+    LaunchplaneAuthzPolicy,
+    LaunchplaneAuthzPolicyRecord,
+    bool,
+    dict[str, object],
+    dict[str, object],
+]:
+    current_policy, current_record, diff = plan_github_actions_authz_policy_grant(
+        record_store=record_store,
+        grant=request.grant,
+    )
+    changed = bool(diff["changed"])
+    desired_rule = request.grant.to_policy_rule()
+    if not changed:
+        audit = authz_policy_grant_audit_payload(
+            request=request,
+            identity=identity,
+            previous_record=current_record,
+            new_record=None,
+            changed=False,
+            trace_id=trace_id,
+            now_timestamp=now_timestamp,
+        )
+        return current_policy, current_record, False, diff, audit
+
+    updated_policy = current_policy.model_copy(
+        update={"github_actions": current_policy.github_actions + (desired_rule,)}
+    )
+    updated_at = now_timestamp()
+    policy_sha256 = authz_policy_sha256(updated_policy)
+    record = LaunchplaneAuthzPolicyRecord(
+        record_id=build_authz_policy_record_id(
+            updated_at=updated_at,
+            policy_sha256=policy_sha256,
+        ),
+        status="active",
+        source=request.grant.source_label,
+        updated_at=updated_at,
+        policy_sha256=policy_sha256,
+        policy=updated_policy,
+        audit=authz_policy_grant_audit_payload(
+            request=request,
+            identity=identity,
+            previous_record=current_record,
+            new_record=None,
+            changed=True,
+            trace_id=trace_id,
+            now_timestamp=now_timestamp,
+        ),
+    )
+    record.audit = authz_policy_grant_audit_payload(
+        request=request,
+        identity=identity,
+        previous_record=current_record,
+        new_record=record,
+        changed=True,
+        trace_id=trace_id,
+        now_timestamp=now_timestamp,
+    )
+    record_store.write_authz_policy_record(record)
+    return updated_policy, record, changed, diff, record.audit
+
+
+def build_authz_policy_grant_service_result(
+    *,
+    authz_policy_record: LaunchplaneAuthzPolicyRecord,
+    changed: bool,
+    mode: Literal["dry_run", "apply"],
+    diff: dict[str, object],
+    audit: dict[str, object],
+) -> tuple[dict[str, object], dict[str, object]]:
+    result: dict[str, object] = {
+        "authz_policy_record_id": authz_policy_record.record_id,
+        "authz_policy_changed": str(changed).lower(),
+    }
+    driver_result = {
+        "authz_policy": summarize_authz_policy_record(authz_policy_record),
+        "changed": changed,
+        "mode": mode,
+        "diff": diff,
+        "audit": authz_policy_grant_response_audit_payload(audit),
+    }
+    return result, driver_result

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -22,6 +22,7 @@ import click
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 from jwt import InvalidTokenError
 
+from control_plane import authz_grant_service as control_plane_authz_grant_service
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import product_config as control_plane_product_config
 from control_plane import product_config_service as control_plane_product_config_service
@@ -100,7 +101,6 @@ from control_plane.launchplane_mutations import (
 )
 from control_plane.service_auth import (
     GitHubActionsIdentity,
-    GitHubActionsPolicyRule,
     GitHubHumanIdentity,
     LaunchplaneAuthzPolicy,
     LaunchplaneIdentity,
@@ -1298,78 +1298,6 @@ class EveryCodePrFeedbackStatusEnvelope(BaseModel):
             raise ValueError("Every Code PR feedback status requires feedback_id")
         if not self.request_id.strip():
             raise ValueError("Every Code PR feedback status requires request_id")
-        return self
-
-
-class AuthzPolicyGitHubActionsGrant(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    repository: str
-    workflow_refs: tuple[str, ...] = ()
-    job_workflow_refs: tuple[str, ...] = ()
-    event_names: tuple[str, ...] = ()
-    refs: tuple[str, ...] = ()
-    environments: tuple[str, ...] = ()
-    products: tuple[str, ...] = ()
-    contexts: tuple[str, ...] = ()
-    actions: tuple[str, ...]
-    source_label: str = "service:authz-policy-grant"
-
-    @staticmethod
-    def _normalized_tuple(values: tuple[str, ...]) -> tuple[str, ...]:
-        return tuple(value.strip() for value in values if value.strip())
-
-    @model_validator(mode="after")
-    def _validate_grant(self) -> "AuthzPolicyGitHubActionsGrant":
-        self.repository = self.repository.strip()
-        if not self.repository:
-            raise ValueError("Authz policy grant requires repository.")
-        self.workflow_refs = self._normalized_tuple(self.workflow_refs)
-        self.job_workflow_refs = self._normalized_tuple(self.job_workflow_refs)
-        self.event_names = self._normalized_tuple(self.event_names)
-        self.refs = self._normalized_tuple(self.refs)
-        self.environments = self._normalized_tuple(self.environments)
-        self.products = self._normalized_tuple(self.products)
-        self.contexts = self._normalized_tuple(self.contexts)
-        self.actions = self._normalized_tuple(self.actions)
-        if not self.actions:
-            raise ValueError("Authz policy grant requires at least one action.")
-        self.source_label = self.source_label.strip() or "service:authz-policy-grant"
-        return self
-
-    def to_policy_rule(self) -> GitHubActionsPolicyRule:
-        return GitHubActionsPolicyRule(
-            repository=self.repository,
-            workflow_refs=self.workflow_refs,
-            job_workflow_refs=self.job_workflow_refs,
-            event_names=self.event_names,
-            refs=self.refs,
-            environments=self.environments,
-            products=self.products,
-            contexts=self.contexts,
-            actions=self.actions,
-        )
-
-
-class AuthzPolicyGitHubActionsGrantEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    product: str
-    mode: Literal["dry_run", "apply"] = "apply"
-    reason: str = ""
-    related_issue: str = ""
-    grant: AuthzPolicyGitHubActionsGrant
-
-    @model_validator(mode="after")
-    def _validate_alignment(self) -> "AuthzPolicyGitHubActionsGrantEnvelope":
-        if self.product.strip() != "launchplane":
-            raise ValueError("Authz policy grant writes require product 'launchplane'.")
-        self.product = "launchplane"
-        self.reason = self.reason.strip()
-        self.related_issue = self.related_issue.strip()
-        if self.mode == "apply" and not self.reason:
-            raise ValueError("Authz policy grant apply requires reason.")
         return self
 
 
@@ -3540,180 +3468,6 @@ def _launchplane_runtime_payload(
     }
 
 
-def _summarize_authz_policy_record(record: LaunchplaneAuthzPolicyRecord) -> dict[str, object]:
-    return {
-        "record_id": record.record_id,
-        "status": record.status,
-        "source": record.source,
-        "updated_at": record.updated_at,
-        "policy_sha256": record.policy_sha256,
-        "github_actions_rule_count": len(record.policy.github_actions),
-        "github_humans_rule_count": len(record.policy.github_humans),
-    }
-
-
-def _authz_policy_operator_payload(identity: LaunchplaneIdentity) -> dict[str, object]:
-    if isinstance(identity, GitHubHumanIdentity):
-        return {
-            "type": "github_human",
-            "login": identity.login,
-            "role": identity.role,
-        }
-    return {
-        "type": "github_actions",
-        "repository": identity.repository,
-        "workflow_ref": identity.workflow_ref,
-        "event_name": identity.event_name,
-        "ref": identity.ref,
-        "sha": identity.sha,
-    }
-
-
-def _authz_policy_grant_diff(
-    *, current_policy: LaunchplaneAuthzPolicy, grant: AuthzPolicyGitHubActionsGrant
-) -> dict[str, object]:
-    desired_rule = grant.to_policy_rule()
-    changed = not any(rule == desired_rule for rule in current_policy.github_actions)
-    return {
-        "changed": changed,
-        "previous_github_actions_rule_count": len(current_policy.github_actions),
-        "new_github_actions_rule_count": len(current_policy.github_actions) + int(changed),
-    }
-
-
-def _authz_policy_grant_audit_payload(
-    *,
-    request: AuthzPolicyGitHubActionsGrantEnvelope,
-    identity: LaunchplaneIdentity,
-    previous_record: LaunchplaneAuthzPolicyRecord,
-    new_record: LaunchplaneAuthzPolicyRecord | None,
-    changed: bool,
-    trace_id: str,
-) -> dict[str, object]:
-    return {
-        "mode": request.mode,
-        "reason": request.reason,
-        "related_issue": request.related_issue,
-        "operator": _authz_policy_operator_payload(identity),
-        "requested_grant": request.grant.to_policy_rule().model_dump(mode="json"),
-        "previous_policy_record_id": previous_record.record_id,
-        "previous_policy_sha256": previous_record.policy_sha256,
-        "new_policy_record_id": new_record.record_id
-        if new_record is not None
-        else previous_record.record_id,
-        "new_policy_sha256": new_record.policy_sha256
-        if new_record is not None
-        else previous_record.policy_sha256,
-        "changed": changed,
-        "trace_id": trace_id,
-        "updated_at": new_record.updated_at if new_record is not None else _now_timestamp(),
-    }
-
-
-def _authz_policy_grant_response_audit_payload(
-    audit: dict[str, object],
-) -> dict[str, object]:
-    response_audit = dict(audit)
-    requested_grant = response_audit.pop("requested_grant", None)
-    if isinstance(requested_grant, dict):
-        response_audit["requested_grant_summary"] = {
-            "repository": requested_grant.get("repository", ""),
-            "workflow_ref_count": len(requested_grant.get("workflow_refs") or ()),
-            "job_workflow_ref_count": len(requested_grant.get("job_workflow_refs") or ()),
-            "event_names": requested_grant.get("event_names") or (),
-            "products": requested_grant.get("products") or (),
-            "contexts": requested_grant.get("contexts") or (),
-            "actions": requested_grant.get("actions") or (),
-        }
-    return response_audit
-
-
-def _plan_github_actions_authz_policy_grant(
-    *,
-    record_store: PostgresRecordStore,
-    grant: AuthzPolicyGitHubActionsGrant,
-) -> tuple[LaunchplaneAuthzPolicy, LaunchplaneAuthzPolicyRecord, dict[str, object]]:
-    active_records = record_store.list_authz_policy_records(status="active", limit=1)
-    if not active_records:
-        raise ValueError("No active Launchplane authz policy record found.")
-    current_record = active_records[0]
-    current_policy = current_record.policy
-    return (
-        current_policy,
-        current_record,
-        _authz_policy_grant_diff(
-            current_policy=current_policy,
-            grant=grant,
-        ),
-    )
-
-
-def _write_github_actions_authz_policy_grant(
-    *,
-    record_store: PostgresRecordStore,
-    request: AuthzPolicyGitHubActionsGrantEnvelope,
-    identity: LaunchplaneIdentity,
-    trace_id: str,
-) -> tuple[
-    LaunchplaneAuthzPolicy,
-    LaunchplaneAuthzPolicyRecord,
-    bool,
-    dict[str, object],
-    dict[str, object],
-]:
-    current_policy, current_record, diff = _plan_github_actions_authz_policy_grant(
-        record_store=record_store,
-        grant=request.grant,
-    )
-    changed = bool(diff["changed"])
-    desired_rule = request.grant.to_policy_rule()
-    if not changed:
-        audit = _authz_policy_grant_audit_payload(
-            request=request,
-            identity=identity,
-            previous_record=current_record,
-            new_record=None,
-            changed=False,
-            trace_id=trace_id,
-        )
-        return current_policy, current_record, False, diff, audit
-
-    updated_policy = current_policy.model_copy(
-        update={"github_actions": current_policy.github_actions + (desired_rule,)}
-    )
-    updated_at = _now_timestamp()
-    policy_sha256 = authz_policy_sha256(updated_policy)
-    record = LaunchplaneAuthzPolicyRecord(
-        record_id=build_authz_policy_record_id(
-            updated_at=updated_at,
-            policy_sha256=policy_sha256,
-        ),
-        status="active",
-        source=request.grant.source_label,
-        updated_at=updated_at,
-        policy_sha256=policy_sha256,
-        policy=updated_policy,
-        audit=_authz_policy_grant_audit_payload(
-            request=request,
-            identity=identity,
-            previous_record=current_record,
-            new_record=None,
-            changed=True,
-            trace_id=trace_id,
-        ),
-    )
-    record.audit = _authz_policy_grant_audit_payload(
-        request=request,
-        identity=identity,
-        previous_record=current_record,
-        new_record=record,
-        changed=True,
-        trace_id=trace_id,
-    )
-    record_store.write_authz_policy_record(record)
-    return updated_policy, record, changed, diff, record.audit
-
-
 def _request_launchplane_self_deploy(
     *,
     control_plane_root_path: Path,
@@ -5685,7 +5439,9 @@ def create_launchplane_service_app(
                         },
                     )
             elif path == "/v1/authz-policies/github-actions/grants":
-                authz_grant_request = AuthzPolicyGitHubActionsGrantEnvelope.model_validate(payload)
+                authz_grant_request = control_plane_authz_grant_service.AuthzPolicyGitHubActionsGrantEnvelope.model_validate(
+                    payload
+                )
                 if not isinstance(record_store, PostgresRecordStore):
                     return _json_response(
                         start_response=start_response,
@@ -5730,17 +5486,22 @@ def create_launchplane_service_app(
                     if idempotent_response is not None:
                         return idempotent_response
                 try:
-                    current_policy, current_record, diff = _plan_github_actions_authz_policy_grant(
+                    (
+                        current_policy,
+                        current_record,
+                        diff,
+                    ) = control_plane_authz_grant_service.plan_github_actions_authz_policy_grant(
                         record_store=record_store,
                         grant=authz_grant_request.grant,
                     )
-                    audit = _authz_policy_grant_audit_payload(
+                    audit = control_plane_authz_grant_service.authz_policy_grant_audit_payload(
                         request=authz_grant_request,
                         identity=identity,
                         previous_record=current_record,
                         new_record=None,
                         changed=bool(diff["changed"]),
                         trace_id=request_trace_id,
+                        now_timestamp=_now_timestamp,
                     )
                     authz_policy_record = current_record
                     changed = bool(diff["changed"])
@@ -5751,11 +5512,12 @@ def create_launchplane_service_app(
                             changed,
                             diff,
                             audit,
-                        ) = _write_github_actions_authz_policy_grant(
+                        ) = control_plane_authz_grant_service.write_github_actions_authz_policy_grant(
                             record_store=record_store,
                             request=authz_grant_request,
                             identity=identity,
                             trace_id=request_trace_id,
+                            now_timestamp=_now_timestamp,
                         )
                     else:
                         updated_policy = current_policy
@@ -5785,17 +5547,15 @@ def create_launchplane_service_app(
                     authz_policy = updated_policy
                     resolved_authz_policy_sha256 = authz_policy_record.policy_sha256
                     resolved_authz_policy_source = "db"
-                result = {
-                    "authz_policy_record_id": authz_policy_record.record_id,
-                    "authz_policy_changed": str(changed).lower(),
-                }
-                driver_result = {
-                    "authz_policy": _summarize_authz_policy_record(authz_policy_record),
-                    "changed": changed,
-                    "mode": authz_grant_request.mode,
-                    "diff": diff,
-                    "audit": _authz_policy_grant_response_audit_payload(audit),
-                }
+                result, driver_result = (
+                    control_plane_authz_grant_service.build_authz_policy_grant_service_result(
+                        authz_policy_record=authz_policy_record,
+                        changed=changed,
+                        mode=authz_grant_request.mode,
+                        diff=diff,
+                        audit=audit,
+                    )
+                )
             elif path == "/v1/runtime-key-safety/policies/apply":
                 runtime_policy_request = RuntimeKeySafetyPolicyApplyEnvelope.model_validate(payload)
                 if not isinstance(record_store, PostgresRecordStore):

--- a/tests/test_authz_grant_service.py
+++ b/tests/test_authz_grant_service.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import json
+import unittest
+from typing import cast
+
+from control_plane.authz_grant_service import (
+    AuthzPolicyGitHubActionsGrant,
+    AuthzPolicyGitHubActionsGrantEnvelope,
+    authz_policy_grant_response_audit_payload,
+    build_authz_policy_grant_service_result,
+    plan_github_actions_authz_policy_grant,
+    write_github_actions_authz_policy_grant,
+)
+from control_plane.contracts.authz_policy_record import (
+    LaunchplaneAuthzPolicyRecord,
+    authz_policy_sha256,
+    build_authz_policy_record_id,
+)
+from control_plane.service_auth import GitHubActionsIdentity, LaunchplaneAuthzPolicy
+
+
+class _AuthzPolicyStore:
+    def __init__(self, records: tuple[LaunchplaneAuthzPolicyRecord, ...]) -> None:
+        self.records = records
+        self.written_records: list[LaunchplaneAuthzPolicyRecord] = []
+
+    def list_authz_policy_records(
+        self,
+        *,
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[LaunchplaneAuthzPolicyRecord, ...]:
+        records = tuple(record for record in self.records if not status or record.status == status)
+        if limit is not None:
+            return records[:limit]
+        return records
+
+    def write_authz_policy_record(self, record: LaunchplaneAuthzPolicyRecord) -> None:
+        self.written_records.append(record)
+        self.records = (record,) + self.records
+
+
+def _identity() -> GitHubActionsIdentity:
+    return GitHubActionsIdentity(
+        repository="cbusillo/launchplane",
+        repository_owner="cbusillo",
+        workflow_ref="cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main",
+        job_workflow_ref="",
+        event_name="workflow_dispatch",
+        ref="refs/heads/main",
+        ref_type="branch",
+        environment="",
+        subject="repo:cbusillo/launchplane:ref:refs/heads/main",
+        sha="abc123",
+        raw_claims={},
+    )
+
+
+def _active_record() -> LaunchplaneAuthzPolicyRecord:
+    policy = LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "cbusillo/launchplane",
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["launchplane_service_deploy.execute"],
+                }
+            ]
+        }
+    )
+    policy_sha256 = authz_policy_sha256(policy)
+    return LaunchplaneAuthzPolicyRecord(
+        record_id=build_authz_policy_record_id(
+            updated_at="2026-05-07T15:00:00Z",
+            policy_sha256=policy_sha256,
+        ),
+        status="active",
+        source="test:bootstrap",
+        updated_at="2026-05-07T15:00:00Z",
+        policy_sha256=policy_sha256,
+        policy=policy,
+    )
+
+
+def _grant_request(mode: str = "apply") -> AuthzPolicyGitHubActionsGrantEnvelope:
+    return AuthzPolicyGitHubActionsGrantEnvelope.model_validate(
+        {
+            "product": "launchplane",
+            "mode": mode,
+            "reason": "Grant product profile read for SYO promotion diagnostics.",
+            "related_issue": "cbusillo/launchplane#83",
+            "grant": {
+                "repository": "cbusillo/launchplane",
+                "workflow_refs": [
+                    "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                ],
+                "event_names": ["workflow_dispatch"],
+                "products": ["sellyouroutboard"],
+                "contexts": ["launchplane"],
+                "actions": ["product_profile.read"],
+                "source_label": "test:audit-grant",
+            },
+        }
+    )
+
+
+class AuthzGrantServiceTests(unittest.TestCase):
+    def test_grant_normalizes_tuple_values(self) -> None:
+        grant = AuthzPolicyGitHubActionsGrant.model_validate(
+            {
+                "repository": " cbusillo/launchplane ",
+                "workflow_refs": [" workflow ", ""],
+                "actions": [" product_profile.read "],
+            }
+        )
+
+        self.assertEqual(grant.repository, "cbusillo/launchplane")
+        self.assertEqual(grant.workflow_refs, ("workflow",))
+        self.assertEqual(grant.actions, ("product_profile.read",))
+
+    def test_plan_and_write_grant_records_changed_policy(self) -> None:
+        store = _AuthzPolicyStore((_active_record(),))
+        request = _grant_request()
+
+        _current_policy, current_record, diff = plan_github_actions_authz_policy_grant(
+            record_store=store,
+            grant=request.grant,
+        )
+        self.assertEqual(current_record.record_id, store.records[0].record_id)
+        self.assertEqual(diff["changed"], True)
+        self.assertEqual(diff["new_github_actions_rule_count"], 2)
+
+        updated_policy, record, changed, write_diff, audit = (
+            write_github_actions_authz_policy_grant(
+                record_store=store,
+                request=request,
+                identity=_identity(),
+                trace_id="trace-1",
+                now_timestamp=lambda: "2026-05-07T16:00:00Z",
+            )
+        )
+
+        self.assertTrue(changed)
+        self.assertEqual(write_diff, diff)
+        self.assertEqual(store.written_records, [record])
+        self.assertEqual(len(updated_policy.github_actions), 2)
+        self.assertEqual(audit["reason"], request.reason)
+        self.assertIn("workflow_refs", json.dumps(audit, sort_keys=True))
+
+        result, driver_result = build_authz_policy_grant_service_result(
+            authz_policy_record=record,
+            changed=changed,
+            mode=request.mode,
+            diff=write_diff,
+            audit=audit,
+        )
+        self.assertEqual(result["authz_policy_record_id"], record.record_id)
+        driver_audit = cast(dict[str, object], driver_result["audit"])
+        self.assertNotIn("requested_grant", driver_audit)
+        requested_grant_summary = cast(dict[str, object], driver_audit["requested_grant_summary"])
+        self.assertEqual(requested_grant_summary["workflow_ref_count"], 1)
+
+    def test_repeated_grant_does_not_write_new_record(self) -> None:
+        store = _AuthzPolicyStore((_active_record(),))
+        request = _grant_request()
+        _updated_policy, record, _changed, _diff, _audit = write_github_actions_authz_policy_grant(
+            record_store=store,
+            request=request,
+            identity=_identity(),
+            trace_id="trace-1",
+            now_timestamp=lambda: "2026-05-07T16:00:00Z",
+        )
+
+        _same_policy, same_record, same_changed, _same_diff, same_audit = (
+            write_github_actions_authz_policy_grant(
+                record_store=store,
+                request=request,
+                identity=_identity(),
+                trace_id="trace-2",
+                now_timestamp=lambda: "2026-05-07T16:01:00Z",
+            )
+        )
+
+        self.assertFalse(same_changed)
+        self.assertEqual(same_record.record_id, record.record_id)
+        self.assertEqual(len(store.written_records), 1)
+        self.assertEqual(same_audit["changed"], False)
+
+    def test_response_audit_replaces_requested_grant_with_summary(self) -> None:
+        audit: dict[str, object] = {
+            "requested_grant": _grant_request().grant.to_policy_rule().model_dump(mode="json"),
+            "mode": "dry_run",
+        }
+
+        response_audit = authz_policy_grant_response_audit_payload(audit)
+
+        self.assertNotIn("requested_grant", response_audit)
+        requested_grant_summary = cast(dict[str, object], response_audit["requested_grant_summary"])
+        self.assertEqual(requested_grant_summary["actions"], ["product_profile.read"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Extract GitHub Actions authz grant envelopes, planning/diff/audit/write helpers, and response shaping into `control_plane/authz_grant_service.py`
- Keep route DB availability, authorization, idempotency, and in-memory policy reload wiring in `service.py`
- Add direct coverage for grant normalization, apply/no-op writes, audit redaction, and service response shaping

Part of #307.

## Validation
- `uv run --extra dev ruff format --check control_plane/service.py control_plane/authz_grant_service.py tests/test_authz_grant_service.py`
- `uv run --extra dev ruff check control_plane/service.py control_plane/authz_grant_service.py tests/test_authz_grant_service.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest tests.test_authz_grant_service tests.test_service.LaunchplaneServiceTests.test_authz_policy_grant_endpoint_writes_db_record_and_updates_runtime tests.test_service.LaunchplaneServiceTests.test_authz_policy_grant_endpoint_dry_run_does_not_write_or_reload tests.test_service.LaunchplaneServiceTests.test_authz_policy_grant_endpoint_allows_admin_human_session tests.test_service.LaunchplaneServiceTests.test_authz_policy_grant_endpoint_apply_requires_reason tests.test_service.LaunchplaneServiceTests.test_authz_policy_grant_endpoint_rejects_without_self_deploy_permission`
- `uv run python -m unittest tests.test_service tests.test_authz_grant_service`
- `uv run python -m unittest`