### PR TITLE
feat(every-code): persist preview gate state

### DIFF
--- a/control_plane/contracts/every_code_preview_gate_record.py
+++ b/control_plane/contracts/every_code_preview_gate_record.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+EveryCodePreviewGateStatus = Literal[
+    "pending",
+    "ready",
+    "blocked",
+    "labeled",
+    "cancelled",
+]
+
+
+class EveryCodePreviewGateRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    gate_id: str
+    request_id: str
+    repository: str
+    issue_number: int = Field(ge=1)
+    issue_url: str
+    issue_author: str = ""
+    pr_number: int = Field(ge=1)
+    pr_url: str
+    head_sha: str
+    status: EveryCodePreviewGateStatus
+    created_at: str
+    updated_at: str
+    ready_at: str = ""
+    labeled_at: str = ""
+    blocked_at: str = ""
+    cancelled_at: str = ""
+    last_checked_at: str = ""
+    pending_reason: str = ""
+    blocked_reason: str = ""
+    check_summary: str = ""
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "EveryCodePreviewGateRecord":
+        if not self.gate_id.strip():
+            raise ValueError("Every Code preview gate requires gate_id")
+        if not self.request_id.strip():
+            raise ValueError("Every Code preview gate requires request_id")
+        if not self.repository.strip() or "/" not in self.repository.strip():
+            raise ValueError("Every Code preview gate requires owner/repo repository")
+        if not self.issue_url.strip():
+            raise ValueError("Every Code preview gate requires issue_url")
+        if not self.pr_url.strip():
+            raise ValueError("Every Code preview gate requires pr_url")
+        if not self.head_sha.strip():
+            raise ValueError("Every Code preview gate requires head_sha")
+        if not self.created_at.strip():
+            raise ValueError("Every Code preview gate requires created_at")
+        if not self.updated_at.strip():
+            raise ValueError("Every Code preview gate requires updated_at")
+        if self.status == "ready" and not self.ready_at.strip():
+            raise ValueError("ready Every Code preview gate requires ready_at")
+        if self.status == "labeled" and not self.labeled_at.strip():
+            raise ValueError("labeled Every Code preview gate requires labeled_at")
+        if self.status == "blocked" and not self.blocked_at.strip():
+            raise ValueError("blocked Every Code preview gate requires blocked_at")
+        if self.status == "cancelled" and not self.cancelled_at.strip():
+            raise ValueError("cancelled Every Code preview gate requires cancelled_at")
+        return self
+
+
+def build_every_code_preview_gate_id(
+    *, repository: str, pr_number: int, head_sha: str
+) -> str:
+    normalized_repository = repository.strip().lower()
+    normalized_sha = head_sha.strip().lower()
+    if not normalized_repository or pr_number < 1 or not normalized_sha:
+        raise ValueError(
+            "Every Code preview gate id requires repository, pr_number, and head_sha"
+        )
+    digest = hashlib.sha256(
+        f"{normalized_repository}#{pr_number}:{normalized_sha}".encode("utf-8")
+    ).hexdigest()[:16]
+    return (
+        f"every-code-preview-gate-{normalized_repository.replace('/', '-')}-{pr_number}"
+        f"-{normalized_sha[:12]}-{digest}"
+    )

--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import UTC, datetime
 import hashlib
 import json
 import os
@@ -19,6 +20,10 @@ from control_plane.contracts.every_code_pr_feedback_record import (
     EveryCodePrFeedbackRecord,
     EveryCodePrFeedbackStatus,
 )
+from control_plane.contracts.every_code_preview_gate_record import (
+    EveryCodePreviewGateRecord,
+    build_every_code_preview_gate_id,
+)
 from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestRecord,
     EveryCodeWorkRequestStatusUpdate,
@@ -35,6 +40,7 @@ from control_plane.workflows.ship import utc_now_timestamp
 EveryCodeWorkerStatus = Literal["empty", "running", "blocked"]
 EveryCodeWorkerFinishStatus = Literal["done", "blocked"]
 TERMINAL_EVERY_CODE_STATES = {"done", "blocked"}
+EVERY_CODE_PREVIEW_GATE_TIMEOUT_SECONDS = 24 * 60 * 60
 
 
 class EveryCodeWorkerStore(Protocol):
@@ -75,6 +81,21 @@ class EveryCodeWorkerStore(Protocol):
     ) -> tuple[EveryCodePrFeedbackRecord, ...]: ...
 
     def write_every_code_pr_feedback_record(self, record: EveryCodePrFeedbackRecord) -> object: ...
+
+    def list_every_code_preview_gate_records(
+        self,
+        *,
+        request_id: str = "",
+        repository: str = "",
+        pr_number: int | None = None,
+        status: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[EveryCodePreviewGateRecord, ...]: ...
+
+    def write_every_code_preview_gate_record(
+        self, record: EveryCodePreviewGateRecord
+    ) -> object: ...
 
 
 Runner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
@@ -234,6 +255,47 @@ class EveryCodeWorkerApiStore:
                 "status": record.status,
             },
             idempotency_key=f"every-code-pr-feedback-{record.feedback_id}-{record.status}",
+        )
+        return payload
+
+    def list_every_code_preview_gate_records(
+        self,
+        *,
+        request_id: str = "",
+        repository: str = "",
+        pr_number: int | None = None,
+        status: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[EveryCodePreviewGateRecord, ...]:
+        query: dict[str, object] = {}
+        if request_id.strip():
+            query["request_id"] = request_id.strip()
+        if repository.strip():
+            query["repository"] = repository.strip()
+        if pr_number is not None:
+            query["pr_number"] = pr_number
+        if status.strip():
+            query["status"] = status.strip()
+        if limit is not None:
+            query["limit"] = limit
+        if offset > 0:
+            query["offset"] = offset
+        suffix = f"?{urlencode(query)}" if query else ""
+        payload = self._request("GET", f"/v1/every-code/preview-gates{suffix}")
+        gates = payload.get("gates", [])
+        if not isinstance(gates, list):
+            raise EveryCodeWorkerApiError("Launchplane preview gate list response is invalid")
+        return tuple(EveryCodePreviewGateRecord.model_validate(item) for item in gates)
+
+    def write_every_code_preview_gate_record(
+        self, record: EveryCodePreviewGateRecord
+    ) -> object:
+        payload = self._request(
+            "POST",
+            "/v1/every-code/preview-gates",
+            body=record.model_dump(mode="json"),
+            idempotency_key=f"every-code-preview-gate-{record.gate_id}-{record.updated_at}",
         )
         return payload
 
@@ -420,6 +482,8 @@ class EveryCodePreviewGateResult:
     pending: int = 0
     blocked: int = 0
     skipped: int = 0
+    cancelled: int = 0
+    reset: int = 0
 
     def as_payload(self) -> dict[str, object]:
         return {
@@ -428,6 +492,8 @@ class EveryCodePreviewGateResult:
             "pending": self.pending,
             "blocked": self.blocked,
             "skipped": self.skipped,
+            "cancelled": self.cancelled,
+            "reset": self.reset,
         }
 
 
@@ -1653,6 +1719,7 @@ def request_ready_every_code_pr_preview_labels(
     record_store: EveryCodeWorkerStore,
     repository: str = "",
     limit: int = 50,
+    gate_timeout_seconds: int = EVERY_CODE_PREVIEW_GATE_TIMEOUT_SECONDS,
     runner: Runner | None = None,
 ) -> EveryCodePreviewGateResult:
     normalized_repository = repository.strip()
@@ -1677,33 +1744,158 @@ def request_ready_every_code_pr_preview_labels(
     pending = 0
     blocked = 0
     skipped = 0
+    cancelled = 0
+    reset = 0
     for record in records:
+        if _every_code_work_request_closed_before_preview(record):
+            cancelled += _cancel_every_code_preview_gates_for_record(
+                record_store=record_store,
+                record=record,
+                reason="Source issue closed before preview was ready.",
+            )
+            continue
         result_pr_url = _every_code_preview_pr_url_for_record(record, runner=run)
         if not result_pr_url:
             skipped += 1
             continue
-        readiness = every_code_pr_preview_readiness(
-            result_pr_url=result_pr_url,
+        reference = github_pull_request_reference(pr_url=result_pr_url)
+        if reference is None:
+            skipped += 1
+            continue
+        payload = _github_pr_view_payload(
+            owner=reference["owner"],
+            repo=reference["repo"],
+            pr_number=reference["pr_number"],
             runner=run,
         )
+        if payload is None:
+            checked += 1
+            blocked += 1
+            continue
+        gate, gate_reset = _reconcile_every_code_preview_gate_record(
+            record_store=record_store,
+            record=record,
+            pr_number=reference["pr_number"],
+            pr_url=result_pr_url,
+            payload=payload,
+        )
+        if gate_reset:
+            reset += 1
+        readiness = every_code_pr_preview_readiness_from_payload(
+            repository=record.repository,
+            payload=payload,
+        )
+        now = utc_now_timestamp()
         if readiness == "ready":
             checked += 1
+            ready_gate = gate.model_copy(
+                update={
+                    "status": "ready",
+                    "updated_at": now,
+                    "ready_at": gate.ready_at or now,
+                    "last_checked_at": now,
+                    "pending_reason": "",
+                    "blocked_reason": "",
+                    "check_summary": _every_code_check_summary(payload),
+                }
+            )
+            record_store.write_every_code_preview_gate_record(ready_gate)
             summary = request_every_code_pr_preview_label(
                 result_pr_url=result_pr_url,
                 runner=run,
             )
             if summary.startswith("Requested Launchplane preview"):
+                record_store.write_every_code_preview_gate_record(
+                    ready_gate.model_copy(
+                        update={
+                            "status": "labeled",
+                            "updated_at": now,
+                            "labeled_at": now,
+                        }
+                    )
+                )
                 labeled += 1
             elif summary:
+                record_store.write_every_code_preview_gate_record(
+                    ready_gate.model_copy(
+                        update={
+                            "status": "blocked",
+                            "updated_at": now,
+                            "blocked_at": now,
+                            "blocked_reason": summary,
+                        }
+                    )
+                )
                 blocked += 1
             else:
                 skipped += 1
         elif readiness == "pending":
             checked += 1
+            if _every_code_preview_gate_timed_out(
+                gate,
+                now=now,
+                timeout_seconds=gate_timeout_seconds,
+            ):
+                record_store.write_every_code_preview_gate_record(
+                    gate.model_copy(
+                        update={
+                            "status": "blocked",
+                            "updated_at": now,
+                            "blocked_at": gate.blocked_at or now,
+                            "last_checked_at": now,
+                            "pending_reason": "",
+                            "blocked_reason": "Timed out waiting for GitHub checks to become preview-ready.",
+                            "check_summary": _every_code_check_summary(payload),
+                        }
+                    )
+                )
+                blocked += 1
+                continue
+            record_store.write_every_code_preview_gate_record(
+                gate.model_copy(
+                    update={
+                        "status": "pending",
+                        "updated_at": now,
+                        "last_checked_at": now,
+                        "pending_reason": _every_code_pending_gate_reason(payload),
+                        "blocked_reason": "",
+                        "check_summary": _every_code_check_summary(payload),
+                    }
+                )
+            )
             pending += 1
         elif readiness == "blocked":
             checked += 1
+            record_store.write_every_code_preview_gate_record(
+                gate.model_copy(
+                    update={
+                        "status": "blocked",
+                        "updated_at": now,
+                        "blocked_at": gate.blocked_at or now,
+                        "last_checked_at": now,
+                        "pending_reason": "",
+                        "blocked_reason": _every_code_blocked_gate_reason(payload),
+                        "check_summary": _every_code_check_summary(payload),
+                    }
+                )
+            )
             blocked += 1
+        elif readiness == "cancelled":
+            checked += 1
+            record_store.write_every_code_preview_gate_record(
+                gate.model_copy(
+                    update={
+                        "status": "cancelled",
+                        "updated_at": now,
+                        "cancelled_at": gate.cancelled_at or now,
+                        "last_checked_at": now,
+                        "pending_reason": "",
+                        "blocked_reason": "Pull request is no longer open.",
+                        "check_summary": _every_code_check_summary(payload),
+                    }
+                )
+            )
+            cancelled += 1
         else:
             skipped += 1
     return EveryCodePreviewGateResult(
@@ -1712,7 +1904,136 @@ def request_ready_every_code_pr_preview_labels(
         pending=pending,
         blocked=blocked,
         skipped=skipped,
+        cancelled=cancelled,
+        reset=reset,
     )
+
+
+def _every_code_work_request_closed_before_preview(
+    record: EveryCodeWorkRequestRecord,
+) -> bool:
+    if record.state != "done":
+        return False
+    summary = (record.result_summary or record.error_message).strip().lower()
+    return summary.startswith("source issue closed") or summary.startswith(
+        "source pull request closed"
+    )
+
+
+def _cancel_every_code_preview_gates_for_record(
+    *,
+    record_store: EveryCodeWorkerStore,
+    record: EveryCodeWorkRequestRecord,
+    reason: str,
+) -> int:
+    now = utc_now_timestamp()
+    cancelled = 0
+    for gate in record_store.list_every_code_preview_gate_records(
+        request_id=record.request_id,
+        limit=100,
+    ):
+        if gate.status in {"labeled", "cancelled"}:
+            continue
+        record_store.write_every_code_preview_gate_record(
+            gate.model_copy(
+                update={
+                    "status": "cancelled",
+                    "updated_at": now,
+                    "cancelled_at": gate.cancelled_at or now,
+                    "pending_reason": "",
+                    "blocked_reason": reason,
+                }
+            )
+        )
+        cancelled += 1
+    return cancelled
+
+
+def _every_code_preview_gate_timed_out(
+    gate: EveryCodePreviewGateRecord,
+    *,
+    now: str,
+    timeout_seconds: int,
+) -> bool:
+    if timeout_seconds <= 0:
+        return False
+    created_at = _parse_utc_timestamp(gate.created_at)
+    checked_at = _parse_utc_timestamp(now)
+    if created_at is None or checked_at is None:
+        return False
+    return (checked_at - created_at).total_seconds() >= timeout_seconds
+
+
+def _parse_utc_timestamp(timestamp: str) -> datetime | None:
+    normalized = timestamp.strip()
+    if not normalized:
+        return None
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _reconcile_every_code_preview_gate_record(
+    *,
+    record_store: EveryCodeWorkerStore,
+    record: EveryCodeWorkRequestRecord,
+    pr_number: int,
+    pr_url: str,
+    payload: dict[str, object],
+) -> tuple[EveryCodePreviewGateRecord, bool]:
+    head_sha = str(payload.get("headRefOid") or "").strip() or "unknown"
+    gate_id = build_every_code_preview_gate_id(
+        repository=record.repository,
+        pr_number=pr_number,
+        head_sha=head_sha,
+    )
+    existing_gates = record_store.list_every_code_preview_gate_records(
+        request_id=record.request_id,
+        pr_number=pr_number,
+        limit=50,
+    )
+    for gate in existing_gates:
+        if gate.gate_id == gate_id:
+            return gate, False
+    now = utc_now_timestamp()
+    gate = EveryCodePreviewGateRecord(
+        gate_id=gate_id,
+        request_id=record.request_id,
+        repository=record.repository,
+        issue_number=record.issue_number,
+        issue_url=record.issue_url,
+        issue_author="",
+        pr_number=pr_number,
+        pr_url=pr_url,
+        head_sha=head_sha,
+        status="pending",
+        created_at=now,
+        updated_at=now,
+        last_checked_at=now,
+        pending_reason="Waiting for GitHub checks to complete.",
+        check_summary=_every_code_check_summary(payload),
+    )
+    record_store.write_every_code_preview_gate_record(gate)
+    cancelled = 0
+    for previous_gate in existing_gates:
+        if previous_gate.status in {"labeled", "cancelled"}:
+            continue
+        record_store.write_every_code_preview_gate_record(
+            previous_gate.model_copy(
+                update={
+                    "status": "cancelled",
+                    "updated_at": now,
+                    "cancelled_at": previous_gate.cancelled_at or now,
+                    "blocked_reason": "Superseded by a newer pull request head SHA.",
+                }
+            )
+        )
+        cancelled += 1
+    return gate, cancelled > 0
 
 
 def route_every_code_pr_check_failures(
@@ -1857,7 +2178,7 @@ def every_code_pr_preview_readiness(
     *,
     result_pr_url: str,
     runner: Runner | None = None,
-) -> Literal["ready", "pending", "blocked", "skipped"]:
+) -> Literal["ready", "pending", "blocked", "skipped", "cancelled"]:
     reference = github_pull_request_reference(pr_url=result_pr_url.strip())
     if reference is None:
         return "skipped"
@@ -1872,8 +2193,23 @@ def every_code_pr_preview_readiness(
     )
     if payload is None:
         return "blocked"
-    if str(payload.get("state") or "").upper() != "OPEN":
+    return every_code_pr_preview_readiness_from_payload(
+        repository=f"{reference['owner']}/{reference['repo']}",
+        payload=payload,
+    )
+
+
+def every_code_pr_preview_readiness_from_payload(
+    *,
+    repository: str,
+    payload: dict[str, object],
+) -> Literal["ready", "pending", "blocked", "skipped", "cancelled"]:
+    reference_repo = repository.strip().split("/", 1)[-1]
+    preview_label = launchplane_anchor_repo_preview_label(repo=reference_repo)
+    if not preview_label:
         return "skipped"
+    if str(payload.get("state") or "").upper() != "OPEN":
+        return "cancelled"
     if _github_pr_payload_has_label(payload, preview_label):
         return "skipped"
     check_rollup = payload.get("statusCheckRollup")
@@ -1897,6 +2233,50 @@ def _every_code_relevant_pr_checks(
         for item in check_rollup
         if isinstance(item, dict) and _github_check_conclusion(item) != "SKIPPED"
     ]
+
+
+def _every_code_check_summary(payload: dict[str, object]) -> str:
+    check_rollup = payload.get("statusCheckRollup")
+    if not isinstance(check_rollup, list):
+        return "GitHub check status is not available yet."
+    checks = _every_code_relevant_pr_checks(check_rollup)
+    if not checks:
+        return "No required GitHub checks reported."
+    return "; ".join(
+        f"{_github_check_name(check) or 'unnamed check'}="
+        f"{_github_check_status(check) or 'UNKNOWN'}/"
+        f"{_github_check_conclusion(check) or 'PENDING'}"
+        for check in checks
+    )
+
+
+def _every_code_pending_gate_reason(payload: dict[str, object]) -> str:
+    check_rollup = payload.get("statusCheckRollup")
+    if not isinstance(check_rollup, list):
+        return "Waiting for GitHub check data."
+    pending_names = [
+        _github_check_name(check) or "unnamed check"
+        for check in _every_code_relevant_pr_checks(check_rollup)
+        if _github_check_status(check) != "COMPLETED"
+    ]
+    if pending_names:
+        return "Waiting for checks: " + ", ".join(sorted(pending_names))
+    return "Waiting for GitHub checks to settle."
+
+
+def _every_code_blocked_gate_reason(payload: dict[str, object]) -> str:
+    check_rollup = payload.get("statusCheckRollup")
+    if not isinstance(check_rollup, list):
+        return "Could not read GitHub check state."
+    failed_names = [
+        _github_check_name(check) or "unnamed check"
+        for check in _every_code_relevant_pr_checks(check_rollup)
+        if _github_check_status(check) == "COMPLETED"
+        and _github_check_conclusion(check) != "SUCCESS"
+    ]
+    if failed_names:
+        return "Checks did not pass: " + ", ".join(sorted(failed_names))
+    return "GitHub checks are blocked."
 
 
 def _github_check_status(check: dict[str, object]) -> str:

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -48,6 +48,9 @@ from control_plane.contracts.every_code_work_request import (
     close_every_code_work_request_for_pull_request,
     requeue_every_code_work_request,
 )
+from control_plane.contracts.every_code_preview_gate_record import (
+    EveryCodePreviewGateRecord,
+)
 from control_plane.contracts.every_code_pr_feedback_record import (
     EveryCodePrFeedbackKind,
     EveryCodePrFeedbackRecord,
@@ -1301,6 +1304,10 @@ class EveryCodePrFeedbackStatusEnvelope(BaseModel):
         return self
 
 
+class EveryCodePreviewGateEnvelope(EveryCodePreviewGateRecord):
+    pass
+
+
 class AuthzPolicyGitHubActionsGrant(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -1755,6 +1762,8 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "every_code_work_request.read", {}
     if len(segments) == 3 and segments == ["v1", "every-code", "pr-feedback"]:
         return "every_code_pr_feedback.read", {}
+    if len(segments) == 3 and segments == ["v1", "every-code", "preview-gates"]:
+        return "every_code_preview_gate.read", {}
     if len(segments) == 4 and segments[:3] == ["v1", "every-code", "work-requests"]:
         return "every_code_work_request.read", {"request_id": segments[3]}
     if len(segments) == 2 and segments == ["v1", "drivers"]:
@@ -1875,6 +1884,7 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/every-code/work-requests/rerun",
         "/v1/every-code/work-requests/status",
         "/v1/every-code/pr-feedback/status",
+        "/v1/every-code/preview-gates",
         "/v1/work-graph/rank",
         "/v1/evidence/deployments",
         "/v1/evidence/backup-gates",
@@ -1947,6 +1957,19 @@ class _EveryCodeWorkRequestStore(Protocol):
         offset: int = 0,
     ) -> tuple[EveryCodePrFeedbackRecord, ...]: ...
 
+    def write_every_code_preview_gate_record(self, record: EveryCodePreviewGateRecord) -> object: ...
+
+    def list_every_code_preview_gate_records(
+        self,
+        *,
+        request_id: str = "",
+        repository: str = "",
+        pr_number: int | None = None,
+        status: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[EveryCodePreviewGateRecord, ...]: ...
+
 
 def _every_code_work_request_store(record_store: object) -> _EveryCodeWorkRequestStore:
     required_methods = (
@@ -1957,6 +1980,8 @@ def _every_code_work_request_store(record_store: object) -> _EveryCodeWorkReques
         "claim_every_code_work_request_record",
         "write_every_code_pr_feedback_record",
         "list_every_code_pr_feedback_records",
+        "write_every_code_preview_gate_record",
+        "list_every_code_preview_gate_records",
     )
     if all(hasattr(record_store, method_name) for method_name in required_methods):
         return cast(_EveryCodeWorkRequestStore, record_store)
@@ -2997,6 +3022,8 @@ def _is_every_code_worker_route(*, method: str, path: str) -> bool:
         return True
     if method == "GET" and path == "/v1/every-code/pr-feedback":
         return True
+    if method == "GET" and path == "/v1/every-code/preview-gates":
+        return True
     if method == "GET" and path.startswith("/v1/every-code/work-requests/"):
         return True
     return method == "POST" and path in {
@@ -3004,6 +3031,7 @@ def _is_every_code_worker_route(*, method: str, path: str) -> bool:
         "/v1/every-code/work-requests/rerun",
         "/v1/every-code/work-requests/status",
         "/v1/every-code/pr-feedback/status",
+        "/v1/every-code/preview-gates",
     }
 
 
@@ -3059,6 +3087,28 @@ def _every_code_read_payload(
             "status_filter": status_filter,
             "feedback": [record.model_dump(mode="json") for record in feedback_records],
         }
+    if path == "/v1/every-code/preview-gates":
+        request_id_filter = str((query.get("request_id") or [""])[0] or "").strip()
+        repository_filter = str((query.get("repository") or [""])[0] or "").strip()
+        status_filter = str((query.get("status") or [""])[0] or "").strip()
+        pr_number_value = str((query.get("pr_number") or [""])[0] or "").strip()
+        pr_number_filter = int(pr_number_value) if pr_number_value else None
+        limit = _every_code_pagination_value(query, key="limit", default=50)
+        offset = _every_code_pagination_value(query, key="offset", default=0)
+        gate_records = every_code_store.list_every_code_preview_gate_records(
+            request_id=request_id_filter,
+            repository=repository_filter,
+            pr_number=pr_number_filter,
+            status=status_filter,
+            limit=limit,
+            offset=offset,
+        )
+        return {
+            "request_id": request_id_filter,
+            "repository": repository_filter,
+            "status_filter": status_filter,
+            "gates": [record.model_dump(mode="json") for record in gate_records],
+        }
     if len(segments) == 4 and segments[:3] == ["v1", "every-code", "work-requests"]:
         record = every_code_store.read_every_code_work_request_record(segments[3])
         return {"request": record.model_dump(mode="json")}
@@ -3107,6 +3157,22 @@ def _handle_every_code_worker_write(
     payload: dict[str, object],
 ) -> list[bytes]:
     every_code_store = _every_code_work_request_store(record_store)
+    if path == "/v1/every-code/preview-gates":
+        gate_record = EveryCodePreviewGateEnvelope.model_validate(payload)
+        every_code_store.write_every_code_preview_gate_record(gate_record)
+        return _json_response(
+            start_response=start_response,
+            status_code=202,
+            payload=_accepted_payload(
+                trace_id=trace_id,
+                result={
+                    "gate_id": gate_record.gate_id,
+                    "request_id": gate_record.request_id,
+                    "status": gate_record.status,
+                },
+                driver_result={"gate": gate_record.model_dump(mode="json")},
+            ),
+        )
     if path == "/v1/every-code/pr-feedback/status":
         feedback_status_request = EveryCodePrFeedbackStatusEnvelope.model_validate(payload)
         feedback_matches = every_code_store.list_every_code_pr_feedback_records(

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -9,6 +9,7 @@ from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRe
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
 from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestRecord,
     claim_every_code_work_request,
@@ -200,6 +201,37 @@ class FilesystemRecordStore:
 
     def write_every_code_pr_feedback_record(self, record: EveryCodePrFeedbackRecord) -> Path:
         return self._write_model("launchplane_every_code_pr_feedback", record.feedback_id, record)
+
+    def write_every_code_preview_gate_record(self, record: EveryCodePreviewGateRecord) -> Path:
+        return self._write_model("launchplane_every_code_preview_gates", record.gate_id, record)
+
+    def list_every_code_preview_gate_records(
+        self,
+        *,
+        request_id: str = "",
+        repository: str = "",
+        pr_number: int | None = None,
+        status: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[EveryCodePreviewGateRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                EveryCodePreviewGateRecord,
+                "launchplane_every_code_preview_gates",
+            )
+            if (not request_id or record.request_id == request_id)
+            and (not repository or record.repository == repository)
+            and (pr_number is None or record.pr_number == pr_number)
+            and (not status or record.status == status)
+        ]
+        records.sort(key=lambda record: (record.updated_at, record.gate_id), reverse=True)
+        if offset > 0:
+            records = records[offset:]
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
 
     def list_every_code_pr_feedback_records(
         self,

--- a/control_plane/storage/migrations/versions/ad34ef56bc78_add_every_code_preview_gates.py
+++ b/control_plane/storage/migrations/versions/ad34ef56bc78_add_every_code_preview_gates.py
@@ -1,0 +1,70 @@
+"""add Every Code preview gates
+
+Revision ID: ad34ef56bc78
+Revises: ac23de45fa67
+Create Date: 2026-05-07 16:30:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "ad34ef56bc78"
+down_revision: str | None = "ac23de45fa67"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "launchplane_every_code_preview_gates",
+        sa.Column("gate_id", sa.String(), nullable=False),
+        sa.Column("request_id", sa.String(), nullable=False),
+        sa.Column("repository", sa.String(), nullable=False),
+        sa.Column("issue_number", sa.Integer(), nullable=False),
+        sa.Column("pr_number", sa.Integer(), nullable=False),
+        sa.Column("head_sha", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("updated_at", sa.String(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("gate_id"),
+    )
+    op.create_index(
+        "launchplane_every_code_preview_gates_request_idx",
+        "launchplane_every_code_preview_gates",
+        ["request_id", sa.text("updated_at DESC")],
+    )
+    op.create_index(
+        "launchplane_every_code_preview_gates_pr_idx",
+        "launchplane_every_code_preview_gates",
+        ["repository", "pr_number", sa.text("updated_at DESC")],
+    )
+    op.create_index(
+        "launchplane_every_code_preview_gates_status_idx",
+        "launchplane_every_code_preview_gates",
+        ["status", sa.text("updated_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "launchplane_every_code_preview_gates_status_idx",
+        table_name="launchplane_every_code_preview_gates",
+    )
+    op.drop_index(
+        "launchplane_every_code_preview_gates_pr_idx",
+        table_name="launchplane_every_code_preview_gates",
+    )
+    op.drop_index(
+        "launchplane_every_code_preview_gates_request_idx",
+        table_name="launchplane_every_code_preview_gates",
+    )
+    op.drop_table("launchplane_every_code_preview_gates")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -28,6 +28,7 @@ from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
 from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestRecord,
     claim_every_code_work_request,
@@ -492,6 +493,38 @@ class LaunchplaneEveryCodePrFeedbackRow(Base):
     actor: Mapped[str] = mapped_column(String, nullable=False)
     received_at: Mapped[str] = mapped_column(String, nullable=False)
     status: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneEveryCodePreviewGateRow(Base):
+    __tablename__ = "launchplane_every_code_preview_gates"
+    __table_args__ = (
+        Index(
+            "launchplane_every_code_preview_gates_request_idx",
+            "request_id",
+            desc("updated_at"),
+        ),
+        Index(
+            "launchplane_every_code_preview_gates_pr_idx",
+            "repository",
+            "pr_number",
+            desc("updated_at"),
+        ),
+        Index(
+            "launchplane_every_code_preview_gates_status_idx",
+            "status",
+            desc("updated_at"),
+        ),
+    )
+
+    gate_id: Mapped[str] = mapped_column(String, primary_key=True)
+    request_id: Mapped[str] = mapped_column(String, nullable=False)
+    repository: Mapped[str] = mapped_column(String, nullable=False)
+    issue_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    pr_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    head_sha: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    updated_at: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -1317,6 +1350,52 @@ class PostgresRecordStore(HumanSessionStore):
                 status=record.status,
                 payload=self._payload_dict(record),
             )
+        )
+
+    def write_every_code_preview_gate_record(self, record: EveryCodePreviewGateRecord) -> None:
+        self._write_row(
+            LaunchplaneEveryCodePreviewGateRow(
+                gate_id=record.gate_id,
+                request_id=record.request_id,
+                repository=record.repository,
+                issue_number=record.issue_number,
+                pr_number=record.pr_number,
+                head_sha=record.head_sha,
+                status=record.status,
+                updated_at=record.updated_at,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def list_every_code_preview_gate_records(
+        self,
+        *,
+        request_id: str = "",
+        repository: str = "",
+        pr_number: int | None = None,
+        status: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[EveryCodePreviewGateRecord, ...]:
+        filters: list[object] = []
+        if request_id:
+            filters.append(LaunchplaneEveryCodePreviewGateRow.request_id == request_id)
+        if repository:
+            filters.append(LaunchplaneEveryCodePreviewGateRow.repository == repository)
+        if pr_number is not None:
+            filters.append(LaunchplaneEveryCodePreviewGateRow.pr_number == pr_number)
+        if status:
+            filters.append(LaunchplaneEveryCodePreviewGateRow.status == status)
+        return self._list_models(
+            model_type=EveryCodePreviewGateRecord,
+            orm_model=LaunchplaneEveryCodePreviewGateRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneEveryCodePreviewGateRow.updated_at.desc(),
+                LaunchplaneEveryCodePreviewGateRow.gate_id.desc(),
+            ),
+            limit=limit,
+            offset=offset,
         )
 
     def list_every_code_pr_feedback_records(
@@ -2166,6 +2245,7 @@ class PostgresRecordStore(HumanSessionStore):
             "preview_lifecycle_cleanups": 0,
             "preview_lifecycle_plans": 0,
             "preview_pr_feedback": 0,
+            "every_code_preview_gates": 0,
             "release_tuples": 0,
             "runtime_key_safety_policies": 0,
         }
@@ -2222,6 +2302,10 @@ class PostgresRecordStore(HumanSessionStore):
             for pr_feedback_record in filesystem_store.list_preview_pr_feedback_records():
                 self.write_preview_pr_feedback_record(pr_feedback_record)
                 counts["preview_pr_feedback"] += 1
+        if hasattr(filesystem_store, "list_every_code_preview_gate_records"):
+            for gate_record in filesystem_store.list_every_code_preview_gate_records():
+                self.write_every_code_preview_gate_record(gate_record)
+                counts["every_code_preview_gates"] += 1
         for release_tuple_record in filesystem_store.list_release_tuple_records():
             self.write_release_tuple_record(release_tuple_record)
             counts["release_tuples"] += 1

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -14,6 +14,8 @@ from click.testing import CliRunner
 
 from control_plane.cli import main
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
+from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
+from control_plane.contracts.every_code_preview_gate_record import build_every_code_preview_gate_id
 from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
 from control_plane.contracts.every_code_work_request import requeue_every_code_work_request
 from control_plane.every_code_worker import (
@@ -99,6 +101,34 @@ def _done_record(*, repository: str, result_pr_url: str) -> EveryCodeWorkRequest
             "started_at": "2026-05-05T22:02:00Z",
             "finished_at": "2026-05-05T22:03:00Z",
         }
+    )
+
+
+def _preview_gate_record(
+    *, status: str = "pending", head_sha: str = "abcdef1234567890"
+) -> EveryCodePreviewGateRecord:
+    return EveryCodePreviewGateRecord(
+        gate_id=build_every_code_preview_gate_id(
+            repository="cbusillo/sellyouroutboard",
+            pr_number=86,
+            head_sha=head_sha,
+        ),
+        request_id="every-code-cbusillo-code-123-test",
+        repository="cbusillo/sellyouroutboard",
+        issue_number=123,
+        issue_url="https://github.com/cbusillo/sellyouroutboard/issues/123",
+        issue_author="Mbanks89",
+        pr_number=86,
+        pr_url="https://github.com/cbusillo/sellyouroutboard/pull/86",
+        head_sha=head_sha,
+        status=status,  # type: ignore[arg-type]
+        created_at="2026-05-06T20:00:00Z",
+        updated_at="2026-05-06T20:00:00Z",
+        ready_at="2026-05-06T20:01:00Z" if status == "ready" else "",
+        labeled_at="2026-05-06T20:02:00Z" if status == "labeled" else "",
+        blocked_at="2026-05-06T20:03:00Z" if status == "blocked" else "",
+        cancelled_at="2026-05-06T20:04:00Z" if status == "cancelled" else "",
+        last_checked_at="2026-05-06T20:00:00Z",
     )
 
 
@@ -206,6 +236,20 @@ class _EveryCodeApiHandler(BaseHTTPRequestHandler):
         if self.headers.get("Authorization") != f"Bearer {self.token}":
             self._write_json(401, {"status": "rejected"})
             return
+        if self.path.startswith("/v1/every-code/preview-gates"):
+            query = parse_qs(urlparse(self.path).query)
+            gate_records = self.store.list_every_code_preview_gate_records(
+                status=str((query.get("status") or [""])[0]),
+                limit=10,
+            )
+            self._write_json(
+                200,
+                {
+                    "status": "ok",
+                    "gates": [record.model_dump(mode="json") for record in gate_records],
+                },
+            )
+            return
         if self.path.startswith("/v1/every-code/pr-feedback"):
             query = parse_qs(urlparse(self.path).query)
             feedback_records = self.store.list_every_code_pr_feedback_records(
@@ -242,6 +286,18 @@ class _EveryCodeApiHandler(BaseHTTPRequestHandler):
             return
         content_length = int(self.headers.get("Content-Length", "0"))
         payload = json.loads(self.rfile.read(content_length).decode("utf-8"))
+        if self.path == "/v1/every-code/preview-gates":
+            gate_record = EveryCodePreviewGateRecord.model_validate(payload)
+            self.store.write_every_code_preview_gate_record(gate_record)
+            self._write_json(
+                202,
+                {
+                    "status": "accepted",
+                    "records": {"gate_id": gate_record.gate_id, "status": gate_record.status},
+                    "result": {"gate": gate_record.model_dump(mode="json")},
+                },
+            )
+            return
         if self.path == "/v1/every-code/pr-feedback/status":
             feedback_records = self.store.list_every_code_pr_feedback_records(
                 request_id=str(payload["request_id"]),
@@ -444,6 +500,39 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(feedback_records[0].feedback_id, _feedback_record().feedback_id)
         self.assertEqual(listed_after_update[0].status, "applied")
 
+    def test_api_store_lists_and_writes_preview_gates_via_service(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            _EveryCodeApiHandler.store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            _EveryCodeApiHandler.store.write_every_code_preview_gate_record(_preview_gate_record())
+            server = ThreadingHTTPServer(("127.0.0.1", 0), _EveryCodeApiHandler)
+            server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+            server_thread.start()
+            try:
+                store = EveryCodeWorkerApiStore(
+                    service_url=f"http://127.0.0.1:{server.server_port}",
+                    worker_token="worker-token",
+                )
+
+                gate_records = store.list_every_code_preview_gate_records(status="pending")
+                blocked_record = gate_records[0].model_copy(
+                    update={
+                        "status": "blocked",
+                        "updated_at": "2026-05-06T20:05:00Z",
+                        "blocked_at": "2026-05-06T20:05:00Z",
+                    }
+                )
+                store.write_every_code_preview_gate_record(blocked_record)
+                listed_after_update = store.list_every_code_preview_gate_records(status="blocked")
+            finally:
+                server.shutdown()
+                server.server_close()
+                server_thread.join(timeout=5)
+
+        self.assertEqual(len(gate_records), 1)
+        self.assertEqual(gate_records[0].gate_id, _preview_gate_record().gate_id)
+        self.assertEqual(listed_after_update[0].status, "blocked")
+
     def test_api_store_reruns_terminal_request_via_service(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             temporary_root = Path(temporary_directory_name)
@@ -626,6 +715,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
             runner = _Runner(
                 pr_view_payload={
                     "state": "OPEN",
+                    "headRefOid": "abcdef1234567890",
                     "labels": [],
                     "statusCheckRollup": [
                         {"name": "static_checks", "status": "COMPLETED", "conclusion": "SUCCESS"},
@@ -638,8 +728,15 @@ class EveryCodeWorkerTests(unittest.TestCase):
                 record_store=store,
                 runner=runner,
             )
+            gate_records = store.list_every_code_preview_gate_records(
+                request_id="every-code-cbusillo-code-123-test",
+                pr_number=86,
+            )
 
         self.assertEqual(result.labeled, 1)
+        self.assertEqual(len(gate_records), 1)
+        self.assertEqual(gate_records[0].status, "labeled")
+        self.assertEqual(gate_records[0].head_sha, "abcdef1234567890")
         self.assertIn(
             (
                 "gh",
@@ -666,6 +763,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
             runner = _Runner(
                 pr_view_payload={
                     "state": "OPEN",
+                    "headRefOid": "abcdef1234567890",
                     "labels": [],
                     "statusCheckRollup": [
                         {"name": "static_checks", "status": "IN_PROGRESS", "conclusion": ""},
@@ -677,8 +775,45 @@ class EveryCodeWorkerTests(unittest.TestCase):
                 record_store=store,
                 runner=runner,
             )
+            gate_records = store.list_every_code_preview_gate_records(status="pending")
 
         self.assertEqual(result.pending, 1)
+        self.assertEqual(len(gate_records), 1)
+        self.assertIn("static_checks", gate_records[0].pending_reason)
+        self.assertFalse(any(call[:3] == ("gh", "pr", "edit") for call in runner.calls))
+
+    def test_preview_gate_blocks_stale_pending_checks_after_timeout(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_every_code_work_request_record(
+                _done_record(
+                    repository="cbusillo/sellyouroutboard",
+                    result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/86",
+                )
+            )
+            store.write_every_code_preview_gate_record(_preview_gate_record())
+            runner = _Runner(
+                pr_view_payload={
+                    "state": "OPEN",
+                    "headRefOid": "abcdef1234567890",
+                    "labels": [],
+                    "statusCheckRollup": [
+                        {"name": "static_checks", "status": "IN_PROGRESS", "conclusion": ""},
+                    ],
+                }
+            )
+
+            result = request_ready_every_code_pr_preview_labels(
+                record_store=store,
+                gate_timeout_seconds=1,
+                runner=runner,
+            )
+            gate_records = store.list_every_code_preview_gate_records(status="blocked")
+
+        self.assertEqual(result.blocked, 1)
+        self.assertEqual(result.pending, 0)
+        self.assertEqual(len(gate_records), 1)
+        self.assertIn("Timed out", gate_records[0].blocked_reason)
         self.assertFalse(any(call[:3] == ("gh", "pr", "edit") for call in runner.calls))
 
     def test_preview_gate_blocks_failed_checks(self) -> None:
@@ -693,6 +828,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
             runner = _Runner(
                 pr_view_payload={
                     "state": "OPEN",
+                    "headRefOid": "abcdef1234567890",
                     "labels": [],
                     "statusCheckRollup": [
                         {"name": "static_checks", "status": "COMPLETED", "conclusion": "FAILURE"},
@@ -704,9 +840,109 @@ class EveryCodeWorkerTests(unittest.TestCase):
                 record_store=store,
                 runner=runner,
             )
+            gate_records = store.list_every_code_preview_gate_records(status="blocked")
 
         self.assertEqual(result.blocked, 1)
+        self.assertEqual(len(gate_records), 1)
+        self.assertIn("static_checks", gate_records[0].blocked_reason)
         self.assertFalse(any(call[:3] == ("gh", "pr", "edit") for call in runner.calls))
+
+    def test_preview_gate_resets_when_pull_request_head_changes(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_every_code_work_request_record(
+                _done_record(
+                    repository="cbusillo/sellyouroutboard",
+                    result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/86",
+                )
+            )
+            store.write_every_code_preview_gate_record(
+                _preview_gate_record(head_sha="oldsha1234567890")
+            )
+            runner = _Runner(
+                pr_view_payload={
+                    "state": "OPEN",
+                    "headRefOid": "newsha1234567890",
+                    "labels": [],
+                    "statusCheckRollup": [
+                        {"name": "static_checks", "status": "IN_PROGRESS", "conclusion": ""},
+                    ],
+                }
+            )
+
+            result = request_ready_every_code_pr_preview_labels(
+                record_store=store,
+                runner=runner,
+            )
+            all_gates = store.list_every_code_preview_gate_records(pr_number=86)
+            pending_gates = store.list_every_code_preview_gate_records(status="pending")
+            cancelled_gates = store.list_every_code_preview_gate_records(status="cancelled")
+
+        self.assertEqual(result.pending, 1)
+        self.assertEqual(result.reset, 1)
+        self.assertEqual(len(all_gates), 2)
+        self.assertEqual(pending_gates[0].head_sha, "newsha1234567890")
+        self.assertEqual(cancelled_gates[0].head_sha, "oldsha1234567890")
+
+    def test_preview_gate_cancels_closed_pull_request(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_every_code_work_request_record(
+                _done_record(
+                    repository="cbusillo/sellyouroutboard",
+                    result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/86",
+                )
+            )
+            runner = _Runner(
+                pr_view_payload={
+                    "state": "CLOSED",
+                    "headRefOid": "abcdef1234567890",
+                    "labels": [],
+                    "statusCheckRollup": [],
+                }
+            )
+
+            result = request_ready_every_code_pr_preview_labels(
+                record_store=store,
+                runner=runner,
+            )
+            gate_records = store.list_every_code_preview_gate_records(status="cancelled")
+
+        self.assertEqual(result.cancelled, 1)
+        self.assertEqual(len(gate_records), 1)
+        self.assertIn("no longer open", gate_records[0].blocked_reason)
+
+    def test_preview_gate_cancels_when_source_issue_closed(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_every_code_work_request_record(
+                _done_record(
+                    repository="cbusillo/sellyouroutboard",
+                    result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/86",
+                ).model_copy(update={"result_summary": "Source issue closed by Mbanks89."})
+            )
+            store.write_every_code_preview_gate_record(_preview_gate_record())
+            runner = _Runner(
+                pr_view_payload={
+                    "state": "OPEN",
+                    "headRefOid": "abcdef1234567890",
+                    "labels": [],
+                    "statusCheckRollup": [
+                        {"name": "static_checks", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                    ],
+                }
+            )
+
+            result = request_ready_every_code_pr_preview_labels(
+                record_store=store,
+                runner=runner,
+            )
+            gate_records = store.list_every_code_preview_gate_records(status="cancelled")
+
+        self.assertEqual(result.cancelled, 1)
+        self.assertEqual(len(gate_records), 1)
+        self.assertIn("Source issue closed", gate_records[0].blocked_reason)
+        self.assertFalse(runner.calls)
 
     def test_preview_gate_skips_pull_request_with_preview_label(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -1938,7 +2174,8 @@ class EveryCodeWorkerTests(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, result.output)
         payload = json.loads(result.output)
-        self.assertEqual(payload["skipped"], 1)
+        self.assertEqual(payload["checked"], 1)
+        self.assertEqual(payload["blocked"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -14,6 +14,7 @@ from control_plane.contracts.artifact_identity import (
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
 from control_plane.contracts.odoo_instance_override_record import OdooAddonSettingOverride
 from control_plane.contracts.odoo_instance_override_record import OdooConfigParameterOverride
@@ -70,6 +71,49 @@ def _health_pass() -> HealthcheckEvidence:
 
 
 class FilesystemRecordStoreTests(unittest.TestCase):
+    def test_write_and_list_every_code_preview_gate_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            older_record = EveryCodePreviewGateRecord(
+                gate_id="every-code-preview-gate-cbusillo-code-26-oldsha",
+                request_id="every-code-cbusillo-code-123-test",
+                repository="cbusillo/code",
+                issue_number=123,
+                issue_url="https://github.com/cbusillo/code/issues/123",
+                issue_author="octocat",
+                pr_number=26,
+                pr_url="https://github.com/cbusillo/code/pull/26",
+                head_sha="oldsha",
+                status="pending",
+                created_at="2026-05-06T17:00:00Z",
+                updated_at="2026-05-06T17:00:00Z",
+            )
+            newer_record = older_record.model_copy(
+                update={
+                    "gate_id": "every-code-preview-gate-cbusillo-code-26-newsha",
+                    "head_sha": "newsha",
+                    "status": "blocked",
+                    "updated_at": "2026-05-06T18:00:00Z",
+                    "blocked_at": "2026-05-06T18:00:00Z",
+                }
+            )
+
+            written_path = store.write_every_code_preview_gate_record(older_record)
+            store.write_every_code_preview_gate_record(newer_record)
+            listed_records = store.list_every_code_preview_gate_records(
+                request_id="every-code-cbusillo-code-123-test",
+                pr_number=26,
+            )
+            blocked_records = store.list_every_code_preview_gate_records(status="blocked")
+            self.assertTrue(written_path.exists())
+
+        self.assertEqual(
+            [record.gate_id for record in listed_records],
+            [newer_record.gate_id, older_record.gate_id],
+        )
+        self.assertEqual([record.gate_id for record in blocked_records], [newer_record.gate_id])
+
     def test_write_and_list_every_code_pr_feedback_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name)

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -21,6 +21,7 @@ from control_plane.contracts.deployment_record import DeploymentRecord, Resolved
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
 from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
@@ -1342,6 +1343,46 @@ class PostgresRecordStoreTests(unittest.TestCase):
         self.assertEqual(listed_records[0].delivery_status, "delivered")
         self.assertEqual(listed_records[0].comment_id, 456)
 
+    def test_every_code_preview_gate_records_round_trip(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_every_code_preview_gate_record(
+                EveryCodePreviewGateRecord(
+                    gate_id="every-code-preview-gate-cbusillo-code-26-abcdef",
+                    request_id="every-code-cbusillo-code-123-test",
+                    repository="cbusillo/code",
+                    issue_number=123,
+                    issue_url="https://github.com/cbusillo/code/issues/123",
+                    issue_author="octocat",
+                    pr_number=26,
+                    pr_url="https://github.com/cbusillo/code/pull/26",
+                    head_sha="abcdef1234567890",
+                    status="blocked",
+                    created_at="2026-05-06T17:00:00Z",
+                    updated_at="2026-05-06T18:00:00Z",
+                    blocked_at="2026-05-06T18:00:00Z",
+                    blocked_reason="Checks did not pass: static_checks",
+                )
+            )
+            listed_records = store.list_every_code_preview_gate_records(
+                request_id="every-code-cbusillo-code-123-test",
+                status="blocked",
+            )
+            store.close()
+
+        self.assertEqual(len(listed_records), 1)
+        self.assertEqual(
+            listed_records[0].gate_id,
+            "every-code-preview-gate-cbusillo-code-26-abcdef",
+        )
+        self.assertEqual(listed_records[0].head_sha, "abcdef1234567890")
+        self.assertEqual(listed_records[0].blocked_reason, "Checks did not pass: static_checks")
+
     def test_write_and_list_dokploy_target_id_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(
@@ -1749,6 +1790,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     "preview_lifecycle_cleanups": 1,
                     "preview_lifecycle_plans": 1,
                     "preview_pr_feedback": 1,
+                    "every_code_preview_gates": 0,
                     "release_tuples": 1,
                     "runtime_key_safety_policies": 1,
                 },


### PR DESCRIPTION
## Summary
- add durable Every Code preview gate records with filesystem/Postgres/API support
- gate preview labels on the matching PR head SHA and reset/cancel superseded gate state on new commits
- keep incomplete checks pending until timeout, block failed checks, and cancel pending gate work when the source issue/PR closes

Closes #394.

## Validation
- uv run --extra dev ruff check .
- uv run python -m unittest tests.test_every_code_worker tests.test_filesystem_store.FilesystemRecordStoreTests.test_write_and_list_every_code_preview_gate_records tests.test_postgres_store.PostgresRecordStoreTests.test_every_code_preview_gate_records_round_trip tests.test_postgres_store.PostgresRecordStoreTests.test_import_core_records_from_filesystem
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest