### PR TITLE
Extract work graph queue hook

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,8 +33,6 @@ import {
   logout,
   readAuthSession,
   readDriverView,
-  readWorkGraphSnapshot,
-  rankWorkGraphSnapshot,
 } from "./api";
 import { ApiErrorPanel, AuthPanel } from "./AuthPanels";
 import { EveryCodeQueue } from "./EveryCodeQueue";
@@ -46,6 +44,7 @@ import {
   secretScopeForTarget,
 } from "./ProductConfigPanel";
 import { StatusIcon, StatusPill, StateBlock, SkeletonRows } from "./status-ui";
+import { useWorkGraphQueue } from "./useWorkGraphQueue";
 import type {
   AuthIdentity,
   DataProvenance,
@@ -370,9 +369,13 @@ export function App() {
   const [workRequests, setWorkRequests] = useState<
     EveryCodeWorkRequestRecord[]
   >([]);
-  const [workGraphItems, setWorkGraphItems] = useState<WorkGraphQueueItem[]>([]);
-  const [workGraphHiddenCount, setWorkGraphHiddenCount] = useState(0);
-  const [workGraphError, setWorkGraphError] = useState("");
+  const {
+    workGraphItems,
+    workGraphHiddenCount,
+    workGraphError,
+    refreshWorkGraph,
+    resetWorkGraph,
+  } = useWorkGraphQueue();
   const [workGraphFilter, setWorkGraphFilter] =
     useState<WorkGraphFilter>("all");
   const [workGraphMode, setWorkGraphMode] = useState<WorkGraphMode>("all");
@@ -434,9 +437,7 @@ export function App() {
       setProductProfiles([]);
       setProductOverviews([]);
       setWorkRequests([]);
-      setWorkGraphItems([]);
-      setWorkGraphHiddenCount(0);
-      setWorkGraphError("");
+      resetWorkGraph();
       setProdView(null);
       setTestingView(null);
       setPreviewView(null);
@@ -494,40 +495,7 @@ export function App() {
           setPreviewView(previewPayload?.view ?? null);
           setProductOverviews(productsPayload.products);
           setWorkRequests(workRequestsPayload.requests);
-          const workGraphSnapshotPayload = await readWorkGraphSnapshot();
-          if (controller.signal.aborted) {
-            return;
-          }
-          const workGraphSnapshot = workGraphSnapshotPayload.snapshot;
-          if (!workGraphSnapshot.issues.length) {
-            setWorkGraphItems([]);
-            setWorkGraphHiddenCount(0);
-            setWorkGraphError("");
-            return;
-          }
-          try {
-            const workGraphPayload = await rankWorkGraphSnapshot(
-              workGraphSnapshot,
-              12,
-            );
-            if (controller.signal.aborted) {
-              return;
-            }
-            setWorkGraphItems(workGraphPayload.result.queue.items);
-            setWorkGraphHiddenCount(workGraphPayload.result.queue.hidden_count);
-            setWorkGraphError("");
-          } catch (apiError) {
-            if (controller.signal.aborted) {
-              return;
-            }
-            setWorkGraphItems([]);
-            setWorkGraphHiddenCount(0);
-            setWorkGraphError(
-              apiError instanceof Error
-                ? apiError.message
-                : "Work graph ranking failed.",
-            );
-          }
+          await refreshWorkGraph(controller.signal);
         },
       )
       .catch((apiError: unknown) => {
@@ -550,7 +518,7 @@ export function App() {
       });
 
     return () => controller.abort();
-  }, [authStatus, selected, refreshKey]);
+  }, [authStatus, selected, refreshKey, refreshWorkGraph, resetWorkGraph]);
 
   const choices = useMemo(() => {
     const driverChoices: DriverChoice[] = drivers.flatMap((driver) => {
@@ -667,9 +635,7 @@ export function App() {
       setProductProfiles([]);
       setProductOverviews([]);
       setWorkRequests([]);
-      setWorkGraphItems([]);
-      setWorkGraphHiddenCount(0);
-      setWorkGraphError("");
+      resetWorkGraph();
       setProdView(null);
       setTestingView(null);
       setPreviewView(null);

--- a/frontend/src/useWorkGraphQueue.ts
+++ b/frontend/src/useWorkGraphQueue.ts
@@ -1,0 +1,61 @@
+import { useCallback, useState } from "react";
+
+import { readWorkGraphSnapshot, rankWorkGraphSnapshot } from "./api";
+import type { WorkGraphQueueItem } from "./types";
+
+export function useWorkGraphQueue() {
+  const [items, setItems] = useState<WorkGraphQueueItem[]>([]);
+  const [hiddenCount, setHiddenCount] = useState(0);
+  const [error, setError] = useState("");
+
+  const reset = useCallback(() => {
+    setItems([]);
+    setHiddenCount(0);
+    setError("");
+  }, []);
+
+  const refresh = useCallback(
+    async (signal: AbortSignal) => {
+      const snapshotPayload = await readWorkGraphSnapshot();
+      if (signal.aborted) {
+        return;
+      }
+
+      const snapshot = snapshotPayload.snapshot;
+      if (!snapshot.issues.length) {
+        reset();
+        return;
+      }
+
+      try {
+        const workGraphPayload = await rankWorkGraphSnapshot(snapshot, 12);
+        if (signal.aborted) {
+          return;
+        }
+        setItems(workGraphPayload.result.queue.items);
+        setHiddenCount(workGraphPayload.result.queue.hidden_count);
+        setError("");
+      } catch (apiError) {
+        if (signal.aborted) {
+          return;
+        }
+        setItems([]);
+        setHiddenCount(0);
+        setError(
+          apiError instanceof Error
+            ? apiError.message
+            : "Work graph ranking failed.",
+        );
+      }
+    },
+    [reset],
+  );
+
+  return {
+    workGraphItems: items,
+    workGraphHiddenCount: hiddenCount,
+    workGraphError: error,
+    refreshWorkGraph: refresh,
+    resetWorkGraph: reset,
+  };
+}


### PR DESCRIPTION
## Summary
- Extract work graph snapshot/rank queue state from `App.tsx` into `frontend/src/useWorkGraphQueue.ts`
- Keep the broader dashboard load flow and UI props unchanged
- Preserve existing behavior: snapshot fetch errors still surface through the main API error flow, while rank failures stay localized to the work graph queue

Part of #307.

## Validation
- `pnpm --dir frontend validate`
- Browser smoke: `/ui/` unauthenticated entry renders with no console app errors
- Browser smoke: `/ui/?fixtures=1` fixture dashboard renders work graph queue with no console app errors

Note: the first frontend validate attempt failed because the fresh worktree lacked `frontend/node_modules`; `pnpm --dir frontend install --frozen-lockfile` restored locked dependencies, and validation then passed.