### PR TITLE
fix(every-code): backfill preview reviewers

### DIFF
--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -484,6 +484,7 @@ class EveryCodePreviewGateResult:
     skipped: int = 0
     cancelled: int = 0
     reset: int = 0
+    reviewer_backfilled: int = 0
 
     def as_payload(self) -> dict[str, object]:
         return {
@@ -494,6 +495,7 @@ class EveryCodePreviewGateResult:
             "skipped": self.skipped,
             "cancelled": self.cancelled,
             "reset": self.reset,
+            "reviewer_backfilled": self.reviewer_backfilled,
         }
 
 
@@ -1746,6 +1748,7 @@ def request_ready_every_code_pr_preview_labels(
     skipped = 0
     cancelled = 0
     reset = 0
+    reviewer_backfilled = 0
     for record in records:
         if _every_code_work_request_closed_before_preview(record):
             cancelled += _cancel_every_code_preview_gates_for_record(
@@ -1897,6 +1900,17 @@ def request_ready_every_code_pr_preview_labels(
             )
             cancelled += 1
         else:
+            if readiness == "skipped" and _github_pr_payload_has_label(
+                payload,
+                launchplane_anchor_repo_preview_label(repo=reference["repo"]),
+            ):
+                reviewer_backfilled += _backfill_every_code_preview_reviewer(
+                    record=record,
+                    owner=reference["owner"],
+                    repo=reference["repo"],
+                    pr_number=reference["pr_number"],
+                    runner=run,
+                )
             skipped += 1
     return EveryCodePreviewGateResult(
         checked=checked,
@@ -1906,6 +1920,7 @@ def request_ready_every_code_pr_preview_labels(
         skipped=skipped,
         cancelled=cancelled,
         reset=reset,
+        reviewer_backfilled=reviewer_backfilled,
     )
 
 
@@ -1975,6 +1990,157 @@ def _parse_utc_timestamp(timestamp: str) -> datetime | None:
     if parsed.tzinfo is None:
         return parsed.replace(tzinfo=UTC)
     return parsed.astimezone(UTC)
+
+
+def _backfill_every_code_preview_reviewer(
+    *,
+    record: EveryCodeWorkRequestRecord,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    runner: Runner,
+) -> int:
+    issue_author = _github_issue_author_login(
+        owner=owner,
+        repo=repo,
+        issue_number=record.issue_number,
+        runner=runner,
+    )
+    if not issue_author:
+        return 0
+    pr_author = _github_pr_author_login(
+        owner=owner,
+        repo=repo,
+        pr_number=pr_number,
+        runner=runner,
+    )
+    if pr_author.casefold() == issue_author.casefold():
+        return 0
+    requested_reviewers = _github_requested_reviewer_logins(
+        owner=owner,
+        repo=repo,
+        pr_number=pr_number,
+        runner=runner,
+    )
+    if issue_author.casefold() in requested_reviewers:
+        return 0
+    return int(
+        _request_github_pull_request_reviewer(
+            owner=owner,
+            repo=repo,
+            pr_number=pr_number,
+            reviewer=issue_author,
+            runner=runner,
+        )
+    )
+
+
+def _github_issue_author_login(
+    *,
+    owner: str,
+    repo: str,
+    issue_number: int,
+    runner: Runner,
+) -> str:
+    payload = _gh_api_payload(
+        runner=runner,
+        path=f"repos/{owner}/{repo}/issues/{issue_number}",
+    )
+    user = payload.get("user")
+    if not isinstance(user, dict):
+        return ""
+    login = user.get("login")
+    return login.strip() if isinstance(login, str) else ""
+
+
+def _github_pr_author_login(
+    *,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    runner: Runner,
+) -> str:
+    payload = _gh_api_payload(
+        runner=runner,
+        path=f"repos/{owner}/{repo}/pulls/{pr_number}",
+    )
+    user = payload.get("user")
+    if not isinstance(user, dict):
+        return ""
+    login = user.get("login")
+    return login.strip() if isinstance(login, str) else ""
+
+
+def _github_requested_reviewer_logins(
+    *,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    runner: Runner,
+) -> frozenset[str]:
+    payload = _gh_api_payload(
+        runner=runner,
+        path=f"repos/{owner}/{repo}/pulls/{pr_number}/requested_reviewers",
+    )
+    users = payload.get("users")
+    if not isinstance(users, list):
+        return frozenset()
+    logins: set[str] = set()
+    for item in users:
+        if not isinstance(item, dict):
+            continue
+        login = item.get("login")
+        if isinstance(login, str) and login.strip():
+            logins.add(login.strip().casefold())
+    return frozenset(logins)
+
+
+def _request_github_pull_request_reviewer(
+    *,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    reviewer: str,
+    runner: Runner,
+) -> bool:
+    result = _run_gh_api(
+        runner=runner,
+        args=(
+            "gh",
+            "api",
+            f"repos/{owner}/{repo}/pulls/{pr_number}/requested_reviewers",
+            "--method",
+            "POST",
+            "--field",
+            f"reviewers[]={reviewer}",
+        ),
+    )
+    return result is not None
+
+
+def _gh_api_payload(*, runner: Runner, path: str) -> dict[str, object]:
+    result = _run_gh_api(runner=runner, args=("gh", "api", path))
+    if result is None:
+        return {}
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _run_gh_api(
+    *,
+    runner: Runner,
+    args: Sequence[str],
+) -> subprocess.CompletedProcess[str] | None:
+    try:
+        result = runner(args)
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    return result
 
 
 def _reconcile_every_code_preview_gate_record(

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -140,12 +140,14 @@ class _Runner:
         existing_branch: bool = False,
         pr_view_payload: dict[str, object] | None = None,
         pr_list_payload: list[dict[str, object]] | None = None,
+        gh_api_payloads: dict[str, dict[str, object]] | None = None,
     ) -> None:
         self.calls: list[tuple[str, ...]] = []
         self.fail_issue_comment = fail_issue_comment
         self.existing_branch = existing_branch
         self.pr_view_payload = pr_view_payload
         self.pr_list_payload = pr_list_payload
+        self.gh_api_payloads = gh_api_payloads or {}
 
     def __call__(self, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
         self.calls.append(tuple(args))
@@ -181,6 +183,16 @@ class _Runner:
             return subprocess.CompletedProcess(args, 0, json.dumps(self.pr_view_payload), "")
         if args[:3] == ("gh", "pr", "list") and self.pr_list_payload is not None:
             return subprocess.CompletedProcess(args, 0, json.dumps(self.pr_list_payload), "")
+        if args[:2] == ("gh", "api"):
+            path = args[2]
+            if "--method" in args:
+                return subprocess.CompletedProcess(args, 0, json.dumps({"ok": True}), "")
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps(self.gh_api_payloads.get(path, {})),
+                "",
+            )
         if args[1] == "display-message":
             return subprocess.CompletedProcess(args, 0, "4242\n", "")
         if args[1] == "has-session":
@@ -968,6 +980,134 @@ class EveryCodeWorkerTests(unittest.TestCase):
 
         self.assertEqual(result.skipped, 1)
         self.assertFalse(any(call[:3] == ("gh", "pr", "edit") for call in runner.calls))
+
+    def test_preview_gate_backfills_reviewer_for_existing_preview_label(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_every_code_work_request_record(
+                _done_record(
+                    repository="cbusillo/sellyouroutboard",
+                    result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/86",
+                )
+            )
+            runner = _Runner(
+                pr_view_payload={
+                    "state": "OPEN",
+                    "headRefOid": "abcdef1234567890",
+                    "labels": [{"name": "preview"}],
+                    "statusCheckRollup": [],
+                },
+                gh_api_payloads={
+                    "repos/cbusillo/sellyouroutboard/issues/123": {"user": {"login": "Mbanks89"}},
+                    "repos/cbusillo/sellyouroutboard/pulls/86": {"user": {"login": "cbusillo"}},
+                    "repos/cbusillo/sellyouroutboard/pulls/86/requested_reviewers": {"users": []},
+                },
+            )
+
+            result = request_ready_every_code_pr_preview_labels(
+                record_store=store,
+                runner=runner,
+            )
+
+        self.assertEqual(result.skipped, 1)
+        self.assertEqual(result.reviewer_backfilled, 1)
+        self.assertIn(
+            (
+                "gh",
+                "api",
+                "repos/cbusillo/sellyouroutboard/pulls/86/requested_reviewers",
+                "--method",
+                "POST",
+                "--field",
+                "reviewers[]=Mbanks89",
+            ),
+            runner.calls,
+        )
+
+    def test_preview_gate_skips_reviewer_backfill_when_already_requested(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_every_code_work_request_record(
+                _done_record(
+                    repository="cbusillo/sellyouroutboard",
+                    result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/86",
+                )
+            )
+            runner = _Runner(
+                pr_view_payload={
+                    "state": "OPEN",
+                    "labels": [{"name": "preview"}],
+                    "statusCheckRollup": [],
+                },
+                gh_api_payloads={
+                    "repos/cbusillo/sellyouroutboard/issues/123": {"user": {"login": "Mbanks89"}},
+                    "repos/cbusillo/sellyouroutboard/pulls/86": {"user": {"login": "cbusillo"}},
+                    "repos/cbusillo/sellyouroutboard/pulls/86/requested_reviewers": {
+                        "users": [{"login": "Mbanks89"}]
+                    },
+                },
+            )
+
+            result = request_ready_every_code_pr_preview_labels(
+                record_store=store,
+                runner=runner,
+            )
+
+        self.assertEqual(result.skipped, 1)
+        self.assertEqual(result.reviewer_backfilled, 0)
+        self.assertFalse(
+            any(
+                call[:4]
+                == (
+                    "gh",
+                    "api",
+                    "repos/cbusillo/sellyouroutboard/pulls/86/requested_reviewers",
+                    "--method",
+                )
+                for call in runner.calls
+            )
+        )
+
+    def test_preview_gate_skips_reviewer_backfill_for_pr_author(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_every_code_work_request_record(
+                _done_record(
+                    repository="cbusillo/sellyouroutboard",
+                    result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/86",
+                )
+            )
+            runner = _Runner(
+                pr_view_payload={
+                    "state": "OPEN",
+                    "labels": [{"name": "preview"}],
+                    "statusCheckRollup": [],
+                },
+                gh_api_payloads={
+                    "repos/cbusillo/sellyouroutboard/issues/123": {"user": {"login": "Mbanks89"}},
+                    "repos/cbusillo/sellyouroutboard/pulls/86": {"user": {"login": "Mbanks89"}},
+                },
+            )
+
+            result = request_ready_every_code_pr_preview_labels(
+                record_store=store,
+                runner=runner,
+            )
+
+        self.assertEqual(result.skipped, 1)
+        self.assertEqual(result.reviewer_backfilled, 0)
+        self.assertFalse(
+            any(
+                call[:4]
+                == (
+                    "gh",
+                    "api",
+                    "repos/cbusillo/sellyouroutboard/pulls/86/requested_reviewers",
+                    "--method",
+                )
+                for call in runner.calls
+            )
+        )
 
     def test_preview_gate_discovers_running_request_pull_request_by_branch(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- backfill the source issue author as reviewer when a reconciled Every Code PR already has the preview label
- keep the operation idempotent by skipping PR authors and already-requested reviewers
- expose the backfill count in the preview reconciliation summary

## Validation
- uv run --extra dev ruff check .
- uv run python -m unittest tests.test_every_code_worker
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest