### PR TITLE
Extract product selection hook

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -44,6 +44,12 @@ import {
   secretScopeForTarget,
 } from "./ProductConfigPanel";
 import { StatusIcon, StatusPill, StateBlock, SkeletonRows } from "./status-ui";
+import {
+  choiceFromProductOverview,
+  choiceKey,
+  type DriverChoice,
+  useProductSelection,
+} from "./useProductSelection";
 import { useWorkGraphQueue } from "./useWorkGraphQueue";
 import type {
   AuthIdentity,
@@ -80,15 +86,6 @@ const assetUrl = (path: string) => `${import.meta.env.BASE_URL}${path}`;
 const launchplaneIconUrl = assetUrl("assets/brand/launchplane-icon.svg");
 
 type AuthStatus = "checking" | "signed_out" | "signed_in";
-type DriverChoice = {
-  driverId: string;
-  testingContext: string;
-  prodContext: string;
-  previewContext: string;
-  label: string;
-  driverLabel: string;
-  repository?: string;
-};
 type PromotionVerdict = "ready" | "pending" | "blocked";
 type PromotionGate = {
   label: string;
@@ -122,40 +119,6 @@ type EvidenceFact = {
 };
 
 const THEME_STORAGE_KEY = "launchplane.theme";
-const DEFAULT_CHOICES: DriverChoice[] = [
-  {
-    driverId: "sellyouroutboard",
-    testingContext: "sellyouroutboard-testing",
-    prodContext: "sellyouroutboard-testing",
-    previewContext: "sellyouroutboard-testing",
-    label: "SellYourOutboard",
-    driverLabel: "generic-web",
-  },
-  {
-    driverId: "verireel",
-    testingContext: "verireel",
-    prodContext: "verireel",
-    previewContext: "verireel-testing",
-    label: "VeriReel",
-    driverLabel: "verireel",
-  },
-  {
-    driverId: "odoo",
-    testingContext: "cm",
-    prodContext: "cm",
-    previewContext: "",
-    label: "Odoo CM",
-    driverLabel: "odoo",
-  },
-  {
-    driverId: "odoo",
-    testingContext: "opw",
-    prodContext: "opw",
-    previewContext: "",
-    label: "Odoo OPW",
-    driverLabel: "odoo",
-  },
-];
 const FIXTURE_ACTIONS: DriverActionDescriptor[] = [
   {
     action_id: "prod_backup_gate",
@@ -234,120 +197,6 @@ const FIXTURE_ODOO_DRIVER: DriverDescriptor = {
   actions: [],
 };
 
-function choiceKey(choice: DriverChoice): string {
-  return `${choice.driverId}:${choice.testingContext}:${choice.prodContext}:${choice.previewContext}`;
-}
-
-function choiceDisplayKey(choice: DriverChoice): string {
-  const normalizedLabel = choice.label.trim().toLowerCase();
-  return `${choice.driverId}:${normalizedLabel}`;
-}
-
-function labelForDriverContext(
-  driver: DriverDescriptor,
-  context: string,
-): string {
-  if (driver.driver_id === "odoo") {
-    if (context === "cm") {
-      return "Odoo CM";
-    }
-    if (context === "opw") {
-      return "Odoo OPW";
-    }
-  }
-  return driver.label;
-}
-
-function displayNameForProduct(profile: ProductProfileRecord): string {
-  if (profile.product === "sellyouroutboard") {
-    return "SellYourOutboard";
-  }
-  return profile.display_name || profile.product;
-}
-
-function contextForProductLane(
-  profile: ProductProfileRecord,
-  instance: "testing" | "prod",
-): string {
-  const lane = profile.lanes.find(
-    (candidate) => candidate.instance === instance,
-  );
-  if (lane?.context.trim()) {
-    return lane.context.trim();
-  }
-  const fallbackLane = profile.lanes.find((candidate) =>
-    candidate.context.trim(),
-  );
-  return fallbackLane?.context.trim() || "";
-}
-
-function choiceFromProductProfile(profile: ProductProfileRecord): DriverChoice {
-  return {
-    driverId: profile.product,
-    testingContext: contextForProductLane(profile, "testing"),
-    prodContext: contextForProductLane(profile, "prod"),
-    previewContext: profile.preview?.enabled
-      ? profile.preview.context.trim()
-      : "",
-    label: displayNameForProduct(profile),
-    driverLabel: profile.driver_id,
-    repository: profile.repository,
-  };
-}
-
-const PRODUCT_ENVIRONMENT_ALIASES: Record<"testing" | "prod", Set<string>> = {
-  testing: new Set(["testing", "test", "staging", "stage", "qa"]),
-  prod: new Set(["prod", "production", "stable", "live"]),
-};
-
-function normalizedProductEnvironment(value: string): string {
-  return value.trim().toLowerCase().replaceAll("_", "-");
-}
-
-function contextForProductEnvironment(
-  product: ProductSiteOverview,
-  environment: "testing" | "prod",
-  reservedContext = "",
-): string {
-  const summaries = product.environments
-    .map((summary) => ({
-      environment: normalizedProductEnvironment(summary.environment),
-      context: summary.context.trim(),
-    }))
-    .filter((summary) => summary.context);
-  const aliases = PRODUCT_ENVIRONMENT_ALIASES[environment];
-  const summary = summaries.find((candidate) =>
-    aliases.has(candidate.environment),
-  );
-  if (summary) {
-    return summary.context;
-  }
-  const distinctFallback = summaries.find(
-    (candidate) => candidate.context !== reservedContext,
-  );
-  return distinctFallback?.context ?? summaries[0]?.context ?? "";
-}
-
-function choiceFromProductOverview(product: ProductSiteOverview): DriverChoice {
-  const prodContext = contextForProductEnvironment(product, "prod");
-  const testingContext = contextForProductEnvironment(
-    product,
-    "testing",
-    prodContext,
-  );
-  return {
-    driverId: product.product,
-    testingContext,
-    prodContext,
-    previewContext: product.preview.enabled
-      ? product.preview.context.trim()
-      : "",
-    label: product.display_name || product.product,
-    driverLabel: product.driver_id,
-    repository: product.repository,
-  };
-}
-
 export function App() {
   const showFixtureGallery =
     import.meta.env.DEV &&
@@ -379,7 +228,11 @@ export function App() {
   const [workGraphFilter, setWorkGraphFilter] =
     useState<WorkGraphFilter>("all");
   const [workGraphMode, setWorkGraphMode] = useState<WorkGraphMode>("all");
-  const [selected, setSelected] = useState<DriverChoice>(DEFAULT_CHOICES[0]);
+  const { choices, selected, setSelected } = useProductSelection({
+    drivers,
+    productProfiles,
+    productOverviews,
+  });
   const [prodView, setProdView] = useState<DriverContextView | null>(null);
   const [testingView, setTestingView] = useState<DriverContextView | null>(
     null,
@@ -519,79 +372,6 @@ export function App() {
 
     return () => controller.abort();
   }, [authStatus, selected, refreshKey, refreshWorkGraph, resetWorkGraph]);
-
-  const choices = useMemo(() => {
-    const driverChoices: DriverChoice[] = drivers.flatMap((driver) => {
-      const stableContexts = driver.context_patterns.filter((context) => {
-        return context !== "verireel-testing" && !context.includes("*");
-      });
-      return stableContexts.map((context) => ({
-        driverId: driver.driver_id,
-        testingContext: context,
-        prodContext: context,
-        previewContext:
-          driver.driver_id === "verireel" && context === "verireel"
-            ? "verireel-testing"
-            : "",
-        label: labelForDriverContext(driver, context),
-        driverLabel: driver.driver_id,
-      }));
-    });
-    const profileChoices: DriverChoice[] = productProfiles.map((profile) =>
-      choiceFromProductProfile(profile),
-    );
-    const overviewChoices: DriverChoice[] = productOverviews.map((overview) =>
-      choiceFromProductOverview(overview),
-    );
-    const merged: DriverChoice[] = [
-      ...overviewChoices,
-      ...profileChoices,
-      ...driverChoices,
-      ...DEFAULT_CHOICES,
-    ];
-    const productDisplayKeys = new Set(
-      [...overviewChoices, ...profileChoices, ...DEFAULT_CHOICES].map(
-        choiceDisplayKey,
-      ),
-    );
-    const seen = new Set<string>();
-    return merged.filter((choice) => {
-      const displayKey = choiceDisplayKey(choice);
-      const key = productDisplayKeys.has(displayKey)
-        ? displayKey
-        : choiceKey(choice);
-      if (seen.has(key)) {
-        return false;
-      }
-      seen.add(key);
-      return true;
-    });
-  }, [drivers, productProfiles, productOverviews]);
-
-  useEffect(() => {
-    if (!choices.length) {
-      return;
-    }
-    const selectedKey = choiceKey(selected);
-    const selectedChoice = choices.find(
-      (choice) => choiceKey(choice) === selectedKey,
-    );
-    const productBackedChoice = choices.find(
-      (choice) => choice.driverId === selected.driverId && choice.repository,
-    );
-    if (
-      productBackedChoice &&
-      choiceKey(productBackedChoice) !== selectedKey &&
-      !selectedChoice?.repository
-    ) {
-      setSelected(productBackedChoice);
-      return;
-    }
-    if (selectedChoice) {
-      return;
-    }
-    setSelected(choices[0]);
-  }, [choices, selected]);
 
   const currentDriver = drivers.find(
     (driver) => driver.driver_id === selected.driverId,

--- a/frontend/src/useProductSelection.ts
+++ b/frontend/src/useProductSelection.ts
@@ -1,0 +1,253 @@
+import { useEffect, useMemo, useState } from "react";
+
+import type {
+  DriverDescriptor,
+  ProductProfileRecord,
+  ProductSiteOverview,
+} from "./types";
+
+export type DriverChoice = {
+  driverId: string;
+  testingContext: string;
+  prodContext: string;
+  previewContext: string;
+  label: string;
+  driverLabel: string;
+  repository?: string;
+};
+
+const DEFAULT_CHOICES: DriverChoice[] = [
+  {
+    driverId: "sellyouroutboard",
+    testingContext: "sellyouroutboard-testing",
+    prodContext: "sellyouroutboard-testing",
+    previewContext: "sellyouroutboard-testing",
+    label: "SellYourOutboard",
+    driverLabel: "generic-web",
+  },
+  {
+    driverId: "verireel",
+    testingContext: "verireel",
+    prodContext: "verireel",
+    previewContext: "verireel-testing",
+    label: "VeriReel",
+    driverLabel: "verireel",
+  },
+  {
+    driverId: "odoo",
+    testingContext: "cm",
+    prodContext: "cm",
+    previewContext: "",
+    label: "Odoo CM",
+    driverLabel: "odoo",
+  },
+  {
+    driverId: "odoo",
+    testingContext: "opw",
+    prodContext: "opw",
+    previewContext: "",
+    label: "Odoo OPW",
+    driverLabel: "odoo",
+  },
+];
+
+const PRODUCT_ENVIRONMENT_ALIASES: Record<"testing" | "prod", Set<string>> = {
+  testing: new Set(["testing", "test", "staging", "stage", "qa"]),
+  prod: new Set(["prod", "production", "stable", "live"]),
+};
+
+export function choiceKey(choice: DriverChoice): string {
+  return `${choice.driverId}:${choice.testingContext}:${choice.prodContext}:${choice.previewContext}`;
+}
+
+function choiceDisplayKey(choice: DriverChoice): string {
+  const normalizedLabel = choice.label.trim().toLowerCase();
+  return `${choice.driverId}:${normalizedLabel}`;
+}
+
+function labelForDriverContext(driver: DriverDescriptor, context: string): string {
+  if (driver.driver_id === "odoo") {
+    if (context === "cm") {
+      return "Odoo CM";
+    }
+    if (context === "opw") {
+      return "Odoo OPW";
+    }
+  }
+  return driver.label;
+}
+
+function displayNameForProduct(profile: ProductProfileRecord): string {
+  if (profile.product === "sellyouroutboard") {
+    return "SellYourOutboard";
+  }
+  return profile.display_name || profile.product;
+}
+
+function contextForProductLane(
+  profile: ProductProfileRecord,
+  instance: "testing" | "prod",
+): string {
+  const lane = profile.lanes.find(
+    (candidate) => candidate.instance === instance,
+  );
+  if (lane?.context.trim()) {
+    return lane.context.trim();
+  }
+  const fallbackLane = profile.lanes.find((candidate) =>
+    candidate.context.trim(),
+  );
+  return fallbackLane?.context.trim() || "";
+}
+
+function choiceFromProductProfile(profile: ProductProfileRecord): DriverChoice {
+  return {
+    driverId: profile.product,
+    testingContext: contextForProductLane(profile, "testing"),
+    prodContext: contextForProductLane(profile, "prod"),
+    previewContext: profile.preview?.enabled
+      ? profile.preview.context.trim()
+      : "",
+    label: displayNameForProduct(profile),
+    driverLabel: profile.driver_id,
+    repository: profile.repository,
+  };
+}
+
+function normalizedProductEnvironment(value: string): string {
+  return value.trim().toLowerCase().replaceAll("_", "-");
+}
+
+function contextForProductEnvironment(
+  product: ProductSiteOverview,
+  environment: "testing" | "prod",
+  reservedContext = "",
+): string {
+  const summaries = product.environments
+    .map((summary) => ({
+      environment: normalizedProductEnvironment(summary.environment),
+      context: summary.context.trim(),
+    }))
+    .filter((summary) => summary.context);
+  const aliases = PRODUCT_ENVIRONMENT_ALIASES[environment];
+  const summary = summaries.find((candidate) =>
+    aliases.has(candidate.environment),
+  );
+  if (summary) {
+    return summary.context;
+  }
+  const distinctFallback = summaries.find(
+    (candidate) => candidate.context !== reservedContext,
+  );
+  return distinctFallback?.context ?? summaries[0]?.context ?? "";
+}
+
+export function choiceFromProductOverview(
+  product: ProductSiteOverview,
+): DriverChoice {
+  const prodContext = contextForProductEnvironment(product, "prod");
+  const testingContext = contextForProductEnvironment(
+    product,
+    "testing",
+    prodContext,
+  );
+  return {
+    driverId: product.product,
+    testingContext,
+    prodContext,
+    previewContext: product.preview.enabled
+      ? product.preview.context.trim()
+      : "",
+    label: product.display_name || product.product,
+    driverLabel: product.driver_id,
+    repository: product.repository,
+  };
+}
+
+export function useProductSelection(
+  {
+    drivers,
+    productProfiles,
+    productOverviews,
+  }: {
+    drivers: DriverDescriptor[];
+    productProfiles: ProductProfileRecord[];
+    productOverviews: ProductSiteOverview[];
+  },
+) {
+  const [selected, setSelected] = useState<DriverChoice>(DEFAULT_CHOICES[0]);
+  const choices = useMemo(() => {
+    const driverChoices: DriverChoice[] = drivers.flatMap((driver) => {
+      const stableContexts = driver.context_patterns.filter((context) => {
+        return context !== "verireel-testing" && !context.includes("*");
+      });
+      return stableContexts.map((context) => ({
+        driverId: driver.driver_id,
+        testingContext: context,
+        prodContext: context,
+        previewContext:
+          driver.driver_id === "verireel" && context === "verireel"
+            ? "verireel-testing"
+            : "",
+        label: labelForDriverContext(driver, context),
+        driverLabel: driver.driver_id,
+      }));
+    });
+    const profileChoices: DriverChoice[] = productProfiles.map((profile) =>
+      choiceFromProductProfile(profile),
+    );
+    const overviewChoices: DriverChoice[] = productOverviews.map((overview) =>
+      choiceFromProductOverview(overview),
+    );
+    const merged: DriverChoice[] = [
+      ...overviewChoices,
+      ...profileChoices,
+      ...driverChoices,
+      ...DEFAULT_CHOICES,
+    ];
+    const productDisplayKeys = new Set(
+      [...overviewChoices, ...profileChoices, ...DEFAULT_CHOICES].map(
+        choiceDisplayKey,
+      ),
+    );
+    const seen = new Set<string>();
+    return merged.filter((choice) => {
+      const displayKey = choiceDisplayKey(choice);
+      const key = productDisplayKeys.has(displayKey)
+        ? displayKey
+        : choiceKey(choice);
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    });
+  }, [drivers, productProfiles, productOverviews]);
+
+  useEffect(() => {
+    if (!choices.length) {
+      return;
+    }
+    const selectedKey = choiceKey(selected);
+    const selectedChoice = choices.find(
+      (choice) => choiceKey(choice) === selectedKey,
+    );
+    const productBackedChoice = choices.find(
+      (choice) => choice.driverId === selected.driverId && choice.repository,
+    );
+    if (
+      productBackedChoice &&
+      choiceKey(productBackedChoice) !== selectedKey &&
+      !selectedChoice?.repository
+    ) {
+      setSelected(productBackedChoice);
+      return;
+    }
+    if (selectedChoice) {
+      return;
+    }
+    setSelected(choices[0]);
+  }, [choices, selected]);
+
+  return { choices, selected, setSelected };
+}


### PR DESCRIPTION
## Summary
- Move operator UI product/driver choice derivation into `useProductSelection`
- Keep App focused on loading and rendering while preserving product overview selection behavior

## Validation
- `pnpm --dir frontend validate`
- Browser smoke: `http://127.0.0.1:4188/ui/` unauthenticated view loaded without app console errors
- Browser smoke: `http://127.0.0.1:4188/ui/?fixtures=1` fixture gallery loaded without app console errors

Part of #307.