### PR TITLE
Extract product overview shell

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,13 +37,14 @@ import { ApiErrorPanel, AuthPanel } from "./AuthPanels";
 import { formatTime, labelForStatus } from "./format";
 import { KeyValue, MetricTile, PanelHead } from "./panel-ui";
 import { ProductInventoryCockpit } from "./ProductInventoryCockpit";
+import { ProductOverviewShell } from "./ProductOverviewShell";
 import {
   ProductConfigPanel,
   runtimeScopeForTarget,
   secretScopeForTarget,
 } from "./ProductConfigPanel";
 import { StatusIcon, StatusPill, StateBlock, SkeletonRows } from "./status-ui";
-import { freshnessLabel, TrustBadge } from "./TrustBadge";
+import { TrustBadge } from "./TrustBadge";
 import {
   choiceFromProductOverview,
   choiceKey,
@@ -674,116 +675,6 @@ function Header({
         </button>
       </div>
     </header>
-  );
-}
-
-function ProductOverviewShell({
-  product,
-  selected,
-  loading,
-}: {
-  product: ProductSiteOverview | null;
-  selected: DriverChoice;
-  loading: boolean;
-}) {
-  const environments = product?.environments ?? [];
-  const enabledActions = product?.available_actions.filter(
-    (action) => action.enabled,
-  );
-  const blockedActions = product?.available_actions.filter(
-    (action) => !action.enabled,
-  );
-  const preview = product?.preview;
-
-  return (
-    <section className="panel product-overview-shell">
-      <PanelHead
-        eyebrow="product workspace"
-        title={product?.display_name || selected.label}
-        right={
-          <div className="panel-badges">
-            <TrustBadge provenance={product?.provenance ?? null} />
-            <StatusPill status={product?.trust_state ?? "missing"} />
-          </div>
-        }
-      />
-      {loading ? (
-        <SkeletonRows />
-      ) : (
-        <div className="product-overview-grid">
-          <div className="product-overview-identity">
-            <div>
-              <span className="overview-label">Product key</span>
-              <code>{product?.product || selected.driverId}</code>
-            </div>
-            <div>
-              <span className="overview-label">Repository</span>
-              <code>
-                {product?.repository || selected.repository || "unknown"}
-              </code>
-            </div>
-            <div>
-              <span className="overview-label">Driver</span>
-              <code>
-                {product?.driver_id || selected.driverLabel}
-                {product?.base_driver_id ? ` / ${product.base_driver_id}` : ""}
-              </code>
-            </div>
-          </div>
-          <div className="product-environment-strip">
-            {environments.length ? (
-              environments.map((environment) => (
-                <div
-                  className="product-environment-pill"
-                  key={`${environment.environment}:${environment.context}`}
-                  data-environment={environment.environment}
-                >
-                  <span>{environment.environment}</span>
-                  <strong>{freshnessLabel(environment.trust_state)}</strong>
-                  <code>{environment.context}</code>
-                </div>
-              ))
-            ) : (
-              <StateBlock
-                icon={<Database size={18} />}
-                title="No product environment read model"
-              />
-            )}
-          </div>
-          <div className="product-overview-sidecar">
-            <KeyValue
-              label="Previews"
-              value={
-                preview?.enabled
-                  ? `${preview.active_count} active / ${preview.context || "no context"}`
-                  : "not enabled"
-              }
-              status={preview?.enabled ? preview.trust_state : "unsupported"}
-            />
-            <KeyValue
-              label="Enabled actions"
-              value={`${enabledActions?.length ?? 0} enabled`}
-              status={enabledActions?.length ? "pass" : "unknown"}
-            />
-            <KeyValue
-              label="Blocked actions"
-              value={`${blockedActions?.length ?? 0} blocked`}
-              status={blockedActions?.length ? "blocked" : "pass"}
-            />
-          </div>
-        </div>
-      )}
-      {product?.warnings.length ? (
-        <div className="overview-warning-list">
-          {product.warnings.map((warning) => (
-            <span key={warning}>
-              <AlertTriangle size={14} aria-hidden="true" />
-              {warning}
-            </span>
-          ))}
-        </div>
-      ) : null}
-    </section>
   );
 }
 

--- a/frontend/src/ProductOverviewShell.tsx
+++ b/frontend/src/ProductOverviewShell.tsx
@@ -1,0 +1,118 @@
+import { AlertTriangle, Database } from "lucide-react";
+
+import { KeyValue, PanelHead } from "./panel-ui";
+import { SkeletonRows, StateBlock, StatusPill } from "./status-ui";
+import { freshnessLabel, TrustBadge } from "./TrustBadge";
+
+import type { DriverChoice } from "./useProductSelection";
+import type { ProductSiteOverview } from "./types";
+
+export function ProductOverviewShell({
+  product,
+  selected,
+  loading,
+}: {
+  product: ProductSiteOverview | null;
+  selected: DriverChoice;
+  loading: boolean;
+}) {
+  const environments = product?.environments ?? [];
+  const enabledActions = product?.available_actions.filter(
+    (action) => action.enabled,
+  );
+  const blockedActions = product?.available_actions.filter(
+    (action) => !action.enabled,
+  );
+  const preview = product?.preview;
+
+  return (
+    <section className="panel product-overview-shell">
+      <PanelHead
+        eyebrow="product workspace"
+        title={product?.display_name || selected.label}
+        right={
+          <div className="panel-badges">
+            <TrustBadge provenance={product?.provenance ?? null} />
+            <StatusPill status={product?.trust_state ?? "missing"} />
+          </div>
+        }
+      />
+      {loading ? (
+        <SkeletonRows />
+      ) : (
+        <div className="product-overview-grid">
+          <div className="product-overview-identity">
+            <div>
+              <span className="overview-label">Product key</span>
+              <code>{product?.product || selected.driverId}</code>
+            </div>
+            <div>
+              <span className="overview-label">Repository</span>
+              <code>
+                {product?.repository || selected.repository || "unknown"}
+              </code>
+            </div>
+            <div>
+              <span className="overview-label">Driver</span>
+              <code>
+                {product?.driver_id || selected.driverLabel}
+                {product?.base_driver_id ? ` / ${product.base_driver_id}` : ""}
+              </code>
+            </div>
+          </div>
+          <div className="product-environment-strip">
+            {environments.length ? (
+              environments.map((environment) => (
+                <div
+                  className="product-environment-pill"
+                  key={`${environment.environment}:${environment.context}`}
+                  data-environment={environment.environment}
+                >
+                  <span>{environment.environment}</span>
+                  <strong>{freshnessLabel(environment.trust_state)}</strong>
+                  <code>{environment.context}</code>
+                </div>
+              ))
+            ) : (
+              <StateBlock
+                icon={<Database size={18} />}
+                title="No product environment read model"
+              />
+            )}
+          </div>
+          <div className="product-overview-sidecar">
+            <KeyValue
+              label="Previews"
+              value={
+                preview?.enabled
+                  ? `${preview.active_count} active / ${preview.context || "no context"}`
+                  : "not enabled"
+              }
+              status={preview?.enabled ? preview.trust_state : "unsupported"}
+            />
+            <KeyValue
+              label="Enabled actions"
+              value={`${enabledActions?.length ?? 0} enabled`}
+              status={enabledActions?.length ? "pass" : "unknown"}
+            />
+            <KeyValue
+              label="Blocked actions"
+              value={`${blockedActions?.length ?? 0} blocked`}
+              status={blockedActions?.length ? "blocked" : "pass"}
+            />
+          </div>
+        </div>
+      )}
+      {product?.warnings.length ? (
+        <div className="overview-warning-list">
+          {product.warnings.map((warning) => (
+            <span key={warning}>
+              <AlertTriangle size={14} aria-hidden="true" />
+              {warning}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Move the product workspace overview panel into `frontend/src/ProductOverviewShell.tsx`
- Keep the existing overview props, environment/status rendering, warning list, and shell markup unchanged
- Reduce `App.tsx` further so it keeps trending toward orchestration-only UI wiring

## Validation
- `pnpm --dir frontend install --frozen-lockfile` in fresh worktree
- `pnpm --dir frontend validate`
- Browser smoke: `http://127.0.0.1:4190/ui/` unauthenticated view loaded without app console errors
- Browser smoke: `http://127.0.0.1:4190/ui/?fixtures=1` fixture dashboard rendered without app console errors

Part of #307.