### PR TITLE
Extract lane panel

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,7 +35,14 @@ import {
 } from "./api";
 import { ApiErrorPanel, AuthPanel } from "./AuthPanels";
 import { formatTime, labelForStatus } from "./format";
-import { KeyValue, MetricTile, PanelHead } from "./panel-ui";
+import { LanePanel } from "./LanePanel";
+import {
+  artifactFromLane,
+  shorten,
+  sourceRefFromLane,
+  worstStatus,
+} from "./laneSummary";
+import { KeyValue, PanelHead } from "./panel-ui";
 import { ProductInventoryCockpit } from "./ProductInventoryCockpit";
 import { ProductOverviewShell } from "./ProductOverviewShell";
 import {
@@ -675,127 +682,6 @@ function Header({
         </button>
       </div>
     </header>
-  );
-}
-
-function LanePanel({
-  title,
-  laneKind,
-  lane,
-  loading,
-}: {
-  title: string;
-  laneKind: "prod" | "testing";
-  lane: LaneSummary | null;
-  loading: boolean;
-}) {
-  const artifact = artifactFromLane(lane);
-  const deployStatus =
-    lane?.latest_deployment?.deploy.status ??
-    lane?.inventory?.deploy.status ??
-    "unknown";
-  const healthStatus =
-    lane?.inventory?.destination_health.status ??
-    lane?.latest_deployment?.destination_health.status ??
-    "unknown";
-  const backupStatus = lane?.latest_backup_gate?.status ?? "unknown";
-  const settingsStatus = lane?.odoo_instance_override ? "pass" : "unknown";
-  const updatedAt =
-    lane?.inventory?.updated_at ??
-    lane?.latest_deployment?.deploy.finished_at ??
-    "";
-  const targetName =
-    lane?.latest_deployment?.deploy.target_name ??
-    lane?.inventory?.deploy.target_name ??
-    "";
-  const releaseIdentity = releaseIdentityFromLane(lane);
-
-  return (
-    <section className={`panel lane-panel lane-${laneKind}`}>
-      <PanelHead
-        eyebrow="environment lane"
-        title={title}
-        right={
-          <div className="panel-badges">
-            <TrustBadge provenance={lane?.provenance ?? null} />
-            <StatusPill status={worstStatus([deployStatus, healthStatus])} />
-          </div>
-        }
-      />
-      {loading ? (
-        <SkeletonRows />
-      ) : (
-        <div className="lane-body">
-          <div className="lane-release">
-            <span className={`lane-chip lane-chip-${laneKind}`}>
-              {laneKind}
-            </span>
-            <code>{releaseIdentity || "release unknown"}</code>
-          </div>
-          <div className="lane-metrics">
-            <MetricTile
-              label="Deploy"
-              status={deployStatus}
-              value={labelForStatus(deployStatus)}
-            />
-            <MetricTile
-              label="Health"
-              status={healthStatus}
-              value={labelForStatus(healthStatus)}
-            />
-            <MetricTile
-              label="Backup"
-              status={backupStatus}
-              value={labelForStatus(backupStatus)}
-            />
-            <MetricTile
-              label="Settings"
-              status={settingsStatus}
-              value={labelForStatus(settingsStatus)}
-            />
-          </div>
-          <KeyValue label="Artifact" value={artifact} mono muted={!artifact} />
-          <KeyValue
-            label="Target"
-            value={targetName}
-            mono
-            muted={!targetName}
-          />
-          <KeyValue
-            label="Source"
-            value={shorten(
-              lane?.inventory?.source_git_ref ??
-                lane?.latest_deployment?.source_git_ref ??
-                "",
-            )}
-            mono
-          />
-          <KeyValue
-            label="Deployment"
-            value={
-              lane?.latest_deployment?.record_id ??
-              lane?.inventory?.deployment_record_id ??
-              ""
-            }
-            mono
-          />
-          <KeyValue
-            label="Promotion"
-            value={
-              lane?.latest_promotion?.record_id ??
-              lane?.inventory?.promotion_record_id ??
-              ""
-            }
-            mono
-            muted={
-              !lane?.latest_promotion && !lane?.inventory?.promotion_record_id
-            }
-          />
-          <KeyValue label="Updated" value={formatTime(updatedAt)} mono />
-          <EvidenceStrip lane={lane} laneKind={laneKind} />
-        </div>
-      )}
-    </section>
   );
 }
 
@@ -2203,24 +2089,6 @@ function SafetyIcon({ safety }: { safety: Safety }) {
   return <Eye size={15} aria-hidden="true" />;
 }
 
-function EvidenceStrip({
-  lane,
-  laneKind,
-}: {
-  lane: LaneSummary | null;
-  laneKind: "prod" | "testing";
-}) {
-  const backup = lane?.latest_backup_gate?.status ?? "unknown";
-  const promotion = lane?.latest_promotion?.deploy.status ?? "unknown";
-  return (
-    <div className="evidence-strip">
-      <span className={`lane-chip lane-chip-${laneKind}`}>{laneKind}</span>
-      <StatusPill status={backup} />
-      <StatusPill status={promotion} />
-    </div>
-  );
-}
-
 function buildPromotionDecision(
   prod: LaneSummary | null,
   testing: LaneSummary | null,
@@ -2695,36 +2563,6 @@ function findDriverView(
   return view?.drivers.find((driver) => driver.driver_id === driverId) ?? null;
 }
 
-function artifactFromLane(lane: LaneSummary | null): string {
-  return (
-    lane?.inventory?.artifact_identity?.artifact_id ??
-    lane?.latest_deployment?.artifact_identity?.artifact_id ??
-    lane?.latest_promotion?.artifact_identity?.artifact_id ??
-    ""
-  );
-}
-
-function sourceRefFromLane(lane: LaneSummary | null): string {
-  return (
-    lane?.inventory?.source_git_ref ??
-    lane?.latest_deployment?.source_git_ref ??
-    ""
-  );
-}
-
-function releaseIdentityFromLane(lane: LaneSummary | null): string {
-  if (lane?.release_tuple?.tuple_id) {
-    return lane.release_tuple.tuple_id;
-  }
-  const artifact = artifactFromLane(lane);
-  if (!artifact) {
-    return "";
-  }
-  return artifact.includes("@")
-    ? (artifact.split("@").at(-1) ?? artifact)
-    : artifact;
-}
-
 function latestEvidenceLabel(
   prod: LaneSummary | null,
   testing: LaneSummary | null,
@@ -2869,26 +2707,6 @@ function fixtureLane({
   };
 }
 
-function worstStatus(statuses: Array<Status | string>): Status | string {
-  if (statuses.includes("fail")) {
-    return "fail";
-  }
-  if (statuses.includes("pending")) {
-    return "pending";
-  }
-  if (statuses.every((status) => status === "pass")) {
-    return "pass";
-  }
-  return "unknown";
-}
-
 function safetyLabel(safety: Safety): string {
   return safety.replace("_", " ").toUpperCase();
-}
-
-function shorten(value: string): string {
-  if (value.length <= 14) {
-    return value;
-  }
-  return `${value.slice(0, 7)}...${value.slice(-4)}`;
 }

--- a/frontend/src/LanePanel.tsx
+++ b/frontend/src/LanePanel.tsx
@@ -1,0 +1,153 @@
+import { formatTime, labelForStatus } from "./format";
+import {
+  artifactFromLane,
+  releaseIdentityFromLane,
+  shorten,
+  worstStatus,
+} from "./laneSummary";
+import { KeyValue, MetricTile, PanelHead } from "./panel-ui";
+import { SkeletonRows, StatusPill } from "./status-ui";
+import { TrustBadge } from "./TrustBadge";
+
+import type { LaneSummary } from "./types";
+
+type LaneKind = "prod" | "testing";
+
+export function LanePanel({
+  title,
+  laneKind,
+  lane,
+  loading,
+}: {
+  title: string;
+  laneKind: LaneKind;
+  lane: LaneSummary | null;
+  loading: boolean;
+}) {
+  const artifact = artifactFromLane(lane);
+  const deployStatus =
+    lane?.latest_deployment?.deploy.status ??
+    lane?.inventory?.deploy.status ??
+    "unknown";
+  const healthStatus =
+    lane?.inventory?.destination_health.status ??
+    lane?.latest_deployment?.destination_health.status ??
+    "unknown";
+  const backupStatus = lane?.latest_backup_gate?.status ?? "unknown";
+  const settingsStatus = lane?.odoo_instance_override ? "pass" : "unknown";
+  const updatedAt =
+    lane?.inventory?.updated_at ??
+    lane?.latest_deployment?.deploy.finished_at ??
+    "";
+  const targetName =
+    lane?.latest_deployment?.deploy.target_name ??
+    lane?.inventory?.deploy.target_name ??
+    "";
+  const releaseIdentity = releaseIdentityFromLane(lane);
+
+  return (
+    <section className={`panel lane-panel lane-${laneKind}`}>
+      <PanelHead
+        eyebrow="environment lane"
+        title={title}
+        right={
+          <div className="panel-badges">
+            <TrustBadge provenance={lane?.provenance ?? null} />
+            <StatusPill status={worstStatus([deployStatus, healthStatus])} />
+          </div>
+        }
+      />
+      {loading ? (
+        <SkeletonRows />
+      ) : (
+        <div className="lane-body">
+          <div className="lane-release">
+            <span className={`lane-chip lane-chip-${laneKind}`}>
+              {laneKind}
+            </span>
+            <code>{releaseIdentity || "release unknown"}</code>
+          </div>
+          <div className="lane-metrics">
+            <MetricTile
+              label="Deploy"
+              status={deployStatus}
+              value={labelForStatus(deployStatus)}
+            />
+            <MetricTile
+              label="Health"
+              status={healthStatus}
+              value={labelForStatus(healthStatus)}
+            />
+            <MetricTile
+              label="Backup"
+              status={backupStatus}
+              value={labelForStatus(backupStatus)}
+            />
+            <MetricTile
+              label="Settings"
+              status={settingsStatus}
+              value={labelForStatus(settingsStatus)}
+            />
+          </div>
+          <KeyValue label="Artifact" value={artifact} mono muted={!artifact} />
+          <KeyValue
+            label="Target"
+            value={targetName}
+            mono
+            muted={!targetName}
+          />
+          <KeyValue
+            label="Source"
+            value={shorten(
+              lane?.inventory?.source_git_ref ??
+                lane?.latest_deployment?.source_git_ref ??
+                "",
+            )}
+            mono
+          />
+          <KeyValue
+            label="Deployment"
+            value={
+              lane?.latest_deployment?.record_id ??
+              lane?.inventory?.deployment_record_id ??
+              ""
+            }
+            mono
+          />
+          <KeyValue
+            label="Promotion"
+            value={
+              lane?.latest_promotion?.record_id ??
+              lane?.inventory?.promotion_record_id ??
+              ""
+            }
+            mono
+            muted={
+              !lane?.latest_promotion && !lane?.inventory?.promotion_record_id
+            }
+          />
+          <KeyValue label="Updated" value={formatTime(updatedAt)} mono />
+          <EvidenceStrip lane={lane} laneKind={laneKind} />
+        </div>
+      )}
+    </section>
+  );
+}
+
+function EvidenceStrip({
+  lane,
+  laneKind,
+}: {
+  lane: LaneSummary | null;
+  laneKind: LaneKind;
+}) {
+  const backup = lane?.latest_backup_gate?.status ?? "unknown";
+  const promotion = lane?.latest_promotion?.deploy.status ?? "unknown";
+  return (
+    <div className="evidence-strip">
+      <span className={`lane-chip lane-chip-${laneKind}`}>{laneKind}</span>
+      <StatusPill status={backup} />
+      <StatusPill status={promotion} />
+    </div>
+  );
+}

--- a/frontend/src/laneSummary.ts
+++ b/frontend/src/laneSummary.ts
@@ -1,0 +1,51 @@
+import type { LaneSummary, Status } from "./types";
+
+export function artifactFromLane(lane: LaneSummary | null): string {
+  return (
+    lane?.inventory?.artifact_identity?.artifact_id ??
+    lane?.latest_deployment?.artifact_identity?.artifact_id ??
+    lane?.latest_promotion?.artifact_identity?.artifact_id ??
+    ""
+  );
+}
+
+export function sourceRefFromLane(lane: LaneSummary | null): string {
+  return (
+    lane?.inventory?.source_git_ref ??
+    lane?.latest_deployment?.source_git_ref ??
+    ""
+  );
+}
+
+export function releaseIdentityFromLane(lane: LaneSummary | null): string {
+  if (lane?.release_tuple?.tuple_id) {
+    return lane.release_tuple.tuple_id;
+  }
+  const artifact = artifactFromLane(lane);
+  if (!artifact) {
+    return "";
+  }
+  return artifact.includes("@")
+    ? (artifact.split("@").at(-1) ?? artifact)
+    : artifact;
+}
+
+export function worstStatus(statuses: Array<Status | string>): Status | string {
+  if (statuses.includes("fail")) {
+    return "fail";
+  }
+  if (statuses.includes("pending")) {
+    return "pending";
+  }
+  if (statuses.every((status) => status === "pass")) {
+    return "pass";
+  }
+  return "unknown";
+}
+
+export function shorten(value: string): string {
+  if (value.length <= 14) {
+    return value;
+  }
+  return `${value.slice(0, 7)}...${value.slice(-4)}`;
+}


### PR DESCRIPTION
## Summary
- Move the environment lane panel into `frontend/src/LanePanel.tsx`
- Move shared lane summary helpers into `frontend/src/laneSummary.ts` for the lane panel, promotion bridge, and evidence timeline
- Preserve existing lane props, status metrics, evidence strip, and markup while reducing `App.tsx` to 2,712 lines in this slice

## Validation
- `pnpm --dir frontend install --frozen-lockfile` in fresh worktree
- `pnpm --dir frontend validate`
- Browser smoke: `http://127.0.0.1:4191/ui/` unauthenticated view loaded without app console errors
- Browser smoke: `http://127.0.0.1:4191/ui/?fixtures=1` fixture dashboard rendered without app console errors
- Browser DOM check confirmed `.panel.lane-panel.lane-testing` rendered in fixture mode

Part of #307.