### PR TITLE
Show expected config status in operator UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ import {
   logout,
   readAuthSession,
   readDriverView,
+  readProductEnvironmentConfigStatus,
 } from "./api";
 import { ApiErrorPanel, AuthPanel } from "./AuthPanels";
 import { formatTime, labelForStatus } from "./format";
@@ -47,6 +48,7 @@ import {
   runtimeScopeForTarget,
   secretScopeForTarget,
 } from "./ProductConfigPanel";
+import { ProductConfigStatusPanel } from "./ProductConfigStatusPanel";
 import { RuntimeAuthorityList } from "./RuntimeAuthorityList";
 import { StatusIcon, StatusPill, StateBlock, SkeletonRows } from "./status-ui";
 import { TrustBadge } from "./TrustBadge";
@@ -71,6 +73,7 @@ import type {
   LaneSummary,
   ProductConfigApplyPayload,
   ProductConfigApplyRequest,
+  ProductEnvironmentConfigStatus,
   ProductEnvironmentSummary,
   ProductProfileRecord,
   ProductSiteOverview,
@@ -206,6 +209,11 @@ export function App() {
   const [workRequests, setWorkRequests] = useState<
     EveryCodeWorkRequestRecord[]
   >([]);
+  const [configStatuses, setConfigStatuses] = useState<
+    ProductEnvironmentConfigStatus[]
+  >([]);
+  const [configStatusLoading, setConfigStatusLoading] = useState(false);
+  const [configStatusError, setConfigStatusError] = useState("");
   const {
     workGraphItems,
     workGraphHiddenCount,
@@ -221,6 +229,10 @@ export function App() {
     productProfiles,
     productOverviews,
   });
+  const selectedProductOverview =
+    productOverviews.find(
+      (overview) => overview.product === selected.driverId,
+    ) ?? null;
   const [prodView, setProdView] = useState<DriverContextView | null>(null);
   const [testingView, setTestingView] = useState<DriverContextView | null>(
     null,
@@ -277,6 +289,8 @@ export function App() {
       setDrivers([]);
       setProductProfiles([]);
       setProductOverviews([]);
+      setConfigStatuses([]);
+      setConfigStatusError("");
       setWorkRequests([]);
       resetWorkGraph();
       setProdView(null);
@@ -361,6 +375,53 @@ export function App() {
     return () => controller.abort();
   }, [authStatus, selected, refreshKey, refreshWorkGraph, resetWorkGraph]);
 
+  useEffect(() => {
+    if (authStatus !== "signed_in" || !selectedProductOverview) {
+      setConfigStatuses([]);
+      setConfigStatusError("");
+      setConfigStatusLoading(false);
+      return;
+    }
+    const controller = new AbortController();
+    const environments = selectedProductOverview.environments.filter(
+      (environment) => environment.environment.trim(),
+    );
+    setConfigStatusLoading(true);
+    setConfigStatusError("");
+    Promise.all(
+      environments.map((environment) =>
+        readProductEnvironmentConfigStatus(
+          selectedProductOverview.product,
+          environment.environment,
+        ).then((payload) => payload.config_status),
+      ),
+    )
+      .then((statuses) => {
+        if (!controller.signal.aborted) {
+          setConfigStatuses(statuses);
+        }
+      })
+      .catch((apiError: unknown) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setConfigStatuses([]);
+        if (apiError instanceof LaunchplaneApiError) {
+          setConfigStatusError(apiError.message);
+        } else if (apiError instanceof Error) {
+          setConfigStatusError(apiError.message);
+        } else {
+          setConfigStatusError("Config status request failed.");
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setConfigStatusLoading(false);
+        }
+      });
+    return () => controller.abort();
+  }, [authStatus, selectedProductOverview, refreshKey]);
+
   const currentDriver = drivers.find(
     (driver) => driver.driver_id === selected.driverId,
   );
@@ -371,11 +432,6 @@ export function App() {
     prodDriverView?.descriptor ??
     testingDriverView?.descriptor ??
     currentDriver;
-  const selectedProductOverview =
-    productOverviews.find(
-      (overview) => overview.product === selected.driverId,
-    ) ?? null;
-
   const actions = useMemo(() => {
     return (
       selectedDriver?.actions ??
@@ -402,6 +458,8 @@ export function App() {
       setDrivers([]);
       setProductProfiles([]);
       setProductOverviews([]);
+      setConfigStatuses([]);
+      setConfigStatusError("");
       setWorkRequests([]);
       resetWorkGraph();
       setProdView(null);
@@ -485,6 +543,11 @@ export function App() {
                 loading={loading}
               />
             </section>
+            <ProductConfigStatusPanel
+              statuses={configStatuses}
+              loading={configStatusLoading}
+              error={configStatusError}
+            />
             <ProductConfigPanel
               productDefault={selectedDriver?.product ?? selected.driverId}
               contextDefault={selected.prodContext}
@@ -976,6 +1039,78 @@ function StateFixtureGallery({
       available_actions: [],
     },
   ];
+  const fixtureConfigStatuses: ProductEnvironmentConfigStatus[] = [
+    {
+      schema_version: 1,
+      product: "sellyouroutboard",
+      display_name: "SellYourOutboard",
+      repository: "cbusillo/sellyouroutboard",
+      driver_id: "generic-web",
+      base_driver_id: "generic-web",
+      environment: "testing",
+      context: "sellyouroutboard-testing",
+      runtime_settings: [
+        {
+          key: "RESEND_FROM_EMAIL",
+          status: "configured",
+          context: "sellyouroutboard-testing",
+          instance: "testing",
+          source_label: "product-config-api",
+          updated_at: "2026-05-07T22:32:00Z",
+          trust_state: "recorded",
+        },
+      ],
+      managed_secrets: [
+        {
+          binding_key: "RESEND_API_KEY",
+          status: "configured",
+          integration: "runtime_environment",
+          context: "sellyouroutboard-testing",
+          instance: "testing",
+          updated_at: "2026-05-07T22:31:00Z",
+          trust_state: "recorded",
+        },
+      ],
+      warnings: [],
+      trust_state: "recorded",
+      provenance: readyTesting.provenance,
+    },
+    {
+      schema_version: 1,
+      product: "sellyouroutboard",
+      display_name: "SellYourOutboard",
+      repository: "cbusillo/sellyouroutboard",
+      driver_id: "generic-web",
+      base_driver_id: "generic-web",
+      environment: "prod",
+      context: "sellyouroutboard-prod",
+      runtime_settings: [
+        {
+          key: "RESEND_FROM_EMAIL",
+          status: "configured",
+          context: "sellyouroutboard-prod",
+          instance: "prod",
+          source_label: "product-config-api",
+          updated_at: "2026-05-07T22:36:00Z",
+          trust_state: "recorded",
+        },
+      ],
+      managed_secrets: [
+        {
+          binding_key: "RESEND_API_KEY",
+          status: "missing",
+          integration: "runtime_environment",
+          context: "sellyouroutboard-prod",
+          instance: "prod",
+          updated_at: "",
+          trust_state: "missing",
+        },
+      ],
+      warnings: [],
+      trust_state: "missing",
+      provenance: missingBackupProd.provenance,
+    },
+  ];
   const fixtureRequests: EveryCodeWorkRequestRecord[] = [
     {
       schema_version: 1,
@@ -1171,6 +1306,13 @@ function StateFixtureGallery({
           testing={readyTesting}
           previews={[]}
           onSelect={setSelectedEvidence}
+        />
+      </div>
+      <div className="fixture-wide">
+        <ProductConfigStatusPanel
+          statuses={fixtureConfigStatuses}
+          loading={false}
+          error=""
         />
       </div>
       <div className="fixture-wide">

--- a/frontend/src/ProductConfigStatusPanel.tsx
+++ b/frontend/src/ProductConfigStatusPanel.tsx
@@ -1,0 +1,218 @@
+import { KeyRound, Settings2 } from "lucide-react";
+
+import { formatTime, labelForStatus } from "./format";
+import type { ReactNode } from "react";
+import { PanelHead } from "./panel-ui";
+import { StatusPill, StateBlock } from "./status-ui";
+import { freshnessLabel } from "./TrustBadge";
+import type {
+  ProductConfigItemStatus,
+  ProductEnvironmentConfigStatus,
+  ProductManagedSecretConfigStatusItem,
+  ProductRuntimeConfigStatusItem,
+} from "./types";
+
+export function ProductConfigStatusPanel({
+  statuses,
+  loading,
+  error,
+}: {
+  statuses: ProductEnvironmentConfigStatus[];
+  loading: boolean;
+  error: string;
+}) {
+  const totals = summarizeConfigStatuses(statuses);
+  return (
+    <section className="panel config-status-panel" aria-busy={loading}>
+      <PanelHead
+        eyebrow="settings readiness"
+        title="Expected config"
+        right={
+          <div className="panel-badges">
+            <StatusPill status={statusToUiStatus(totals.worst)} />
+            <span className="count-chip">{totals.configured}/{totals.total}</span>
+          </div>
+        }
+      />
+      {error ? (
+        <div className="config-status-alert">
+          <span>Config status unavailable</span>
+          <code>{error}</code>
+        </div>
+      ) : null}
+      {loading && !statuses.length ? <ConfigStatusSkeleton /> : null}
+      {!loading && !statuses.length && !error ? (
+        <StateBlock icon={<Settings2 size={18} />} title="No expected config status" />
+      ) : null}
+      {statuses.map((status) => (
+        <EnvironmentConfigStatus key={`${status.product}:${status.environment}`} status={status} />
+      ))}
+    </section>
+  );
+}
+
+function EnvironmentConfigStatus({
+  status,
+}: {
+  status: ProductEnvironmentConfigStatus;
+}) {
+  const runtimeItems = status.runtime_settings;
+  const secretItems = status.managed_secrets;
+  return (
+    <div className="config-status-environment" data-environment={status.environment}>
+      <div className="config-status-environment-head">
+        <div>
+          <strong>{status.environment}</strong>
+          <code>{status.context}</code>
+        </div>
+        <span className="trust-badge trust-compact" data-freshness={status.trust_state}>
+          <span>{freshnessLabel(status.trust_state)}</span>
+        </span>
+      </div>
+      <ConfigStatusGroup
+        title="Runtime settings"
+        emptyTitle="No expected runtime keys"
+        icon={<Settings2 size={16} aria-hidden="true" />}
+        items={runtimeItems.map((item) => ({
+          id: `${item.context}:${item.instance}:${item.key}`,
+          name: item.key,
+          status: item.status,
+          route: configRouteLabel(item.context, item.instance),
+          detail: item.source_label || freshnessLabel(item.trust_state),
+          updatedAt: item.updated_at,
+        }))}
+      />
+      <ConfigStatusGroup
+        title="Secrets"
+        emptyTitle="No expected secret bindings"
+        icon={<KeyRound size={16} aria-hidden="true" />}
+        items={secretItems.map((item) => secretStatusRow(item))}
+      />
+    </div>
+  );
+}
+
+function ConfigStatusGroup({
+  title,
+  emptyTitle,
+  icon,
+  items,
+}: {
+  title: string;
+  emptyTitle: string;
+  icon: ReactNode;
+  items: ConfigStatusRowItem[];
+}) {
+  return (
+    <div className="config-status-group">
+      <div className="config-status-group-title">
+        {icon}
+        <span>{title}</span>
+      </div>
+      <div className="config-status-list">
+        {items.length ? (
+          items.map((item) => <ConfigStatusRow item={item} key={item.id} />)
+        ) : (
+          <StateBlock icon={icon} title={emptyTitle} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+type ConfigStatusRowItem = {
+  id: string;
+  name: string;
+  status: ProductConfigItemStatus;
+  route: string;
+  detail: string;
+  updatedAt: string;
+};
+
+function ConfigStatusRow({ item }: { item: ConfigStatusRowItem }) {
+  return (
+    <div className="config-status-row" data-status={statusToUiStatus(item.status)}>
+      <StatusPill status={statusToUiStatus(item.status)} />
+      <div>
+        <strong>{item.name}</strong>
+        <span>{labelForStatus(item.status)}</span>
+      </div>
+      <code>{item.route}</code>
+      <span>{item.updatedAt ? formatTime(item.updatedAt) : item.detail}</span>
+    </div>
+  );
+}
+
+function secretStatusRow(
+  item: ProductManagedSecretConfigStatusItem,
+): ConfigStatusRowItem {
+  return {
+    id: `${item.integration}:${item.context}:${item.instance}:${item.binding_key}`,
+    name: item.binding_key,
+    status: item.status,
+    route: configRouteLabel(item.context, item.instance),
+    detail: item.integration,
+    updatedAt: item.updated_at,
+  };
+}
+
+function summarizeConfigStatuses(statuses: ProductEnvironmentConfigStatus[]) {
+  const items = statuses.flatMap((status) => [
+    ...status.runtime_settings.map((item) => item.status),
+    ...status.managed_secrets.map((item) => item.status),
+  ]);
+  const configured = items.filter((status) => status === "configured").length;
+  return {
+    configured,
+    total: items.length,
+    worst: worstConfigStatus(items),
+  };
+}
+
+function worstConfigStatus(
+  statuses: ProductConfigItemStatus[],
+): ProductConfigItemStatus {
+  if (statuses.some((status) => status === "missing" || status === "disabled")) {
+    return "missing";
+  }
+  if (statuses.some((status) => status === "stale" || status === "unvalidated")) {
+    return "stale";
+  }
+  if (statuses.some((status) => status === "unsupported")) {
+    return "unsupported";
+  }
+  if (statuses.some((status) => status === "configured")) {
+    return "configured";
+  }
+  return "unsupported";
+}
+
+function statusToUiStatus(status: ProductConfigItemStatus): string {
+  if (status === "configured") {
+    return "pass";
+  }
+  if (status === "stale" || status === "unvalidated") {
+    return "pending";
+  }
+  if (status === "unsupported") {
+    return "unknown";
+  }
+  return "blocked";
+}
+
+function configRouteLabel(context: string, instance: string): string {
+  if (context && instance) {
+    return `${context}/${instance}`;
+  }
+  return context || "global";
+}
+
+function ConfigStatusSkeleton() {
+  return (
+    <div className="config-status-skeleton" aria-hidden="true">
+      <span />
+      <span />
+      <span />
+    </div>
+  );
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -11,6 +11,7 @@ import type {
   LogoutPayload,
   ProductConfigApplyPayload,
   ProductConfigApplyRequest,
+  ProductEnvironmentConfigStatusPayload,
   ProductListPayload,
   ProductProfileListPayload,
   WorkGraphRankPayload,
@@ -96,6 +97,15 @@ export function listProductProfiles(
 
 export function listProducts(): Promise<ProductListPayload> {
   return requestJson<ProductListPayload>("/v1/products");
+}
+
+export function readProductEnvironmentConfigStatus(
+  product: string,
+  environment: string,
+): Promise<ProductEnvironmentConfigStatusPayload> {
+  return requestJson<ProductEnvironmentConfigStatusPayload>(
+    `/v1/products/${encodeURIComponent(product)}/environments/${encodeURIComponent(environment)}/config-status`,
+  );
 }
 
 export function listEveryCodeWorkRequests(

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1075,6 +1075,145 @@ p {
   display: grid;
 }
 
+.config-status-panel {
+  display: grid;
+}
+
+.config-status-environment {
+  display: grid;
+  grid-template-columns: minmax(180px, 0.42fr) minmax(0, 1fr) minmax(0, 1fr);
+  min-width: 0;
+  border-top: 1px solid var(--hair-soft);
+}
+
+.config-status-environment:first-of-type {
+  border-top: 0;
+}
+
+.config-status-environment[data-environment="prod"] {
+  border-left: 3px solid var(--lane-prod);
+}
+
+.config-status-environment[data-environment="testing"] {
+  border-left: 3px solid var(--lane-testing);
+}
+
+.config-status-environment-head,
+.config-status-group {
+  min-width: 0;
+  border-left: 1px solid var(--hair-soft);
+  padding: 12px 14px;
+}
+
+.config-status-environment-head {
+  display: grid;
+  align-content: start;
+  gap: 10px;
+  border-left: 0;
+}
+
+.config-status-environment-head div,
+.config-status-group {
+  display: grid;
+  gap: 8px;
+}
+
+.config-status-environment-head strong {
+  color: var(--fg-strong);
+  text-transform: capitalize;
+}
+
+.config-status-environment-head code,
+.config-status-row code,
+.config-status-row strong,
+.config-status-row span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.config-status-environment-head code {
+  color: var(--fg-faint);
+}
+
+.config-status-group-title {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 24px;
+  color: var(--fg-muted);
+  font-weight: 650;
+}
+
+.config-status-list {
+  display: grid;
+  gap: 6px;
+}
+
+.config-status-row {
+  display: grid;
+  grid-template-columns: max-content minmax(120px, 0.75fr) minmax(0, 1fr) minmax(90px, auto);
+  gap: 9px;
+  align-items: center;
+  min-height: 34px;
+  border: 1px solid var(--hair-soft);
+  border-radius: 6px;
+  background: var(--bg-0);
+  padding: 6px 8px;
+}
+
+.config-status-row > div {
+  display: grid;
+  min-width: 0;
+  gap: 1px;
+}
+
+.config-status-row strong {
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.config-status-row span {
+  color: var(--fg-faint);
+  font-size: 11px;
+}
+
+.config-status-row > span:last-child {
+  text-align: right;
+}
+
+.config-status-alert {
+  display: grid;
+  grid-template-columns: minmax(180px, 0.36fr) minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  border-top: 1px solid color-mix(in oklab, var(--status-warn) 52%, var(--hair));
+  color: var(--status-warn);
+  padding: 10px 14px;
+}
+
+.config-status-alert code {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--fg-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.config-status-skeleton {
+  display: grid;
+  gap: 8px;
+  padding: 12px 14px;
+}
+
+.config-status-skeleton span {
+  height: 34px;
+  border-radius: 6px;
+  background: linear-gradient(90deg, var(--bg-2), var(--bg-3), var(--bg-2));
+}
+
 .config-target-grid,
 .config-edit-grid {
   display: grid;
@@ -1720,8 +1859,14 @@ p {
   .product-overview-grid,
   .work-grid,
   .work-grid-evidence,
+  .config-status-environment,
   .config-edit-grid {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .config-status-group {
+    border-top: 1px solid var(--hair-soft);
+    border-left: 0;
   }
 
   .product-environment-strip {
@@ -1798,6 +1943,8 @@ p {
   .preview-row,
   .secret-row,
   .evidence-row,
+  .config-status-row,
+  .config-status-alert,
   .config-target-grid,
   .config-row-runtime,
   .config-row-secret,
@@ -1819,7 +1966,8 @@ p {
   }
 
   .preview-row .status-pill,
-  .secret-row .status-pill {
+  .secret-row .status-pill,
+  .config-status-row .status-pill {
     width: max-content;
   }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -454,6 +454,56 @@ export interface ProductSiteOverview {
   available_actions: ProductActionAvailability[];
 }
 
+export type ProductConfigItemStatus =
+  | "configured"
+  | "missing"
+  | "disabled"
+  | "unvalidated"
+  | "stale"
+  | "unsupported";
+
+export interface ProductRuntimeConfigStatusItem {
+  key: string;
+  status: ProductConfigItemStatus;
+  context: string;
+  instance: string;
+  source_label: string;
+  updated_at: string;
+  trust_state: FreshnessStatus;
+}
+
+export interface ProductManagedSecretConfigStatusItem {
+  binding_key: string;
+  status: ProductConfigItemStatus;
+  integration: string;
+  context: string;
+  instance: string;
+  updated_at: string;
+  trust_state: FreshnessStatus | "disabled";
+}
+
+export interface ProductEnvironmentConfigStatus {
+  schema_version: number;
+  product: string;
+  display_name: string;
+  repository: string;
+  driver_id: string;
+  base_driver_id: string;
+  environment: string;
+  context: string;
+  runtime_settings: ProductRuntimeConfigStatusItem[];
+  managed_secrets: ProductManagedSecretConfigStatusItem[];
+  warnings: string[];
+  trust_state: FreshnessStatus;
+  provenance: DataProvenance;
+}
+
+export interface ProductEnvironmentConfigStatusPayload {
+  status: "ok";
+  trace_id: string;
+  config_status: ProductEnvironmentConfigStatus;
+}
+
 export interface ProductListPayload {
   status: "ok";
   trace_id: string;


### PR DESCRIPTION
Refs #153

## Summary
- add frontend types/API call for product environment config-status
- render a read-only expected config panel before the runtime config write form
- show runtime key and managed secret binding readiness by stable lane without values or secret IDs

## Verification
- `pnpm --dir frontend validate`
- Browser fixture smoke at `http://127.0.0.1:4195/ui/?fixtures=1` on desktop and narrow/mobile viewport

## Notes
- Python `ruff` was not applicable to the changed TypeScript/CSS files; the frontend validator covers typecheck/build/fixture assertions.