### PR TITLE
Add operator environment detail strip

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -233,6 +233,11 @@ export function App() {
     productOverviews.find(
       (overview) => overview.product === selected.driverId,
     ) ?? null;
+  const [selectedEnvironment, setSelectedEnvironment] = useState("prod");
+  const activeEnvironment =
+    selectedProductOverview?.environments.find(
+      (environment) => environment.environment === selectedEnvironment,
+    ) ?? selectedProductOverview?.environments[0];
   const [prodView, setProdView] = useState<DriverContextView | null>(null);
   const [testingView, setTestingView] = useState<DriverContextView | null>(
     null,
@@ -386,9 +391,15 @@ export function App() {
     const environments = selectedProductOverview.environments.filter(
       (environment) => environment.environment.trim(),
     );
+    setConfigStatuses([]);
+    if (!environments.length) {
+      setConfigStatusError("");
+      setConfigStatusLoading(false);
+      return;
+    }
     setConfigStatusLoading(true);
     setConfigStatusError("");
-    Promise.all(
+    Promise.allSettled(
       environments.map((environment) =>
         readProductEnvironmentConfigStatus(
           selectedProductOverview.product,
@@ -396,9 +407,23 @@ export function App() {
         ).then((payload) => payload.config_status),
       ),
     )
-      .then((statuses) => {
+      .then((results) => {
         if (!controller.signal.aborted) {
+          const statuses = results.flatMap((result) =>
+            result.status === "fulfilled" ? [result.value] : [],
+          );
+          const failures = results.flatMap((result, index) =>
+            result.status === "rejected"
+              ? [
+                  configStatusErrorMessage(
+                    environments[index].environment,
+                    result.reason,
+                  ),
+                ]
+              : [],
+          );
           setConfigStatuses(statuses);
+          setConfigStatusError(failures[0] ?? "");
         }
       })
       .catch((apiError: unknown) => {
@@ -421,6 +446,17 @@ export function App() {
       });
     return () => controller.abort();
   }, [authStatus, selectedProductOverview, refreshKey]);
+
+  useEffect(() => {
+    if (
+      selectedProductOverview?.environments.length &&
+      !selectedProductOverview.environments.some(
+        (environment) => environment.environment === selectedEnvironment,
+      )
+    ) {
+      setSelectedEnvironment(selectedProductOverview.environments[0].environment);
+    }
+  }, [selectedProductOverview, selectedEnvironment]);
 
   const currentDriver = drivers.find(
     (driver) => driver.driver_id === selected.driverId,
@@ -518,6 +554,8 @@ export function App() {
               product={selectedProductOverview}
               selected={selected}
               loading={loading}
+              selectedEnvironment={activeEnvironment?.environment ?? selectedEnvironment}
+              onSelectEnvironment={setSelectedEnvironment}
             />
             <section className="lane-grid" aria-busy={loading}>
               <LanePanel
@@ -930,6 +968,17 @@ function EvidenceDetailDrawer({
   );
 }
 
+function configStatusErrorMessage(environment: string, apiError: unknown): string {
+  const prefix = `${environment} config status`;
+  if (apiError instanceof LaunchplaneApiError) {
+    return `${prefix}: ${apiError.message}`;
+  }
+  if (apiError instanceof Error) {
+    return `${prefix}: ${apiError.message}`;
+  }
+  return `${prefix}: request failed.`;
+}
+
 function StateFixtureGallery({
   actions,
 }: {
@@ -942,6 +991,7 @@ function StateFixtureGallery({
     useState<WorkGraphFilter>("all");
   const [fixtureWorkGraphMode, setFixtureWorkGraphMode] =
     useState<WorkGraphMode>("all");
+  const [fixtureEnvironment, setFixtureEnvironment] = useState("prod");
   const readyProd = fixtureLane({
     instance: "prod",
     artifact: "ghcr.io/every/verireel@sha256:11112222",
@@ -976,7 +1026,16 @@ function StateFixtureGallery({
       trust_state: "verified",
       provenance: readyTesting.provenance,
       warnings: [],
-      available_actions: [],
+      available_actions: FIXTURE_GENERIC_WEB_ACTIONS.map((action) => ({
+        ...action,
+        authz_action: "product_environment.write",
+        enabled: action.action_id === "prod_promotion_workflow",
+        disabled_reasons:
+          action.action_id === "prod_promotion"
+            ? ["Prod promotion runs through the product-owned workflow."]
+            : [],
+        trust_state: "verified",
+      })),
     },
     {
       environment: "prod",
@@ -986,7 +1045,13 @@ function StateFixtureGallery({
       trust_state: "verified",
       provenance: readyProd.provenance,
       warnings: [],
-      available_actions: [],
+      available_actions: FIXTURE_GENERIC_WEB_ACTIONS.map((action) => ({
+        ...action,
+        authz_action: "product_environment.write",
+        enabled: false,
+        disabled_reasons: ["Prod lane writes require fresh backup evidence."],
+        trust_state: "recorded",
+      })),
     },
   ];
   const fixtureProducts: ProductSiteOverview[] = [
@@ -1298,6 +1363,15 @@ function StateFixtureGallery({
         <RuntimeAuthorityList
           driver={FIXTURE_VERIREEL_DRIVER}
           lane={readyProd}
+        />
+      </div>
+      <div className="fixture-wide">
+        <ProductOverviewShell
+          product={fixtureProducts[0]}
+          selected={choiceFromProductOverview(fixtureProducts[0])}
+          loading={false}
+          selectedEnvironment={fixtureEnvironment}
+          onSelectEnvironment={setFixtureEnvironment}
         />
       </div>
       <div className="fixture-wide">

--- a/frontend/src/ProductOverviewShell.tsx
+++ b/frontend/src/ProductOverviewShell.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, Database } from "lucide-react";
+import { AlertTriangle, Database, ExternalLink } from "lucide-react";
 
 import { KeyValue, PanelHead } from "./panel-ui";
 import { SkeletonRows, StateBlock, StatusPill } from "./status-ui";
@@ -11,12 +11,20 @@ export function ProductOverviewShell({
   product,
   selected,
   loading,
+  selectedEnvironment,
+  onSelectEnvironment,
 }: {
   product: ProductSiteOverview | null;
   selected: DriverChoice;
   loading: boolean;
+  selectedEnvironment: string;
+  onSelectEnvironment: (environment: string) => void;
 }) {
   const environments = product?.environments ?? [];
+  const activeEnvironment =
+    environments.find(
+      (environment) => environment.environment === selectedEnvironment,
+    ) ?? environments[0];
   const enabledActions = product?.available_actions.filter(
     (action) => action.enabled,
   );
@@ -63,15 +71,20 @@ export function ProductOverviewShell({
           <div className="product-environment-strip">
             {environments.length ? (
               environments.map((environment) => (
-                <div
+                <button
+                  type="button"
                   className="product-environment-pill"
                   key={`${environment.environment}:${environment.context}`}
                   data-environment={environment.environment}
+                  data-selected={
+                    activeEnvironment?.environment === environment.environment
+                  }
+                  onClick={() => onSelectEnvironment(environment.environment)}
                 >
                   <span>{environment.environment}</span>
                   <strong>{freshnessLabel(environment.trust_state)}</strong>
                   <code>{environment.context}</code>
-                </div>
+                </button>
               ))
             ) : (
               <StateBlock
@@ -103,6 +116,9 @@ export function ProductOverviewShell({
           </div>
         </div>
       )}
+      {!loading && activeEnvironment ? (
+        <EnvironmentDetailStrip environment={activeEnvironment} />
+      ) : null}
       {product?.warnings.length ? (
         <div className="overview-warning-list">
           {product.warnings.map((warning) => (
@@ -114,5 +130,66 @@ export function ProductOverviewShell({
         </div>
       ) : null}
     </section>
+  );
+}
+
+function EnvironmentDetailStrip({
+  environment,
+}: {
+  environment: ProductSiteOverview["environments"][number];
+}) {
+  const enabledActions = environment.available_actions.filter(
+    (action) => action.enabled,
+  );
+  const blockedActions = environment.available_actions.filter(
+    (action) => !action.enabled,
+  );
+  return (
+    <div className="environment-detail-strip" data-environment={environment.environment}>
+      <div className="environment-detail-identity">
+        <span className={`lane-chip lane-chip-${environment.environment}`}>
+          {environment.environment}
+        </span>
+        <code>{environment.context}</code>
+        {environment.base_url ? (
+          <a href={environment.base_url} target="_blank" rel="noreferrer">
+            <ExternalLink size={13} aria-hidden="true" />
+            {environment.base_url}
+          </a>
+        ) : null}
+      </div>
+      <div className="environment-detail-facts">
+        <KeyValue
+          label="Health URL"
+          value={environment.health_url}
+          mono
+          muted={!environment.health_url}
+        />
+        <KeyValue
+          label="Enabled lane actions"
+          value={`${enabledActions.length} enabled`}
+          status={enabledActions.length ? "pass" : "unknown"}
+        />
+        <KeyValue
+          label="Blocked lane actions"
+          value={`${blockedActions.length} blocked`}
+          status={blockedActions.length ? "blocked" : "pass"}
+        />
+      </div>
+      {environment.available_actions.length ? (
+        <div className="environment-action-strip">
+          {environment.available_actions.slice(0, 4).map((action) => (
+            <span
+              className="environment-action-chip"
+              data-enabled={action.enabled}
+              key={action.action_id}
+              title={action.disabled_reasons.join("; ") || action.description}
+            >
+              {action.label}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </div>
   );
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -598,6 +598,7 @@ p {
 }
 
 .product-environment-pill {
+  appearance: none;
   display: grid;
   min-height: 86px;
   align-content: space-between;
@@ -605,7 +606,33 @@ p {
   border: 1px solid var(--hair);
   border-radius: 6px;
   background: var(--bg-2);
+  color: inherit;
+  font: inherit;
   padding: 10px;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background 140ms ease,
+    border-color 140ms ease,
+    box-shadow 140ms ease,
+    transform 140ms ease;
+}
+
+.product-environment-pill:hover,
+.product-environment-pill:focus-visible {
+  border-color: var(--accent);
+  background: color-mix(in oklab, var(--accent) 7%, var(--bg-2));
+  outline: 0;
+}
+
+.product-environment-pill:focus-visible {
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 24%, transparent);
+}
+
+.product-environment-pill[data-selected="true"] {
+  border-color: var(--accent);
+  background: color-mix(in oklab, var(--accent) 10%, var(--bg-2));
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--accent) 34%, transparent);
 }
 
 .product-environment-pill[data-environment="prod"] {
@@ -626,6 +653,91 @@ p {
   color: var(--fg-muted);
   font-size: 11px;
   font-weight: 600;
+}
+
+.environment-detail-strip {
+  display: grid;
+  grid-template-columns: minmax(240px, 0.9fr) minmax(0, 1.45fr);
+  gap: 1px;
+  margin: 0 16px 16px;
+  overflow: hidden;
+  border: 1px solid var(--hair);
+  border-radius: 6px;
+  background: var(--hair);
+}
+
+.environment-detail-strip[data-environment="prod"] {
+  border-color: color-mix(in oklab, var(--lane-prod) 36%, var(--hair));
+}
+
+.environment-detail-strip[data-environment="testing"] {
+  border-color: color-mix(in oklab, var(--lane-testing) 36%, var(--hair));
+}
+
+.environment-detail-identity,
+.environment-detail-facts,
+.environment-action-strip {
+  min-width: 0;
+  background: var(--panel);
+  padding: 12px;
+}
+
+.environment-detail-identity {
+  display: grid;
+  align-content: start;
+  gap: 8px;
+}
+
+.environment-detail-identity code,
+.environment-detail-identity a,
+.environment-detail-facts code,
+.environment-action-chip {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.environment-detail-identity a {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.environment-detail-identity a:hover {
+  text-decoration: underline;
+}
+
+.environment-detail-facts {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) repeat(2, minmax(120px, 0.65fr));
+  gap: 10px;
+}
+
+.environment-action-strip {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  border-top: 1px solid var(--hair);
+}
+
+.environment-action-chip {
+  min-height: 34px;
+  border: 1px solid var(--hair-soft);
+  border-radius: 6px;
+  background: var(--bg-2);
+  color: var(--fg-muted);
+  padding: 8px 10px;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.environment-action-chip[data-enabled="true"] {
+  border-color: color-mix(in oklab, var(--status-pass) 34%, var(--hair-soft));
+  color: var(--fg-strong);
 }
 
 .overview-warning-list {
@@ -1857,6 +1969,8 @@ p {
   .operator-cockpit,
   .lane-grid,
   .product-overview-grid,
+  .environment-detail-strip,
+  .environment-detail-facts,
   .work-grid,
   .work-grid-evidence,
   .config-status-environment,
@@ -1870,6 +1984,10 @@ p {
   }
 
   .product-environment-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .environment-action-strip {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
@@ -1923,6 +2041,14 @@ p {
   }
 
   .product-environment-strip {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .environment-detail-strip {
+    margin: 0 12px 12px;
+  }
+
+  .environment-action-strip {
     grid-template-columns: minmax(0, 1fr);
   }
 


### PR DESCRIPTION
## Summary
- make product environment pills selectable in the operator overview
- show the selected stable environment context, URLs, and lane action availability
- clear stale config-status rows on product changes and preserve partial status results when one environment fetch fails

## Validation
- pnpm --dir frontend validate
- browser smoke: http://127.0.0.1:4196/ui/?fixtures=1 desktop and mobile fixture passes

Refs #153