### PR TITLE
Scope config readiness to selected environment

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -586,6 +586,7 @@ export function App() {
             </section>
             <ProductConfigStatusPanel
               statuses={configStatuses}
+              selectedEnvironment={activeEnvironment?.environment ?? selectedEnvironment}
               loading={configStatusLoading}
               error={configStatusError}
             />
@@ -1390,6 +1391,7 @@ function StateFixtureGallery({
       <div className="fixture-wide">
         <ProductConfigStatusPanel
           statuses={fixtureConfigStatuses}
+          selectedEnvironment={fixtureEnvironment}
           loading={false}
           error=""
         />

--- a/frontend/src/ProductConfigStatusPanel.tsx
+++ b/frontend/src/ProductConfigStatusPanel.tsx
@@ -14,19 +14,24 @@ import type {
 
 export function ProductConfigStatusPanel({
   statuses,
+  selectedEnvironment,
   loading,
   error,
 }: {
   statuses: ProductEnvironmentConfigStatus[];
+  selectedEnvironment: string;
   loading: boolean;
   error: string;
 }) {
-  const totals = summarizeConfigStatuses(statuses);
+  const scopedStatuses = selectedEnvironment.trim()
+    ? statuses.filter((status) => status.environment === selectedEnvironment)
+    : statuses;
+  const totals = summarizeConfigStatuses(scopedStatuses);
   return (
     <section className="panel config-status-panel" aria-busy={loading}>
       <PanelHead
         eyebrow="settings readiness"
-        title="Expected config"
+        title={`Expected config${selectedEnvironment ? ` / ${selectedEnvironment}` : ""}`}
         right={
           <div className="panel-badges">
             <StatusPill status={statusToUiStatus(totals.worst)} />
@@ -40,11 +45,18 @@ export function ProductConfigStatusPanel({
           <code>{error}</code>
         </div>
       ) : null}
-      {loading && !statuses.length ? <ConfigStatusSkeleton /> : null}
-      {!loading && !statuses.length && !error ? (
-        <StateBlock icon={<Settings2 size={18} />} title="No expected config status" />
+      {loading && !scopedStatuses.length ? <ConfigStatusSkeleton /> : null}
+      {!loading && !scopedStatuses.length && !error ? (
+        <StateBlock
+          icon={<Settings2 size={18} />}
+          title={
+            selectedEnvironment
+              ? `No expected config status for ${selectedEnvironment}`
+              : "No expected config status"
+          }
+        />
       ) : null}
-      {statuses.map((status) => (
+      {scopedStatuses.map((status) => (
         <EnvironmentConfigStatus key={`${status.product}:${status.environment}`} status={status} />
       ))}
     </section>


### PR DESCRIPTION
## Summary
- pass the selected stable environment into the config readiness panel
- filter config-status rows and totals to the active lane
- keep the fixture panel tied to the selected fixture environment

## Validation
- pnpm --dir frontend validate

Refs #153