### PR TITLE
Add human authz policy grant route

### DIFF
--- a/control_plane/authz_grant_service.py
+++ b/control_plane/authz_grant_service.py
@@ -12,6 +12,7 @@ from control_plane.contracts.authz_policy_record import (
 )
 from control_plane.service_auth import (
     GitHubActionsPolicyRule,
+    GitHubHumanPolicyRule,
     GitHubHumanIdentity,
     LaunchplaneAuthzPolicy,
     LaunchplaneIdentity,
@@ -104,6 +105,77 @@ class AuthzPolicyGitHubActionsGrantEnvelope(BaseModel):
         return self
 
 
+class AuthzPolicyGitHubHumanGrant(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    logins: tuple[str, ...] = ()
+    organizations: tuple[str, ...] = ()
+    teams: tuple[str, ...] = ()
+    roles: tuple[Literal["read_only", "admin"], ...] = ()
+    products: tuple[str, ...] = ()
+    contexts: tuple[str, ...] = ()
+    actions: tuple[str, ...]
+    source_label: str = "service:authz-human-policy-grant"
+
+    @staticmethod
+    def _normalized_tuple(values: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(value.strip() for value in values if value.strip())
+
+    @model_validator(mode="after")
+    def _validate_grant(self) -> "AuthzPolicyGitHubHumanGrant":
+        self.logins = self._normalized_tuple(self.logins)
+        self.organizations = self._normalized_tuple(self.organizations)
+        self.teams = self._normalized_tuple(self.teams)
+        self.products = self._normalized_tuple(self.products)
+        self.contexts = self._normalized_tuple(self.contexts)
+        self.actions = self._normalized_tuple(self.actions)
+        if not (self.logins or self.organizations or self.teams):
+            raise ValueError("Authz human policy grant requires a login, organization, or team.")
+        if not self.actions:
+            raise ValueError("Authz human policy grant requires at least one action.")
+        self.source_label = self.source_label.strip() or "service:authz-human-policy-grant"
+        return self
+
+    def to_policy_rule(self) -> GitHubHumanPolicyRule:
+        return GitHubHumanPolicyRule(
+            logins=self.logins,
+            organizations=self.organizations,
+            teams=self.teams,
+            roles=self.roles,
+            products=self.products,
+            contexts=self.contexts,
+            actions=self.actions,
+        )
+
+
+class AuthzPolicyGitHubHumanGrantEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    mode: Literal["dry_run", "apply"] = "apply"
+    reason: str = ""
+    related_issue: str = ""
+    grant: AuthzPolicyGitHubHumanGrant
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "AuthzPolicyGitHubHumanGrantEnvelope":
+        if self.product.strip() != "launchplane":
+            raise ValueError("Authz human policy grant writes require product 'launchplane'.")
+        self.product = "launchplane"
+        self.reason = self.reason.strip()
+        self.related_issue = self.related_issue.strip()
+        if self.mode == "apply" and not self.reason:
+            raise ValueError("Authz human policy grant apply requires reason.")
+        return self
+
+
+AuthzPolicyGrant = AuthzPolicyGitHubActionsGrant | AuthzPolicyGitHubHumanGrant
+AuthzPolicyGrantEnvelope = (
+    AuthzPolicyGitHubActionsGrantEnvelope | AuthzPolicyGitHubHumanGrantEnvelope
+)
+
+
 def summarize_authz_policy_record(record: LaunchplaneAuthzPolicyRecord) -> dict[str, object]:
     return {
         "record_id": record.record_id,
@@ -134,20 +206,27 @@ def authz_policy_operator_payload(identity: LaunchplaneIdentity) -> dict[str, ob
 
 
 def authz_policy_grant_diff(
-    *, current_policy: LaunchplaneAuthzPolicy, grant: AuthzPolicyGitHubActionsGrant
+    *, current_policy: LaunchplaneAuthzPolicy, grant: AuthzPolicyGrant
 ) -> dict[str, object]:
     desired_rule = grant.to_policy_rule()
-    changed = not any(rule == desired_rule for rule in current_policy.github_actions)
+    if isinstance(grant, AuthzPolicyGitHubHumanGrant):
+        changed = not any(rule == desired_rule for rule in current_policy.github_humans)
+    else:
+        changed = not any(rule == desired_rule for rule in current_policy.github_actions)
     return {
         "changed": changed,
         "previous_github_actions_rule_count": len(current_policy.github_actions),
-        "new_github_actions_rule_count": len(current_policy.github_actions) + int(changed),
+        "new_github_actions_rule_count": len(current_policy.github_actions)
+        + int(changed and isinstance(grant, AuthzPolicyGitHubActionsGrant)),
+        "previous_github_humans_rule_count": len(current_policy.github_humans),
+        "new_github_humans_rule_count": len(current_policy.github_humans)
+        + int(changed and isinstance(grant, AuthzPolicyGitHubHumanGrant)),
     }
 
 
 def authz_policy_grant_audit_payload(
     *,
-    request: AuthzPolicyGitHubActionsGrantEnvelope,
+    request: AuthzPolicyGrantEnvelope,
     identity: LaunchplaneIdentity,
     previous_record: LaunchplaneAuthzPolicyRecord,
     new_record: LaunchplaneAuthzPolicyRecord | None,
@@ -181,15 +260,28 @@ def authz_policy_grant_response_audit_payload(
     response_audit = dict(audit)
     requested_grant = response_audit.pop("requested_grant", None)
     if isinstance(requested_grant, dict):
-        response_audit["requested_grant_summary"] = {
-            "repository": requested_grant.get("repository", ""),
-            "workflow_ref_count": len(requested_grant.get("workflow_refs") or ()),
-            "job_workflow_ref_count": len(requested_grant.get("job_workflow_refs") or ()),
-            "event_names": requested_grant.get("event_names") or (),
-            "products": requested_grant.get("products") or (),
-            "contexts": requested_grant.get("contexts") or (),
-            "actions": requested_grant.get("actions") or (),
-        }
+        if "repository" in requested_grant:
+            response_audit["requested_grant_summary"] = {
+                "principal_type": "github_actions",
+                "repository": requested_grant.get("repository", ""),
+                "workflow_ref_count": len(requested_grant.get("workflow_refs") or ()),
+                "job_workflow_ref_count": len(requested_grant.get("job_workflow_refs") or ()),
+                "event_names": requested_grant.get("event_names") or (),
+                "products": requested_grant.get("products") or (),
+                "contexts": requested_grant.get("contexts") or (),
+                "actions": requested_grant.get("actions") or (),
+            }
+        else:
+            response_audit["requested_grant_summary"] = {
+                "principal_type": "github_human",
+                "login_count": len(requested_grant.get("logins") or ()),
+                "organization_count": len(requested_grant.get("organizations") or ()),
+                "team_count": len(requested_grant.get("teams") or ()),
+                "roles": requested_grant.get("roles") or (),
+                "products": requested_grant.get("products") or (),
+                "contexts": requested_grant.get("contexts") or (),
+                "actions": requested_grant.get("actions") or (),
+            }
     return response_audit
 
 
@@ -197,6 +289,26 @@ def plan_github_actions_authz_policy_grant(
     *,
     record_store: AuthzPolicyRecordStore,
     grant: AuthzPolicyGitHubActionsGrant,
+) -> tuple[LaunchplaneAuthzPolicy, LaunchplaneAuthzPolicyRecord, dict[str, object]]:
+    active_records = record_store.list_authz_policy_records(status="active", limit=1)
+    if not active_records:
+        raise ValueError("No active Launchplane authz policy record found.")
+    current_record = active_records[0]
+    current_policy = current_record.policy
+    return (
+        current_policy,
+        current_record,
+        authz_policy_grant_diff(
+            current_policy=current_policy,
+            grant=grant,
+        ),
+    )
+
+
+def plan_github_human_authz_policy_grant(
+    *,
+    record_store: AuthzPolicyRecordStore,
+    grant: AuthzPolicyGitHubHumanGrant,
 ) -> tuple[LaunchplaneAuthzPolicy, LaunchplaneAuthzPolicyRecord, dict[str, object]]:
     active_records = record_store.list_authz_policy_records(status="active", limit=1)
     if not active_records:
@@ -247,6 +359,76 @@ def write_github_actions_authz_policy_grant(
 
     updated_policy = current_policy.model_copy(
         update={"github_actions": current_policy.github_actions + (desired_rule,)}
+    )
+    updated_at = now_timestamp()
+    policy_sha256 = authz_policy_sha256(updated_policy)
+    record = LaunchplaneAuthzPolicyRecord(
+        record_id=build_authz_policy_record_id(
+            updated_at=updated_at,
+            policy_sha256=policy_sha256,
+        ),
+        status="active",
+        source=request.grant.source_label,
+        updated_at=updated_at,
+        policy_sha256=policy_sha256,
+        policy=updated_policy,
+        audit=authz_policy_grant_audit_payload(
+            request=request,
+            identity=identity,
+            previous_record=current_record,
+            new_record=None,
+            changed=True,
+            trace_id=trace_id,
+            now_timestamp=now_timestamp,
+        ),
+    )
+    record.audit = authz_policy_grant_audit_payload(
+        request=request,
+        identity=identity,
+        previous_record=current_record,
+        new_record=record,
+        changed=True,
+        trace_id=trace_id,
+        now_timestamp=now_timestamp,
+    )
+    record_store.write_authz_policy_record(record)
+    return updated_policy, record, changed, diff, record.audit
+
+
+def write_github_human_authz_policy_grant(
+    *,
+    record_store: AuthzPolicyRecordStore,
+    request: AuthzPolicyGitHubHumanGrantEnvelope,
+    identity: LaunchplaneIdentity,
+    trace_id: str,
+    now_timestamp: TimestampProvider,
+) -> tuple[
+    LaunchplaneAuthzPolicy,
+    LaunchplaneAuthzPolicyRecord,
+    bool,
+    dict[str, object],
+    dict[str, object],
+]:
+    current_policy, current_record, diff = plan_github_human_authz_policy_grant(
+        record_store=record_store,
+        grant=request.grant,
+    )
+    changed = bool(diff["changed"])
+    desired_rule = request.grant.to_policy_rule()
+    if not changed:
+        audit = authz_policy_grant_audit_payload(
+            request=request,
+            identity=identity,
+            previous_record=current_record,
+            new_record=None,
+            changed=False,
+            trace_id=trace_id,
+            now_timestamp=now_timestamp,
+        )
+        return current_policy, current_record, False, diff, audit
+
+    updated_policy = current_policy.model_copy(
+        update={"github_humans": current_policy.github_humans + (desired_rule,)}
     )
     updated_at = now_timestamp()
     policy_sha256 = authz_policy_sha256(updated_policy)

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -13007,6 +13007,105 @@ def authz_policies_grant_workflow(
     click.echo(json.dumps(response_payload, indent=2, sort_keys=True))
 
 
+@authz_policies.command("grant-human")
+@click.option(
+    "--service-url",
+    required=True,
+    help="Deployed Launchplane service base URL. Shared/prod grants go through the service API.",
+)
+@click.option(
+    "--bearer-token-env",
+    default="LAUNCHPLANE_SERVICE_TOKEN",
+    show_default=True,
+    help="Environment variable containing a short-lived bearer token for the service.",
+)
+@click.option(
+    "--session-cookie",
+    default="",
+    help="Launchplane browser session cookie. Use instead of --bearer-token-env.",
+)
+@click.option("--login", "logins", multiple=True, help="Allowed GitHub login.")
+@click.option(
+    "--organization", "organizations", multiple=True, help="Allowed GitHub organization."
+)
+@click.option("--team", "teams", multiple=True, help="Allowed GitHub team.")
+@click.option(
+    "--role",
+    "roles",
+    multiple=True,
+    type=click.Choice(("read_only", "admin")),
+    help="Allowed Launchplane role.",
+)
+@click.option("--product", "products", multiple=True, required=True, help="Allowed product.")
+@click.option("--context", "contexts", multiple=True, help="Allowed Launchplane context.")
+@click.option(
+    "--action", "actions", multiple=True, required=True, help="Allowed Launchplane action."
+)
+@click.option("--reason", default="", help="Required audit reason when --apply is used.")
+@click.option(
+    "--related-issue",
+    default="",
+    help="Optional related GitHub issue, e.g. cbusillo/launchplane#153.",
+)
+@click.option("--source-label", default="cli:authz-grant-human", show_default=True)
+@click.option(
+    "--idempotency-key", default="", help="Optional explicit Idempotency-Key for apply requests."
+)
+@click.option("--dry-run", "mode", flag_value="dry_run", default="dry_run")
+@click.option("--apply", "mode", flag_value="apply")
+def authz_policies_grant_human(
+    service_url: str,
+    bearer_token_env: str,
+    session_cookie: str,
+    logins: tuple[str, ...],
+    organizations: tuple[str, ...],
+    teams: tuple[str, ...],
+    roles: tuple[str, ...],
+    products: tuple[str, ...],
+    contexts: tuple[str, ...],
+    actions: tuple[str, ...],
+    reason: str,
+    related_issue: str,
+    source_label: str,
+    idempotency_key: str,
+    mode: str,
+) -> None:
+    bearer_token = ""
+    if not session_cookie.strip():
+        token_env_key = bearer_token_env.strip() or "LAUNCHPLANE_SERVICE_TOKEN"
+        bearer_token = os.environ.get(token_env_key, "").strip()
+        if not bearer_token:
+            raise click.ClickException(
+                f"{token_env_key} is required unless --session-cookie is provided."
+            )
+    payload = {
+        "schema_version": 1,
+        "product": "launchplane",
+        "mode": mode,
+        "reason": reason,
+        "related_issue": related_issue,
+        "grant": {
+            "logins": list(logins),
+            "organizations": list(organizations),
+            "teams": list(teams),
+            "roles": list(roles),
+            "products": list(products),
+            "contexts": list(contexts),
+            "actions": list(actions),
+            "source_label": source_label,
+        },
+    }
+    response_payload = _post_launchplane_service_json(
+        service_url=service_url,
+        path="/v1/authz-policies/github-humans/grants",
+        payload=payload,
+        bearer_token=bearer_token,
+        session_cookie=session_cookie,
+        idempotency_key=idempotency_key,
+    )
+    click.echo(json.dumps(response_payload, indent=2, sort_keys=True))
+
+
 @runtime_key_safety.command("list-policies")
 @click.option(
     "--database-url",

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1171,6 +1171,7 @@ _HUMAN_IDENTITY_MUTATION_ROUTES = frozenset(
         _GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path,
         _GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.route_path,
         "/v1/authz-policies/github-actions/grants",
+        "/v1/authz-policies/github-humans/grants",
     }
 )
 _HUMAN_IDENTITY_READ_MODEL_POST_ROUTES = frozenset({"/v1/work-graph/rank"})
@@ -1781,6 +1782,7 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/evidence/previews/generations",
         "/v1/evidence/previews/destroyed",
         "/v1/authz-policies/github-actions/grants",
+        "/v1/authz-policies/github-humans/grants",
         "/v1/runtime-key-safety/policies/apply",
         "/v1/live-target-runtime/apply",
         "/v1/product-onboarding/apply",
@@ -2952,7 +2954,11 @@ def _should_store_idempotency_record(
     if path in _NON_IDEMPOTENT_DRIVER_RESULT_ROUTES:
         return False
     if (
-        path == "/v1/authz-policies/github-actions/grants"
+        path
+        in {
+            "/v1/authz-policies/github-actions/grants",
+            "/v1/authz-policies/github-humans/grants",
+        }
         and isinstance(driver_result, dict)
         and driver_result.get("mode") == "dry_run"
     ):
@@ -5602,6 +5608,124 @@ def create_launchplane_service_app(
                         authz_policy_record=authz_policy_record,
                         changed=changed,
                         mode=authz_grant_request.mode,
+                        diff=diff,
+                        audit=audit,
+                    )
+                )
+            elif path == "/v1/authz-policies/github-humans/grants":
+                human_authz_grant_request = control_plane_authz_grant_service.AuthzPolicyGitHubHumanGrantEnvelope.model_validate(
+                    payload
+                )
+                if not isinstance(record_store, PostgresRecordStore):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "database_required",
+                                "message": "Authz human policy grant writes require Launchplane database storage.",
+                            },
+                        },
+                    )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="launchplane_service_deploy.execute",
+                    product=human_authz_grant_request.product,
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot write Launchplane authz human policy grants.",
+                            },
+                        },
+                    )
+                if human_authz_grant_request.mode == "apply":
+                    idempotent_response = _check_idempotent_request(
+                        record_store=record_store,
+                        scope=request_scope,
+                        route_path=path,
+                        idempotency_key=request_idempotency_key,
+                        request_fingerprint=request_fingerprint,
+                        start_response=start_response,
+                        trace_id=request_trace_id,
+                    )
+                    if idempotent_response is not None:
+                        return idempotent_response
+                try:
+                    (
+                        current_policy,
+                        current_record,
+                        diff,
+                    ) = control_plane_authz_grant_service.plan_github_human_authz_policy_grant(
+                        record_store=record_store,
+                        grant=human_authz_grant_request.grant,
+                    )
+                    audit = control_plane_authz_grant_service.authz_policy_grant_audit_payload(
+                        request=human_authz_grant_request,
+                        identity=identity,
+                        previous_record=current_record,
+                        new_record=None,
+                        changed=bool(diff["changed"]),
+                        trace_id=request_trace_id,
+                        now_timestamp=_now_timestamp,
+                    )
+                    authz_policy_record = current_record
+                    changed = bool(diff["changed"])
+                    if human_authz_grant_request.mode == "apply":
+                        (
+                            updated_policy,
+                            authz_policy_record,
+                            changed,
+                            diff,
+                            audit,
+                        ) = control_plane_authz_grant_service.write_github_human_authz_policy_grant(
+                            record_store=record_store,
+                            request=human_authz_grant_request,
+                            identity=identity,
+                            trace_id=request_trace_id,
+                            now_timestamp=_now_timestamp,
+                        )
+                    else:
+                        updated_policy = current_policy
+                        authz_policy_record = LaunchplaneAuthzPolicyRecord(
+                            record_id=current_record.record_id,
+                            status=current_record.status,
+                            source=current_record.source,
+                            updated_at=current_record.updated_at,
+                            policy_sha256=current_record.policy_sha256,
+                            policy=current_record.policy,
+                            audit=audit,
+                        )
+                except ValueError:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authz_policy_unavailable",
+                                "message": "Launchplane active authz policy is unavailable.",
+                            },
+                        },
+                    )
+                if human_authz_grant_request.mode == "apply":
+                    authz_policy = updated_policy
+                    resolved_authz_policy_sha256 = authz_policy_record.policy_sha256
+                    resolved_authz_policy_source = "db"
+                result, driver_result = (
+                    control_plane_authz_grant_service.build_authz_policy_grant_service_result(
+                        authz_policy_record=authz_policy_record,
+                        changed=changed,
+                        mode=human_authz_grant_request.mode,
                         diff=diff,
                         audit=audit,
                     )

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -90,6 +90,7 @@ Current implementation scope:
 - `POST /v1/evidence/previews/generations`
 - `POST /v1/evidence/previews/destroyed`
 - `POST /v1/authz-policies/github-actions/grants`
+- `POST /v1/authz-policies/github-humans/grants`
 - `POST /v1/product-profiles/context-cutover/apply`
 - `POST /v1/previews/lifecycle-plan`
 - `POST /v1/drivers/verireel/preview-refresh`
@@ -117,6 +118,7 @@ rather than creating separate ad hoc ingress patterns.
 Operators should mutate shared or production authz through the deployed service,
 not by running arbitrary local DB writes from a checkout. Use
 `uv run launchplane authz-policies grant-workflow --service-url ... --dry-run`
+or `uv run launchplane authz-policies grant-human --service-url ... --dry-run`
 to inspect the diff, then rerun with `--apply --reason ...` and an idempotency
 key when the grant is approved. The CLI is a thin service client: it sends a
 short-lived bearer token or a Launchplane browser session cookie, and the
@@ -126,8 +128,8 @@ metadata, and reloads the current service worker's active policy.
 The deploy workflow maintains DB-backed grants for SellYourOutboard operational
 workflows, including product profile cutover reads/writes, production promotion,
 and generic-web preview refresh/destroy requests. The grant request returns only
-authz policy record metadata and rule counts; it does not echo workflow refs or
-the full policy body.
+authz policy record metadata and rule counts; it does not echo workflow refs,
+human logins, or the full policy body.
 
 The manual Product Context Cutover workflow plans or applies the same
 current-authority record move through the Launchplane service. Run it first with

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -52,6 +52,7 @@ VeriReel product paths:
   - `POST /v1/product-profiles/legacy-context-cleanup/apply`
 - authz policy maintenance route:
   - `POST /v1/authz-policies/github-actions/grants`
+  - `POST /v1/authz-policies/github-humans/grants`
 - Every Code local automation work-request routes:
   - `POST /v1/every-code/github-webhook`
   - `GET /v1/every-code/work-requests`
@@ -94,15 +95,15 @@ Launchplane verifies GitHub OIDC, authorizes workflow identity claims, accepts
 deployment/promotion/preview lifecycle evidence over HTTP, and executes the
 current Odoo/VeriReel artifact, deploy, backup, promotion, rollback, maintenance,
 and preview mutations as authenticated Launchplane routes. The authz policy
-grant route accepts GitHub Actions OIDC callers and authenticated admin human
-sessions, requires the `launchplane_service_deploy.execute` action, and remains
-the service-owned write/reload boundary for DB-backed GitHub Actions policy
-rules. Grant requests support `dry_run` and `apply` modes. Apply requests must
-include an audit reason, write a new active policy record only when the grant is
-not already present, and immediately refresh the in-process policy used by the
-current service worker. Responses return record metadata, rule counts, a compact
-diff, and redacted audit metadata rather than echoing workflow refs or the full
-policy body.
+grant routes accept GitHub Actions OIDC callers and authenticated admin human
+sessions, require the `launchplane_service_deploy.execute` action, and remain
+the service-owned write/reload boundary for DB-backed GitHub Actions and GitHub
+human policy rules. Grant requests support `dry_run` and `apply` modes. Apply
+requests must include an audit reason, write a new active policy record only
+when the grant is not already present, and immediately refresh the in-process
+policy used by the current service worker. Responses return record metadata,
+rule counts, a compact diff, and redacted audit metadata rather than echoing
+workflow refs, human logins, or the full policy body.
 
 The service also serves the built operator UI shell at `/`, with `/ui` retained
 as a compatibility alias. Built assets live under `/ui/assets/...`, while

--- a/tests/test_authz_grant_service.py
+++ b/tests/test_authz_grant_service.py
@@ -7,10 +7,14 @@ from typing import cast
 from control_plane.authz_grant_service import (
     AuthzPolicyGitHubActionsGrant,
     AuthzPolicyGitHubActionsGrantEnvelope,
+    AuthzPolicyGitHubHumanGrant,
+    AuthzPolicyGitHubHumanGrantEnvelope,
     authz_policy_grant_response_audit_payload,
     build_authz_policy_grant_service_result,
     plan_github_actions_authz_policy_grant,
+    plan_github_human_authz_policy_grant,
     write_github_actions_authz_policy_grant,
+    write_github_human_authz_policy_grant,
 )
 from control_plane.contracts.authz_policy_record import (
     LaunchplaneAuthzPolicyRecord,
@@ -106,6 +110,25 @@ def _grant_request(mode: str = "apply") -> AuthzPolicyGitHubActionsGrantEnvelope
     )
 
 
+def _human_grant_request(mode: str = "apply") -> AuthzPolicyGitHubHumanGrantEnvelope:
+    return AuthzPolicyGitHubHumanGrantEnvelope.model_validate(
+        {
+            "product": "launchplane",
+            "mode": mode,
+            "reason": "Grant SYO promotion workflow dispatch to the operator.",
+            "related_issue": "cbusillo/launchplane#153",
+            "grant": {
+                "logins": ["cbusillo"],
+                "roles": ["admin"],
+                "products": ["sellyouroutboard"],
+                "contexts": ["sellyouroutboard"],
+                "actions": ["generic_web_prod_promotion.dispatch"],
+                "source_label": "test:human-grant",
+            },
+        }
+    )
+
+
 class AuthzGrantServiceTests(unittest.TestCase):
     def test_grant_normalizes_tuple_values(self) -> None:
         grant = AuthzPolicyGitHubActionsGrant.model_validate(
@@ -119,6 +142,19 @@ class AuthzGrantServiceTests(unittest.TestCase):
         self.assertEqual(grant.repository, "cbusillo/launchplane")
         self.assertEqual(grant.workflow_refs, ("workflow",))
         self.assertEqual(grant.actions, ("product_profile.read",))
+
+    def test_human_grant_normalizes_tuple_values(self) -> None:
+        grant = AuthzPolicyGitHubHumanGrant.model_validate(
+            {
+                "logins": [" cbusillo ", ""],
+                "roles": ["admin"],
+                "actions": [" generic_web_prod_promotion.dispatch "],
+            }
+        )
+
+        self.assertEqual(grant.logins, ("cbusillo",))
+        self.assertEqual(grant.roles, ("admin",))
+        self.assertEqual(grant.actions, ("generic_web_prod_promotion.dispatch",))
 
     def test_plan_and_write_grant_records_changed_policy(self) -> None:
         store = _AuthzPolicyStore((_active_record(),))
@@ -148,6 +184,7 @@ class AuthzGrantServiceTests(unittest.TestCase):
         self.assertEqual(len(updated_policy.github_actions), 2)
         self.assertEqual(audit["reason"], request.reason)
         self.assertIn("workflow_refs", json.dumps(audit, sort_keys=True))
+        self.assertEqual(write_diff["new_github_humans_rule_count"], 0)
 
         result, driver_result = build_authz_policy_grant_service_result(
             authz_policy_record=record,
@@ -161,6 +198,50 @@ class AuthzGrantServiceTests(unittest.TestCase):
         self.assertNotIn("requested_grant", driver_audit)
         requested_grant_summary = cast(dict[str, object], driver_audit["requested_grant_summary"])
         self.assertEqual(requested_grant_summary["workflow_ref_count"], 1)
+
+    def test_plan_and_write_human_grant_records_changed_policy(self) -> None:
+        store = _AuthzPolicyStore((_active_record(),))
+        request = _human_grant_request()
+
+        _current_policy, current_record, diff = plan_github_human_authz_policy_grant(
+            record_store=store,
+            grant=request.grant,
+        )
+        self.assertEqual(current_record.record_id, store.records[0].record_id)
+        self.assertEqual(diff["changed"], True)
+        self.assertEqual(diff["new_github_actions_rule_count"], 1)
+        self.assertEqual(diff["new_github_humans_rule_count"], 1)
+
+        updated_policy, record, changed, write_diff, audit = (
+            write_github_human_authz_policy_grant(
+                record_store=store,
+                request=request,
+                identity=_identity(),
+                trace_id="trace-human",
+                now_timestamp=lambda: "2026-05-07T16:00:00Z",
+            )
+        )
+
+        self.assertTrue(changed)
+        self.assertEqual(write_diff, diff)
+        self.assertEqual(store.written_records, [record])
+        self.assertEqual(len(updated_policy.github_humans), 1)
+        self.assertEqual(audit["reason"], request.reason)
+        self.assertIn("logins", json.dumps(audit, sort_keys=True))
+
+        result, driver_result = build_authz_policy_grant_service_result(
+            authz_policy_record=record,
+            changed=changed,
+            mode=request.mode,
+            diff=write_diff,
+            audit=audit,
+        )
+        self.assertEqual(result["authz_policy_record_id"], record.record_id)
+        driver_audit = cast(dict[str, object], driver_result["audit"])
+        requested_grant_summary = cast(dict[str, object], driver_audit["requested_grant_summary"])
+        self.assertEqual(requested_grant_summary["principal_type"], "github_human")
+        self.assertEqual(requested_grant_summary["login_count"], 1)
+        self.assertNotIn("logins", requested_grant_summary)
 
     def test_repeated_grant_does_not_write_new_record(self) -> None:
         store = _AuthzPolicyStore((_active_record(),))
@@ -199,6 +280,22 @@ class AuthzGrantServiceTests(unittest.TestCase):
         self.assertNotIn("requested_grant", response_audit)
         requested_grant_summary = cast(dict[str, object], response_audit["requested_grant_summary"])
         self.assertEqual(requested_grant_summary["actions"], ["product_profile.read"])
+
+    def test_response_audit_summarizes_human_grant_without_logins(self) -> None:
+        audit: dict[str, object] = {
+            "requested_grant": _human_grant_request().grant.to_policy_rule().model_dump(
+                mode="json"
+            ),
+            "mode": "dry_run",
+        }
+
+        response_audit = authz_policy_grant_response_audit_payload(audit)
+
+        self.assertNotIn("requested_grant", response_audit)
+        self.assertNotIn("cbusillo", json.dumps(response_audit, sort_keys=True))
+        requested_grant_summary = cast(dict[str, object], response_audit["requested_grant_summary"])
+        self.assertEqual(requested_grant_summary["principal_type"], "github_human")
+        self.assertEqual(requested_grant_summary["login_count"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -383,6 +383,7 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
                     control_plane_service._GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path,
                     control_plane_service._GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.route_path,
                     "/v1/authz-policies/github-actions/grants",
+                    "/v1/authz-policies/github-humans/grants",
                 }
             ),
         )

--- a/tests/test_every_code_reconciliation.py
+++ b/tests/test_every_code_reconciliation.py
@@ -99,6 +99,61 @@ class EveryCodeIssueReconciliationTests(unittest.TestCase):
         self.assertEqual(result.exit_code, 1)
         self.assertIn("LAUNCHPLANE_SERVICE_TOKEN is required", result.output)
 
+    def test_cli_authz_grant_human_posts_service_request(self) -> None:
+        runner = CliRunner()
+        captured_request: dict[str, object] = {}
+
+        def fake_post(**kwargs: object) -> dict[str, object]:
+            captured_request.update(kwargs)
+            return {
+                "status": "accepted",
+                "result": {"mode": "apply", "changed": True},
+            }
+
+        with patch("control_plane.cli._post_launchplane_service_json", side_effect=fake_post):
+            result = runner.invoke(
+                main,
+                [
+                    "authz-policies",
+                    "grant-human",
+                    "--service-url",
+                    "https://launchplane.example",
+                    "--session-cookie",
+                    "launchplane_session=signed",
+                    "--login",
+                    "cbusillo",
+                    "--role",
+                    "admin",
+                    "--product",
+                    "sellyouroutboard",
+                    "--context",
+                    "sellyouroutboard",
+                    "--action",
+                    "generic_web_prod_promotion.dispatch",
+                    "--reason",
+                    "Allow SYO workflow dry-run validation.",
+                    "--related-issue",
+                    "cbusillo/launchplane#153",
+                    "--idempotency-key",
+                    "authz-human-grant:syo-dispatch",
+                    "--apply",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(captured_request["bearer_token"], "")
+        self.assertEqual(captured_request["session_cookie"], "launchplane_session=signed")
+        self.assertEqual(captured_request["path"], "/v1/authz-policies/github-humans/grants")
+        self.assertEqual(captured_request["idempotency_key"], "authz-human-grant:syo-dispatch")
+        payload = captured_request["payload"]
+        assert isinstance(payload, dict)
+        self.assertEqual(payload["mode"], "apply")
+        grant = payload["grant"]
+        assert isinstance(grant, dict)
+        self.assertEqual(grant["logins"], ["cbusillo"])
+        self.assertEqual(grant["roles"], ["admin"])
+        self.assertEqual(grant["actions"], ["generic_web_prod_promotion.dispatch"])
+
     def test_creates_queued_request_when_trigger_label_is_present(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             store = FilesystemRecordStore(state_dir=Path(tempdir))

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -8089,7 +8089,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                             "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
                         ],
                         "event_names": ["workflow_dispatch"],
-                        "products": ["sellyouroutboard"],
+                        "products": ["sellyouroutboard", "launchplane"],
                         "contexts": ["launchplane"],
                         "actions": ["product_profile.read"],
                         "source_label": "test:audit-grant",
@@ -8128,7 +8128,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                             "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
                         ],
                         "event_names": ["workflow_dispatch"],
-                        "products": ["sellyouroutboard"],
+                        "products": ["sellyouroutboard", "launchplane"],
                         "contexts": ["launchplane"],
                         "actions": ["product_profile.read"],
                         "source_label": "test:audit-grant",
@@ -8330,6 +8330,221 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertIsInstance(human_operator, dict)
         assert isinstance(human_operator, dict)
         self.assertEqual(human_operator["type"], "github_human")
+
+    def test_human_authz_policy_grant_endpoint_writes_db_record_and_updates_runtime(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_humans": [
+                        {
+                            "logins": ["alice"],
+                            "roles": ["admin"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["launchplane_service_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=_StubGitHubOAuthClient(_human_identity(role="admin")),  # type: ignore[arg-type]
+            )
+            cookie = _signed_in_cookie(app)
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/authz-policies/github-humans/grants",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "mode": "apply",
+                    "reason": "Allow SYO promotion workflow dispatch from the operator UI.",
+                    "related_issue": "cbusillo/launchplane#153",
+                    "grant": {
+                        "logins": ["alice"],
+                        "roles": ["admin"],
+                        "products": ["sellyouroutboard"],
+                        "contexts": ["sellyouroutboard", "launchplane"],
+                        "actions": [
+                            "generic_web_prod_promotion.dispatch",
+                            "product_environment.read",
+                        ],
+                        "source_label": "test:human-promotion-grant",
+                    },
+                },
+                authorization="",
+                headers={
+                    "Cookie": cookie,
+                    "Idempotency-Key": "authz-human-grant:dispatch",
+                },
+            )
+            repeat_status_code, repeat_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/authz-policies/github-humans/grants",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "mode": "apply",
+                    "reason": "Allow SYO promotion workflow dispatch from the operator UI.",
+                    "related_issue": "cbusillo/launchplane#153",
+                    "grant": {
+                        "logins": ["alice"],
+                        "roles": ["admin"],
+                        "products": ["sellyouroutboard"],
+                        "contexts": ["sellyouroutboard", "launchplane"],
+                        "actions": [
+                            "generic_web_prod_promotion.dispatch",
+                            "product_environment.read",
+                        ],
+                        "source_label": "test:human-promotion-grant",
+                    },
+                },
+                authorization="",
+                headers={
+                    "Cookie": cookie,
+                    "Idempotency-Key": "authz-human-grant:dispatch-repeat",
+                },
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                active_policy = store.list_authz_policy_records(status="active", limit=1)[0]
+            finally:
+                store.close()
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["changed"], True)
+        self.assertEqual(
+            payload["result"]["diff"]["new_github_humans_rule_count"], 2
+        )
+        self.assertEqual(
+            payload["result"]["audit"]["requested_grant_summary"]["login_count"], 1
+        )
+        self.assertNotIn("alice", json.dumps(payload["result"]["audit"]["requested_grant_summary"], sort_keys=True))
+        self.assertEqual(repeat_status_code, 202)
+        self.assertEqual(repeat_payload["result"]["changed"], False)
+        self.assertTrue(
+            active_policy.policy.allows(
+                identity=_human_identity(role="admin"),
+                action="generic_web_prod_promotion.dispatch",
+                product="sellyouroutboard",
+                context="sellyouroutboard",
+            )
+        )
+
+    def test_human_authz_policy_grant_endpoint_dry_run_does_not_write_or_reload(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_humans": [
+                        {
+                            "logins": ["alice"],
+                            "roles": ["admin"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["launchplane_service_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=_StubGitHubOAuthClient(_human_identity(role="admin")),  # type: ignore[arg-type]
+            )
+            profile_payload = _product_profile_payload_with_prod()
+            profile_payload["lanes"] = tuple(
+                {**lane, "context": "sellyouroutboard"}
+                for lane in _product_profile_lanes(profile_payload)
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                store.write_product_profile_record(
+                    LaunchplaneProductProfileRecord.model_validate(profile_payload)
+                )
+            finally:
+                store.close()
+            cookie = _signed_in_cookie(app)
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/authz-policies/github-humans/grants",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "mode": "dry_run",
+                    "reason": "Inspect SYO operator promotion grant.",
+                    "related_issue": "cbusillo/launchplane#153",
+                    "grant": {
+                        "logins": ["alice"],
+                        "roles": ["admin"],
+                        "products": ["sellyouroutboard"],
+                        "contexts": ["sellyouroutboard"],
+                        "actions": ["generic_web_prod_promotion.dispatch"],
+                        "source_label": "test:human-promotion-grant",
+                    },
+                },
+                authorization="",
+                headers={
+                    "Cookie": cookie,
+                    "Idempotency-Key": "authz-human-grant:dry-run",
+                },
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                active_records = store.list_authz_policy_records(status="active")
+                dry_run_idempotency_record = store.read_idempotency_record(
+                    scope="github-human:alice",
+                    route_path="/v1/authz-policies/github-humans/grants",
+                    idempotency_key="authz-human-grant:dry-run",
+                )
+            finally:
+                store.close()
+            workflow_status_code, workflow_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/generic-web/prod-promotion-workflow",
+                payload={
+                    "schema_version": 1,
+                    "product": "sellyouroutboard",
+                    "workflow": {
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "context": "sellyouroutboard",
+                        "dry_run": True,
+                    },
+                },
+                authorization="",
+                headers={"Cookie": cookie},
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "dry_run")
+        self.assertEqual(payload["result"]["changed"], True)
+        self.assertEqual(len(active_records), 1)
+        self.assertIsNone(dry_run_idempotency_record)
+        self.assertEqual(workflow_status_code, 403)
+        self.assertEqual(workflow_payload["error"]["code"], "authorization_denied")
 
     def test_authz_policy_grant_endpoint_apply_requires_reason(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add DB-backed GitHub human authz grant models, service route, and CLI command
- keep apply/dry-run semantics aligned with workflow grants, including immediate in-process policy reload on apply
- document the human-grant operator path and extend authz/service coverage

## Validation
- uv run python -m unittest tests.test_authz_grant_service tests.test_service_auth tests.test_product_read_service tests.test_product_environment_read_model
- uv run python -m unittest tests.test_authz_grant_service tests.test_service -k authz_policy_grant
- uv run python -m unittest tests.test_every_code_reconciliation
- pnpm --dir frontend install --frozen-lockfile && pnpm --dir frontend validate
- uv run python -m unittest

Refs #153
