### PR TITLE
Add read-only terminal-agent auth

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -66,6 +66,9 @@ jobs:
       LAUNCHPLANE_WORK_GRAPH_GH_TOKEN: ${{ secrets.LAUNCHPLANE_WORK_GRAPH_GH_TOKEN }}
       LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN: ${{ secrets.LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN }}
       LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET: ${{ secrets.LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET }}
+      LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN: ${{ secrets.LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN }}
+      LAUNCHPLANE_TERMINAL_AGENT_SUBJECT: ${{ vars.LAUNCHPLANE_TERMINAL_AGENT_SUBJECT }}
+      LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL: ${{ vars.LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL }}
     steps:
       - name: Resolve deploy inputs
         id: prep
@@ -228,6 +231,9 @@ jobs:
                 --arg enable_every_code_runtime_secrets "${LAUNCHPLANE_ENABLE_EVERY_CODE_RUNTIME_SECRETS:-}" \
                 --arg every_code_worker_token "${LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN:-}" \
                 --arg every_code_webhook_secret "${LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET:-}" \
+                --arg terminal_agent_read_token "${LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN:-}" \
+                --arg terminal_agent_subject "${LAUNCHPLANE_TERMINAL_AGENT_SUBJECT:-}" \
+                --arg terminal_agent_token_label "${LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL:-}" \
                 --argjson omit_every_code_env '${{ inputs.omit_every_code_env || false }}' \
                 '(
                   {
@@ -236,7 +242,10 @@ jobs:
                   LAUNCHPLANE_PUBLIC_URL: $public_url,
                   LAUNCHPLANE_SESSION_SECRET: $session_secret,
                   LAUNCHPLANE_COOKIE_SECURE: $cookie_secure,
-                  LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS: $bootstrap_admin_emails
+                  LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS: $bootstrap_admin_emails,
+                  LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN: $terminal_agent_read_token,
+                  LAUNCHPLANE_TERMINAL_AGENT_SUBJECT: $terminal_agent_subject,
+                  LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL: $terminal_agent_token_label
                   }
                   + (
                     if (($omit_every_code_env | not)

--- a/control_plane/authz_grant_service.py
+++ b/control_plane/authz_grant_service.py
@@ -11,11 +11,14 @@ from control_plane.contracts.authz_policy_record import (
     build_authz_policy_record_id,
 )
 from control_plane.service_auth import (
+    GitHubActionsIdentity,
     GitHubActionsPolicyRule,
     GitHubHumanPolicyRule,
     GitHubHumanIdentity,
     LaunchplaneAuthzPolicy,
     LaunchplaneIdentity,
+    TerminalAgentIdentity,
+    TerminalAgentPolicyRule,
 )
 
 
@@ -170,9 +173,79 @@ class AuthzPolicyGitHubHumanGrantEnvelope(BaseModel):
         return self
 
 
-AuthzPolicyGrant = AuthzPolicyGitHubActionsGrant | AuthzPolicyGitHubHumanGrant
+class AuthzPolicyTerminalAgentGrant(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    subjects: tuple[str, ...] = ()
+    token_labels: tuple[str, ...] = ()
+    products: tuple[str, ...] = ()
+    contexts: tuple[str, ...] = ()
+    actions: tuple[str, ...]
+    source_label: str = "service:authz-terminal-agent-policy-grant"
+
+    @staticmethod
+    def _normalized_tuple(values: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(value.strip() for value in values if value.strip())
+
+    @model_validator(mode="after")
+    def _validate_grant(self) -> "AuthzPolicyTerminalAgentGrant":
+        self.subjects = self._normalized_tuple(self.subjects)
+        self.token_labels = self._normalized_tuple(self.token_labels)
+        self.products = self._normalized_tuple(self.products)
+        self.contexts = self._normalized_tuple(self.contexts)
+        self.actions = self._normalized_tuple(self.actions)
+        if not self.subjects:
+            raise ValueError("Authz terminal-agent policy grant requires a subject.")
+        if not self.token_labels:
+            raise ValueError("Authz terminal-agent policy grant requires a token label.")
+        if not self.actions:
+            raise ValueError("Authz terminal-agent policy grant requires at least one action.")
+        self.source_label = (
+            self.source_label.strip() or "service:authz-terminal-agent-policy-grant"
+        )
+        return self
+
+    def to_policy_rule(self) -> TerminalAgentPolicyRule:
+        return TerminalAgentPolicyRule(
+            subjects=self.subjects,
+            token_labels=self.token_labels,
+            products=self.products,
+            contexts=self.contexts,
+            actions=self.actions,
+        )
+
+
+class AuthzPolicyTerminalAgentGrantEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    mode: Literal["dry_run", "apply"] = "apply"
+    reason: str = ""
+    related_issue: str = ""
+    grant: AuthzPolicyTerminalAgentGrant
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "AuthzPolicyTerminalAgentGrantEnvelope":
+        if self.product.strip() != "launchplane":
+            raise ValueError("Authz terminal-agent policy grant writes require product 'launchplane'.")
+        self.product = "launchplane"
+        self.reason = self.reason.strip()
+        self.related_issue = self.related_issue.strip()
+        if self.mode == "apply" and not self.reason:
+            raise ValueError("Authz terminal-agent policy grant apply requires reason.")
+        return self
+
+
+AuthzPolicyGrant = (
+    AuthzPolicyGitHubActionsGrant
+    | AuthzPolicyGitHubHumanGrant
+    | AuthzPolicyTerminalAgentGrant
+)
 AuthzPolicyGrantEnvelope = (
-    AuthzPolicyGitHubActionsGrantEnvelope | AuthzPolicyGitHubHumanGrantEnvelope
+    AuthzPolicyGitHubActionsGrantEnvelope
+    | AuthzPolicyGitHubHumanGrantEnvelope
+    | AuthzPolicyTerminalAgentGrantEnvelope
 )
 
 
@@ -185,6 +258,7 @@ def summarize_authz_policy_record(record: LaunchplaneAuthzPolicyRecord) -> dict[
         "policy_sha256": record.policy_sha256,
         "github_actions_rule_count": len(record.policy.github_actions),
         "github_humans_rule_count": len(record.policy.github_humans),
+        "terminal_agents_rule_count": len(record.policy.terminal_agents),
     }
 
 
@@ -195,6 +269,13 @@ def authz_policy_operator_payload(identity: LaunchplaneIdentity) -> dict[str, ob
             "login": identity.login,
             "role": identity.role,
         }
+    if isinstance(identity, TerminalAgentIdentity):
+        return {
+            "type": "terminal_agent",
+            "subject": identity.subject,
+            "token_label": identity.token_label,
+        }
+    assert isinstance(identity, GitHubActionsIdentity)
     return {
         "type": "github_actions",
         "repository": identity.repository,
@@ -211,6 +292,8 @@ def authz_policy_grant_diff(
     desired_rule = grant.to_policy_rule()
     if isinstance(grant, AuthzPolicyGitHubHumanGrant):
         changed = not any(rule == desired_rule for rule in current_policy.github_humans)
+    elif isinstance(grant, AuthzPolicyTerminalAgentGrant):
+        changed = not any(rule == desired_rule for rule in current_policy.terminal_agents)
     else:
         changed = not any(rule == desired_rule for rule in current_policy.github_actions)
     return {
@@ -221,6 +304,9 @@ def authz_policy_grant_diff(
         "previous_github_humans_rule_count": len(current_policy.github_humans),
         "new_github_humans_rule_count": len(current_policy.github_humans)
         + int(changed and isinstance(grant, AuthzPolicyGitHubHumanGrant)),
+        "previous_terminal_agents_rule_count": len(current_policy.terminal_agents),
+        "new_terminal_agents_rule_count": len(current_policy.terminal_agents)
+        + int(changed and isinstance(grant, AuthzPolicyTerminalAgentGrant)),
     }
 
 
@@ -271,6 +357,15 @@ def authz_policy_grant_response_audit_payload(
                 "contexts": requested_grant.get("contexts") or (),
                 "actions": requested_grant.get("actions") or (),
             }
+        elif "subjects" in requested_grant or "token_labels" in requested_grant:
+            response_audit["requested_grant_summary"] = {
+                "principal_type": "terminal_agent",
+                "subject_count": len(requested_grant.get("subjects") or ()),
+                "token_label_count": len(requested_grant.get("token_labels") or ()),
+                "products": requested_grant.get("products") or (),
+                "contexts": requested_grant.get("contexts") or (),
+                "actions": requested_grant.get("actions") or (),
+            }
         else:
             response_audit["requested_grant_summary"] = {
                 "principal_type": "github_human",
@@ -309,6 +404,26 @@ def plan_github_human_authz_policy_grant(
     *,
     record_store: AuthzPolicyRecordStore,
     grant: AuthzPolicyGitHubHumanGrant,
+) -> tuple[LaunchplaneAuthzPolicy, LaunchplaneAuthzPolicyRecord, dict[str, object]]:
+    active_records = record_store.list_authz_policy_records(status="active", limit=1)
+    if not active_records:
+        raise ValueError("No active Launchplane authz policy record found.")
+    current_record = active_records[0]
+    current_policy = current_record.policy
+    return (
+        current_policy,
+        current_record,
+        authz_policy_grant_diff(
+            current_policy=current_policy,
+            grant=grant,
+        ),
+    )
+
+
+def plan_terminal_agent_authz_policy_grant(
+    *,
+    record_store: AuthzPolicyRecordStore,
+    grant: AuthzPolicyTerminalAgentGrant,
 ) -> tuple[LaunchplaneAuthzPolicy, LaunchplaneAuthzPolicyRecord, dict[str, object]]:
     active_records = record_store.list_authz_policy_records(status="active", limit=1)
     if not active_records:
@@ -429,6 +544,76 @@ def write_github_human_authz_policy_grant(
 
     updated_policy = current_policy.model_copy(
         update={"github_humans": current_policy.github_humans + (desired_rule,)}
+    )
+    updated_at = now_timestamp()
+    policy_sha256 = authz_policy_sha256(updated_policy)
+    record = LaunchplaneAuthzPolicyRecord(
+        record_id=build_authz_policy_record_id(
+            updated_at=updated_at,
+            policy_sha256=policy_sha256,
+        ),
+        status="active",
+        source=request.grant.source_label,
+        updated_at=updated_at,
+        policy_sha256=policy_sha256,
+        policy=updated_policy,
+        audit=authz_policy_grant_audit_payload(
+            request=request,
+            identity=identity,
+            previous_record=current_record,
+            new_record=None,
+            changed=True,
+            trace_id=trace_id,
+            now_timestamp=now_timestamp,
+        ),
+    )
+    record.audit = authz_policy_grant_audit_payload(
+        request=request,
+        identity=identity,
+        previous_record=current_record,
+        new_record=record,
+        changed=True,
+        trace_id=trace_id,
+        now_timestamp=now_timestamp,
+    )
+    record_store.write_authz_policy_record(record)
+    return updated_policy, record, changed, diff, record.audit
+
+
+def write_terminal_agent_authz_policy_grant(
+    *,
+    record_store: AuthzPolicyRecordStore,
+    request: AuthzPolicyTerminalAgentGrantEnvelope,
+    identity: LaunchplaneIdentity,
+    trace_id: str,
+    now_timestamp: TimestampProvider,
+) -> tuple[
+    LaunchplaneAuthzPolicy,
+    LaunchplaneAuthzPolicyRecord,
+    bool,
+    dict[str, object],
+    dict[str, object],
+]:
+    current_policy, current_record, diff = plan_terminal_agent_authz_policy_grant(
+        record_store=record_store,
+        grant=request.grant,
+    )
+    changed = bool(diff["changed"])
+    desired_rule = request.grant.to_policy_rule()
+    if not changed:
+        audit = authz_policy_grant_audit_payload(
+            request=request,
+            identity=identity,
+            previous_record=current_record,
+            new_record=None,
+            changed=False,
+            trace_id=trace_id,
+            now_timestamp=now_timestamp,
+        )
+        return current_policy, current_record, False, diff, audit
+
+    updated_policy = current_policy.model_copy(
+        update={"terminal_agents": current_policy.terminal_agents + (desired_rule,)}
     )
     updated_at = now_timestamp()
     policy_sha256 = authz_policy_sha256(updated_policy)

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -13106,6 +13106,97 @@ def authz_policies_grant_human(
     click.echo(json.dumps(response_payload, indent=2, sort_keys=True))
 
 
+@authz_policies.command("grant-terminal-agent")
+@click.option(
+    "--service-url",
+    required=True,
+    help="Deployed Launchplane service base URL. Shared/prod grants go through the service API.",
+)
+@click.option(
+    "--bearer-token-env",
+    default="LAUNCHPLANE_SERVICE_TOKEN",
+    show_default=True,
+    help="Environment variable containing a short-lived bearer token for the service.",
+)
+@click.option(
+    "--session-cookie",
+    default="",
+    help="Launchplane browser session cookie. Use instead of --bearer-token-env.",
+)
+@click.option("--subject", "subjects", multiple=True, required=True, help="Allowed terminal-agent subject.")
+@click.option(
+    "--token-label",
+    "token_labels",
+    multiple=True,
+    required=True,
+    help="Allowed terminal-agent token label.",
+)
+@click.option("--product", "products", multiple=True, required=True, help="Allowed product.")
+@click.option("--context", "contexts", multiple=True, help="Allowed Launchplane context.")
+@click.option(
+    "--action", "actions", multiple=True, required=True, help="Allowed Launchplane action."
+)
+@click.option("--reason", default="", help="Required audit reason when --apply is used.")
+@click.option(
+    "--related-issue",
+    default="",
+    help="Optional related GitHub issue, e.g. cbusillo/launchplane#426.",
+)
+@click.option("--source-label", default="cli:authz-grant-terminal-agent", show_default=True)
+@click.option(
+    "--idempotency-key", default="", help="Optional explicit Idempotency-Key for apply requests."
+)
+@click.option("--dry-run", "mode", flag_value="dry_run", default="dry_run")
+@click.option("--apply", "mode", flag_value="apply")
+def authz_policies_grant_terminal_agent(
+    service_url: str,
+    bearer_token_env: str,
+    session_cookie: str,
+    subjects: tuple[str, ...],
+    token_labels: tuple[str, ...],
+    products: tuple[str, ...],
+    contexts: tuple[str, ...],
+    actions: tuple[str, ...],
+    reason: str,
+    related_issue: str,
+    source_label: str,
+    idempotency_key: str,
+    mode: str,
+) -> None:
+    bearer_token = ""
+    if not session_cookie.strip():
+        token_env_key = bearer_token_env.strip() or "LAUNCHPLANE_SERVICE_TOKEN"
+        bearer_token = os.environ.get(token_env_key, "").strip()
+        if not bearer_token:
+            raise click.ClickException(
+                f"{token_env_key} is required unless --session-cookie is provided."
+            )
+    payload = {
+        "schema_version": 1,
+        "product": "launchplane",
+        "mode": mode,
+        "reason": reason,
+        "related_issue": related_issue,
+        "grant": {
+            "subjects": list(subjects),
+            "token_labels": list(token_labels),
+            "products": list(products),
+            "contexts": list(contexts),
+            "actions": list(actions),
+            "source_label": source_label,
+        },
+    }
+    response_payload = _post_launchplane_service_json(
+        service_url=service_url,
+        path="/v1/authz-policies/terminal-agents/grants",
+        payload=payload,
+        bearer_token=bearer_token,
+        session_cookie=session_cookie,
+        idempotency_key=idempotency_key,
+    )
+    click.echo(json.dumps(response_payload, indent=2, sort_keys=True))
+
+
 @runtime_key_safety.command("list-policies")
 @click.option(
     "--database-url",

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -109,6 +109,7 @@ from control_plane.service_auth import (
     GitHubHumanIdentity,
     LaunchplaneAuthzPolicy,
     LaunchplaneIdentity,
+    TerminalAgentIdentity,
     TokenVerifier,
     load_authz_policy,
     parse_authz_policy_toml,
@@ -330,6 +331,9 @@ _LAUNCHPLANE_SELF_DEPLOY_OAUTH_ENV_KEYS = frozenset(
         "LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS",
         "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET",
         "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN",
+        "LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN",
+        "LAUNCHPLANE_TERMINAL_AGENT_SUBJECT",
+        "LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL",
         "LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER",
         "LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER",
         "LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT",
@@ -1172,6 +1176,7 @@ _HUMAN_IDENTITY_MUTATION_ROUTES = frozenset(
         _GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.route_path,
         "/v1/authz-policies/github-actions/grants",
         "/v1/authz-policies/github-humans/grants",
+        "/v1/authz-policies/terminal-agents/grants",
     }
 )
 _HUMAN_IDENTITY_READ_MODEL_POST_ROUTES = frozenset({"/v1/work-graph/rank"})
@@ -1783,6 +1788,7 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/evidence/previews/destroyed",
         "/v1/authz-policies/github-actions/grants",
         "/v1/authz-policies/github-humans/grants",
+        "/v1/authz-policies/terminal-agents/grants",
         "/v1/runtime-key-safety/policies/apply",
         "/v1/live-target-runtime/apply",
         "/v1/product-onboarding/apply",
@@ -2717,6 +2723,8 @@ def _idempotency_key(environ: dict[str, object]) -> str:
 def _identity_actor(identity: LaunchplaneIdentity) -> str:
     if isinstance(identity, GitHubHumanIdentity):
         return f"github:{identity.login}"
+    if isinstance(identity, TerminalAgentIdentity):
+        return f"terminal-agent:{identity.subject}"
     return (
         f"github-actions:{identity.repository}:{identity.workflow_ref or identity.job_workflow_ref}"
     )
@@ -2725,6 +2733,8 @@ def _identity_actor(identity: LaunchplaneIdentity) -> str:
 def _idempotency_scope(identity: LaunchplaneIdentity) -> str:
     if isinstance(identity, GitHubHumanIdentity):
         return "|".join(("github-human", identity.login, str(identity.github_id)))
+    if isinstance(identity, TerminalAgentIdentity):
+        return "|".join(("terminal-agent", identity.subject, identity.token_label))
     workflow_ref = identity.workflow_ref or identity.job_workflow_ref or ""
     return "|".join(
         (
@@ -2958,6 +2968,7 @@ def _should_store_idempotency_record(
         in {
             "/v1/authz-policies/github-actions/grants",
             "/v1/authz-policies/github-humans/grants",
+            "/v1/authz-policies/terminal-agents/grants",
         }
         and isinstance(driver_result, dict)
         and driver_result.get("mode") == "dry_run"
@@ -3009,6 +3020,35 @@ def _bearer_token(environ: dict[str, object]) -> str:
 
 def _every_code_worker_token_from_env() -> str:
     return os.environ.get("LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN", "").strip()
+
+
+def _terminal_agent_read_token_from_env() -> str:
+    return os.environ.get("LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN", "").strip()
+
+
+def _terminal_agent_subject_from_env() -> str:
+    return os.environ.get("LAUNCHPLANE_TERMINAL_AGENT_SUBJECT", "local-owner-agent").strip()
+
+
+def _terminal_agent_token_label_from_env() -> str:
+    return os.environ.get("LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL", "local-owner-read").strip()
+
+
+def _terminal_agent_identity_from_bearer(
+    environ: dict[str, object]
+) -> TerminalAgentIdentity | None:
+    expected_token = _terminal_agent_read_token_from_env()
+    if not expected_token:
+        return None
+    try:
+        provided_token = _bearer_token(environ)
+    except PermissionError:
+        return None
+    if not secrets.compare_digest(provided_token, expected_token):
+        return None
+    subject = _terminal_agent_subject_from_env() or "local-owner-agent"
+    token_label = _terminal_agent_token_label_from_env() or "local-owner-read"
+    return TerminalAgentIdentity(subject=subject, token_label=token_label)
 
 
 def _is_every_code_worker_route(*, method: str, path: str) -> bool:
@@ -3322,8 +3362,14 @@ def _read_identity(
     human_identity = _session_identity(environ=environ, session_manager=session_manager)
     if human_identity is not None:
         return human_identity
+    terminal_agent_identity = _terminal_agent_identity_from_bearer(environ)
+    if terminal_agent_identity is not None:
+        return terminal_agent_identity
     token = _bearer_token(environ)
-    return verifier.verify(token)
+    try:
+        return verifier.verify(token)
+    except ValueError as error:
+        raise PermissionError(str(error)) from error
 
 
 def _human_identity_payload(identity: GitHubHumanIdentity) -> dict[str, object]:
@@ -3353,6 +3399,12 @@ def _authz_diagnostic_payload(
             "type": "github_human",
             "login": identity.login,
             "role": identity.role,
+        }
+    elif isinstance(identity, TerminalAgentIdentity):
+        identity_payload = {
+            "type": "terminal_agent",
+            "subject": identity.subject,
+            "token_label": identity.token_label,
         }
     else:
         identity_payload = {
@@ -4512,6 +4564,22 @@ def create_launchplane_service_app(
                     identity = verifier.verify(token)
                     if not isinstance(identity, GitHubActionsIdentity):
                         raise PermissionError("Mutation routes require GitHub Actions OIDC.")
+            if isinstance(identity, TerminalAgentIdentity) and method != "GET":
+                return _json_response(
+                    start_response=start_response,
+                    status_code=403,
+                    payload={
+                        "status": "rejected",
+                        "trace_id": request_trace_id,
+                        "error": {
+                            "code": "authorization_denied",
+                            "message": (
+                                "Terminal agent credentials can only read redacted "
+                                "Launchplane context."
+                            ),
+                        },
+                    },
+                )
             if method == "GET":
                 assert read_route is not None
                 action, params = read_route
@@ -5726,6 +5794,124 @@ def create_launchplane_service_app(
                         authz_policy_record=authz_policy_record,
                         changed=changed,
                         mode=human_authz_grant_request.mode,
+                        diff=diff,
+                        audit=audit,
+                    )
+                )
+            elif path == "/v1/authz-policies/terminal-agents/grants":
+                terminal_authz_grant_request = control_plane_authz_grant_service.AuthzPolicyTerminalAgentGrantEnvelope.model_validate(
+                    payload
+                )
+                if not isinstance(record_store, PostgresRecordStore):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "database_required",
+                                "message": "Authz terminal-agent policy grant writes require Launchplane database storage.",
+                            },
+                        },
+                    )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="launchplane_service_deploy.execute",
+                    product=terminal_authz_grant_request.product,
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot write Launchplane authz terminal-agent policy grants.",
+                            },
+                        },
+                    )
+                if terminal_authz_grant_request.mode == "apply":
+                    idempotent_response = _check_idempotent_request(
+                        record_store=record_store,
+                        scope=request_scope,
+                        route_path=path,
+                        idempotency_key=request_idempotency_key,
+                        request_fingerprint=request_fingerprint,
+                        start_response=start_response,
+                        trace_id=request_trace_id,
+                    )
+                    if idempotent_response is not None:
+                        return idempotent_response
+                try:
+                    (
+                        current_policy,
+                        current_record,
+                        diff,
+                    ) = control_plane_authz_grant_service.plan_terminal_agent_authz_policy_grant(
+                        record_store=record_store,
+                        grant=terminal_authz_grant_request.grant,
+                    )
+                    audit = control_plane_authz_grant_service.authz_policy_grant_audit_payload(
+                        request=terminal_authz_grant_request,
+                        identity=identity,
+                        previous_record=current_record,
+                        new_record=None,
+                        changed=bool(diff["changed"]),
+                        trace_id=request_trace_id,
+                        now_timestamp=_now_timestamp,
+                    )
+                    authz_policy_record = current_record
+                    changed = bool(diff["changed"])
+                    if terminal_authz_grant_request.mode == "apply":
+                        (
+                            updated_policy,
+                            authz_policy_record,
+                            changed,
+                            diff,
+                            audit,
+                        ) = control_plane_authz_grant_service.write_terminal_agent_authz_policy_grant(
+                            record_store=record_store,
+                            request=terminal_authz_grant_request,
+                            identity=identity,
+                            trace_id=request_trace_id,
+                            now_timestamp=_now_timestamp,
+                        )
+                    else:
+                        updated_policy = current_policy
+                        authz_policy_record = LaunchplaneAuthzPolicyRecord(
+                            record_id=current_record.record_id,
+                            status=current_record.status,
+                            source=current_record.source,
+                            updated_at=current_record.updated_at,
+                            policy_sha256=current_record.policy_sha256,
+                            policy=current_record.policy,
+                            audit=audit,
+                        )
+                except ValueError:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authz_policy_unavailable",
+                                "message": "Launchplane active authz policy is unavailable.",
+                            },
+                        },
+                    )
+                if terminal_authz_grant_request.mode == "apply":
+                    authz_policy = updated_policy
+                    resolved_authz_policy_sha256 = authz_policy_record.policy_sha256
+                    resolved_authz_policy_source = "db"
+                result, driver_result = (
+                    control_plane_authz_grant_service.build_authz_policy_grant_service_result(
+                        authz_policy_record=authz_policy_record,
+                        changed=changed,
+                        mode=terminal_authz_grant_request.mode,
                         diff=diff,
                         audit=audit,
                     )

--- a/control_plane/service_auth.py
+++ b/control_plane/service_auth.py
@@ -39,7 +39,13 @@ class GitHubHumanIdentity:
     role: Literal["read_only", "admin"]
 
 
-LaunchplaneIdentity = GitHubActionsIdentity | GitHubHumanIdentity
+@dataclass(frozen=True)
+class TerminalAgentIdentity:
+    subject: str
+    token_label: str
+
+
+LaunchplaneIdentity = GitHubActionsIdentity | GitHubHumanIdentity | TerminalAgentIdentity
 
 
 class TokenVerifier(Protocol):
@@ -208,12 +214,43 @@ class GitHubHumanPolicyRule(BaseModel):
         return True
 
 
+class TerminalAgentPolicyRule(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    subjects: tuple[str, ...] = ()
+    token_labels: tuple[str, ...] = ()
+    products: tuple[str, ...] = ()
+    contexts: tuple[str, ...] = ()
+    actions: tuple[str, ...] = ()
+
+    @staticmethod
+    def _matches_any(value: str, allowed_values: tuple[str, ...]) -> bool:
+        normalized_value = value.strip()
+        return any(fnmatchcase(normalized_value, allowed_value) for allowed_value in allowed_values)
+
+    def allows(
+        self, *, identity: TerminalAgentIdentity, action: str, product: str, context: str
+    ) -> bool:
+        if self.subjects and not self._matches_any(identity.subject, self.subjects):
+            return False
+        if self.token_labels and not self._matches_any(identity.token_label, self.token_labels):
+            return False
+        if self.products and product not in self.products:
+            return False
+        if self.contexts and context not in self.contexts:
+            return False
+        if self.actions and action not in self.actions:
+            return False
+        return True
+
+
 class LaunchplaneAuthzPolicy(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     schema_version: int = Field(default=1, ge=1)
     github_actions: tuple[GitHubActionsPolicyRule, ...] = ()
     github_humans: tuple[GitHubHumanPolicyRule, ...] = ()
+    terminal_agents: tuple[TerminalAgentPolicyRule, ...] = ()
 
     def allows(
         self, *, identity: LaunchplaneIdentity, action: str, product: str, context: str
@@ -222,6 +259,11 @@ class LaunchplaneAuthzPolicy(BaseModel):
             return any(
                 rule.allows(identity=identity, action=action, product=product, context=context)
                 for rule in self.github_humans
+            )
+        if isinstance(identity, TerminalAgentIdentity):
+            return any(
+                rule.allows(identity=identity, action=action, product=product, context=context)
+                for rule in self.terminal_agents
             )
         return any(
             rule.allows(identity=identity, action=action, product=product, context=context)

--- a/docs/config-boundary.md
+++ b/docs/config-boundary.md
@@ -40,6 +40,7 @@ it can reach, trust, or decrypt DB-backed state.
 | Process wiring | `LAUNCHPLANE_SERVICE_HOST`, `LAUNCHPLANE_SERVICE_PORT`, `LAUNCHPLANE_SERVICE_AUDIENCE`, `LAUNCHPLANE_STATE_DIR`, `LAUNCHPLANE_APP_ROOT` | Service target env | Runtime/process wiring, not product config. |
 | Every Code webhook ingress secret | `LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET` | Bootstrap env or platform secret | Required before unauthenticated GitHub webhook ingress can trust the request body. Store it outside repository config. |
 | Every Code worker bearer token | `LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN` | Bootstrap env or platform secret | Shared by the Launchplane service and local worker to authorize worker read/claim/status routes. Store it outside repository config. |
+| Terminal-agent read bearer token | `LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN`, optional `LAUNCHPLANE_TERMINAL_AGENT_SUBJECT`, optional `LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL` | Bootstrap env or platform secret | Shared by the Launchplane service and a trusted local terminal agent for redacted `GET` context reads only. Store it outside repository config and keep it distinct from Every Code worker credentials. |
 
 The Launchplane self-deploy workflow has a manual `omit_every_code_env`
 compatibility input for the one deploy that teaches an older running service to

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -108,6 +108,9 @@ title: Secrets
   - `LAUNCHPLANE_DATABASE_URL`
   - `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`
   - policy/bootstrap selectors such as `LAUNCHPLANE_POLICY_*`
+  - service-ingress bearer secrets such as
+    `LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN` and
+    `LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN`
 - Treat these as DB-backed Launchplane-owned data instead of live service-host
   env once the shared store is available:
   - `DOKPLOY_HOST`

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -53,6 +53,7 @@ VeriReel product paths:
 - authz policy maintenance route:
   - `POST /v1/authz-policies/github-actions/grants`
   - `POST /v1/authz-policies/github-humans/grants`
+  - `POST /v1/authz-policies/terminal-agents/grants`
 - Every Code local automation work-request routes:
   - `POST /v1/every-code/github-webhook`
   - `GET /v1/every-code/work-requests`
@@ -98,7 +99,8 @@ and preview mutations as authenticated Launchplane routes. The authz policy
 grant routes accept GitHub Actions OIDC callers and authenticated admin human
 sessions, require the `launchplane_service_deploy.execute` action, and remain
 the service-owned write/reload boundary for DB-backed GitHub Actions and GitHub
-human policy rules. Grant requests support `dry_run` and `apply` modes. Apply
+human policy rules. The terminal-agent grant route uses the same boundary for
+DB-backed terminal-agent read rules. Grant requests support `dry_run` and `apply` modes. Apply
 requests must include an audit reason, write a new active policy record only
 when the grant is not already present, and immediately refresh the in-process
 policy used by the current service worker. Responses return record metadata,
@@ -134,6 +136,22 @@ scoped in code to `GET /v1/every-code/work-requests`,
 write product records, or access other Launchplane service routes. This keeps
 remote DB credentials on the Launchplane host while still allowing visible local
 Code/tmux work sessions to claim, rerun terminal requests, and report progress.
+
+Local terminal agents that need Launchplane context use a separate read-only
+bearer credential, not the browser OAuth session cookie and not
+`LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN`. Configure
+`LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN` on the service and provide the same
+secret to the trusted local terminal agent out of band. Optional
+`LAUNCHPLANE_TERMINAL_AGENT_SUBJECT` and
+`LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL` values identify the local owner subject
+and token label used by `terminal_agents` authz policy rules; the defaults are
+`local-owner-agent` and `local-owner-read`. The service only accepts this
+identity on `GET` routes, so even an overly broad terminal-agent policy rule
+cannot dispatch product config writes, prod promotion, destructive cleanup,
+authz policy mutation, read-model POSTs, or plaintext secret reveal routes.
+Policy still scopes which redacted read actions and product/context pairs the
+agent can access, such as `product_environment.read` for product environment and
+config-status diagnostics.
 
 `POST /v1/work-graph/rank` ranks a caller-supplied work graph snapshot and
 returns the queue payload under `result.queue`. The route requires the
@@ -188,6 +206,12 @@ browser session after OAuth callback and sets an `HttpOnly`, `SameSite=Lax`
 session cookie signed with `LAUNCHPLANE_SESSION_SECRET`. Sessions are backed by
 the Launchplane database when `LAUNCHPLANE_DATABASE_URL` is configured. GitHub
 access tokens stay server-side and are not exposed to the React operator UI.
+
+Local terminal agents should use the dedicated terminal-agent read bearer token
+when they only need redacted Launchplane context from a trusted operator shell.
+This avoids copying browser session cookies into terminal processes and keeps
+agent credentials independent from GitHub Actions OIDC and Every Code worker
+automation.
 
 Launchplane should verify:
 

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -384,6 +384,7 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
                     control_plane_service._GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.route_path,
                     "/v1/authz-policies/github-actions/grants",
                     "/v1/authz-policies/github-humans/grants",
+                    "/v1/authz-policies/terminal-agents/grants",
                 }
             ),
         )

--- a/tests/test_every_code_reconciliation.py
+++ b/tests/test_every_code_reconciliation.py
@@ -154,6 +154,61 @@ class EveryCodeIssueReconciliationTests(unittest.TestCase):
         self.assertEqual(grant["roles"], ["admin"])
         self.assertEqual(grant["actions"], ["generic_web_prod_promotion.dispatch"])
 
+    def test_cli_authz_grant_terminal_agent_posts_service_request(self) -> None:
+        runner = CliRunner()
+        captured_request: dict[str, object] = {}
+
+        def fake_post(**kwargs: object) -> dict[str, object]:
+            captured_request.update(kwargs)
+            return {
+                "status": "accepted",
+                "result": {"mode": "apply", "changed": True},
+            }
+
+        with patch("control_plane.cli._post_launchplane_service_json", side_effect=fake_post):
+            result = runner.invoke(
+                main,
+                [
+                    "authz-policies",
+                    "grant-terminal-agent",
+                    "--service-url",
+                    "https://launchplane.example",
+                    "--session-cookie",
+                    "launchplane_session=signed",
+                    "--subject",
+                    "local-owner-agent",
+                    "--token-label",
+                    "local-owner-read",
+                    "--product",
+                    "sellyouroutboard",
+                    "--context",
+                    "sellyouroutboard",
+                    "--action",
+                    "product_environment.read",
+                    "--reason",
+                    "Allow local terminal agent product context reads.",
+                    "--related-issue",
+                    "cbusillo/launchplane#426",
+                    "--idempotency-key",
+                    "authz-terminal-agent-grant:syo-read",
+                    "--apply",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(captured_request["bearer_token"], "")
+        self.assertEqual(captured_request["session_cookie"], "launchplane_session=signed")
+        self.assertEqual(captured_request["path"], "/v1/authz-policies/terminal-agents/grants")
+        self.assertEqual(captured_request["idempotency_key"], "authz-terminal-agent-grant:syo-read")
+        payload = captured_request["payload"]
+        assert isinstance(payload, dict)
+        self.assertEqual(payload["mode"], "apply")
+        grant = payload["grant"]
+        assert isinstance(grant, dict)
+        self.assertEqual(grant["subjects"], ["local-owner-agent"])
+        self.assertEqual(grant["token_labels"], ["local-owner-read"])
+        self.assertEqual(grant["actions"], ["product_environment.read"])
+
     def test_creates_queued_request_when_trigger_label_is_present(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             store = FilesystemRecordStore(state_dir=Path(tempdir))

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -55,6 +55,7 @@ from control_plane.service_auth import (
     GitHubActionsIdentity,
     GitHubHumanIdentity,
     LaunchplaneAuthzPolicy,
+    TerminalAgentIdentity,
 )
 from control_plane.service_human_auth import (
     GITHUB_EMAILS_URL,
@@ -4303,6 +4304,184 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
 
+    def test_terminal_agent_read_token_can_read_redacted_product_environment(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
+            )
+            store.write_runtime_environment_record(
+                RuntimeEnvironmentRecord(
+                    scope="instance",
+                    context="example-site",
+                    instance="prod",
+                    env={"INTERNAL_CALLBACK_URL": "https://internal.example-site.invalid"},
+                    updated_at="2026-05-02T22:32:00Z",
+                    source_label="test",
+                )
+            )
+            with patch.dict(
+                os.environ,
+                {control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"},
+                clear=True,
+            ):
+                control_plane_secrets.write_secret_value(
+                    record_store=store,
+                    scope="context_instance",
+                    integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+                    name="SMTP_PASSWORD",
+                    plaintext_value="super-secret-password",
+                    binding_key="SMTP_PASSWORD",
+                    context_name="example-site",
+                    instance_name="prod",
+                    actor="test",
+                )
+            store.close()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "terminal_agents": [
+                        {
+                            "subjects": ["local-owner-agent"],
+                            "token_labels": ["local-owner-read"],
+                            "products": ["example-site"],
+                            "contexts": ["example-site"],
+                            "actions": ["product_environment.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            with patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN": "terminal-read-token"},
+                clear=True,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/products/example-site/environments/prod/config-status",
+                    authorization="Bearer terminal-read-token",
+                )
+
+        response_text = json.dumps(payload)
+        self.assertEqual(status_code, 200)
+        self.assertEqual(payload["config_status"]["product"], "example-site")
+        self.assertNotIn("https://internal.example-site.invalid", response_text)
+        self.assertNotIn("super-secret-password", response_text)
+
+    def test_terminal_agent_read_token_rejects_non_read_routes_even_if_policy_grants_action(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload_with_prod())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "terminal_agents": [
+                        {
+                            "subjects": ["local-owner-agent"],
+                            "token_labels": ["local-owner-read"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["generic_web_prod_promotion.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN": "terminal-read-token"},
+                clear=True,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/prod-promotion",
+                    authorization="Bearer terminal-read-token",
+                    payload={
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "promotion": {
+                            "schema_version": 1,
+                            "product": "sellyouroutboard",
+                            "artifact_id": "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+                            "source_git_ref": "abc123",
+                        },
+                    },
+                )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertIn("can only read", payload["error"]["message"])
+
+    def test_terminal_agent_read_token_requires_matching_configured_secret(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "terminal_agents": [
+                        {
+                            "subjects": ["local-owner-agent"],
+                            "token_labels": ["local-owner-read"],
+                            "products": ["example-site"],
+                            "contexts": ["example-site"],
+                            "actions": ["product_environment.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN": "terminal-read-token"},
+                clear=True,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/products/example-site/environments/prod/config-status",
+                    authorization="Bearer wrong-token",
+                )
+
+        self.assertEqual(status_code, 401)
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+
     def test_product_context_cutover_endpoint_updates_profile_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -7932,6 +8111,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                                 "LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS": ("info@shinycomputers.com"),
                                 "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": ("webhook-secret"),
                                 "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "worker-token",
+                                "LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN": "terminal-read-token",
+                                "LAUNCHPLANE_TERMINAL_AGENT_SUBJECT": "local-owner-agent",
+                                "LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL": "local-owner-read",
                                 "LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER": "cbusillo",
                                 "LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER": "4",
                                 "LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT": "200",
@@ -7969,6 +8151,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
             updated_env_text,
         )
         self.assertIn("LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN=worker-token", updated_env_text)
+        self.assertIn("LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN=terminal-read-token", updated_env_text)
+        self.assertIn("LAUNCHPLANE_TERMINAL_AGENT_SUBJECT=local-owner-agent", updated_env_text)
+        self.assertIn("LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL=local-owner-read", updated_env_text)
         self.assertIn("LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER=cbusillo", updated_env_text)
         self.assertIn("LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER=4", updated_env_text)
         self.assertIn("LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT=200", updated_env_text)
@@ -8545,6 +8730,210 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertIsNone(dry_run_idempotency_record)
         self.assertEqual(workflow_status_code, 403)
         self.assertEqual(workflow_payload["error"]["code"], "authorization_denied")
+
+    def test_terminal_agent_authz_policy_grant_endpoint_writes_db_record_and_updates_runtime(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_humans": [
+                        {
+                            "logins": ["alice"],
+                            "roles": ["admin"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["launchplane_service_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=_StubGitHubOAuthClient(_human_identity(role="admin")),  # type: ignore[arg-type]
+            )
+            cookie = _signed_in_cookie(app)
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/authz-policies/terminal-agents/grants",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "mode": "apply",
+                    "reason": "Allow local terminal agent product context reads.",
+                    "related_issue": "cbusillo/launchplane#426",
+                    "grant": {
+                        "subjects": ["local-owner-agent"],
+                        "token_labels": ["local-owner-read"],
+                        "products": ["sellyouroutboard"],
+                        "contexts": ["sellyouroutboard"],
+                        "actions": ["product_environment.read"],
+                        "source_label": "test:terminal-agent-grant",
+                    },
+                },
+                authorization="",
+                headers={
+                    "Cookie": cookie,
+                    "Idempotency-Key": "authz-terminal-agent-grant:syo-read",
+                },
+            )
+            repeat_status_code, repeat_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/authz-policies/terminal-agents/grants",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "mode": "apply",
+                    "reason": "Allow local terminal agent product context reads.",
+                    "related_issue": "cbusillo/launchplane#426",
+                    "grant": {
+                        "subjects": ["local-owner-agent"],
+                        "token_labels": ["local-owner-read"],
+                        "products": ["sellyouroutboard"],
+                        "contexts": ["sellyouroutboard"],
+                        "actions": ["product_environment.read"],
+                        "source_label": "test:terminal-agent-grant",
+                    },
+                },
+                authorization="",
+                headers={
+                    "Cookie": cookie,
+                    "Idempotency-Key": "authz-terminal-agent-grant:syo-read-repeat",
+                },
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                active_policy = store.list_authz_policy_records(status="active", limit=1)[0]
+            finally:
+                store.close()
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["changed"], True)
+        self.assertEqual(
+            payload["result"]["diff"]["new_terminal_agents_rule_count"], 1
+        )
+        self.assertEqual(
+            payload["result"]["audit"]["requested_grant_summary"]["subject_count"], 1
+        )
+        self.assertNotIn(
+            "local-owner-agent",
+            json.dumps(payload["result"]["audit"]["requested_grant_summary"], sort_keys=True),
+        )
+        self.assertEqual(repeat_status_code, 202)
+        self.assertEqual(repeat_payload["result"]["changed"], False)
+        self.assertTrue(
+            active_policy.policy.allows(
+                identity=TerminalAgentIdentity(
+                    subject="local-owner-agent", token_label="local-owner-read"
+                ),
+                action="product_environment.read",
+                product="sellyouroutboard",
+                context="sellyouroutboard",
+            )
+        )
+
+    def test_terminal_agent_authz_policy_grant_endpoint_dry_run_does_not_write_or_reload(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_humans": [
+                        {
+                            "logins": ["alice"],
+                            "roles": ["admin"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["launchplane_service_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=_StubGitHubOAuthClient(_human_identity(role="admin")),  # type: ignore[arg-type]
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                store.write_product_profile_record(
+                    LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
+                )
+            finally:
+                store.close()
+            cookie = _signed_in_cookie(app)
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/authz-policies/terminal-agents/grants",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "mode": "dry_run",
+                    "reason": "Inspect terminal-agent product context grant.",
+                    "related_issue": "cbusillo/launchplane#426",
+                    "grant": {
+                        "subjects": ["local-owner-agent"],
+                        "token_labels": ["local-owner-read"],
+                        "products": ["example-site"],
+                        "contexts": ["example-site"],
+                        "actions": ["product_environment.read"],
+                        "source_label": "test:terminal-agent-grant",
+                    },
+                },
+                authorization="",
+                headers={
+                    "Cookie": cookie,
+                    "Idempotency-Key": "authz-terminal-agent-grant:dry-run",
+                },
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                active_records = store.list_authz_policy_records(status="active")
+                dry_run_idempotency_record = store.read_idempotency_record(
+                    scope="github-human:alice",
+                    route_path="/v1/authz-policies/terminal-agents/grants",
+                    idempotency_key="authz-terminal-agent-grant:dry-run",
+                )
+            finally:
+                store.close()
+
+            with patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN": "terminal-read-token"},
+                clear=True,
+            ):
+                read_status_code, read_payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/products/example-site/environments/prod/config-status",
+                    authorization="Bearer terminal-read-token",
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "dry_run")
+        self.assertEqual(payload["result"]["changed"], True)
+        self.assertEqual(len(active_records), 1)
+        self.assertIsNone(dry_run_idempotency_record)
+        self.assertEqual(read_status_code, 403)
+        self.assertEqual(read_payload["error"]["code"], "authorization_denied")
 
     def test_authz_policy_grant_endpoint_apply_requires_reason(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -12,6 +12,8 @@ from control_plane.service_auth import (
     GitHubHumanPolicyRule,
     GitHubOidcVerifier,
     LaunchplaneAuthzPolicy,
+    TerminalAgentIdentity,
+    TerminalAgentPolicyRule,
     parse_authz_policy_toml,
 )
 from control_plane.service_human_auth import (
@@ -70,6 +72,18 @@ def _human_identity(**overrides: object) -> GitHubHumanIdentity:
         organizations=values["organizations"],  # type: ignore[arg-type]
         teams=values["teams"],  # type: ignore[arg-type]
         role=values["role"],  # type: ignore[arg-type]
+    )
+
+
+def _terminal_agent_identity(**overrides: object) -> TerminalAgentIdentity:
+    values: dict[str, object] = {
+        "subject": "local-owner-agent",
+        "token_label": "local-owner-read",
+    }
+    values.update(overrides)
+    return TerminalAgentIdentity(
+        subject=str(values["subject"]),
+        token_label=str(values["token_label"]),
     )
 
 
@@ -263,6 +277,80 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
             )
         )
 
+    def test_terminal_agent_policy_fails_closed_by_subject_label_and_scope(self) -> None:
+        rule = TerminalAgentPolicyRule(
+            subjects=("local-*-agent",),
+            token_labels=("local-owner-*",),
+            products=("sellyouroutboard",),
+            contexts=("sellyouroutboard-testing",),
+            actions=("product_environment.read",),
+        )
+        identity = _terminal_agent_identity()
+
+        self.assertTrue(
+            rule.allows(
+                identity=identity,
+                action="product_environment.read",
+                product="sellyouroutboard",
+                context="sellyouroutboard-testing",
+            )
+        )
+        denied_cases = (
+            ("subject", _terminal_agent_identity(subject="other-agent"), "sellyouroutboard", "sellyouroutboard-testing", "product_environment.read"),
+            ("token_label", _terminal_agent_identity(token_label="write-token"), "sellyouroutboard", "sellyouroutboard-testing", "product_environment.read"),
+            ("product", identity, "other-product", "sellyouroutboard-testing", "product_environment.read"),
+            ("context", identity, "sellyouroutboard", "other-context", "product_environment.read"),
+            ("action", identity, "sellyouroutboard", "sellyouroutboard-testing", "generic_web_prod_promotion.execute"),
+        )
+        for name, case_identity, product, context, action in denied_cases:
+            with self.subTest(name=name):
+                self.assertFalse(
+                    rule.allows(
+                        identity=case_identity,
+                        action=action,
+                        product=product,
+                        context=context,
+                    )
+                )
+
+    def test_combined_policy_separates_terminal_agents_from_other_identities(self) -> None:
+        policy = LaunchplaneAuthzPolicy(
+            terminal_agents=(
+                TerminalAgentPolicyRule(
+                    subjects=("local-owner-agent",),
+                    token_labels=("local-owner-read",),
+                    products=("sellyouroutboard",),
+                    contexts=("sellyouroutboard-testing",),
+                    actions=("product_environment.read",),
+                ),
+            )
+        )
+
+        self.assertTrue(
+            policy.allows(
+                identity=_terminal_agent_identity(),
+                action="product_environment.read",
+                product="sellyouroutboard",
+                context="sellyouroutboard-testing",
+            )
+        )
+        self.assertFalse(
+            policy.allows(
+                identity=_actions_identity(repository="cbusillo/sellyouroutboard"),
+                action="product_environment.read",
+                product="sellyouroutboard",
+                context="sellyouroutboard-testing",
+            )
+        )
+        self.assertFalse(
+            policy.allows(
+                identity=_human_identity(login="local-owner-agent"),
+                action="product_environment.read",
+                product="sellyouroutboard",
+                context="sellyouroutboard-testing",
+            )
+        )
+
     def test_syo_preview_grant_covers_pull_request_branch_refs(self) -> None:
         rule = GitHubActionsPolicyRule(
             repository="cbusillo/sellyouroutboard",
@@ -348,13 +436,22 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
             teams = ["cbusillo/platform"]
             roles = ["admin"]
             actions = ["*"]
+
+            [[terminal_agents]]
+            subjects = ["local-owner-agent"]
+            token_labels = ["local-owner-read"]
+            products = ["sellyouroutboard"]
+            contexts = ["sellyouroutboard-testing"]
+            actions = ["product_environment.read"]
             """
         )
 
         self.assertEqual(len(policy.github_actions), 1)
         self.assertEqual(len(policy.github_humans), 1)
+        self.assertEqual(len(policy.terminal_agents), 1)
         self.assertEqual(policy.github_actions[0].repository, "cbusillo/verireel")
         self.assertEqual(policy.github_humans[0].roles, ("admin",))
+        self.assertEqual(policy.terminal_agents[0].subjects, ("local-owner-agent",))
 
 
 class HumanSessionBoundaryTests(unittest.TestCase):


### PR DESCRIPTION
## Summary\n- add a distinct terminal-agent identity and terminal-agent authz policy rules\n- authenticate trusted local terminal agents with a dedicated read bearer token\n- hard-deny terminal-agent credentials on non-GET service routes, even with broad policy\n- forward terminal-agent bootstrap env through Launchplane self-deploy and document the contract\n\n## Validation\n- uv run python -m unittest\n- uv run --extra dev mypy control_plane tests\n- uv run --extra dev ruff check .\n- actionlint .github/workflows/deploy-launchplane.yml\n\nRefs #426