### PR TITLE
Add direct Dokploy rollback fallback for Launchplane deploys

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -74,6 +74,8 @@ jobs:
       LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN: ${{ secrets.LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN }}
       LAUNCHPLANE_TERMINAL_AGENT_SUBJECT: ${{ vars.LAUNCHPLANE_TERMINAL_AGENT_SUBJECT }}
       LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL: ${{ vars.LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL }}
+      LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST: ${{ secrets.LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST }}
+      LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN: ${{ secrets.LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN }}
     steps:
       - name: Resolve deploy inputs
         id: prep
@@ -403,11 +405,97 @@ jobs:
             -H "Content-Type: application/json" \
             -H "Idempotency-Key: launchplane-self-deploy-rollback:${previous_image_reference}:${{ github.run_id }}:${{ github.run_attempt }}" \
             --data "$rollback_payload" \
-            "${{ steps.service.outputs.service_url }}/v1/drivers/launchplane/self-deploy")"
+            "${{ steps.service.outputs.service_url }}/v1/drivers/launchplane/self-deploy" || true)"
           if [ "$rollback_status" != "200" ] && [ "$rollback_status" != "202" ]; then
             cat "$rollback_response_file" >&2
-            echo "Launchplane rollback request failed with HTTP ${rollback_status}." >&2
-            exit 1
+            echo "Launchplane rollback request failed with HTTP ${rollback_status}; trying direct Dokploy fallback." >&2
+
+            if [ -z "${LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST:-}" ] || [ -z "${LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN:-}" ]; then
+              echo "Direct Dokploy rollback fallback requires LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST and LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN secrets." >&2
+              exit 1
+            fi
+
+          LAUNCHPLANE_ROLLBACK_IMAGE_REFERENCE="$previous_image_reference" uv run python - <<'PY'
+          import json
+          import os
+
+          from control_plane import dokploy as control_plane_dokploy
+
+
+          def _required_env(key: str) -> str:
+              value = os.environ.get(key, "").strip()
+              if not value:
+                  raise SystemExit(f"Missing required environment variable: {key}")
+              return value
+
+
+          host = _required_env("LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST")
+          token = _required_env("LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN")
+          target_type = _required_env("LAUNCHPLANE_DOKPLOY_TARGET_TYPE")
+          target_id = _required_env("LAUNCHPLANE_DOKPLOY_TARGET_ID")
+          image_reference = _required_env("LAUNCHPLANE_ROLLBACK_IMAGE_REFERENCE")
+          deploy_timeout_seconds = int(
+              os.environ.get("LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS") or "600"
+          )
+
+          target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
+              host=host,
+              token=token,
+              target_type=target_type,
+              target_id=target_id,
+          )
+          raw_env_text = str(target_payload.get("env") or "")
+          updated_env_text = control_plane_dokploy.render_dokploy_env_text_with_overrides(
+              raw_env_text,
+              updates={"DOCKER_IMAGE_REFERENCE": image_reference},
+          )
+          if updated_env_text != raw_env_text:
+              control_plane_dokploy.update_dokploy_target_env(
+                  host=host,
+                  token=token,
+                  target_type=target_type,
+                  target_id=target_id,
+                  target_payload=target_payload,
+                  env_text=updated_env_text,
+              )
+          latest_before = control_plane_dokploy.latest_deployment_for_target(
+              host=host,
+              token=token,
+              target_type=target_type,
+              target_id=target_id,
+          )
+          control_plane_dokploy.trigger_deployment(
+              host=host,
+              token=token,
+              target_type=target_type,
+              target_id=target_id,
+              no_cache=True,
+          )
+          deployment_result = control_plane_dokploy.wait_for_target_deployment(
+              host=host,
+              token=token,
+              target_type=target_type,
+              target_id=target_id,
+              before_key=control_plane_dokploy.deployment_key(latest_before),
+              timeout_seconds=deploy_timeout_seconds,
+          )
+          print(
+              json.dumps(
+                  {
+                      "status": "accepted",
+                      "target_type": target_type,
+                      "target_id": target_id,
+                      "image_reference": image_reference,
+                      "image_reference_changed": updated_env_text != raw_env_text,
+                      "deployment_result": deployment_result,
+                  },
+                  indent=2,
+                  sort_keys=True,
+              )
+          )
+          PY
+          else
+            cat "$rollback_response_file"
           fi
 
           deadline=$((SECONDS + ${LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS:-600} + ${LAUNCHPLANE_DEPLOY_HEALTH_TIMEOUT_SECONDS:-180}))
@@ -424,6 +512,13 @@ jobs:
                 break
               fi
             done < <(printf '%s\n' "$LAUNCHPLANE_DEPLOY_HEALTH_URLS" | tr ',' '\n')
+
+            oidc_token="$({
+              curl -fsSL \
+                -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+                "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${{ steps.service.outputs.service_audience }}" \
+              | jq -r '.value'
+            })"
 
             runtime_payload="$(curl -fsSL \
               -H "Authorization: Bearer ${oidc_token}" \

--- a/README.md
+++ b/README.md
@@ -184,14 +184,18 @@ Configure these GitHub settings before enabling it:
 - repository secrets:
   - optional `LAUNCHPLANE_GITHUB_CLIENT_SECRET`
   - optional `LAUNCHPLANE_SESSION_SECRET`
+  - emergency rollback fallback `LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST`
+  - emergency rollback fallback `LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN`
 
 The deploy workflow now uses GitHub OIDC plus Launchplane's own service API to
 request a self-deploy. It updates the immutable image reference and known OAuth
 env keys while preserving the target's minimal bootstrap policy env. Live
 product/workflow authz changes should move through DB-backed policy records, not
-repo-local TOML. Dokploy
-credentials should live in Launchplane-managed secrets inside the shared store,
-not in GitHub repository secrets.
+repo-local TOML. Normal Dokploy credentials should live in Launchplane-managed
+secrets inside the shared store, not in GitHub repository secrets. The emergency
+rollback fallback secrets are intentionally narrower: the deploy workflow uses
+them only after a failed rollout makes the Launchplane service route unavailable
+for self-rollback.
 
 `LAUNCHPLANE_DEPLOY_HEALTH_URLS` must point at Launchplane URLs that GitHub-hosted
 runners can reach, typically the public `https://.../v1/health` endpoint.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -231,7 +231,11 @@ The workflow should use GitHub OIDC to call Launchplane's own service API and
 update the image digest plus known OAuth env only. DB-backed authz policy records
 own live product/workflow grants; keep Dokploy host/token authority in
 Launchplane-managed secrets instead of duplicating those credentials in GitHub
-repository secrets.
+repository secrets for normal deploy execution. The deploy workflow also needs
+break-glass `LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST` and
+`LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN` repository secrets for rollback fallback:
+they are used only when a failed rollout makes the Launchplane service route
+unable to accept its own rollback request.
 
 `LAUNCHPLANE_DEPLOY_HEALTH_URLS` must resolve from the runner that executes the
 deploy workflow. Use a Launchplane `GET /v1/health` endpoint reachable from that


### PR DESCRIPTION
## Summary
- keep normal Launchplane deploy rollback through the service API first
- add a direct Dokploy rollback fallback when the failed rollout breaks the Launchplane HTTP route
- document the emergency rollback secrets separately from normal managed Dokploy credentials

## Validation
- `git diff --check`
- `actionlint .github/workflows/deploy-launchplane.yml`
- rollback shell block extracted with GitHub expressions stubbed: `bash -n`
- `uv run python -m unittest tests.test_dokploy`

## Notes
This is the recovery slice for #426: the terminal-agent auth code is merged but not live because the deploy workflow could not recover through the service route after a bad rollout returned plain `404 page not found`. The fallback requires `LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST` and `LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN` repository secrets only if the service rollback call fails.