### PR TITLE
Keep authz policy hashes compatible with existing records

### DIFF
--- a/control_plane/contracts/authz_policy_record.py
+++ b/control_plane/contracts/authz_policy_record.py
@@ -14,6 +14,8 @@ AuthzPolicyStatus = Literal["active", "superseded"]
 
 def authz_policy_sha256(policy: LaunchplaneAuthzPolicy) -> str:
     payload = policy.model_dump(mode="json", exclude_none=True)
+    if not policy.terminal_agents:
+        payload.pop("terminal_agents", None)
     canonical_json = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canonical_json.encode("utf-8")).hexdigest()
 

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+import hashlib
+import json
 from types import SimpleNamespace
 import unittest
 from unittest.mock import Mock, patch
@@ -16,6 +18,7 @@ from control_plane.service_auth import (
     TerminalAgentPolicyRule,
     parse_authz_policy_toml,
 )
+from control_plane.contracts.authz_policy_record import authz_policy_sha256
 from control_plane.service_human_auth import (
     GitHubOAuthConfig,
     HumanSessionManager,
@@ -537,6 +540,52 @@ class GitHubOidcVerifierHardeningTests(unittest.TestCase):
 
 
 class LaunchplaneAuthzPolicyCompatibilityTests(unittest.TestCase):
+    def test_policy_sha256_omits_empty_terminal_agents_for_existing_records(self) -> None:
+        policy = LaunchplaneAuthzPolicy(
+            github_actions=(
+                GitHubActionsPolicyRule(
+                    repository="cbusillo/launchplane",
+                    products=("launchplane",),
+                    contexts=("launchplane",),
+                    actions=("launchplane_service_deploy.execute",),
+                ),
+            )
+        )
+        legacy_payload = policy.model_dump(mode="json", exclude_none=True)
+        legacy_payload.pop("terminal_agents", None)
+        legacy_sha256 = hashlib.sha256(
+            json.dumps(legacy_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+
+        self.assertEqual(authz_policy_sha256(policy), legacy_sha256)
+
+    def test_policy_sha256_includes_terminal_agent_rules_when_present(self) -> None:
+        base_policy = LaunchplaneAuthzPolicy(
+            github_actions=(
+                GitHubActionsPolicyRule(
+                    repository="cbusillo/launchplane",
+                    products=("launchplane",),
+                    contexts=("launchplane",),
+                    actions=("launchplane_service_deploy.execute",),
+                ),
+            )
+        )
+        terminal_policy = base_policy.model_copy(
+            update={
+                "terminal_agents": (
+                    TerminalAgentPolicyRule(
+                        subjects=("local-owner-agent",),
+                        token_labels=("local-owner-read",),
+                        products=("sellyouroutboard",),
+                        contexts=("sellyouroutboard",),
+                        actions=("product_environment.read",),
+                    ),
+                )
+            }
+        )
+
+        self.assertNotEqual(authz_policy_sha256(terminal_policy), authz_policy_sha256(base_policy))
+
     def test_actions_policy_matches_patterns_and_scopes(self) -> None:
         rule = GitHubActionsPolicyRule(
             repository="cbusillo/site",


### PR DESCRIPTION
## Summary
- keep authz policy hashing compatible with existing DB records that predate `terminal_agents`
- still include terminal-agent rules in the hash once rules are present
- add regression coverage for both behaviors

## Evidence
A controlled hosted repro of the failed Launchplane image showed the container repeatedly restarting, not a proxy-only route issue. The service failed during startup while loading active authz policy records:

```text
pydantic_core._pydantic_core.ValidationError: 1 validation error for LaunchplaneAuthzPolicyRecord
Value error, authz policy record policy_sha256 does not match policy payload
```

The old active DB records were written before `terminal_agents` existed. After #441, the default empty `terminal_agents` field changed canonical hash input even though the effective policy stayed the same.

## Validation
- `uv run python -m unittest tests.test_service_auth tests.test_authz_grant_service`
- `uv run --extra dev ruff check control_plane/contracts/authz_policy_record.py tests/test_service_auth.py`
- `uv run --extra dev mypy control_plane/contracts/authz_policy_record.py tests/test_service_auth.py`
- `git diff --check`

## Recovery note
The controlled repro restored the previous known-good image afterward; public health returned 200 with trace `launchplane_req_427b6f0e0cd745a694618afbd2eae526`.