### PR TITLE
Make work graph queue items agent-actionable

### DIFF
--- a/control_plane/contracts/work_graph_read_model.py
+++ b/control_plane/contracts/work_graph_read_model.py
@@ -145,6 +145,15 @@ class WorkGraphRecommendationReason(BaseModel):
     detail: str
 
 
+class WorkGraphQueueEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: str
+    state: Literal["verified", "recorded", "stale", "missing", "unsupported"]
+    detail: str
+    source_url: str = ""
+
+
 class WorkGraphQueueItem(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -162,6 +171,13 @@ class WorkGraphQueueItem(BaseModel):
     recommendation: WorkItemRecommendation
     score: int
     updated_at: str = ""
+    safe_to_start: bool
+    next_action: str
+    why_now: str
+    blocked_by_count: int = Field(default=0, ge=0)
+    source_of_truth_url: str
+    handoff_url: str = ""
+    evidence: tuple[WorkGraphQueueEvidence, ...] = ()
     reasons: tuple[WorkGraphRecommendationReason, ...]
 
 
@@ -375,6 +391,13 @@ def _build_queue_item(
         recommendation=recommendation,
         score=_score(issue=issue, repo=repo, state=state, recommendation=recommendation),
         updated_at=issue.updated_at,
+        safe_to_start=_safe_to_start(issue=issue, state=state),
+        next_action=_next_action(issue=issue, state=state, recommendation=recommendation),
+        why_now=_why_now(issue=issue, repo=repo, state=state, recommendation=recommendation),
+        blocked_by_count=issue.blocked_by,
+        source_of_truth_url=issue.url,
+        handoff_url=issue.url,
+        evidence=_queue_evidence(issue=issue),
         reasons=reasons,
     )
 
@@ -492,6 +515,103 @@ def _recommendation_reasons(
     if issue.finish_line.strip():
         reasons.append(WorkGraphRecommendationReason(code="finish_line", detail=issue.finish_line))
     return tuple(reasons)
+
+
+def _safe_to_start(*, issue: WorkGraphIssueSnapshot, state: WorkItemState) -> bool:
+    if state != "ready":
+        return False
+    return issue.focus in {"Now", "Next"} or issue.check_state == "failure" or issue.deploy_state == "failure"
+
+
+def _next_action(
+    *,
+    issue: WorkGraphIssueSnapshot,
+    state: WorkItemState,
+    recommendation: WorkItemRecommendation,
+) -> str:
+    if state == "blocked":
+        return "Inspect the blocking dependency before starting implementation."
+    if state == "waiting":
+        return "Wait for the next external signal or move the item into a ready lane."
+    if issue.check_state == "failure" or issue.deploy_state == "failure":
+        return "Open the failing check or deploy source and fix the current regression."
+    if issue.focus == "Now":
+        return "Continue the active implementation path from the linked source of truth."
+    if recommendation == "quick_win":
+        return "Start a focused branch from the linked source of truth."
+    if recommendation == "deep_work":
+        return "Confirm the next slice, then start a focused branch from the linked source of truth."
+    return "Review the linked source of truth before changing code."
+
+
+def _why_now(
+    *,
+    issue: WorkGraphIssueSnapshot,
+    repo: WorkGraphRepoSnapshot,
+    state: WorkItemState,
+    recommendation: WorkItemRecommendation,
+) -> str:
+    if issue.check_state == "failure" or issue.deploy_state == "failure":
+        return "A failing check or deploy signal needs operator attention."
+    if state == "blocked":
+        return "The item is visible because dependency cleanup may unblock later work."
+    if issue.blocking:
+        return f"It unblocks {issue.blocking} other item(s)."
+    if recommendation == "quick_win":
+        return "It is ready, focused, and has no tracked subissues."
+    if issue.focus == "Now":
+        return "It is marked as the active focus item."
+    if repo.classification == "managed_runtime":
+        return "It belongs to a Launchplane-managed runtime repo."
+    return "It is ranked from compact planning and operational signals."
+
+
+def _queue_evidence(issue: WorkGraphIssueSnapshot) -> tuple[WorkGraphQueueEvidence, ...]:
+    evidence = [
+        WorkGraphQueueEvidence(
+            code="source_of_truth",
+            state="verified",
+            detail="Linked GitHub issue or pull request is the source of truth.",
+            source_url=issue.url,
+        )
+    ]
+    if issue.focus != "Unknown":
+        evidence.append(
+            WorkGraphQueueEvidence(
+                code="focus",
+                state="recorded",
+                detail=f"Focus lane is {issue.focus}.",
+                source_url=issue.url,
+            )
+        )
+    if issue.check_state != "unknown":
+        evidence.append(
+            WorkGraphQueueEvidence(
+                code="checks",
+                state="verified",
+                detail=f"Check state is {issue.check_state}.",
+                source_url=issue.url,
+            )
+        )
+    if issue.deploy_state != "unknown":
+        evidence.append(
+            WorkGraphQueueEvidence(
+                code="deploy",
+                state="verified",
+                detail=f"Deploy state is {issue.deploy_state}.",
+                source_url=issue.url,
+            )
+        )
+    if issue.blocked_by:
+        evidence.append(
+            WorkGraphQueueEvidence(
+                code="blocked_by",
+                state="verified",
+                detail=f"Blocked by {issue.blocked_by} dependency item(s).",
+                source_url=issue.url,
+            )
+        )
+    return tuple(evidence)
 
 
 def _queue_sort_key(item: WorkGraphQueueItem) -> tuple[int, str, str, int]:

--- a/docs/work-graph-read-model.md
+++ b/docs/work-graph-read-model.md
@@ -42,10 +42,27 @@ The command prints a `WorkGraphQueue` JSON payload with:
 
 - ranked items
 - ready/waiting/blocked state
+- agent-actionable fields: `safe_to_start`, `next_action`, `why_now`,
+  `blocked_by_count`, `source_of_truth_url`, `handoff_url`, and compact
+  `evidence`
 - recommendation category, such as `quick_win`, `deep_work`, or
   `attention_needed`
 - score and explanation reasons
 - hidden count for closed, done, or overflow items
+
+Queue items are intentionally compact. `source_of_truth_url` and `handoff_url`
+point agents back to GitHub issues or pull requests instead of copying issue
+bodies or long planning prose into Launchplane. `safe_to_start` is true only for
+ready items that are in the active/next lane or have a failing check/deploy
+signal that needs attention. Waiting and blocked items stay visible for
+awareness, but agents should inspect the blocker or external signal before
+starting implementation.
+
+`evidence` entries carry small source-linked signals with a trust state of
+`verified`, `recorded`, `stale`, `missing`, or `unsupported`. The first slice
+uses verified/recorded signals from the supplied snapshot. Future persisted
+snapshot history can make stale/missing provider evidence explicit without
+changing the queue shape.
 
 ## Service Route
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,10 +30,7 @@ import {
 import { ApiErrorPanel, AuthPanel } from "./AuthPanels";
 import { formatTime, labelForStatus } from "./format";
 import { LanePanel } from "./LanePanel";
-import {
-  artifactFromLane,
-  worstStatus,
-} from "./laneSummary";
+import { artifactFromLane, worstStatus } from "./laneSummary";
 import { KeyValue, PanelHead } from "./panel-ui";
 import { PreviewInventory } from "./PreviewInventory";
 import {
@@ -82,10 +79,7 @@ import type {
   Status,
   WorkGraphQueueItem,
 } from "./types";
-import {
-  type WorkGraphFilter,
-  type WorkGraphMode,
-} from "./WorkGraphQueue";
+import { type WorkGraphFilter, type WorkGraphMode } from "./WorkGraphQueue";
 
 type Theme = "dark" | "light";
 const assetUrl = (path: string) => `${import.meta.env.BASE_URL}${path}`;
@@ -455,7 +449,9 @@ export function App() {
         (environment) => environment.environment === selectedEnvironment,
       )
     ) {
-      setSelectedEnvironment(selectedProductOverview.environments[0].environment);
+      setSelectedEnvironment(
+        selectedProductOverview.environments[0].environment,
+      );
     }
   }, [selectedProductOverview, selectedEnvironment]);
 
@@ -555,7 +551,9 @@ export function App() {
               product={selectedProductOverview}
               selected={selected}
               loading={loading}
-              selectedEnvironment={activeEnvironment?.environment ?? selectedEnvironment}
+              selectedEnvironment={
+                activeEnvironment?.environment ?? selectedEnvironment
+              }
               onSelectEnvironment={setSelectedEnvironment}
             />
             <section className="lane-grid" aria-busy={loading}>
@@ -572,7 +570,9 @@ export function App() {
                 environmentActions={activeEnvironment?.available_actions ?? []}
                 product={selectedDriver?.product ?? selected.driverId}
                 context={selected.prodContext}
-                environment={activeEnvironment?.environment ?? selectedEnvironment}
+                environment={
+                  activeEnvironment?.environment ?? selectedEnvironment
+                }
                 decision={promotionDecision}
                 loading={loading}
                 onAction={setReviewAction}
@@ -586,7 +586,9 @@ export function App() {
             </section>
             <ProductConfigStatusPanel
               statuses={configStatuses}
-              selectedEnvironment={activeEnvironment?.environment ?? selectedEnvironment}
+              selectedEnvironment={
+                activeEnvironment?.environment ?? selectedEnvironment
+              }
               loading={configStatusLoading}
               error={configStatusError}
             />
@@ -972,7 +974,10 @@ function EvidenceDetailDrawer({
   );
 }
 
-function configStatusErrorMessage(environment: string, apiError: unknown): string {
+function configStatusErrorMessage(
+  environment: string,
+  apiError: unknown,
+): string {
   const prefix = `${environment} config status`;
   if (apiError instanceof LaunchplaneApiError) {
     return `${prefix}: ${apiError.message}`;
@@ -1090,8 +1095,10 @@ function StateFixtureGallery({
       base_driver_id: "generic-web",
       environments: configEnvironments.map((environment) => ({
         ...environment,
-        context: environment.environment === "prod" ? "verireel" : "verireel-testing",
-        trust_state: environment.environment === "prod" ? "recorded" : "verified",
+        context:
+          environment.environment === "prod" ? "verireel" : "verireel-testing",
+        trust_state:
+          environment.environment === "prod" ? "recorded" : "verified",
       })),
       preview: {
         enabled: true,
@@ -1102,7 +1109,9 @@ function StateFixtureGallery({
         trust_state: "recorded",
         provenance: readyTesting.provenance,
       },
-      warnings: ["Runtime owner route evidence is recorded, not provider verified."],
+      warnings: [
+        "Runtime owner route evidence is recorded, not provider verified.",
+      ],
       trust_state: "recorded",
       provenance: readyTesting.provenance,
       available_actions: [],
@@ -1220,6 +1229,21 @@ function StateFixtureGallery({
       recommendation: "deep_work",
       score: 126,
       updated_at: "2026-05-06T02:12:00Z",
+      safe_to_start: true,
+      next_action:
+        "Continue the active implementation path from the linked source of truth.",
+      why_now: "It is marked as the active focus item.",
+      blocked_by_count: 0,
+      source_of_truth_url: "https://github.com/cbusillo/launchplane/issues/190",
+      handoff_url: "https://github.com/cbusillo/launchplane/issues/190",
+      evidence: [
+        {
+          code: "source_of_truth",
+          state: "verified",
+          detail: "Linked GitHub issue is the source of truth.",
+          source_url: "https://github.com/cbusillo/launchplane/issues/190",
+        },
+      ],
       reasons: [{ code: "focus", detail: "Now lane" }],
     },
     {
@@ -1237,6 +1261,20 @@ function StateFixtureGallery({
       recommendation: "quick_win",
       score: 110,
       updated_at: "2026-05-06T01:03:00Z",
+      safe_to_start: true,
+      next_action: "Start a focused branch from the linked source of truth.",
+      why_now: "It is ready, focused, and has no tracked subissues.",
+      blocked_by_count: 0,
+      source_of_truth_url: "https://github.com/cbusillo/verireel/pull/169",
+      handoff_url: "https://github.com/cbusillo/verireel/pull/169",
+      evidence: [
+        {
+          code: "source_of_truth",
+          state: "verified",
+          detail: "Linked GitHub pull request is the source of truth.",
+          source_url: "https://github.com/cbusillo/verireel/pull/169",
+        },
+      ],
       reasons: [{ code: "small", detail: "No subissues" }],
     },
     {
@@ -1254,7 +1292,25 @@ function StateFixtureGallery({
       recommendation: "blocked_cleanup",
       score: 42,
       updated_at: "2026-05-05T23:00:00Z",
-      reasons: [{ code: "blocked", detail: "Waiting on downstream validation" }],
+      safe_to_start: false,
+      next_action:
+        "Inspect the blocking dependency before starting implementation.",
+      why_now:
+        "The item is visible because dependency cleanup may unblock later work.",
+      blocked_by_count: 1,
+      source_of_truth_url: "https://github.com/cbusillo/launchplane/issues/248",
+      handoff_url: "https://github.com/cbusillo/launchplane/issues/248",
+      evidence: [
+        {
+          code: "blocked_by",
+          state: "verified",
+          detail: "Blocked by one dependency item.",
+          source_url: "https://github.com/cbusillo/launchplane/issues/248",
+        },
+      ],
+      reasons: [
+        { code: "blocked", detail: "Waiting on downstream validation" },
+      ],
     },
     {
       repository: "cbusillo/odoo-tenant-opw",
@@ -1266,12 +1322,30 @@ function StateFixtureGallery({
       url: "https://github.com/cbusillo/odoo-tenant-opw/issues/302",
       focus: "Later",
       manager: "Unassigned",
-      finish_line: "Choose whether this belongs in Launchplane or stays tenant-owned.",
+      finish_line:
+        "Choose whether this belongs in Launchplane or stays tenant-owned.",
       state: "ready",
       recommendation: "switch_projects",
       score: 58,
       updated_at: "2026-05-05T21:30:00Z",
-      reasons: [{ code: "repo_classification", detail: "Awareness-only repo." }],
+      safe_to_start: false,
+      next_action: "Review the linked source of truth before changing code.",
+      why_now: "It is ranked from compact planning and operational signals.",
+      blocked_by_count: 0,
+      source_of_truth_url:
+        "https://github.com/cbusillo/odoo-tenant-opw/issues/302",
+      handoff_url: "https://github.com/cbusillo/odoo-tenant-opw/issues/302",
+      evidence: [
+        {
+          code: "source_of_truth",
+          state: "verified",
+          detail: "Linked GitHub issue is the source of truth.",
+          source_url: "https://github.com/cbusillo/odoo-tenant-opw/issues/302",
+        },
+      ],
+      reasons: [
+        { code: "repo_classification", detail: "Awareness-only repo." },
+      ],
     },
   ];
 

--- a/frontend/src/WorkGraphQueue.tsx
+++ b/frontend/src/WorkGraphQueue.tsx
@@ -88,7 +88,10 @@ export function WorkGraphQueue({
         <StateBlock icon={<Route size={18} />} title="No ranked work yet" />
       ) : null}
       {!loading && !error && items.length && !filteredItems.length ? (
-        <StateBlock icon={<Route size={18} />} title="No work matches filters" />
+        <StateBlock
+          icon={<Route size={18} />}
+          title="No work matches filters"
+        />
       ) : null}
       {filteredItems.slice(0, 5).map((item) => (
         <a
@@ -111,22 +114,36 @@ export function WorkGraphQueue({
               <span>{item.manager || "Unassigned"}</span>
               <span>{formatTime(item.updated_at)}</span>
               <span>
-                {item.product_display_name || item.product || item.repo_classification}
+                {item.product_display_name ||
+                  item.product ||
+                  item.repo_classification}
               </span>
             </span>
             {item.finish_line ? (
               <span className="work-graph-finish">{item.finish_line}</span>
             ) : null}
+            {item.next_action ? (
+              <span className="work-graph-next-action">{item.next_action}</span>
+            ) : null}
             <span className="work-graph-tags">
-              <span className="status-pill" data-status={workGraphStateStatus(item.state)}>
+              <span
+                className="status-pill"
+                data-status={workGraphStateStatus(item.state)}
+              >
                 <StatusIcon status={workGraphStateStatus(item.state)} />
                 {item.state}
+              </span>
+              <span className="reason-chip">
+                {item.safe_to_start ? "safe to start" : "needs review"}
               </span>
               <span className="recommendation-chip">
                 {recommendationLabel(item.recommendation)}
               </span>
               {item.reasons.slice(0, 2).map((reason) => (
-                <span className="reason-chip" key={`${item.repository}:${item.number}:${reason.code}`}>
+                <span
+                  className="reason-chip"
+                  key={`${item.repository}:${item.number}:${reason.code}`}
+                >
                   {reasonLabel(reason.code)}
                 </span>
               ))}
@@ -135,7 +152,9 @@ export function WorkGraphQueue({
         </a>
       ))}
       {hiddenCount ? (
-        <code className="work-graph-hidden">{hiddenCount} hidden by rank or state</code>
+        <code className="work-graph-hidden">
+          {hiddenCount} hidden by rank or state
+        </code>
       ) : null}
     </div>
   );

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -499,13 +499,21 @@ p {
   white-space: nowrap;
 }
 
-.work-graph-finish {
+.work-graph-finish,
+.work-graph-next-action {
   overflow: hidden;
-  color: var(--fg-muted);
   font-size: 12px;
   line-height: 1.35;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.work-graph-finish {
+  color: var(--fg-muted);
+}
+
+.work-graph-next-action {
+  color: var(--fg-strong);
 }
 
 .work-graph-tags {
@@ -632,7 +640,8 @@ p {
 .product-environment-pill[data-selected="true"] {
   border-color: var(--accent);
   background: color-mix(in oklab, var(--accent) 10%, var(--bg-2));
-  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--accent) 34%, transparent);
+  box-shadow: inset 0 0 0 1px
+    color-mix(in oklab, var(--accent) 34%, transparent);
 }
 
 .product-environment-pill[data-environment="prod"] {
@@ -1308,7 +1317,10 @@ p {
 
 .config-status-row {
   display: grid;
-  grid-template-columns: max-content minmax(120px, 0.75fr) minmax(0, 1fr) minmax(90px, auto);
+  grid-template-columns: max-content minmax(120px, 0.75fr) minmax(
+      0,
+      1fr
+    ) minmax(90px, auto);
   gap: 9px;
   align-items: center;
   min-height: 34px;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -560,7 +560,12 @@ export type WorkGraphFocus =
   | "Later"
   | "Done"
   | "Unknown";
-export type WorkGraphState = "ready" | "waiting" | "blocked" | "done" | "hidden";
+export type WorkGraphState =
+  | "ready"
+  | "waiting"
+  | "blocked"
+  | "done"
+  | "hidden";
 export type WorkGraphRecommendation =
   | "quick_win"
   | "deep_work"
@@ -629,6 +634,18 @@ export interface WorkGraphQueueItem {
   recommendation: WorkGraphRecommendation;
   score: number;
   updated_at: string;
+  safe_to_start: boolean;
+  next_action: string;
+  why_now: string;
+  blocked_by_count: number;
+  source_of_truth_url: string;
+  handoff_url: string;
+  evidence: Array<{
+    code: string;
+    state: "verified" | "recorded" | "stale" | "missing" | "unsupported";
+    detail: string;
+    source_url: string;
+  }>;
   reasons: Array<{ code: string; detail: string }>;
 }
 

--- a/tests/test_work_graph_read_model.py
+++ b/tests/test_work_graph_read_model.py
@@ -109,6 +109,13 @@ class WorkGraphReadModelTests(unittest.TestCase):
         self.assertEqual(first.repo_classification, "managed_runtime")
         self.assertEqual(first.product, "launchplane")
         self.assertGreater(first.score, queue.items[1].score)
+        self.assertTrue(first.safe_to_start)
+        self.assertEqual(first.blocked_by_count, 0)
+        self.assertEqual(first.source_of_truth_url, first.url)
+        self.assertEqual(first.handoff_url, first.url)
+        self.assertIn("Start a focused branch", first.next_action)
+        self.assertIn("unblocks 2", first.why_now)
+        self.assertIn("source_of_truth", {entry.code for entry in first.evidence})
         self.assertIn("repo_classification", {reason.code for reason in first.reasons})
         self.assertIn("finish_line", {reason.code for reason in first.reasons})
 
@@ -131,7 +138,39 @@ class WorkGraphReadModelTests(unittest.TestCase):
         self.assertEqual(queue.items[0].number, 153)
         self.assertEqual(queue.items[0].state, "ready")
         self.assertEqual(queue.items[0].recommendation, "attention_needed")
+        self.assertTrue(queue.items[0].safe_to_start)
+        self.assertIn("failing check", queue.items[0].next_action)
+        self.assertIn("operator attention", queue.items[0].why_now)
+        self.assertIn("checks", {entry.code for entry in queue.items[0].evidence})
         self.assertIn("failed_signal", {reason.code for reason in queue.items[0].reasons})
+
+    def test_blocked_item_is_not_safe_to_start_and_names_dependency_count(self) -> None:
+        snapshot = WorkGraphSnapshot.model_validate(
+            {
+                "generated_at": "2026-05-06T01:45:00Z",
+                "repos": (_repo().model_dump(mode="json"),),
+                "issues": (
+                    _issue(
+                        number=260,
+                        title="Blocked tenant work",
+                        url="https://github.com/cbusillo/launchplane/issues/260",
+                        focus="Waiting",
+                        labels=("plan", "plan:blocked"),
+                        blocked_by=2,
+                    ).model_dump(mode="json"),
+                ),
+            }
+        )
+
+        queue = build_work_graph_queue(snapshot)
+
+        item = queue.items[0]
+        self.assertFalse(item.safe_to_start)
+        self.assertEqual(item.state, "blocked")
+        self.assertEqual(item.blocked_by_count, 2)
+        self.assertIn("blocking dependency", item.next_action)
+        self.assertIn("dependency cleanup", item.why_now)
+        self.assertIn("blocked_by", {entry.code for entry in item.evidence})
 
     def test_closed_and_done_items_are_hidden(self) -> None:
         snapshot = WorkGraphSnapshot.model_validate(


### PR DESCRIPTION
## Summary
- add agent-actionable work graph queue fields for safe_to_start, next_action, why_now, blocker count, source/handoff links, and compact evidence
- surface the next action and safety state in the operator work graph queue
- document the compact source-linked queue contract for agent consumers

Refs #383

## Validation
- uv run python -m unittest tests.test_work_graph_read_model tests.test_work_graph_service
- uv run --extra dev mypy control_plane/contracts/work_graph_read_model.py control_plane/work_graph_service.py tests/test_work_graph_read_model.py tests/test_work_graph_service.py
- uv run --extra dev ruff check --diff control_plane/contracts/work_graph_read_model.py tests/test_work_graph_read_model.py
- uv run --extra dev ruff check control_plane/contracts/work_graph_read_model.py tests/test_work_graph_read_model.py
- pnpm --dir frontend validate
- uv run python -m unittest
- browser fixture review at http://127.0.0.1:5173/ui/?fixtures=1, screenshot: scratch/ui-checks/work-graph-agent-actionable.png
