### PR TITLE
Add repo product mapping read model

### DIFF
--- a/control_plane/contracts/repo_product_mapping_read_model.py
+++ b/control_plane/contracts/repo_product_mapping_read_model.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from typing import Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+
+
+RepoProductClassification = Literal[
+    "managed_runtime",
+    "active_awareness",
+    "support_dependency",
+    "out_of_scope",
+]
+
+
+class RepoProductMappingProductStore(Protocol):
+    def list_product_profile_records(
+        self,
+        *,
+        driver_id: str = "",
+    ) -> tuple[LaunchplaneProductProfileRecord, ...]: ...
+
+
+class RepoProductMappingWorkRequestStore(Protocol):
+    def list_every_code_work_request_records(
+        self,
+        *,
+        state: str = "",
+        repository: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[EveryCodeWorkRequestRecord, ...]: ...
+
+
+class RepoProductMappingEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    repository: str
+    classification: RepoProductClassification
+    product: str = ""
+    display_name: str = ""
+    driver_id: str = ""
+    contexts: tuple[str, ...] = ()
+    environments: tuple[str, ...] = ()
+    preview_context: str = ""
+    source: Literal["product_profile", "every_code_work_request", "explicit"]
+    updated_at: str = ""
+
+    @model_validator(mode="after")
+    def _validate_entry(self) -> "RepoProductMappingEntry":
+        if not self.repository.strip() or "/" not in self.repository.strip():
+            raise ValueError("repo product mapping entry requires owner/repo repository")
+        if self.classification == "managed_runtime" and not self.product.strip():
+            raise ValueError("managed runtime repo mapping requires product")
+        self.contexts = _dedupe_non_empty(self.contexts)
+        self.environments = _dedupe_non_empty(self.environments)
+        return self
+
+
+class RepoProductMapping(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    generated_at: str
+    repositories: tuple[RepoProductMappingEntry, ...]
+
+    @model_validator(mode="after")
+    def _validate_mapping(self) -> "RepoProductMapping":
+        if not self.generated_at.strip():
+            raise ValueError("repo product mapping requires generated_at")
+        repositories = [entry.repository.strip().lower() for entry in self.repositories]
+        if len(repositories) != len(set(repositories)):
+            raise ValueError("repo product mapping repositories must be unique")
+        return self
+
+
+def build_repo_product_mapping_from_records(
+    *,
+    generated_at: str,
+    product_profiles: tuple[LaunchplaneProductProfileRecord, ...],
+    work_requests: tuple[EveryCodeWorkRequestRecord, ...] = (),
+) -> RepoProductMapping:
+    entries: dict[str, RepoProductMappingEntry] = {}
+    for profile in product_profiles:
+        repository = profile.repository.strip()
+        if not repository or "/" not in repository:
+            continue
+        entries[repository.lower()] = _product_profile_entry(profile)
+
+    for request in work_requests:
+        repository = request.repository.strip()
+        if not repository or "/" not in repository:
+            continue
+        entries.setdefault(
+            repository.lower(),
+            RepoProductMappingEntry(
+                repository=repository,
+                classification="active_awareness",
+                display_name=repository.rsplit("/", maxsplit=1)[-1],
+                source="every_code_work_request",
+                updated_at=request.updated_at or request.queued_at,
+            ),
+        )
+    return RepoProductMapping(
+        generated_at=generated_at,
+        repositories=tuple(sorted(entries.values(), key=lambda entry: entry.repository.lower())),
+    )
+
+
+def _product_profile_entry(profile: LaunchplaneProductProfileRecord) -> RepoProductMappingEntry:
+    contexts = tuple(lane.context for lane in profile.lanes) + profile.historical_contexts
+    environments = tuple(lane.instance for lane in profile.lanes)
+    return RepoProductMappingEntry(
+        repository=profile.repository,
+        classification="managed_runtime",
+        product=profile.product,
+        display_name=profile.display_name,
+        driver_id=profile.driver_id,
+        contexts=contexts,
+        environments=environments,
+        preview_context=profile.preview.context if profile.preview.enabled else "",
+        source="product_profile",
+        updated_at=profile.updated_at,
+    )
+
+
+def _dedupe_non_empty(values: tuple[str, ...]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    for raw_value in values:
+        value = raw_value.strip()
+        if value and value not in normalized:
+            normalized.append(value)
+    return tuple(normalized)

--- a/control_plane/contracts/work_graph_read_model.py
+++ b/control_plane/contracts/work_graph_read_model.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
 from control_plane.contracts.product_environment_read_model import ProductSiteOverview
+from control_plane.contracts.repo_product_mapping_read_model import RepoProductMapping
 
 
 RepoClassification = Literal[
@@ -228,6 +229,53 @@ def build_work_graph_snapshot_from_records(
     for request in work_requests:
         key = (request.repository.strip().lower(), request.issue_number)
         request_issue_keys.add(key)
+        issues.append(
+            _apply_planning_issue_facts(
+                _work_request_issue_snapshot(request),
+                planning_facts_by_issue.get(key),
+            )
+        )
+    for facts in planning_issue_facts:
+        repository_key = facts.repository.strip().lower()
+        key = (repository_key, facts.number)
+        if key in request_issue_keys or repository_key not in repo_snapshots:
+            continue
+        issue = _planning_facts_issue_snapshot(facts)
+        if issue is not None:
+            issues.append(issue)
+    return WorkGraphSnapshot(
+        generated_at=generated_at,
+        repos=tuple(repo_snapshots.values()),
+        issues=tuple(issues),
+    )
+
+
+def build_work_graph_snapshot_from_repo_mapping(
+    *,
+    generated_at: str,
+    repo_mapping: RepoProductMapping,
+    work_requests: tuple[EveryCodeWorkRequestRecord, ...],
+    planning_issue_facts: tuple[WorkGraphPlanningIssueFacts, ...] = (),
+) -> WorkGraphSnapshot:
+    repo_snapshots = {
+        entry.repository.strip().lower(): WorkGraphRepoSnapshot(
+            repository=entry.repository,
+            classification=entry.classification,
+            product=entry.product,
+            display_name=entry.display_name,
+        )
+        for entry in repo_mapping.repositories
+    }
+    planning_facts_by_issue = {
+        (facts.repository.strip().lower(), facts.number): facts for facts in planning_issue_facts
+    }
+    request_issue_keys: set[tuple[str, int]] = set()
+    issues: list[WorkGraphIssueSnapshot] = []
+    for request in work_requests:
+        key = (request.repository.strip().lower(), request.issue_number)
+        request_issue_keys.add(key)
+        if key[0] not in repo_snapshots:
+            continue
         issues.append(
             _apply_planning_issue_facts(
                 _work_request_issue_snapshot(request),

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -142,6 +142,7 @@ from control_plane.work_graph_service import (
     WorkGraphPlanningFactsProvider,
 )
 from control_plane.work_graph_http import (
+    handle_repo_product_mapping_read,
     handle_work_graph_snapshot_read,
     rank_work_graph_snapshot,
     work_graph_rank_denied_response,
@@ -1702,6 +1703,8 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "launchplane_service.read", {}
     if len(segments) == 3 and segments == ["v1", "work-graph", "snapshot"]:
         return "work_graph.rank", {}
+    if len(segments) == 2 and segments == ["v1", "repo-product-mapping"]:
+        return "product_environment.read", {"repo_product_mapping": "true"}
     if len(segments) == 2 and segments == ["v1", "product-profiles"]:
         return "product_profile.read", {}
     if (
@@ -5157,6 +5160,18 @@ def create_launchplane_service_app(
                             action=requested_action,
                             product=requested_product,
                             context=requested_context,
+                        )
+
+                    if params.get("repo_product_mapping") == "true":
+                        return handle_repo_product_mapping_read(
+                            authz_policy=authz_policy,
+                            identity=identity,
+                            trace_id=request_trace_id,
+                            product_store=record_store,
+                            work_request_store=_every_code_work_request_store(record_store),
+                            utc_now=_utc_now_timestamp,
+                            json_response=_json_response,
+                            start_response=start_response,
                         )
 
                     if control_plane_product_read_service.is_product_environment_detail_request(

--- a/control_plane/work_graph_http.py
+++ b/control_plane/work_graph_http.py
@@ -11,6 +11,7 @@ from control_plane.work_graph_service import (
     WorkGraphPlanningFactsProvider,
     WorkGraphRankEnvelope,
     WorkGraphWorkRequestStore,
+    build_repo_product_mapping_service_payload,
     build_work_graph_rank_result,
     build_work_graph_snapshot_service_payload,
 )
@@ -77,6 +78,52 @@ def handle_work_graph_snapshot_read(
             "status": "ok",
             "trace_id": trace_id,
             **work_graph_payload,
+        },
+    )
+
+
+def handle_repo_product_mapping_read(
+    *,
+    authz_policy: LaunchplaneAuthzPolicy,
+    identity: LaunchplaneIdentity,
+    trace_id: str,
+    product_store: ProductReadModelStore,
+    work_request_store: WorkGraphWorkRequestStore,
+    utc_now: UtcNow,
+    json_response: JsonResponse,
+    start_response: StartResponse,
+) -> list[bytes]:
+    if not authz_policy.allows(
+        identity=identity,
+        action="product_environment.read",
+        product="launchplane",
+        context=LAUNCHPLANE_SERVICE_CONTEXT,
+    ):
+        return json_response(
+            start_response=start_response,
+            status_code=403,
+            payload={
+                "status": "rejected",
+                "trace_id": trace_id,
+                "error": {
+                    "code": "authorization_denied",
+                    "message": "Workflow cannot read the Launchplane repo product mapping.",
+                },
+            },
+        )
+
+    mapping_payload = build_repo_product_mapping_service_payload(
+        generated_at=utc_now(),
+        product_store=product_store,
+        work_request_store=work_request_store,
+    )
+    return json_response(
+        start_response=start_response,
+        status_code=200,
+        payload={
+            "status": "ok",
+            "trace_id": trace_id,
+            **mapping_payload,
         },
     )
 

--- a/control_plane/work_graph_service.py
+++ b/control_plane/work_graph_service.py
@@ -11,11 +11,16 @@ from control_plane.contracts.product_environment_read_model import (
     ProductReadModelStore,
     build_product_site_overviews,
 )
+from control_plane.contracts.repo_product_mapping_read_model import (
+    RepoProductMappingProductStore,
+    RepoProductMappingWorkRequestStore,
+    build_repo_product_mapping_from_records,
+)
 from control_plane.contracts.work_graph_read_model import (
     WorkGraphPlanningIssueFacts,
     WorkGraphSnapshot,
     build_work_graph_queue,
-    build_work_graph_snapshot_from_records,
+    build_work_graph_snapshot_from_repo_mapping,
 )
 
 
@@ -54,10 +59,20 @@ def build_work_graph_snapshot_service_payload(
         record_store=product_store,
         action_allowed=action_allowed,
     )
+    readable_product_profiles = tuple(
+        profile
+        for profile in product_store.list_product_profile_records()
+        if action_allowed("product_environment.read", profile.product, "launchplane")
+    )
     planning_issue_facts = planning_facts_provider() if planning_facts_provider is not None else ()
-    snapshot = build_work_graph_snapshot_from_records(
+    repo_mapping = build_repo_product_mapping_from_records(
         generated_at=generated_at,
-        product_overviews=product_overviews,
+        product_profiles=readable_product_profiles,
+        work_requests=work_requests,
+    )
+    snapshot = build_work_graph_snapshot_from_repo_mapping(
+        generated_at=generated_at,
+        repo_mapping=repo_mapping,
         work_requests=work_requests,
         planning_issue_facts=planning_issue_facts,
     )
@@ -67,6 +82,28 @@ def build_work_graph_snapshot_service_payload(
             "product_count": len(product_overviews),
             "work_request_count": len(work_requests),
             "planning_fact_count": len(planning_issue_facts),
+        },
+    }
+
+
+def build_repo_product_mapping_service_payload(
+    *,
+    generated_at: str,
+    product_store: RepoProductMappingProductStore,
+    work_request_store: RepoProductMappingWorkRequestStore,
+) -> dict[str, object]:
+    product_profiles = product_store.list_product_profile_records()
+    work_requests = work_request_store.list_every_code_work_request_records(limit=100)
+    mapping = build_repo_product_mapping_from_records(
+        generated_at=generated_at,
+        product_profiles=product_profiles,
+        work_requests=work_requests,
+    )
+    return {
+        "mapping": mapping.model_dump(mode="json"),
+        "source": {
+            "product_count": len(product_profiles),
+            "work_request_count": len(work_requests),
         },
     }
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -63,6 +63,7 @@ VeriReel product paths:
   - `POST /v1/every-code/work-requests/rerun`
   - `POST /v1/every-code/work-requests/status`
 - work graph chooser route:
+  - `GET /v1/repo-product-mapping`
   - `GET /v1/work-graph/snapshot`
   - `POST /v1/work-graph/rank`
 - product driver routes:
@@ -100,12 +101,12 @@ grant routes accept GitHub Actions OIDC callers and authenticated admin human
 sessions, require the `launchplane_service_deploy.execute` action, and remain
 the service-owned write/reload boundary for DB-backed GitHub Actions and GitHub
 human policy rules. The terminal-agent grant route uses the same boundary for
-DB-backed terminal-agent read rules. Grant requests support `dry_run` and `apply` modes. Apply
-requests must include an audit reason, write a new active policy record only
-when the grant is not already present, and immediately refresh the in-process
-policy used by the current service worker. Responses return record metadata,
-rule counts, a compact diff, and redacted audit metadata rather than echoing
-workflow refs, human logins, or the full policy body.
+DB-backed terminal-agent read rules. Grant requests support `dry_run` and
+`apply` modes. Apply requests must include an audit reason, write a new active
+policy record only when the grant is not already present, and immediately
+refresh the in-process policy used by the current service worker. Responses
+return record metadata, rule counts, a compact diff, and redacted audit metadata
+rather than echoing workflow refs, human logins, or the full policy body.
 
 The service also serves the built operator UI shell at `/`, with `/ui` retained
 as a compatibility alias. Built assets live under `/ui/assets/...`, while
@@ -158,6 +159,14 @@ returns the queue payload under `result.queue`. The route requires the
 `work_graph.rank` action for product/context `launchplane`, performs no storage
 writes, and does not make Launchplane authoritative for copied GitHub or Code
 Plans state.
+
+`GET /v1/repo-product-mapping` returns the repository ownership/awareness read
+model used by work graph and future agent context. The route requires
+`product_environment.read` for product/context `launchplane`, performs no
+writes, and distinguishes Launchplane-managed runtime repos from awareness-only
+Every Code work-request repos. Managed runtime entries come from product profile
+records and include product, contexts, stable environments, driver id, and
+preview context; awareness entries do not imply Launchplane runtime ownership.
 
 `GET /v1/work-graph/snapshot` returns the current Launchplane-assembled work
 graph snapshot for the same authorization boundary. It composes product

--- a/docs/work-graph-read-model.md
+++ b/docs/work-graph-read-model.md
@@ -99,6 +99,23 @@ until Launchplane has an explicit repo classification. Empty planning facts do
 not erase Every Code work-request facts. The snapshot route does not fetch or
 store GitHub issue bodies and does not write new records.
 
+Agents and operator tools can read the same repository classification source
+without asking for a ranked queue first:
+
+```sh
+GET /v1/repo-product-mapping
+```
+
+The route requires `product_environment.read` for the Launchplane service
+context. It returns `mapping.repositories` with each repository's
+classification, product key when Launchplane owns the runtime, display name,
+driver id, known contexts, stable environments, preview context, update time,
+and source. Product profile records create `managed_runtime` mappings. Durable
+Every Code work requests create `active_awareness` mappings only when no product
+profile already owns the repo. The mapping is a read model for work graph and
+future agent context; it does not make awareness/support repos Launchplane-owned
+runtime repos.
+
 The GitHub Project provider shells out to:
 
 ```sh

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -14,6 +14,7 @@ import type {
   ProductEnvironmentConfigStatusPayload,
   ProductListPayload,
   ProductProfileListPayload,
+  RepoProductMappingPayload,
   WorkGraphRankPayload,
   WorkGraphSnapshot,
   WorkGraphSnapshotPayload,
@@ -124,6 +125,10 @@ export function listEveryCodeWorkRequests(
 
 export function readWorkGraphSnapshot(): Promise<WorkGraphSnapshotPayload> {
   return requestJson<WorkGraphSnapshotPayload>("/v1/work-graph/snapshot");
+}
+
+export function readRepoProductMapping(): Promise<RepoProductMappingPayload> {
+  return requestJson<RepoProductMappingPayload>("/v1/repo-product-mapping");
 }
 
 export function rankWorkGraphSnapshot(

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -619,6 +619,33 @@ export interface WorkGraphSnapshotPayload {
   };
 }
 
+export interface RepoProductMappingEntry {
+  repository: string;
+  classification: WorkGraphRepoClassification;
+  product: string;
+  display_name: string;
+  driver_id: string;
+  contexts: string[];
+  environments: string[];
+  preview_context: string;
+  source: "product_profile" | "every_code_work_request" | "explicit";
+  updated_at: string;
+}
+
+export interface RepoProductMappingPayload {
+  status: "ok";
+  trace_id: string;
+  mapping: {
+    schema_version: number;
+    generated_at: string;
+    repositories: RepoProductMappingEntry[];
+  };
+  source: {
+    product_count: number;
+    work_request_count: number;
+  };
+}
+
 export interface WorkGraphQueueItem {
   repository: string;
   repo_classification: WorkGraphRepoClassification;

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3344,6 +3344,90 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
 
+    def test_repo_product_mapping_returns_managed_and_awareness_repos(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": ["*"],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": [
+                            "product_environment.read",
+                            "every_code_work_request.write",
+                        ],
+                    }
+                ]
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            create_status, _ = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/create",
+                payload={
+                    "repository": "cbusillo/tooling",
+                    "issue_number": 12,
+                    "issue_url": "https://github.com/cbusillo/tooling/issues/12",
+                    "issue_title": "Support repo follow-up",
+                    "trigger_label": "every-code",
+                    "trigger_actor": "cbusillo",
+                    "source": "manual",
+                    "queued_at": "2026-05-08T18:00:00Z",
+                },
+                headers={"Idempotency-Key": "every-code-create-tooling-12"},
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/repo-product-mapping",
+            )
+
+        self.assertEqual(create_status, 202)
+        self.assertEqual(status_code, 200)
+        self.assertEqual(payload["status"], "ok")
+        repositories = payload["mapping"]["repositories"]
+        by_repository = {repository["repository"]: repository for repository in repositories}
+        self.assertEqual(by_repository["every/example-site"]["classification"], "managed_runtime")
+        self.assertEqual(by_repository["every/example-site"]["product"], "example-site")
+        self.assertEqual(by_repository["every/example-site"]["environments"], ["testing", "prod"])
+        self.assertEqual(by_repository["cbusillo/tooling"]["classification"], "active_awareness")
+        self.assertEqual(payload["source"]["product_count"], 1)
+        self.assertEqual(payload["source"]["work_request_count"], 1)
+
+    def test_repo_product_mapping_rejects_unauthorized_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/repo-product-mapping",
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
     def test_health_endpoint_reports_storage_backend(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             app = create_launchplane_service_app(

--- a/tests/test_work_graph_service.py
+++ b/tests/test_work_graph_service.py
@@ -8,6 +8,7 @@ from control_plane.contracts.product_profile_record import LaunchplaneProductPro
 from control_plane.contracts.work_graph_read_model import WorkGraphPlanningIssueFacts
 from control_plane.work_graph_service import (
     WorkGraphRankEnvelope,
+    build_repo_product_mapping_service_payload,
     build_work_graph_rank_result,
     build_work_graph_snapshot_service_payload,
 )
@@ -33,15 +34,25 @@ def _work_request(**overrides: object) -> EveryCodeWorkRequestRecord:
 
 
 class _EmptyProductStore:
+    def __init__(
+        self, records: tuple[LaunchplaneProductProfileRecord, ...] = ()
+    ) -> None:
+        self.records = records
+
     def list_product_profile_records(
         self,
         *,
         driver_id: str = "",
     ) -> tuple[LaunchplaneProductProfileRecord, ...]:
-        return ()
+        if not driver_id:
+            return self.records
+        return tuple(record for record in self.records if record.driver_id == driver_id)
 
     def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
-        raise AssertionError("empty product store should not read product profiles")
+        for record in self.records:
+            if record.product == product:
+                return record
+        raise AssertionError(f"test product store has no product profile for {product!r}")
 
 
 class _WorkRequestStore:
@@ -62,6 +73,64 @@ class _WorkRequestStore:
 
 
 class WorkGraphServiceTests(unittest.TestCase):
+    def test_repo_product_mapping_payload_classifies_products_and_awareness_repos(self) -> None:
+        payload = build_repo_product_mapping_service_payload(
+            generated_at="2026-05-08T18:05:00Z",
+            product_store=_EmptyProductStore(
+                (
+                    LaunchplaneProductProfileRecord.model_validate(
+                        {
+                            "schema_version": 1,
+                            "product": "example-site",
+                            "display_name": "Example Site",
+                            "repository": "every/example-site",
+                            "driver_id": "generic-web",
+                            "image": {"repository": "ghcr.io/every/example-site"},
+                            "runtime_port": 3000,
+                            "health_path": "/healthz",
+                            "lanes": (
+                                {"instance": "testing", "context": "example-site"},
+                                {"instance": "prod", "context": "example-site"},
+                            ),
+                            "historical_contexts": ("example-site-legacy",),
+                            "preview": {"enabled": True, "context": "example-site-preview"},
+                            "updated_at": "2026-05-02T22:30:00Z",
+                            "source": "test",
+                        }
+                    ),
+                )
+            ),
+            work_request_store=_WorkRequestStore(
+                (
+                    _work_request(repository="every/example-site"),
+                    _work_request(
+                        request_id="every-code-cbusillo-tooling-12",
+                        repository="cbusillo/tooling",
+                        issue_number=12,
+                        issue_url="https://github.com/cbusillo/tooling/issues/12",
+                    ),
+                )
+            ),
+        )
+
+        self.assertEqual(payload["source"], {"product_count": 1, "work_request_count": 2})
+        mapping = cast(dict[str, object], payload["mapping"])
+        repositories = cast(list[dict[str, object]], mapping["repositories"])
+        by_repository = {str(repo["repository"]): repo for repo in repositories}
+        product_repo = by_repository["every/example-site"]
+        self.assertEqual(product_repo["classification"], "managed_runtime")
+        self.assertEqual(product_repo["product"], "example-site")
+        self.assertEqual(product_repo["display_name"], "Example Site")
+        self.assertEqual(product_repo["driver_id"], "generic-web")
+        self.assertEqual(product_repo["contexts"], ["example-site", "example-site-legacy"])
+        self.assertEqual(product_repo["environments"], ["testing", "prod"])
+        self.assertEqual(product_repo["preview_context"], "example-site-preview")
+        self.assertEqual(product_repo["source"], "product_profile")
+        awareness_repo = by_repository["cbusillo/tooling"]
+        self.assertEqual(awareness_repo["classification"], "active_awareness")
+        self.assertEqual(awareness_repo["product"], "")
+        self.assertEqual(awareness_repo["source"], "every_code_work_request")
+
     def test_snapshot_payload_builds_source_counts_and_applies_planning_facts(self) -> None:
         work_request_store = _WorkRequestStore((_work_request(),))
 
@@ -96,6 +165,42 @@ class WorkGraphServiceTests(unittest.TestCase):
         self.assertEqual(issues[0]["focus"], "Now")
         self.assertEqual(issues[0]["manager"], "@cellmechanic")
         self.assertEqual(issues[0]["blocking"], 2)
+
+    def test_snapshot_payload_does_not_classify_unauthorized_product_repo_as_managed(
+        self,
+    ) -> None:
+        product = LaunchplaneProductProfileRecord.model_validate(
+            {
+                "schema_version": 1,
+                "product": "example-site",
+                "display_name": "Example Site",
+                "repository": "every/example-site",
+                "driver_id": "generic-web",
+                "image": {"repository": "ghcr.io/every/example-site"},
+                "runtime_port": 3000,
+                "health_path": "/healthz",
+                "lanes": ({"instance": "prod", "context": "example-site"},),
+                "updated_at": "2026-05-02T22:30:00Z",
+                "source": "test",
+            }
+        )
+
+        payload = build_work_graph_snapshot_service_payload(
+            generated_at="2026-05-06T02:05:00Z",
+            product_store=_EmptyProductStore((product,)),
+            work_request_store=_WorkRequestStore(
+                (_work_request(repository="every/example-site"),)
+            ),
+            action_allowed=lambda _action, _product, _context: False,
+            planning_facts_provider=None,
+        )
+
+        snapshot = cast(dict[str, object], payload["snapshot"])
+        source = cast(dict[str, object], payload["source"])
+        repos = cast(list[dict[str, object]], snapshot["repos"])
+        self.assertEqual(source["product_count"], 1)
+        self.assertEqual(repos[0]["classification"], "active_awareness")
+        self.assertEqual(repos[0]["product"], "")
 
     def test_rank_result_returns_summary_and_driver_queue(self) -> None:
         snapshot_payload = build_work_graph_snapshot_service_payload(


### PR DESCRIPTION
## Summary
- add a reusable repo/product mapping read model for managed-runtime and active-awareness repositories
- expose GET /v1/repo-product-mapping behind the Launchplane product_environment.read boundary
- have work graph snapshot assembly consume the same mapping source while preserving product read authorization
- document the new route and add frontend API/types for future consumers

Refs #382

## Validation
- uv run python -m unittest tests.test_work_graph_service tests.test_work_graph_read_model tests.test_service.LaunchplaneServiceTests.test_repo_product_mapping_returns_managed_and_awareness_repos tests.test_service.LaunchplaneServiceTests.test_repo_product_mapping_rejects_unauthorized_identity tests.test_service.LaunchplaneServiceTests.test_work_graph_snapshot_returns_launchplane_assembled_snapshot tests.test_service.LaunchplaneServiceTests.test_work_graph_snapshot_uses_compact_planning_facts_when_available
- uv run --extra dev mypy control_plane/contracts/repo_product_mapping_read_model.py control_plane/contracts/work_graph_read_model.py control_plane/work_graph_service.py control_plane/work_graph_http.py tests/test_work_graph_service.py tests/test_work_graph_read_model.py
- uv run --extra dev ruff check --diff control_plane/contracts/repo_product_mapping_read_model.py control_plane/contracts/work_graph_read_model.py control_plane/work_graph_service.py control_plane/work_graph_http.py tests/test_work_graph_service.py tests/test_service.py
- uv run --extra dev ruff check control_plane/contracts/repo_product_mapping_read_model.py control_plane/contracts/work_graph_read_model.py control_plane/work_graph_service.py control_plane/work_graph_http.py tests/test_work_graph_service.py tests/test_service.py
- pnpm --dir frontend validate
- uv run python -m unittest
