### PR TITLE
Add Every Code agent summary projection

### DIFF
--- a/control_plane/contracts/every_code_summary_read_model.py
+++ b/control_plane/contracts/every_code_summary_read_model.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from typing import Literal, Protocol, cast
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.every_code_work_request import (
+    EveryCodeWorkRequestRecord,
+    EveryCodeWorkRequestState,
+)
+
+
+EveryCodeSummaryStatus = Literal["active", "stuck", "complete", "rerunnable"]
+
+
+class EveryCodeSummaryStore(Protocol):
+    def list_every_code_work_request_records(
+        self,
+        *,
+        state: str = "",
+        repository: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[EveryCodeWorkRequestRecord, ...]: ...
+
+
+class EveryCodeWorkRequestSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    request_id: str
+    repository: str
+    issue_number: int = Field(ge=1)
+    issue_url: str
+    issue_title: str = ""
+    state: EveryCodeWorkRequestState
+    summary_status: EveryCodeSummaryStatus
+    source: str
+    trigger_label: str
+    trigger_actor: str = ""
+    claimed_by_host: str = ""
+    queued_at: str
+    updated_at: str
+    claimed_at: str = ""
+    started_at: str = ""
+    finished_at: str = ""
+    result_pr_url: str = ""
+    result_summary: str = ""
+    safe_to_rerun: bool
+    next_action: str
+
+    @model_validator(mode="after")
+    def _validate_summary(self) -> "EveryCodeWorkRequestSummary":
+        if not self.request_id.strip():
+            raise ValueError("Every Code summary requires request_id")
+        if not self.repository.strip() or "/" not in self.repository.strip():
+            raise ValueError("Every Code summary requires owner/repo repository")
+        if not self.issue_url.strip():
+            raise ValueError("Every Code summary requires issue_url")
+        return self
+
+
+class EveryCodeSummaryReadModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    generated_at: str
+    repository: str = ""
+    issue_number: int | None = Field(default=None, ge=1)
+    state_filter: EveryCodeWorkRequestState | Literal[""] = ""
+    summaries: tuple[EveryCodeWorkRequestSummary, ...]
+
+    @model_validator(mode="after")
+    def _validate_read_model(self) -> "EveryCodeSummaryReadModel":
+        if not self.generated_at.strip():
+            raise ValueError("Every Code summary read model requires generated_at")
+        return self
+
+
+def build_every_code_summary_read_model(
+    *,
+    generated_at: str,
+    record_store: EveryCodeSummaryStore,
+    repository: str = "",
+    issue_number: int | None = None,
+    state: str = "",
+    limit: int = 50,
+    offset: int = 0,
+) -> EveryCodeSummaryReadModel:
+    normalized_repository = repository.strip()
+    normalized_state = state.strip()
+    if normalized_state not in {"", "queued", "claimed", "running", "done", "blocked"}:
+        raise ValueError("Every Code summary state filter is invalid")
+    records = record_store.list_every_code_work_request_records(
+        state=normalized_state,
+        repository=normalized_repository,
+        limit=limit,
+        offset=offset,
+    )
+    if issue_number is not None:
+        records = tuple(record for record in records if record.issue_number == issue_number)
+    return EveryCodeSummaryReadModel(
+        generated_at=generated_at,
+        repository=normalized_repository,
+        issue_number=issue_number,
+        state_filter=cast(EveryCodeWorkRequestState | Literal[""], normalized_state),
+        summaries=tuple(_summary_from_record(record) for record in records),
+    )
+
+
+def _summary_from_record(record: EveryCodeWorkRequestRecord) -> EveryCodeWorkRequestSummary:
+    summary_status = _summary_status(record)
+    return EveryCodeWorkRequestSummary(
+        request_id=record.request_id,
+        repository=record.repository,
+        issue_number=record.issue_number,
+        issue_url=record.issue_url,
+        issue_title=record.issue_title,
+        state=record.state,
+        summary_status=summary_status,
+        source=record.source,
+        trigger_label=record.trigger_label,
+        trigger_actor=record.trigger_actor,
+        claimed_by_host=record.claimed_by_host,
+        queued_at=record.queued_at,
+        updated_at=record.updated_at,
+        claimed_at=record.claimed_at,
+        started_at=record.started_at,
+        finished_at=record.finished_at,
+        result_pr_url=record.result_pr_url,
+        result_summary=record.result_summary if record.state == "done" else "",
+        safe_to_rerun=record.state in {"done", "blocked"},
+        next_action=_next_action(record=record, summary_status=summary_status),
+    )
+
+
+def _summary_status(record: EveryCodeWorkRequestRecord) -> EveryCodeSummaryStatus:
+    if record.state in {"queued", "claimed", "running"}:
+        return "active"
+    if record.state == "blocked":
+        return "stuck"
+    if record.result_pr_url.strip():
+        return "complete"
+    return "rerunnable"
+
+
+def _next_action(
+    *,
+    record: EveryCodeWorkRequestRecord,
+    summary_status: EveryCodeSummaryStatus,
+) -> str:
+    if summary_status == "active":
+        if record.state == "queued":
+            return "Wait for a local worker to claim this request."
+        return "Check the claimed local worker session before rerunning."
+    if summary_status == "stuck":
+        return "Inspect the linked issue and rerun when the blocker is resolved."
+    if summary_status == "complete":
+        return "Review the linked result PR or issue handoff."
+    return "Rerun the request if the issue still needs local automation."

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -56,6 +56,9 @@ from control_plane.contracts.every_code_pr_feedback_record import (
     apply_every_code_pr_feedback_status,
     build_every_code_pr_feedback_id,
 )
+from control_plane.contracts.every_code_summary_read_model import (
+    build_every_code_summary_read_model,
+)
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.idempotency_record import build_launchplane_idempotency_record_id
 from control_plane.contracts.preview_mutation_request import (
@@ -1644,6 +1647,8 @@ def _serve_ui_route(
 
 def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
     segments = [segment for segment in path.split("/") if segment]
+    if len(segments) == 3 and segments == ["v1", "every-code", "summary"]:
+        return "every_code_work_request.read", {"summary": "true"}
     if len(segments) == 3 and segments == ["v1", "every-code", "work-requests"]:
         return "every_code_work_request.read", {}
     if len(segments) == 3 and segments == ["v1", "every-code", "pr-feedback"]:
@@ -3055,6 +3060,8 @@ def _terminal_agent_identity_from_bearer(
 
 
 def _is_every_code_worker_route(*, method: str, path: str) -> bool:
+    if method == "GET" and path == "/v1/every-code/summary":
+        return True
     if method == "GET" and path == "/v1/every-code/work-requests":
         return True
     if method == "GET" and path == "/v1/every-code/pr-feedback":
@@ -3102,6 +3109,23 @@ def _every_code_read_payload(
 ) -> dict[str, object]:
     every_code_store = _every_code_work_request_store(record_store)
     segments = [segment for segment in path.split("/") if segment]
+    if path == "/v1/every-code/summary":
+        repository_filter = str((query.get("repository") or [""])[0] or "").strip()
+        issue_number_value = str((query.get("issue_number") or [""])[0] or "").strip()
+        issue_number_filter = int(issue_number_value) if issue_number_value else None
+        state_filter = str((query.get("state") or [""])[0] or "").strip()
+        limit = _every_code_pagination_value(query, key="limit", default=50)
+        offset = _every_code_pagination_value(query, key="offset", default=0)
+        summary = build_every_code_summary_read_model(
+            generated_at=_utc_now_timestamp(),
+            record_store=every_code_store,
+            repository=repository_filter,
+            issue_number=issue_number_filter,
+            state=state_filter,
+            limit=limit,
+            offset=offset,
+        )
+        return {"summary": summary.model_dump(mode="json")}
     if path == "/v1/every-code/pr-feedback":
         request_id_filter = str((query.get("request_id") or [""])[0] or "").strip()
         repository_filter = str((query.get("repository") or [""])[0] or "").strip()

--- a/docs/records.md
+++ b/docs/records.md
@@ -596,6 +596,12 @@ state/
   to linked issues. A single pull request can close multiple Every Code requests;
   queued matches are terminalized with service-owned claim metadata so terminal
   records still satisfy the work-request contract.
+- Agent callers should prefer `GET /v1/every-code/summary` over raw work-request
+  reads when they only need status. The summary projection links back to the
+  issue and result PR, reports whether work is active, stuck, complete, or
+  rerunnable, and includes safe rerun guidance without exposing webhook delivery
+  ids, blocked error messages, issue bodies, prompt text, or local checkout
+  paths.
 
 ## Inventory
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -56,6 +56,7 @@ VeriReel product paths:
   - `POST /v1/authz-policies/terminal-agents/grants`
 - Every Code local automation work-request routes:
   - `POST /v1/every-code/github-webhook`
+  - `GET /v1/every-code/summary`
   - `GET /v1/every-code/work-requests`
   - `GET /v1/every-code/work-requests/{request_id}`
   - `POST /v1/every-code/work-requests/create`
@@ -153,6 +154,14 @@ authz policy mutation, read-model POSTs, or plaintext secret reveal routes.
 Policy still scopes which redacted read actions and product/context pairs the
 agent can access, such as `product_environment.read` for product environment and
 config-status diagnostics.
+
+`GET /v1/every-code/summary` returns a compact agent-safe projection of Every
+Code work requests. It requires `every_code_work_request.read` for
+product/context `launchplane` and supports `repository`, `issue_number`,
+`state`, `limit`, and `offset` query parameters. Summary entries include source
+links, state, summary status, claim metadata, timestamps, result PR URL, and
+safe rerun guidance. They intentionally omit raw webhook delivery ids, error
+messages, issue bodies, prompt text, and local checkout paths.
 
 `POST /v1/work-graph/rank` ranks a caller-supplied work graph snapshot and
 returns the queue payload under `result.queue`. The route requires the

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -3,6 +3,7 @@ import type {
   AuthSessionPayload,
   DriverListPayload,
   DriverViewPayload,
+  EveryCodeSummaryPayload,
   EveryCodeWorkRequestListPayload,
   GenericWebProdPromotionPayload,
   GenericWebProdPromotionRequest,
@@ -120,6 +121,14 @@ export function listEveryCodeWorkRequests(
 ): Promise<EveryCodeWorkRequestListPayload> {
   return requestJson<EveryCodeWorkRequestListPayload>(
     `/v1/every-code/work-requests?limit=${encodeURIComponent(String(limit))}`,
+  );
+}
+
+export function readEveryCodeSummary(
+  limit = 12,
+): Promise<EveryCodeSummaryPayload> {
+  return requestJson<EveryCodeSummaryPayload>(
+    `/v1/every-code/summary?limit=${encodeURIComponent(String(limit))}`,
   );
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -548,6 +548,42 @@ export interface EveryCodeWorkRequestListPayload {
   requests: EveryCodeWorkRequestRecord[];
 }
 
+export interface EveryCodeWorkRequestSummary {
+  request_id: string;
+  repository: string;
+  issue_number: number;
+  issue_url: string;
+  issue_title: string;
+  state: EveryCodeWorkRequestRecord["state"];
+  summary_status: "active" | "stuck" | "complete" | "rerunnable";
+  source: string;
+  trigger_label: string;
+  trigger_actor: string;
+  claimed_by_host: string;
+  queued_at: string;
+  updated_at: string;
+  claimed_at: string;
+  started_at: string;
+  finished_at: string;
+  result_pr_url: string;
+  result_summary: string;
+  safe_to_rerun: boolean;
+  next_action: string;
+}
+
+export interface EveryCodeSummaryPayload {
+  status: "ok";
+  trace_id: string;
+  summary: {
+    schema_version: number;
+    generated_at: string;
+    repository: string;
+    issue_number: number | null;
+    state_filter: EveryCodeWorkRequestRecord["state"] | "";
+    summaries: EveryCodeWorkRequestSummary[];
+  };
+}
+
 export type WorkGraphRepoClassification =
   | "managed_runtime"
   | "active_awareness"

--- a/tests/test_every_code_summary_read_model.py
+++ b/tests/test_every_code_summary_read_model.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import unittest
+
+from control_plane.contracts.every_code_summary_read_model import (
+    build_every_code_summary_read_model,
+)
+from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
+
+
+def _record(**overrides: object) -> EveryCodeWorkRequestRecord:
+    payload: dict[str, object] = {
+        "request_id": "every-code-cbusillo-launchplane-190",
+        "source": "github_issue_label",
+        "state": "queued",
+        "repository": "cbusillo/launchplane",
+        "issue_number": 190,
+        "issue_url": "https://github.com/cbusillo/launchplane/issues/190",
+        "issue_title": "Build What To Work On Next cockpit",
+        "trigger_label": "every-code",
+        "trigger_actor": "cbusillo",
+        "github_delivery_id": "delivery-190",
+        "queued_at": "2026-05-06T02:00:00Z",
+        "updated_at": "2026-05-06T02:00:00Z",
+    }
+    payload.update(overrides)
+    return EveryCodeWorkRequestRecord.model_validate(payload)
+
+
+class _Store:
+    def __init__(self, records: tuple[EveryCodeWorkRequestRecord, ...]) -> None:
+        self.records = records
+
+    def list_every_code_work_request_records(
+        self,
+        *,
+        state: str = "",
+        repository: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[EveryCodeWorkRequestRecord, ...]:
+        records = tuple(
+            record
+            for record in self.records
+            if (not state or record.state == state)
+            and (not repository or record.repository == repository)
+        )
+        if offset:
+            records = records[offset:]
+        if limit is not None:
+            records = records[:limit]
+        return records
+
+
+class EveryCodeSummaryReadModelTests(unittest.TestCase):
+    def test_summary_projects_compact_agent_safe_fields(self) -> None:
+        read_model = build_every_code_summary_read_model(
+            generated_at="2026-05-08T18:25:00Z",
+            record_store=_Store(
+                (
+                    _record(),
+                    _record(
+                        request_id="every-code-cbusillo-launchplane-191",
+                        state="blocked",
+                        issue_number=191,
+                        issue_url="https://github.com/cbusillo/launchplane/issues/191",
+                        claimed_at="2026-05-06T02:01:00Z",
+                        claimed_by_host="local-mac",
+                        started_at="2026-05-06T02:02:00Z",
+                        finished_at="2026-05-06T02:08:00Z",
+                        updated_at="2026-05-06T02:08:00Z",
+                        error_message="/Users/chris/private checkout failed",
+                    ),
+                    _record(
+                        request_id="every-code-cbusillo-launchplane-192",
+                        state="done",
+                        issue_number=192,
+                        issue_url="https://github.com/cbusillo/launchplane/issues/192",
+                        claimed_at="2026-05-06T02:01:00Z",
+                        claimed_by_host="local-mac",
+                        started_at="2026-05-06T02:02:00Z",
+                        finished_at="2026-05-06T02:08:00Z",
+                        updated_at="2026-05-06T02:08:00Z",
+                        result_pr_url="https://github.com/cbusillo/launchplane/pull/200",
+                        result_summary="PR opened with focused implementation.",
+                    ),
+                )
+            ),
+        )
+
+        summaries = {summary.issue_number: summary for summary in read_model.summaries}
+        self.assertEqual(summaries[190].summary_status, "active")
+        self.assertFalse(summaries[190].safe_to_rerun)
+        self.assertEqual(summaries[191].summary_status, "stuck")
+        self.assertTrue(summaries[191].safe_to_rerun)
+        self.assertNotIn("private", summaries[191].model_dump_json())
+        self.assertEqual(summaries[192].summary_status, "complete")
+        self.assertEqual(summaries[192].result_pr_url, "https://github.com/cbusillo/launchplane/pull/200")
+        self.assertEqual(summaries[192].result_summary, "PR opened with focused implementation.")
+
+    def test_summary_supports_repo_issue_and_state_filters(self) -> None:
+        read_model = build_every_code_summary_read_model(
+            generated_at="2026-05-08T18:25:00Z",
+            record_store=_Store(
+                (
+                    _record(repository="cbusillo/launchplane", issue_number=190),
+                    _record(
+                        request_id="every-code-cbusillo-code-12",
+                        repository="cbusillo/code",
+                        issue_number=12,
+                        issue_url="https://github.com/cbusillo/code/issues/12",
+                        state="done",
+                        claimed_at="2026-05-06T02:01:00Z",
+                        claimed_by_host="local-mac",
+                        started_at="2026-05-06T02:02:00Z",
+                        finished_at="2026-05-06T02:08:00Z",
+                        updated_at="2026-05-06T02:08:00Z",
+                    ),
+                )
+            ),
+            repository="cbusillo/code",
+            issue_number=12,
+            state="done",
+        )
+
+        self.assertEqual(read_model.repository, "cbusillo/code")
+        self.assertEqual(read_model.issue_number, 12)
+        self.assertEqual(read_model.state_filter, "done")
+        self.assertEqual(len(read_model.summaries), 1)
+        self.assertEqual(read_model.summaries[0].repository, "cbusillo/code")
+        self.assertEqual(read_model.summaries[0].issue_number, 12)
+
+    def test_invalid_state_filter_fails_closed(self) -> None:
+        with self.assertRaisesRegex(ValueError, "state filter is invalid"):
+            build_every_code_summary_read_model(
+                generated_at="2026-05-08T18:25:00Z",
+                record_store=_Store(()),
+                state="secret",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1095,6 +1095,88 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(show_payload["request"]["state"], "claimed")
         self.assertEqual(show_payload["request"]["github_delivery_id"], "delivery-1")
 
+    def test_every_code_summary_returns_agent_safe_projection(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": ["*"],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["every_code_work_request.read"],
+                    }
+                ]
+            }
+        )
+        issue_payload = _every_code_github_issue_labeled_payload()
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(
+                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
+                ),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            webhook_status, _ = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=issue_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-1",
+                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                },
+            )
+            summary_status, summary_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/every-code/summary",
+                query_string="repository=cbusillo/code&issue_number=123&state=queued",
+            )
+
+        self.assertEqual(webhook_status, 202)
+        self.assertEqual(summary_status, 200)
+        summary = summary_payload["summary"]
+        self.assertEqual(summary["repository"], "cbusillo/code")
+        self.assertEqual(summary["issue_number"], 123)
+        self.assertEqual(summary["state_filter"], "queued")
+        self.assertEqual(len(summary["summaries"]), 1)
+        request_summary = summary["summaries"][0]
+        self.assertEqual(request_summary["repository"], "cbusillo/code")
+        self.assertEqual(request_summary["issue_number"], 123)
+        self.assertEqual(request_summary["summary_status"], "active")
+        self.assertFalse(request_summary["safe_to_rerun"])
+        self.assertNotIn("github_delivery_id", request_summary)
+
+    def test_every_code_summary_rejects_unauthorized_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/every-code/summary",
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
     def test_every_code_github_webhook_dedupes_finished_request(self) -> None:
         secret = "launchplane-every-code-webhook-secret"
         policy = LaunchplaneAuthzPolicy.model_validate(


### PR DESCRIPTION
## Summary
- add an agent-safe Every Code summary read model that classifies requests as active, stuck, complete, or rerunnable
- expose GET /v1/every-code/summary behind the existing every_code_work_request.read boundary with repository/issue/state pagination filters
- add frontend API/types for the summary payload
- document the summary route as the preferred status surface over raw work-request records for agents

Refs #384

## Validation
- uv run python -m unittest tests.test_every_code_summary_read_model tests.test_service.LaunchplaneServiceTests.test_every_code_summary_returns_agent_safe_projection tests.test_service.LaunchplaneServiceTests.test_every_code_summary_rejects_unauthorized_identity
- uv run --extra dev mypy control_plane/contracts/every_code_summary_read_model.py control_plane/service.py tests/test_every_code_summary_read_model.py tests/test_service.py
- uv run --extra dev ruff check --diff control_plane/contracts/every_code_summary_read_model.py control_plane/service.py tests/test_every_code_summary_read_model.py tests/test_service.py
- uv run --extra dev ruff check control_plane/contracts/every_code_summary_read_model.py control_plane/service.py tests/test_every_code_summary_read_model.py tests/test_service.py
- pnpm --dir frontend validate
- uv run python -m unittest
