### PR TITLE
Expose preview readiness read model

### DIFF
--- a/control_plane/contracts/preview_readiness_read_model.py
+++ b/control_plane/contracts/preview_readiness_read_model.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from typing import Literal, Protocol, cast
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.every_code_preview_gate_record import (
+    EveryCodePreviewGateRecord,
+    EveryCodePreviewGateStatus,
+)
+
+
+PreviewReadinessStatus = Literal[
+    "waiting_on_checks",
+    "ready",
+    "needs_attention",
+    "cancelled",
+]
+PreviewReadinessFreshness = Literal["verified", "recorded", "stale", "missing", "unsupported"]
+
+
+class PreviewReadinessStore(Protocol):
+    def list_every_code_preview_gate_records(
+        self,
+        *,
+        request_id: str = "",
+        repository: str = "",
+        pr_number: int | None = None,
+        status: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[EveryCodePreviewGateRecord, ...]: ...
+
+
+class PreviewReadinessItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    gate_id: str
+    request_id: str
+    repository: str
+    issue_number: int = Field(ge=1)
+    issue_url: str
+    pr_number: int = Field(ge=1)
+    pr_url: str
+    head_sha: str
+    gate_status: EveryCodePreviewGateStatus
+    readiness_status: PreviewReadinessStatus
+    freshness_status: PreviewReadinessFreshness
+    provenance: str = "every_code_preview_gate"
+    updated_at: str
+    last_checked_at: str = ""
+    ready_at: str = ""
+    terminal_at: str = ""
+    detail: str
+    check_summary: str = ""
+    source_of_truth_url: str
+    safe_to_request_preview: bool
+    needs_operator_attention: bool
+
+    @model_validator(mode="after")
+    def _validate_item(self) -> "PreviewReadinessItem":
+        if not self.gate_id.strip():
+            raise ValueError("preview readiness item requires gate_id")
+        if not self.repository.strip() or "/" not in self.repository.strip():
+            raise ValueError("preview readiness item requires owner/repo repository")
+        if not self.issue_url.strip():
+            raise ValueError("preview readiness item requires issue_url")
+        if not self.pr_url.strip():
+            raise ValueError("preview readiness item requires pr_url")
+        if not self.source_of_truth_url.strip():
+            raise ValueError("preview readiness item requires source_of_truth_url")
+        if not self.updated_at.strip():
+            raise ValueError("preview readiness item requires updated_at")
+        return self
+
+
+class PreviewReadinessReadModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    generated_at: str
+    repository: str = ""
+    pr_number: int | None = Field(default=None, ge=1)
+    status_filter: EveryCodePreviewGateStatus | Literal[""] = ""
+    items: tuple[PreviewReadinessItem, ...]
+
+    @model_validator(mode="after")
+    def _validate_read_model(self) -> "PreviewReadinessReadModel":
+        if not self.generated_at.strip():
+            raise ValueError("preview readiness read model requires generated_at")
+        return self
+
+
+def build_preview_readiness_read_model(
+    *,
+    generated_at: str,
+    record_store: PreviewReadinessStore,
+    repository: str = "",
+    pr_number: int | None = None,
+    status: str = "",
+    limit: int = 50,
+    offset: int = 0,
+) -> PreviewReadinessReadModel:
+    normalized_repository = repository.strip()
+    normalized_status = status.strip()
+    if normalized_status not in {"", "pending", "ready", "blocked", "labeled", "cancelled"}:
+        raise ValueError("preview readiness status filter is invalid")
+    gate_records = record_store.list_every_code_preview_gate_records(
+        repository=normalized_repository,
+        pr_number=pr_number,
+        status=normalized_status,
+        limit=limit,
+        offset=offset,
+    )
+    return PreviewReadinessReadModel(
+        generated_at=generated_at,
+        repository=normalized_repository,
+        pr_number=pr_number,
+        status_filter=cast(EveryCodePreviewGateStatus | Literal[""], normalized_status),
+        items=tuple(_readiness_item_from_gate(gate) for gate in gate_records),
+    )
+
+
+def _readiness_item_from_gate(gate: EveryCodePreviewGateRecord) -> PreviewReadinessItem:
+    readiness_status = _readiness_status(gate)
+    return PreviewReadinessItem(
+        gate_id=gate.gate_id,
+        request_id=gate.request_id,
+        repository=gate.repository,
+        issue_number=gate.issue_number,
+        issue_url=gate.issue_url,
+        pr_number=gate.pr_number,
+        pr_url=gate.pr_url,
+        head_sha=gate.head_sha,
+        gate_status=gate.status,
+        readiness_status=readiness_status,
+        freshness_status=_freshness_status(gate),
+        updated_at=gate.updated_at,
+        last_checked_at=gate.last_checked_at,
+        ready_at=gate.ready_at or gate.labeled_at,
+        terminal_at=gate.cancelled_at,
+        detail=_detail(gate=gate, readiness_status=readiness_status),
+        check_summary=gate.check_summary,
+        source_of_truth_url=gate.pr_url,
+        safe_to_request_preview=gate.status in {"ready", "labeled"},
+        needs_operator_attention=gate.status == "blocked",
+    )
+
+
+def _readiness_status(gate: EveryCodePreviewGateRecord) -> PreviewReadinessStatus:
+    if gate.status == "pending":
+        return "waiting_on_checks"
+    if gate.status in {"ready", "labeled"}:
+        return "ready"
+    if gate.status == "blocked":
+        return "needs_attention"
+    return "cancelled"
+
+
+def _freshness_status(gate: EveryCodePreviewGateRecord) -> PreviewReadinessFreshness:
+    if gate.status in {"ready", "labeled", "blocked", "cancelled"}:
+        return "verified"
+    if gate.last_checked_at.strip():
+        return "recorded"
+    return "missing"
+
+
+def _detail(
+    *,
+    gate: EveryCodePreviewGateRecord,
+    readiness_status: PreviewReadinessStatus,
+) -> str:
+    if readiness_status == "waiting_on_checks":
+        return gate.pending_reason or "Preview readiness is waiting on required checks."
+    if readiness_status == "ready":
+        return "Preview can be requested from the linked pull request."
+    if readiness_status == "needs_attention":
+        return gate.blocked_reason or "Preview readiness needs operator attention."
+    return gate.blocked_reason or "Preview readiness is terminal for this pull request."

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -80,6 +80,9 @@ from control_plane.contracts.preview_pr_feedback_record import (
     PreviewPrFeedbackRecord,
     PreviewPrFeedbackStatus,
 )
+from control_plane.contracts.preview_readiness_read_model import (
+    build_preview_readiness_read_model,
+)
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductLaneProfile,
@@ -1647,6 +1650,8 @@ def _serve_ui_route(
 
 def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
     segments = [segment for segment in path.split("/") if segment]
+    if len(segments) == 3 and segments == ["v1", "previews", "readiness"]:
+        return "every_code_preview_gate.read", {"readiness": "true"}
     if len(segments) == 3 and segments == ["v1", "every-code", "summary"]:
         return "every_code_work_request.read", {"summary": "true"}
     if len(segments) == 3 and segments == ["v1", "every-code", "work-requests"]:
@@ -3060,6 +3065,8 @@ def _terminal_agent_identity_from_bearer(
 
 
 def _is_every_code_worker_route(*, method: str, path: str) -> bool:
+    if method == "GET" and path == "/v1/previews/readiness":
+        return True
     if method == "GET" and path == "/v1/every-code/summary":
         return True
     if method == "GET" and path == "/v1/every-code/work-requests":
@@ -3109,6 +3116,23 @@ def _every_code_read_payload(
 ) -> dict[str, object]:
     every_code_store = _every_code_work_request_store(record_store)
     segments = [segment for segment in path.split("/") if segment]
+    if path == "/v1/previews/readiness":
+        repository_filter = str((query.get("repository") or [""])[0] or "").strip()
+        pr_number_value = str((query.get("pr_number") or [""])[0] or "").strip()
+        pr_number_filter = int(pr_number_value) if pr_number_value else None
+        status_filter = str((query.get("status") or [""])[0] or "").strip()
+        limit = _every_code_pagination_value(query, key="limit", default=50)
+        offset = _every_code_pagination_value(query, key="offset", default=0)
+        readiness = build_preview_readiness_read_model(
+            generated_at=_utc_now_timestamp(),
+            record_store=every_code_store,
+            repository=repository_filter,
+            pr_number=pr_number_filter,
+            status=status_filter,
+            limit=limit,
+            offset=offset,
+        )
+        return {"readiness": readiness.model_dump(mode="json")}
     if path == "/v1/every-code/summary":
         repository_filter = str((query.get("repository") or [""])[0] or "").strip()
         issue_number_value = str((query.get("issue_number") or [""])[0] or "").strip()
@@ -5009,6 +5033,32 @@ def create_launchplane_service_app(
                                 "error": {
                                     "code": "authorization_denied",
                                     "message": "Workflow cannot read Every Code work requests.",
+                                },
+                            },
+                        )
+                    return _handle_every_code_work_request_read(
+                        start_response=start_response,
+                        trace_id=request_trace_id,
+                        record_store=record_store,
+                        path=path,
+                        query=query,
+                    )
+                if action == "every_code_preview_gate.read":
+                    if not authz_policy.allows(
+                        identity=identity,
+                        action=action,
+                        product="launchplane",
+                        context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                    ):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=403,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "authorization_denied",
+                                    "message": "Workflow cannot read Every Code preview readiness.",
                                 },
                             },
                         )

--- a/docs/records.md
+++ b/docs/records.md
@@ -602,6 +602,10 @@ state/
   rerunnable, and includes safe rerun guidance without exposing webhook delivery
   ids, blocked error messages, issue bodies, prompt text, or local checkout
   paths.
+- Agent callers should prefer `GET /v1/previews/readiness` over raw preview-gate
+  reads when they only need preview gate status. The readiness projection maps
+  gate state to waiting, ready, needs-attention, or cancelled statuses with
+  source links, freshness/provenance, and safe request-preview guidance.
 
 ## Inventory
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -57,6 +57,7 @@ VeriReel product paths:
 - Every Code local automation work-request routes:
   - `POST /v1/every-code/github-webhook`
   - `GET /v1/every-code/summary`
+  - `GET /v1/previews/readiness`
   - `GET /v1/every-code/work-requests`
   - `GET /v1/every-code/work-requests/{request_id}`
   - `POST /v1/every-code/work-requests/create`
@@ -162,6 +163,14 @@ product/context `launchplane` and supports `repository`, `issue_number`,
 links, state, summary status, claim metadata, timestamps, result PR URL, and
 safe rerun guidance. They intentionally omit raw webhook delivery ids, error
 messages, issue bodies, prompt text, and local checkout paths.
+
+`GET /v1/previews/readiness` returns a compact agent-safe projection of Every
+Code preview gate records. It requires `every_code_preview_gate.read` for
+product/context `launchplane` and supports `repository`, `pr_number`, `status`,
+`limit`, and `offset` query parameters. Readiness items map gate records to
+agent-facing states such as waiting on checks, ready, needs attention, or
+cancelled, include source links and freshness/provenance, and avoid provider-only
+internals or secrets.
 
 `POST /v1/work-graph/rank` ranks a caller-supplied work graph snapshot and
 returns the queue payload under `result.queue`. The route requires the

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -15,6 +15,7 @@ import type {
   ProductEnvironmentConfigStatusPayload,
   ProductListPayload,
   ProductProfileListPayload,
+  PreviewReadinessPayload,
   RepoProductMappingPayload,
   WorkGraphRankPayload,
   WorkGraphSnapshot,
@@ -129,6 +130,14 @@ export function readEveryCodeSummary(
 ): Promise<EveryCodeSummaryPayload> {
   return requestJson<EveryCodeSummaryPayload>(
     `/v1/every-code/summary?limit=${encodeURIComponent(String(limit))}`,
+  );
+}
+
+export function readPreviewReadiness(
+  limit = 12,
+): Promise<PreviewReadinessPayload> {
+  return requestJson<PreviewReadinessPayload>(
+    `/v1/previews/readiness?limit=${encodeURIComponent(String(limit))}`,
   );
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -584,6 +584,52 @@ export interface EveryCodeSummaryPayload {
   };
 }
 
+export interface PreviewReadinessItem {
+  gate_id: string;
+  request_id: string;
+  repository: string;
+  issue_number: number;
+  issue_url: string;
+  pr_number: number;
+  pr_url: string;
+  head_sha: string;
+  gate_status: "pending" | "ready" | "blocked" | "labeled" | "cancelled";
+  readiness_status:
+    | "waiting_on_checks"
+    | "ready"
+    | "needs_attention"
+    | "cancelled";
+  freshness_status:
+    | "verified"
+    | "recorded"
+    | "stale"
+    | "missing"
+    | "unsupported";
+  provenance: string;
+  updated_at: string;
+  last_checked_at: string;
+  ready_at: string;
+  terminal_at: string;
+  detail: string;
+  check_summary: string;
+  source_of_truth_url: string;
+  safe_to_request_preview: boolean;
+  needs_operator_attention: boolean;
+}
+
+export interface PreviewReadinessPayload {
+  status: "ok";
+  trace_id: string;
+  readiness: {
+    schema_version: number;
+    generated_at: string;
+    repository: string;
+    pr_number: number | null;
+    status_filter: PreviewReadinessItem["gate_status"] | "";
+    items: PreviewReadinessItem[];
+  };
+}
+
 export type WorkGraphRepoClassification =
   | "managed_runtime"
   | "active_awareness"

--- a/tests/test_preview_readiness_read_model.py
+++ b/tests/test_preview_readiness_read_model.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import unittest
+
+from control_plane.contracts.every_code_preview_gate_record import (
+    EveryCodePreviewGateRecord,
+    build_every_code_preview_gate_id,
+)
+from control_plane.contracts.preview_readiness_read_model import (
+    build_preview_readiness_read_model,
+)
+
+
+def _gate(
+    *,
+    status: str = "pending",
+    head_sha: str = "abcdef1234567890",
+    pr_number: int = 86,
+    blocked_reason: str = "",
+    pending_reason: str = "",
+    check_summary: str = "",
+) -> EveryCodePreviewGateRecord:
+    return EveryCodePreviewGateRecord(
+        gate_id=build_every_code_preview_gate_id(
+            repository="cbusillo/sellyouroutboard",
+            pr_number=pr_number,
+            head_sha=head_sha,
+        ),
+        request_id="every-code-cbusillo-sellyouroutboard-123-test",
+        repository="cbusillo/sellyouroutboard",
+        issue_number=123,
+        issue_url="https://github.com/cbusillo/sellyouroutboard/issues/123",
+        issue_author="Mbanks89",
+        pr_number=pr_number,
+        pr_url=f"https://github.com/cbusillo/sellyouroutboard/pull/{pr_number}",
+        head_sha=head_sha,
+        status=status,  # type: ignore[arg-type]
+        created_at="2026-05-06T20:00:00Z",
+        updated_at="2026-05-06T20:01:00Z",
+        ready_at="2026-05-06T20:02:00Z" if status == "ready" else "",
+        labeled_at="2026-05-06T20:03:00Z" if status == "labeled" else "",
+        blocked_at="2026-05-06T20:04:00Z" if status == "blocked" else "",
+        cancelled_at="2026-05-06T20:05:00Z" if status == "cancelled" else "",
+        last_checked_at="2026-05-06T20:01:00Z",
+        pending_reason=pending_reason,
+        blocked_reason=blocked_reason,
+        check_summary=check_summary,
+    )
+
+
+class _Store:
+    def __init__(self, gates: tuple[EveryCodePreviewGateRecord, ...]) -> None:
+        self.gates = gates
+
+    def list_every_code_preview_gate_records(
+        self,
+        *,
+        request_id: str = "",
+        repository: str = "",
+        pr_number: int | None = None,
+        status: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[EveryCodePreviewGateRecord, ...]:
+        gates = tuple(
+            gate
+            for gate in self.gates
+            if (not request_id or gate.request_id == request_id)
+            and (not repository or gate.repository == repository)
+            and (pr_number is None or gate.pr_number == pr_number)
+            and (not status or gate.status == status)
+        )
+        if offset:
+            gates = gates[offset:]
+        if limit is not None:
+            gates = gates[:limit]
+        return gates
+
+
+class PreviewReadinessReadModelTests(unittest.TestCase):
+    def test_preview_readiness_maps_gate_statuses_to_agent_statuses(self) -> None:
+        read_model = build_preview_readiness_read_model(
+            generated_at="2026-05-08T18:35:00Z",
+            record_store=_Store(
+                (
+                    _gate(status="pending", pending_reason="Waiting on static_checks."),
+                    _gate(status="ready", pr_number=87),
+                    _gate(status="labeled", pr_number=88),
+                    _gate(
+                        status="blocked",
+                        pr_number=89,
+                        blocked_reason="static_checks failed.",
+                    ),
+                    _gate(
+                        status="cancelled",
+                        pr_number=90,
+                        blocked_reason="Source issue closed.",
+                    ),
+                )
+            ),
+        )
+
+        by_pr = {item.pr_number: item for item in read_model.items}
+        self.assertEqual(by_pr[86].readiness_status, "waiting_on_checks")
+        self.assertEqual(by_pr[86].freshness_status, "recorded")
+        self.assertFalse(by_pr[86].safe_to_request_preview)
+        self.assertEqual(by_pr[87].readiness_status, "ready")
+        self.assertTrue(by_pr[87].safe_to_request_preview)
+        self.assertEqual(by_pr[88].readiness_status, "ready")
+        self.assertEqual(by_pr[89].readiness_status, "needs_attention")
+        self.assertTrue(by_pr[89].needs_operator_attention)
+        self.assertEqual(by_pr[90].readiness_status, "cancelled")
+        self.assertEqual(by_pr[90].terminal_at, "2026-05-06T20:05:00Z")
+
+    def test_preview_readiness_supports_repo_pr_and_status_filters(self) -> None:
+        read_model = build_preview_readiness_read_model(
+            generated_at="2026-05-08T18:35:00Z",
+            record_store=_Store((_gate(status="blocked", blocked_reason="Timed out."),)),
+            repository="cbusillo/sellyouroutboard",
+            pr_number=86,
+            status="blocked",
+        )
+
+        self.assertEqual(read_model.repository, "cbusillo/sellyouroutboard")
+        self.assertEqual(read_model.pr_number, 86)
+        self.assertEqual(read_model.status_filter, "blocked")
+        self.assertEqual(len(read_model.items), 1)
+        self.assertEqual(read_model.items[0].detail, "Timed out.")
+
+    def test_invalid_status_filter_fails_closed(self) -> None:
+        with self.assertRaisesRegex(ValueError, "status filter is invalid"):
+            build_preview_readiness_read_model(
+                generated_at="2026-05-08T18:35:00Z",
+                record_store=_Store(()),
+                status="secret",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -23,6 +23,7 @@ from control_plane.contracts.authz_policy_record import (
     authz_policy_sha256,
 )
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
@@ -1172,6 +1173,88 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 app,
                 method="GET",
                 path="/v1/every-code/summary",
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_preview_readiness_returns_agent_safe_projection(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": ["*"],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["every_code_preview_gate.read"],
+                    }
+                ]
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_every_code_preview_gate_record(
+                EveryCodePreviewGateRecord(
+                    gate_id="every-code-preview-gate-cbusillo-code-26-abcdef",
+                    request_id="every-code-cbusillo-code-26-test",
+                    repository="cbusillo/code",
+                    issue_number=26,
+                    issue_url="https://github.com/cbusillo/code/issues/26",
+                    pr_number=31,
+                    pr_url="https://github.com/cbusillo/code/pull/31",
+                    head_sha="abcdef1234567890",
+                    status="blocked",
+                    created_at="2026-05-08T18:00:00Z",
+                    updated_at="2026-05-08T18:01:00Z",
+                    blocked_at="2026-05-08T18:01:00Z",
+                    last_checked_at="2026-05-08T18:01:00Z",
+                    blocked_reason="static_checks failed.",
+                    check_summary="static_checks=failure",
+                )
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/previews/readiness",
+                query_string="repository=cbusillo/code&pr_number=31&status=blocked",
+            )
+
+        self.assertEqual(status_code, 200)
+        readiness = payload["readiness"]
+        self.assertEqual(readiness["repository"], "cbusillo/code")
+        self.assertEqual(readiness["pr_number"], 31)
+        self.assertEqual(readiness["status_filter"], "blocked")
+        self.assertEqual(len(readiness["items"]), 1)
+        item = readiness["items"][0]
+        self.assertEqual(item["readiness_status"], "needs_attention")
+        self.assertEqual(item["freshness_status"], "verified")
+        self.assertEqual(item["source_of_truth_url"], "https://github.com/cbusillo/code/pull/31")
+        self.assertTrue(item["needs_operator_attention"])
+
+    def test_preview_readiness_rejects_unauthorized_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/previews/readiness",
             )
 
         self.assertEqual(status_code, 403)


### PR DESCRIPTION
## Summary
- add a preview readiness read model over Every Code preview gate records
- expose GET /v1/previews/readiness behind every_code_preview_gate.read with repository/PR/status pagination filters
- add frontend API/types for preview readiness consumers
- document the route as the agent-safe preview gate status surface

Refs #385

## Validation
- uv run python -m unittest tests.test_preview_readiness_read_model tests.test_service.LaunchplaneServiceTests.test_preview_readiness_returns_agent_safe_projection tests.test_service.LaunchplaneServiceTests.test_preview_readiness_rejects_unauthorized_identity
- uv run --extra dev mypy control_plane/contracts/preview_readiness_read_model.py control_plane/service.py tests/test_preview_readiness_read_model.py tests/test_service.py
- uv run --extra dev ruff check --diff control_plane/contracts/preview_readiness_read_model.py control_plane/service.py tests/test_preview_readiness_read_model.py tests/test_service.py
- uv run --extra dev ruff check control_plane/contracts/preview_readiness_read_model.py control_plane/service.py tests/test_preview_readiness_read_model.py tests/test_service.py
- pnpm --dir frontend validate
- uv run python -m unittest
