### PR TITLE
Define agent context safety rules

### DIFF
--- a/control_plane/contracts/data_provenance.py
+++ b/control_plane/contracts/data_provenance.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import re
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
@@ -5,6 +8,17 @@ from pydantic import BaseModel, ConfigDict
 
 FreshnessStatus = Literal["verified", "recorded", "stale", "missing", "unsupported"]
 SourceKind = Literal["record", "provider", "descriptor", "unsupported"]
+AgentContextSensitivity = Literal["public", "internal", "restricted"]
+AgentContextEvidenceState = FreshnessStatus
+
+_MAX_AGENT_CONTEXT_TEXT_LENGTH = 240
+_PATH_PATTERN = re.compile(r"(?<!\w)(?:/[^\s,;:=]+){2,}")
+_TOKEN_ASSIGNMENT_PATTERN = re.compile(
+    r"(?i)\b([a-z0-9_.-]*(?:token|secret|password|passwd|api[_-]?key|bearer)[a-z0-9_.-]*)"
+    r"\s*[:=]\s*([^\s,;]+)"
+)
+_BEARER_PATTERN = re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/=-]{8,}")
+_LONG_SECRET_PATTERN = re.compile(r"(?<![a-zA-Z0-9])[a-zA-Z0-9._~+/=-]{32,}(?![a-zA-Z0-9])")
 
 
 class DataProvenance(BaseModel):
@@ -17,3 +31,51 @@ class DataProvenance(BaseModel):
     freshness_status: FreshnessStatus
     stale_after: str = ""
     detail: str = ""
+
+
+class AgentContextEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: str
+    state: AgentContextEvidenceState
+    detail: str
+    source_url: str = ""
+    sensitivity: AgentContextSensitivity = "public"
+    recorded_at: str = ""
+
+
+class AgentContextProvenance(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_kind: SourceKind
+    freshness_status: FreshnessStatus
+    source_url: str = ""
+    source_record_id: str = ""
+    recorded_at: str = ""
+    refreshed_at: str = ""
+    stale_after: str = ""
+    detail: str = ""
+    sensitivity: AgentContextSensitivity = "public"
+
+
+def safe_agent_context_text(value: str, *, fallback: str) -> str:
+    """Return bounded text suitable for agent-facing context payloads."""
+
+    text = " ".join(value.strip().split())
+    if not text:
+        return fallback
+    text = _PATH_PATTERN.sub("[redacted-path]", text)
+    text = _TOKEN_ASSIGNMENT_PATTERN.sub(lambda match: f"{match.group(1)}=[redacted]", text)
+    text = _BEARER_PATTERN.sub("Bearer [redacted]", text)
+    text = _LONG_SECRET_PATTERN.sub("[redacted-secret]", text)
+    if len(text) > _MAX_AGENT_CONTEXT_TEXT_LENGTH:
+        text = text[: _MAX_AGENT_CONTEXT_TEXT_LENGTH - 1].rstrip() + "..."
+    return text or fallback
+
+
+def agent_safe_host_label(value: str) -> str:
+    """Collapse local host identity to a non-topology-bearing label."""
+
+    if value.strip():
+        return "claimed_local_worker"
+    return ""

--- a/control_plane/contracts/every_code_summary_read_model.py
+++ b/control_plane/contracts/every_code_summary_read_model.py
@@ -4,6 +4,12 @@ from typing import Literal, Protocol, cast
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane.contracts.data_provenance import (
+    AgentContextEvidence,
+    AgentContextProvenance,
+    agent_safe_host_label,
+    safe_agent_context_text,
+)
 from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestRecord,
     EveryCodeWorkRequestState,
@@ -47,6 +53,8 @@ class EveryCodeWorkRequestSummary(BaseModel):
     result_summary: str = ""
     safe_to_rerun: bool
     next_action: str
+    provenance: AgentContextProvenance
+    evidence: tuple[AgentContextEvidence, ...] = ()
 
     @model_validator(mode="after")
     def _validate_summary(self) -> "EveryCodeWorkRequestSummary":
@@ -114,22 +122,28 @@ def _summary_from_record(record: EveryCodeWorkRequestRecord) -> EveryCodeWorkReq
         repository=record.repository,
         issue_number=record.issue_number,
         issue_url=record.issue_url,
-        issue_title=record.issue_title,
+        issue_title=safe_agent_context_text(record.issue_title, fallback=""),
         state=record.state,
         summary_status=summary_status,
         source=record.source,
         trigger_label=record.trigger_label,
         trigger_actor=record.trigger_actor,
-        claimed_by_host=record.claimed_by_host,
+        claimed_by_host=agent_safe_host_label(record.claimed_by_host),
         queued_at=record.queued_at,
         updated_at=record.updated_at,
         claimed_at=record.claimed_at,
         started_at=record.started_at,
         finished_at=record.finished_at,
         result_pr_url=record.result_pr_url,
-        result_summary=record.result_summary if record.state == "done" else "",
+        result_summary=(
+            safe_agent_context_text(record.result_summary, fallback="")
+            if record.state == "done"
+            else ""
+        ),
         safe_to_rerun=record.state in {"done", "blocked"},
         next_action=_next_action(record=record, summary_status=summary_status),
+        provenance=_provenance(record),
+        evidence=_evidence(record=record, summary_status=summary_status),
     )
 
 
@@ -157,3 +171,47 @@ def _next_action(
     if summary_status == "complete":
         return "Review the linked result PR or issue handoff."
     return "Rerun the request if the issue still needs local automation."
+
+
+def _provenance(record: EveryCodeWorkRequestRecord) -> AgentContextProvenance:
+    return AgentContextProvenance(
+        source_kind="record",
+        source_record_id=record.request_id,
+        source_url=record.issue_url,
+        recorded_at=record.queued_at,
+        refreshed_at=record.updated_at,
+        freshness_status="recorded",
+        detail="Every Code work request record projected for agent status context.",
+    )
+
+
+def _evidence(
+    *, record: EveryCodeWorkRequestRecord, summary_status: EveryCodeSummaryStatus
+) -> tuple[AgentContextEvidence, ...]:
+    evidence = [
+        AgentContextEvidence(
+            code="source_of_truth",
+            state="verified",
+            detail="Linked GitHub issue is the source of truth for requested work.",
+            source_url=record.issue_url,
+            recorded_at=record.queued_at,
+        ),
+        AgentContextEvidence(
+            code="work_request_record",
+            state="recorded",
+            detail=f"Every Code work request is {summary_status}.",
+            source_url=record.issue_url,
+            recorded_at=record.updated_at or record.queued_at,
+        ),
+    ]
+    if record.result_pr_url.strip():
+        evidence.append(
+            AgentContextEvidence(
+                code="result_pr",
+                state="verified",
+                detail="Result pull request is linked from the work request record.",
+                source_url=record.result_pr_url,
+                recorded_at=record.finished_at or record.updated_at,
+            )
+        )
+    return tuple(evidence)

--- a/control_plane/contracts/preview_readiness_read_model.py
+++ b/control_plane/contracts/preview_readiness_read_model.py
@@ -4,6 +4,11 @@ from typing import Literal, Protocol, cast
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane.contracts.data_provenance import (
+    AgentContextEvidence,
+    AgentContextProvenance,
+    safe_agent_context_text,
+)
 from control_plane.contracts.every_code_preview_gate_record import (
     EveryCodePreviewGateRecord,
     EveryCodePreviewGateStatus,
@@ -56,6 +61,8 @@ class PreviewReadinessItem(BaseModel):
     source_of_truth_url: str
     safe_to_request_preview: bool
     needs_operator_attention: bool
+    context_provenance: AgentContextProvenance
+    evidence: tuple[AgentContextEvidence, ...] = ()
 
     @model_validator(mode="after")
     def _validate_item(self) -> "PreviewReadinessItem":
@@ -139,11 +146,16 @@ def _readiness_item_from_gate(gate: EveryCodePreviewGateRecord) -> PreviewReadin
         last_checked_at=gate.last_checked_at,
         ready_at=gate.ready_at or gate.labeled_at,
         terminal_at=gate.cancelled_at,
-        detail=_detail(gate=gate, readiness_status=readiness_status),
-        check_summary=gate.check_summary,
+        detail=safe_agent_context_text(
+            _detail(gate=gate, readiness_status=readiness_status),
+            fallback="Preview readiness status is recorded without detail.",
+        ),
+        check_summary=safe_agent_context_text(gate.check_summary, fallback=""),
         source_of_truth_url=gate.pr_url,
         safe_to_request_preview=gate.status in {"ready", "labeled"},
         needs_operator_attention=gate.status == "blocked",
+        context_provenance=_provenance(gate),
+        evidence=_evidence(gate),
     )
 
 
@@ -177,3 +189,45 @@ def _detail(
     if readiness_status == "needs_attention":
         return gate.blocked_reason or "Preview readiness needs operator attention."
     return gate.blocked_reason or "Preview readiness is terminal for this pull request."
+
+
+def _provenance(gate: EveryCodePreviewGateRecord) -> AgentContextProvenance:
+    return AgentContextProvenance(
+        source_kind="record",
+        source_record_id=gate.gate_id,
+        source_url=gate.pr_url,
+        recorded_at=gate.created_at,
+        refreshed_at=gate.updated_at,
+        freshness_status=_freshness_status(gate),
+        detail="Every Code preview gate record projected for agent readiness context.",
+    )
+
+
+def _evidence(gate: EveryCodePreviewGateRecord) -> tuple[AgentContextEvidence, ...]:
+    evidence = [
+        AgentContextEvidence(
+            code="source_of_truth",
+            state="verified",
+            detail="Linked pull request is the source of truth for preview readiness.",
+            source_url=gate.pr_url,
+            recorded_at=gate.updated_at,
+        ),
+        AgentContextEvidence(
+            code="preview_gate_record",
+            state=_freshness_status(gate),
+            detail=f"Preview gate status is {gate.status}.",
+            source_url=gate.pr_url,
+            recorded_at=gate.last_checked_at or gate.updated_at,
+        ),
+    ]
+    if gate.issue_url.strip():
+        evidence.append(
+            AgentContextEvidence(
+                code="source_issue",
+                state="verified",
+                detail="Linked issue requested the local automation work.",
+                source_url=gate.issue_url,
+                recorded_at=gate.created_at,
+            )
+        )
+    return tuple(evidence)

--- a/control_plane/contracts/work_graph_read_model.py
+++ b/control_plane/contracts/work_graph_read_model.py
@@ -4,6 +4,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane.contracts.data_provenance import agent_safe_host_label
 from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
 from control_plane.contracts.product_environment_read_model import ProductSiteOverview
 from control_plane.contracts.repo_product_mapping_read_model import RepoProductMapping
@@ -326,7 +327,7 @@ def _work_request_issue_snapshot(request: EveryCodeWorkRequestRecord) -> WorkGra
         url=request.issue_url,
         state="closed" if request.state == "done" else "open",
         focus=_work_request_focus(request),
-        manager=request.claimed_by_host or request.trigger_actor or "Code",
+        manager=agent_safe_host_label(request.claimed_by_host) or request.trigger_actor or "Code",
         finish_line=request.result_summary,
         labels=tuple(label for label in (request.trigger_label,) if label),
         blocked_by=1 if request.state == "blocked" else 0,

--- a/docs/operator-experience.md
+++ b/docs/operator-experience.md
@@ -142,6 +142,13 @@ Every operator-visible field needs a trust state:
 Do not show fixture, demo, fallback, inferred, or placeholder operational data in
 production UI without a visible trust state.
 
+Agent-facing context uses the same trust vocabulary and applies stricter safety
+rules because payloads may be copied into local terminal sessions. Agent context
+must include compact provenance for the source record or source URL, distinguish
+verified, recorded, stale, missing, and unsupported evidence, and redact local
+paths, secret-shaped values, bearer tokens, provider-only topology, raw issue
+bodies, and worker hostnames before response serialization.
+
 ## UI Rebuild
 
 When the API contract is ready, rebuild the UI around:

--- a/docs/records.md
+++ b/docs/records.md
@@ -600,12 +600,15 @@ state/
   reads when they only need status. The summary projection links back to the
   issue and result PR, reports whether work is active, stuck, complete, or
   rerunnable, and includes safe rerun guidance without exposing webhook delivery
-  ids, blocked error messages, issue bodies, prompt text, or local checkout
-  paths.
+  ids, blocked error messages, issue bodies, prompt text, local checkout paths,
+  or local worker hostnames. Summary entries include compact agent-context
+  provenance and evidence for the source issue and recorded work-request state.
 - Agent callers should prefer `GET /v1/previews/readiness` over raw preview-gate
   reads when they only need preview gate status. The readiness projection maps
   gate state to waiting, ready, needs-attention, or cancelled statuses with
-  source links, freshness/provenance, and safe request-preview guidance.
+  source links, freshness/provenance, and safe request-preview guidance. Detail
+  fields are bounded and redacted so provider-only internals, local paths, and
+  secret-shaped values are not copied into agent context payloads.
 
 ## Inventory
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -162,7 +162,9 @@ product/context `launchplane` and supports `repository`, `issue_number`,
 `state`, `limit`, and `offset` query parameters. Summary entries include source
 links, state, summary status, claim metadata, timestamps, result PR URL, and
 safe rerun guidance. They intentionally omit raw webhook delivery ids, error
-messages, issue bodies, prompt text, and local checkout paths.
+messages, issue bodies, prompt text, local checkout paths, and local worker
+hostnames. Entries include compact agent-context provenance and evidence so
+callers can tell recorded request state apart from source-of-truth links.
 
 `GET /v1/previews/readiness` returns a compact agent-safe projection of Every
 Code preview gate records. It requires `every_code_preview_gate.read` for
@@ -170,7 +172,8 @@ product/context `launchplane` and supports `repository`, `pr_number`, `status`,
 `limit`, and `offset` query parameters. Readiness items map gate records to
 agent-facing states such as waiting on checks, ready, needs attention, or
 cancelled, include source links and freshness/provenance, and avoid provider-only
-internals or secrets.
+internals, local paths, or secrets. Detail fields and check summaries are bounded
+and redacted before they leave the read-model projection.
 
 `POST /v1/work-graph/rank` ranks a caller-supplied work graph snapshot and
 returns the queue payload under `result.queue`. The route requires the

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -23,6 +23,27 @@ export interface DataProvenance {
   detail: string;
 }
 
+export interface AgentContextEvidence {
+  code: string;
+  state: FreshnessStatus;
+  detail: string;
+  source_url: string;
+  sensitivity: "public" | "internal" | "restricted";
+  recorded_at: string;
+}
+
+export interface AgentContextProvenance {
+  source_kind: "record" | "provider" | "descriptor" | "unsupported";
+  freshness_status: FreshnessStatus;
+  source_url: string;
+  source_record_id: string;
+  recorded_at: string;
+  refreshed_at: string;
+  stale_after: string;
+  detail: string;
+  sensitivity: "public" | "internal" | "restricted";
+}
+
 export interface DriverActionDescriptor {
   action_id: string;
   label: string;
@@ -569,6 +590,8 @@ export interface EveryCodeWorkRequestSummary {
   result_summary: string;
   safe_to_rerun: boolean;
   next_action: string;
+  provenance: AgentContextProvenance;
+  evidence: AgentContextEvidence[];
 }
 
 export interface EveryCodeSummaryPayload {
@@ -615,6 +638,8 @@ export interface PreviewReadinessItem {
   source_of_truth_url: string;
   safe_to_request_preview: boolean;
   needs_operator_attention: boolean;
+  context_provenance: AgentContextProvenance;
+  evidence: AgentContextEvidence[];
 }
 
 export interface PreviewReadinessPayload {

--- a/tests/test_agent_context_safety.py
+++ b/tests/test_agent_context_safety.py
@@ -10,9 +10,10 @@ from control_plane.contracts.data_provenance import (
 
 class AgentContextSafetyTests(unittest.TestCase):
     def test_safe_agent_context_text_redacts_paths_and_secret_shaped_values(self) -> None:
+        token_assignment = "token=" + ("x" * 36)
+        bearer_header = "Authorization: Bearer " + ("a" * 36)
         detail = safe_agent_context_text(
-            "Failed in /Users/chris/private/checkout with token=ghp_123456789012345678901234567890abcd "
-            "and Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456",
+            f"Failed in /Users/chris/private/checkout with {token_assignment} and {bearer_header}",
             fallback="No detail recorded.",
         )
 
@@ -20,8 +21,8 @@ class AgentContextSafetyTests(unittest.TestCase):
         self.assertIn("token=[redacted]", detail)
         self.assertIn("Bearer [redacted]", detail)
         self.assertNotIn("/Users/chris", detail)
-        self.assertNotIn("ghp_", detail)
-        self.assertNotIn("abcdefghijklmnopqrstuvwxyz", detail)
+        self.assertNotIn("x" * 36, detail)
+        self.assertNotIn("a" * 36, detail)
 
     def test_safe_agent_context_text_uses_fallback_for_blank_values(self) -> None:
         self.assertEqual(

--- a/tests/test_agent_context_safety.py
+++ b/tests/test_agent_context_safety.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import unittest
+
+from control_plane.contracts.data_provenance import (
+    agent_safe_host_label,
+    safe_agent_context_text,
+)
+
+
+class AgentContextSafetyTests(unittest.TestCase):
+    def test_safe_agent_context_text_redacts_paths_and_secret_shaped_values(self) -> None:
+        detail = safe_agent_context_text(
+            "Failed in /Users/chris/private/checkout with token=ghp_123456789012345678901234567890abcd "
+            "and Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456",
+            fallback="No detail recorded.",
+        )
+
+        self.assertIn("[redacted-path]", detail)
+        self.assertIn("token=[redacted]", detail)
+        self.assertIn("Bearer [redacted]", detail)
+        self.assertNotIn("/Users/chris", detail)
+        self.assertNotIn("ghp_", detail)
+        self.assertNotIn("abcdefghijklmnopqrstuvwxyz", detail)
+
+    def test_safe_agent_context_text_uses_fallback_for_blank_values(self) -> None:
+        self.assertEqual(
+            safe_agent_context_text("   ", fallback="No detail recorded."),
+            "No detail recorded.",
+        )
+
+    def test_agent_safe_host_label_hides_local_topology(self) -> None:
+        self.assertEqual(agent_safe_host_label("Chris-Studio.local"), "claimed_local_worker")
+        self.assertEqual(agent_safe_host_label(""), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_every_code_summary_read_model.py
+++ b/tests/test_every_code_summary_read_model.py
@@ -65,7 +65,7 @@ class EveryCodeSummaryReadModelTests(unittest.TestCase):
                         issue_number=191,
                         issue_url="https://github.com/cbusillo/launchplane/issues/191",
                         claimed_at="2026-05-06T02:01:00Z",
-                        claimed_by_host="local-mac",
+                        claimed_by_host="Chris-Studio.local",
                         started_at="2026-05-06T02:02:00Z",
                         finished_at="2026-05-06T02:08:00Z",
                         updated_at="2026-05-06T02:08:00Z",
@@ -93,6 +93,9 @@ class EveryCodeSummaryReadModelTests(unittest.TestCase):
         self.assertFalse(summaries[190].safe_to_rerun)
         self.assertEqual(summaries[191].summary_status, "stuck")
         self.assertTrue(summaries[191].safe_to_rerun)
+        self.assertEqual(summaries[191].claimed_by_host, "claimed_local_worker")
+        self.assertEqual(summaries[191].provenance.source_record_id, summaries[191].request_id)
+        self.assertIn("work_request_record", {entry.code for entry in summaries[191].evidence})
         self.assertNotIn("private", summaries[191].model_dump_json())
         self.assertEqual(summaries[192].summary_status, "complete")
         self.assertEqual(summaries[192].result_pr_url, "https://github.com/cbusillo/launchplane/pull/200")

--- a/tests/test_preview_readiness_read_model.py
+++ b/tests/test_preview_readiness_read_model.py
@@ -127,6 +127,29 @@ class PreviewReadinessReadModelTests(unittest.TestCase):
         self.assertEqual(len(read_model.items), 1)
         self.assertEqual(read_model.items[0].detail, "Timed out.")
 
+    def test_preview_readiness_redacts_agent_unsafe_detail(self) -> None:
+        read_model = build_preview_readiness_read_model(
+            generated_at="2026-05-08T18:35:00Z",
+            record_store=_Store(
+                (
+                    _gate(
+                        status="blocked",
+                        blocked_reason="Failed in /Users/chris/private/checkout with token=secret-value",
+                        check_summary="Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456",
+                    ),
+                )
+            ),
+        )
+
+        item = read_model.items[0]
+        self.assertIn("[redacted-path]", item.detail)
+        self.assertIn("token=[redacted]", item.detail)
+        self.assertIn("Bearer [redacted]", item.check_summary)
+        self.assertNotIn("/Users/chris", item.model_dump_json())
+        self.assertNotIn("secret-value", item.model_dump_json())
+        self.assertEqual(item.context_provenance.source_record_id, item.gate_id)
+        self.assertIn("preview_gate_record", {entry.code for entry in item.evidence})
+
     def test_invalid_status_filter_fails_closed(self) -> None:
         with self.assertRaisesRegex(ValueError, "status filter is invalid"):
             build_preview_readiness_read_model(

--- a/tests/test_work_graph_read_model.py
+++ b/tests/test_work_graph_read_model.py
@@ -368,7 +368,7 @@ class WorkGraphReadModelTests(unittest.TestCase):
 
         issue = snapshot.issues[0]
         self.assertEqual(issue.focus, "Now")
-        self.assertEqual(issue.manager, "local-mac")
+        self.assertEqual(issue.manager, "claimed_local_worker")
         self.assertEqual(issue.updated_at, "2026-05-06T03:50:00Z")
 
     def test_sparse_planning_subissue_completion_does_not_break_snapshot(self) -> None:


### PR DESCRIPTION
## Summary
- adds shared agent-context provenance/evidence models plus bounded redaction helpers
- applies agent-safe redaction and local worker host hiding to Every Code summary, preview readiness, and work graph projections
- documents agent context trust/redaction rules and updates frontend response types

Refs #381

## Validation
- uv run python -m unittest tests.test_agent_context_safety tests.test_every_code_summary_read_model tests.test_preview_readiness_read_model tests.test_work_graph_read_model
- uv run --extra dev ruff check --diff control_plane/contracts/data_provenance.py control_plane/contracts/every_code_summary_read_model.py control_plane/contracts/preview_readiness_read_model.py control_plane/contracts/work_graph_read_model.py tests/test_agent_context_safety.py tests/test_every_code_summary_read_model.py tests/test_preview_readiness_read_model.py tests/test_work_graph_read_model.py
- uv run --extra dev ruff check control_plane/contracts/data_provenance.py control_plane/contracts/every_code_summary_read_model.py control_plane/contracts/preview_readiness_read_model.py control_plane/contracts/work_graph_read_model.py tests/test_agent_context_safety.py tests/test_every_code_summary_read_model.py tests/test_preview_readiness_read_model.py tests/test_work_graph_read_model.py
- uv run --extra dev mypy control_plane/contracts/data_provenance.py control_plane/contracts/every_code_summary_read_model.py control_plane/contracts/preview_readiness_read_model.py control_plane/contracts/work_graph_read_model.py tests/test_agent_context_safety.py tests/test_every_code_summary_read_model.py tests/test_preview_readiness_read_model.py tests/test_work_graph_read_model.py
- pnpm --dir frontend validate
- uv run python -m unittest