### PR TITLE
Define agent consumer authz model

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -117,6 +117,7 @@ from control_plane.service_auth import (
     LaunchplaneIdentity,
     TerminalAgentIdentity,
     TokenVerifier,
+    agent_consumer_subject,
     load_authz_policy,
     parse_authz_policy_toml,
 )
@@ -3471,6 +3472,12 @@ def _authz_diagnostic_payload(
         }
     payload: dict[str, object] = {
         "identity": identity_payload,
+        "agent_consumer": agent_consumer_subject(
+            identity=identity,
+            action=action,
+            product=product,
+            context=context,
+        ).model_dump(mode="json"),
         "policy_source": authz_policy_source,
         "policy_sha256": authz_policy_sha256_value,
     }

--- a/control_plane/service_auth.py
+++ b/control_plane/service_auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from fnmatch import fnmatchcase
+import re
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
@@ -46,6 +47,16 @@ class TerminalAgentIdentity:
 
 
 LaunchplaneIdentity = GitHubActionsIdentity | GitHubHumanIdentity | TerminalAgentIdentity
+AgentConsumerSubjectType = Literal["github_actions", "github_human", "terminal_agent"]
+AgentConsumerActionSafety = Literal[
+    "read",
+    "safe_write",
+    "mutation",
+    "prod",
+    "destructive",
+    "secret_backed",
+    "policy_admin",
+]
 
 
 class TokenVerifier(Protocol):
@@ -242,6 +253,85 @@ class TerminalAgentPolicyRule(BaseModel):
         if self.actions and action not in self.actions:
             return False
         return True
+
+
+class AgentConsumerSubject(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    subject_type: AgentConsumerSubjectType
+    subject: str
+    display_label: str
+    role: Literal["read_only", "admin", "worker"] = "read_only"
+    product: str = ""
+    context: str = ""
+    action: str = ""
+    action_safety: AgentConsumerActionSafety = "read"
+    read_only_context: bool = False
+    approval_capable: bool = False
+
+
+def action_safety(action: str) -> AgentConsumerActionSafety:
+    normalized_action = action.strip()
+    if not normalized_action:
+        return "read"
+    action_parts = tuple(part for part in re.split(r"[_.-]+", normalized_action) if part)
+    if normalized_action.startswith("authz_policy"):
+        return "policy_admin"
+    if "secret" in action_parts:
+        return "secret_backed"
+    if any(part in action_parts for part in ("destroy", "cleanup", "delete", "rollback")):
+        return "destructive"
+    if "prod" in action_parts or "promotion" in action_parts:
+        return "prod"
+    if normalized_action.endswith(".read") or normalized_action == "work_graph.rank":
+        return "read"
+    if normalized_action.endswith(".write") or "rerun" in action_parts:
+        return "safe_write"
+    return "mutation"
+
+
+def agent_consumer_subject(
+    *, identity: LaunchplaneIdentity, action: str = "", product: str = "", context: str = ""
+) -> AgentConsumerSubject:
+    safety = action_safety(action)
+    if isinstance(identity, GitHubHumanIdentity):
+        return AgentConsumerSubject(
+            subject_type="github_human",
+            subject=identity.login,
+            display_label=identity.login,
+            role=identity.role,
+            product=product,
+            context=context,
+            action=action,
+            action_safety=safety,
+            read_only_context=identity.role == "read_only",
+            approval_capable=identity.role == "admin",
+        )
+    if isinstance(identity, TerminalAgentIdentity):
+        return AgentConsumerSubject(
+            subject_type="terminal_agent",
+            subject=identity.subject,
+            display_label=identity.token_label,
+            role="worker",
+            product=product,
+            context=context,
+            action=action,
+            action_safety=safety,
+            read_only_context=True,
+            approval_capable=False,
+        )
+    return AgentConsumerSubject(
+        subject_type="github_actions",
+        subject=identity.subject or identity.workflow_ref,
+        display_label=identity.repository,
+        role="worker",
+        product=product,
+        context=context,
+        action=action,
+        action_safety=safety,
+        read_only_context=safety == "read",
+        approval_capable=safety in {"mutation", "prod", "destructive", "secret_backed", "policy_admin"},
+    )
 
 
 class LaunchplaneAuthzPolicy(BaseModel):

--- a/docs/records.md
+++ b/docs/records.md
@@ -609,6 +609,10 @@ state/
   source links, freshness/provenance, and safe request-preview guidance. Detail
   fields are bounded and redacted so provider-only internals, local paths, and
   secret-shaped values are not copied into agent context payloads.
+- Agent-consumer authorization diagnostics use a compact subject model for
+  GitHub Actions, terminal agents, and GitHub humans. The model records the
+  requested action, product, context, safety family, read-only-context status,
+  and approval-capable status without replacing exact policy-rule authorization.
 
 ## Inventory
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -400,6 +400,27 @@ authorize read endpoints, but POST mutation routes remain GitHub Actions OIDC
 only until browser-initiated mutation workflows get a dedicated CSRF and audit
 design.
 
+Agent consumers use the same allow-list policy but are classified into a compact
+subject model before diagnostics or downstream intent contracts consume them:
+
+- `github_actions`: workflow subjects from verified OIDC claims. Read actions
+  are context-only; write, prod, destructive, secret-backed, and policy-admin
+  actions require explicit matching policy grants for the workflow identity.
+- `terminal_agent`: trusted local terminal agents authenticated by the dedicated
+  read bearer token. These subjects are always read-only context consumers and
+  cannot use POST routes, product mutations, authz policy changes, destructive
+  cleanup, or secret-backed actions even if a policy rule is too broad.
+- `github_human`: browser-session humans with `read_only` or `admin` role from
+  GitHub human policy rules or bootstrap admin email matching. Read-only humans
+  can consume scoped context; admin humans are approval-capable for future
+  operator-mediated intent flows, but direct mutation routes still require their
+  own CSRF/audit design before broad browser writes are allowed.
+
+Action names are classified for agent context as `read`, `safe_write`,
+`mutation`, `prod`, `destructive`, `secret_backed`, or `policy_admin`. This
+classification is diagnostic and contractual; authorization still fails closed
+through the exact action/product/context policy rule.
+
 For first access, `LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS` may name comma-separated
 verified GitHub email addresses that receive the `admin` role even before a
 matching `github_humans` rule exists. The GitHub OAuth client requests

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -5166,6 +5166,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
         self.assertEqual(payload["authz"]["identity"]["repository"], "every/verireel")
+        self.assertEqual(payload["authz"]["agent_consumer"]["subject_type"], "github_actions")
+        self.assertEqual(payload["authz"]["agent_consumer"]["action_safety"], "read")
+        self.assertTrue(payload["authz"]["agent_consumer"]["read_only_context"])
+        self.assertFalse(payload["authz"]["agent_consumer"]["approval_capable"])
         self.assertEqual(payload["authz"]["policy_source"], "bootstrap_seeded_store")
 
     def test_product_profile_list_denial_includes_authz_diagnostics(self) -> None:

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -16,6 +16,8 @@ from control_plane.service_auth import (
     LaunchplaneAuthzPolicy,
     TerminalAgentIdentity,
     TerminalAgentPolicyRule,
+    action_safety,
+    agent_consumer_subject,
     parse_authz_policy_toml,
 )
 from control_plane.contracts.authz_policy_record import authz_policy_sha256
@@ -164,6 +166,72 @@ class GitHubOidcVerifierBoundaryTests(unittest.TestCase):
 
 
 class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
+    def test_agent_consumer_subject_classifies_terminal_agent_as_read_only_context(self) -> None:
+        subject = agent_consumer_subject(
+            identity=_terminal_agent_identity(),
+            action="product_environment.read",
+            product="sellyouroutboard",
+            context="sellyouroutboard-testing",
+        )
+
+        self.assertEqual(subject.subject_type, "terminal_agent")
+        self.assertEqual(subject.role, "worker")
+        self.assertEqual(subject.action_safety, "read")
+        self.assertTrue(subject.read_only_context)
+        self.assertFalse(subject.approval_capable)
+
+    def test_agent_consumer_subject_classifies_human_admin_as_approval_capable(self) -> None:
+        subject = agent_consumer_subject(
+            identity=_human_identity(role="admin"),
+            action="generic_web_prod_promotion.execute",
+            product="verireel",
+            context="verireel",
+        )
+
+        self.assertEqual(subject.subject_type, "github_human")
+        self.assertEqual(subject.role, "admin")
+        self.assertEqual(subject.action_safety, "prod")
+        self.assertFalse(subject.read_only_context)
+        self.assertTrue(subject.approval_capable)
+
+    def test_agent_consumer_subject_classifies_actions_by_requested_safety(self) -> None:
+        read_subject = agent_consumer_subject(
+            identity=_actions_identity(),
+            action="product_environment.read",
+            product="verireel",
+            context="verireel-testing",
+        )
+        prod_subject = agent_consumer_subject(
+            identity=_actions_identity(),
+            action="verireel_prod_deploy.execute",
+            product="verireel",
+            context="verireel",
+        )
+
+        self.assertEqual(read_subject.subject_type, "github_actions")
+        self.assertTrue(read_subject.read_only_context)
+        self.assertFalse(read_subject.approval_capable)
+        self.assertEqual(prod_subject.action_safety, "prod")
+        self.assertFalse(prod_subject.read_only_context)
+        self.assertTrue(prod_subject.approval_capable)
+
+    def test_action_safety_classifies_privileged_action_families(self) -> None:
+        cases = {
+            "product_environment.read": "read",
+            "work_graph.rank": "read",
+            "preview_pr_feedback.write": "safe_write",
+            "every_code_work_request.rerun": "safe_write",
+            "product_config.apply": "mutation",
+            "generic_web_prod_promotion.execute": "prod",
+            "preview_destroy.execute": "destructive",
+            "secret_binding.apply": "secret_backed",
+            "authz_policy_grant.write": "policy_admin",
+        }
+
+        for action, expected_safety in cases.items():
+            with self.subTest(action=action):
+                self.assertEqual(action_safety(action), expected_safety)
+
     def test_actions_policy_fails_closed_by_claim_and_scope(self) -> None:
         rule = GitHubActionsPolicyRule(
             repository="cbusillo/verireel",


### PR DESCRIPTION
## Summary
- adds a compact agent-consumer subject model for GitHub Actions, GitHub humans, and terminal agents
- classifies requested actions into read/safe_write/mutation/prod/destructive/secret_backed/policy_admin safety families
- includes agent-consumer diagnostics in authz denial payloads and documents the subject model

Refs #380

## Validation
- uv run python -m unittest tests.test_service_auth tests.test_service.LaunchplaneServiceTests.test_product_profile_list_denial_includes_authz_diagnostics
- uv run --extra dev ruff check --diff control_plane/service_auth.py control_plane/service.py tests/test_service_auth.py tests/test_service.py
- uv run --extra dev ruff check control_plane/service_auth.py control_plane/service.py tests/test_service_auth.py tests/test_service.py
- uv run --extra dev mypy control_plane/service_auth.py control_plane/service.py tests/test_service_auth.py tests/test_service.py
- uv run python -m unittest