### PR TITLE
Add agent authz audit provenance

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -111,13 +111,14 @@ from control_plane.launchplane_mutations import (
     control_plane_root,
 )
 from control_plane.service_auth import (
+    AgentAuthzDecision,
     GitHubActionsIdentity,
     GitHubHumanIdentity,
     LaunchplaneAuthzPolicy,
     LaunchplaneIdentity,
     TerminalAgentIdentity,
     TokenVerifier,
-    agent_consumer_subject,
+    agent_authz_audit,
     load_authz_policy,
     parse_authz_policy_toml,
 )
@@ -3445,6 +3446,8 @@ def _authz_diagnostic_payload(
     action: str = "",
     product: str = "",
     context: str = "",
+    decision: str = "denied",
+    reason_code: str = "authorization_denied",
 ) -> dict[str, object]:
     if isinstance(identity, GitHubHumanIdentity):
         identity_payload: dict[str, object] = {
@@ -3470,14 +3473,21 @@ def _authz_diagnostic_payload(
             "environment": identity.environment,
             "subject": identity.subject,
         }
+    normalized_decision: AgentAuthzDecision = "allowed" if decision == "allowed" else "denied"
+    audit = agent_authz_audit(
+        identity=identity,
+        action=action,
+        product=product,
+        context=context,
+        decision=normalized_decision,
+        reason_code=reason_code,
+        policy_source=authz_policy_source,
+        policy_sha256=authz_policy_sha256_value,
+    )
     payload: dict[str, object] = {
         "identity": identity_payload,
-        "agent_consumer": agent_consumer_subject(
-            identity=identity,
-            action=action,
-            product=product,
-            context=context,
-        ).model_dump(mode="json"),
+        "agent_consumer": audit.subject.model_dump(mode="json"),
+        "agent_audit": audit.model_dump(mode="json"),
         "policy_source": authz_policy_source,
         "policy_sha256": authz_policy_sha256_value,
     }

--- a/control_plane/service_auth.py
+++ b/control_plane/service_auth.py
@@ -57,6 +57,7 @@ AgentConsumerActionSafety = Literal[
     "secret_backed",
     "policy_admin",
 ]
+AgentAuthzDecision = Literal["allowed", "denied"]
 
 
 class TokenVerifier(Protocol):
@@ -270,6 +271,20 @@ class AgentConsumerSubject(BaseModel):
     approval_capable: bool = False
 
 
+class AgentAuthzAudit(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    decision: AgentAuthzDecision
+    reason_code: str
+    subject: AgentConsumerSubject
+    action: str
+    product: str
+    context: str
+    policy_source: str
+    policy_sha256: str
+    source_kind: Literal["authz_policy"] = "authz_policy"
+
+
 def action_safety(action: str) -> AgentConsumerActionSafety:
     normalized_action = action.strip()
     if not normalized_action:
@@ -331,6 +346,34 @@ def agent_consumer_subject(
         action_safety=safety,
         read_only_context=safety == "read",
         approval_capable=safety in {"mutation", "prod", "destructive", "secret_backed", "policy_admin"},
+    )
+
+
+def agent_authz_audit(
+    *,
+    identity: LaunchplaneIdentity,
+    action: str,
+    product: str,
+    context: str,
+    decision: AgentAuthzDecision,
+    reason_code: str,
+    policy_source: str,
+    policy_sha256: str,
+) -> AgentAuthzAudit:
+    return AgentAuthzAudit(
+        decision=decision,
+        reason_code=reason_code,
+        subject=agent_consumer_subject(
+            identity=identity,
+            action=action,
+            product=product,
+            context=context,
+        ),
+        action=action,
+        product=product,
+        context=context,
+        policy_source=policy_source,
+        policy_sha256=policy_sha256,
     )
 
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -613,6 +613,10 @@ state/
   GitHub Actions, terminal agents, and GitHub humans. The model records the
   requested action, product, context, safety family, read-only-context status,
   and approval-capable status without replacing exact policy-rule authorization.
+- Agent-facing authorization diagnostics include an `agent_audit` response
+  provenance envelope with decision, safe reason code, subject, action, product,
+  context, policy source, policy digest, and `authz_policy` source kind. It is
+  intentionally not a persisted write-intent record yet.
 
 ## Inventory
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -421,6 +421,13 @@ Action names are classified for agent context as `read`, `safe_write`,
 classification is diagnostic and contractual; authorization still fails closed
 through the exact action/product/context policy rule.
 
+Agent-facing authorization diagnostics include an `agent_audit` envelope with
+the decision, safe reason code, agent subject, action, product, context, policy
+source, policy digest, and `authz_policy` source kind. This first audit surface
+is response provenance, not a persisted intent record. Future scoped write-intent
+routes should reuse the same shape and add durable record links once they create
+records.
+
 For first access, `LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS` may name comma-separated
 verified GitHub email addresses that receive the `admin` role even before a
 matching `github_humans` rule exists. The GitHub OAuth client requests

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -5170,6 +5170,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["authz"]["agent_consumer"]["action_safety"], "read")
         self.assertTrue(payload["authz"]["agent_consumer"]["read_only_context"])
         self.assertFalse(payload["authz"]["agent_consumer"]["approval_capable"])
+        self.assertEqual(payload["authz"]["agent_audit"]["decision"], "denied")
+        self.assertEqual(
+            payload["authz"]["agent_audit"]["reason_code"], "authorization_denied"
+        )
+        self.assertEqual(payload["authz"]["agent_audit"]["subject"]["action_safety"], "read")
         self.assertEqual(payload["authz"]["policy_source"], "bootstrap_seeded_store")
 
     def test_product_profile_list_denial_includes_authz_diagnostics(self) -> None:
@@ -11877,6 +11882,14 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["authz"]["request"]["action"], "preview_pr_feedback.write")
         self.assertEqual(payload["authz"]["request"]["product"], "verireel")
         self.assertEqual(payload["authz"]["request"]["context"], "verireel-testing")
+        self.assertEqual(payload["authz"]["agent_audit"]["decision"], "denied")
+        self.assertEqual(
+            payload["authz"]["agent_audit"]["reason_code"], "authorization_denied"
+        )
+        self.assertEqual(
+            payload["authz"]["agent_audit"]["subject"]["action_safety"], "safe_write"
+        )
+        self.assertEqual(payload["authz"]["agent_audit"]["source_kind"], "authz_policy")
         self.assertIn("policy_sha256", payload["authz"])
         self.assertIn("policy_source", payload["authz"])
 

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -17,6 +17,7 @@ from control_plane.service_auth import (
     TerminalAgentIdentity,
     TerminalAgentPolicyRule,
     action_safety,
+    agent_authz_audit,
     agent_consumer_subject,
     parse_authz_policy_toml,
 )
@@ -231,6 +232,26 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
         for action, expected_safety in cases.items():
             with self.subTest(action=action):
                 self.assertEqual(action_safety(action), expected_safety)
+
+    def test_agent_authz_audit_records_safe_denial_metadata(self) -> None:
+        audit = agent_authz_audit(
+            identity=_actions_identity(),
+            action="preview_pr_feedback.write",
+            product="verireel",
+            context="verireel-testing",
+            decision="denied",
+            reason_code="authorization_denied",
+            policy_source="db",
+            policy_sha256="abc123",
+        )
+
+        self.assertEqual(audit.decision, "denied")
+        self.assertEqual(audit.reason_code, "authorization_denied")
+        self.assertEqual(audit.subject.subject_type, "github_actions")
+        self.assertEqual(audit.subject.action_safety, "safe_write")
+        self.assertEqual(audit.source_kind, "authz_policy")
+        self.assertEqual(audit.policy_source, "db")
+        self.assertEqual(audit.policy_sha256, "abc123")
 
     def test_actions_policy_fails_closed_by_claim_and_scope(self) -> None:
         rule = GitHubActionsPolicyRule(


### PR DESCRIPTION
## Summary
- adds a reusable agent authz audit envelope with decision, safe reason code, subject, resource, and policy provenance
- includes the audit envelope in existing authz diagnostics while preserving the agent_consumer compatibility field
- documents the response-provenance contract as the first #389 slice before durable write-intent records

Refs #389

## Validation
- uv run python -m unittest tests.test_service_auth tests.test_service.LaunchplaneServiceTests.test_product_profile_list_denial_includes_authz_diagnostics tests.test_service.LaunchplaneServiceTests.test_preview_pr_feedback_endpoint_rejects_unauthorized_workflow
- uv run --extra dev ruff check --diff control_plane/service_auth.py control_plane/service.py tests/test_service_auth.py tests/test_service.py
- uv run --extra dev ruff check control_plane/service_auth.py control_plane/service.py tests/test_service_auth.py tests/test_service.py
- uv run --extra dev mypy control_plane/service_auth.py control_plane/service.py tests/test_service_auth.py tests/test_service.py
- uv run python -m unittest