### PR TITLE
Add scoped agent write-intent evaluation

### DIFF
--- a/control_plane/contracts/agent_write_intent.py
+++ b/control_plane/contracts/agent_write_intent.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.service_auth import AgentAuthzAudit
+
+
+AgentWriteIntentKind = Literal[
+    "every_code_rerun",
+    "preview_refresh",
+    "preview_cleanup",
+    "preview_request",
+    "product_config_apply",
+    "promotion_dry_run",
+    "promotion_dispatch",
+]
+AgentWriteIntentMode = Literal["dry_run", "apply"]
+AgentWriteIntentStatus = Literal["allowed", "denied"]
+
+_INTENT_AUTHZ_ACTIONS: dict[AgentWriteIntentKind, str] = {
+    "every_code_rerun": "every_code_work_request.write",
+    "preview_refresh": "preview_refresh.execute",
+    "preview_cleanup": "preview_lifecycle.cleanup",
+    "preview_request": "preview_generation.write",
+    "product_config_apply": "product_config.apply",
+    "promotion_dry_run": "generic_web_prod_promotion.dry_run",
+    "promotion_dispatch": "generic_web_prod_promotion_workflow.execute",
+}
+_DRY_RUN_ONLY_INTENTS: frozenset[AgentWriteIntentKind] = frozenset(
+    {"product_config_apply", "promotion_dry_run"}
+)
+
+
+class AgentWriteIntentRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    intent: AgentWriteIntentKind
+    mode: AgentWriteIntentMode = "dry_run"
+    product: str = "launchplane"
+    context: str = "launchplane"
+    source_url: str
+    idempotency_key: str = ""
+    reason: str
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "AgentWriteIntentRequest":
+        if not self.product.strip():
+            raise ValueError("agent write intent requires product")
+        if not self.context.strip():
+            raise ValueError("agent write intent requires context")
+        if not self.source_url.strip():
+            raise ValueError("agent write intent requires source_url")
+        if not self.reason.strip():
+            raise ValueError("agent write intent requires reason")
+        return self
+
+
+class AgentWriteIntentEvaluation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    intent: AgentWriteIntentKind
+    mode: AgentWriteIntentMode
+    status: AgentWriteIntentStatus
+    authz_action: str
+    product: str
+    context: str
+    source_url: str
+    safe_to_execute: bool
+    next_action: str
+    reason_code: str
+    audit: AgentAuthzAudit
+
+
+def authz_action_for_agent_write_intent(intent: AgentWriteIntentKind) -> str:
+    return _INTENT_AUTHZ_ACTIONS[intent]
+
+
+def evaluate_agent_write_intent(
+    *, request: AgentWriteIntentRequest, authorized: bool, audit: AgentAuthzAudit
+) -> AgentWriteIntentEvaluation:
+    authz_action = authz_action_for_agent_write_intent(request.intent)
+    if request.mode == "apply" and request.intent in _DRY_RUN_ONLY_INTENTS:
+        return AgentWriteIntentEvaluation(
+            intent=request.intent,
+            mode=request.mode,
+            status="denied",
+            authz_action=authz_action,
+            product=request.product,
+            context=request.context,
+            source_url=request.source_url,
+            safe_to_execute=False,
+            next_action="Run this intent in dry_run mode before requesting apply authority.",
+            reason_code="dry_run_required",
+            audit=audit.model_copy(update={"decision": "denied", "reason_code": "dry_run_required"}),
+        )
+    if not authorized:
+        return AgentWriteIntentEvaluation(
+            intent=request.intent,
+            mode=request.mode,
+            status="denied",
+            authz_action=authz_action,
+            product=request.product,
+            context=request.context,
+            source_url=request.source_url,
+            safe_to_execute=False,
+            next_action="Request a narrower policy grant for this intent, product, and context.",
+            reason_code="authorization_denied",
+            audit=audit,
+        )
+    return AgentWriteIntentEvaluation(
+        intent=request.intent,
+        mode=request.mode,
+        status="allowed",
+        authz_action=authz_action,
+        product=request.product,
+        context=request.context,
+        source_url=request.source_url,
+        safe_to_execute=request.mode == "apply",
+        next_action=(
+            "Submit the matching Launchplane action route with the same source and idempotency key."
+            if request.mode == "apply"
+            else "Review the dry-run result before requesting apply authority."
+        ),
+        reason_code="authorized",
+        audit=audit,
+    )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -35,6 +35,11 @@ from control_plane.contracts.authz_policy_record import (
     authz_policy_sha256,
     build_authz_policy_record_id,
 )
+from control_plane.contracts.agent_write_intent import (
+    AgentWriteIntentRequest,
+    authz_action_for_agent_write_intent,
+    evaluate_agent_write_intent,
+)
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.every_code_work_request import (
@@ -1181,6 +1186,7 @@ _VERIREEL_PREVIEW_VERIFICATION_ROUTE = _DriverRouteExecutionMetadata(
 
 _HUMAN_IDENTITY_MUTATION_ROUTES = frozenset(
     {
+        "/v1/agent/write-intents/evaluate",
         _GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path,
         _GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.route_path,
         "/v1/authz-policies/github-actions/grants",
@@ -1790,6 +1796,7 @@ def _driver_write_routes_from_descriptors() -> frozenset[str]:
 def _build_write_routes() -> frozenset[str]:
     launchplane_write_routes = {
         _EVERY_CODE_GITHUB_WEBHOOK_ROUTE,
+        "/v1/agent/write-intents/evaluate",
         "/v1/every-code/work-requests/create",
         "/v1/every-code/work-requests/claim",
         "/v1/every-code/work-requests/rerun",
@@ -4632,7 +4639,11 @@ def create_launchplane_service_app(
                     identity = verifier.verify(token)
                     if not isinstance(identity, GitHubActionsIdentity):
                         raise PermissionError("Mutation routes require GitHub Actions OIDC.")
-            if isinstance(identity, TerminalAgentIdentity) and method != "GET":
+            if (
+                isinstance(identity, TerminalAgentIdentity)
+                and method != "GET"
+                and path != "/v1/agent/write-intents/evaluate"
+            ):
                 return _json_response(
                     start_response=start_response,
                     status_code=403,
@@ -5425,6 +5436,34 @@ def create_launchplane_service_app(
                 every_code_store.write_every_code_work_request_record(record)
                 result = {"request_id": record.request_id, "state": record.state}
                 driver_result = {"request": record.model_dump(mode="json")}
+            elif path == "/v1/agent/write-intents/evaluate":
+                intent_request = AgentWriteIntentRequest.model_validate(payload)
+                intent_authz_action = authz_action_for_agent_write_intent(
+                    intent_request.intent
+                )
+                authorized = authz_policy.allows(
+                    identity=identity,
+                    action=intent_authz_action,
+                    product=intent_request.product,
+                    context=intent_request.context,
+                )
+                intent_audit = agent_authz_audit(
+                    identity=identity,
+                    action=intent_authz_action,
+                    product=intent_request.product,
+                    context=intent_request.context,
+                    decision="allowed" if authorized else "denied",
+                    reason_code="authorized" if authorized else "authorization_denied",
+                    policy_source=resolved_authz_policy_source,
+                    policy_sha256=resolved_authz_policy_sha256,
+                )
+                evaluation = evaluate_agent_write_intent(
+                    request=intent_request,
+                    authorized=authorized,
+                    audit=intent_audit,
+                )
+                result = {"intent": evaluation.model_dump(mode="json")}
+                driver_result = result
             elif path == "/v1/every-code/work-requests/claim":
                 if not authz_policy.allows(
                     identity=identity,

--- a/docs/records.md
+++ b/docs/records.md
@@ -617,6 +617,11 @@ state/
   provenance envelope with decision, safe reason code, subject, action, product,
   context, policy source, policy digest, and `authz_policy` source kind. It is
   intentionally not a persisted write-intent record yet.
+- Scoped agent write-intent evaluation is exposed at
+  `POST /v1/agent/write-intents/evaluate`. It validates intent shape, maps the
+  intent to an exact existing policy action, evaluates authorization, and returns
+  status/evidence links without executing runtime mutations or returning
+  credentials.
 
 ## Inventory
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -428,6 +428,15 @@ is response provenance, not a persisted intent record. Future scoped write-inten
 routes should reuse the same shape and add durable record links once they create
 records.
 
+`POST /v1/agent/write-intents/evaluate` is the first scoped intent surface. It
+does not execute product/runtime mutations. It validates a requested intent,
+maps it to the exact existing policy action, evaluates the caller's policy grant,
+and returns status, safe next action, source URL, and `agent_audit` metadata.
+Agents can use it to preflight safe rerun, preview, config, cleanup, and
+promotion-dispatch candidates without receiving a generic write token or reusable
+credentials. Some intents, such as product config apply and promotion dry-run,
+remain dry-run-first even when the caller has the underlying policy action.
+
 For first access, `LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS` may name comma-separated
 verified GitHub email addresses that receive the `admin` role even before a
 matching `github_humans` rule exists. The GitHub OAuth client requests

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -382,6 +382,7 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
                 {
                     control_plane_service._GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path,
                     control_plane_service._GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.route_path,
+                    "/v1/agent/write-intents/evaluate",
                     "/v1/authz-policies/github-actions/grants",
                     "/v1/authz-policies/github-humans/grants",
                     "/v1/authz-policies/terminal-agents/grants",

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -5214,6 +5214,199 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["authz"]["identity"]["repository"], "every/verireel")
         self.assertEqual(payload["authz"]["policy_source"], "bootstrap_seeded_store")
 
+    def test_agent_write_intent_evaluate_returns_allowed_dry_run_without_execution(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["every_code_work_request.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/agent/write-intents/evaluate",
+                payload={
+                    "intent": "every_code_rerun",
+                    "mode": "dry_run",
+                    "product": "launchplane",
+                    "context": "launchplane",
+                    "source_url": "https://github.com/cbusillo/launchplane/issues/386",
+                    "reason": "Check whether rerun can be requested safely.",
+                },
+            )
+
+        self.assertEqual(status_code, 202)
+        intent = payload["result"]["intent"]
+        self.assertEqual(intent["status"], "allowed")
+        self.assertEqual(intent["authz_action"], "every_code_work_request.write")
+        self.assertFalse(intent["safe_to_execute"])
+        self.assertEqual(intent["reason_code"], "authorized")
+        self.assertEqual(intent["audit"]["decision"], "allowed")
+        self.assertEqual(intent["audit"]["subject"]["action_safety"], "safe_write")
+
+    def test_agent_write_intent_evaluate_denies_ungranted_intent(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["every_code_work_request.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/agent/write-intents/evaluate",
+                payload={
+                    "intent": "promotion_dispatch",
+                    "mode": "apply",
+                    "product": "verireel",
+                    "context": "verireel",
+                    "source_url": "https://github.com/cbusillo/launchplane/issues/386",
+                    "reason": "Request prod promotion dispatch.",
+                },
+            )
+
+        self.assertEqual(status_code, 202)
+        intent = payload["result"]["intent"]
+        self.assertEqual(intent["status"], "denied")
+        self.assertEqual(intent["reason_code"], "authorization_denied")
+        self.assertFalse(intent["safe_to_execute"])
+        self.assertEqual(intent["audit"]["decision"], "denied")
+        self.assertEqual(intent["audit"]["subject"]["action_safety"], "prod")
+
+    def test_agent_write_intent_evaluate_requires_dry_run_for_config_apply(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel-testing"],
+                            "actions": ["product_config.apply"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/agent/write-intents/evaluate",
+                payload={
+                    "intent": "product_config_apply",
+                    "mode": "apply",
+                    "product": "verireel",
+                    "context": "verireel-testing",
+                    "source_url": "https://github.com/cbusillo/launchplane/issues/386",
+                    "reason": "Apply product config after review.",
+                },
+            )
+
+        self.assertEqual(status_code, 202)
+        intent = payload["result"]["intent"]
+        self.assertEqual(intent["status"], "denied")
+        self.assertEqual(intent["reason_code"], "dry_run_required")
+        self.assertFalse(intent["safe_to_execute"])
+        self.assertEqual(intent["audit"]["reason_code"], "dry_run_required")
+
+    def test_terminal_agent_write_intent_evaluate_checks_scoped_policy(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "terminal_agents": [
+                        {
+                            "subjects": ["local-owner-agent"],
+                            "token_labels": ["local-owner-read"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["every_code_work_request.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN": "terminal-read-token"},
+                clear=True,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/agent/write-intents/evaluate",
+                    authorization="Bearer terminal-read-token",
+                    payload={
+                        "intent": "every_code_rerun",
+                        "mode": "dry_run",
+                        "product": "launchplane",
+                        "context": "launchplane",
+                        "source_url": "https://github.com/cbusillo/launchplane/issues/386",
+                        "reason": "Check whether local agent can request a rerun.",
+                    },
+                )
+
+        self.assertEqual(status_code, 202)
+        intent = payload["result"]["intent"]
+        self.assertEqual(intent["status"], "allowed")
+        self.assertEqual(intent["audit"]["subject"]["subject_type"], "terminal_agent")
+        self.assertFalse(intent["audit"]["subject"]["approval_capable"])
+
     def test_product_profile_write_rejects_unauthorized_product(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -253,6 +253,24 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
         self.assertEqual(audit.policy_source, "db")
         self.assertEqual(audit.policy_sha256, "abc123")
 
+    def test_agent_write_intent_actions_use_existing_policy_action_names(self) -> None:
+        from control_plane.contracts.agent_write_intent import (
+            authz_action_for_agent_write_intent,
+        )
+
+        self.assertEqual(
+            authz_action_for_agent_write_intent("every_code_rerun"),
+            "every_code_work_request.write",
+        )
+        self.assertEqual(
+            authz_action_for_agent_write_intent("preview_refresh"),
+            "preview_refresh.execute",
+        )
+        self.assertEqual(
+            authz_action_for_agent_write_intent("promotion_dispatch"),
+            "generic_web_prod_promotion_workflow.execute",
+        )
+
     def test_actions_policy_fails_closed_by_claim_and_scope(self) -> None:
         rule = GitHubActionsPolicyRule(
             repository="cbusillo/verireel",


### PR DESCRIPTION
## Summary
- Add a scoped agent write-intent evaluation contract that maps safe intent names to existing policy actions.
- Expose POST /v1/agent/write-intents/evaluate for GitHub Actions, humans, and terminal agents to receive allowed/denied status, audit provenance, source links, and next-action guidance without executing mutations or returning credentials.
- Document the service and record boundary for this evaluation-only surface.

Refs #386

## Validation
- uv run python -m unittest tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_route_policy_sets_use_execution_metadata tests.test_service_auth tests.test_service.LaunchplaneServiceTests.test_agent_write_intent_evaluate_returns_allowed_dry_run_without_execution tests.test_service.LaunchplaneServiceTests.test_agent_write_intent_evaluate_denies_ungranted_intent tests.test_service.LaunchplaneServiceTests.test_agent_write_intent_evaluate_requires_dry_run_for_config_apply tests.test_service.LaunchplaneServiceTests.test_terminal_agent_write_intent_evaluate_checks_scoped_policy tests.test_service.LaunchplaneServiceTests.test_terminal_agent_read_token_rejects_non_read_routes_even_if_policy_grants_action
- uv run --extra dev ruff check --diff control_plane/contracts/agent_write_intent.py control_plane/service.py tests/test_service.py tests/test_service_auth.py tests/test_driver_descriptors.py
- uv run --extra dev ruff check control_plane/contracts/agent_write_intent.py control_plane/service.py tests/test_service.py tests/test_service_auth.py tests/test_driver_descriptors.py
- uv run --extra dev mypy control_plane/contracts/agent_write_intent.py control_plane/service.py tests/test_service.py tests/test_service_auth.py tests/test_driver_descriptors.py
- uv run python -m unittest