### PR TITLE
Add secret-backed write-intent evidence

### DIFF
--- a/control_plane/contracts/agent_write_intent.py
+++ b/control_plane/contracts/agent_write_intent.py
@@ -4,6 +4,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyEvaluation
 from control_plane.service_auth import AgentAuthzAudit
 
 
@@ -18,6 +19,7 @@ AgentWriteIntentKind = Literal[
 ]
 AgentWriteIntentMode = Literal["dry_run", "apply"]
 AgentWriteIntentStatus = Literal["allowed", "denied"]
+AgentWriteIntentSecretStatus = Literal["not_required", "pass", "fail", "unavailable"]
 
 _INTENT_AUTHZ_ACTIONS: dict[AgentWriteIntentKind, str] = {
     "every_code_rerun": "every_code_work_request.write",
@@ -33,6 +35,24 @@ _DRY_RUN_ONLY_INTENTS: frozenset[AgentWriteIntentKind] = frozenset(
 )
 
 
+class AgentWriteIntentDestination(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["runtime_environment"] = "runtime_environment"
+    context: str
+    instance: str
+
+    @model_validator(mode="after")
+    def _validate_destination(self) -> "AgentWriteIntentDestination":
+        if not self.context.strip():
+            raise ValueError("agent write intent destination requires context")
+        if not self.instance.strip():
+            raise ValueError("agent write intent destination requires instance")
+        self.context = self.context.strip()
+        self.instance = self.instance.strip()
+        return self
+
+
 class AgentWriteIntentRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -44,6 +64,8 @@ class AgentWriteIntentRequest(BaseModel):
     source_url: str
     idempotency_key: str = ""
     reason: str
+    secret_bindings: tuple[str, ...] = ()
+    destination: AgentWriteIntentDestination | None = None
 
     @model_validator(mode="after")
     def _validate_request(self) -> "AgentWriteIntentRequest":
@@ -55,7 +77,21 @@ class AgentWriteIntentRequest(BaseModel):
             raise ValueError("agent write intent requires source_url")
         if not self.reason.strip():
             raise ValueError("agent write intent requires reason")
+        self.secret_bindings = _normalize_secret_binding_keys(self.secret_bindings)
+        if self.secret_bindings and self.destination is None:
+            raise ValueError("secret-backed agent write intent requires destination")
         return self
+
+
+class AgentWriteIntentSecretEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: AgentWriteIntentSecretStatus = "not_required"
+    destination: AgentWriteIntentDestination | None = None
+    checked_binding_keys: tuple[str, ...] = ()
+    policy_record_id: str = ""
+    policy_sha256: str = ""
+    findings: tuple[dict[str, object], ...] = ()
 
 
 class AgentWriteIntentEvaluation(BaseModel):
@@ -73,16 +109,71 @@ class AgentWriteIntentEvaluation(BaseModel):
     next_action: str
     reason_code: str
     audit: AgentAuthzAudit
+    secret_evidence: AgentWriteIntentSecretEvidence = Field(
+        default_factory=AgentWriteIntentSecretEvidence
+    )
 
 
 def authz_action_for_agent_write_intent(intent: AgentWriteIntentKind) -> str:
     return _INTENT_AUTHZ_ACTIONS[intent]
 
 
+def agent_write_intent_secret_action(request: AgentWriteIntentRequest) -> str:
+    if not request.secret_bindings:
+        return ""
+    return f"{authz_action_for_agent_write_intent(request.intent)}.secret"
+
+
+def secret_evidence_for_agent_write_intent(
+    *,
+    request: AgentWriteIntentRequest,
+    evaluation: RuntimeKeySafetyEvaluation | None,
+    policy_record_id: str = "",
+    policy_sha256: str = "",
+    unavailable: bool = False,
+) -> AgentWriteIntentSecretEvidence:
+    if not request.secret_bindings:
+        return AgentWriteIntentSecretEvidence()
+    if unavailable or evaluation is None:
+        return AgentWriteIntentSecretEvidence(
+            status="unavailable",
+            destination=request.destination,
+            checked_binding_keys=request.secret_bindings,
+        )
+    return AgentWriteIntentSecretEvidence(
+        status=evaluation.status,
+        destination=request.destination,
+        checked_binding_keys=evaluation.checked_binding_keys,
+        policy_record_id=policy_record_id,
+        policy_sha256=policy_sha256,
+        findings=tuple(finding.model_dump(mode="json") for finding in evaluation.findings),
+    )
+
+
 def evaluate_agent_write_intent(
-    *, request: AgentWriteIntentRequest, authorized: bool, audit: AgentAuthzAudit
+    *,
+    request: AgentWriteIntentRequest,
+    authorized: bool,
+    audit: AgentAuthzAudit,
+    secret_evidence: AgentWriteIntentSecretEvidence | None = None,
 ) -> AgentWriteIntentEvaluation:
     authz_action = authz_action_for_agent_write_intent(request.intent)
+    resolved_secret_evidence = secret_evidence or AgentWriteIntentSecretEvidence()
+    if request.secret_bindings and resolved_secret_evidence.status != "pass":
+        return AgentWriteIntentEvaluation(
+            intent=request.intent,
+            mode=request.mode,
+            status="denied",
+            authz_action=authz_action,
+            product=request.product,
+            context=request.context,
+            source_url=request.source_url,
+            safe_to_execute=False,
+            next_action="Fix the managed secret binding policy or destination before requesting this intent.",
+            reason_code="secret_evidence_denied",
+            audit=audit.model_copy(update={"decision": "denied", "reason_code": "secret_evidence_denied"}),
+            secret_evidence=resolved_secret_evidence,
+        )
     if request.mode == "apply" and request.intent in _DRY_RUN_ONLY_INTENTS:
         return AgentWriteIntentEvaluation(
             intent=request.intent,
@@ -96,6 +187,7 @@ def evaluate_agent_write_intent(
             next_action="Run this intent in dry_run mode before requesting apply authority.",
             reason_code="dry_run_required",
             audit=audit.model_copy(update={"decision": "denied", "reason_code": "dry_run_required"}),
+            secret_evidence=resolved_secret_evidence,
         )
     if not authorized:
         return AgentWriteIntentEvaluation(
@@ -110,6 +202,7 @@ def evaluate_agent_write_intent(
             next_action="Request a narrower policy grant for this intent, product, and context.",
             reason_code="authorization_denied",
             audit=audit,
+            secret_evidence=resolved_secret_evidence,
         )
     return AgentWriteIntentEvaluation(
         intent=request.intent,
@@ -127,4 +220,16 @@ def evaluate_agent_write_intent(
         ),
         reason_code="authorized",
         audit=audit,
+        secret_evidence=resolved_secret_evidence,
     )
+
+
+def _normalize_secret_binding_keys(values: tuple[str, ...]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    for raw_value in values:
+        value = raw_value.strip()
+        if not value:
+            raise ValueError("agent write intent secret binding keys must be non-empty")
+        if value not in normalized:
+            normalized.append(value)
+    return tuple(normalized)

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -37,8 +37,11 @@ from control_plane.contracts.authz_policy_record import (
 )
 from control_plane.contracts.agent_write_intent import (
     AgentWriteIntentRequest,
+    AgentWriteIntentSecretEvidence,
+    agent_write_intent_secret_action,
     authz_action_for_agent_write_intent,
     evaluate_agent_write_intent,
+    secret_evidence_for_agent_write_intent,
 )
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
@@ -98,6 +101,12 @@ from control_plane.contracts.promotion_record import (
     PostDeployUpdateEvidence,
     PromotionRecord,
     ReleaseStatus,
+)
+from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyTarget
+from control_plane.runtime_key_safety import (
+    evaluate_runtime_key_safety_from_store,
+    latest_active_runtime_key_safety_policy,
+    runtime_key_safety_environment_class,
 )
 from control_plane.runtime_key_safety_http import (
     RuntimeKeySafetyPolicyRouteResult,
@@ -2870,6 +2879,43 @@ def _replay_idempotent_response(
     )
 
 
+def _agent_write_intent_secret_evidence(
+    *, record_store: object, request: AgentWriteIntentRequest
+) -> AgentWriteIntentSecretEvidence:
+    if not request.secret_bindings:
+        return secret_evidence_for_agent_write_intent(request=request, evaluation=None)
+    if request.destination is None:
+        return secret_evidence_for_agent_write_intent(
+            request=request, evaluation=None, unavailable=True
+        )
+    try:
+        policy_record = latest_active_runtime_key_safety_policy(
+            record_store  # type: ignore[arg-type]
+        )
+        evaluation = evaluate_runtime_key_safety_from_store(
+            record_store=record_store,  # type: ignore[arg-type]
+            policy_record=policy_record,
+            target=RuntimeKeySafetyTarget(
+                context=request.destination.context,
+                instance=request.destination.instance,
+                environment_class=runtime_key_safety_environment_class(
+                    request.destination.instance
+                ),
+            ),
+            required_binding_keys=request.secret_bindings,
+        )
+    except (AttributeError, ValueError):
+        return secret_evidence_for_agent_write_intent(
+            request=request, evaluation=None, unavailable=True
+        )
+    return secret_evidence_for_agent_write_intent(
+        request=request,
+        evaluation=evaluation,
+        policy_record_id=policy_record.record_id,
+        policy_sha256=policy_record.policy_sha256,
+    )
+
+
 def _read_idempotency_record(
     *,
     record_store: object,
@@ -5447,6 +5493,14 @@ def create_launchplane_service_app(
                     product=intent_request.product,
                     context=intent_request.context,
                 )
+                if intent_request.secret_bindings:
+                    secret_authz_action = agent_write_intent_secret_action(intent_request)
+                    authorized = authorized and authz_policy.allows(
+                        identity=identity,
+                        action=secret_authz_action,
+                        product=intent_request.product,
+                        context=intent_request.context,
+                    )
                 intent_audit = agent_authz_audit(
                     identity=identity,
                     action=intent_authz_action,
@@ -5457,10 +5511,15 @@ def create_launchplane_service_app(
                     policy_source=resolved_authz_policy_source,
                     policy_sha256=resolved_authz_policy_sha256,
                 )
+                secret_evidence = _agent_write_intent_secret_evidence(
+                    record_store=record_store,
+                    request=intent_request,
+                )
                 evaluation = evaluate_agent_write_intent(
                     request=intent_request,
                     authorized=authorized,
                     audit=intent_audit,
+                    secret_evidence=secret_evidence,
                 )
                 result = {"intent": evaluation.model_dump(mode="json")}
                 driver_result = result

--- a/control_plane/service_auth.py
+++ b/control_plane/service_auth.py
@@ -292,7 +292,7 @@ def action_safety(action: str) -> AgentConsumerActionSafety:
     action_parts = tuple(part for part in re.split(r"[_.-]+", normalized_action) if part)
     if normalized_action.startswith("authz_policy"):
         return "policy_admin"
-    if "secret" in action_parts:
+    if "secret" in action_parts or normalized_action.endswith(".secret"):
         return "secret_backed"
     if any(part in action_parts for part in ("destroy", "cleanup", "delete", "rollback")):
         return "destructive"

--- a/docs/records.md
+++ b/docs/records.md
@@ -622,6 +622,11 @@ state/
   intent to an exact existing policy action, evaluates authorization, and returns
   status/evidence links without executing runtime mutations or returning
   credentials.
+- Secret-backed write-intent evaluation is metadata-only. Requests may include
+  managed secret binding keys and a runtime destination, but responses include
+  only binding keys, runtime key-safety policy ids/digests, and finding codes.
+  They must not include plaintext, ciphertext, token prefixes, or provider env
+  dumps.
 
 ## Inventory
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -436,6 +436,12 @@ Agents can use it to preflight safe rerun, preview, config, cleanup, and
 promotion-dispatch candidates without receiving a generic write token or reusable
 credentials. Some intents, such as product config apply and promotion dry-run,
 remain dry-run-first even when the caller has the underlying policy action.
+Secret-backed intents may name managed secret binding keys plus a runtime
+destination. Launchplane evaluates the existing runtime key-safety policy and an
+additional `.secret` policy action such as `product_config.apply.secret`, then
+returns sanitized binding keys, policy ids, and finding codes only. It never
+returns plaintext secret values, ciphertext, provider env dumps, or token
+prefixes to the agent.
 
 For first access, `LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS` may name comma-separated
 verified GitHub email addresses that receive the `admin` role even before a

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -50,6 +50,7 @@ from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeKeySafetyPolicyRecord,
     RuntimeSecretSafetyRule,
 )
+from control_plane.contracts.secret_record import SecretBinding
 from control_plane.contracts.work_graph_read_model import WorkGraphPlanningIssueFacts
 from control_plane.service import create_launchplane_service_app
 from control_plane.service_auth import (
@@ -5406,6 +5407,278 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(intent["status"], "allowed")
         self.assertEqual(intent["audit"]["subject"]["subject_type"], "terminal_agent")
         self.assertFalse(intent["audit"]["subject"]["approval_capable"])
+
+    def test_agent_write_intent_evaluate_checks_secret_binding_policy_without_reveal(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_runtime_key_safety_policy_record(
+                RuntimeKeySafetyPolicyRecord(
+                    record_id="runtime-key-safety-policy-service-test",
+                    status="active",
+                    source="test",
+                    updated_at="2026-05-05T20:00:00Z",
+                    rules=(
+                        RuntimeSecretSafetyRule(
+                            binding_key="SMTP_PASSWORD",
+                            secret_class="prod_only",
+                            allowed_contexts=("sellyouroutboard",),
+                            allowed_instances=("prod",),
+                        ),
+                    ),
+                )
+            )
+            store.write_secret_binding(
+                SecretBinding(
+                    binding_id="secret-smtp-password-binding-smtp-password",
+                    secret_id="secret-smtp-password",
+                    integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+                    binding_key="SMTP_PASSWORD",
+                    context="sellyouroutboard",
+                    instance="prod",
+                    created_at="2026-05-05T20:00:00Z",
+                    updated_at="2026-05-05T20:00:00Z",
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard"],
+                            "actions": [
+                                "product_config.apply",
+                                "product_config.apply.secret",
+                            ],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/agent/write-intents/evaluate",
+                payload={
+                    "intent": "product_config_apply",
+                    "mode": "dry_run",
+                    "product": "sellyouroutboard",
+                    "context": "sellyouroutboard",
+                    "source_url": "https://github.com/cbusillo/launchplane/issues/387",
+                    "reason": "Preflight managed secret-backed product config.",
+                    "secret_bindings": ["SMTP_PASSWORD"],
+                    "destination": {
+                        "kind": "runtime_environment",
+                        "context": "sellyouroutboard",
+                        "instance": "prod",
+                    },
+                },
+            )
+
+        response_text = json.dumps(payload, sort_keys=True)
+        self.assertEqual(status_code, 202)
+        intent = payload["result"]["intent"]
+        self.assertEqual(intent["status"], "allowed")
+        self.assertEqual(intent["secret_evidence"]["status"], "pass")
+        self.assertEqual(intent["secret_evidence"]["checked_binding_keys"], ["SMTP_PASSWORD"])
+        self.assertEqual(intent["secret_evidence"]["findings"], [])
+        self.assertNotIn("smtp-secret-value", response_text)
+        self.assertNotIn("ciphertext", response_text)
+
+    def test_agent_write_intent_evaluate_denies_secret_without_secret_action_grant(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_runtime_key_safety_policy_record(
+                RuntimeKeySafetyPolicyRecord(
+                    record_id="runtime-key-safety-policy-service-test",
+                    status="active",
+                    source="test",
+                    updated_at="2026-05-05T20:00:00Z",
+                    rules=(
+                        RuntimeSecretSafetyRule(
+                            binding_key="SMTP_PASSWORD",
+                            secret_class="prod_only",
+                            allowed_contexts=("sellyouroutboard",),
+                            allowed_instances=("prod",),
+                        ),
+                    ),
+                )
+            )
+            store.write_secret_binding(
+                SecretBinding(
+                    binding_id="secret-smtp-password-binding-smtp-password",
+                    secret_id="secret-smtp-password",
+                    integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+                    binding_key="SMTP_PASSWORD",
+                    context="sellyouroutboard",
+                    instance="prod",
+                    created_at="2026-05-05T20:00:00Z",
+                    updated_at="2026-05-05T20:00:00Z",
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard"],
+                            "actions": ["product_config.apply"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/agent/write-intents/evaluate",
+                payload={
+                    "intent": "product_config_apply",
+                    "mode": "dry_run",
+                    "product": "sellyouroutboard",
+                    "context": "sellyouroutboard",
+                    "source_url": "https://github.com/cbusillo/launchplane/issues/387",
+                    "reason": "Preflight managed secret-backed product config.",
+                    "secret_bindings": ["SMTP_PASSWORD"],
+                    "destination": {
+                        "kind": "runtime_environment",
+                        "context": "sellyouroutboard",
+                        "instance": "prod",
+                    },
+                },
+            )
+
+        self.assertEqual(status_code, 202)
+        intent = payload["result"]["intent"]
+        self.assertEqual(intent["status"], "denied")
+        self.assertEqual(intent["reason_code"], "authorization_denied")
+        self.assertEqual(intent["secret_evidence"]["status"], "pass")
+
+    def test_agent_write_intent_evaluate_denies_disallowed_secret_destination(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_runtime_key_safety_policy_record(
+                RuntimeKeySafetyPolicyRecord(
+                    record_id="runtime-key-safety-policy-service-test",
+                    status="active",
+                    source="test",
+                    updated_at="2026-05-05T20:00:00Z",
+                    rules=(
+                        RuntimeSecretSafetyRule(
+                            binding_key="SMTP_PASSWORD",
+                            secret_class="prod_only",
+                            allowed_contexts=("sellyouroutboard",),
+                            allowed_instances=("prod",),
+                        ),
+                    ),
+                )
+            )
+            store.write_secret_binding(
+                SecretBinding(
+                    binding_id="secret-smtp-password-binding-smtp-password",
+                    secret_id="secret-smtp-password",
+                    integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+                    binding_key="SMTP_PASSWORD",
+                    context="sellyouroutboard",
+                    instance="testing",
+                    created_at="2026-05-05T20:00:00Z",
+                    updated_at="2026-05-05T20:00:00Z",
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard"],
+                            "actions": [
+                                "product_config.apply",
+                                "product_config.apply.secret",
+                            ],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/agent/write-intents/evaluate",
+                payload={
+                    "intent": "product_config_apply",
+                    "mode": "dry_run",
+                    "product": "sellyouroutboard",
+                    "context": "sellyouroutboard",
+                    "source_url": "https://github.com/cbusillo/launchplane/issues/387",
+                    "reason": "Preflight managed secret-backed product config.",
+                    "secret_bindings": ["SMTP_PASSWORD"],
+                    "destination": {
+                        "kind": "runtime_environment",
+                        "context": "sellyouroutboard",
+                        "instance": "testing",
+                    },
+                },
+            )
+
+        self.assertEqual(status_code, 202)
+        intent = payload["result"]["intent"]
+        self.assertEqual(intent["status"], "denied")
+        self.assertEqual(intent["reason_code"], "secret_evidence_denied")
+        self.assertEqual(intent["secret_evidence"]["status"], "fail")
+        self.assertEqual(
+            intent["secret_evidence"]["findings"][0]["code"],
+            "secret_class_not_allowed",
+        )
 
     def test_product_profile_write_rejects_unauthorized_product(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -223,6 +223,7 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
             "preview_pr_feedback.write": "safe_write",
             "every_code_work_request.rerun": "safe_write",
             "product_config.apply": "mutation",
+            "product_config.apply.secret": "secret_backed",
             "generic_web_prod_promotion.execute": "prod",
             "preview_destroy.execute": "destructive",
             "secret_binding.apply": "secret_backed",


### PR DESCRIPTION
## Summary
- Extend scoped write-intent evaluation with metadata-only managed secret binding references and runtime destinations.
- Require an additional secret-scoped policy action such as product_config.apply.secret and reuse runtime key-safety policy evaluation before allowing secret-backed intents.
- Return sanitized secret evidence only: binding keys, policy ids/digests, destination, and finding codes, never plaintext/ciphertext/provider env data.

Refs #387

## Validation
- uv run python -m unittest tests.test_service_auth.LaunchplaneAuthzPolicyBoundaryTests.test_action_safety_classifies_privileged_action_families tests.test_service.LaunchplaneServiceTests.test_agent_write_intent_evaluate_checks_secret_binding_policy_without_reveal tests.test_service.LaunchplaneServiceTests.test_agent_write_intent_evaluate_denies_secret_without_secret_action_grant tests.test_service.LaunchplaneServiceTests.test_agent_write_intent_evaluate_denies_disallowed_secret_destination tests.test_service.LaunchplaneServiceTests.test_agent_write_intent_evaluate_returns_allowed_dry_run_without_execution tests.test_service.LaunchplaneServiceTests.test_terminal_agent_read_token_rejects_non_read_routes_even_if_policy_grants_action
- uv run python -m unittest tests.test_service_auth tests.test_service.LaunchplaneServiceTests.test_agent_write_intent_evaluate_returns_allowed_dry_run_without_execution tests.test_service.LaunchplaneServiceTests.test_agent_write_intent_evaluate_denies_ungranted_intent tests.test_service.LaunchplaneServiceTests.test_agent_write_intent_evaluate_requires_dry_run_for_config_apply tests.test_service.LaunchplaneServiceTests.test_terminal_agent_write_intent_evaluate_checks_scoped_policy tests.test_service.LaunchplaneServiceTests.test_agent_write_intent_evaluate_checks_secret_binding_policy_without_reveal tests.test_service.LaunchplaneServiceTests.test_agent_write_intent_evaluate_denies_secret_without_secret_action_grant tests.test_service.LaunchplaneServiceTests.test_agent_write_intent_evaluate_denies_disallowed_secret_destination tests.test_service.LaunchplaneServiceTests.test_terminal_agent_read_token_rejects_non_read_routes_even_if_policy_grants_action
- uv run --extra dev ruff check --diff control_plane/contracts/agent_write_intent.py control_plane/service.py control_plane/service_auth.py tests/test_service.py tests/test_service_auth.py
- uv run --extra dev ruff check control_plane/contracts/agent_write_intent.py control_plane/service.py control_plane/service_auth.py tests/test_service.py tests/test_service_auth.py
- uv run --extra dev mypy control_plane/contracts/agent_write_intent.py control_plane/service.py control_plane/service_auth.py tests/test_service.py tests/test_service_auth.py
- uv run python -m unittest