### PR TITLE
ci: use registry cache for image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,30 @@ jobs:
     runs-on:
       - self-hosted
       - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR for build cache
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
       - name: Build runtime image
-        run: docker build -t launchplane-ci:test .
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          tags: launchplane-ci:test
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
 
       - name: Scan runtime image
         run: |

--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -189,6 +189,8 @@ jobs:
           tags: |
             ${{ steps.prep.outputs.image_repository }}:main
             ${{ steps.prep.outputs.image_repository }}:sha-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+          cache-from: type=registry,ref=${{ steps.prep.outputs.image_repository }}:buildcache
+          cache-to: type=registry,ref=${{ steps.prep.outputs.image_repository }}:buildcache,mode=max
 
       - name: Resolve image reference
         id: image


### PR DESCRIPTION
## Summary
- switch the CI container scan build to Buildx with GHCR cache import while keeping the image loaded for Trivy
- export/import the same registry cache in the Launchplane deploy image build
- avoid persistent local BuildKit state on chris-testing

## Validation
- `/usr/local/bin/actionlint .github/workflows/ci.yml .github/workflows/deploy-launchplane.yml`