### PR TITLE
Add agent context aggregation endpoint

### DIFF
--- a/control_plane/agent_context_service.py
+++ b/control_plane/agent_context_service.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.every_code_summary_read_model import (
+    build_every_code_summary_read_model,
+)
+from control_plane.contracts.preview_readiness_read_model import (
+    build_preview_readiness_read_model,
+)
+from control_plane.contracts.product_environment_read_model import ActionAllowed
+from control_plane.service_auth import LaunchplaneAuthzPolicy, LaunchplaneIdentity
+from control_plane.work_graph_service import (
+    WorkGraphPlanningFactsProvider,
+    WorkGraphWorkRequestStore,
+    build_repo_product_mapping_service_payload,
+    build_work_graph_snapshot_service_payload,
+)
+
+
+LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
+AgentContextSectionStatus = Literal["available", "unauthorized", "unavailable"]
+
+
+class AgentContextSection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: AgentContextSectionStatus
+    payload: dict[str, object] = Field(default_factory=dict)
+    reason_code: str = ""
+
+
+class AgentContextPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    generated_at: str
+    repository: str = ""
+    source: dict[str, object]
+    sections: dict[str, AgentContextSection]
+
+    @model_validator(mode="after")
+    def _validate_payload(self) -> "AgentContextPayload":
+        if not self.generated_at.strip():
+            raise ValueError("agent context payload requires generated_at")
+        return self
+
+
+UtcNow = Callable[[], str]
+
+
+def build_agent_context_service_payload(
+    *,
+    generated_at: str,
+    repository: str,
+    product_store: object,
+    work_request_store: WorkGraphWorkRequestStore,
+    preview_readiness_store: object,
+    action_allowed: ActionAllowed,
+    planning_facts_provider: WorkGraphPlanningFactsProvider | None,
+) -> AgentContextPayload:
+    normalized_repository = repository.strip()
+    sections = {
+        "repo_product_mapping": _available_section(
+            build_repo_product_mapping_service_payload(
+                generated_at=generated_at,
+                product_store=product_store,  # type: ignore[arg-type]
+                work_request_store=work_request_store,
+            )
+        ),
+        "work_graph_snapshot": _build_work_graph_snapshot_section(
+            generated_at=generated_at,
+            product_store=product_store,
+            work_request_store=work_request_store,
+            action_allowed=action_allowed,
+            planning_facts_provider=planning_facts_provider,
+        ),
+        "every_code_summary": _available_section(
+            {
+                "summary": build_every_code_summary_read_model(
+                    generated_at=generated_at,
+                    record_store=work_request_store,
+                    repository=normalized_repository,
+                    limit=25,
+                    offset=0,
+                ).model_dump(mode="json")
+            }
+        ),
+        "preview_readiness": _available_section(
+            {
+                "readiness": build_preview_readiness_read_model(
+                    generated_at=generated_at,
+                    record_store=preview_readiness_store,  # type: ignore[arg-type]
+                    repository=normalized_repository,
+                    limit=25,
+                    offset=0,
+                ).model_dump(mode="json")
+            }
+        ),
+    }
+    return AgentContextPayload(
+        generated_at=generated_at,
+        repository=normalized_repository,
+        source={
+            "section_count": len(sections),
+            "available_section_count": sum(
+                1 for section in sections.values() if section.status == "available"
+            ),
+        },
+        sections=sections,
+    )
+
+
+def agent_context_allowed(
+    *, authz_policy: LaunchplaneAuthzPolicy, identity: LaunchplaneIdentity
+) -> bool:
+    return authz_policy.allows(
+        identity=identity,
+        action="product_environment.read",
+        product="launchplane",
+        context=LAUNCHPLANE_SERVICE_CONTEXT,
+    )
+
+
+def agent_context_action_allowed(
+    *, authz_policy: LaunchplaneAuthzPolicy, identity: LaunchplaneIdentity
+) -> ActionAllowed:
+    def action_allowed(requested_action: str, requested_product: str, requested_context: str) -> bool:
+        return authz_policy.allows(
+            identity=identity,
+            action=requested_action,
+            product=requested_product,
+            context=requested_context,
+        )
+
+    return action_allowed
+
+
+def _build_work_graph_snapshot_section(
+    *,
+    generated_at: str,
+    product_store: object,
+    work_request_store: WorkGraphWorkRequestStore,
+    action_allowed: ActionAllowed,
+    planning_facts_provider: WorkGraphPlanningFactsProvider | None,
+) -> AgentContextSection:
+    try:
+        return _available_section(
+            build_work_graph_snapshot_service_payload(
+                generated_at=generated_at,
+                product_store=product_store,  # type: ignore[arg-type]
+                work_request_store=work_request_store,
+                action_allowed=action_allowed,
+                planning_facts_provider=planning_facts_provider,
+            )
+        )
+    except RuntimeError:
+        return AgentContextSection(status="unavailable", reason_code="work_graph_unavailable")
+
+
+def _available_section(payload: dict[str, object]) -> AgentContextSection:
+    return AgentContextSection(status="available", payload=payload)

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -30,6 +30,11 @@ from control_plane import product_onboarding_service as control_plane_product_on
 from control_plane import product_read_service as control_plane_product_read_service
 from control_plane import live_target_runtime as control_plane_live_target_runtime
 from control_plane import secrets as control_plane_secrets
+from control_plane.agent_context_service import (
+    agent_context_action_allowed,
+    agent_context_allowed,
+    build_agent_context_service_payload,
+)
 from control_plane.contracts.authz_policy_record import (
     LaunchplaneAuthzPolicyRecord,
     authz_policy_sha256,
@@ -1677,6 +1682,8 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "every_code_pr_feedback.read", {}
     if len(segments) == 3 and segments == ["v1", "every-code", "preview-gates"]:
         return "every_code_preview_gate.read", {}
+    if len(segments) == 3 and segments == ["v1", "agent", "context"]:
+        return "product_environment.read", {"agent_context": "true"}
     if len(segments) == 4 and segments[:3] == ["v1", "every-code", "work-requests"]:
         return "every_code_work_request.read", {"request_id": segments[3]}
     if len(segments) == 2 and segments == ["v1", "drivers"]:
@@ -5308,6 +5315,48 @@ def create_launchplane_service_app(
                             action=requested_action,
                             product=requested_product,
                             context=requested_context,
+                        )
+
+                    if params.get("agent_context") == "true":
+                        if not agent_context_allowed(
+                            authz_policy=authz_policy,
+                            identity=identity,
+                        ):
+                            return _json_response(
+                                start_response=start_response,
+                                status_code=403,
+                                payload={
+                                    "status": "rejected",
+                                    "trace_id": request_trace_id,
+                                    "error": {
+                                        "code": "authorization_denied",
+                                        "message": "Workflow cannot read Launchplane agent context.",
+                                    },
+                                },
+                            )
+                        repository_filter = str(
+                            (query.get("repository") or [""])[0] or ""
+                        ).strip()
+                        agent_context = build_agent_context_service_payload(
+                            generated_at=_utc_now_timestamp(),
+                            repository=repository_filter,
+                            product_store=record_store,
+                            work_request_store=_every_code_work_request_store(record_store),
+                            preview_readiness_store=_every_code_work_request_store(record_store),
+                            action_allowed=agent_context_action_allowed(
+                                authz_policy=authz_policy,
+                                identity=identity,
+                            ),
+                            planning_facts_provider=work_graph_planning_facts_provider,
+                        )
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=200,
+                            payload={
+                                "status": "ok",
+                                "trace_id": request_trace_id,
+                                "context": agent_context.model_dump(mode="json"),
+                            },
                         )
 
                     if params.get("repo_product_mapping") == "true":

--- a/docs/records.md
+++ b/docs/records.md
@@ -609,6 +609,11 @@ state/
   source links, freshness/provenance, and safe request-preview guidance. Detail
   fields are bounded and redacted so provider-only internals, local paths, and
   secret-shaped values are not copied into agent context payloads.
+- Agent callers can use `GET /v1/agent/context` for a single read-only preflight
+  context. It aggregates the existing repo-product mapping, work graph snapshot,
+  Every Code summary, and preview readiness projections, then reports each
+  section as available, unauthorized, or unavailable. It is not a persisted
+  record and must not fetch or store issue bodies.
 - Agent-consumer authorization diagnostics use a compact subject model for
   GitHub Actions, terminal agents, and GitHub humans. The model records the
   requested action, product, context, safety family, read-only-context status,

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -65,6 +65,7 @@ VeriReel product paths:
   - `POST /v1/every-code/work-requests/rerun`
   - `POST /v1/every-code/work-requests/status`
 - work graph chooser route:
+  - `GET /v1/agent/context`
   - `GET /v1/repo-product-mapping`
   - `GET /v1/work-graph/snapshot`
   - `POST /v1/work-graph/rank`
@@ -209,6 +210,16 @@ when present. Deploy automation also withholds the Project provider env bundle
 until that secret exists, so prepared repo variables do not enable
 unauthenticated runtime reads. That token is not a Launchplane record and must
 remain outside the repo.
+
+`GET /v1/agent/context` is a thin read-only aggregation endpoint for public-safe
+skill preflight. It requires `product_environment.read` for product/context
+`launchplane`, accepts an optional `repository` filter, and composes the existing
+repo-product mapping, work graph snapshot, Every Code summary, and preview
+readiness projections under named sections. Each section reports `available`,
+`unauthorized`, or `unavailable`; optional work-graph planning provider failures
+mark only that section unavailable instead of dropping the whole context or
+silently omitting the failure. The endpoint writes no records, fetches no issue
+bodies, and must preserve the lower-level redaction/provenance rules.
 
 ## Host Assumption
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3594,6 +3594,151 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
 
+    def test_agent_context_returns_thin_aggregated_read_models(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": ["*"],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane", "example-site"],
+                        "contexts": ["launchplane", "example-site"],
+                        "actions": [
+                            "product_environment.read",
+                            "every_code_work_request.write",
+                        ],
+                    }
+                ]
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
+            )
+            store.write_every_code_preview_gate_record(
+                EveryCodePreviewGateRecord(
+                    gate_id="every-code-preview-gate-every-example-site-190-31",
+                    request_id="every-code-every-example-site-190-test",
+                    repository="every/example-site",
+                    issue_number=190,
+                    issue_url="https://github.com/every/example-site/issues/190",
+                    pr_number=31,
+                    pr_url="https://github.com/every/example-site/pull/31",
+                    head_sha="abcdef1234567890",
+                    status="ready",
+                    created_at="2026-05-08T18:00:00Z",
+                    updated_at="2026-05-08T18:01:00Z",
+                    ready_at="2026-05-08T18:01:00Z",
+                    last_checked_at="2026-05-08T18:01:00Z",
+                )
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            create_status, _ = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/create",
+                payload={
+                    "repository": "every/example-site",
+                    "issue_number": 190,
+                    "issue_url": "https://github.com/every/example-site/issues/190",
+                    "issue_title": "Build operator chooser",
+                    "trigger_label": "every-code",
+                    "trigger_actor": "cbusillo",
+                    "source": "manual",
+                    "queued_at": "2026-05-06T02:00:00Z",
+                },
+                headers={"Idempotency-Key": "every-code-create-agent-context-190"},
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/agent/context",
+                query_string="repository=every/example-site",
+            )
+
+        self.assertEqual(create_status, 202)
+        self.assertEqual(status_code, 200)
+        context = payload["context"]
+        self.assertEqual(context["schema_version"], 1)
+        self.assertEqual(context["repository"], "every/example-site")
+        sections = context["sections"]
+        self.assertEqual(sections["repo_product_mapping"]["status"], "available")
+        self.assertEqual(sections["work_graph_snapshot"]["status"], "available")
+        self.assertEqual(sections["every_code_summary"]["status"], "available")
+        self.assertEqual(sections["preview_readiness"]["status"], "available")
+        summary = sections["every_code_summary"]["payload"]["summary"]
+        self.assertEqual(summary["repository"], "every/example-site")
+        self.assertEqual(summary["summaries"][0]["issue_number"], 190)
+        readiness = sections["preview_readiness"]["payload"]["readiness"]
+        self.assertEqual(readiness["repository"], "every/example-site")
+        self.assertEqual(readiness["items"][0]["readiness_status"], "ready")
+
+    def test_agent_context_rejects_unauthorized_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(app, method="GET", path="/v1/agent/context")
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_agent_context_marks_work_graph_unavailable_without_dropping_sections(
+        self,
+    ) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": ["*"],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["product_environment.read"],
+                    }
+                ]
+            }
+        )
+
+        def unavailable_planning_facts() -> tuple[WorkGraphPlanningIssueFacts, ...]:
+            raise RuntimeError("planning provider unavailable")
+
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(
+                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
+                ),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+                work_graph_planning_facts_provider=unavailable_planning_facts,
+            )
+            status_code, payload = _invoke_app(app, method="GET", path="/v1/agent/context")
+
+        self.assertEqual(status_code, 200)
+        sections = payload["context"]["sections"]
+        self.assertEqual(sections["repo_product_mapping"]["status"], "available")
+        self.assertEqual(sections["work_graph_snapshot"]["status"], "unavailable")
+        self.assertEqual(
+            sections["work_graph_snapshot"]["reason_code"], "work_graph_unavailable"
+        )
+        self.assertEqual(sections["every_code_summary"]["status"], "available")
+
     def test_health_endpoint_reports_storage_backend(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             app = create_launchplane_service_app(


### PR DESCRIPTION
## Summary
- Add GET /v1/agent/context as a read-only aggregation endpoint for public-safe skill preflight.
- Compose existing repo-product mapping, work graph snapshot, Every Code summary, and preview readiness projections into named sections.
- Preserve lower-level auth/redaction behavior and mark optional work-graph provider failures as an unavailable section instead of silently dropping context.

Refs #390

## Validation
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_agent_context_returns_thin_aggregated_read_models tests.test_service.LaunchplaneServiceTests.test_agent_context_rejects_unauthorized_identity tests.test_service.LaunchplaneServiceTests.test_agent_context_marks_work_graph_unavailable_without_dropping_sections tests.test_service.LaunchplaneServiceTests.test_work_graph_snapshot_returns_launchplane_assembled_snapshot tests.test_service.LaunchplaneServiceTests.test_repo_product_mapping_returns_managed_and_awareness_repos
- uv run --extra dev ruff check --diff control_plane/agent_context_service.py control_plane/service.py tests/test_service.py
- uv run --extra dev ruff check control_plane/agent_context_service.py control_plane/service.py tests/test_service.py
- uv run --extra dev mypy control_plane/agent_context_service.py control_plane/service.py tests/test_service.py
- uv run python -m unittest