### PR TITLE
Add limited remote user agent profiles

### DIFF
--- a/control_plane/service_auth.py
+++ b/control_plane/service_auth.py
@@ -48,6 +48,12 @@ class TerminalAgentIdentity:
 
 LaunchplaneIdentity = GitHubActionsIdentity | GitHubHumanIdentity | TerminalAgentIdentity
 AgentConsumerSubjectType = Literal["github_actions", "github_human", "terminal_agent"]
+AgentConsumerAccessProfile = Literal[
+    "automation_worker",
+    "human_admin",
+    "limited_remote_user",
+    "owner_local_agent",
+]
 AgentConsumerActionSafety = Literal[
     "read",
     "safe_write",
@@ -262,6 +268,7 @@ class AgentConsumerSubject(BaseModel):
     subject_type: AgentConsumerSubjectType
     subject: str
     display_label: str
+    access_profile: AgentConsumerAccessProfile
     role: Literal["read_only", "admin", "worker"] = "read_only"
     product: str = ""
     context: str = ""
@@ -305,6 +312,10 @@ def action_safety(action: str) -> AgentConsumerActionSafety:
     return "mutation"
 
 
+def limited_remote_user_action_allowed(action: str) -> bool:
+    return action_safety(action) in {"read", "safe_write"}
+
+
 def agent_consumer_subject(
     *, identity: LaunchplaneIdentity, action: str = "", product: str = "", context: str = ""
 ) -> AgentConsumerSubject:
@@ -314,6 +325,7 @@ def agent_consumer_subject(
             subject_type="github_human",
             subject=identity.login,
             display_label=identity.login,
+            access_profile=("human_admin" if identity.role == "admin" else "limited_remote_user"),
             role=identity.role,
             product=product,
             context=context,
@@ -327,6 +339,7 @@ def agent_consumer_subject(
             subject_type="terminal_agent",
             subject=identity.subject,
             display_label=identity.token_label,
+            access_profile="owner_local_agent",
             role="worker",
             product=product,
             context=context,
@@ -339,6 +352,7 @@ def agent_consumer_subject(
         subject_type="github_actions",
         subject=identity.subject or identity.workflow_ref,
         display_label=identity.repository,
+        access_profile="automation_worker",
         role="worker",
         product=product,
         context=context,
@@ -389,6 +403,8 @@ class LaunchplaneAuthzPolicy(BaseModel):
         self, *, identity: LaunchplaneIdentity, action: str, product: str, context: str
     ) -> bool:
         if isinstance(identity, GitHubHumanIdentity):
+            if identity.role == "read_only" and not limited_remote_user_action_allowed(action):
+                return False
             return any(
                 rule.allows(identity=identity, action=action, product=product, context=context)
                 for rule in self.github_humans

--- a/docs/records.md
+++ b/docs/records.md
@@ -617,7 +617,9 @@ state/
 - Agent-consumer authorization diagnostics use a compact subject model for
   GitHub Actions, terminal agents, and GitHub humans. The model records the
   requested action, product, context, safety family, read-only-context status,
-  and approval-capable status without replacing exact policy-rule authorization.
+  access profile, and approval-capable status without replacing exact
+  policy-rule authorization. Limited remote-user profiles fail closed to read and
+  safe-write action families even when a human policy rule is too broad.
 - Agent-facing authorization diagnostics include an `agent_audit` response
   provenance envelope with decision, safe reason code, subject, action, product,
   context, policy source, policy digest, and `authz_policy` source kind. It is

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -423,9 +423,12 @@ subject model before diagnostics or downstream intent contracts consume them:
   cleanup, or secret-backed actions even if a policy rule is too broad.
 - `github_human`: browser-session humans with `read_only` or `admin` role from
   GitHub human policy rules or bootstrap admin email matching. Read-only humans
-  can consume scoped context; admin humans are approval-capable for future
-  operator-mediated intent flows, but direct mutation routes still require their
-  own CSRF/audit design before broad browser writes are allowed.
+  are `limited_remote_user` consumers: even if a rule is accidentally broad,
+  Launchplane only allows read and safe-write action families for them, scoped by
+  the exact repo/product/context/action rule. Admin humans are `human_admin`
+  consumers and are approval-capable for future operator-mediated intent flows,
+  but direct mutation routes still require their own CSRF/audit design before
+  broad browser writes are allowed.
 
 Action names are classified for agent context as `read`, `safe_write`,
 `mutation`, `prod`, `destructive`, `secret_backed`, or `policy_admin`. This

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -19,6 +19,7 @@ from control_plane.service_auth import (
     action_safety,
     agent_authz_audit,
     agent_consumer_subject,
+    limited_remote_user_action_allowed,
     parse_authz_policy_toml,
 )
 from control_plane.contracts.authz_policy_record import authz_policy_sha256
@@ -176,6 +177,7 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
         )
 
         self.assertEqual(subject.subject_type, "terminal_agent")
+        self.assertEqual(subject.access_profile, "owner_local_agent")
         self.assertEqual(subject.role, "worker")
         self.assertEqual(subject.action_safety, "read")
         self.assertTrue(subject.read_only_context)
@@ -190,6 +192,7 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
         )
 
         self.assertEqual(subject.subject_type, "github_human")
+        self.assertEqual(subject.access_profile, "human_admin")
         self.assertEqual(subject.role, "admin")
         self.assertEqual(subject.action_safety, "prod")
         self.assertFalse(subject.read_only_context)
@@ -210,6 +213,7 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
         )
 
         self.assertEqual(read_subject.subject_type, "github_actions")
+        self.assertEqual(read_subject.access_profile, "automation_worker")
         self.assertTrue(read_subject.read_only_context)
         self.assertFalse(read_subject.approval_capable)
         self.assertEqual(prod_subject.action_safety, "prod")
@@ -233,6 +237,78 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
         for action, expected_safety in cases.items():
             with self.subTest(action=action):
                 self.assertEqual(action_safety(action), expected_safety)
+
+    def test_limited_remote_user_action_allowlist_excludes_privileged_families(self) -> None:
+        allowed_actions = (
+            "product_environment.read",
+            "work_graph.rank",
+            "preview_pr_feedback.write",
+        )
+        denied_actions = (
+            "product_config.apply",
+            "product_config.apply.secret",
+            "generic_web_prod_promotion.execute",
+            "preview_destroy.execute",
+        )
+
+        for action in allowed_actions:
+            with self.subTest(action=action):
+                self.assertTrue(limited_remote_user_action_allowed(action))
+        for action in denied_actions:
+            with self.subTest(action=action):
+                self.assertFalse(limited_remote_user_action_allowed(action))
+
+    def test_human_read_only_role_fails_closed_for_privileged_actions(self) -> None:
+        policy = LaunchplaneAuthzPolicy(
+            github_humans=(
+                GitHubHumanPolicyRule(
+                    logins=("alice",),
+                    roles=("read_only",),
+                    products=("verireel",),
+                    contexts=("verireel", "verireel-testing"),
+                    actions=(
+                        "product_environment.read",
+                        "preview_pr_feedback.write",
+                        "generic_web_prod_promotion.execute",
+                        "product_config.apply.secret",
+                    ),
+                ),
+            )
+        )
+        identity = _human_identity(role="read_only")
+
+        self.assertTrue(
+            policy.allows(
+                identity=identity,
+                action="product_environment.read",
+                product="verireel",
+                context="verireel-testing",
+            )
+        )
+        self.assertTrue(
+            policy.allows(
+                identity=identity,
+                action="preview_pr_feedback.write",
+                product="verireel",
+                context="verireel-testing",
+            )
+        )
+        self.assertFalse(
+            policy.allows(
+                identity=identity,
+                action="generic_web_prod_promotion.execute",
+                product="verireel",
+                context="verireel",
+            )
+        )
+        self.assertFalse(
+            policy.allows(
+                identity=identity,
+                action="product_config.apply.secret",
+                product="verireel",
+                context="verireel-testing",
+            )
+        )
 
     def test_agent_authz_audit_records_safe_denial_metadata(self) -> None:
         audit = agent_authz_audit(


### PR DESCRIPTION
## Summary
- add explicit agent consumer access profiles for automation workers, local owner agents, human admins, and limited remote users
- fail closed for read-only GitHub human/limited remote-user identities so broad rules cannot authorize privileged action families
- document the new profile diagnostics and limited remote-user safety behavior

## Validation
- uv run python -m unittest tests.test_service_auth
- uv run python -m unittest tests.test_service_auth tests.test_service.GitHubHumanAuthTests.test_human_session_can_read_allowed_driver_metadata tests.test_service.GitHubHumanAuthTests.test_read_only_human_session_rejects_runtime_read tests.test_service.GitHubHumanAuthTests.test_human_session_does_not_authorize_post_mutations tests.test_service.LaunchplaneServiceTests.test_human_session_can_rank_work_graph_snapshot tests.test_service.LaunchplaneServiceTests.test_product_profile_list_denial_includes_authz_diagnostics
- uv run --extra dev ruff check --diff control_plane/service_auth.py tests/test_service_auth.py tests/test_service.py
- uv run --extra dev ruff check control_plane/service_auth.py tests/test_service_auth.py tests/test_service.py
- uv run --extra dev mypy control_plane/service_auth.py tests/test_service_auth.py tests/test_service.py
- uv run python -m unittest

Refs #388