### PR TITLE
Persist agent write intent evaluations

### DIFF
--- a/control_plane/contracts/agent_write_intent.py
+++ b/control_plane/contracts/agent_write_intent.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import json
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -114,8 +116,51 @@ class AgentWriteIntentEvaluation(BaseModel):
     )
 
 
+class AgentWriteIntentRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    record_id: str
+    recorded_at: str
+    trace_id: str
+    idempotency_key: str = ""
+    request: AgentWriteIntentRequest
+    evaluation: AgentWriteIntentEvaluation
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "AgentWriteIntentRecord":
+        if not self.record_id.strip():
+            raise ValueError("agent write intent record requires record_id")
+        if not self.recorded_at.strip():
+            raise ValueError("agent write intent record requires recorded_at")
+        if not self.trace_id.strip():
+            raise ValueError("agent write intent record requires trace_id")
+        return self
+
+
 def authz_action_for_agent_write_intent(intent: AgentWriteIntentKind) -> str:
     return _INTENT_AUTHZ_ACTIONS[intent]
+
+
+def build_agent_write_intent_record_id(
+    *,
+    recorded_at: str,
+    trace_id: str,
+    request: AgentWriteIntentRequest,
+    evaluation: AgentWriteIntentEvaluation,
+) -> str:
+    normalized_timestamp = recorded_at.replace("-", "").replace(":", "").replace(
+        "+00:00", "Z"
+    )
+    payload = {
+        "trace_id": trace_id,
+        "intent": request.model_dump(mode="json"),
+        "evaluation": evaluation.model_dump(mode="json"),
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:16]
+    return f"agent-write-intent-{normalized_timestamp}-{digest}"
 
 
 def agent_write_intent_secret_action(request: AgentWriteIntentRequest) -> str:

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -41,10 +41,12 @@ from control_plane.contracts.authz_policy_record import (
     build_authz_policy_record_id,
 )
 from control_plane.contracts.agent_write_intent import (
+    AgentWriteIntentRecord,
     AgentWriteIntentRequest,
     AgentWriteIntentSecretEvidence,
     agent_write_intent_secret_action,
     authz_action_for_agent_write_intent,
+    build_agent_write_intent_record_id,
     evaluate_agent_write_intent,
     secret_evidence_for_agent_write_intent,
 )
@@ -1907,6 +1909,10 @@ class _EveryCodeWorkRequestStore(Protocol):
     ) -> tuple[EveryCodePreviewGateRecord, ...]: ...
 
 
+class _AgentWriteIntentRecordStore(Protocol):
+    def write_agent_write_intent_record(self, record: AgentWriteIntentRecord) -> object: ...
+
+
 def _every_code_work_request_store(record_store: object) -> _EveryCodeWorkRequestStore:
     required_methods = (
         "write_every_code_work_request_record",
@@ -1922,6 +1928,12 @@ def _every_code_work_request_store(record_store: object) -> _EveryCodeWorkReques
     if all(hasattr(record_store, method_name) for method_name in required_methods):
         return cast(_EveryCodeWorkRequestStore, record_store)
     raise TypeError("record store does not support Every Code work requests")
+
+
+def _agent_write_intent_record_store(record_store: object) -> _AgentWriteIntentRecordStore:
+    if hasattr(record_store, "write_agent_write_intent_record"):
+        return cast(_AgentWriteIntentRecordStore, record_store)
+    raise TypeError("record store does not support agent write intent records")
 
 
 def _supports_every_code_work_requests(record_store: object) -> bool:
@@ -5570,7 +5582,30 @@ def create_launchplane_service_app(
                     audit=intent_audit,
                     secret_evidence=secret_evidence,
                 )
-                result = {"intent": evaluation.model_dump(mode="json")}
+                recorded_at = _utc_now_timestamp()
+                intent_record = AgentWriteIntentRecord(
+                    record_id=build_agent_write_intent_record_id(
+                        recorded_at=recorded_at,
+                        trace_id=request_trace_id,
+                        request=intent_request,
+                        evaluation=evaluation,
+                    ),
+                    recorded_at=recorded_at,
+                    trace_id=request_trace_id,
+                    idempotency_key=request_idempotency_key,
+                    request=intent_request,
+                    evaluation=evaluation,
+                )
+                _agent_write_intent_record_store(record_store).write_agent_write_intent_record(
+                    intent_record
+                )
+                result = {
+                    "intent": evaluation.model_dump(mode="json"),
+                    "record": {
+                        "record_id": intent_record.record_id,
+                        "recorded_at": intent_record.recorded_at,
+                    },
+                }
                 driver_result = result
             elif path == "/v1/every-code/work-requests/claim":
                 if not authz_policy.allows(

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -5,6 +5,7 @@ from typing import TypeVar
 from pydantic import BaseModel
 
 from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
+from control_plane.contracts.agent_write_intent import AgentWriteIntentRecord
 from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRecord
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
@@ -117,6 +118,44 @@ class FilesystemRecordStore:
         return self._write_model(
             "launchplane_runtime_key_safety_policies", record.record_id, record
         )
+
+    def write_agent_write_intent_record(self, record: AgentWriteIntentRecord) -> Path:
+        return self._write_model("launchplane_agent_write_intents", record.record_id, record)
+
+    def read_agent_write_intent_record(self, record_id: str) -> AgentWriteIntentRecord:
+        return AgentWriteIntentRecord.model_validate(
+            self._read_model(
+                AgentWriteIntentRecord,
+                "launchplane_agent_write_intents",
+                record_id,
+            ).model_dump(mode="json")
+        )
+
+    def list_agent_write_intent_records(
+        self,
+        *,
+        status: str = "",
+        product: str = "",
+        context_name: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[AgentWriteIntentRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                AgentWriteIntentRecord,
+                "launchplane_agent_write_intents",
+            )
+            if (not status or record.evaluation.status == status)
+            and (not product or record.evaluation.product == product)
+            and (not context_name or record.evaluation.context == context_name)
+        ]
+        records.sort(key=lambda record: (record.recorded_at, record.record_id), reverse=True)
+        if offset > 0:
+            records = records[offset:]
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
 
     def list_runtime_key_safety_policy_records(
         self,

--- a/control_plane/storage/migrations/versions/ae45f067cd89_add_agent_write_intents.py
+++ b/control_plane/storage/migrations/versions/ae45f067cd89_add_agent_write_intents.py
@@ -1,0 +1,62 @@
+"""add agent write intents
+
+Revision ID: ae45f067cd89
+Revises: ad34ef56bc78
+Create Date: 2026-05-08 20:55:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "ae45f067cd89"
+down_revision: str | None = "ad34ef56bc78"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "launchplane_agent_write_intents",
+        sa.Column("record_id", sa.String(), nullable=False),
+        sa.Column("recorded_at", sa.String(), nullable=False),
+        sa.Column("trace_id", sa.String(), nullable=False),
+        sa.Column("intent", sa.String(), nullable=False),
+        sa.Column("mode", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("authz_action", sa.String(), nullable=False),
+        sa.Column("product", sa.String(), nullable=False),
+        sa.Column("context", sa.String(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("record_id"),
+    )
+    op.create_index(
+        "launchplane_agent_write_intents_product_context_idx",
+        "launchplane_agent_write_intents",
+        ["product", "context", sa.text("recorded_at DESC")],
+    )
+    op.create_index(
+        "launchplane_agent_write_intents_status_idx",
+        "launchplane_agent_write_intents",
+        ["status", sa.text("recorded_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "launchplane_agent_write_intents_status_idx",
+        table_name="launchplane_agent_write_intents",
+    )
+    op.drop_index(
+        "launchplane_agent_write_intents_product_context_idx",
+        table_name="launchplane_agent_write_intents",
+    )
+    op.drop_table("launchplane_agent_write_intents")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -22,6 +22,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, sessionmaker
 
 from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
+from control_plane.contracts.agent_write_intent import AgentWriteIntentRecord
 from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRecord
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
@@ -525,6 +526,34 @@ class LaunchplaneEveryCodePreviewGateRow(Base):
     head_sha: Mapped[str] = mapped_column(String, nullable=False)
     status: Mapped[str] = mapped_column(String, nullable=False)
     updated_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneAgentWriteIntentRow(Base):
+    __tablename__ = "launchplane_agent_write_intents"
+    __table_args__ = (
+        Index(
+            "launchplane_agent_write_intents_product_context_idx",
+            "product",
+            "context",
+            desc("recorded_at"),
+        ),
+        Index(
+            "launchplane_agent_write_intents_status_idx",
+            "status",
+            desc("recorded_at"),
+        ),
+    )
+
+    record_id: Mapped[str] = mapped_column(String, primary_key=True)
+    recorded_at: Mapped[str] = mapped_column(String, nullable=False)
+    trace_id: Mapped[str] = mapped_column(String, nullable=False)
+    intent: Mapped[str] = mapped_column(String, nullable=False)
+    mode: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    authz_action: Mapped[str] = mapped_column(String, nullable=False)
+    product: Mapped[str] = mapped_column(String, nullable=False)
+    context: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -1350,6 +1379,57 @@ class PostgresRecordStore(HumanSessionStore):
                 status=record.status,
                 payload=self._payload_dict(record),
             )
+        )
+
+    def write_agent_write_intent_record(self, record: AgentWriteIntentRecord) -> None:
+        self._write_row(
+            LaunchplaneAgentWriteIntentRow(
+                record_id=record.record_id,
+                recorded_at=record.recorded_at,
+                trace_id=record.trace_id,
+                intent=record.evaluation.intent,
+                mode=record.evaluation.mode,
+                status=record.evaluation.status,
+                authz_action=record.evaluation.authz_action,
+                product=record.evaluation.product,
+                context=record.evaluation.context,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def read_agent_write_intent_record(self, record_id: str) -> AgentWriteIntentRecord:
+        return self._read_model(
+            model_type=AgentWriteIntentRecord,
+            orm_model=LaunchplaneAgentWriteIntentRow,
+            filters=(LaunchplaneAgentWriteIntentRow.record_id == record_id,),
+        )
+
+    def list_agent_write_intent_records(
+        self,
+        *,
+        status: str = "",
+        product: str = "",
+        context_name: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[AgentWriteIntentRecord, ...]:
+        filters: list[object] = []
+        if status:
+            filters.append(LaunchplaneAgentWriteIntentRow.status == status)
+        if product:
+            filters.append(LaunchplaneAgentWriteIntentRow.product == product)
+        if context_name:
+            filters.append(LaunchplaneAgentWriteIntentRow.context == context_name)
+        return self._list_models(
+            model_type=AgentWriteIntentRecord,
+            orm_model=LaunchplaneAgentWriteIntentRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneAgentWriteIntentRow.recorded_at.desc(),
+                LaunchplaneAgentWriteIntentRow.record_id.desc(),
+            ),
+            limit=limit,
+            offset=offset,
         )
 
     def write_every_code_preview_gate_record(self, record: EveryCodePreviewGateRecord) -> None:
@@ -2246,6 +2326,7 @@ class PostgresRecordStore(HumanSessionStore):
             "preview_lifecycle_plans": 0,
             "preview_pr_feedback": 0,
             "every_code_preview_gates": 0,
+            "agent_write_intents": 0,
             "release_tuples": 0,
             "runtime_key_safety_policies": 0,
         }
@@ -2306,6 +2387,10 @@ class PostgresRecordStore(HumanSessionStore):
             for gate_record in filesystem_store.list_every_code_preview_gate_records():
                 self.write_every_code_preview_gate_record(gate_record)
                 counts["every_code_preview_gates"] += 1
+        if hasattr(filesystem_store, "list_agent_write_intent_records"):
+            for intent_record in filesystem_store.list_agent_write_intent_records():
+                self.write_agent_write_intent_record(intent_record)
+                counts["agent_write_intents"] += 1
         for release_tuple_record in filesystem_store.list_release_tuple_records():
             self.write_release_tuple_record(release_tuple_record)
             counts["release_tuples"] += 1

--- a/docs/records.md
+++ b/docs/records.md
@@ -622,8 +622,11 @@ state/
   safe-write action families even when a human policy rule is too broad.
 - Agent-facing authorization diagnostics include an `agent_audit` response
   provenance envelope with decision, safe reason code, subject, action, product,
-  context, policy source, policy digest, and `authz_policy` source kind. It is
-  intentionally not a persisted write-intent record yet.
+  context, policy source, policy digest, and `authz_policy` source kind.
+- Agent write-intent evaluations are persisted as
+  `launchplane_agent_write_intents` records. Each record stores the request,
+  evaluation result, `agent_audit` envelope, trace id, optional idempotency key,
+  and recorded timestamp so later action routes can link to durable evidence.
 - Scoped agent write-intent evaluation is exposed at
   `POST /v1/agent/write-intents/evaluate`. It validates intent shape, maps the
   intent to an exact existing policy action, evaluates authorization, and returns

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -437,15 +437,15 @@ through the exact action/product/context policy rule.
 
 Agent-facing authorization diagnostics include an `agent_audit` envelope with
 the decision, safe reason code, agent subject, action, product, context, policy
-source, policy digest, and `authz_policy` source kind. This first audit surface
-is response provenance, not a persisted intent record. Future scoped write-intent
-routes should reuse the same shape and add durable record links once they create
-records.
+source, policy digest, and `authz_policy` source kind. Write-intent evaluations
+persist that same provenance as `launchplane_agent_write_intents` records and
+return the record id so later action routes can link to durable evidence.
 
 `POST /v1/agent/write-intents/evaluate` is the first scoped intent surface. It
 does not execute product/runtime mutations. It validates a requested intent,
 maps it to the exact existing policy action, evaluates the caller's policy grant,
-and returns status, safe next action, source URL, and `agent_audit` metadata.
+persists the evaluation record, and returns status, safe next action, source URL,
+record id, and `agent_audit` metadata.
 Agents can use it to preflight safe rerun, preview, config, cleanup, and
 promotion-dispatch candidates without receiving a generic write token or reusable
 credentials. Some intents, such as product config apply and promotion dry-run,

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -15,6 +15,12 @@ from control_plane.contracts.artifact_identity import (
     ArtifactIdentityManifest,
     ArtifactImageReference,
 )
+from control_plane.contracts.agent_write_intent import (
+    AgentWriteIntentEvaluation,
+    AgentWriteIntentRecord,
+    AgentWriteIntentRequest,
+    build_agent_write_intent_record_id,
+)
 from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRecord
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
@@ -71,7 +77,12 @@ from control_plane.contracts.secret_record import (
     SecretRecord,
     SecretVersion,
 )
-from control_plane.service_auth import GitHubHumanIdentity, LaunchplaneAuthzPolicy
+from control_plane.service_auth import (
+    GitHubActionsIdentity,
+    GitHubHumanIdentity,
+    LaunchplaneAuthzPolicy,
+    agent_authz_audit,
+)
 from control_plane.service_human_auth import LaunchplaneHumanSession
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
@@ -420,6 +431,69 @@ def _human_session(*, session_id: str = "session-1") -> LaunchplaneHumanSession:
             teams=frozenset({"shinycomputers/launchplane-admins"}),
             role="admin",
         ),
+    )
+
+
+def _agent_write_intent_record(
+    *, record_id: str = "", recorded_at: str = "2026-05-08T20:55:00Z"
+) -> AgentWriteIntentRecord:
+    identity = GitHubActionsIdentity(
+        repository="every/verireel",
+        repository_owner="every",
+        workflow_ref="every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main",
+        job_workflow_ref="",
+        ref="refs/heads/main",
+        ref_type="branch",
+        event_name="pull_request",
+        environment="",
+        subject="repo:every/verireel:ref:refs/heads/main",
+        sha="abc123",
+        raw_claims={},
+    )
+    request = AgentWriteIntentRequest(
+        intent="every_code_rerun",
+        mode="dry_run",
+        product="launchplane",
+        context="launchplane",
+        source_url="https://github.com/cbusillo/launchplane/issues/386",
+        reason="Check whether rerun can be requested safely.",
+    )
+    audit = agent_authz_audit(
+        identity=identity,
+        action="every_code_work_request.write",
+        product="launchplane",
+        context="launchplane",
+        decision="allowed",
+        reason_code="authorized",
+        policy_source="test",
+        policy_sha256="abc123",
+    )
+    evaluation = AgentWriteIntentEvaluation(
+        intent="every_code_rerun",
+        mode="dry_run",
+        status="allowed",
+        authz_action="every_code_work_request.write",
+        product="launchplane",
+        context="launchplane",
+        source_url="https://github.com/cbusillo/launchplane/issues/386",
+        safe_to_execute=False,
+        next_action="Review the dry-run result before requesting apply authority.",
+        reason_code="authorized",
+        audit=audit,
+    )
+    resolved_record_id = record_id or build_agent_write_intent_record_id(
+        recorded_at=recorded_at,
+        trace_id="launchplane_req_test_write_intent",
+        request=request,
+        evaluation=evaluation,
+    )
+    return AgentWriteIntentRecord(
+        record_id=resolved_record_id,
+        recorded_at=recorded_at,
+        trace_id="launchplane_req_test_write_intent",
+        idempotency_key="intent-eval-1",
+        request=request,
+        evaluation=evaluation,
     )
 
 
@@ -1383,6 +1457,30 @@ class PostgresRecordStoreTests(unittest.TestCase):
         self.assertEqual(listed_records[0].head_sha, "abcdef1234567890")
         self.assertEqual(listed_records[0].blocked_reason, "Checks did not pass: static_checks")
 
+    def test_agent_write_intent_records_round_trip(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            record = _agent_write_intent_record()
+            store.write_agent_write_intent_record(record)
+            loaded_record = store.read_agent_write_intent_record(record.record_id)
+            listed_records = store.list_agent_write_intent_records(
+                status="allowed",
+                product="launchplane",
+                context_name="launchplane",
+            )
+            store.close()
+
+        self.assertEqual(loaded_record.record_id, record.record_id)
+        self.assertEqual(loaded_record.evaluation.intent, "every_code_rerun")
+        self.assertEqual(len(listed_records), 1)
+        self.assertEqual(listed_records[0].trace_id, "launchplane_req_test_write_intent")
+        self.assertEqual(listed_records[0].evaluation.audit.reason_code, "authorized")
+
     def test_write_and_list_dokploy_target_id_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(
@@ -1791,6 +1889,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     "preview_lifecycle_plans": 1,
                     "preview_pr_feedback": 1,
                     "every_code_preview_gates": 0,
+                    "agent_write_intents": 0,
                     "release_tuples": 1,
                     "runtime_key_safety_policies": 1,
                 },

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -5363,6 +5363,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
     def test_agent_write_intent_evaluate_returns_allowed_dry_run_without_execution(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
+            state_dir = root / "state"
             policy = LaunchplaneAuthzPolicy.model_validate(
                 {
                     "github_actions": [
@@ -5380,7 +5381,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 }
             )
             app = create_launchplane_service_app(
-                state_dir=root / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=policy,
                 control_plane_root_path=root,
@@ -5400,6 +5401,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
 
+            record_pointer = payload["result"]["record"]
+            record = FilesystemRecordStore(state_dir).read_agent_write_intent_record(
+                record_pointer["record_id"]
+            )
+
         self.assertEqual(status_code, 202)
         intent = payload["result"]["intent"]
         self.assertEqual(intent["status"], "allowed")
@@ -5408,6 +5414,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(intent["reason_code"], "authorized")
         self.assertEqual(intent["audit"]["decision"], "allowed")
         self.assertEqual(intent["audit"]["subject"]["action_safety"], "safe_write")
+        self.assertEqual(record.evaluation.status, "allowed")
+        self.assertEqual(record.evaluation.intent, "every_code_rerun")
+        self.assertEqual(record.request.source_url, "https://github.com/cbusillo/launchplane/issues/386")
+        self.assertEqual(record.trace_id, payload["trace_id"])
 
     def test_agent_write_intent_evaluate_denies_ungranted_intent(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add a durable AgentWriteIntentRecord contract plus filesystem/Postgres storage and Alembic migration
- persist every /v1/agent/write-intents/evaluate decision with request, evaluation, agent audit, trace id, and optional idempotency key
- return a compact record pointer from write-intent evaluation responses and update service/records docs

## Validation
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_agent_write_intent_evaluate_returns_allowed_dry_run_without_execution tests.test_postgres_store.PostgresRecordStoreTests.test_agent_write_intent_records_round_trip
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_agent_write_intent_evaluate_returns_allowed_dry_run_without_execution tests.test_service.LaunchplaneServiceTests.test_agent_write_intent_evaluate_denies_ungranted_intent tests.test_service.LaunchplaneServiceTests.test_agent_write_intent_evaluate_requires_dry_run_for_config_apply tests.test_service.LaunchplaneServiceTests.test_terminal_agent_write_intent_evaluate_checks_scoped_policy tests.test_service.LaunchplaneServiceTests.test_agent_write_intent_evaluate_checks_secret_binding_policy_without_reveal tests.test_service.LaunchplaneServiceTests.test_agent_write_intent_evaluate_denies_secret_without_secret_action_grant tests.test_service.LaunchplaneServiceTests.test_agent_write_intent_evaluate_denies_disallowed_secret_destination tests.test_postgres_store.PostgresRecordStoreTests.test_agent_write_intent_records_round_trip tests.test_postgres_store.PostgresRecordStoreTests.test_alembic_baseline_creates_schema_used_by_record_store tests.test_postgres_store.PostgresRecordStoreTests.test_alembic_baseline_downgrades_to_empty_schema
- uv run --extra dev ruff check --diff control_plane/contracts/agent_write_intent.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/ae45f067cd89_add_agent_write_intents.py control_plane/service.py tests/test_service.py tests/test_postgres_store.py
- uv run --extra dev ruff check control_plane/contracts/agent_write_intent.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/ae45f067cd89_add_agent_write_intents.py control_plane/service.py tests/test_service.py tests/test_postgres_store.py
- uv run --extra dev mypy control_plane/contracts/agent_write_intent.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/ae45f067cd89_add_agent_write_intents.py control_plane/service.py tests/test_service.py tests/test_postgres_store.py
- uv run python -m unittest

Refs #386