### PR TITLE
Document agent context boundary

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,8 @@ Use these docs as the source of truth for `launchplane`.
   environment, settings, promotion, cleanup, and UI rebuild contract.
 - [work-graph-read-model.md](work-graph-read-model.md) — Code Plans/GitHub work
   graph snapshot and recommendation queue contract.
+- [agent-context-boundary.md](agent-context-boundary.md) — public-safe agent
+  context, caller profiles, scoped intent, redaction, and provenance boundary.
 - [operations.md](operations.md) — operator workflows and runtime boundary rules.
 - [records.md](records.md) — persisted record formats and storage policy.
 - [public-readiness.md](public-readiness.md) — current blockers and exit criteria

--- a/docs/agent-context-boundary.md
+++ b/docs/agent-context-boundary.md
@@ -1,0 +1,118 @@
+---
+title: Launchplane Agent Context Boundary
+---
+
+## Purpose
+
+Launchplane gives coding agents compact operational context and scoped intent
+preflight without becoming a second planning database, a secret broker, or a
+generic production mutation token. GitHub issues, pull requests, Projects,
+checks, and deployments remain the planning and code workflow source of truth.
+Launchplane compiles product/runtime/evidence facts it owns, links back to
+source systems, and records provenance so agents can decide what to inspect or
+request next.
+
+## Source Of Truth
+
+- GitHub remains authoritative for issue bodies, PR review, merge state, Project
+  fields, dependencies, subissues, and check state.
+- Launchplane remains authoritative for product profiles, runtime environment
+  records, managed secret metadata, deployment/promotion evidence, Every Code
+  work requests, preview gates, authz policy records, and write-intent
+  evaluation records.
+- Agent-facing payloads should prefer source URLs and compact evidence over
+  copied planning prose or provider internals.
+- Launchplane read models must mark unavailable provider evidence explicitly
+  instead of silently returning partial context as complete.
+
+## Caller Profiles
+
+Agent context callers are identified as compact agent consumers:
+
+- `automation_worker`: GitHub Actions or service automation. Authorization comes
+  from exact workflow, repository, event, product, context, and action policy
+  rules.
+- `owner_local_agent`: trusted local terminal agent using
+  `LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN`. The service admits this identity only
+  on `GET` routes; policy still scopes products, contexts, and read actions.
+- `limited_remote_user`: authenticated GitHub human with read-only role. This
+  profile fails closed to read and safe-write action families even if a policy
+  rule is accidentally broad.
+- `human_admin`: authenticated GitHub human admin. Admin capability still flows
+  through exact action/product/context policy rules.
+
+These profiles are diagnostics and safety rails. They do not replace exact
+Launchplane authz policy matching.
+
+## Read Context
+
+The preferred preflight endpoint is:
+
+```text
+GET /v1/agent/context
+```
+
+It aggregates existing read models into named sections:
+
+- repo-product mapping
+- work graph snapshot and ranked queue
+- Every Code summary
+- preview readiness
+
+Each section reports `available`, `unauthorized`, or `unavailable`. The endpoint
+writes no records, fetches no issue bodies, and should preserve the underlying
+read models' redaction, freshness, and provenance fields.
+
+Agents may call lower-level read models directly when they need a narrower
+surface:
+
+- `GET /v1/repo-product-mapping`
+- `GET /v1/work-graph/snapshot`
+- `POST /v1/work-graph/rank`
+- `GET /v1/every-code/summary`
+- `GET /v1/previews/readiness`
+
+## Scoped Intents
+
+Agents do not receive broad write credentials. They can preflight a scoped
+candidate through:
+
+```text
+POST /v1/agent/write-intents/evaluate
+```
+
+The request names a specific intent, mode, product, context, source URL, and
+reason. Launchplane maps the intent to an existing policy action, evaluates the
+caller, applies dry-run-first and secret-backed evidence rules, persists a
+`launchplane_agent_write_intents` record, and returns a compact result with the
+record id. The evaluation route does not execute product/runtime mutations and
+does not return reusable credentials.
+
+Follow-on execution routes should require a route-specific policy action. They
+should link back to the durable write-intent record rather than treating the
+record as a bearer capability.
+
+## Redaction And Provenance
+
+Agent payloads must not include plaintext secrets, ciphertext, token prefixes,
+provider environment dumps, local checkout paths, local worker hostnames, raw
+webhook delivery ids, issue bodies, or prompt text. Managed secret evidence is
+metadata-only: binding keys, runtime destinations, policy ids/digests, and safe
+finding codes.
+
+Every agent-facing authorization response should include an `agent_audit`
+envelope with decision, safe reason code, subject, action, product, context,
+policy source, policy digest, and authz-policy source kind. Read models should
+carry compact evidence with source links and trust/freshness states such as
+`verified`, `recorded`, `stale`, `missing`, or `unsupported`.
+
+## Operations
+
+- Use the deployed Launchplane service API or operator UI for shared and
+  production live mutations.
+- Keep service-host environment values bootstrap-only unless a specific doc
+  says otherwise.
+- Add docs in the same PR as behavior changes to agent-facing endpoints,
+  authorization profiles, redaction rules, or write-intent records.
+- Prefer narrow follow-on routes for approved intent families. Do not add a
+  generic agent write token or a catch-all mutation proxy.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -68,6 +68,8 @@ Launchplane should eventually expose API ingress for at least:
 
 The first explicit version of that boundary, including the OIDC claim mapping
 and endpoint list, lives in [`service-boundary.md`](service-boundary.md).
+Agent-facing read context and scoped write-intent consumption rules live in
+[`agent-context-boundary.md`](agent-context-boundary.md).
 
 The first implemented service command is:
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -547,6 +547,10 @@ state/
 
 ## Every Code Work Request Record
 
+See [agent-context-boundary.md](agent-context-boundary.md) for the agent-facing
+rules that compose these records into public-safe context and scoped intent
+preflights.
+
 - One durable request per approved Every Code automation trigger.
 - Record the source, repository, issue number and URL, trigger label, trigger
   actor, optional GitHub delivery id, queue/update timestamps, claim host, run

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -19,6 +19,10 @@ The current repo-local CLI and file-backed state directory are implementation
 scaffolding. This document defines the boundary those adapters should converge
 on.
 
+Agent-facing context and scoped write-intent rules are summarized in
+[agent-context-boundary.md](agent-context-boundary.md). Keep that page aligned
+with this endpoint inventory whenever agent-visible behavior changes.
+
 Product repos should build, test, and publish product artifacts, then call this
 boundary with minimal trigger facts. They should not carry Launchplane lifecycle
 truth, provider mutation logic, rendered evidence payloads, or copied driver

--- a/docs/work-graph-read-model.md
+++ b/docs/work-graph-read-model.md
@@ -14,6 +14,11 @@ from existing product and Every Code records, and return ranked queues with
 compact recommendation reasons. Later service/UI slices can add live GitHub or
 Code Plans ingestion behind the same snapshot and queue contracts.
 
+The agent-facing consumption boundary for this read model is summarized in
+[agent-context-boundary.md](agent-context-boundary.md). This page owns the queue
+shape; the boundary page owns how agents should consume it without turning
+Launchplane into planning authority.
+
 ## Snapshot Contract
 
 A snapshot contains:


### PR DESCRIPTION
## Summary
- add a dedicated Launchplane agent context boundary doc for source-of-truth, caller profiles, read context, scoped intents, redaction, and operations rules
- link the new doc from the docs index plus service, work-graph, records, and operations docs
- consolidate the now-implemented #379 behavior into one durable reference for future skills integration

## Validation
- uv run --extra dev markdownlint-cli2 docs/agent-context-boundary.md docs/README.md docs/service-boundary.md docs/work-graph-read-model.md docs/records.md docs/operations.md
- git diff --check

Refs #391