### PR TITLE
Read all work requests for repo mapping

### DIFF
--- a/control_plane/work_graph_service.py
+++ b/control_plane/work_graph_service.py
@@ -54,7 +54,7 @@ def build_work_graph_snapshot_service_payload(
     action_allowed: ActionAllowed,
     planning_facts_provider: WorkGraphPlanningFactsProvider | None,
 ) -> dict[str, object]:
-    work_requests = work_request_store.list_every_code_work_request_records(limit=100)
+    work_requests = work_request_store.list_every_code_work_request_records(limit=None)
     product_overviews = build_product_site_overviews(
         record_store=product_store,
         action_allowed=action_allowed,
@@ -93,7 +93,7 @@ def build_repo_product_mapping_service_payload(
     work_request_store: RepoProductMappingWorkRequestStore,
 ) -> dict[str, object]:
     product_profiles = product_store.list_product_profile_records()
-    work_requests = work_request_store.list_every_code_work_request_records(limit=100)
+    work_requests = work_request_store.list_every_code_work_request_records(limit=None)
     mapping = build_repo_product_mapping_from_records(
         generated_at=generated_at,
         product_profiles=product_profiles,

--- a/tests/test_work_graph_service.py
+++ b/tests/test_work_graph_service.py
@@ -69,7 +69,16 @@ class _WorkRequestStore:
         offset: int = 0,
     ) -> tuple[EveryCodeWorkRequestRecord, ...]:
         self.seen_limit = limit
-        return self.records
+        records = self.records
+        if repository:
+            records = tuple(record for record in records if record.repository == repository)
+        if state:
+            records = tuple(record for record in records if record.state == state)
+        if offset > 0:
+            records = records[offset:]
+        if limit is not None:
+            records = records[:limit]
+        return records
 
 
 class WorkGraphServiceTests(unittest.TestCase):
@@ -152,7 +161,7 @@ class WorkGraphServiceTests(unittest.TestCase):
             ),
         )
 
-        self.assertEqual(work_request_store.seen_limit, 100)
+        self.assertIsNone(work_request_store.seen_limit)
         self.assertEqual(
             payload["source"],
             {"product_count": 0, "work_request_count": 1, "planning_fact_count": 1},
@@ -165,6 +174,34 @@ class WorkGraphServiceTests(unittest.TestCase):
         self.assertEqual(issues[0]["focus"], "Now")
         self.assertEqual(issues[0]["manager"], "@cellmechanic")
         self.assertEqual(issues[0]["blocking"], 2)
+
+    def test_repo_product_mapping_reads_past_first_hundred_work_requests(self) -> None:
+        work_request_store = _WorkRequestStore(
+            tuple(
+                _work_request(
+                    request_id=f"every-code-cbusillo-tool-{index}",
+                    repository=f"cbusillo/tool-{index}",
+                    issue_number=index + 1,
+                    issue_url=f"https://github.com/cbusillo/tool-{index}/issues/{index + 1}",
+                )
+                for index in range(105)
+            )
+        )
+
+        payload = build_repo_product_mapping_service_payload(
+            generated_at="2026-05-08T18:05:00Z",
+            product_store=_EmptyProductStore(),
+            work_request_store=work_request_store,
+        )
+
+        mapping = cast(dict[str, object], payload["mapping"])
+        repositories = cast(list[dict[str, object]], mapping["repositories"])
+        self.assertIsNone(work_request_store.seen_limit)
+        self.assertEqual(payload["source"], {"product_count": 0, "work_request_count": 105})
+        self.assertIn(
+            "cbusillo/tool-104",
+            {str(repository["repository"]) for repository in repositories},
+        )
 
     def test_snapshot_payload_does_not_classify_unauthorized_product_repo_as_managed(
         self,


### PR DESCRIPTION
## Summary
- remove the hard 100-record cap when building repo-product mapping and work-graph snapshots
- add a >100 work-request regression test so awareness repositories past the old cap remain classified
- keep filtering/offset behavior in the test store aligned with the real store contract

## Validation
- uv run python -m unittest tests.test_work_graph_service
- uv run --extra dev ruff check --diff control_plane/work_graph_service.py tests/test_work_graph_service.py
- uv run --extra dev ruff check control_plane/work_graph_service.py tests/test_work_graph_service.py
- uv run --extra dev mypy control_plane/work_graph_service.py tests/test_work_graph_service.py
- uv run python -m unittest

Refs auto-review finding: Remove the hard 100-record cap from repo-product mapping