### PR TITLE
Add merge train policy contract

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -41,6 +41,10 @@ from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.every_code_work_request import build_every_code_work_request_id
 from control_plane.contracts.github_pull_request_event import GitHubPullRequestEvent
 from control_plane.contracts.github_webhook_replay_envelope import GitHubWebhookReplayEnvelope
+from control_plane.contracts.merge_train_policy import (
+    build_sellyouroutboard_main_merge_train_policy,
+    load_merge_train_policy,
+)
 from control_plane.contracts.odoo_instance_override_record import OdooAddonSettingOverride
 from control_plane.contracts.odoo_instance_override_record import OdooConfigParameterOverride
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
@@ -9356,6 +9360,44 @@ def work_graph_rank(snapshot_file: Path, limit: int) -> None:
     except (OSError, JSONDecodeError, ValidationError, ValueError) as error:
         raise click.ClickException(str(error)) from error
     click.echo(json.dumps(queue.model_dump(mode="json"), indent=2, sort_keys=True))
+
+
+@work_graph.command("merge-train-policy")
+@click.option(
+    "--policy-file",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False),
+    default=None,
+    help="Optional merge-train policy TOML to validate instead of the bundled smoke policy.",
+)
+@click.option("--repository", default="", help="Optional owner/name repository lookup.")
+@click.option("--base-branch", default="main", show_default=True)
+def work_graph_merge_train_policy(
+    policy_file: Path | None, repository: str, base_branch: str
+) -> None:
+    try:
+        policy = (
+            load_merge_train_policy(policy_file)
+            if policy_file is not None
+            else build_sellyouroutboard_main_merge_train_policy()
+        )
+        selected_policy = None
+        if repository.strip():
+            selected_policy = policy.find_repository_policy(
+                repository=repository, base_branch=base_branch
+            )
+    except (OSError, ValidationError, ValueError) as error:
+        raise click.ClickException(str(error)) from error
+    payload: dict[str, object] = {
+        "status": "ok",
+        "policy_sha256": policy.policy_sha256,
+        "repository_count": len(policy.policies),
+        "policies": [
+            repository_policy.model_dump(mode="json") for repository_policy in policy.policies
+        ],
+    }
+    if selected_policy is not None:
+        payload["selected_policy"] = selected_policy.model_dump(mode="json")
+    click.echo(json.dumps(payload, indent=2, sort_keys=True))
 
 
 @every_code.command("run-once")

--- a/control_plane/contracts/merge_train_policy.py
+++ b/control_plane/contracts/merge_train_policy.py
@@ -1,0 +1,166 @@
+import hashlib
+import json
+import tomllib
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+MergeTrainActorRole = Literal["repo_owner", "repo_admin"]
+MergeTrainFailurePolicy = Literal["pause_train", "continue_after_blocking_pr"]
+MergeTrainIdentityKind = Literal["github_actions_oidc", "github_app", "github_token_secret"]
+MergeTrainMergeMethod = Literal["merge", "squash", "rebase"]
+
+
+class MergeTrainEnqueuePolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    label_required: bool = True
+    allowed_actor_roles: tuple[MergeTrainActorRole, ...] = ("repo_owner", "repo_admin")
+
+    @model_validator(mode="after")
+    def _validate_enqueue_policy(self) -> "MergeTrainEnqueuePolicy":
+        if not self.allowed_actor_roles:
+            raise ValueError("merge train enqueue policy requires at least one actor role")
+        self.allowed_actor_roles = tuple(dict.fromkeys(self.allowed_actor_roles))
+        return self
+
+
+class MergeTrainIdentity(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: MergeTrainIdentityKind
+    name: str
+
+    @model_validator(mode="after")
+    def _validate_identity(self) -> "MergeTrainIdentity":
+        if not self.name.strip():
+            raise ValueError("merge train identity requires name")
+        self.name = self.name.strip()
+        return self
+
+
+class MergeTrainRepositoryPolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    repository: str
+    base_branch: str
+    enqueue_label: str
+    blocked_label: str
+    merge_method: MergeTrainMergeMethod
+    failure_policy: MergeTrainFailurePolicy
+    enqueue: MergeTrainEnqueuePolicy
+    merge_identity: MergeTrainIdentity
+
+    @model_validator(mode="after")
+    def _validate_repository_policy(self) -> "MergeTrainRepositoryPolicy":
+        self.repository = _normalize_required_value(
+            self.repository, "merge train policy requires repository"
+        )
+        if "/" not in self.repository:
+            raise ValueError("merge train repository must be owner/name")
+        self.base_branch = _normalize_required_value(
+            self.base_branch, "merge train policy requires base_branch"
+        )
+        self.enqueue_label = _normalize_required_value(
+            self.enqueue_label, "merge train policy requires enqueue_label"
+        )
+        self.blocked_label = _normalize_required_value(
+            self.blocked_label, "merge train policy requires blocked_label"
+        )
+        if self.enqueue_label == self.blocked_label:
+            raise ValueError("merge train enqueue_label and blocked_label must differ")
+        return self
+
+    @property
+    def policy_key(self) -> str:
+        return f"{self.repository}:{self.base_branch}"
+
+
+class MergeTrainPolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    policies: tuple[MergeTrainRepositoryPolicy, ...]
+
+    @model_validator(mode="after")
+    def _validate_policy(self) -> "MergeTrainPolicy":
+        if not self.policies:
+            raise ValueError("merge train policy requires at least one repository policy")
+        seen_keys: set[str] = set()
+        for repository_policy in self.policies:
+            if repository_policy.policy_key in seen_keys:
+                raise ValueError("merge train policies must be unique by repository/base_branch")
+            seen_keys.add(repository_policy.policy_key)
+        return self
+
+    @property
+    def policy_sha256(self) -> str:
+        return merge_train_policy_sha256(self)
+
+    def find_repository_policy(
+        self, *, repository: str, base_branch: str
+    ) -> MergeTrainRepositoryPolicy:
+        normalized_repository = _normalize_required_value(
+            repository, "merge train policy lookup requires repository"
+        )
+        normalized_base_branch = _normalize_required_value(
+            base_branch, "merge train policy lookup requires base_branch"
+        )
+        for repository_policy in self.policies:
+            if (
+                repository_policy.repository == normalized_repository
+                and repository_policy.base_branch == normalized_base_branch
+            ):
+                return repository_policy
+        raise ValueError(
+            "merge train policy not found for "
+            f"{normalized_repository}:{normalized_base_branch}"
+        )
+
+
+SELLYOUROUTBOARD_MAIN_POLICY_TOML = """schema_version = 1
+
+[[policies]]
+repository = "cbusillo/sellyouroutboard"
+base_branch = "main"
+enqueue_label = "ready-to-merge"
+blocked_label = "merge-blocked"
+merge_method = "merge"
+failure_policy = "pause_train"
+
+[policies.enqueue]
+label_required = true
+allowed_actor_roles = ["repo_owner", "repo_admin"]
+
+[policies.merge_identity]
+kind = "github_actions_oidc"
+name = "launchplane-merge-train"
+"""
+
+
+def parse_merge_train_policy_toml(policy_toml: str) -> MergeTrainPolicy:
+    return MergeTrainPolicy.model_validate(tomllib.loads(policy_toml))
+
+
+def load_merge_train_policy(policy_file: Path) -> MergeTrainPolicy:
+    return parse_merge_train_policy_toml(policy_file.read_text(encoding="utf-8"))
+
+
+def build_sellyouroutboard_main_merge_train_policy() -> MergeTrainPolicy:
+    return parse_merge_train_policy_toml(SELLYOUROUTBOARD_MAIN_POLICY_TOML)
+
+
+def merge_train_policy_sha256(policy: MergeTrainPolicy) -> str:
+    encoded = json.dumps(
+        policy.model_dump(mode="json"), sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _normalize_required_value(value: str, message: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(message)
+    return normalized

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,8 @@ Use these docs as the source of truth for `launchplane`.
   environment, settings, promotion, cleanup, and UI rebuild contract.
 - [work-graph-read-model.md](work-graph-read-model.md) — Code Plans/GitHub work
   graph snapshot and recommendation queue contract.
+- [merge-train-policy.md](merge-train-policy.md) — repository/base-branch merge
+  train policy contract, enqueue authority, and smoke-target policy.
 - [agent-context-boundary.md](agent-context-boundary.md) — public-safe agent
   context, caller profiles, scoped intent, redaction, and provenance boundary.
 - [operations.md](operations.md) — operator workflows and runtime boundary rules.

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -1,0 +1,83 @@
+# Merge Train Policy Contract
+
+Launchplane merge trains use an explicit repository policy before any worker is
+allowed to enqueue, update, or merge pull requests. The policy is a bootstrap
+contract for the sequential merge train work in #410; it is not a live tracked
+`config/*.toml` authority.
+
+The first live smoke target is SellYourOutboard `main`. The policy is bundled in
+code for CLI and worker dry-runs so the next implementation slice can discover a
+stable contract without adding repo-local runtime config.
+
+## Fields
+
+Each repository policy contains:
+
+- `repository`: GitHub `owner/name` repository.
+- `base_branch`: Branch the train protects and merges into.
+- `enqueue_label`: Label required before a pull request can enter the train.
+- `blocked_label`: Label Launchplane applies when a queued pull request blocks.
+- `merge_method`: GitHub merge strategy, one of `merge`, `squash`, or `rebase`.
+- `failure_policy`: Whether Launchplane pauses the whole train or continues
+  after marking the blocked pull request.
+- `enqueue`: Requirements for who may enqueue.
+- `merge_identity`: Token or workload identity allowed to update branches and
+  merge pull requests.
+
+The initial enqueue policy is intentionally narrow: the enqueue label must be
+present and the enqueue action must come from a repo owner or repo admin. That
+keeps the runner fail-closed until #410 wires live GitHub role checks.
+
+## Failure Semantics
+
+The default SellYourOutboard policy uses `pause_train`. If any pull request in
+the train cannot update, pass checks, or merge, Launchplane marks that pull
+request with `blocked_label` and stops processing later queued pull requests.
+
+`continue_after_blocking_pr` is reserved for repositories that explicitly choose
+higher throughput over strict ordering. A worker must still mark the failed pull
+request with `blocked_label` before considering later entries.
+
+## Initial Smoke Policy
+
+```toml
+schema_version = 1
+
+[[policies]]
+repository = "cbusillo/sellyouroutboard"
+base_branch = "main"
+enqueue_label = "ready-to-merge"
+blocked_label = "merge-blocked"
+merge_method = "merge"
+failure_policy = "pause_train"
+
+[policies.enqueue]
+label_required = true
+allowed_actor_roles = ["repo_owner", "repo_admin"]
+
+[policies.merge_identity]
+kind = "github_actions_oidc"
+name = "launchplane-merge-train"
+```
+
+## Discoverability
+
+The contract is available to dry-run tooling with:
+
+```sh
+uv run launchplane work-graph merge-train-policy \
+  --repository cbusillo/sellyouroutboard \
+  --base-branch main
+```
+
+Operators can validate an external bootstrap TOML without treating it as live
+authority:
+
+```sh
+uv run launchplane work-graph merge-train-policy \
+  --policy-file path/to/merge-train-policy.toml
+```
+
+Workers should load the same typed contract before enqueuing or merging. A
+missing policy for a repository/base branch is a hard failure, not a fallback to
+implicit behavior.

--- a/tests/test_merge_train_policy.py
+++ b/tests/test_merge_train_policy.py
@@ -1,0 +1,121 @@
+import json
+import textwrap
+import unittest
+
+from click.testing import CliRunner
+from pydantic import ValidationError
+
+from control_plane.cli import main
+from control_plane.contracts.merge_train_policy import (
+    build_sellyouroutboard_main_merge_train_policy,
+    parse_merge_train_policy_toml,
+)
+
+
+class MergeTrainPolicyTests(unittest.TestCase):
+    def test_sellyouroutboard_main_policy_is_initial_smoke_target(self) -> None:
+        policy = build_sellyouroutboard_main_merge_train_policy()
+
+        repository_policy = policy.find_repository_policy(
+            repository="cbusillo/sellyouroutboard", base_branch="main"
+        )
+
+        self.assertEqual(repository_policy.enqueue_label, "ready-to-merge")
+        self.assertEqual(repository_policy.blocked_label, "merge-blocked")
+        self.assertEqual(repository_policy.merge_method, "merge")
+        self.assertEqual(repository_policy.failure_policy, "pause_train")
+        self.assertTrue(repository_policy.enqueue.label_required)
+        self.assertEqual(
+            repository_policy.enqueue.allowed_actor_roles, ("repo_owner", "repo_admin")
+        )
+        self.assertEqual(repository_policy.merge_identity.kind, "github_actions_oidc")
+        self.assertEqual(repository_policy.merge_identity.name, "launchplane-merge-train")
+        self.assertEqual(len(policy.policy_sha256), 64)
+
+    def test_parse_rejects_duplicate_repository_branch_policy(self) -> None:
+        policy_toml = textwrap.dedent(
+            """
+            schema_version = 1
+
+            [[policies]]
+            repository = "example/app"
+            base_branch = "main"
+            enqueue_label = "ready-to-merge"
+            blocked_label = "merge-blocked"
+            merge_method = "merge"
+            failure_policy = "pause_train"
+            [policies.enqueue]
+            label_required = true
+            allowed_actor_roles = ["repo_owner"]
+            [policies.merge_identity]
+            kind = "github_app"
+            name = "launchplane"
+
+            [[policies]]
+            repository = "example/app"
+            base_branch = "main"
+            enqueue_label = "ready-to-merge"
+            blocked_label = "merge-blocked"
+            merge_method = "merge"
+            failure_policy = "pause_train"
+            [policies.enqueue]
+            label_required = true
+            allowed_actor_roles = ["repo_admin"]
+            [policies.merge_identity]
+            kind = "github_app"
+            name = "launchplane"
+            """
+        ).strip()
+
+        with self.assertRaisesRegex(ValidationError, "unique by repository/base_branch"):
+            parse_merge_train_policy_toml(policy_toml)
+
+    def test_parse_rejects_ambiguous_labels(self) -> None:
+        policy_toml = textwrap.dedent(
+            """
+            schema_version = 1
+
+            [[policies]]
+            repository = "example/app"
+            base_branch = "main"
+            enqueue_label = "ready-to-merge"
+            blocked_label = "ready-to-merge"
+            merge_method = "merge"
+            failure_policy = "continue_after_blocking_pr"
+            [policies.enqueue]
+            label_required = true
+            allowed_actor_roles = ["repo_admin"]
+            [policies.merge_identity]
+            kind = "github_token_secret"
+            name = "MERGE_TRAIN_TOKEN"
+            """
+        ).strip()
+
+        with self.assertRaisesRegex(ValidationError, "must differ"):
+            parse_merge_train_policy_toml(policy_toml)
+
+    def test_work_graph_merge_train_policy_cli_renders_dry_run_contract(self) -> None:
+        result = CliRunner().invoke(
+            main,
+            [
+                "work-graph",
+                "merge-train-policy",
+                "--repository",
+                "cbusillo/sellyouroutboard",
+                "--base-branch",
+                "main",
+            ],
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["repository_count"], 1)
+        self.assertEqual(
+            payload["selected_policy"]["repository"], "cbusillo/sellyouroutboard"
+        )
+        self.assertEqual(payload["selected_policy"]["base_branch"], "main")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a typed merge-train policy contract with explicit enqueue authority, merge identity, failure policy, and repo/base uniqueness
- add a dry-run CLI surface under `work-graph merge-train-policy` using the SellYourOutboard `main` smoke policy
- document the bootstrap contract and add focused validation tests

Refs #412

## Validation
- `uv run python -m unittest tests.test_merge_train_policy`
- `uv run --extra dev ruff check --diff control_plane/contracts/merge_train_policy.py control_plane/cli.py tests/test_merge_train_policy.py`
- `uv run --extra dev markdownlint-cli2 docs/merge-train-policy.md docs/README.md`
- `uv run --extra dev ruff check control_plane/contracts/merge_train_policy.py control_plane/cli.py tests/test_merge_train_policy.py`
- `uv run --extra dev mypy control_plane/contracts/merge_train_policy.py tests/test_merge_train_policy.py`
- `uv run python -m unittest`