### PR TITLE
Add merge train dry-run evaluator

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -123,6 +123,10 @@ from control_plane.launchplane_mutations import (
     control_plane_root as shared_control_plane_root,
     upsert_launchplane_preview_from_request as shared_upsert_launchplane_preview_from_request,
 )
+from control_plane.merge_train import (
+    MergeTrainDryRunSnapshot,
+    build_merge_train_dry_run_result,
+)
 from control_plane.service import serve_launchplane_service
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.factory import build_record_store, resolve_database_url
@@ -9398,6 +9402,36 @@ def work_graph_merge_train_policy(
     if selected_policy is not None:
         payload["selected_policy"] = selected_policy.model_dump(mode="json")
     click.echo(json.dumps(payload, indent=2, sort_keys=True))
+
+
+@work_graph.command("merge-train-dry-run")
+@click.option(
+    "--snapshot-file",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False),
+    required=True,
+    help="Merge-train dry-run snapshot JSON containing repository, base_branch, and pull_requests.",
+)
+@click.option(
+    "--policy-file",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False),
+    default=None,
+    help="Optional merge-train policy TOML to validate instead of the bundled smoke policy.",
+)
+def work_graph_merge_train_dry_run(
+    snapshot_file: Path, policy_file: Path | None
+) -> None:
+    try:
+        snapshot_payload = json.loads(snapshot_file.read_text(encoding="utf-8"))
+        snapshot = MergeTrainDryRunSnapshot.model_validate(snapshot_payload)
+        policy = (
+            load_merge_train_policy(policy_file)
+            if policy_file is not None
+            else build_sellyouroutboard_main_merge_train_policy()
+        )
+        result = build_merge_train_dry_run_result(policy=policy, snapshot=snapshot)
+    except (OSError, JSONDecodeError, ValidationError, ValueError) as error:
+        raise click.ClickException(str(error)) from error
+    click.echo(json.dumps(result.model_dump(mode="json"), indent=2, sort_keys=True))
 
 
 @every_code.command("run-once")

--- a/control_plane/merge_train.py
+++ b/control_plane/merge_train.py
@@ -1,0 +1,213 @@
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.merge_train_policy import MergeTrainPolicy
+from control_plane.contracts.merge_train_policy import MergeTrainRepositoryPolicy
+
+
+MergeTrainCheckStatus = Literal["pass", "fail", "pending", "unknown"]
+MergeTrainDryRunAction = Literal[
+    "idle", "block", "merge", "update_branch", "wait_for_checks"
+]
+MergeTrainMergeableState = Literal["mergeable", "conflicting", "unknown"]
+MergeTrainPullRequestState = Literal["open", "closed", "merged"]
+
+
+class MergeTrainPullRequestSnapshot(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    number: int = Field(gt=0)
+    url: str = ""
+    title: str = ""
+    state: MergeTrainPullRequestState = "open"
+    is_draft: bool = False
+    created_at: str
+    labels: tuple[str, ...] = ()
+    actor_role: str = "unknown"
+    head_sha: str
+    base_sha: str = ""
+    mergeable: MergeTrainMergeableState = "unknown"
+    required_checks_status: MergeTrainCheckStatus = "unknown"
+    branch_update_required: bool = False
+
+    @model_validator(mode="after")
+    def _validate_snapshot(self) -> "MergeTrainPullRequestSnapshot":
+        self.url = self.url.strip()
+        self.title = self.title.strip()
+        self.created_at = _normalize_required_value(
+            self.created_at, "merge train pull request snapshot requires created_at"
+        )
+        self.labels = _normalize_unique_values(self.labels)
+        self.actor_role = _normalize_required_value(
+            self.actor_role, "merge train pull request snapshot requires actor_role"
+        )
+        self.head_sha = _normalize_required_value(
+            self.head_sha, "merge train pull request snapshot requires head_sha"
+        )
+        self.base_sha = self.base_sha.strip()
+        return self
+
+
+class MergeTrainDryRunSnapshot(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    repository: str
+    base_branch: str
+    pull_requests: tuple[MergeTrainPullRequestSnapshot, ...]
+
+    @model_validator(mode="after")
+    def _validate_snapshot(self) -> "MergeTrainDryRunSnapshot":
+        self.repository = _normalize_required_value(
+            self.repository, "merge train dry-run snapshot requires repository"
+        )
+        self.base_branch = _normalize_required_value(
+            self.base_branch, "merge train dry-run snapshot requires base_branch"
+        )
+        return self
+
+
+class MergeTrainQueueEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    number: int
+    url: str = ""
+    title: str = ""
+    created_at: str
+    head_sha: str
+    labels: tuple[str, ...]
+    actor_role: str
+    mergeable: MergeTrainMergeableState
+    required_checks_status: MergeTrainCheckStatus
+    branch_update_required: bool
+    eligible: bool
+    ineligible_reasons: tuple[str, ...] = ()
+
+
+class MergeTrainDryRunResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["dry-run"] = "dry-run"
+    repository: str
+    base_branch: str
+    policy_key: str
+    merge_method: str
+    failure_policy: str
+    enqueue_label: str
+    blocked_label: str
+    queue_order: tuple[int, ...]
+    queue: tuple[MergeTrainQueueEntry, ...]
+    selected_pr: MergeTrainQueueEntry | None = None
+    intended_next_action: MergeTrainDryRunAction
+    next_action_detail: str
+
+
+def build_merge_train_dry_run_result(
+    *, policy: MergeTrainPolicy, snapshot: MergeTrainDryRunSnapshot
+) -> MergeTrainDryRunResult:
+    repository_policy = policy.find_repository_policy(
+        repository=snapshot.repository, base_branch=snapshot.base_branch
+    )
+    queue = tuple(
+        _build_queue_entry(repository_policy, pull_request)
+        for pull_request in sorted(
+            snapshot.pull_requests, key=lambda item: (item.created_at, item.number)
+        )
+    )
+    selected_pr = next((entry for entry in queue if entry.eligible), None)
+    intended_next_action, next_action_detail = _next_action_for_selected_pr(
+        repository_policy, selected_pr
+    )
+    return MergeTrainDryRunResult(
+        repository=snapshot.repository,
+        base_branch=snapshot.base_branch,
+        policy_key=repository_policy.policy_key,
+        merge_method=repository_policy.merge_method,
+        failure_policy=repository_policy.failure_policy,
+        enqueue_label=repository_policy.enqueue_label,
+        blocked_label=repository_policy.blocked_label,
+        queue_order=tuple(entry.number for entry in queue if entry.eligible),
+        queue=queue,
+        selected_pr=selected_pr,
+        intended_next_action=intended_next_action,
+        next_action_detail=next_action_detail,
+    )
+
+
+def _build_queue_entry(
+    repository_policy: MergeTrainRepositoryPolicy,
+    pull_request: MergeTrainPullRequestSnapshot,
+) -> MergeTrainQueueEntry:
+    ineligible_reasons: list[str] = []
+    if pull_request.state != "open":
+        ineligible_reasons.append("pull request is not open")
+    if pull_request.is_draft:
+        ineligible_reasons.append("draft pull request")
+    if (
+        repository_policy.enqueue.label_required
+        and repository_policy.enqueue_label not in pull_request.labels
+    ):
+        ineligible_reasons.append(f"missing {repository_policy.enqueue_label} label")
+    if pull_request.actor_role not in repository_policy.enqueue.allowed_actor_roles:
+        ineligible_reasons.append("actor role is not allowed to enqueue")
+    return MergeTrainQueueEntry(
+        number=pull_request.number,
+        url=pull_request.url,
+        title=pull_request.title,
+        created_at=pull_request.created_at,
+        head_sha=pull_request.head_sha,
+        labels=pull_request.labels,
+        actor_role=pull_request.actor_role,
+        mergeable=pull_request.mergeable,
+        required_checks_status=pull_request.required_checks_status,
+        branch_update_required=pull_request.branch_update_required,
+        eligible=not ineligible_reasons,
+        ineligible_reasons=tuple(ineligible_reasons),
+    )
+
+
+def _next_action_for_selected_pr(
+    repository_policy: MergeTrainRepositoryPolicy,
+    selected_pr: MergeTrainQueueEntry | None,
+) -> tuple[MergeTrainDryRunAction, str]:
+    if selected_pr is None:
+        return "idle", "No eligible pull requests are queued."
+    if selected_pr.mergeable == "conflicting":
+        return (
+            "block",
+            f"Add {repository_policy.blocked_label}; pull request has merge conflicts.",
+        )
+    if selected_pr.required_checks_status == "fail":
+        return (
+            "block",
+            f"Add {repository_policy.blocked_label}; required checks failed.",
+        )
+    if selected_pr.branch_update_required:
+        return "update_branch", "Refresh the pull request against the current base branch."
+    if selected_pr.mergeable == "unknown" or selected_pr.required_checks_status in {
+        "pending",
+        "unknown",
+    }:
+        return "wait_for_checks", "Wait for mergeability and required checks on the head SHA."
+    return (
+        "merge",
+        f"Merge with {repository_policy.merge_method} after confirming current head checks.",
+    )
+
+
+def _normalize_required_value(value: str, message: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(message)
+    return normalized
+
+
+def _normalize_unique_values(values: tuple[str, ...]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    for raw_value in values:
+        value = raw_value.strip()
+        if not value:
+            raise ValueError("merge train labels must be non-empty")
+        if value not in normalized:
+            normalized.append(value)
+    return tuple(normalized)

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -81,3 +81,15 @@ uv run launchplane work-graph merge-train-policy \
 Workers should load the same typed contract before enqueuing or merging. A
 missing policy for a repository/base branch is a hard failure, not a fallback to
 implicit behavior.
+
+The sequential train dry-run accepts a JSON snapshot of candidate pull requests
+and reports queue order plus the next intended action without mutating GitHub:
+
+```sh
+uv run launchplane work-graph merge-train-dry-run \
+  --snapshot-file path/to/merge-train-snapshot.json
+```
+
+The dry-run orders eligible pull requests by `created_at` and then PR number. It
+excludes draft, closed, unlabeled, or unauthorized entries and fails closed when
+the snapshot repository/base branch has no explicit policy.

--- a/tests/test_merge_train.py
+++ b/tests/test_merge_train.py
@@ -1,0 +1,155 @@
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from click.testing import CliRunner
+
+from control_plane.cli import main
+from control_plane.contracts.merge_train_policy import (
+    build_sellyouroutboard_main_merge_train_policy,
+)
+from control_plane.merge_train import (
+    MergeTrainDryRunSnapshot,
+    MergeTrainPullRequestSnapshot,
+    build_merge_train_dry_run_result,
+)
+
+
+class MergeTrainDryRunTests(unittest.TestCase):
+    def test_dry_run_orders_oldest_eligible_ready_pull_requests_first(self) -> None:
+        result = build_merge_train_dry_run_result(
+            policy=build_sellyouroutboard_main_merge_train_policy(),
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(
+                    _pull_request(12, created_at="2026-05-08T12:00:00Z"),
+                    _pull_request(10, created_at="2026-05-08T10:00:00Z"),
+                    _pull_request(11, created_at="2026-05-08T11:00:00Z", is_draft=True),
+                ),
+            ),
+        )
+
+        self.assertEqual(result.queue_order, (10, 12))
+        self.assertEqual(result.selected_pr.number if result.selected_pr else None, 10)
+        self.assertEqual(result.intended_next_action, "merge")
+        self.assertEqual(result.merge_method, "merge")
+
+    def test_dry_run_fails_closed_when_policy_is_missing(self) -> None:
+        with self.assertRaisesRegex(ValueError, "policy not found"):
+            build_merge_train_dry_run_result(
+                policy=build_sellyouroutboard_main_merge_train_policy(),
+                snapshot=MergeTrainDryRunSnapshot(
+                    repository="cbusillo/other",
+                    base_branch="main",
+                    pull_requests=(_pull_request(1),),
+                ),
+            )
+
+    def test_dry_run_excludes_missing_label_and_disallowed_actor_role(self) -> None:
+        result = build_merge_train_dry_run_result(
+            policy=build_sellyouroutboard_main_merge_train_policy(),
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(
+                    _pull_request(4, labels=()),
+                    _pull_request(5, actor_role="external_contributor"),
+                ),
+            ),
+        )
+
+        self.assertEqual(result.queue_order, ())
+        self.assertIsNone(result.selected_pr)
+        self.assertEqual(result.intended_next_action, "idle")
+        self.assertIn("missing ready-to-merge label", result.queue[0].ineligible_reasons)
+        self.assertIn("actor role is not allowed", result.queue[1].ineligible_reasons[0])
+
+    def test_dry_run_reports_block_and_update_actions(self) -> None:
+        blocked_result = build_merge_train_dry_run_result(
+            policy=build_sellyouroutboard_main_merge_train_policy(),
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(_pull_request(6, mergeable="conflicting"),),
+            ),
+        )
+        update_result = build_merge_train_dry_run_result(
+            policy=build_sellyouroutboard_main_merge_train_policy(),
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(_pull_request(7, branch_update_required=True),),
+            ),
+        )
+
+        self.assertEqual(blocked_result.intended_next_action, "block")
+        self.assertIn("merge-blocked", blocked_result.next_action_detail)
+        self.assertEqual(update_result.intended_next_action, "update_branch")
+
+    def test_cli_renders_merge_train_dry_run_snapshot(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            snapshot_file = Path(temp_dir) / "snapshot.json"
+            snapshot_file.write_text(
+                json.dumps(
+                    {
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "pull_requests": [
+                            _pull_request(22, created_at="2026-05-08T22:00:00Z")
+                            .model_dump(mode="json")
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "work-graph",
+                    "merge-train-dry-run",
+                    "--snapshot-file",
+                    str(snapshot_file),
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["mode"], "dry-run")
+        self.assertEqual(payload["queue_order"], [22])
+        self.assertEqual(payload["selected_pr"]["number"], 22)
+
+
+def _pull_request(
+    number: int,
+    *,
+    created_at: str = "2026-05-08T10:00:00Z",
+    labels: tuple[str, ...] = ("ready-to-merge",),
+    actor_role: str = "repo_admin",
+    is_draft: bool = False,
+    mergeable: str = "mergeable",
+    required_checks_status: str = "pass",
+    branch_update_required: bool = False,
+) -> MergeTrainPullRequestSnapshot:
+    return MergeTrainPullRequestSnapshot.model_validate(
+        {
+            "number": number,
+            "url": f"https://github.com/cbusillo/sellyouroutboard/pull/{number}",
+            "title": f"PR {number}",
+            "created_at": created_at,
+            "labels": labels,
+            "actor_role": actor_role,
+            "is_draft": is_draft,
+            "head_sha": f"head-{number}",
+            "base_sha": "base-main",
+            "mergeable": mergeable,
+            "required_checks_status": required_checks_status,
+            "branch_update_required": branch_update_required,
+        }
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a mutation-free merge-train dry-run evaluator for repository/base-branch snapshots
- apply the #412 policy contract for fail-closed lookup, enqueue label/actor checks, draft exclusion, deterministic queue order, and intended next action
- expose the evaluator through `work-graph merge-train-dry-run` and document the snapshot behavior

Refs #410

## Validation
- `uv run python -m unittest tests.test_merge_train tests.test_merge_train_policy`
- `uv run --extra dev ruff check --diff control_plane/merge_train.py control_plane/cli.py tests/test_merge_train.py`
- `uv run --extra dev ruff check control_plane/merge_train.py control_plane/cli.py tests/test_merge_train.py`
- `uv run --extra dev mypy control_plane/merge_train.py tests/test_merge_train.py`
- `uv run --extra dev markdownlint-cli2 docs/merge-train-policy.md`
- `uv run python -m unittest`