### PR TITLE
Add merge train block label action

### DIFF
--- a/control_plane/merge_train.py
+++ b/control_plane/merge_train.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, Protocol
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -12,6 +12,12 @@ MergeTrainDryRunAction = Literal[
 ]
 MergeTrainMergeableState = Literal["mergeable", "conflicting", "unknown"]
 MergeTrainPullRequestState = Literal["open", "closed", "merged"]
+
+
+class MergeTrainLabelClient(Protocol):
+    def add_pull_request_label(
+        self, *, repository: str, pull_request_number: int, label: str
+    ) -> None: ...
 
 
 class MergeTrainPullRequestSnapshot(BaseModel):
@@ -102,6 +108,18 @@ class MergeTrainDryRunResult(BaseModel):
     next_action_detail: str
 
 
+class MergeTrainBlockResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["blocked", "skipped"]
+    repository: str
+    base_branch: str
+    pull_request_number: int | None = None
+    blocked_label: str
+    train_should_continue: bool
+    detail: str
+
+
 def build_merge_train_dry_run_result(
     *, policy: MergeTrainPolicy, snapshot: MergeTrainDryRunSnapshot
 ) -> MergeTrainDryRunResult:
@@ -131,6 +149,53 @@ def build_merge_train_dry_run_result(
         selected_pr=selected_pr,
         intended_next_action=intended_next_action,
         next_action_detail=next_action_detail,
+    )
+
+
+def apply_merge_train_block_intent(
+    *,
+    dry_run_result: MergeTrainDryRunResult,
+    label_client: MergeTrainLabelClient,
+) -> MergeTrainBlockResult:
+    if dry_run_result.intended_next_action != "block" or dry_run_result.selected_pr is None:
+        return MergeTrainBlockResult(
+            status="skipped",
+            repository=dry_run_result.repository,
+            base_branch=dry_run_result.base_branch,
+            blocked_label=dry_run_result.blocked_label,
+            train_should_continue=True,
+            detail="Dry-run result does not require a block label.",
+        )
+    train_should_continue = dry_run_result.failure_policy == "continue_after_blocking_pr"
+    if dry_run_result.blocked_label in dry_run_result.selected_pr.labels:
+        return MergeTrainBlockResult(
+            status="blocked",
+            repository=dry_run_result.repository,
+            base_branch=dry_run_result.base_branch,
+            pull_request_number=dry_run_result.selected_pr.number,
+            blocked_label=dry_run_result.blocked_label,
+            train_should_continue=train_should_continue,
+            detail=(
+                f"Pull request #{dry_run_result.selected_pr.number} already has "
+                f"{dry_run_result.blocked_label}."
+            ),
+        )
+    label_client.add_pull_request_label(
+        repository=dry_run_result.repository,
+        pull_request_number=dry_run_result.selected_pr.number,
+        label=dry_run_result.blocked_label,
+    )
+    return MergeTrainBlockResult(
+        status="blocked",
+        repository=dry_run_result.repository,
+        base_branch=dry_run_result.base_branch,
+        pull_request_number=dry_run_result.selected_pr.number,
+        blocked_label=dry_run_result.blocked_label,
+        train_should_continue=train_should_continue,
+        detail=(
+            f"Applied {dry_run_result.blocked_label} to pull request "
+            f"#{dry_run_result.selected_pr.number}."
+        ),
     )
 
 

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -93,3 +93,9 @@ uv run launchplane work-graph merge-train-dry-run \
 The dry-run orders eligible pull requests by `created_at` and then PR number. It
 excludes draft, closed, unlabeled, or unauthorized entries and fails closed when
 the snapshot repository/base branch has no explicit policy.
+
+When the selected pull request is blocked by failed checks or conflicts, the
+first live mutation is idempotent application of `blocked_label`. Repositories
+using `pause_train` stop after that label action; repositories using
+`continue_after_blocking_pr` may continue to the next eligible pull request once
+the blocked pull request has been labeled.

--- a/tests/test_merge_train.py
+++ b/tests/test_merge_train.py
@@ -7,13 +7,25 @@ from click.testing import CliRunner
 
 from control_plane.cli import main
 from control_plane.contracts.merge_train_policy import (
+    MergeTrainPolicy,
     build_sellyouroutboard_main_merge_train_policy,
 )
 from control_plane.merge_train import (
     MergeTrainDryRunSnapshot,
     MergeTrainPullRequestSnapshot,
+    apply_merge_train_block_intent,
     build_merge_train_dry_run_result,
 )
+
+
+class _FakeLabelClient:
+    def __init__(self) -> None:
+        self.applied_labels: list[tuple[str, int, str]] = []
+
+    def add_pull_request_label(
+        self, *, repository: str, pull_request_number: int, label: str
+    ) -> None:
+        self.applied_labels.append((repository, pull_request_number, label))
 
 
 class MergeTrainDryRunTests(unittest.TestCase):
@@ -120,6 +132,97 @@ class MergeTrainDryRunTests(unittest.TestCase):
         self.assertEqual(payload["mode"], "dry-run")
         self.assertEqual(payload["queue_order"], [22])
         self.assertEqual(payload["selected_pr"]["number"], 22)
+
+
+class MergeTrainBlockIntentTests(unittest.TestCase):
+    def test_block_intent_applies_blocked_label_and_pauses_train(self) -> None:
+        dry_run_result = build_merge_train_dry_run_result(
+            policy=build_sellyouroutboard_main_merge_train_policy(),
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(_pull_request(31, required_checks_status="fail"),),
+            ),
+        )
+        label_client = _FakeLabelClient()
+
+        result = apply_merge_train_block_intent(
+            dry_run_result=dry_run_result, label_client=label_client
+        )
+
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(result.pull_request_number, 31)
+        self.assertEqual(result.blocked_label, "merge-blocked")
+        self.assertFalse(result.train_should_continue)
+        self.assertEqual(
+            label_client.applied_labels,
+            [("cbusillo/sellyouroutboard", 31, "merge-blocked")],
+        )
+
+    def test_block_intent_skips_non_block_actions_without_mutation(self) -> None:
+        dry_run_result = build_merge_train_dry_run_result(
+            policy=build_sellyouroutboard_main_merge_train_policy(),
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(_pull_request(32),),
+            ),
+        )
+        label_client = _FakeLabelClient()
+
+        result = apply_merge_train_block_intent(
+            dry_run_result=dry_run_result, label_client=label_client
+        )
+
+        self.assertEqual(result.status, "skipped")
+        self.assertTrue(result.train_should_continue)
+        self.assertEqual(label_client.applied_labels, [])
+
+    def test_block_intent_is_idempotent_when_blocked_label_exists(self) -> None:
+        dry_run_result = build_merge_train_dry_run_result(
+            policy=build_sellyouroutboard_main_merge_train_policy(),
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(
+                    _pull_request(
+                        34,
+                        labels=("ready-to-merge", "merge-blocked"),
+                        required_checks_status="fail",
+                    ),
+                ),
+            ),
+        )
+        label_client = _FakeLabelClient()
+
+        result = apply_merge_train_block_intent(
+            dry_run_result=dry_run_result, label_client=label_client
+        )
+
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(result.pull_request_number, 34)
+        self.assertEqual(label_client.applied_labels, [])
+
+    def test_block_intent_can_continue_train_when_policy_allows_it(self) -> None:
+        base_policy = build_sellyouroutboard_main_merge_train_policy()
+        repository_policy = base_policy.policies[0].model_copy(
+            update={"failure_policy": "continue_after_blocking_pr"}
+        )
+        dry_run_result = build_merge_train_dry_run_result(
+            policy=MergeTrainPolicy(policies=(repository_policy,)),
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(_pull_request(33, mergeable="conflicting"),),
+            ),
+        )
+
+        result = apply_merge_train_block_intent(
+            dry_run_result=dry_run_result, label_client=_FakeLabelClient()
+        )
+
+        self.assertEqual(result.status, "blocked")
+        self.assertTrue(result.train_should_continue)
 
 
 def _pull_request(


### PR DESCRIPTION
## Summary
- add a merge-train block action that applies the configured blocked label for block intents
- make the label action idempotent when the selected PR already carries `blocked_label`
- return pause/continue train behavior from the configured failure policy and document the mutation boundary

Refs #410

## Validation
- `uv run python -m unittest tests.test_merge_train`
- `uv run --extra dev ruff check --diff control_plane/merge_train.py tests/test_merge_train.py`
- `uv run --extra dev ruff check control_plane/merge_train.py tests/test_merge_train.py`
- `uv run --extra dev mypy control_plane/merge_train.py tests/test_merge_train.py`
- `uv run --extra dev markdownlint-cli2 docs/merge-train-policy.md`
- `uv run python -m unittest`