### PR TITLE
Add merge train branch update action

### DIFF
--- a/control_plane/merge_train.py
+++ b/control_plane/merge_train.py
@@ -20,6 +20,12 @@ class MergeTrainLabelClient(Protocol):
     ) -> None: ...
 
 
+class MergeTrainBranchClient(Protocol):
+    def update_pull_request_branch(
+        self, *, repository: str, pull_request_number: int, expected_head_sha: str
+    ) -> None: ...
+
+
 class MergeTrainPullRequestSnapshot(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -120,6 +126,18 @@ class MergeTrainBlockResult(BaseModel):
     detail: str
 
 
+class MergeTrainBranchUpdateResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["updated", "skipped"]
+    repository: str
+    base_branch: str
+    pull_request_number: int | None = None
+    expected_head_sha: str = ""
+    reread_required: bool
+    detail: str
+
+
 def build_merge_train_dry_run_result(
     *, policy: MergeTrainPolicy, snapshot: MergeTrainDryRunSnapshot
 ) -> MergeTrainDryRunResult:
@@ -195,6 +213,41 @@ def apply_merge_train_block_intent(
         detail=(
             f"Applied {dry_run_result.blocked_label} to pull request "
             f"#{dry_run_result.selected_pr.number}."
+        ),
+    )
+
+
+def apply_merge_train_branch_update_intent(
+    *,
+    dry_run_result: MergeTrainDryRunResult,
+    branch_client: MergeTrainBranchClient,
+) -> MergeTrainBranchUpdateResult:
+    if (
+        dry_run_result.intended_next_action != "update_branch"
+        or dry_run_result.selected_pr is None
+    ):
+        return MergeTrainBranchUpdateResult(
+            status="skipped",
+            repository=dry_run_result.repository,
+            base_branch=dry_run_result.base_branch,
+            reread_required=False,
+            detail="Dry-run result does not require a branch update.",
+        )
+    branch_client.update_pull_request_branch(
+        repository=dry_run_result.repository,
+        pull_request_number=dry_run_result.selected_pr.number,
+        expected_head_sha=dry_run_result.selected_pr.head_sha,
+    )
+    return MergeTrainBranchUpdateResult(
+        status="updated",
+        repository=dry_run_result.repository,
+        base_branch=dry_run_result.base_branch,
+        pull_request_number=dry_run_result.selected_pr.number,
+        expected_head_sha=dry_run_result.selected_pr.head_sha,
+        reread_required=True,
+        detail=(
+            "Updated pull request branch; re-read mergeability and required checks "
+            "before continuing."
         ),
     )
 

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -99,3 +99,8 @@ first live mutation is idempotent application of `blocked_label`. Repositories
 using `pause_train` stop after that label action; repositories using
 `continue_after_blocking_pr` may continue to the next eligible pull request once
 the blocked pull request has been labeled.
+
+When the selected pull request needs a branch refresh, Launchplane updates that
+pull request using the observed head SHA as the compare point. The worker must
+then re-read mergeability and required checks before any later merge decision;
+pre-update check results are stale after a branch refresh.

--- a/tests/test_merge_train.py
+++ b/tests/test_merge_train.py
@@ -13,6 +13,7 @@ from control_plane.contracts.merge_train_policy import (
 from control_plane.merge_train import (
     MergeTrainDryRunSnapshot,
     MergeTrainPullRequestSnapshot,
+    apply_merge_train_branch_update_intent,
     apply_merge_train_block_intent,
     build_merge_train_dry_run_result,
 )
@@ -26,6 +27,16 @@ class _FakeLabelClient:
         self, *, repository: str, pull_request_number: int, label: str
     ) -> None:
         self.applied_labels.append((repository, pull_request_number, label))
+
+
+class _FakeBranchClient:
+    def __init__(self) -> None:
+        self.updated_branches: list[tuple[str, int, str]] = []
+
+    def update_pull_request_branch(
+        self, *, repository: str, pull_request_number: int, expected_head_sha: str
+    ) -> None:
+        self.updated_branches.append((repository, pull_request_number, expected_head_sha))
 
 
 class MergeTrainDryRunTests(unittest.TestCase):
@@ -223,6 +234,51 @@ class MergeTrainBlockIntentTests(unittest.TestCase):
 
         self.assertEqual(result.status, "blocked")
         self.assertTrue(result.train_should_continue)
+
+
+class MergeTrainBranchUpdateIntentTests(unittest.TestCase):
+    def test_branch_update_intent_updates_selected_pr_and_requires_reread(self) -> None:
+        dry_run_result = build_merge_train_dry_run_result(
+            policy=build_sellyouroutboard_main_merge_train_policy(),
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(_pull_request(41, branch_update_required=True),),
+            ),
+        )
+        branch_client = _FakeBranchClient()
+
+        result = apply_merge_train_branch_update_intent(
+            dry_run_result=dry_run_result, branch_client=branch_client
+        )
+
+        self.assertEqual(result.status, "updated")
+        self.assertEqual(result.pull_request_number, 41)
+        self.assertEqual(result.expected_head_sha, "head-41")
+        self.assertTrue(result.reread_required)
+        self.assertEqual(
+            branch_client.updated_branches,
+            [("cbusillo/sellyouroutboard", 41, "head-41")],
+        )
+
+    def test_branch_update_intent_skips_other_actions_without_mutation(self) -> None:
+        dry_run_result = build_merge_train_dry_run_result(
+            policy=build_sellyouroutboard_main_merge_train_policy(),
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(_pull_request(42),),
+            ),
+        )
+        branch_client = _FakeBranchClient()
+
+        result = apply_merge_train_branch_update_intent(
+            dry_run_result=dry_run_result, branch_client=branch_client
+        )
+
+        self.assertEqual(result.status, "skipped")
+        self.assertFalse(result.reread_required)
+        self.assertEqual(branch_client.updated_branches, [])
 
 
 def _pull_request(


### PR DESCRIPTION
## Summary
- add a merge-train branch-update action for `update_branch` intents
- pass repository, PR number, and observed head SHA through a branch client interface
- require PR/check state to be re-read after branch refresh before any merge decision

Refs #410

## Validation
- `uv run python -m unittest tests.test_merge_train`
- `uv run --extra dev ruff check --diff control_plane/merge_train.py tests/test_merge_train.py`
- `uv run --extra dev ruff check control_plane/merge_train.py tests/test_merge_train.py`
- `uv run --extra dev mypy control_plane/merge_train.py tests/test_merge_train.py`
- `uv run --extra dev markdownlint-cli2 docs/merge-train-policy.md`
- `uv run python -m unittest`