### PR TITLE
Add merge train reread transition

### DIFF
--- a/control_plane/merge_train.py
+++ b/control_plane/merge_train.py
@@ -26,6 +26,12 @@ class MergeTrainBranchClient(Protocol):
     ) -> None: ...
 
 
+class MergeTrainSnapshotReader(Protocol):
+    def read_merge_train_snapshot(
+        self, *, repository: str, base_branch: str
+    ) -> "MergeTrainDryRunSnapshot": ...
+
+
 class MergeTrainPullRequestSnapshot(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -135,6 +141,16 @@ class MergeTrainBranchUpdateResult(BaseModel):
     pull_request_number: int | None = None
     expected_head_sha: str = ""
     reread_required: bool
+    detail: str
+
+
+class MergeTrainRereadResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["reread", "skipped"]
+    repository: str
+    base_branch: str
+    refreshed_result: MergeTrainDryRunResult | None = None
     detail: str
 
 
@@ -249,6 +265,33 @@ def apply_merge_train_branch_update_intent(
             "Updated pull request branch; re-read mergeability and required checks "
             "before continuing."
         ),
+    )
+
+
+def reread_merge_train_after_branch_update(
+    *,
+    branch_update_result: MergeTrainBranchUpdateResult,
+    policy: MergeTrainPolicy,
+    snapshot_reader: MergeTrainSnapshotReader,
+) -> MergeTrainRereadResult:
+    if not branch_update_result.reread_required:
+        return MergeTrainRereadResult(
+            status="skipped",
+            repository=branch_update_result.repository,
+            base_branch=branch_update_result.base_branch,
+            detail="Branch update result does not require a reread.",
+        )
+    snapshot = snapshot_reader.read_merge_train_snapshot(
+        repository=branch_update_result.repository,
+        base_branch=branch_update_result.base_branch,
+    )
+    refreshed_result = build_merge_train_dry_run_result(policy=policy, snapshot=snapshot)
+    return MergeTrainRereadResult(
+        status="reread",
+        repository=branch_update_result.repository,
+        base_branch=branch_update_result.base_branch,
+        refreshed_result=refreshed_result,
+        detail="Re-read mergeability and required checks after branch update.",
     )
 
 

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -104,3 +104,7 @@ When the selected pull request needs a branch refresh, Launchplane updates that
 pull request using the observed head SHA as the compare point. The worker must
 then re-read mergeability and required checks before any later merge decision;
 pre-update check results are stale after a branch refresh.
+
+The reread step rebuilds the dry-run decision from a fresh pull request snapshot.
+If checks are still pending or mergeability is unknown, the next action remains
+`wait_for_checks`; Launchplane must not merge from pre-refresh evidence.

--- a/tests/test_merge_train.py
+++ b/tests/test_merge_train.py
@@ -16,6 +16,7 @@ from control_plane.merge_train import (
     apply_merge_train_branch_update_intent,
     apply_merge_train_block_intent,
     build_merge_train_dry_run_result,
+    reread_merge_train_after_branch_update,
 )
 
 
@@ -37,6 +38,18 @@ class _FakeBranchClient:
         self, *, repository: str, pull_request_number: int, expected_head_sha: str
     ) -> None:
         self.updated_branches.append((repository, pull_request_number, expected_head_sha))
+
+
+class _FakeSnapshotReader:
+    def __init__(self, snapshot: MergeTrainDryRunSnapshot) -> None:
+        self.snapshot = snapshot
+        self.reads: list[tuple[str, str]] = []
+
+    def read_merge_train_snapshot(
+        self, *, repository: str, base_branch: str
+    ) -> MergeTrainDryRunSnapshot:
+        self.reads.append((repository, base_branch))
+        return self.snapshot
 
 
 class MergeTrainDryRunTests(unittest.TestCase):
@@ -279,6 +292,79 @@ class MergeTrainBranchUpdateIntentTests(unittest.TestCase):
         self.assertEqual(result.status, "skipped")
         self.assertFalse(result.reread_required)
         self.assertEqual(branch_client.updated_branches, [])
+
+
+class MergeTrainRereadTests(unittest.TestCase):
+    def test_reread_after_branch_update_re_evaluates_fresh_snapshot(self) -> None:
+        policy = build_sellyouroutboard_main_merge_train_policy()
+        stale_result = build_merge_train_dry_run_result(
+            policy=policy,
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(_pull_request(51, branch_update_required=True),),
+            ),
+        )
+        branch_update_result = apply_merge_train_branch_update_intent(
+            dry_run_result=stale_result, branch_client=_FakeBranchClient()
+        )
+        snapshot_reader = _FakeSnapshotReader(
+            MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(
+                    _pull_request(
+                        51,
+                        created_at="2026-05-08T10:00:00Z",
+                        required_checks_status="pending",
+                    ),
+                ),
+            )
+        )
+
+        result = reread_merge_train_after_branch_update(
+            branch_update_result=branch_update_result,
+            policy=policy,
+            snapshot_reader=snapshot_reader,
+        )
+
+        self.assertEqual(result.status, "reread")
+        self.assertEqual(snapshot_reader.reads, [("cbusillo/sellyouroutboard", "main")])
+        self.assertIsNotNone(result.refreshed_result)
+        refreshed_result = result.refreshed_result
+        assert refreshed_result is not None
+        self.assertEqual(refreshed_result.intended_next_action, "wait_for_checks")
+
+    def test_reread_skips_when_branch_update_was_not_required(self) -> None:
+        policy = build_sellyouroutboard_main_merge_train_policy()
+        dry_run_result = build_merge_train_dry_run_result(
+            policy=policy,
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(_pull_request(52),),
+            ),
+        )
+        branch_update_result = apply_merge_train_branch_update_intent(
+            dry_run_result=dry_run_result, branch_client=_FakeBranchClient()
+        )
+        snapshot_reader = _FakeSnapshotReader(
+            MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(),
+            )
+        )
+
+        result = reread_merge_train_after_branch_update(
+            branch_update_result=branch_update_result,
+            policy=policy,
+            snapshot_reader=snapshot_reader,
+        )
+
+        self.assertEqual(result.status, "skipped")
+        self.assertIsNone(result.refreshed_result)
+        self.assertEqual(snapshot_reader.reads, [])
 
 
 def _pull_request(


### PR DESCRIPTION
## Summary
- add a snapshot-reader transition for post-branch-update rereads
- re-run the merge-train dry-run decision from fresh PR state when `reread_required` is true
- document that pending/unknown checks remain wait states and pre-refresh evidence must not drive merge decisions

Refs #410

## Validation
- `uv run python -m unittest tests.test_merge_train`
- `uv run --extra dev ruff check --diff control_plane/merge_train.py tests/test_merge_train.py`
- `uv run --extra dev ruff check control_plane/merge_train.py tests/test_merge_train.py`
- `uv run --extra dev mypy control_plane/merge_train.py tests/test_merge_train.py`
- `uv run --extra dev markdownlint-cli2 docs/merge-train-policy.md`
- `uv run python -m unittest`