### PR TITLE
Use mirrored container base images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,14 +88,16 @@ jobs:
           context: .
           load: true
           tags: launchplane-ci:test
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
+          cache-from: >-
+            type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
 
       - name: Scan runtime image
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v "${RUNNER_TEMP}/trivy-cache:/root/.cache" \
-            aquasec/trivy:0.70.0 image \
+            ghcr.io/aquasecurity/trivy:0.70.0 \
+            image \
             --scanners vulnerability \
             --ignore-unfixed \
             --severity HIGH,CRITICAL \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bookworm-slim AS frontend-build
+FROM mirror.gcr.io/library/node:22-bookworm-slim AS frontend-build
 
 WORKDIR /app
 
@@ -12,7 +12,7 @@ RUN pnpm install --frozen-lockfile
 COPY frontend /app/frontend
 RUN pnpm build
 
-FROM python:3.13-slim
+FROM mirror.gcr.io/library/python:3.13-slim
 
 LABEL org.opencontainers.image.source="https://github.com/cbusillo/launchplane"
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -207,6 +207,10 @@ Dokploy-hosted.
   replacement.
 - The current repo workflow for that posture is
   `.github/workflows/deploy-launchplane.yml`.
+- Launchplane image builds use Docker Hub public mirror-qualified base images
+  and the CI container scan pulls Trivy from GHCR so self-hosted runners do not
+  fail closed on Docker Hub anonymous pull limits before Launchplane code is
+  built or scanned.
 - Deploy verification should probe Launchplane's live health endpoint, currently
   `GET /v1/health`, after the Dokploy update.
 - When rollout health fails, deploy automation should restore the previous


### PR DESCRIPTION
## Summary
- switch Launchplane runtime Dockerfile base images to mirror.gcr.io-qualified Docker Hub mirrors
- pull Trivy from GHCR in CI container_scan to avoid Docker Hub anonymous pull limits
- document the CI/deploy posture for mirror-qualified image builds

## Why
Post-merge CI for #465 failed twice in container_scan before scanning because Docker Buildx hit Docker Hub anonymous pull limits resolving node:22-bookworm-slim. This keeps the same image families while moving build metadata pulls away from unauthenticated Docker Hub.

## Validation
- docker build -t launchplane-ci:test .
- docker run --rm ghcr.io/aquasecurity/trivy:0.70.0 --version
- uv run --extra dev markdownlint-cli2 docs/operations.md
- npx --yes prettier --check .github/workflows/ci.yml

Refs #414
Refs #413