### PR TITLE
Add merge train wait state result

### DIFF
--- a/control_plane/merge_train.py
+++ b/control_plane/merge_train.py
@@ -154,6 +154,20 @@ class MergeTrainRereadResult(BaseModel):
     detail: str
 
 
+class MergeTrainWaitResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["waiting", "skipped"]
+    repository: str
+    base_branch: str
+    pull_request_number: int | None = None
+    head_sha: str = ""
+    mergeable: MergeTrainMergeableState | None = None
+    required_checks_status: MergeTrainCheckStatus | None = None
+    poll_required: bool
+    detail: str
+
+
 def build_merge_train_dry_run_result(
     *, policy: MergeTrainPolicy, snapshot: MergeTrainDryRunSnapshot
 ) -> MergeTrainDryRunResult:
@@ -292,6 +306,33 @@ def reread_merge_train_after_branch_update(
         base_branch=branch_update_result.base_branch,
         refreshed_result=refreshed_result,
         detail="Re-read mergeability and required checks after branch update.",
+    )
+
+
+def build_merge_train_wait_result(
+    *, dry_run_result: MergeTrainDryRunResult
+) -> MergeTrainWaitResult:
+    if (
+        dry_run_result.intended_next_action != "wait_for_checks"
+        or dry_run_result.selected_pr is None
+    ):
+        return MergeTrainWaitResult(
+            status="skipped",
+            repository=dry_run_result.repository,
+            base_branch=dry_run_result.base_branch,
+            poll_required=False,
+            detail="Dry-run result does not require check polling.",
+        )
+    return MergeTrainWaitResult(
+        status="waiting",
+        repository=dry_run_result.repository,
+        base_branch=dry_run_result.base_branch,
+        pull_request_number=dry_run_result.selected_pr.number,
+        head_sha=dry_run_result.selected_pr.head_sha,
+        mergeable=dry_run_result.selected_pr.mergeable,
+        required_checks_status=dry_run_result.selected_pr.required_checks_status,
+        poll_required=True,
+        detail=dry_run_result.next_action_detail,
     )
 
 

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -108,3 +108,9 @@ pre-update check results are stale after a branch refresh.
 The reread step rebuilds the dry-run decision from a fresh pull request snapshot.
 If checks are still pending or mergeability is unknown, the next action remains
 `wait_for_checks`; Launchplane must not merge from pre-refresh evidence.
+
+The wait step records the selected pull request, its observed head SHA,
+mergeability state, and required-check status as a polling boundary. It does not
+merge or mutate GitHub. A later worker pass must read a fresh snapshot for the
+same repository/base branch and continue only when that fresh dry-run result
+selects `merge`.

--- a/tests/test_merge_train.py
+++ b/tests/test_merge_train.py
@@ -16,6 +16,7 @@ from control_plane.merge_train import (
     apply_merge_train_branch_update_intent,
     apply_merge_train_block_intent,
     build_merge_train_dry_run_result,
+    build_merge_train_wait_result,
     reread_merge_train_after_branch_update,
 )
 
@@ -365,6 +366,71 @@ class MergeTrainRereadTests(unittest.TestCase):
         self.assertEqual(result.status, "skipped")
         self.assertIsNone(result.refreshed_result)
         self.assertEqual(snapshot_reader.reads, [])
+
+
+class MergeTrainWaitTests(unittest.TestCase):
+    def test_wait_result_records_selected_pr_and_head_sha_for_pending_checks(
+        self,
+    ) -> None:
+        dry_run_result = build_merge_train_dry_run_result(
+            policy=build_sellyouroutboard_main_merge_train_policy(),
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(
+                    _pull_request(61, required_checks_status="pending"),
+                ),
+            ),
+        )
+
+        result = build_merge_train_wait_result(dry_run_result=dry_run_result)
+
+        self.assertEqual(result.status, "waiting")
+        self.assertEqual(result.pull_request_number, 61)
+        self.assertEqual(result.head_sha, "head-61")
+        self.assertEqual(result.mergeable, "mergeable")
+        self.assertEqual(result.required_checks_status, "pending")
+        self.assertTrue(result.poll_required)
+        self.assertIn("Wait for mergeability", result.detail)
+
+    def test_wait_result_records_unknown_mergeability(self) -> None:
+        dry_run_result = build_merge_train_dry_run_result(
+            policy=build_sellyouroutboard_main_merge_train_policy(),
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(
+                    _pull_request(62, mergeable="unknown"),
+                ),
+            ),
+        )
+
+        result = build_merge_train_wait_result(dry_run_result=dry_run_result)
+
+        self.assertEqual(result.status, "waiting")
+        self.assertEqual(result.pull_request_number, 62)
+        self.assertEqual(result.mergeable, "unknown")
+        self.assertEqual(result.required_checks_status, "pass")
+        self.assertTrue(result.poll_required)
+
+    def test_wait_result_skips_non_wait_actions(self) -> None:
+        dry_run_result = build_merge_train_dry_run_result(
+            policy=build_sellyouroutboard_main_merge_train_policy(),
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(_pull_request(63),),
+            ),
+        )
+
+        result = build_merge_train_wait_result(dry_run_result=dry_run_result)
+
+        self.assertEqual(result.status, "skipped")
+        self.assertIsNone(result.pull_request_number)
+        self.assertEqual(result.head_sha, "")
+        self.assertIsNone(result.mergeable)
+        self.assertIsNone(result.required_checks_status)
+        self.assertFalse(result.poll_required)
 
 
 def _pull_request(


### PR DESCRIPTION
## Summary
- add `MergeTrainWaitResult` as the explicit polling boundary for `wait_for_checks` decisions
- expose `build_merge_train_wait_result` so the worker can record the selected PR/head SHA without mutating GitHub
- cover pending checks, unknown mergeability, and non-wait skip paths; document that a later pass must reread before merge

## Validation
- uv run python -m unittest tests.test_merge_train
- uv run --extra dev ruff check --diff control_plane/merge_train.py tests/test_merge_train.py
- uv run --extra dev ruff check control_plane/merge_train.py tests/test_merge_train.py
- uv run --extra dev mypy control_plane/merge_train.py tests/test_merge_train.py
- uv run --extra dev markdownlint-cli2 docs/merge-train-policy.md
- uv run python -m unittest

Refs #410