### PR TITLE
Add merge train merge intent

### DIFF
--- a/control_plane/merge_train.py
+++ b/control_plane/merge_train.py
@@ -2,6 +2,7 @@ from typing import Literal, Protocol
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane.contracts.merge_train_policy import MergeTrainMergeMethod
 from control_plane.contracts.merge_train_policy import MergeTrainPolicy
 from control_plane.contracts.merge_train_policy import MergeTrainRepositoryPolicy
 
@@ -24,6 +25,17 @@ class MergeTrainBranchClient(Protocol):
     def update_pull_request_branch(
         self, *, repository: str, pull_request_number: int, expected_head_sha: str
     ) -> None: ...
+
+
+class MergeTrainMergeClient(Protocol):
+    def merge_pull_request(
+        self,
+        *,
+        repository: str,
+        pull_request_number: int,
+        head_sha: str,
+        merge_method: MergeTrainMergeMethod,
+    ) -> str: ...
 
 
 class MergeTrainSnapshotReader(Protocol):
@@ -109,7 +121,7 @@ class MergeTrainDryRunResult(BaseModel):
     repository: str
     base_branch: str
     policy_key: str
-    merge_method: str
+    merge_method: MergeTrainMergeMethod
     failure_policy: str
     enqueue_label: str
     blocked_label: str
@@ -165,6 +177,20 @@ class MergeTrainWaitResult(BaseModel):
     mergeable: MergeTrainMergeableState | None = None
     required_checks_status: MergeTrainCheckStatus | None = None
     poll_required: bool
+    detail: str
+
+
+class MergeTrainMergeResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["merged", "skipped"]
+    repository: str
+    base_branch: str
+    pull_request_number: int | None = None
+    head_sha: str = ""
+    merge_method: MergeTrainMergeMethod | None = None
+    merge_commit_sha: str = ""
+    reread_required: bool
     detail: str
 
 
@@ -333,6 +359,41 @@ def build_merge_train_wait_result(
         required_checks_status=dry_run_result.selected_pr.required_checks_status,
         poll_required=True,
         detail=dry_run_result.next_action_detail,
+    )
+
+
+def apply_merge_train_merge_intent(
+    *,
+    dry_run_result: MergeTrainDryRunResult,
+    merge_client: MergeTrainMergeClient,
+) -> MergeTrainMergeResult:
+    if dry_run_result.intended_next_action != "merge" or dry_run_result.selected_pr is None:
+        return MergeTrainMergeResult(
+            status="skipped",
+            repository=dry_run_result.repository,
+            base_branch=dry_run_result.base_branch,
+            reread_required=False,
+            detail="Dry-run result does not allow a merge.",
+        )
+    merge_commit_sha = merge_client.merge_pull_request(
+        repository=dry_run_result.repository,
+        pull_request_number=dry_run_result.selected_pr.number,
+        head_sha=dry_run_result.selected_pr.head_sha,
+        merge_method=dry_run_result.merge_method,
+    )
+    return MergeTrainMergeResult(
+        status="merged",
+        repository=dry_run_result.repository,
+        base_branch=dry_run_result.base_branch,
+        pull_request_number=dry_run_result.selected_pr.number,
+        head_sha=dry_run_result.selected_pr.head_sha,
+        merge_method=dry_run_result.merge_method,
+        merge_commit_sha=merge_commit_sha,
+        reread_required=True,
+        detail=(
+            f"Merged pull request #{dry_run_result.selected_pr.number}; "
+            "re-read the merge train before selecting the next queued entry."
+        ),
     )
 
 

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -114,3 +114,9 @@ mergeability state, and required-check status as a polling boundary. It does not
 merge or mutate GitHub. A later worker pass must read a fresh snapshot for the
 same repository/base branch and continue only when that fresh dry-run result
 selects `merge`.
+
+The merge step is allowed only from a fresh dry-run result whose next action is
+`merge`. The merge request must use the selected pull request's observed
+`head_sha` as the GitHub merge `sha` guard and the repository policy's
+`merge_method`. After a successful merge, the worker must re-read the train
+before selecting another queued pull request.

--- a/tests/test_merge_train.py
+++ b/tests/test_merge_train.py
@@ -15,6 +15,7 @@ from control_plane.merge_train import (
     MergeTrainPullRequestSnapshot,
     apply_merge_train_branch_update_intent,
     apply_merge_train_block_intent,
+    apply_merge_train_merge_intent,
     build_merge_train_dry_run_result,
     build_merge_train_wait_result,
     reread_merge_train_after_branch_update,
@@ -39,6 +40,24 @@ class _FakeBranchClient:
         self, *, repository: str, pull_request_number: int, expected_head_sha: str
     ) -> None:
         self.updated_branches.append((repository, pull_request_number, expected_head_sha))
+
+
+class _FakeMergeClient:
+    def __init__(self) -> None:
+        self.merged_pull_requests: list[tuple[str, int, str, str]] = []
+
+    def merge_pull_request(
+        self,
+        *,
+        repository: str,
+        pull_request_number: int,
+        head_sha: str,
+        merge_method: str,
+    ) -> str:
+        self.merged_pull_requests.append(
+            (repository, pull_request_number, head_sha, merge_method)
+        )
+        return f"merge-{pull_request_number}"
 
 
 class _FakeSnapshotReader:
@@ -431,6 +450,57 @@ class MergeTrainWaitTests(unittest.TestCase):
         self.assertIsNone(result.mergeable)
         self.assertIsNone(result.required_checks_status)
         self.assertFalse(result.poll_required)
+
+
+class MergeTrainMergeIntentTests(unittest.TestCase):
+    def test_merge_intent_uses_selected_head_sha_and_policy_method(self) -> None:
+        dry_run_result = build_merge_train_dry_run_result(
+            policy=build_sellyouroutboard_main_merge_train_policy(),
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(_pull_request(71),),
+            ),
+        )
+        merge_client = _FakeMergeClient()
+
+        result = apply_merge_train_merge_intent(
+            dry_run_result=dry_run_result, merge_client=merge_client
+        )
+
+        self.assertEqual(result.status, "merged")
+        self.assertEqual(result.pull_request_number, 71)
+        self.assertEqual(result.head_sha, "head-71")
+        self.assertEqual(result.merge_method, "merge")
+        self.assertEqual(result.merge_commit_sha, "merge-71")
+        self.assertTrue(result.reread_required)
+        self.assertEqual(
+            merge_client.merged_pull_requests,
+            [("cbusillo/sellyouroutboard", 71, "head-71", "merge")],
+        )
+
+    def test_merge_intent_skips_non_merge_actions_without_mutation(self) -> None:
+        dry_run_result = build_merge_train_dry_run_result(
+            policy=build_sellyouroutboard_main_merge_train_policy(),
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(_pull_request(72, required_checks_status="pending"),),
+            ),
+        )
+        merge_client = _FakeMergeClient()
+
+        result = apply_merge_train_merge_intent(
+            dry_run_result=dry_run_result, merge_client=merge_client
+        )
+
+        self.assertEqual(result.status, "skipped")
+        self.assertIsNone(result.pull_request_number)
+        self.assertEqual(result.head_sha, "")
+        self.assertIsNone(result.merge_method)
+        self.assertEqual(result.merge_commit_sha, "")
+        self.assertFalse(result.reread_required)
+        self.assertEqual(merge_client.merged_pull_requests, [])
 
 
 def _pull_request(


### PR DESCRIPTION
## Summary
- add a merge client protocol and typed merge result for merge-train execution
- gate merge mutation on a fresh dry-run result whose next action is `merge`
- pass the selected PR head SHA and policy merge method to the merge client, then require a reread after a successful merge
- document that Launchplane maps `head_sha` to GitHub's merge `sha` guard

## Validation
- uv run python -m unittest tests.test_merge_train
- uv run --extra dev ruff check --diff control_plane/merge_train.py tests/test_merge_train.py
- uv run --extra dev ruff check control_plane/merge_train.py tests/test_merge_train.py
- uv run --extra dev mypy control_plane/merge_train.py tests/test_merge_train.py
- uv run --extra dev markdownlint-cli2 docs/merge-train-policy.md
- uv run python -m unittest

Refs #410