### PR TITLE
Add merge train GitHub adapter

### DIFF
--- a/control_plane/merge_train_github.py
+++ b/control_plane/merge_train_github.py
@@ -1,0 +1,181 @@
+import json
+from typing import Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from control_plane.contracts.merge_train_policy import MergeTrainMergeMethod
+
+
+class MergeTrainGitHubError(RuntimeError):
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class MergeTrainGitHubStaleHeadError(MergeTrainGitHubError):
+    """Raised when GitHub refuses a guarded merge because the head SHA changed."""
+
+
+class MergeTrainGitHubTransport(Protocol):
+    def request(
+        self, *, method: str, path: str, body: dict[str, object] | None = None
+    ) -> object: ...
+
+
+class UrllibMergeTrainGitHubTransport:
+    def __init__(self, *, token: str, api_base_url: str = "https://api.github.com") -> None:
+        self.token = _required_value(token, "GitHub token is required.")
+        self.api_base_url = _required_value(api_base_url, "GitHub API base URL is required.").rstrip(
+            "/"
+        )
+
+    def request(
+        self, *, method: str, path: str, body: dict[str, object] | None = None
+    ) -> object:
+        request_body = None
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {self.token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if body is not None:
+            request_body = json.dumps(body).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        request = Request(
+            url=f"{self.api_base_url}{path}",
+            method=method,
+            headers=headers,
+            data=request_body,
+        )
+        try:
+            with urlopen(request, timeout=15) as response:
+                response_text = response.read().decode("utf-8")
+                return json.loads(response_text) if response_text.strip() else None
+        except HTTPError as error:
+            raise _github_http_error(path=path, status_code=error.code, error=error) from error
+        except (URLError, OSError) as error:
+            raise MergeTrainGitHubError(f"GitHub API request failed for {path}: {error}") from error
+        except json.JSONDecodeError as error:
+            raise MergeTrainGitHubError(
+                f"GitHub API response for {path} was not valid JSON."
+            ) from error
+
+
+class GitHubMergeTrainClient:
+    def __init__(self, *, transport: MergeTrainGitHubTransport) -> None:
+        self.transport = transport
+
+    def add_pull_request_label(
+        self, *, repository: str, pull_request_number: int, label: str
+    ) -> None:
+        repository_path = _repository_path(repository)
+        normalized_label = _required_value(label, "GitHub label is required.")
+        self.transport.request(
+            method="POST",
+            path=f"/repos/{repository_path}/issues/{pull_request_number}/labels",
+            body={"labels": [normalized_label]},
+        )
+
+    def update_pull_request_branch(
+        self, *, repository: str, pull_request_number: int, expected_head_sha: str
+    ) -> None:
+        repository_path = _repository_path(repository)
+        self.transport.request(
+            method="PUT",
+            path=f"/repos/{repository_path}/pulls/{pull_request_number}/update-branch",
+            body={
+                "expected_head_sha": _required_value(
+                    expected_head_sha, "Expected pull request head SHA is required."
+                )
+            },
+        )
+
+    def merge_pull_request(
+        self,
+        *,
+        repository: str,
+        pull_request_number: int,
+        head_sha: str,
+        merge_method: MergeTrainMergeMethod,
+    ) -> str:
+        repository_path = _repository_path(repository)
+        payload = self.transport.request(
+            method="PUT",
+            path=f"/repos/{repository_path}/pulls/{pull_request_number}/merge",
+            body={
+                "sha": _required_value(head_sha, "Pull request head SHA is required."),
+                "merge_method": merge_method,
+            },
+        )
+        if not isinstance(payload, dict):
+            raise MergeTrainGitHubError(
+                "GitHub merge response must be a JSON object.", status_code=None
+            )
+        merge_commit_sha = str(payload.get("sha") or "").strip()
+        if not merge_commit_sha:
+            raise MergeTrainGitHubError(
+                "GitHub merge response did not include a merge commit SHA.", status_code=None
+            )
+        return merge_commit_sha
+
+
+class MergeTrainGitHubRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    method: str
+    path: str
+    body: dict[str, object] | None = None
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "MergeTrainGitHubRequest":
+        self.method = _required_value(self.method, "GitHub request method is required.").upper()
+        self.path = _required_value(self.path, "GitHub request path is required.")
+        if not self.path.startswith("/"):
+            raise ValueError("GitHub request path must start with '/'.")
+        return self
+
+
+class RecordingMergeTrainGitHubTransport:
+    def __init__(self, *, responses: tuple[object, ...] = ()) -> None:
+        self.responses = list(responses)
+        self.requests: list[MergeTrainGitHubRequest] = []
+
+    def request(
+        self, *, method: str, path: str, body: dict[str, object] | None = None
+    ) -> object:
+        self.requests.append(
+            MergeTrainGitHubRequest.model_validate(
+                {"method": method, "path": path, "body": body}
+            )
+        )
+        if self.responses:
+            response = self.responses.pop(0)
+            if isinstance(response, BaseException):
+                raise response
+            return response
+        return {}
+
+
+def _repository_path(repository: str) -> str:
+    normalized = _required_value(repository, "GitHub repository is required.")
+    parts = normalized.split("/")
+    if len(parts) != 2 or not all(part.strip() for part in parts):
+        raise ValueError("GitHub repository must be formatted as owner/name.")
+    return "/".join(quote(part.strip(), safe="") for part in parts)
+
+
+def _required_value(value: str, message: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(message)
+    return normalized
+
+
+def _github_http_error(*, path: str, status_code: int, error: HTTPError) -> MergeTrainGitHubError:
+    message = f"GitHub API request failed for {path}: HTTP {status_code}"
+    if status_code == 409:
+        return MergeTrainGitHubStaleHeadError(message, status_code=status_code)
+    return MergeTrainGitHubError(message, status_code=status_code)

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -120,3 +120,9 @@ The merge step is allowed only from a fresh dry-run result whose next action is
 `head_sha` as the GitHub merge `sha` guard and the repository policy's
 `merge_method`. After a successful merge, the worker must re-read the train
 before selecting another queued pull request.
+
+The GitHub adapter maps Launchplane's domain fields to the REST API endpoints:
+blocked labels use the issue labels endpoint, branch refresh uses
+`expected_head_sha`, and merge uses `sha`. A GitHub `409 Conflict` from the
+guarded merge call is treated as stale-head evidence and requires a fresh read
+instead of a blind retry.

--- a/tests/test_merge_train_github.py
+++ b/tests/test_merge_train_github.py
@@ -1,0 +1,110 @@
+import unittest
+from email.message import Message
+from unittest.mock import patch
+from urllib.error import HTTPError
+
+from control_plane.merge_train_github import GitHubMergeTrainClient
+from control_plane.merge_train_github import MergeTrainGitHubError
+from control_plane.merge_train_github import MergeTrainGitHubStaleHeadError
+from control_plane.merge_train_github import RecordingMergeTrainGitHubTransport
+from control_plane.merge_train_github import UrllibMergeTrainGitHubTransport
+
+
+class GitHubMergeTrainClientTests(unittest.TestCase):
+    def test_add_pull_request_label_uses_issue_labels_endpoint(self) -> None:
+        transport = RecordingMergeTrainGitHubTransport()
+        client = GitHubMergeTrainClient(transport=transport)
+
+        client.add_pull_request_label(
+            repository="cbusillo/sellyouroutboard",
+            pull_request_number=42,
+            label="merge-blocked",
+        )
+
+        self.assertEqual(len(transport.requests), 1)
+        request = transport.requests[0]
+        self.assertEqual(request.method, "POST")
+        self.assertEqual(
+            request.path, "/repos/cbusillo/sellyouroutboard/issues/42/labels"
+        )
+        self.assertEqual(request.body, {"labels": ["merge-blocked"]})
+
+    def test_update_pull_request_branch_uses_expected_head_sha(self) -> None:
+        transport = RecordingMergeTrainGitHubTransport()
+        client = GitHubMergeTrainClient(transport=transport)
+
+        client.update_pull_request_branch(
+            repository="cbusillo/sellyouroutboard",
+            pull_request_number=42,
+            expected_head_sha="head-42",
+        )
+
+        self.assertEqual(len(transport.requests), 1)
+        request = transport.requests[0]
+        self.assertEqual(request.method, "PUT")
+        self.assertEqual(
+            request.path, "/repos/cbusillo/sellyouroutboard/pulls/42/update-branch"
+        )
+        self.assertEqual(request.body, {"expected_head_sha": "head-42"})
+
+    def test_merge_pull_request_uses_sha_guard_and_policy_method(self) -> None:
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=({"sha": "merge-sha-42"},)
+        )
+        client = GitHubMergeTrainClient(transport=transport)
+
+        merge_commit_sha = client.merge_pull_request(
+            repository="cbusillo/sellyouroutboard",
+            pull_request_number=42,
+            head_sha="head-42",
+            merge_method="merge",
+        )
+
+        self.assertEqual(merge_commit_sha, "merge-sha-42")
+        self.assertEqual(len(transport.requests), 1)
+        request = transport.requests[0]
+        self.assertEqual(request.method, "PUT")
+        self.assertEqual(request.path, "/repos/cbusillo/sellyouroutboard/pulls/42/merge")
+        self.assertEqual(request.body, {"sha": "head-42", "merge_method": "merge"})
+
+    def test_merge_pull_request_requires_merge_response_sha(self) -> None:
+        transport = RecordingMergeTrainGitHubTransport(responses=({"merged": True},))
+        client = GitHubMergeTrainClient(transport=transport)
+
+        with self.assertRaisesRegex(MergeTrainGitHubError, "merge commit SHA"):
+            client.merge_pull_request(
+                repository="cbusillo/sellyouroutboard",
+                pull_request_number=42,
+                head_sha="head-42",
+                merge_method="merge",
+            )
+
+    def test_repository_must_be_owner_name(self) -> None:
+        client = GitHubMergeTrainClient(transport=RecordingMergeTrainGitHubTransport())
+
+        with self.assertRaisesRegex(ValueError, "owner/name"):
+            client.add_pull_request_label(
+                repository="cbusillo",
+                pull_request_number=42,
+                label="merge-blocked",
+            )
+
+    def test_transport_maps_conflict_to_stale_head_error(self) -> None:
+        transport = UrllibMergeTrainGitHubTransport(token="token")
+        http_error = HTTPError(
+            url="https://api.github.com/repos/cbusillo/repo/pulls/1/merge",
+            code=409,
+            msg="Conflict",
+            hdrs=Message(),
+            fp=None,
+        )
+
+        with patch("control_plane.merge_train_github.urlopen", side_effect=http_error):
+            with self.assertRaises(MergeTrainGitHubStaleHeadError) as caught:
+                transport.request(method="PUT", path="/repos/cbusillo/repo/pulls/1/merge")
+
+        self.assertEqual(caught.exception.status_code, 409)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a GitHub merge-train adapter for block labels, branch updates, and guarded merges
- map Launchplane domain fields to GitHub REST bodies: labels, `expected_head_sha`, and merge `sha`
- surface 409 guarded-merge conflicts as stale-head errors for reread/re-evaluation
- document the adapter endpoint semantics in the merge-train policy doc

## Validation
- uv run python -m unittest tests.test_merge_train_github tests.test_merge_train
- uv run --extra dev ruff check --diff control_plane/merge_train_github.py tests/test_merge_train_github.py
- uv run --extra dev ruff check control_plane/merge_train_github.py tests/test_merge_train_github.py
- uv run --extra dev mypy control_plane/merge_train_github.py tests/test_merge_train_github.py
- uv run --extra dev markdownlint-cli2 docs/merge-train-policy.md
- uv run python -m unittest

Refs #410