### PR TITLE
Add merge train worker step

### DIFF
--- a/control_plane/workflows/merge_train_worker.py
+++ b/control_plane/workflows/merge_train_worker.py
@@ -1,0 +1,167 @@
+from dataclasses import dataclass
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from control_plane.contracts.merge_train_policy import MergeTrainPolicy
+from control_plane.merge_train import MergeTrainBranchClient
+from control_plane.merge_train import MergeTrainBranchUpdateResult
+from control_plane.merge_train import MergeTrainBlockResult
+from control_plane.merge_train import MergeTrainDryRunAction
+from control_plane.merge_train import MergeTrainDryRunResult
+from control_plane.merge_train import MergeTrainDryRunSnapshot
+from control_plane.merge_train import MergeTrainLabelClient
+from control_plane.merge_train import MergeTrainMergeClient
+from control_plane.merge_train import MergeTrainMergeResult
+from control_plane.merge_train import MergeTrainWaitResult
+from control_plane.merge_train import apply_merge_train_branch_update_intent
+from control_plane.merge_train import apply_merge_train_block_intent
+from control_plane.merge_train import apply_merge_train_merge_intent
+from control_plane.merge_train import build_merge_train_dry_run_result
+from control_plane.merge_train import build_merge_train_wait_result
+from control_plane.merge_train_github import MergeTrainGitHubStaleHeadError
+
+
+MergeTrainWorkerStepStatus = Literal[
+    "blocked", "branch_updated", "waiting", "merged", "idle", "stale_head"
+]
+
+
+@dataclass(frozen=True)
+class MergeTrainWorkerClients:
+    label_client: MergeTrainLabelClient
+    branch_client: MergeTrainBranchClient
+    merge_client: MergeTrainMergeClient
+
+
+class MergeTrainWorkerStepResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    repository: str
+    base_branch: str
+    intended_next_action: MergeTrainDryRunAction
+    selected_pr_number: int | None = None
+    status: MergeTrainWorkerStepStatus
+    reread_required: bool
+    poll_required: bool
+    detail: str
+    dry_run_result: MergeTrainDryRunResult
+    block_result: MergeTrainBlockResult | None = None
+    branch_update_result: MergeTrainBranchUpdateResult | None = None
+    wait_result: MergeTrainWaitResult | None = None
+    merge_result: MergeTrainMergeResult | None = None
+
+
+def run_merge_train_worker_step(
+    *,
+    policy: MergeTrainPolicy,
+    snapshot: MergeTrainDryRunSnapshot,
+    clients: MergeTrainWorkerClients,
+) -> MergeTrainWorkerStepResult:
+    dry_run_result = build_merge_train_dry_run_result(policy=policy, snapshot=snapshot)
+    selected_pr_number = (
+        dry_run_result.selected_pr.number if dry_run_result.selected_pr is not None else None
+    )
+
+    if dry_run_result.intended_next_action == "block":
+        block_result = apply_merge_train_block_intent(
+            dry_run_result=dry_run_result, label_client=clients.label_client
+        )
+        return _build_worker_step_result(
+            dry_run_result=dry_run_result,
+            selected_pr_number=selected_pr_number,
+            status="blocked",
+            reread_required=False,
+            poll_required=False,
+            detail=block_result.detail,
+            block_result=block_result,
+        )
+
+    if dry_run_result.intended_next_action == "update_branch":
+        branch_update_result = apply_merge_train_branch_update_intent(
+            dry_run_result=dry_run_result, branch_client=clients.branch_client
+        )
+        return _build_worker_step_result(
+            dry_run_result=dry_run_result,
+            selected_pr_number=selected_pr_number,
+            status="branch_updated",
+            reread_required=branch_update_result.reread_required,
+            poll_required=False,
+            detail=branch_update_result.detail,
+            branch_update_result=branch_update_result,
+        )
+
+    if dry_run_result.intended_next_action == "wait_for_checks":
+        wait_result = build_merge_train_wait_result(dry_run_result=dry_run_result)
+        return _build_worker_step_result(
+            dry_run_result=dry_run_result,
+            selected_pr_number=selected_pr_number,
+            status="waiting",
+            reread_required=False,
+            poll_required=wait_result.poll_required,
+            detail=wait_result.detail,
+            wait_result=wait_result,
+        )
+
+    if dry_run_result.intended_next_action == "merge":
+        try:
+            merge_result = apply_merge_train_merge_intent(
+                dry_run_result=dry_run_result, merge_client=clients.merge_client
+            )
+        except MergeTrainGitHubStaleHeadError as exc:
+            return _build_worker_step_result(
+                dry_run_result=dry_run_result,
+                selected_pr_number=selected_pr_number,
+                status="stale_head",
+                reread_required=True,
+                poll_required=False,
+                detail=str(exc),
+            )
+        return _build_worker_step_result(
+            dry_run_result=dry_run_result,
+            selected_pr_number=selected_pr_number,
+            status="merged",
+            reread_required=merge_result.reread_required,
+            poll_required=False,
+            detail=merge_result.detail,
+            merge_result=merge_result,
+        )
+
+    return _build_worker_step_result(
+        dry_run_result=dry_run_result,
+        selected_pr_number=selected_pr_number,
+        status="idle",
+        reread_required=False,
+        poll_required=False,
+        detail=dry_run_result.next_action_detail,
+    )
+
+
+def _build_worker_step_result(
+    *,
+    dry_run_result: MergeTrainDryRunResult,
+    selected_pr_number: int | None,
+    status: MergeTrainWorkerStepStatus,
+    reread_required: bool,
+    poll_required: bool,
+    detail: str,
+    block_result: MergeTrainBlockResult | None = None,
+    branch_update_result: MergeTrainBranchUpdateResult | None = None,
+    wait_result: MergeTrainWaitResult | None = None,
+    merge_result: MergeTrainMergeResult | None = None,
+) -> MergeTrainWorkerStepResult:
+    return MergeTrainWorkerStepResult(
+        repository=dry_run_result.repository,
+        base_branch=dry_run_result.base_branch,
+        intended_next_action=dry_run_result.intended_next_action,
+        selected_pr_number=selected_pr_number,
+        status=status,
+        reread_required=reread_required,
+        poll_required=poll_required,
+        detail=detail,
+        dry_run_result=dry_run_result,
+        block_result=block_result,
+        branch_update_result=branch_update_result,
+        wait_result=wait_result,
+        merge_result=merge_result,
+    )

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -115,6 +115,11 @@ merge or mutate GitHub. A later worker pass must read a fresh snapshot for the
 same repository/base branch and continue only when that fresh dry-run result
 selects `merge`.
 
+A worker pass applies at most one transition from one fresh snapshot. It may add
+the block label, request a branch refresh, record a wait boundary, perform one
+guarded merge, or report an idle queue; it must not chain follow-up reads or
+mutations in the same pass.
+
 The merge step is allowed only from a fresh dry-run result whose next action is
 `merge`. The merge request must use the selected pull request's observed
 `head_sha` as the GitHub merge `sha` guard and the repository policy's

--- a/tests/test_merge_train_worker.py
+++ b/tests/test_merge_train_worker.py
@@ -1,0 +1,243 @@
+import unittest
+
+from control_plane.contracts.merge_train_policy import build_sellyouroutboard_main_merge_train_policy
+from control_plane.merge_train import MergeTrainCheckStatus
+from control_plane.merge_train import MergeTrainDryRunSnapshot
+from control_plane.merge_train import MergeTrainMergeableState
+from control_plane.merge_train import MergeTrainPullRequestSnapshot
+from control_plane.merge_train_github import MergeTrainGitHubStaleHeadError
+from control_plane.workflows.merge_train_worker import MergeTrainWorkerClients
+from control_plane.workflows.merge_train_worker import run_merge_train_worker_step
+
+
+class _FakeLabelClient:
+    def __init__(self) -> None:
+        self.applied_labels: list[tuple[str, int, str]] = []
+
+    def add_pull_request_label(
+        self, *, repository: str, pull_request_number: int, label: str
+    ) -> None:
+        self.applied_labels.append((repository, pull_request_number, label))
+
+
+class _FakeBranchClient:
+    def __init__(self) -> None:
+        self.updated_branches: list[tuple[str, int, str]] = []
+
+    def update_pull_request_branch(
+        self, *, repository: str, pull_request_number: int, expected_head_sha: str
+    ) -> None:
+        self.updated_branches.append((repository, pull_request_number, expected_head_sha))
+
+
+class _FakeMergeClient:
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error
+        self.merged_pull_requests: list[tuple[str, int, str, str]] = []
+
+    def merge_pull_request(
+        self,
+        *,
+        repository: str,
+        pull_request_number: int,
+        head_sha: str,
+        merge_method: str,
+    ) -> str:
+        self.merged_pull_requests.append(
+            (repository, pull_request_number, head_sha, merge_method)
+        )
+        if self.error is not None:
+            raise self.error
+        return f"merge-{pull_request_number}"
+
+
+class MergeTrainWorkerStepTests(unittest.TestCase):
+    def test_worker_step_applies_block_label_once(self) -> None:
+        label_client = _FakeLabelClient()
+        clients = _clients(label_client=label_client)
+
+        result = run_merge_train_worker_step(
+            policy=build_sellyouroutboard_main_merge_train_policy(),
+            snapshot=_snapshot(_pull_request(11, required_checks_status="fail")),
+            clients=clients,
+        )
+
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(result.intended_next_action, "block")
+        self.assertEqual(result.selected_pr_number, 11)
+        self.assertFalse(result.reread_required)
+        self.assertFalse(result.poll_required)
+        self.assertIsNotNone(result.block_result)
+        self.assertEqual(label_client.applied_labels, [("cbusillo/sellyouroutboard", 11, "merge-blocked")])
+
+    def test_worker_step_does_not_reapply_existing_block_label(self) -> None:
+        label_client = _FakeLabelClient()
+
+        result = run_merge_train_worker_step(
+            policy=build_sellyouroutboard_main_merge_train_policy(),
+            snapshot=_snapshot(
+                _pull_request(
+                    12,
+                    labels=("ready-to-merge", "merge-blocked"),
+                    mergeable="conflicting",
+                )
+            ),
+            clients=_clients(label_client=label_client),
+        )
+
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(label_client.applied_labels, [])
+
+    def test_worker_step_updates_branch_once_and_requires_reread(self) -> None:
+        branch_client = _FakeBranchClient()
+
+        result = run_merge_train_worker_step(
+            policy=build_sellyouroutboard_main_merge_train_policy(),
+            snapshot=_snapshot(_pull_request(21, branch_update_required=True)),
+            clients=_clients(branch_client=branch_client),
+        )
+
+        self.assertEqual(result.status, "branch_updated")
+        self.assertEqual(result.intended_next_action, "update_branch")
+        self.assertTrue(result.reread_required)
+        self.assertFalse(result.poll_required)
+        self.assertIsNotNone(result.branch_update_result)
+        self.assertEqual(branch_client.updated_branches, [("cbusillo/sellyouroutboard", 21, "head-21")])
+
+    def test_worker_step_waits_without_mutating_github(self) -> None:
+        label_client = _FakeLabelClient()
+        branch_client = _FakeBranchClient()
+        merge_client = _FakeMergeClient()
+
+        result = run_merge_train_worker_step(
+            policy=build_sellyouroutboard_main_merge_train_policy(),
+            snapshot=_snapshot(_pull_request(31, required_checks_status="pending")),
+            clients=MergeTrainWorkerClients(
+                label_client=label_client,
+                branch_client=branch_client,
+                merge_client=merge_client,
+            ),
+        )
+
+        self.assertEqual(result.status, "waiting")
+        self.assertEqual(result.intended_next_action, "wait_for_checks")
+        self.assertFalse(result.reread_required)
+        self.assertTrue(result.poll_required)
+        self.assertIsNotNone(result.wait_result)
+        self.assertEqual(label_client.applied_labels, [])
+        self.assertEqual(branch_client.updated_branches, [])
+        self.assertEqual(merge_client.merged_pull_requests, [])
+
+    def test_worker_step_merges_once_and_requires_reread(self) -> None:
+        merge_client = _FakeMergeClient()
+
+        result = run_merge_train_worker_step(
+            policy=build_sellyouroutboard_main_merge_train_policy(),
+            snapshot=_snapshot(_pull_request(41)),
+            clients=_clients(merge_client=merge_client),
+        )
+
+        self.assertEqual(result.status, "merged")
+        self.assertEqual(result.intended_next_action, "merge")
+        self.assertTrue(result.reread_required)
+        self.assertFalse(result.poll_required)
+        self.assertIsNotNone(result.merge_result)
+        self.assertEqual(merge_client.merged_pull_requests, [("cbusillo/sellyouroutboard", 41, "head-41", "merge")])
+
+    def test_worker_step_treats_guarded_merge_conflict_as_stale_head(self) -> None:
+        merge_client = _FakeMergeClient(
+            MergeTrainGitHubStaleHeadError("GitHub merge rejected stale head", status_code=409)
+        )
+
+        result = run_merge_train_worker_step(
+            policy=build_sellyouroutboard_main_merge_train_policy(),
+            snapshot=_snapshot(_pull_request(42)),
+            clients=_clients(merge_client=merge_client),
+        )
+
+        self.assertEqual(result.status, "stale_head")
+        self.assertEqual(result.intended_next_action, "merge")
+        self.assertTrue(result.reread_required)
+        self.assertFalse(result.poll_required)
+        self.assertIsNone(result.merge_result)
+        self.assertEqual(merge_client.merged_pull_requests, [("cbusillo/sellyouroutboard", 42, "head-42", "merge")])
+
+    def test_worker_step_idles_without_mutating_github(self) -> None:
+        label_client = _FakeLabelClient()
+        branch_client = _FakeBranchClient()
+        merge_client = _FakeMergeClient()
+
+        result = run_merge_train_worker_step(
+            policy=build_sellyouroutboard_main_merge_train_policy(),
+            snapshot=_snapshot(_pull_request(51, labels=())),
+            clients=MergeTrainWorkerClients(
+                label_client=label_client,
+                branch_client=branch_client,
+                merge_client=merge_client,
+            ),
+        )
+
+        self.assertEqual(result.status, "idle")
+        self.assertEqual(result.intended_next_action, "idle")
+        self.assertIsNone(result.selected_pr_number)
+        self.assertFalse(result.reread_required)
+        self.assertFalse(result.poll_required)
+        self.assertEqual(label_client.applied_labels, [])
+        self.assertEqual(branch_client.updated_branches, [])
+        self.assertEqual(merge_client.merged_pull_requests, [])
+
+    def test_worker_step_fails_closed_when_policy_is_missing(self) -> None:
+        with self.assertRaisesRegex(ValueError, "policy not found"):
+            run_merge_train_worker_step(
+                policy=build_sellyouroutboard_main_merge_train_policy(),
+                snapshot=MergeTrainDryRunSnapshot(
+                    repository="cbusillo/other",
+                    base_branch="main",
+                    pull_requests=(_pull_request(61),),
+                ),
+                clients=_clients(),
+            )
+
+
+def _clients(
+    *,
+    label_client: _FakeLabelClient | None = None,
+    branch_client: _FakeBranchClient | None = None,
+    merge_client: _FakeMergeClient | None = None,
+) -> MergeTrainWorkerClients:
+    return MergeTrainWorkerClients(
+        label_client=label_client or _FakeLabelClient(),
+        branch_client=branch_client or _FakeBranchClient(),
+        merge_client=merge_client or _FakeMergeClient(),
+    )
+
+
+def _snapshot(*pull_requests: MergeTrainPullRequestSnapshot) -> MergeTrainDryRunSnapshot:
+    return MergeTrainDryRunSnapshot(
+        repository="cbusillo/sellyouroutboard",
+        base_branch="main",
+        pull_requests=pull_requests,
+    )
+
+
+def _pull_request(
+    number: int,
+    *,
+    labels: tuple[str, ...] = ("ready-to-merge",),
+    mergeable: MergeTrainMergeableState = "mergeable",
+    required_checks_status: MergeTrainCheckStatus = "pass",
+    branch_update_required: bool = False,
+) -> MergeTrainPullRequestSnapshot:
+    return MergeTrainPullRequestSnapshot(
+        number=number,
+        url=f"https://github.com/cbusillo/sellyouroutboard/pull/{number}",
+        title=f"Pull request {number}",
+        created_at=f"2026-05-08T10:{number:02d}:00Z",
+        labels=labels,
+        actor_role="repo_owner",
+        head_sha=f"head-{number}",
+        base_sha="base-sha",
+        mergeable=mergeable,
+        required_checks_status=required_checks_status,
+        branch_update_required=branch_update_required,
+    )


### PR DESCRIPTION
Refs #410\n\n## Summary\n- add a single-pass merge-train worker dispatcher that evaluates one fresh snapshot and applies at most one transition\n- return a typed worker-step envelope around block, branch-update, wait, merge, idle, and stale-head outcomes\n- document the one-transition worker pass boundary\n\n## Verification\n- uv run --extra dev ruff check --diff control_plane/workflows/merge_train_worker.py tests/test_merge_train_worker.py\n- uv run --extra dev ruff check control_plane/workflows/merge_train_worker.py tests/test_merge_train_worker.py\n- uv run --extra dev mypy control_plane/workflows/merge_train_worker.py tests/test_merge_train_worker.py\n- uv run --extra dev markdownlint-cli2 docs/merge-train-policy.md\n- uv run python -m unittest tests.test_merge_train_worker tests.test_merge_train tests.test_merge_train_github\n- uv run python -m unittest\n