### PR TITLE
Add merge train GitHub snapshot reader

### DIFF
--- a/control_plane/merge_train_github.py
+++ b/control_plane/merge_train_github.py
@@ -1,12 +1,17 @@
 import json
 from typing import Protocol
 from urllib.error import HTTPError, URLError
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 from urllib.request import Request, urlopen
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
 from control_plane.contracts.merge_train_policy import MergeTrainMergeMethod
+from control_plane.merge_train import MergeTrainCheckStatus
+from control_plane.merge_train import MergeTrainDryRunSnapshot
+from control_plane.merge_train import MergeTrainMergeableState
+from control_plane.merge_train import MergeTrainPullRequestSnapshot
+from control_plane.merge_train import MergeTrainPullRequestState
 
 
 class MergeTrainGitHubError(RuntimeError):
@@ -122,6 +127,140 @@ class GitHubMergeTrainClient:
         return merge_commit_sha
 
 
+class GitHubMergeTrainSnapshotReader:
+    def __init__(self, *, transport: MergeTrainGitHubTransport) -> None:
+        self.transport = transport
+
+    def read_merge_train_snapshot(
+        self, *, repository: str, base_branch: str
+    ) -> MergeTrainDryRunSnapshot:
+        repository_path = _repository_path(repository)
+        normalized_base_branch = _required_value(
+            base_branch, "GitHub pull request base branch is required."
+        )
+        pull_requests = tuple(
+            self._pull_request_snapshot(
+                repository=repository,
+                repository_path=repository_path,
+                pull_request=pull_request,
+            )
+            for pull_request in self._list_open_pull_requests(
+                repository_path=repository_path, base_branch=normalized_base_branch
+            )
+        )
+        return MergeTrainDryRunSnapshot(
+            repository=repository,
+            base_branch=normalized_base_branch,
+            pull_requests=pull_requests,
+        )
+
+    def _list_open_pull_requests(
+        self, *, repository_path: str, base_branch: str
+    ) -> tuple[dict[str, object], ...]:
+        pull_requests: list[dict[str, object]] = []
+        page = 1
+        while True:
+            query = urlencode(
+                {
+                    "state": "open",
+                    "base": base_branch,
+                    "sort": "created",
+                    "direction": "asc",
+                    "per_page": "100",
+                    "page": str(page),
+                }
+            )
+            payload = self.transport.request(
+                method="GET", path=f"/repos/{repository_path}/pulls?{query}"
+            )
+            if not isinstance(payload, list):
+                raise MergeTrainGitHubError(
+                    "GitHub pull request list response must be a JSON array."
+                )
+            page_pull_requests = [_json_object(item, "GitHub pull request entry") for item in payload]
+            pull_requests.extend(page_pull_requests)
+            if len(page_pull_requests) < 100:
+                return tuple(pull_requests)
+            page += 1
+
+    def _pull_request_snapshot(
+        self, *, repository: str, repository_path: str, pull_request: dict[str, object]
+    ) -> MergeTrainPullRequestSnapshot:
+        pull_request_number = _required_int(
+            pull_request.get("number"), "GitHub pull request entry requires number."
+        )
+        detail = _json_object(
+            self.transport.request(
+                method="GET", path=f"/repos/{repository_path}/pulls/{pull_request_number}"
+            ),
+            "GitHub pull request detail response",
+        )
+        source = pull_request | detail
+        head = _json_object(source.get("head"), "GitHub pull request head")
+        base = _json_object(source.get("base"), "GitHub pull request base")
+        head_sha = _required_text(head.get("sha"), "GitHub pull request head requires sha.")
+        user = _json_object(source.get("user"), "GitHub pull request user")
+        actor_role = self._actor_role_for_pull_request(
+            repository_path=repository_path,
+            username=_required_text(user.get("login"), "GitHub pull request user requires login."),
+            author_association=str(source.get("author_association") or ""),
+        )
+        return MergeTrainPullRequestSnapshot(
+            number=pull_request_number,
+            url=str(source.get("html_url") or "").strip(),
+            title=str(source.get("title") or "").strip(),
+            state=_pull_request_state(str(source.get("state") or "")),
+            is_draft=bool(source.get("draft")),
+            created_at=_required_text(
+                source.get("created_at"), "GitHub pull request entry requires created_at."
+            ),
+            labels=_labels(source.get("labels")),
+            actor_role=actor_role,
+            head_sha=head_sha,
+            base_sha=str(base.get("sha") or "").strip(),
+            mergeable=_mergeable_state(source),
+            required_checks_status=self._required_checks_status(
+                repository_path=repository_path, head_sha=head_sha
+            ),
+            branch_update_required=_branch_update_required(source),
+        )
+
+    def _actor_role_for_pull_request(
+        self, *, repository_path: str, username: str, author_association: str
+    ) -> str:
+        if author_association.upper() == "OWNER":
+            return "repo_owner"
+        payload = _json_object(
+            self.transport.request(
+                method="GET",
+                path=f"/repos/{repository_path}/collaborators/{quote(username, safe='')}/permission",
+            ),
+            "GitHub collaborator permission response",
+        )
+        return "repo_admin" if str(payload.get("permission") or "") == "admin" else "unknown"
+
+    def _required_checks_status(
+        self, *, repository_path: str, head_sha: str
+    ) -> MergeTrainCheckStatus:
+        encoded_head_sha = quote(head_sha, safe="")
+        status_payload = _json_object(
+            self.transport.request(
+                method="GET", path=f"/repos/{repository_path}/commits/{encoded_head_sha}/status"
+            ),
+            "GitHub combined status response",
+        )
+        check_runs_payload = _json_object(
+            self.transport.request(
+                method="GET",
+                path=f"/repos/{repository_path}/commits/{encoded_head_sha}/check-runs?per_page=100",
+            ),
+            "GitHub check runs response",
+        )
+        return _combine_check_statuses(
+            _combined_status_state(status_payload), _check_runs_status(check_runs_payload)
+        )
+
+
 class MergeTrainGitHubRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -165,6 +304,116 @@ def _repository_path(repository: str) -> str:
     if len(parts) != 2 or not all(part.strip() for part in parts):
         raise ValueError("GitHub repository must be formatted as owner/name.")
     return "/".join(quote(part.strip(), safe="") for part in parts)
+
+
+def _json_object(value: object, label: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise MergeTrainGitHubError(f"{label} must be a JSON object.")
+    return value
+
+
+def _required_int(value: object, message: str) -> int:
+    if not isinstance(value, int) or value <= 0:
+        raise MergeTrainGitHubError(message)
+    return value
+
+
+def _required_text(value: object, message: str) -> str:
+    if not isinstance(value, str):
+        raise MergeTrainGitHubError(message)
+    normalized = value.strip()
+    if not normalized:
+        raise MergeTrainGitHubError(message)
+    return normalized
+
+
+def _pull_request_state(value: str) -> MergeTrainPullRequestState:
+    normalized = value.strip().lower()
+    if normalized == "open":
+        return "open"
+    if normalized == "closed":
+        return "closed"
+    raise MergeTrainGitHubError("GitHub pull request state must be open or closed.")
+
+
+def _labels(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise MergeTrainGitHubError("GitHub pull request labels must be a JSON array.")
+    labels: list[str] = []
+    for item in value:
+        label = _json_object(item, "GitHub pull request label")
+        name = _required_text(label.get("name"), "GitHub pull request label requires name.")
+        if name not in labels:
+            labels.append(name)
+    return tuple(labels)
+
+
+def _mergeable_state(source: dict[str, object]) -> MergeTrainMergeableState:
+    if bool(source.get("draft")):
+        return "unknown"
+    mergeable = source.get("mergeable")
+    if mergeable is True:
+        return "mergeable"
+    if mergeable is False:
+        return "conflicting"
+    return "unknown"
+
+
+def _branch_update_required(source: dict[str, object]) -> bool:
+    mergeable_state = str(source.get("mergeable_state") or "").strip().lower()
+    return mergeable_state == "behind"
+
+
+def _combined_status_state(payload: dict[str, object]) -> MergeTrainCheckStatus:
+    if payload.get("total_count") == 0:
+        return "unknown"
+    state = str(payload.get("state") or "").strip().lower()
+    if state == "success":
+        return "pass"
+    if state in {"failure", "error"}:
+        return "fail"
+    if state == "pending":
+        return "pending"
+    return "unknown"
+
+
+def _check_runs_status(payload: dict[str, object]) -> MergeTrainCheckStatus:
+    check_runs = payload.get("check_runs")
+    if not isinstance(check_runs, list):
+        raise MergeTrainGitHubError("GitHub check runs response must include check_runs.")
+    if not check_runs:
+        return "unknown"
+    statuses: list[MergeTrainCheckStatus] = []
+    for item in check_runs:
+        check_run = _json_object(item, "GitHub check run")
+        statuses.append(_check_run_status(check_run))
+    return _combine_check_statuses(*statuses)
+
+
+def _check_run_status(check_run: dict[str, object]) -> MergeTrainCheckStatus:
+    status = str(check_run.get("status") or "").strip().lower()
+    if status != "completed":
+        return "pending" if status else "unknown"
+    conclusion = str(check_run.get("conclusion") or "").strip().lower()
+    if conclusion in {"success", "neutral", "skipped"}:
+        return "pass"
+    if conclusion in {"failure", "timed_out", "cancelled", "action_required"}:
+        return "fail"
+    return "unknown"
+
+
+def _combine_check_statuses(*statuses: MergeTrainCheckStatus) -> MergeTrainCheckStatus:
+    if any(status == "fail" for status in statuses):
+        return "fail"
+    if any(status == "pending" for status in statuses):
+        return "pending"
+    if statuses and all(status == "pass" for status in statuses):
+        return "pass"
+    if any(status == "pass" for status in statuses):
+        return "pass"
+    return "unknown"
 
 
 def _required_value(value: str, message: str) -> str:

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -131,3 +131,8 @@ blocked labels use the issue labels endpoint, branch refresh uses
 `expected_head_sha`, and merge uses `sha`. A GitHub `409 Conflict` from the
 guarded merge call is treated as stale-head evidence and requires a fresh read
 instead of a blind retry.
+
+Live worker reads build the same `MergeTrainDryRunSnapshot` contract from
+GitHub pull requests for the policy repository/base branch. The reader only uses
+GET requests, preserves unknown mergeability or check evidence as `unknown` or
+`pending`, and fails closed when required pull request fields are missing.

--- a/tests/test_merge_train_github.py
+++ b/tests/test_merge_train_github.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from urllib.error import HTTPError
 
 from control_plane.merge_train_github import GitHubMergeTrainClient
+from control_plane.merge_train_github import GitHubMergeTrainSnapshotReader
 from control_plane.merge_train_github import MergeTrainGitHubError
 from control_plane.merge_train_github import MergeTrainGitHubStaleHeadError
 from control_plane.merge_train_github import RecordingMergeTrainGitHubTransport
@@ -104,6 +105,166 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 transport.request(method="PUT", path="/repos/cbusillo/repo/pulls/1/merge")
 
         self.assertEqual(caught.exception.status_code, 409)
+
+
+class GitHubMergeTrainSnapshotReaderTests(unittest.TestCase):
+    def test_snapshot_reader_builds_pull_request_snapshots_from_github(self) -> None:
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                [
+                    _github_pull_request(42, mergeable=None),
+                ],
+                _github_pull_request(42, mergeable=True),
+                {"permission": "admin"},
+                {"state": "success"},
+                {"check_runs": [_check_run("completed", "success")]},
+            )
+        )
+        reader = GitHubMergeTrainSnapshotReader(transport=transport)
+
+        snapshot = reader.read_merge_train_snapshot(
+            repository="cbusillo/sellyouroutboard", base_branch="main"
+        )
+
+        self.assertEqual(snapshot.repository, "cbusillo/sellyouroutboard")
+        self.assertEqual(snapshot.base_branch, "main")
+        self.assertEqual(len(snapshot.pull_requests), 1)
+        pull_request = snapshot.pull_requests[0]
+        self.assertEqual(pull_request.number, 42)
+        self.assertEqual(pull_request.labels, ("ready-to-merge",))
+        self.assertEqual(pull_request.actor_role, "repo_admin")
+        self.assertEqual(pull_request.head_sha, "head-42")
+        self.assertEqual(pull_request.base_sha, "base-42")
+        self.assertEqual(pull_request.mergeable, "mergeable")
+        self.assertEqual(pull_request.required_checks_status, "pass")
+        self.assertFalse(pull_request.branch_update_required)
+        self.assertEqual(
+            [request.path for request in transport.requests],
+            [
+                "/repos/cbusillo/sellyouroutboard/pulls?state=open&base=main&sort=created&direction=asc&per_page=100&page=1",
+                "/repos/cbusillo/sellyouroutboard/pulls/42",
+                "/repos/cbusillo/sellyouroutboard/collaborators/cbusillo/permission",
+                "/repos/cbusillo/sellyouroutboard/commits/head-42/status",
+                "/repos/cbusillo/sellyouroutboard/commits/head-42/check-runs?per_page=100",
+            ],
+        )
+
+    def test_snapshot_reader_paginates_pull_requests(self) -> None:
+        first_page = [_github_pull_request(number) for number in range(1, 101)]
+        second_page = [_github_pull_request(101)]
+        responses: list[object] = [first_page, second_page]
+        for number in range(1, 102):
+            responses.extend(
+                [
+                    _github_pull_request(number),
+                    {"permission": "admin"},
+                    {"state": "success"},
+                    {"check_runs": [_check_run("completed", "success")]},
+                ]
+            )
+        transport = RecordingMergeTrainGitHubTransport(responses=tuple(responses))
+
+        snapshot = GitHubMergeTrainSnapshotReader(transport=transport).read_merge_train_snapshot(
+            repository="cbusillo/sellyouroutboard", base_branch="main"
+        )
+
+        self.assertEqual(len(snapshot.pull_requests), 101)
+        self.assertEqual(snapshot.pull_requests[0].number, 1)
+        self.assertEqual(snapshot.pull_requests[-1].number, 101)
+
+    def test_snapshot_reader_maps_owner_association_without_permission_lookup(self) -> None:
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                [_github_pull_request(12, author_association="OWNER")],
+                _github_pull_request(12, author_association="OWNER"),
+                {"state": "success"},
+                {"check_runs": [_check_run("completed", "success")]},
+            )
+        )
+
+        snapshot = GitHubMergeTrainSnapshotReader(transport=transport).read_merge_train_snapshot(
+            repository="cbusillo/sellyouroutboard", base_branch="main"
+        )
+
+        self.assertEqual(snapshot.pull_requests[0].actor_role, "repo_owner")
+        self.assertNotIn("collaborators", "\n".join(request.path for request in transport.requests))
+
+    def test_snapshot_reader_combines_pending_checks_without_mutation(self) -> None:
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                [_github_pull_request(13)],
+                _github_pull_request(13, mergeable=None, mergeable_state="behind"),
+                {"permission": "admin"},
+                {"state": "success"},
+                {"check_runs": [_check_run("queued", None)]},
+            )
+        )
+
+        snapshot = GitHubMergeTrainSnapshotReader(transport=transport).read_merge_train_snapshot(
+            repository="cbusillo/sellyouroutboard", base_branch="main"
+        )
+
+        pull_request = snapshot.pull_requests[0]
+        self.assertEqual(pull_request.mergeable, "unknown")
+        self.assertEqual(pull_request.required_checks_status, "pending")
+        self.assertTrue(pull_request.branch_update_required)
+        self.assertTrue(all(request.method == "GET" for request in transport.requests))
+
+    def test_snapshot_reader_uses_check_runs_when_legacy_statuses_are_absent(self) -> None:
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                [_github_pull_request(14)],
+                _github_pull_request(14),
+                {"permission": "admin"},
+                {"state": "pending", "total_count": 0},
+                {"check_runs": [_check_run("completed", "success")]},
+            )
+        )
+
+        snapshot = GitHubMergeTrainSnapshotReader(transport=transport).read_merge_train_snapshot(
+            repository="cbusillo/sellyouroutboard", base_branch="main"
+        )
+
+        self.assertEqual(snapshot.pull_requests[0].required_checks_status, "pass")
+
+    def test_snapshot_reader_fails_closed_on_missing_required_shape(self) -> None:
+        transport = RecordingMergeTrainGitHubTransport(responses=([{"number": 1}],))
+
+        with self.assertRaisesRegex(MergeTrainGitHubError, "head"):
+            GitHubMergeTrainSnapshotReader(transport=transport).read_merge_train_snapshot(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+
+
+def _github_pull_request(
+    number: int,
+    *,
+    mergeable: bool | None = True,
+    mergeable_state: str = "clean",
+    author_association: str = "COLLABORATOR",
+) -> dict[str, object]:
+    return {
+        "number": number,
+        "html_url": f"https://github.com/cbusillo/sellyouroutboard/pull/{number}",
+        "title": f"Pull request {number}",
+        "state": "open",
+        "draft": False,
+        "created_at": f"2026-05-08T10:{number % 60:02d}:00Z",
+        "labels": [{"name": "ready-to-merge"}],
+        "user": {"login": "cbusillo"},
+        "author_association": author_association,
+        "head": {"sha": f"head-{number}"},
+        "base": {"sha": f"base-{number}"},
+        "mergeable": mergeable,
+        "mergeable_state": mergeable_state,
+    }
+
+
+def _check_run(status: str, conclusion: str | None) -> dict[str, object]:
+    payload: dict[str, object] = {"status": status}
+    if conclusion is not None:
+        payload["conclusion"] = conclusion
+    return payload
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs #410\n\n## Summary\n- add a read-only GitHub snapshot reader that builds MergeTrainDryRunSnapshot from open PRs on a policy base branch\n- map labels, actor role, mergeability, branch-update evidence, combined statuses, and check runs into the existing merge-train snapshot contract\n- document the live snapshot reader boundary and fail-closed behavior\n\n## Docs checked\n- GitHub REST pull request list/get docs for base filtering and PR fields\n- GitHub REST commit status docs for combined status state\n- GitHub REST check runs docs for check-run status/conclusion mapping\n\n## Verification\n- uv run --extra dev ruff check --diff control_plane/merge_train_github.py tests/test_merge_train_github.py\n- uv run --extra dev ruff check control_plane/merge_train_github.py tests/test_merge_train_github.py\n- uv run --extra dev mypy control_plane/merge_train_github.py tests/test_merge_train_github.py\n- uv run --extra dev markdownlint-cli2 docs/merge-train-policy.md\n- uv run python -m unittest tests.test_merge_train_github tests.test_merge_train tests.test_merge_train_worker\n- uv run python -m unittest\n