### PR TITLE
Add merge train run-once command

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -127,6 +127,11 @@ from control_plane.merge_train import (
     MergeTrainDryRunSnapshot,
     build_merge_train_dry_run_result,
 )
+from control_plane.merge_train_github import (
+    GitHubMergeTrainClient,
+    GitHubMergeTrainSnapshotReader,
+    UrllibMergeTrainGitHubTransport,
+)
 from control_plane.service import serve_launchplane_service
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.factory import build_record_store, resolve_database_url
@@ -189,6 +194,10 @@ from control_plane.workflows.ship import (
     generate_deployment_record_id,
     utc_now_timestamp,
 )
+from control_plane.workflows.merge_train_worker import (
+    MergeTrainWorkerClients,
+    run_merge_train_worker_step,
+)
 
 ARTIFACT_IMAGE_REFERENCE_ENV_KEY = "DOCKER_IMAGE_REFERENCE"
 DEFAULT_DOKPLOY_SHIP_SOURCE_GIT_REF = "origin/main"
@@ -203,6 +212,7 @@ _RUNTIME_CONTRACT_ENV_KEYS = (
 )
 _DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
 _EVERY_CODE_WORKER_TOKEN_ENV_KEY = "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN"
+_MERGE_TRAIN_GITHUB_TOKEN_ENV_KEY = "GITHUB_TOKEN"
 _MASTER_ENCRYPTION_KEY_ENV_KEYS = ("LAUNCHPLANE_MASTER_ENCRYPTION_KEY",)
 _LAUNCHPLANE_SERVICE_POLICY_ENV_KEYS = (
     "LAUNCHPLANE_POLICY_TOML",
@@ -9432,6 +9442,93 @@ def work_graph_merge_train_dry_run(
     except (OSError, JSONDecodeError, ValidationError, ValueError) as error:
         raise click.ClickException(str(error)) from error
     click.echo(json.dumps(result.model_dump(mode="json"), indent=2, sort_keys=True))
+
+
+@work_graph.command("merge-train-run-once")
+@click.option(
+    "--policy-file",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False),
+    default=None,
+    help="Optional merge-train policy TOML to validate instead of the bundled smoke policy.",
+)
+@click.option(
+    "--repository",
+    default="cbusillo/sellyouroutboard",
+    show_default=True,
+    help="owner/name repository whose policy should run once.",
+)
+@click.option("--base-branch", default="main", show_default=True)
+@click.option(
+    "--github-token-env",
+    default=_MERGE_TRAIN_GITHUB_TOKEN_ENV_KEY,
+    show_default=True,
+    help="Environment variable containing the GitHub token used by the merge train.",
+)
+@click.option(
+    "--github-api-base-url",
+    default="https://api.github.com",
+    show_default=True,
+    help="GitHub API base URL.",
+)
+@click.option(
+    "--mutate/--dry-run",
+    default=False,
+    show_default=True,
+    help="Apply the selected worker transition. The default only reads GitHub and reports intent.",
+)
+def work_graph_merge_train_run_once(
+    policy_file: Path | None,
+    repository: str,
+    base_branch: str,
+    github_token_env: str,
+    github_api_base_url: str,
+    mutate: bool,
+) -> None:
+    try:
+        policy = (
+            load_merge_train_policy(policy_file)
+            if policy_file is not None
+            else build_sellyouroutboard_main_merge_train_policy()
+        )
+        policy.find_repository_policy(repository=repository, base_branch=base_branch)
+        token_env = github_token_env.strip()
+        if not token_env:
+            raise click.ClickException("merge-train run-once requires --github-token-env.")
+        token = os.environ.get(token_env, "").strip()
+        if not token:
+            raise click.ClickException(f"Missing GitHub token in environment variable {token_env}.")
+        transport = UrllibMergeTrainGitHubTransport(
+            token=token, api_base_url=github_api_base_url
+        )
+        snapshot_reader = GitHubMergeTrainSnapshotReader(transport=transport)
+        snapshot = snapshot_reader.read_merge_train_snapshot(
+            repository=repository, base_branch=base_branch
+        )
+        dry_run_result = build_merge_train_dry_run_result(policy=policy, snapshot=snapshot)
+        if mutate:
+            github_client = GitHubMergeTrainClient(transport=transport)
+            worker_step_result = run_merge_train_worker_step(
+                policy=policy,
+                snapshot=snapshot,
+                clients=MergeTrainWorkerClients(
+                    label_client=github_client,
+                    branch_client=github_client,
+                    merge_client=github_client,
+                ),
+            )
+            payload: dict[str, object] = worker_step_result.model_dump(mode="json")
+            payload["mode"] = "mutate"
+        else:
+            payload = {
+                "mode": "dry-run",
+                "repository": snapshot.repository,
+                "base_branch": snapshot.base_branch,
+                "snapshot": snapshot.model_dump(mode="json"),
+                "dry_run_result": dry_run_result.model_dump(mode="json"),
+            }
+    except (OSError, ValidationError, ValueError) as error:
+        raise click.ClickException(str(error)) from error
+    click.echo(json.dumps(payload, indent=2, sort_keys=True))
 
 
 @every_code.command("run-once")

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -90,6 +90,19 @@ uv run launchplane work-graph merge-train-dry-run \
   --snapshot-file path/to/merge-train-snapshot.json
 ```
 
+The smoke-target run-once command reads a live GitHub snapshot for the selected
+repository/base branch and reports the same worker-step intent without mutating
+by default:
+
+```sh
+GITHUB_TOKEN=... uv run launchplane work-graph merge-train-run-once
+```
+
+Passing `--mutate` applies exactly one worker transition from that fresh
+snapshot. Use it only from the intended operator environment for the smoke
+target; the command is a narrow bootstrap surface, not a long-running train
+scheduler.
+
 The dry-run orders eligible pull requests by `created_at` and then PR number. It
 excludes draft, closed, unlabeled, or unauthorized entries and fails closed when
 the snapshot repository/base branch has no explicit policy.

--- a/tests/test_merge_train.py
+++ b/tests/test_merge_train.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import unittest
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
@@ -176,6 +177,118 @@ class MergeTrainDryRunTests(unittest.TestCase):
         self.assertEqual(payload["mode"], "dry-run")
         self.assertEqual(payload["queue_order"], [22])
         self.assertEqual(payload["selected_pr"]["number"], 22)
+
+    def test_cli_merge_train_run_once_reads_live_snapshot_without_mutation(self) -> None:
+        snapshot_reader = _FakeSnapshotReader(
+            MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(_pull_request(23),),
+            )
+        )
+
+        with (
+            patch(
+                "control_plane.cli.UrllibMergeTrainGitHubTransport",
+                return_value=object(),
+            ) as transport_class,
+            patch(
+                "control_plane.cli.GitHubMergeTrainSnapshotReader",
+                return_value=snapshot_reader,
+            ) as reader_class,
+            patch.dict("os.environ", {"GITHUB_TOKEN": "token"}, clear=True),
+        ):
+            result = CliRunner().invoke(
+                main,
+                ["work-graph", "merge-train-run-once"],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["mode"], "dry-run")
+        self.assertEqual(payload["repository"], "cbusillo/sellyouroutboard")
+        self.assertEqual(payload["base_branch"], "main")
+        self.assertEqual(payload["dry_run_result"]["intended_next_action"], "merge")
+        self.assertEqual(snapshot_reader.reads, [("cbusillo/sellyouroutboard", "main")])
+        transport_class.assert_called_once_with(
+            token="token", api_base_url="https://api.github.com"
+        )
+        reader_class.assert_called_once()
+
+    def test_cli_merge_train_run_once_mutates_one_worker_step_when_requested(self) -> None:
+        snapshot_reader = _FakeSnapshotReader(
+            MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(_pull_request(24, required_checks_status="fail"),),
+            )
+        )
+        label_client = _FakeLabelClient()
+
+        class _FakeGitHubClient:
+            def __init__(self, *, transport: object) -> None:
+                self.transport = transport
+
+            def add_pull_request_label(
+                self, *, repository: str, pull_request_number: int, label: str
+            ) -> None:
+                label_client.add_pull_request_label(
+                    repository=repository,
+                    pull_request_number=pull_request_number,
+                    label=label,
+                )
+
+            def update_pull_request_branch(
+                self, *, repository: str, pull_request_number: int, expected_head_sha: str
+            ) -> None:
+                raise AssertionError("block path should not update branches")
+
+            def merge_pull_request(
+                self,
+                *,
+                repository: str,
+                pull_request_number: int,
+                head_sha: str,
+                merge_method: str,
+            ) -> str:
+                raise AssertionError("block path should not merge")
+
+        with (
+            patch(
+                "control_plane.cli.UrllibMergeTrainGitHubTransport",
+                return_value=object(),
+            ),
+            patch(
+                "control_plane.cli.GitHubMergeTrainSnapshotReader",
+                return_value=snapshot_reader,
+            ),
+            patch("control_plane.cli.GitHubMergeTrainClient", _FakeGitHubClient),
+            patch.dict("os.environ", {"GITHUB_TOKEN": "token"}, clear=True),
+        ):
+            result = CliRunner().invoke(
+                main,
+                ["work-graph", "merge-train-run-once", "--mutate"],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["mode"], "mutate")
+        self.assertEqual(payload["status"], "blocked")
+        self.assertEqual(payload["block_result"]["pull_request_number"], 24)
+        self.assertEqual(
+            label_client.applied_labels,
+            [("cbusillo/sellyouroutboard", 24, "merge-blocked")],
+        )
+
+    def test_cli_merge_train_run_once_requires_github_token(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            result = CliRunner().invoke(
+                main,
+                ["work-graph", "merge-train-run-once"],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Missing GitHub token", result.output)
 
 
 class MergeTrainBlockIntentTests(unittest.TestCase):


### PR DESCRIPTION
Refs #410

## Summary
- add `work-graph merge-train-run-once` to wire the bundled policy, live GitHub snapshot reader, GitHub mutation client, and single-pass worker step
- default the command to dry-run/read-only output and require `--mutate` for one GitHub transition
- document the smoke-target command and bootstrap-only operator boundary

## Verification
- `uv run --extra dev ruff check --diff control_plane/cli.py tests/test_merge_train.py`
- `uv run --extra dev ruff check control_plane/cli.py tests/test_merge_train.py`
- `uv run --extra dev mypy control_plane/cli.py tests/test_merge_train.py`
- `uv run --extra dev markdownlint-cli2 docs/merge-train-policy.md`
- `uv run python -m unittest tests.test_merge_train tests.test_merge_train_worker tests.test_merge_train_github`
- `uv run python -m unittest`
