### PR TITLE
Move Launchplane preview aliases into product profiles

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -160,7 +160,6 @@ from control_plane.workflows.launchplane import (
     launchplane_preview_label_enabled,
     DEFAULT_LAUNCHPLANE_BASELINE_CHANNEL,
     LAUNCHPLANE_PREVIEW_ENABLE_LABEL,
-    LAUNCHPLANE_TENANT_ANCHOR_CONTEXTS,
     resolve_pull_request_event_manifest,
     resolve_launchplane_github_webhook_secret,
     verify_github_webhook_signature,
@@ -421,6 +420,7 @@ def _summarize_product_profile_record(record: LaunchplaneProductProfileRecord) -
         "lane_count": len(record.lanes),
         "preview_enabled": record.preview.enabled,
         "preview_context": record.preview.context,
+        "preview_enable_label": record.preview.enable_label,
         "updated_at": record.updated_at,
         "source": record.source,
     }
@@ -783,11 +783,22 @@ def _relative_href(*, from_file: Path, to_file: Path) -> str:
     return os.path.relpath(to_file, start=from_file.parent)
 
 
-def _launchplane_context_anchor_repo(*, context_name: str) -> str:
+def _launchplane_preview_profile_rows(record_store: FilesystemRecordStore) -> tuple[tuple[str, str], ...]:
+    rows: list[tuple[str, str]] = []
+    for profile in record_store.list_product_profile_records():
+        if not profile.preview.enabled or not profile.preview.context.strip():
+            continue
+        rows.append((profile.repository.strip().rsplit("/", maxsplit=1)[-1], profile.preview.context))
+    return tuple(sorted(rows))
+
+
+def _launchplane_context_anchor_repo_from_store(
+    *, record_store: FilesystemRecordStore, context_name: str
+) -> str:
     normalized_context = context_name.strip()
     if not normalized_context:
         return ""
-    for repo_name, repo_context in sorted(LAUNCHPLANE_TENANT_ANCHOR_CONTEXTS.items()):
+    for repo_name, repo_context in _launchplane_preview_profile_rows(record_store):
         if repo_context == normalized_context:
             return repo_name
     return ""
@@ -1840,9 +1851,15 @@ def _build_launchplane_tenant_payload(
     resolved_context = context_name.strip()
     resolved_anchor_repo = anchor_repo.strip()
     if resolved_context and not resolved_anchor_repo:
-        resolved_anchor_repo = _launchplane_context_anchor_repo(context_name=resolved_context)
+        resolved_anchor_repo = _launchplane_context_anchor_repo_from_store(
+            record_store=record_store,
+            context_name=resolved_context,
+        )
     if resolved_anchor_repo and not resolved_context:
-        resolved_context = launchplane_anchor_repo_context(repo=resolved_anchor_repo)
+        resolved_context = launchplane_anchor_repo_context(
+            record_store=record_store,
+            repo=resolved_anchor_repo,
+        )
 
     if not resolved_context and not resolved_anchor_repo:
         return None
@@ -4072,6 +4089,7 @@ def _render_launchplane_preview_index_page_html(
 def _render_launchplane_preview_policy_page_html(
     payload: dict[str, object],
     *,
+    eligible_contexts: tuple[tuple[str, str], ...] = (),
     nav_links: dict[str, str] | None = None,
 ) -> str:
     context_name = str(payload.get("context", ""))
@@ -4124,7 +4142,7 @@ def _render_launchplane_preview_policy_page_html(
     """
     eligible_context_rows = "".join(
         f"<tr><td>{escape(repo)}</td><td>{escape(context)}</td></tr>"
-        for repo, context in sorted(LAUNCHPLANE_TENANT_ANCHOR_CONTEXTS.items())
+        for repo, context in sorted(eligible_contexts)
     )
     companion_items = "".join(
         f"<li><code>{escape(repo)}</code></li>" for repo in LAUNCHPLANE_ALLOWED_COMPANION_REPOS
@@ -12155,7 +12173,9 @@ def _ingest_launchplane_github_webhook_payload(
     deliver_feedback: bool,
 ) -> dict[str, object]:
     control_plane_root = _control_plane_root()
+    record_store = _store(state_dir)
     signature_verification = _verify_launchplane_github_webhook_signature(
+        record_store=record_store,
         control_plane_root=control_plane_root,
         event_name=event_name,
         webhook_payload=webhook_payload,
@@ -12217,6 +12237,7 @@ def _load_github_webhook_replay_envelope(
 
 def _verify_launchplane_github_webhook_signature(
     *,
+    record_store: FilesystemRecordStore,
     control_plane_root: Path,
     event_name: str,
     webhook_payload: dict[str, object],
@@ -12232,6 +12253,7 @@ def _verify_launchplane_github_webhook_signature(
         }
 
     context_name = _resolve_launchplane_github_webhook_context(
+        record_store=record_store,
         event_name=event_name,
         webhook_payload=webhook_payload,
     )
@@ -12260,7 +12282,7 @@ def _verify_launchplane_github_webhook_signature(
 
 
 def _resolve_launchplane_github_webhook_context(
-    *, event_name: str, webhook_payload: dict[str, object]
+    *, record_store: FilesystemRecordStore, event_name: str, webhook_payload: dict[str, object]
 ) -> str:
     if event_name.strip() != "pull_request":
         return ""
@@ -12270,7 +12292,7 @@ def _resolve_launchplane_github_webhook_context(
     repo_name = repository_payload.get("name")
     if not isinstance(repo_name, str) or not repo_name.strip():
         return ""
-    return launchplane_anchor_repo_context(repo=repo_name)
+    return launchplane_anchor_repo_context(record_store=record_store, repo=repo_name)
 
 
 @launchplane_previews.command("list")
@@ -12351,11 +12373,15 @@ def launchplane_previews_render_policy_page(
     context_name: str,
     output_file: Path | None,
 ) -> None:
+    record_store = _store(state_dir)
     payload = build_preview_inventory_payload(
-        record_store=_store(state_dir),
+        record_store=record_store,
         context_name=context_name,
     )
-    html_output = _render_launchplane_preview_policy_page_html(payload)
+    html_output = _render_launchplane_preview_policy_page_html(
+        payload,
+        eligible_contexts=_launchplane_preview_profile_rows(record_store),
+    )
     if output_file is not None:
         output_file.write_text(html_output, encoding="utf-8")
         return
@@ -13679,6 +13705,12 @@ def product_profiles_audit_context_cutover(
 )
 @click.option("--preview-enabled/--preview-disabled", default=False, show_default=True)
 @click.option("--preview-context", default="", help="Preview context when previews are enabled.")
+@click.option(
+    "--preview-enable-label",
+    default=LAUNCHPLANE_PREVIEW_ENABLE_LABEL,
+    show_default=True,
+    help="Pull request label that opts this product into Launchplane previews.",
+)
 @click.option("--preview-slug-template", default="pr-{number}", show_default=True)
 @click.option("--updated-at", default="", help="Override updated timestamp.")
 @click.option("--source-label", default="cli:product-profiles:upsert", show_default=True)
@@ -13694,6 +13726,7 @@ def product_profiles_upsert(
     lanes_json: str,
     preview_enabled: bool,
     preview_context: str,
+    preview_enable_label: str,
     preview_slug_template: str,
     updated_at: str,
     source_label: str,
@@ -13711,6 +13744,7 @@ def product_profiles_upsert(
             preview=ProductPreviewProfile(
                 enabled=preview_enabled,
                 context=preview_context,
+                enable_label=preview_enable_label,
                 slug_template=preview_slug_template,
             ),
             updated_at=updated_at.strip() or utc_now_timestamp(),

--- a/control_plane/contracts/product_onboarding_manifest.py
+++ b/control_plane/contracts/product_onboarding_manifest.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane.contracts.dokploy_target_record import DokployTargetType
 from control_plane.contracts.product_profile_record import (
+    PRODUCT_PREVIEW_DEFAULT_ENABLE_LABEL,
     ProductExpectedConfigProfile,
     ProductPreviewProfile,
     ProductPromotionWorkflowProfile,
@@ -34,6 +35,7 @@ class ProductOnboardingPreviewManifest(BaseModel):
 
     enabled: bool = False
     context: str = ""
+    enable_label: str = PRODUCT_PREVIEW_DEFAULT_ENABLE_LABEL
     slug_template: str = "pr-{number}"
     app_name_prefix: str = ""
     template_instance: str = "testing"

--- a/control_plane/contracts/product_profile_record.py
+++ b/control_plane/contracts/product_profile_record.py
@@ -3,6 +3,9 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
+PRODUCT_PREVIEW_DEFAULT_ENABLE_LABEL = "launchplane-preview"
+
+
 class ProductImageProfile(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -37,6 +40,7 @@ class ProductPreviewProfile(BaseModel):
 
     enabled: bool = False
     context: str = ""
+    enable_label: str = PRODUCT_PREVIEW_DEFAULT_ENABLE_LABEL
     slug_template: str = "pr-{number}"
     app_name_prefix: str = ""
     template_instance: str = "testing"
@@ -55,6 +59,10 @@ class ProductPreviewProfile(BaseModel):
     def _validate_preview(self) -> "ProductPreviewProfile":
         if self.enabled and not self.context.strip():
             raise ValueError("enabled product preview profile requires context")
+        enable_label = self.enable_label.strip() or PRODUCT_PREVIEW_DEFAULT_ENABLE_LABEL
+        if self.enabled and not enable_label:
+            raise ValueError("enabled product preview profile requires enable_label")
+        self.enable_label = enable_label
         if self.enabled and "{number}" not in self.slug_template:
             raise ValueError("enabled product preview profile slug_template requires {number}")
         if self.enabled and not self.template_instance.strip():

--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -30,6 +30,7 @@ from control_plane.contracts.every_code_work_request import (
     apply_every_code_work_request_status,
     resume_every_code_work_request,
 )
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.workflows.launchplane import (
     github_pull_request_reference,
     launchplane_anchor_repo_preview_label,
@@ -96,6 +97,12 @@ class EveryCodeWorkerStore(Protocol):
     def write_every_code_preview_gate_record(
         self, record: EveryCodePreviewGateRecord
     ) -> object: ...
+
+    def list_product_profile_records(
+        self,
+        *,
+        driver_id: str = "",
+    ) -> tuple[LaunchplaneProductProfileRecord, ...]: ...
 
 
 Runner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
@@ -298,6 +305,21 @@ class EveryCodeWorkerApiStore:
             idempotency_key=f"every-code-preview-gate-{record.gate_id}-{record.updated_at}",
         )
         return payload
+
+    def list_product_profile_records(
+        self,
+        *,
+        driver_id: str = "",
+    ) -> tuple[LaunchplaneProductProfileRecord, ...]:
+        query: dict[str, object] = {}
+        if driver_id.strip():
+            query["driver_id"] = driver_id.strip()
+        suffix = f"?{urlencode(query)}" if query else ""
+        payload = self._request("GET", f"/v1/product-profiles{suffix}")
+        profiles = payload.get("profiles", [])
+        if not isinstance(profiles, list):
+            raise EveryCodeWorkerApiError("Launchplane product profile list response is invalid")
+        return tuple(LaunchplaneProductProfileRecord.model_validate(item) for item in profiles)
 
     def _request(
         self,
@@ -1865,6 +1887,7 @@ def request_ready_every_code_pr_preview_labels(
         if gate_reset:
             reset += 1
         readiness = every_code_pr_preview_readiness_from_payload(
+            record_store=record_store,
             repository=record.repository,
             payload=payload,
         )
@@ -1884,6 +1907,7 @@ def request_ready_every_code_pr_preview_labels(
             )
             record_store.write_every_code_preview_gate_record(ready_gate)
             summary = request_every_code_pr_preview_label(
+                record_store=record_store,
                 result_pr_url=result_pr_url,
                 runner=run,
             )
@@ -1982,7 +2006,10 @@ def request_ready_every_code_pr_preview_labels(
         else:
             if readiness == "skipped" and _github_pr_payload_has_label(
                 payload,
-                launchplane_anchor_repo_preview_label(repo=reference["repo"]),
+                launchplane_anchor_repo_preview_label(
+                    record_store=record_store,
+                    repo=reference["repo"],
+                ),
             ):
                 reviewer_backfilled += _backfill_every_code_preview_reviewer(
                     record=record,
@@ -2422,13 +2449,17 @@ def route_every_code_pr_check_failures(
 
 def every_code_pr_preview_readiness(
     *,
+    record_store: EveryCodeWorkerStore,
     result_pr_url: str,
     runner: Runner | None = None,
 ) -> Literal["ready", "pending", "blocked", "skipped", "cancelled"]:
     reference = github_pull_request_reference(pr_url=result_pr_url.strip())
     if reference is None:
         return "skipped"
-    preview_label = launchplane_anchor_repo_preview_label(repo=reference["repo"])
+    preview_label = launchplane_anchor_repo_preview_label(
+        record_store=record_store,
+        repo=reference["repo"],
+    )
     if not preview_label:
         return "skipped"
     payload = _github_pr_view_payload(
@@ -2440,6 +2471,7 @@ def every_code_pr_preview_readiness(
     if payload is None:
         return "blocked"
     return every_code_pr_preview_readiness_from_payload(
+        record_store=record_store,
         repository=f"{reference['owner']}/{reference['repo']}",
         payload=payload,
     )
@@ -2447,11 +2479,15 @@ def every_code_pr_preview_readiness(
 
 def every_code_pr_preview_readiness_from_payload(
     *,
+    record_store: EveryCodeWorkerStore,
     repository: str,
     payload: dict[str, object],
 ) -> Literal["ready", "pending", "blocked", "skipped", "cancelled"]:
     reference_repo = repository.strip().split("/", 1)[-1]
-    preview_label = launchplane_anchor_repo_preview_label(repo=reference_repo)
+    preview_label = launchplane_anchor_repo_preview_label(
+        record_store=record_store,
+        repo=reference_repo,
+    )
     if not preview_label:
         return "skipped"
     if str(payload.get("state") or "").upper() != "OPEN":
@@ -2847,13 +2883,17 @@ def _github_pr_payload_has_label(payload: dict[str, object], label_name: str) ->
 
 def request_every_code_pr_preview_label(
     *,
+    record_store: EveryCodeWorkerStore,
     result_pr_url: str,
     runner: Runner | None = None,
 ) -> str:
     reference = github_pull_request_reference(pr_url=result_pr_url.strip())
     if reference is None:
         return ""
-    preview_label = launchplane_anchor_repo_preview_label(repo=reference["repo"])
+    preview_label = launchplane_anchor_repo_preview_label(
+        record_store=record_store,
+        repo=reference["repo"],
+    )
     if not preview_label:
         return ""
     run = runner or _run_subprocess

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2393,7 +2393,10 @@ def _handle_every_code_preview_validation_webhook(
     if not comment_body.strip().lower().startswith("/preview"):
         return None
     every_code_store = _every_code_work_request_store(record_store)
-    context_name = launchplane_anchor_repo_context(repo=repo)
+    context_name = launchplane_anchor_repo_context(
+        record_store=cast(FilesystemRecordStore, record_store),
+        repo=repo,
+    )
     if not context_name:
         context_name = f"{repo}-preview"
     try:

--- a/control_plane/workflows/launchplane.py
+++ b/control_plane/workflows/launchplane.py
@@ -38,25 +38,21 @@ from control_plane.contracts.preview_request_metadata import (
     LaunchplanePreviewRequestParseResult,
 )
 from control_plane.contracts.preview_record import PreviewRecord, PreviewState
+from control_plane.contracts.product_profile_record import (
+    PRODUCT_PREVIEW_DEFAULT_ENABLE_LABEL,
+    LaunchplaneProductProfileRecord,
+)
 from control_plane.contracts.promotion_record import ReleaseStatus
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.ship import utc_now_timestamp
 
 RECENT_GENERATION_LIMIT = 3
 LAUNCHPLANE_PREVIEW_BASE_URL_ENV_KEYS = ("LAUNCHPLANE_PREVIEW_BASE_URL",)
-LAUNCHPLANE_PREVIEW_ENABLE_LABEL = "launchplane-preview"
+LAUNCHPLANE_PREVIEW_ENABLE_LABEL = PRODUCT_PREVIEW_DEFAULT_ENABLE_LABEL
 LAUNCHPLANE_GITHUB_TOKEN_ENV_KEY = "GITHUB_TOKEN"
 LAUNCHPLANE_GITHUB_WEBHOOK_SECRET_ENV_KEY = "GITHUB_WEBHOOK_SECRET"
 DEFAULT_LAUNCHPLANE_BASELINE_CHANNEL = "testing"
 LaunchplanePullRequestAction = str
-LAUNCHPLANE_TENANT_ANCHOR_CONTEXTS: dict[str, str] = {
-    "sellyouroutboard": "sellyouroutboard-testing",
-    "tenant-cm": "cm",
-    "tenant-opw": "opw",
-}
-LAUNCHPLANE_TENANT_ANCHOR_PREVIEW_LABELS: dict[str, str] = {
-    "sellyouroutboard": "preview",
-}
 LAUNCHPLANE_PREVIEW_REQUEST_BLOCK_PATTERN = re.compile(
     rf"```{re.escape(LAUNCHPLANE_PREVIEW_REQUEST_BLOCK_INFO_STRING)}[ \t]*\r?\n(?P<body>.*?)\r?\n```",
     flags=re.IGNORECASE | re.DOTALL,
@@ -80,6 +76,13 @@ class PreviewMutationRecordStore(Protocol):
     def list_preview_generation_records(
         self, *, preview_id: str = "", limit: int | None = None
     ) -> tuple[PreviewGenerationRecord, ...]: ...
+
+class ProductProfileListStore(Protocol):
+    def list_product_profile_records(
+        self,
+        *,
+        driver_id: str = "",
+    ) -> tuple[LaunchplaneProductProfileRecord, ...]: ...
 
 
 class GitHubPullRequestReference(TypedDict):
@@ -110,19 +113,42 @@ def launchplane_preview_label_enabled(*, label_names: tuple[str, ...]) -> bool:
     return LAUNCHPLANE_PREVIEW_ENABLE_LABEL in {label_name.strip() for label_name in label_names}
 
 
-def launchplane_anchor_repo_context(*, repo: str) -> str:
-    return LAUNCHPLANE_TENANT_ANCHOR_CONTEXTS.get(repo.strip(), "")
-
-
-def launchplane_anchor_repo_eligible(*, repo: str) -> bool:
-    return bool(launchplane_anchor_repo_context(repo=repo))
-
-
-def launchplane_anchor_repo_preview_label(*, repo: str) -> str:
+def launchplane_anchor_repo_profile(
+    *, record_store: ProductProfileListStore, repo: str
+) -> LaunchplaneProductProfileRecord | None:
     repo_name = repo.strip()
-    if not launchplane_anchor_repo_eligible(repo=repo_name):
+    if not repo_name:
+        return None
+    for profile in record_store.list_product_profile_records():
+        if not profile.preview.enabled or not profile.preview.context.strip():
+            continue
+        repository = profile.repository.strip()
+        anchor_repo = repository.rsplit("/", maxsplit=1)[-1]
+        if repo_name in {repository, anchor_repo}:
+            return profile
+    return None
+
+
+def launchplane_anchor_repo_context(
+    *, record_store: ProductProfileListStore, repo: str
+) -> str:
+    profile = launchplane_anchor_repo_profile(record_store=record_store, repo=repo)
+    return profile.preview.context if profile is not None else ""
+
+
+def launchplane_anchor_repo_eligible(
+    *, record_store: ProductProfileListStore, repo: str
+) -> bool:
+    return bool(launchplane_anchor_repo_context(record_store=record_store, repo=repo))
+
+
+def launchplane_anchor_repo_preview_label(
+    *, record_store: ProductProfileListStore, repo: str
+) -> str:
+    profile = launchplane_anchor_repo_profile(record_store=record_store, repo=repo)
+    if profile is None:
         return ""
-    return LAUNCHPLANE_TENANT_ANCHOR_PREVIEW_LABELS.get(repo_name, LAUNCHPLANE_PREVIEW_ENABLE_LABEL)
+    return profile.preview.enable_label
 
 
 def classify_pull_request_event_for_launchplane(
@@ -985,7 +1011,7 @@ def resolve_pull_request_event_decision(
     record_store: FilesystemRecordStore,
     event: GitHubPullRequestEvent,
 ) -> tuple[LaunchplanePullRequestAction, str, PreviewRecord | None]:
-    resolved_context = launchplane_anchor_repo_context(repo=event.repo)
+    resolved_context = launchplane_anchor_repo_context(record_store=record_store, repo=event.repo)
     preview = find_preview_record(
         record_store=record_store,
         context_name="",

--- a/docs/records.md
+++ b/docs/records.md
@@ -133,10 +133,11 @@ JSONB until they graduate into normal product behavior.
 Product profile records are DB-backed Launchplane configuration for product
 identity and driver selection. They hold product key, display name, owning repo,
 driver id, image repository, runtime port, health path, stable lane bindings,
-and preview context policy. Generic-web preview policy can also name the source
-template lane, required template env keys, copied or omitted settings, preview
-URL/domain env keys, required provider fields, and the declared data transport
-mode so readiness can fail before Launchplane mutates a provider.
+preview context policy, and the pull-request label that enables previews for the
+product. Generic-web preview policy can also name the source template lane,
+required template env keys, copied or omitted settings, preview URL/domain env
+keys, required provider fields, and the declared data transport mode so
+readiness can fail before Launchplane mutates a provider.
 
 Product profiles may also declare expected config requirements for stable lanes:
 runtime-environment key names and managed secret binding keys by context and

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -18,6 +18,9 @@ from control_plane.contracts.every_code_preview_gate_record import EveryCodePrev
 from control_plane.contracts.every_code_preview_gate_record import build_every_code_preview_gate_id
 from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
 from control_plane.contracts.every_code_work_request import requeue_every_code_work_request
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.product_profile_record import ProductImageProfile
+from control_plane.contracts.product_profile_record import ProductPreviewProfile
 from control_plane.every_code_worker import (
     EveryCodeWorkerApiStore,
     apply_every_code_pr_feedback_for_host,
@@ -129,6 +132,42 @@ def _preview_gate_record(
         blocked_at="2026-05-06T20:03:00Z" if status == "blocked" else "",
         cancelled_at="2026-05-06T20:04:00Z" if status == "cancelled" else "",
         last_checked_at="2026-05-06T20:00:00Z",
+    )
+
+
+def _preview_product_profile(
+    *,
+    product: str,
+    repository: str,
+    preview_context: str,
+    enable_label: str = "launchplane-preview",
+) -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord(
+        product=product,
+        display_name=product.title(),
+        repository=repository,
+        driver_id="generic-web",
+        image=ProductImageProfile(repository=f"ghcr.io/{repository}"),
+        runtime_port=3000,
+        health_path="/health",
+        preview=ProductPreviewProfile(
+            enabled=True,
+            context=preview_context,
+            enable_label=enable_label,
+        ),
+        updated_at="2026-05-09T00:00:00Z",
+        source="test",
+    )
+
+
+def _write_sellyouroutboard_preview_profile(store: FilesystemRecordStore) -> None:
+    store.write_product_profile_record(
+        _preview_product_profile(
+            product="sellyouroutboard",
+            repository="cbusillo/sellyouroutboard",
+            preview_context="sellyouroutboard-testing",
+            enable_label="preview",
+        )
     )
 
 
@@ -283,6 +322,19 @@ class _EveryCodeApiHandler(BaseHTTPRequestHandler):
                 {
                     "status": "ok",
                     "feedback": [record.model_dump(mode="json") for record in feedback_records],
+                },
+            )
+            return
+        if self.path.startswith("/v1/product-profiles"):
+            query = parse_qs(urlparse(self.path).query)
+            profile_records = self.store.list_product_profile_records(
+                driver_id=str((query.get("driver_id") or [""])[0])
+            )
+            self._write_json(
+                200,
+                {
+                    "status": "ok",
+                    "profiles": [record.model_dump(mode="json") for record in profile_records],
                 },
             )
             return
@@ -555,6 +607,36 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(gate_records[0].gate_id, _preview_gate_record().gate_id)
         self.assertEqual(listed_after_update[0].status, "blocked")
 
+    def test_api_store_lists_product_profiles_via_service(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            _EveryCodeApiHandler.store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            _EveryCodeApiHandler.store.write_product_profile_record(
+                _preview_product_profile(
+                    product="sellyouroutboard",
+                    repository="cbusillo/sellyouroutboard",
+                    preview_context="sellyouroutboard-testing",
+                    enable_label="preview",
+                )
+            )
+            server = ThreadingHTTPServer(("127.0.0.1", 0), _EveryCodeApiHandler)
+            server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+            server_thread.start()
+            try:
+                store = EveryCodeWorkerApiStore(
+                    service_url=f"http://127.0.0.1:{server.server_port}",
+                    worker_token="worker-token",
+                )
+
+                profiles = store.list_product_profile_records(driver_id="generic-web")
+            finally:
+                server.shutdown()
+                server.server_close()
+
+        self.assertEqual(len(profiles), 1)
+        self.assertEqual(profiles[0].repository, "cbusillo/sellyouroutboard")
+        self.assertEqual(profiles[0].preview.enable_label, "preview")
+
     def test_api_store_reruns_terminal_request_via_service(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             temporary_root = Path(temporary_directory_name)
@@ -669,12 +751,22 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertIn("EVERY_CODE_ISSUE_URL=https://github.com/cbusillo/code/issues/123", command)
 
     def test_preview_label_request_labels_eligible_pull_request(self) -> None:
-        runner = _Runner()
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_product_profile_record(
+                _preview_product_profile(
+                    product="tenant-opw",
+                    repository="every/tenant-opw",
+                    preview_context="opw",
+                )
+            )
+            runner = _Runner()
 
-        summary = request_every_code_pr_preview_label(
-            result_pr_url="https://github.com/every/tenant-opw/pull/123",
-            runner=runner,
-        )
+            summary = request_every_code_pr_preview_label(
+                record_store=store,
+                result_pr_url="https://github.com/every/tenant-opw/pull/123",
+                runner=runner,
+            )
 
         self.assertIn("Requested Launchplane preview", summary)
         self.assertIn(
@@ -692,12 +784,23 @@ class EveryCodeWorkerTests(unittest.TestCase):
         )
 
     def test_preview_label_request_labels_sellyouroutboard_pull_request(self) -> None:
-        runner = _Runner()
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_product_profile_record(
+                _preview_product_profile(
+                    product="sellyouroutboard",
+                    repository="cbusillo/sellyouroutboard",
+                    preview_context="sellyouroutboard-testing",
+                    enable_label="preview",
+                )
+            )
+            runner = _Runner()
 
-        summary = request_every_code_pr_preview_label(
-            result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/71",
-            runner=runner,
-        )
+            summary = request_every_code_pr_preview_label(
+                record_store=store,
+                result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/71",
+                runner=runner,
+            )
 
         self.assertIn("Requested Launchplane preview", summary)
         self.assertIn(
@@ -715,12 +818,15 @@ class EveryCodeWorkerTests(unittest.TestCase):
         )
 
     def test_preview_label_request_skips_ineligible_pull_request(self) -> None:
-        runner = _Runner()
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            runner = _Runner()
 
-        summary = request_every_code_pr_preview_label(
-            result_pr_url="https://github.com/cbusillo/code/pull/123",
-            runner=runner,
-        )
+            summary = request_every_code_pr_preview_label(
+                record_store=store,
+                result_pr_url="https://github.com/cbusillo/code/pull/123",
+                runner=runner,
+            )
 
         self.assertEqual(summary, "")
         self.assertEqual(runner.calls, [])
@@ -728,6 +834,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
     def test_preview_gate_labels_done_pull_request_after_checks_pass(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            _write_sellyouroutboard_preview_profile(store)
             store.write_every_code_work_request_record(
                 _done_record(
                     repository="cbusillo/sellyouroutboard",
@@ -776,6 +883,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
     def test_preview_gate_waits_for_incomplete_checks(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            _write_sellyouroutboard_preview_profile(store)
             store.write_every_code_work_request_record(
                 _done_record(
                     repository="cbusillo/sellyouroutboard",
@@ -807,6 +915,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
     def test_preview_gate_blocks_stale_pending_checks_after_timeout(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            _write_sellyouroutboard_preview_profile(store)
             store.write_every_code_work_request_record(
                 _done_record(
                     repository="cbusillo/sellyouroutboard",
@@ -841,6 +950,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
     def test_preview_gate_blocks_failed_checks(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            _write_sellyouroutboard_preview_profile(store)
             store.write_every_code_work_request_record(
                 _done_record(
                     repository="cbusillo/sellyouroutboard",
@@ -872,6 +982,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
     def test_preview_gate_resets_when_pull_request_head_changes(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            _write_sellyouroutboard_preview_profile(store)
             store.write_every_code_work_request_record(
                 _done_record(
                     repository="cbusillo/sellyouroutboard",
@@ -909,6 +1020,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
     def test_preview_gate_cancels_closed_pull_request(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            _write_sellyouroutboard_preview_profile(store)
             store.write_every_code_work_request_record(
                 _done_record(
                     repository="cbusillo/sellyouroutboard",
@@ -937,6 +1049,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
     def test_preview_gate_cancels_when_source_issue_closed(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            _write_sellyouroutboard_preview_profile(store)
             store.write_every_code_work_request_record(
                 _done_record(
                     repository="cbusillo/sellyouroutboard",
@@ -969,6 +1082,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
     def test_preview_gate_skips_pull_request_with_preview_label(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            _write_sellyouroutboard_preview_profile(store)
             store.write_every_code_work_request_record(
                 _done_record(
                     repository="cbusillo/sellyouroutboard",
@@ -994,6 +1108,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
     def test_preview_gate_backfills_reviewer_for_existing_preview_label(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            _write_sellyouroutboard_preview_profile(store)
             store.write_every_code_work_request_record(
                 _done_record(
                     repository="cbusillo/sellyouroutboard",
@@ -1037,6 +1152,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
     def test_preview_gate_skips_reviewer_backfill_when_already_requested(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            _write_sellyouroutboard_preview_profile(store)
             store.write_every_code_work_request_record(
                 _done_record(
                     repository="cbusillo/sellyouroutboard",
@@ -1081,6 +1197,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
     def test_preview_gate_skips_reviewer_backfill_for_pr_author(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            _write_sellyouroutboard_preview_profile(store)
             store.write_every_code_work_request_record(
                 _done_record(
                     repository="cbusillo/sellyouroutboard",
@@ -1122,6 +1239,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
     def test_preview_gate_discovers_running_request_pull_request_by_branch(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            _write_sellyouroutboard_preview_profile(store)
             running_record = _queued_record().model_copy(
                 update={
                     "state": "running",

--- a/tests/test_launchplane_previews.py
+++ b/tests/test_launchplane_previews.py
@@ -23,6 +23,9 @@ from control_plane.contracts.preview_generation_record import (
     PreviewSourceRecord,
 )
 from control_plane.contracts.preview_record import PreviewRecord, PreviewState
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.product_profile_record import ProductImageProfile
+from control_plane.contracts.product_profile_record import ProductPreviewProfile
 from control_plane.contracts.preview_request_metadata import (
     LaunchplaneCompanionPullRequestReference,
     LaunchplanePreviewRequestParseStatus,
@@ -104,6 +107,56 @@ def _preview_record(
         latest_generation_id=latest_generation_id,
         latest_manifest_fingerprint=latest_manifest_fingerprint,
     )
+
+
+def _preview_product_profile(
+    *,
+    product: str,
+    repository: str,
+    preview_context: str,
+    enable_label: str = "launchplane-preview",
+) -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord(
+        product=product,
+        display_name=product.title(),
+        repository=repository,
+        driver_id="generic-web",
+        image=ProductImageProfile(repository=f"ghcr.io/{repository}"),
+        runtime_port=3000,
+        health_path="/health",
+        preview=ProductPreviewProfile(
+            enabled=True,
+            context=preview_context,
+            enable_label=enable_label,
+        ),
+        updated_at="2026-05-09T00:00:00Z",
+        source="test",
+    )
+
+
+def _write_opw_preview_product_profile(store: FilesystemRecordStore) -> None:
+    store.write_product_profile_record(
+        _preview_product_profile(
+            product="tenant-opw",
+            repository="every/tenant-opw",
+            preview_context="opw",
+        )
+    )
+
+
+def _write_cm_preview_product_profile(store: FilesystemRecordStore) -> None:
+    store.write_product_profile_record(
+        _preview_product_profile(
+            product="tenant-cm",
+            repository="every/tenant-cm",
+            preview_context="cm",
+        )
+    )
+
+
+def _write_default_preview_product_profiles(store: FilesystemRecordStore) -> None:
+    _write_opw_preview_product_profile(store)
+    _write_cm_preview_product_profile(store)
 
 
 def _generation_record(
@@ -302,6 +355,9 @@ def _promotion_record(
 
 
 def _write_release_tuples_file(control_plane_root: Path) -> None:
+    _write_default_preview_product_profiles(
+        FilesystemRecordStore(state_dir=control_plane_root / "state")
+    )
     database_url = _runtime_environments_database_url(control_plane_root)
     store = PostgresRecordStore(database_url=database_url)
     store.ensure_schema()
@@ -702,12 +758,33 @@ ODOO_DB_PASSWORD = "local-secret"
         self.assertFalse(launchplane_preview_label_enabled(label_names=("bug", "needs-review")))
 
     def test_launchplane_anchor_repo_resolution_accepts_tenant_repos_only(self) -> None:
-        self.assertEqual(launchplane_anchor_repo_context(repo="tenant-opw"), "opw")
-        self.assertEqual(launchplane_anchor_repo_context(repo="tenant-cm"), "cm")
-        self.assertTrue(launchplane_anchor_repo_eligible(repo="tenant-opw"))
-        self.assertTrue(launchplane_anchor_repo_eligible(repo="tenant-cm"))
-        self.assertFalse(launchplane_anchor_repo_eligible(repo="shared-addons"))
-        self.assertFalse(launchplane_anchor_repo_eligible(repo="control-plane"))
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_product_profile_record(
+                _preview_product_profile(
+                    product="tenant-opw",
+                    repository="every/tenant-opw",
+                    preview_context="opw",
+                )
+            )
+            store.write_product_profile_record(
+                _preview_product_profile(
+                    product="tenant-cm",
+                    repository="every/tenant-cm",
+                    preview_context="cm",
+                )
+            )
+
+            self.assertEqual(
+                launchplane_anchor_repo_context(record_store=store, repo="tenant-opw"), "opw"
+            )
+            self.assertEqual(
+                launchplane_anchor_repo_context(record_store=store, repo="tenant-cm"), "cm"
+            )
+            self.assertTrue(launchplane_anchor_repo_eligible(record_store=store, repo="tenant-opw"))
+            self.assertTrue(launchplane_anchor_repo_eligible(record_store=store, repo="tenant-cm"))
+            self.assertFalse(launchplane_anchor_repo_eligible(record_store=store, repo="shared-addons"))
+            self.assertFalse(launchplane_anchor_repo_eligible(record_store=store, repo="control-plane"))
 
     def test_classify_pull_request_event_for_launchplane_enables_preview_when_label_added(
         self,
@@ -1063,6 +1140,7 @@ ODOO_DB_PASSWORD = "local-secret"
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
             store = FilesystemRecordStore(state_dir=state_dir)
+            _write_opw_preview_product_profile(store)
             store.write_environment_inventory(
                 _environment_inventory(
                     instance="testing",
@@ -1229,6 +1307,7 @@ ODOO_DB_PASSWORD = "local-secret"
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
+            _write_opw_preview_product_profile(FilesystemRecordStore(state_dir=state_dir))
             input_file = Path(temporary_directory_name) / "pr-event.json"
             input_file.write_text(
                 json.dumps(
@@ -1321,6 +1400,7 @@ ODOO_DB_PASSWORD = "local-secret"
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
+            _write_opw_preview_product_profile(FilesystemRecordStore(state_dir=state_dir))
             input_file = Path(temporary_directory_name) / "pr-event.json"
             input_file.write_text(
                 json.dumps(
@@ -1994,6 +2074,7 @@ ODOO_DB_PASSWORD = "local-secret"
             state_dir = Path(temporary_directory_name) / "state"
             output_file = Path(temporary_directory_name) / "launchplane-policy.html"
             store = FilesystemRecordStore(state_dir=state_dir)
+            _write_default_preview_product_profiles(store)
             store.write_preview_record(
                 _preview_record(
                     preview_id="hpr_live",
@@ -2046,6 +2127,7 @@ ODOO_DB_PASSWORD = "local-secret"
             state_dir = Path(temporary_directory_name) / "state"
             output_file = Path(temporary_directory_name) / "launchplane-policy-all.html"
             store = FilesystemRecordStore(state_dir=state_dir)
+            _write_default_preview_product_profiles(store)
             store.write_preview_record(
                 _preview_record(
                     preview_id="hpr_opw",
@@ -3707,6 +3789,8 @@ ENV_OVERRIDE_DISABLE_CRON = true
             control_plane_root = Path(temporary_directory_name)
             _write_release_tuples_file(control_plane_root)
             state_dir = control_plane_root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            _write_opw_preview_product_profile(store)
             input_file = control_plane_root / "pr-event.json"
             input_file.write_text(
                 json.dumps(
@@ -3788,6 +3872,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
             _write_runtime_environments_file(control_plane_root)
             state_dir = control_plane_root / "state"
             store = FilesystemRecordStore(state_dir=state_dir)
+            _write_opw_preview_product_profile(store)
             store.write_preview_record(_preview_record(preview_id="hpr_01jabc", state="active"))
             store.write_preview_generation_record(
                 _generation_record(
@@ -3866,6 +3951,8 @@ ENV_OVERRIDE_DISABLE_CRON = true
             control_plane_root = Path(temporary_directory_name)
             _write_release_tuples_file(control_plane_root)
             state_dir = control_plane_root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            _write_opw_preview_product_profile(store)
             input_file = control_plane_root / "pr-event.json"
             input_file.write_text(
                 json.dumps(
@@ -3922,6 +4009,8 @@ ENV_OVERRIDE_DISABLE_CRON = true
             control_plane_root = Path(temporary_directory_name)
             _write_release_tuples_file(control_plane_root)
             state_dir = control_plane_root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            _write_opw_preview_product_profile(store)
             input_file = control_plane_root / "pr-event.json"
             input_file.write_text(
                 json.dumps(
@@ -4127,6 +4216,8 @@ ENV_OVERRIDE_DISABLE_CRON = true
             _write_release_tuples_file(control_plane_root)
             _write_runtime_environments_file(control_plane_root)
             state_dir = control_plane_root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            _write_opw_preview_product_profile(store)
             input_file = control_plane_root / "pr-event.json"
             input_file.write_text(
                 json.dumps(
@@ -4202,6 +4293,8 @@ ENV_OVERRIDE_DISABLE_CRON = true
             _write_release_tuples_file(control_plane_root)
             _write_runtime_environments_file(control_plane_root)
             state_dir = control_plane_root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            _write_opw_preview_product_profile(store)
             input_file = control_plane_root / "pr-event.json"
             input_file.write_text(
                 json.dumps(
@@ -4685,6 +4778,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
             control_plane_root = Path(temporary_directory_name)
             _write_release_tuples_file(control_plane_root)
             _write_runtime_environments_file(control_plane_root)
+            state_dir = control_plane_root / "state"
             input_file = control_plane_root / "github-webhook.json"
             webhook_payload = _github_pull_request_webhook_payload()
             input_file.write_text(json.dumps(webhook_payload), encoding="utf-8")
@@ -4695,6 +4789,8 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "ingest-github-webhook",
+                        "--state-dir",
+                        str(state_dir),
                         "--input-file",
                         str(input_file),
                         "--signature-256",

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1206,6 +1206,8 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     "--preview-enabled",
                     "--preview-context",
                     "sellyouroutboard-testing",
+                    "--preview-enable-label",
+                    "preview",
                     "--updated-at",
                     "2026-04-30T22:00:00Z",
                     "--source-label",
@@ -1242,6 +1244,8 @@ class PostgresRecordStoreTests(unittest.TestCase):
         self.assertIn('"product": "sellyouroutboard"', list_result.output)
         self.assertEqual(show_result.exit_code, 0, show_result.output)
         self.assertIn('"preview_context": "sellyouroutboard-testing"', list_result.output)
+        self.assertIn('"preview_enable_label": "preview"', list_result.output)
+        self.assertIn('"enable_label": "preview"', show_result.output)
         self.assertIn('"health_path": "/api/health"', show_result.output)
 
     def test_preview_lifecycle_plan_records_round_trip(self) -> None:

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -40,6 +40,7 @@ def _manifest_payload() -> dict[str, object]:
         "preview": {
             "enabled": True,
             "context": "example-site-preview",
+            "enable_label": "preview-requested",
             "slug_template": "pr-{number}",
         },
         "dokploy_targets": [
@@ -127,6 +128,7 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertEqual(profile.driver_id, "generic-web")
         self.assertEqual(profile.lanes[0].health_url, "https://testing.example.invalid/api/health")
         self.assertEqual(profile.lanes[1].health_url, "https://example.invalid/status")
+        self.assertEqual(profile.preview.enable_label, "preview-requested")
         self.assertEqual(profile.expected_config.runtime_environment_keys[0].key, "PUBLIC_BASE_URL")
         self.assertEqual(
             profile.expected_config.managed_secret_bindings[0].binding_key,


### PR DESCRIPTION
## Summary

- Removes hard-coded Launchplane preview repo/context alias maps from generic preview workflow code.
- Resolves preview anchor context and opt-in label from product profile records, including Every Code preview gate labeling.
- Adds `preview.enable_label` to product profile/onboarding contracts and CLI upsert, with docs and tests.

Refs #476

## Validation

- `uv run --extra dev ruff check control_plane/cli.py control_plane/contracts/product_onboarding_manifest.py control_plane/contracts/product_profile_record.py control_plane/every_code_worker.py control_plane/service.py control_plane/workflows/launchplane.py tests/test_every_code_worker.py tests/test_launchplane_previews.py tests/test_postgres_store.py tests/test_product_onboarding.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`

## Follow-up

- #477 still tracks moving the Every Code webhook URL default out of production code.
