### PR TITLE
Require Every Code webhook URL config

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -211,6 +211,7 @@ _RUNTIME_CONTRACT_ENV_KEYS = (
 )
 _DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
 _EVERY_CODE_WORKER_TOKEN_ENV_KEY = "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN"
+_EVERY_CODE_WEBHOOK_URL_ENV_KEY = "LAUNCHPLANE_EVERY_CODE_WEBHOOK_URL"
 _MERGE_TRAIN_GITHUB_TOKEN_ENV_KEY = "GITHUB_TOKEN"
 _MASTER_ENCRYPTION_KEY_ENV_KEYS = ("LAUNCHPLANE_MASTER_ENCRYPTION_KEY",)
 _LAUNCHPLANE_SERVICE_POLICY_ENV_KEYS = (
@@ -10167,8 +10168,12 @@ def every_code_reconcile_issue(
 @click.option("--topic", default="every-code", show_default=True)
 @click.option(
     "--webhook-url",
-    default=control_plane_every_code_webhooks.EVERY_CODE_WEBHOOK_URL,
-    show_default=True,
+    envvar=_EVERY_CODE_WEBHOOK_URL_ENV_KEY,
+    default="",
+    help=(
+        "Every Code GitHub webhook URL. Can also be supplied via "
+        f"{_EVERY_CODE_WEBHOOK_URL_ENV_KEY}."
+    ),
 )
 @click.option(
     "--webhook-secret-env",
@@ -10186,11 +10191,16 @@ def every_code_sync_webhooks(
     webhook_secret = os.environ.get(secret_env_key, "").strip()
     if not webhook_secret:
         raise click.ClickException(f"{secret_env_key} is required.")
+    resolved_webhook_url = webhook_url.strip()
+    if not resolved_webhook_url:
+        raise click.ClickException(
+            f"--webhook-url or {_EVERY_CODE_WEBHOOK_URL_ENV_KEY} is required."
+        )
     try:
         results = control_plane_every_code_webhooks.sync_every_code_webhooks(
             owner=resolved_owner,
             webhook_secret=webhook_secret,
-            webhook_url=webhook_url,
+            webhook_url=resolved_webhook_url,
             topic=topic,
         )
     except (ValueError, subprocess.CalledProcessError) as error:
@@ -10202,7 +10212,7 @@ def every_code_sync_webhooks(
                 "status": "error" if failed else "ok",
                 "owner": resolved_owner,
                 "topic": topic,
-                "webhook_url": webhook_url,
+                "webhook_url": resolved_webhook_url,
                 "events": list(control_plane_every_code_webhooks.EVERY_CODE_WEBHOOK_EVENTS),
                 "repositories": [result.as_payload() for result in results],
             },

--- a/control_plane/every_code_webhooks.py
+++ b/control_plane/every_code_webhooks.py
@@ -13,7 +13,6 @@ EVERY_CODE_WEBHOOK_EVENTS = (
     "pull_request_review",
     "pull_request_review_comment",
 )
-EVERY_CODE_WEBHOOK_URL = "https://launchplane.shinycomputers.com/v1/every-code/github-webhook"
 
 
 @dataclass(frozen=True)
@@ -86,7 +85,7 @@ def sync_every_code_webhooks(
     *,
     owner: str,
     webhook_secret: str,
-    webhook_url: str = EVERY_CODE_WEBHOOK_URL,
+    webhook_url: str,
     topic: str = "every-code",
     events: tuple[str, ...] = EVERY_CODE_WEBHOOK_EVENTS,
     runner: Runner | None = None,
@@ -97,6 +96,8 @@ def sync_every_code_webhooks(
         raise ValueError("Every Code webhook sync requires owner")
     if not normalized_secret:
         raise ValueError("Every Code webhook sync requires webhook_secret")
+    if not webhook_url.strip():
+        raise ValueError("Every Code webhook sync requires webhook_url")
     run = runner or _run_gh
     repos = _topic_repositories(owner=normalized_owner, topic=topic, runner=run)
     results: list[EveryCodeWebhookSyncResult] = []

--- a/tests/test_every_code_webhooks.py
+++ b/tests/test_every_code_webhooks.py
@@ -3,6 +3,9 @@ import subprocess
 import unittest
 from collections.abc import Sequence
 
+from click.testing import CliRunner
+
+from control_plane.cli import main
 from control_plane.every_code_webhooks import sync_every_code_webhooks
 
 
@@ -53,14 +56,13 @@ class _WebhookRunner:
 
 class EveryCodeWebhookSyncTests(unittest.TestCase):
     def test_sync_updates_existing_hook_and_creates_missing_hook(self) -> None:
+        webhook_url = "https://launchplane.example/v1/every-code/github-webhook"
         runner = _WebhookRunner(
             hooks={
                 "cbusillo/code": [
                     {
                         "id": 12,
-                        "config": {
-                            "url": "https://launchplane.shinycomputers.com/v1/every-code/github-webhook"
-                        },
+                        "config": {"url": webhook_url},
                     }
                 ],
                 "cbusillo/launchplane": [],
@@ -70,6 +72,7 @@ class EveryCodeWebhookSyncTests(unittest.TestCase):
         results = sync_every_code_webhooks(
             owner="cbusillo",
             webhook_secret="secret",
+            webhook_url=webhook_url,
             runner=runner,
         )
 
@@ -94,6 +97,8 @@ class EveryCodeWebhookSyncTests(unittest.TestCase):
         ]
         self.assertEqual(patch_payload["events"], expected_events)
         self.assertEqual(post_payload["events"], expected_events)
+        self.assertEqual(patch_payload["config"]["url"], webhook_url)
+        self.assertEqual(post_payload["config"]["url"], webhook_url)
         self.assertEqual(patch_payload["config"]["secret"], "secret")
         label_edits = [command for command, _input in runner.calls if command[:3] == ("gh", "label", "edit")]
         label_creates = [command for command, _input in runner.calls if command[:3] == ("gh", "label", "create")]
@@ -127,6 +132,25 @@ class EveryCodeWebhookSyncTests(unittest.TestCase):
             ),
             label_creates,
         )
+
+    def test_sync_requires_explicit_webhook_url(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires webhook_url"):
+            sync_every_code_webhooks(
+                owner="cbusillo",
+                webhook_secret="secret",
+                webhook_url="",
+                runner=_WebhookRunner(hooks={}),
+            )
+
+    def test_cli_sync_webhooks_requires_webhook_url_config(self) -> None:
+        result = CliRunner().invoke(
+            main,
+            ["every-code", "sync-webhooks", "--owner", "cbusillo"],
+            env={"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": "secret"},
+        )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("--webhook-url or LAUNCHPLANE_EVERY_CODE_WEBHOOK_URL is required", result.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Removes the hard-coded deployed Every Code webhook URL from production code.
- Requires `every-code sync-webhooks` to receive `--webhook-url` or `LAUNCHPLANE_EVERY_CODE_WEBHOOK_URL`.
- Keeps webhook sync fail-closed when either URL or secret config is missing.

Refs #477

## Validation

- `uv run python -m unittest tests.test_every_code_webhooks`
- `uv run --extra dev ruff check control_plane/cli.py control_plane/every_code_webhooks.py tests/test_every_code_webhooks.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`
