### PR TITLE
Harden merge train GitHub reads

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -130,6 +130,7 @@ from control_plane.merge_train import (
 from control_plane.merge_train_github import (
     GitHubMergeTrainClient,
     GitHubMergeTrainSnapshotReader,
+    MergeTrainGitHubError,
     UrllibMergeTrainGitHubTransport,
 )
 from control_plane.service import serve_launchplane_service
@@ -9545,6 +9546,11 @@ def work_graph_merge_train_run_once(
                 "snapshot": snapshot.model_dump(mode="json"),
                 "dry_run_result": dry_run_result.model_dump(mode="json"),
             }
+    except MergeTrainGitHubError as error:
+        detail = str(error)
+        if error.status_code is not None:
+            detail = f"{detail} (HTTP {error.status_code})"
+        raise click.ClickException(f"GitHub merge train request failed: {detail}") from error
     except (OSError, ValidationError, ValueError) as error:
         raise click.ClickException(str(error)) from error
     click.echo(json.dumps(payload, indent=2, sort_keys=True))

--- a/control_plane/merge_train_github.py
+++ b/control_plane/merge_train_github.py
@@ -230,13 +230,18 @@ class GitHubMergeTrainSnapshotReader:
     ) -> str:
         if author_association.upper() == "OWNER":
             return "repo_owner"
-        payload = _json_object(
-            self.transport.request(
-                method="GET",
-                path=f"/repos/{repository_path}/collaborators/{quote(username, safe='')}/permission",
-            ),
-            "GitHub collaborator permission response",
-        )
+        try:
+            payload = _json_object(
+                self.transport.request(
+                    method="GET",
+                    path=f"/repos/{repository_path}/collaborators/{quote(username, safe='')}/permission",
+                ),
+                "GitHub collaborator permission response",
+            )
+        except MergeTrainGitHubError as error:
+            if error.status_code == 404:
+                return "unknown"
+            raise
         return "repo_admin" if str(payload.get("permission") or "") == "admin" else "unknown"
 
     def _required_checks_status(
@@ -249,16 +254,41 @@ class GitHubMergeTrainSnapshotReader:
             ),
             "GitHub combined status response",
         )
-        check_runs_payload = _json_object(
-            self.transport.request(
-                method="GET",
-                path=f"/repos/{repository_path}/commits/{encoded_head_sha}/check-runs?per_page=100",
-            ),
-            "GitHub check runs response",
+        check_runs_payload = self._list_check_runs(
+            repository_path=repository_path, encoded_head_sha=encoded_head_sha
         )
         return _combine_check_statuses(
             _combined_status_state(status_payload), _check_runs_status(check_runs_payload)
         )
+
+    def _list_check_runs(
+        self, *, repository_path: str, encoded_head_sha: str
+    ) -> dict[str, object]:
+        check_runs: list[object] = []
+        page = 1
+        total_count: int | None = None
+        while True:
+            query = urlencode({"per_page": "100", "page": str(page)})
+            payload = _json_object(
+                self.transport.request(
+                    method="GET",
+                    path=(
+                        f"/repos/{repository_path}/commits/{encoded_head_sha}/check-runs?{query}"
+                    ),
+                ),
+                "GitHub check runs response",
+            )
+            raw_check_runs = payload.get("check_runs")
+            if not isinstance(raw_check_runs, list):
+                raise MergeTrainGitHubError("GitHub check runs response must include check_runs.")
+            raw_total_count = payload.get("total_count")
+            if isinstance(raw_total_count, int):
+                total_count = raw_total_count
+            check_runs.extend(raw_check_runs)
+            if len(raw_check_runs) < 100:
+                break
+            page += 1
+        return {"total_count": total_count if total_count is not None else len(check_runs), "check_runs": check_runs}
 
 
 class MergeTrainGitHubRequest(BaseModel):

--- a/tests/test_merge_train.py
+++ b/tests/test_merge_train.py
@@ -21,6 +21,7 @@ from control_plane.merge_train import (
     build_merge_train_wait_result,
     reread_merge_train_after_branch_update,
 )
+from control_plane.merge_train_github import MergeTrainGitHubError
 
 
 class _FakeLabelClient:
@@ -62,14 +63,21 @@ class _FakeMergeClient:
 
 
 class _FakeSnapshotReader:
-    def __init__(self, snapshot: MergeTrainDryRunSnapshot) -> None:
+    def __init__(
+        self,
+        snapshot: MergeTrainDryRunSnapshot,
+        error: Exception | None = None,
+    ) -> None:
         self.snapshot = snapshot
+        self.error = error
         self.reads: list[tuple[str, str]] = []
 
     def read_merge_train_snapshot(
         self, *, repository: str, base_branch: str
     ) -> MergeTrainDryRunSnapshot:
         self.reads.append((repository, base_branch))
+        if self.error is not None:
+            raise self.error
         return self.snapshot
 
 
@@ -289,6 +297,37 @@ class MergeTrainDryRunTests(unittest.TestCase):
 
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn("Missing GitHub token", result.output)
+
+    def test_cli_merge_train_run_once_reports_github_transport_error(self) -> None:
+        snapshot_reader = _FakeSnapshotReader(
+            MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(),
+            ),
+            error=MergeTrainGitHubError("rate limited", status_code=403),
+        )
+
+        with (
+            patch(
+                "control_plane.cli.UrllibMergeTrainGitHubTransport",
+                return_value=object(),
+            ),
+            patch(
+                "control_plane.cli.GitHubMergeTrainSnapshotReader",
+                return_value=snapshot_reader,
+            ),
+            patch.dict("os.environ", {"GITHUB_TOKEN": "token"}, clear=True),
+        ):
+            result = CliRunner().invoke(
+                main,
+                ["work-graph", "merge-train-run-once"],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("GitHub merge train request failed", result.output)
+        self.assertIn("rate limited", result.output)
+        self.assertIn("HTTP 403", result.output)
 
 
 class MergeTrainBlockIntentTests(unittest.TestCase):

--- a/tests/test_merge_train_github.py
+++ b/tests/test_merge_train_github.py
@@ -145,7 +145,54 @@ class GitHubMergeTrainSnapshotReaderTests(unittest.TestCase):
                 "/repos/cbusillo/sellyouroutboard/pulls/42",
                 "/repos/cbusillo/sellyouroutboard/collaborators/cbusillo/permission",
                 "/repos/cbusillo/sellyouroutboard/commits/head-42/status",
-                "/repos/cbusillo/sellyouroutboard/commits/head-42/check-runs?per_page=100",
+                "/repos/cbusillo/sellyouroutboard/commits/head-42/check-runs?per_page=100&page=1",
+            ],
+        )
+
+    def test_snapshot_reader_downgrades_missing_collaborator_permission_to_unknown(
+        self,
+    ) -> None:
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                [_github_pull_request(15, author_association="CONTRIBUTOR")],
+                _github_pull_request(15, author_association="CONTRIBUTOR"),
+                MergeTrainGitHubError("permission not found", status_code=404),
+                {"state": "success"},
+                {"check_runs": [_check_run("completed", "success")]},
+            )
+        )
+
+        snapshot = GitHubMergeTrainSnapshotReader(transport=transport).read_merge_train_snapshot(
+            repository="cbusillo/sellyouroutboard", base_branch="main"
+        )
+
+        self.assertEqual(snapshot.pull_requests[0].actor_role, "unknown")
+
+    def test_snapshot_reader_paginates_check_runs_before_computing_status(self) -> None:
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                [_github_pull_request(16)],
+                _github_pull_request(16),
+                {"permission": "admin"},
+                {"state": "success"},
+                {
+                    "total_count": 101,
+                    "check_runs": [_check_run("completed", "success") for _ in range(100)],
+                },
+                {"total_count": 101, "check_runs": [_check_run("completed", "failure")]},
+            )
+        )
+
+        snapshot = GitHubMergeTrainSnapshotReader(transport=transport).read_merge_train_snapshot(
+            repository="cbusillo/sellyouroutboard", base_branch="main"
+        )
+
+        self.assertEqual(snapshot.pull_requests[0].required_checks_status, "fail")
+        self.assertEqual(
+            [request.path for request in transport.requests if "check-runs" in request.path],
+            [
+                "/repos/cbusillo/sellyouroutboard/commits/head-16/check-runs?per_page=100&page=1",
+                "/repos/cbusillo/sellyouroutboard/commits/head-16/check-runs?per_page=100&page=2",
             ],
         )
 


### PR DESCRIPTION
## Summary
- tolerate 404 collaborator permission lookups for external contributors by marking actor role unknown
- page GitHub check runs before computing required check status
- report GitHub transport failures cleanly from merge-train-run-once

## Validation
- uv run python -m unittest tests.test_merge_train_github tests.test_merge_train
- uv run --extra dev ruff check --diff control_plane/cli.py control_plane/merge_train_github.py tests/test_merge_train.py tests/test_merge_train_github.py
- uv run --extra dev ruff check control_plane/cli.py control_plane/merge_train_github.py tests/test_merge_train.py tests/test_merge_train_github.py
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest

## Notes
Auto-review also mentioned a retryable service status for upstream GitHub failures, but current main does not have a merge-train service route; this PR addresses the live snapshot reader and CLI findings.