### PR TITLE
Add policy-backed merge train service endpoint

### DIFF
--- a/control_plane/contracts/merge_train_policy.py
+++ b/control_plane/contracts/merge_train_policy.py
@@ -41,6 +41,38 @@ class MergeTrainIdentity(BaseModel):
         return self
 
 
+class MergeTrainServiceAuthz(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    action: str = "merge_train.run_once"
+    product: str = "launchplane"
+    context: str = "launchplane"
+
+    @model_validator(mode="after")
+    def _validate_service_authz(self) -> "MergeTrainServiceAuthz":
+        self.action = _normalize_required_value(
+            self.action, "merge train service authz requires action"
+        )
+        self.product = _normalize_required_value(
+            self.product, "merge train service authz requires product"
+        )
+        self.context = _normalize_required_value(
+            self.context, "merge train service authz requires context"
+        )
+        return self
+
+
+class MergeTrainGitHubTokenSource(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    env_var: str = ""
+
+    @model_validator(mode="after")
+    def _validate_token_source(self) -> "MergeTrainGitHubTokenSource":
+        self.env_var = self.env_var.strip()
+        return self
+
+
 class MergeTrainRepositoryPolicy(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -52,6 +84,10 @@ class MergeTrainRepositoryPolicy(BaseModel):
     failure_policy: MergeTrainFailurePolicy
     enqueue: MergeTrainEnqueuePolicy
     merge_identity: MergeTrainIdentity
+    service_authz: MergeTrainServiceAuthz = Field(default_factory=MergeTrainServiceAuthz)
+    github_token: MergeTrainGitHubTokenSource = Field(
+        default_factory=MergeTrainGitHubTokenSource
+    )
 
     @model_validator(mode="after")
     def _validate_repository_policy(self) -> "MergeTrainRepositoryPolicy":
@@ -137,6 +173,14 @@ allowed_actor_roles = ["repo_owner", "repo_admin"]
 [policies.merge_identity]
 kind = "github_actions_oidc"
 name = "launchplane-merge-train"
+
+[policies.service_authz]
+action = "merge_train.run_once"
+product = "launchplane"
+context = "launchplane"
+
+[policies.github_token]
+env_var = "GITHUB_TOKEN"
 """
 
 

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -76,6 +76,9 @@ from control_plane.contracts.every_code_summary_read_model import (
 )
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.idempotency_record import build_launchplane_idempotency_record_id
+from control_plane.contracts.merge_train_policy import (
+    build_sellyouroutboard_main_merge_train_policy,
+)
 from control_plane.contracts.preview_mutation_request import (
     PreviewDestroyMutationRequest,
     PreviewGenerationMutationRequest,
@@ -175,6 +178,17 @@ from control_plane.work_graph_http import (
     handle_work_graph_snapshot_read,
     rank_work_graph_snapshot,
     work_graph_rank_denied_response,
+)
+from control_plane.merge_train import build_merge_train_dry_run_result
+from control_plane.merge_train_github import (
+    GitHubMergeTrainClient,
+    GitHubMergeTrainSnapshotReader,
+    MergeTrainGitHubError,
+    UrllibMergeTrainGitHubTransport,
+)
+from control_plane.workflows.merge_train_worker import (
+    MergeTrainWorkerClients,
+    run_merge_train_worker_step,
 )
 from control_plane.workflows.evidence_ingestion import (
     apply_deployment_evidence,
@@ -290,7 +304,31 @@ from control_plane.workflows.verireel_preview_driver import (
 
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 _EVERY_CODE_GITHUB_WEBHOOK_ROUTE = "/v1/every-code/github-webhook"
+_MERGE_TRAIN_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/run-once"
 _EVERY_CODE_GITHUB_WEBHOOK_SECRET_ENV_KEY = "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET"
+
+
+class MergeTrainRunOnceEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    repository: str
+    base_branch: str = "main"
+    mutate: bool = False
+    github_api_base_url: str = "https://api.github.com"
+
+    @model_validator(mode="after")
+    def _validate_envelope(self) -> "MergeTrainRunOnceEnvelope":
+        self.repository = self.repository.strip()
+        self.base_branch = self.base_branch.strip()
+        self.github_api_base_url = self.github_api_base_url.strip() or "https://api.github.com"
+        if not self.repository:
+            raise ValueError("merge train run-once requires repository")
+        if "/" not in self.repository:
+            raise ValueError("merge train repository must be owner/name")
+        if not self.base_branch:
+            raise ValueError("merge train run-once requires base_branch")
+        return self
 _GITHUB_CLOSING_REFERENCE_PATTERN = re.compile(
     r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+([^\n\r]+)", re.IGNORECASE
 )
@@ -1814,6 +1852,7 @@ def _driver_write_routes_from_descriptors() -> frozenset[str]:
 def _build_write_routes() -> frozenset[str]:
     launchplane_write_routes = {
         _EVERY_CODE_GITHUB_WEBHOOK_ROUTE,
+        _MERGE_TRAIN_RUN_ONCE_ROUTE,
         "/v1/agent/write-intents/evaluate",
         "/v1/every-code/work-requests/create",
         "/v1/every-code/work-requests/claim",
@@ -5546,6 +5585,93 @@ def create_launchplane_service_app(
                 every_code_store.write_every_code_work_request_record(record)
                 result = {"request_id": record.request_id, "state": record.state}
                 driver_result = {"request": record.model_dump(mode="json")}
+            elif path == _MERGE_TRAIN_RUN_ONCE_ROUTE:
+                merge_train_request = MergeTrainRunOnceEnvelope.model_validate(payload)
+                policy = build_sellyouroutboard_main_merge_train_policy()
+                repository_policy = policy.find_repository_policy(
+                    repository=merge_train_request.repository,
+                    base_branch=merge_train_request.base_branch,
+                )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action=repository_policy.service_authz.action,
+                    product=repository_policy.service_authz.product,
+                    context=repository_policy.service_authz.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot run the requested merge train policy.",
+                            },
+                        },
+                    )
+                token_env = repository_policy.github_token.env_var
+                if not token_env:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "github_token_not_configured",
+                                "message": "Merge train policy does not define a GitHub token environment variable.",
+                            },
+                        },
+                    )
+                token = os.environ.get(token_env, "").strip()
+                if not token:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "github_token_not_configured",
+                                "message": "Configured merge train GitHub token is not available.",
+                            },
+                        },
+                    )
+                transport = UrllibMergeTrainGitHubTransport(
+                    token=token,
+                    api_base_url=merge_train_request.github_api_base_url,
+                )
+                snapshot = GitHubMergeTrainSnapshotReader(
+                    transport=transport
+                ).read_merge_train_snapshot(
+                    repository=merge_train_request.repository,
+                    base_branch=merge_train_request.base_branch,
+                )
+                dry_run_result = build_merge_train_dry_run_result(
+                    policy=policy, snapshot=snapshot
+                )
+                result = {
+                    "repository": merge_train_request.repository,
+                    "base_branch": merge_train_request.base_branch,
+                    "mode": "mutate" if merge_train_request.mutate else "dry-run",
+                    "dry_run_result": dry_run_result.model_dump(mode="json"),
+                }
+                if merge_train_request.mutate:
+                    github_client = GitHubMergeTrainClient(transport=transport)
+                    worker_step_result = run_merge_train_worker_step(
+                        policy=policy,
+                        snapshot=snapshot,
+                        clients=MergeTrainWorkerClients(
+                            label_client=github_client,
+                            branch_client=github_client,
+                            merge_client=github_client,
+                        ),
+                    )
+                    result["worker_step_result"] = worker_step_result.model_dump(mode="json")
+                    driver_result = worker_step_result
+                else:
+                    driver_result = result
             elif path == "/v1/agent/write-intents/evaluate":
                 intent_request = AgentWriteIntentRequest.model_validate(payload)
                 intent_authz_action = authz_action_for_agent_write_intent(
@@ -8104,6 +8230,19 @@ def create_launchplane_service_app(
                     "error": {
                         "code": "product_driver_mismatch",
                         "message": "Product is not configured for the requested driver route.",
+                    },
+                },
+            )
+        except MergeTrainGitHubError:
+            return _json_response(
+                start_response=start_response,
+                status_code=502,
+                payload={
+                    "status": "rejected",
+                    "trace_id": request_trace_id,
+                    "error": {
+                        "code": "github_request_failed",
+                        "message": "GitHub merge train request failed; retry after upstream recovers.",
                     },
                 },
             )

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -23,6 +23,10 @@ Each repository policy contains:
 - `enqueue`: Requirements for who may enqueue.
 - `merge_identity`: Token or workload identity allowed to update branches and
   merge pull requests.
+- `service_authz`: Launchplane authz action/product/context required before the
+  service endpoint may run the policy.
+- `github_token`: Launchplane service-host token source used for live GitHub
+  API calls.
 
 The initial enqueue policy is intentionally narrow: the enqueue label must be
 present and the enqueue action must come from a repo owner or repo admin. That
@@ -58,6 +62,14 @@ allowed_actor_roles = ["repo_owner", "repo_admin"]
 [policies.merge_identity]
 kind = "github_actions_oidc"
 name = "launchplane-merge-train"
+
+[policies.service_authz]
+action = "merge_train.run_once"
+product = "launchplane"
+context = "launchplane"
+
+[policies.github_token]
+env_var = "GITHUB_TOKEN"
 ```
 
 ## Discoverability
@@ -132,6 +144,15 @@ A worker pass applies at most one transition from one fresh snapshot. It may add
 the block label, request a branch refresh, record a wait boundary, perform one
 guarded merge, or report an idle queue; it must not chain follow-up reads or
 mutations in the same pass.
+
+The service endpoint `POST /v1/work-graph/merge-train/run-once` uses the same
+policy. Request payloads name `repository`, `base_branch`, and optional
+`mutate`; the service finds the repository/base policy before any GitHub call,
+authorizes the caller through `service_authz`, resolves the GitHub token from
+`github_token.env_var`, reads a fresh snapshot, and either returns the dry-run
+result or applies exactly one worker step. Unsupported repository/base pairs,
+missing token configuration, and denied authorization all fail closed. Generic
+service code must not contain product repository conditionals.
 
 The merge step is allowed only from a fresh dry-run result whose next action is
 `merge`. The merge request must use the selected pull request's observed

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -73,6 +73,7 @@ VeriReel product paths:
   - `GET /v1/repo-product-mapping`
   - `GET /v1/work-graph/snapshot`
   - `POST /v1/work-graph/rank`
+  - `POST /v1/work-graph/merge-train/run-once`
 - product driver routes:
   - `POST /v1/drivers/generic-web/deploy`
   - `POST /v1/drivers/generic-web/prod-promotion`
@@ -185,6 +186,14 @@ returns the queue payload under `result.queue`. The route requires the
 `work_graph.rank` action for product/context `launchplane`, performs no storage
 writes, and does not make Launchplane authoritative for copied GitHub or Code
 Plans state.
+
+`POST /v1/work-graph/merge-train/run-once` executes one policy-backed
+merge-train pass for a requested repository/base branch. It requires the
+`service_authz` action/product/context declared by the matching merge-train
+repository policy, resolves its GitHub token from that policy's
+`github_token.env_var`, and fails closed before GitHub calls when no matching
+policy or token is available. The route is dry-run by default; `mutate: true`
+applies at most one worker transition from one fresh snapshot.
 
 `GET /v1/repo-product-mapping` returns the repository ownership/awareness read
 model used by work graph and future agent context. The route requires

--- a/tests/test_merge_train_policy.py
+++ b/tests/test_merge_train_policy.py
@@ -30,6 +30,10 @@ class MergeTrainPolicyTests(unittest.TestCase):
         )
         self.assertEqual(repository_policy.merge_identity.kind, "github_actions_oidc")
         self.assertEqual(repository_policy.merge_identity.name, "launchplane-merge-train")
+        self.assertEqual(repository_policy.service_authz.action, "merge_train.run_once")
+        self.assertEqual(repository_policy.service_authz.product, "launchplane")
+        self.assertEqual(repository_policy.service_authz.context, "launchplane")
+        self.assertEqual(repository_policy.github_token.env_var, "GITHUB_TOKEN")
         self.assertEqual(len(policy.policy_sha256), 64)
 
     def test_parse_rejects_duplicate_repository_branch_policy(self) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -52,6 +52,7 @@ from control_plane.contracts.runtime_key_safety_policy import (
 )
 from control_plane.contracts.secret_record import SecretBinding
 from control_plane.contracts.work_graph_read_model import WorkGraphPlanningIssueFacts
+from control_plane.merge_train import MergeTrainDryRunSnapshot, MergeTrainPullRequestSnapshot
 from control_plane.service import create_launchplane_service_app
 from control_plane.service_auth import (
     GitHubActionsIdentity,
@@ -151,6 +152,58 @@ class _FakeOAuth2Session:
     def get(self, url: str) -> _FakeGitHubResponse:
         self.requested_urls.append(url)
         return _FakeGitHubResponse(self.payloads[url])
+
+
+class _FakeMergeTrainGitHubClient:
+    def __init__(self, *, transport: object) -> None:
+        self.transport = transport
+
+    def add_pull_request_label(
+        self, *, repository: str, pull_request_number: int, label: str
+    ) -> None:
+        return None
+
+    def update_pull_request_branch(
+        self, *, repository: str, pull_request_number: int, expected_head_sha: str
+    ) -> None:
+        return None
+
+    def merge_pull_request(
+        self,
+        *,
+        repository: str,
+        pull_request_number: int,
+        head_sha: str,
+        merge_method: str,
+    ) -> str:
+        return f"merge-{pull_request_number}"
+
+
+class _FakeMergeTrainSnapshotReader:
+    def __init__(self, *, transport: object) -> None:
+        self.transport = transport
+
+    def read_merge_train_snapshot(
+        self, *, repository: str, base_branch: str
+    ) -> MergeTrainDryRunSnapshot:
+        return MergeTrainDryRunSnapshot(
+            repository=repository,
+            base_branch=base_branch,
+            pull_requests=(
+                MergeTrainPullRequestSnapshot(
+                    number=1,
+                    url=f"https://github.com/{repository}/pull/1",
+                    title="Ready PR",
+                    created_at="2026-05-08T10:00:00Z",
+                    labels=("ready-to-merge",),
+                    actor_role="repo_admin",
+                    head_sha="head-1",
+                    base_sha="base-main",
+                    mergeable="mergeable",
+                    required_checks_status="pass",
+                ),
+            ),
+        )
 
 
 def _identity(
@@ -934,6 +987,222 @@ class GitHubHumanAuthTests(unittest.TestCase):
 
 
 class LaunchplaneServiceTests(unittest.TestCase):
+    def test_merge_train_run_once_service_returns_dry_run_from_policy(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/merge-train.yml@refs/heads/main"
+                        ],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["merge_train.run_once"],
+                    }
+                ]
+            }
+        )
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/merge-train.yml@refs/heads/main",
+            event_name="workflow_dispatch",
+        )
+
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(identity),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with (
+                patch(
+                    "control_plane.service.GitHubMergeTrainSnapshotReader",
+                    _FakeMergeTrainSnapshotReader,
+                ),
+                patch.dict("os.environ", {"GITHUB_TOKEN": "token"}, clear=True),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                    },
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "dry-run")
+        self.assertEqual(payload["result"]["repository"], "cbusillo/sellyouroutboard")
+        self.assertEqual(payload["result"]["base_branch"], "main")
+        self.assertEqual(payload["result"]["dry_run_result"]["intended_next_action"], "merge")
+
+    def test_merge_train_run_once_service_mutates_one_worker_step(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/merge-train.yml@refs/heads/main"
+                        ],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["merge_train.run_once"],
+                    }
+                ]
+            }
+        )
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/merge-train.yml@refs/heads/main",
+            event_name="workflow_dispatch",
+        )
+
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(identity),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with (
+                patch(
+                    "control_plane.service.GitHubMergeTrainSnapshotReader",
+                    _FakeMergeTrainSnapshotReader,
+                ),
+                patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient),
+                patch.dict("os.environ", {"GITHUB_TOKEN": "token"}, clear=True),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["status"], "merged")
+        self.assertEqual(payload["result"]["intended_next_action"], "merge")
+        self.assertEqual(payload["result"]["selected_pr_number"], 1)
+
+    def test_merge_train_run_once_service_rejects_unauthorized_identity(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate({"github_actions": []})
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with (
+                patch(
+                    "control_plane.service.GitHubMergeTrainSnapshotReader",
+                    _FakeMergeTrainSnapshotReader,
+                ),
+                patch.dict("os.environ", {"GITHUB_TOKEN": "token"}, clear=True),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                    },
+                )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_merge_train_run_once_service_rejects_missing_token(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "every/verireel",
+                        "workflow_refs": [
+                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                        ],
+                        "event_names": ["pull_request"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["merge_train.run_once"],
+                    }
+                ]
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch.dict("os.environ", {}, clear=True):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                    },
+                )
+
+        self.assertEqual(status_code, 503)
+        self.assertEqual(payload["error"]["code"], "github_token_not_configured")
+
+    def test_merge_train_run_once_service_rejects_unsupported_policy(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "every/verireel",
+                        "workflow_refs": [
+                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                        ],
+                        "event_names": ["pull_request"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["merge_train.run_once"],
+                    }
+                ]
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/work-graph/merge-train/run-once",
+                payload={
+                    "schema_version": 1,
+                    "repository": "cbusillo/other",
+                    "base_branch": "main",
+                },
+            )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+
     def test_every_code_github_webhook_creates_work_request(self) -> None:
         secret = "launchplane-every-code-webhook-secret"
         policy = LaunchplaneAuthzPolicy.model_validate(


### PR DESCRIPTION
## Summary
- extend merge-train repository policy with explicit service authz and GitHub token source fields
- add POST /v1/work-graph/merge-train/run-once with policy lookup, authz, fail-closed token resolution, dry-run default, and one-step mutate mode
- document the service endpoint and add targeted service/policy coverage

Closes #473

## Validation
- uv run python -m unittest tests.test_merge_train_policy tests.test_service.LaunchplaneServiceTests.test_merge_train_run_once_service_returns_dry_run_from_policy tests.test_service.LaunchplaneServiceTests.test_merge_train_run_once_service_mutates_one_worker_step tests.test_service.LaunchplaneServiceTests.test_merge_train_run_once_service_rejects_unauthorized_identity tests.test_service.LaunchplaneServiceTests.test_merge_train_run_once_service_rejects_missing_token tests.test_service.LaunchplaneServiceTests.test_merge_train_run_once_service_rejects_unsupported_policy
- uv run --extra dev ruff check --diff control_plane/contracts/merge_train_policy.py control_plane/service.py tests/test_merge_train_policy.py tests/test_service.py docs/merge-train-policy.md docs/service-boundary.md
- uv run --extra dev ruff check control_plane/contracts/merge_train_policy.py control_plane/service.py tests/test_merge_train_policy.py tests/test_service.py
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest

## Notes
Generic service code performs repository/base policy lookup and does not branch on product repository names.