### PR TITLE
Persist merge train run records

### DIFF
--- a/control_plane/contracts/merge_train_run_record.py
+++ b/control_plane/contracts/merge_train_run_record.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.merge_train import MergeTrainDryRunResult
+from control_plane.merge_train import MergeTrainDryRunSnapshot
+from control_plane.workflows.merge_train_worker import MergeTrainWorkerStepResult
+
+
+MergeTrainRunMode = Literal["dry_run", "mutate"]
+
+
+class MergeTrainRunRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    run_id: str
+    recorded_at: str
+    trace_id: str
+    repository: str
+    base_branch: str
+    mode: MergeTrainRunMode
+    status: str
+    intended_next_action: str
+    selected_pr_number: int | None = None
+    selected_head_sha: str = ""
+    selected_mergeable: str = ""
+    selected_required_checks_status: str = ""
+    reread_required: bool = False
+    poll_required: bool = False
+    policy_key: str
+    policy_sha256: str
+    dry_run_result: dict[str, object]
+    worker_step_result: dict[str, object] | None = None
+    snapshot: dict[str, object]
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "MergeTrainRunRecord":
+        self.run_id = _normalize_required_value(
+            self.run_id, "merge train run record requires run_id"
+        )
+        self.recorded_at = _normalize_required_value(
+            self.recorded_at, "merge train run record requires recorded_at"
+        )
+        self.trace_id = _normalize_required_value(
+            self.trace_id, "merge train run record requires trace_id"
+        )
+        self.repository = _normalize_required_value(
+            self.repository, "merge train run record requires repository"
+        )
+        self.base_branch = _normalize_required_value(
+            self.base_branch, "merge train run record requires base_branch"
+        )
+        self.status = _normalize_required_value(
+            self.status, "merge train run record requires status"
+        )
+        self.intended_next_action = _normalize_required_value(
+            self.intended_next_action,
+            "merge train run record requires intended_next_action",
+        )
+        self.selected_head_sha = self.selected_head_sha.strip()
+        self.selected_mergeable = self.selected_mergeable.strip()
+        self.selected_required_checks_status = self.selected_required_checks_status.strip()
+        self.policy_key = _normalize_required_value(
+            self.policy_key, "merge train run record requires policy_key"
+        )
+        self.policy_sha256 = _normalize_required_value(
+            self.policy_sha256, "merge train run record requires policy_sha256"
+        )
+        return self
+
+
+def build_merge_train_run_record(
+    *,
+    recorded_at: str,
+    trace_id: str,
+    policy_sha256: str,
+    snapshot: MergeTrainDryRunSnapshot,
+    dry_run_result: MergeTrainDryRunResult,
+    worker_step_result: MergeTrainWorkerStepResult | None = None,
+) -> MergeTrainRunRecord:
+    selected_pr = dry_run_result.selected_pr
+    mode: MergeTrainRunMode = "mutate" if worker_step_result is not None else "dry_run"
+    status = (
+        worker_step_result.status
+        if worker_step_result is not None
+        else dry_run_result.intended_next_action
+    )
+    record_without_id = MergeTrainRunRecord(
+        run_id="pending",
+        recorded_at=recorded_at,
+        trace_id=trace_id,
+        repository=dry_run_result.repository,
+        base_branch=dry_run_result.base_branch,
+        mode=mode,
+        status=status,
+        intended_next_action=dry_run_result.intended_next_action,
+        selected_pr_number=selected_pr.number if selected_pr is not None else None,
+        selected_head_sha=selected_pr.head_sha if selected_pr is not None else "",
+        selected_mergeable=selected_pr.mergeable if selected_pr is not None else "",
+        selected_required_checks_status=(
+            selected_pr.required_checks_status if selected_pr is not None else ""
+        ),
+        reread_required=worker_step_result.reread_required if worker_step_result else False,
+        poll_required=worker_step_result.poll_required if worker_step_result else False,
+        policy_key=dry_run_result.policy_key,
+        policy_sha256=policy_sha256,
+        dry_run_result=dry_run_result.model_dump(mode="json"),
+        worker_step_result=(
+            worker_step_result.model_dump(mode="json") if worker_step_result else None
+        ),
+        snapshot=snapshot.model_dump(mode="json"),
+    )
+    return record_without_id.model_copy(
+        update={"run_id": build_merge_train_run_record_id(record_without_id)}
+    )
+
+
+def build_merge_train_run_record_id(record: MergeTrainRunRecord) -> str:
+    normalized_timestamp = record.recorded_at.replace("-", "").replace(":", "").replace(
+        "+00:00", "Z"
+    )
+    digest_payload = record.model_dump(mode="json", exclude={"run_id"})
+    digest = hashlib.sha256(
+        json.dumps(digest_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:16]
+    return f"merge-train-run-{normalized_timestamp}-{digest}"
+
+
+def _normalize_required_value(value: str, error_message: str) -> str:
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise ValueError(error_message)
+    return normalized_value

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -79,6 +79,7 @@ from control_plane.contracts.idempotency_record import build_launchplane_idempot
 from control_plane.contracts.merge_train_policy import (
     build_sellyouroutboard_main_merge_train_policy,
 )
+from control_plane.contracts.merge_train_run_record import build_merge_train_run_record
 from control_plane.contracts.preview_mutation_request import (
     PreviewDestroyMutationRequest,
     PreviewGenerationMutationRequest,
@@ -2908,6 +2909,7 @@ def _accepted_payload(
                 "transition",
                 "request_id",
                 "state",
+                "merge_train_run_id",
             }
         },
         **({"result": serialized_driver_result} if serialized_driver_result else {}),
@@ -5657,6 +5659,7 @@ def create_launchplane_service_app(
                     "mode": "mutate" if merge_train_request.mutate else "dry-run",
                     "dry_run_result": dry_run_result.model_dump(mode="json"),
                 }
+                worker_step_result = None
                 if merge_train_request.mutate:
                     github_client = GitHubMergeTrainClient(transport=transport)
                     worker_step_result = run_merge_train_worker_step(
@@ -5672,6 +5675,16 @@ def create_launchplane_service_app(
                     driver_result = worker_step_result
                 else:
                     driver_result = result
+                run_record = build_merge_train_run_record(
+                    recorded_at=_utc_now_timestamp(),
+                    trace_id=request_trace_id,
+                    policy_sha256=policy.policy_sha256,
+                    snapshot=snapshot,
+                    dry_run_result=dry_run_result,
+                    worker_step_result=worker_step_result,
+                )
+                record_store.write_merge_train_run_record(run_record)
+                result["merge_train_run_id"] = run_record.run_id
             elif path == "/v1/agent/write-intents/evaluate":
                 intent_request = AgentWriteIntentRequest.model_validate(payload)
                 intent_authz_action = authz_action_for_agent_write_intent(

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -17,6 +17,7 @@ from control_plane.contracts.every_code_work_request import (
 )
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
+from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.preview_enablement_record import PreviewEnablementRecord
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
@@ -151,6 +152,46 @@ class FilesystemRecordStore:
             and (not context_name or record.evaluation.context == context_name)
         ]
         records.sort(key=lambda record: (record.recorded_at, record.record_id), reverse=True)
+        if offset > 0:
+            records = records[offset:]
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def write_merge_train_run_record(self, record: MergeTrainRunRecord) -> Path:
+        return self._write_model("launchplane_merge_train_runs", record.run_id, record)
+
+    def read_merge_train_run_record(self, run_id: str) -> MergeTrainRunRecord:
+        return MergeTrainRunRecord.model_validate(
+            self._read_model(
+                MergeTrainRunRecord,
+                "launchplane_merge_train_runs",
+                run_id,
+            ).model_dump(mode="json")
+        )
+
+    def list_merge_train_run_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        mode: str = "",
+        status: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[MergeTrainRunRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                MergeTrainRunRecord,
+                "launchplane_merge_train_runs",
+            )
+            if (not repository or record.repository == repository)
+            and (not base_branch or record.base_branch == base_branch)
+            and (not mode or record.mode == mode)
+            and (not status or record.status == status)
+        ]
+        records.sort(key=lambda record: (record.recorded_at, record.run_id), reverse=True)
         if offset > 0:
             records = records[offset:]
         if limit is not None:

--- a/control_plane/storage/migrations/versions/af56b078de90_add_merge_train_runs.py
+++ b/control_plane/storage/migrations/versions/af56b078de90_add_merge_train_runs.py
@@ -1,0 +1,64 @@
+"""add merge train run records
+
+Revision ID: af56b078de90
+Revises: ae45f067cd89
+Create Date: 2026-05-09 02:05:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "af56b078de90"
+down_revision: str | None = "ae45f067cd89"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "launchplane_merge_train_runs",
+        sa.Column("run_id", sa.String(), nullable=False),
+        sa.Column("recorded_at", sa.String(), nullable=False),
+        sa.Column("trace_id", sa.String(), nullable=False),
+        sa.Column("repository", sa.String(), nullable=False),
+        sa.Column("base_branch", sa.String(), nullable=False),
+        sa.Column("mode", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("intended_next_action", sa.String(), nullable=False),
+        sa.Column("selected_pr_number", sa.Integer(), nullable=True),
+        sa.Column("policy_key", sa.String(), nullable=False),
+        sa.Column("policy_sha256", sa.String(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("run_id"),
+    )
+    op.create_index(
+        "launchplane_merge_train_runs_repository_base_idx",
+        "launchplane_merge_train_runs",
+        ["repository", "base_branch", sa.text("recorded_at DESC")],
+    )
+    op.create_index(
+        "launchplane_merge_train_runs_status_idx",
+        "launchplane_merge_train_runs",
+        ["status", sa.text("recorded_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "launchplane_merge_train_runs_status_idx",
+        table_name="launchplane_merge_train_runs",
+    )
+    op.drop_index(
+        "launchplane_merge_train_runs_repository_base_idx",
+        table_name="launchplane_merge_train_runs",
+    )
+    op.drop_table("launchplane_merge_train_runs")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -37,6 +37,7 @@ from control_plane.contracts.every_code_work_request import (
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
+from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
@@ -554,6 +555,36 @@ class LaunchplaneAgentWriteIntentRow(Base):
     authz_action: Mapped[str] = mapped_column(String, nullable=False)
     product: Mapped[str] = mapped_column(String, nullable=False)
     context: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneMergeTrainRunRow(Base):
+    __tablename__ = "launchplane_merge_train_runs"
+    __table_args__ = (
+        Index(
+            "launchplane_merge_train_runs_repository_base_idx",
+            "repository",
+            "base_branch",
+            desc("recorded_at"),
+        ),
+        Index(
+            "launchplane_merge_train_runs_status_idx",
+            "status",
+            desc("recorded_at"),
+        ),
+    )
+
+    run_id: Mapped[str] = mapped_column(String, primary_key=True)
+    recorded_at: Mapped[str] = mapped_column(String, nullable=False)
+    trace_id: Mapped[str] = mapped_column(String, nullable=False)
+    repository: Mapped[str] = mapped_column(String, nullable=False)
+    base_branch: Mapped[str] = mapped_column(String, nullable=False)
+    mode: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    intended_next_action: Mapped[str] = mapped_column(String, nullable=False)
+    selected_pr_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    policy_key: Mapped[str] = mapped_column(String, nullable=False)
+    policy_sha256: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -1427,6 +1458,62 @@ class PostgresRecordStore(HumanSessionStore):
             order_by=(
                 LaunchplaneAgentWriteIntentRow.recorded_at.desc(),
                 LaunchplaneAgentWriteIntentRow.record_id.desc(),
+            ),
+            limit=limit,
+            offset=offset,
+        )
+
+    def write_merge_train_run_record(self, record: MergeTrainRunRecord) -> None:
+        self._write_row(
+            LaunchplaneMergeTrainRunRow(
+                run_id=record.run_id,
+                recorded_at=record.recorded_at,
+                trace_id=record.trace_id,
+                repository=record.repository,
+                base_branch=record.base_branch,
+                mode=record.mode,
+                status=record.status,
+                intended_next_action=record.intended_next_action,
+                selected_pr_number=record.selected_pr_number,
+                policy_key=record.policy_key,
+                policy_sha256=record.policy_sha256,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def read_merge_train_run_record(self, run_id: str) -> MergeTrainRunRecord:
+        return self._read_model(
+            model_type=MergeTrainRunRecord,
+            orm_model=LaunchplaneMergeTrainRunRow,
+            filters=(LaunchplaneMergeTrainRunRow.run_id == run_id,),
+        )
+
+    def list_merge_train_run_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        mode: str = "",
+        status: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[MergeTrainRunRecord, ...]:
+        filters: list[object] = []
+        if repository:
+            filters.append(LaunchplaneMergeTrainRunRow.repository == repository)
+        if base_branch:
+            filters.append(LaunchplaneMergeTrainRunRow.base_branch == base_branch)
+        if mode:
+            filters.append(LaunchplaneMergeTrainRunRow.mode == mode)
+        if status:
+            filters.append(LaunchplaneMergeTrainRunRow.status == status)
+        return self._list_models(
+            model_type=MergeTrainRunRecord,
+            orm_model=LaunchplaneMergeTrainRunRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneMergeTrainRunRow.recorded_at.desc(),
+                LaunchplaneMergeTrainRunRow.run_id.desc(),
             ),
             limit=limit,
             offset=offset,
@@ -2327,6 +2414,7 @@ class PostgresRecordStore(HumanSessionStore):
             "preview_pr_feedback": 0,
             "every_code_preview_gates": 0,
             "agent_write_intents": 0,
+            "merge_train_runs": 0,
             "release_tuples": 0,
             "runtime_key_safety_policies": 0,
         }
@@ -2391,6 +2479,10 @@ class PostgresRecordStore(HumanSessionStore):
             for intent_record in filesystem_store.list_agent_write_intent_records():
                 self.write_agent_write_intent_record(intent_record)
                 counts["agent_write_intents"] += 1
+        if hasattr(filesystem_store, "list_merge_train_run_records"):
+            for run_record in filesystem_store.list_merge_train_run_records():
+                self.write_merge_train_run_record(run_record)
+                counts["merge_train_runs"] += 1
         for release_tuple_record in filesystem_store.list_release_tuple_records():
             self.write_release_tuple_record(release_tuple_record)
             counts["release_tuples"] += 1

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -150,9 +150,12 @@ policy. Request payloads name `repository`, `base_branch`, and optional
 `mutate`; the service finds the repository/base policy before any GitHub call,
 authorizes the caller through `service_authz`, resolves the GitHub token from
 `github_token.env_var`, reads a fresh snapshot, and either returns the dry-run
-result or applies exactly one worker step. Unsupported repository/base pairs,
-missing token configuration, and denied authorization all fail closed. Generic
-service code must not contain product repository conditionals.
+result or applies exactly one worker step. Accepted calls write a
+`launchplane_merge_train_runs` record with the policy digest, fresh snapshot,
+dry-run decision, selected pull request metadata, and optional worker mutation
+result. Unsupported repository/base pairs, missing token configuration, and
+denied authorization all fail closed. Generic service code must not contain
+product repository conditionals.
 
 The merge step is allowed only from a fresh dry-run result whose next action is
 `merge`. The merge request must use the selected pull request's observed

--- a/docs/records.md
+++ b/docs/records.md
@@ -632,6 +632,12 @@ preflights.
   `launchplane_agent_write_intents` records. Each record stores the request,
   evaluation result, `agent_audit` envelope, trace id, optional idempotency key,
   and recorded timestamp so later action routes can link to durable evidence.
+- Merge train service runs are persisted as `launchplane_merge_train_runs`
+  records. Each record stores the repository/base branch, mode, status, policy
+  key and digest, fresh GitHub snapshot, dry-run decision, selected pull request
+  metadata, trace id, recorded timestamp, and optional one-step worker result.
+  The record is evidence for a single service call, not queue authority for a
+  later pass.
 - Scoped agent write-intent evaluation is exposed at
   `POST /v1/agent/write-intents/evaluate`. It validates intent shape, maps the
   intent to an exact existing policy action, evaluates authorization, and returns

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -234,6 +234,13 @@ mark only that section unavailable instead of dropping the whole context or
 silently omitting the failure. The endpoint writes no records, fetches no issue
 bodies, and must preserve the lower-level redaction/provenance rules.
 
+`POST /v1/work-graph/merge-train/run-once` is the authenticated service ingress
+for one merge-train read or mutation pass. It resolves repository/base policy
+before authorization, token lookup, or GitHub reads, authorizes against the
+policy's `service_authz`, reads a fresh GitHub snapshot, and writes a
+`launchplane_merge_train_runs` record for accepted dry-run and mutate calls.
+Mutation mode still applies at most one worker transition from that snapshot.
+
 ## Host Assumption
 
 - Launchplane runs behind an operator-owned HTTPS host.

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -32,6 +32,18 @@ from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFee
 from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.idempotency_record import build_launchplane_idempotency_record_id
+from control_plane.contracts.merge_train_policy import (
+    build_sellyouroutboard_main_merge_train_policy,
+)
+from control_plane.contracts.merge_train_run_record import (
+    MergeTrainRunRecord,
+    build_merge_train_run_record,
+)
+from control_plane.merge_train import (
+    MergeTrainDryRunSnapshot,
+    MergeTrainPullRequestSnapshot,
+    build_merge_train_dry_run_result,
+)
 from control_plane.contracts.odoo_instance_override_record import OdooConfigParameterOverride
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.odoo_instance_override_record import OdooOverrideValue
@@ -494,6 +506,38 @@ def _agent_write_intent_record(
         idempotency_key="intent-eval-1",
         request=request,
         evaluation=evaluation,
+    )
+
+
+def _merge_train_run_record(
+    *, recorded_at: str = "2026-05-09T02:05:00Z"
+) -> MergeTrainRunRecord:
+    policy = build_sellyouroutboard_main_merge_train_policy()
+    snapshot = MergeTrainDryRunSnapshot(
+        repository="cbusillo/sellyouroutboard",
+        base_branch="main",
+        pull_requests=(
+            MergeTrainPullRequestSnapshot(
+                number=42,
+                url="https://github.com/cbusillo/sellyouroutboard/pull/42",
+                title="Ready merge train PR",
+                created_at="2026-05-09T01:00:00Z",
+                labels=("ready-to-merge",),
+                actor_role="repo_admin",
+                head_sha="head-42",
+                base_sha="base-main",
+                mergeable="mergeable",
+                required_checks_status="pass",
+            ),
+        ),
+    )
+    dry_run_result = build_merge_train_dry_run_result(policy=policy, snapshot=snapshot)
+    return build_merge_train_run_record(
+        recorded_at=recorded_at,
+        trace_id="launchplane_req_merge_train_test",
+        policy_sha256=policy.policy_sha256,
+        snapshot=snapshot,
+        dry_run_result=dry_run_result,
     )
 
 
@@ -1485,6 +1529,32 @@ class PostgresRecordStoreTests(unittest.TestCase):
         self.assertEqual(listed_records[0].trace_id, "launchplane_req_test_write_intent")
         self.assertEqual(listed_records[0].evaluation.audit.reason_code, "authorized")
 
+    def test_merge_train_run_records_round_trip(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            record = _merge_train_run_record()
+            store.write_merge_train_run_record(record)
+            loaded_record = store.read_merge_train_run_record(record.run_id)
+            listed_records = store.list_merge_train_run_records(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                mode="dry_run",
+                status="merge",
+            )
+            store.close()
+
+        self.assertEqual(loaded_record.run_id, record.run_id)
+        self.assertEqual(loaded_record.selected_pr_number, 42)
+        self.assertEqual(loaded_record.selected_head_sha, "head-42")
+        self.assertEqual(loaded_record.policy_key, "cbusillo/sellyouroutboard:main")
+        self.assertEqual(len(listed_records), 1)
+        self.assertEqual(listed_records[0].trace_id, "launchplane_req_merge_train_test")
+
     def test_write_and_list_dokploy_target_id_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(
@@ -1872,6 +1942,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     ),
                 )
             )
+            filesystem_store.write_merge_train_run_record(_merge_train_run_record())
 
             counts = store.import_core_records_from_filesystem(filesystem_store)
             self.assertEqual(
@@ -1894,6 +1965,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     "preview_pr_feedback": 1,
                     "every_code_preview_gates": 0,
                     "agent_write_intents": 0,
+                    "merge_train_runs": 1,
                     "release_tuples": 1,
                     "runtime_key_safety_policies": 1,
                 },

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1010,19 +1010,19 @@ class LaunchplaneServiceTests(unittest.TestCase):
             event_name="workflow_dispatch",
         )
 
-        with TemporaryDirectory() as temporary_directory_name:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GITHUB_TOKEN": "token"}, clear=True),
+        ):
             app = create_launchplane_service_app(
                 state_dir=Path(temporary_directory_name) / "state",
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            with (
-                patch(
-                    "control_plane.service.GitHubMergeTrainSnapshotReader",
-                    _FakeMergeTrainSnapshotReader,
-                ),
-                patch.dict("os.environ", {"GITHUB_TOKEN": "token"}, clear=True),
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                _FakeMergeTrainSnapshotReader,
             ):
                 status_code, payload = _invoke_app(
                     app,
@@ -1034,12 +1034,22 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "base_branch": "main",
                     },
                 )
+            run_id = payload["records"]["merge_train_run_id"]
+            loaded_record = FilesystemRecordStore(
+                Path(temporary_directory_name) / "state"
+            ).read_merge_train_run_record(run_id)
 
         self.assertEqual(status_code, 202)
         self.assertEqual(payload["result"]["mode"], "dry-run")
         self.assertEqual(payload["result"]["repository"], "cbusillo/sellyouroutboard")
         self.assertEqual(payload["result"]["base_branch"], "main")
         self.assertEqual(payload["result"]["dry_run_result"]["intended_next_action"], "merge")
+        self.assertEqual(loaded_record.mode, "dry_run")
+        self.assertEqual(loaded_record.status, "merge")
+        self.assertEqual(loaded_record.selected_pr_number, 1)
+        self.assertEqual(loaded_record.selected_head_sha, "head-1")
+        self.assertEqual(loaded_record.policy_key, "cbusillo/sellyouroutboard:main")
+        self.assertEqual(loaded_record.worker_step_result, None)
 
     def test_merge_train_run_once_service_mutates_one_worker_step(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(
@@ -1064,7 +1074,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
             event_name="workflow_dispatch",
         )
 
-        with TemporaryDirectory() as temporary_directory_name:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GITHUB_TOKEN": "token"}, clear=True),
+        ):
             app = create_launchplane_service_app(
                 state_dir=Path(temporary_directory_name) / "state",
                 verifier=_StubVerifier(identity),
@@ -1077,7 +1090,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     _FakeMergeTrainSnapshotReader,
                 ),
                 patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient),
-                patch.dict("os.environ", {"GITHUB_TOKEN": "token"}, clear=True),
             ):
                 status_code, payload = _invoke_app(
                     app,
@@ -1090,11 +1102,20 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "mutate": True,
                     },
                 )
+            run_id = payload["records"]["merge_train_run_id"]
+            loaded_record = FilesystemRecordStore(
+                Path(temporary_directory_name) / "state"
+            ).read_merge_train_run_record(run_id)
 
         self.assertEqual(status_code, 202)
         self.assertEqual(payload["result"]["status"], "merged")
         self.assertEqual(payload["result"]["intended_next_action"], "merge")
         self.assertEqual(payload["result"]["selected_pr_number"], 1)
+        self.assertEqual(loaded_record.mode, "mutate")
+        self.assertEqual(loaded_record.status, "merged")
+        self.assertTrue(loaded_record.reread_required)
+        self.assertFalse(loaded_record.poll_required)
+        self.assertIsNotNone(loaded_record.worker_step_result)
 
     def test_merge_train_run_once_service_rejects_unauthorized_identity(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate({"github_actions": []})


### PR DESCRIPTION
## Summary
- add a typed merge-train run record and Postgres migration/table
- persist accepted merge-train service dry-run and mutate calls with snapshot, policy digest, selected PR metadata, and optional worker result
- expose the run id in accepted service responses and document the durable record boundary

Refs #410

## Validation
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_merge_train_run_once_service_returns_dry_run_from_policy tests.test_service.LaunchplaneServiceTests.test_merge_train_run_once_service_mutates_one_worker_step tests.test_postgres_store.PostgresRecordStoreTests.test_merge_train_run_records_round_trip tests.test_postgres_store.PostgresRecordStoreTests.test_import_core_records_from_filesystem tests.test_postgres_store.PostgresRecordStoreTests.test_alembic_baseline_creates_schema_used_by_record_store tests.test_postgres_store.PostgresRecordStoreTests.test_alembic_baseline_downgrades_to_empty_schema
- uv run --extra dev ruff check --diff control_plane/contracts/merge_train_run_record.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/af56b078de90_add_merge_train_runs.py control_plane/service.py tests/test_service.py tests/test_postgres_store.py
- uv run --extra dev ruff check control_plane/contracts/merge_train_run_record.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/af56b078de90_add_merge_train_runs.py control_plane/service.py tests/test_service.py tests/test_postgres_store.py
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest