### PR TITLE
Add merge train admission decisions

### DIFF
--- a/control_plane/contracts/merge_train_admission.py
+++ b/control_plane/contracts/merge_train_admission.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
+
+
+MergeTrainAdmissionStatus = Literal["admitted", "deferred"]
+MergeTrainAdmissionReason = Literal[
+    "no_prior_run",
+    "dry_run_history_only",
+    "reread_required",
+    "poll_interval_elapsed",
+    "poll_interval_pending",
+    "backoff_elapsed",
+    "backoff_pending",
+]
+
+
+class MergeTrainAdmissionDecision(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    repository: str
+    base_branch: str
+    status: MergeTrainAdmissionStatus
+    reason_code: MergeTrainAdmissionReason
+    requested_at: str
+    next_allowed_at: str
+    latest_run_id: str = ""
+    latest_run_status: str = ""
+    latest_run_recorded_at: str = ""
+    detail: str
+
+    @model_validator(mode="after")
+    def _validate_decision(self) -> "MergeTrainAdmissionDecision":
+        self.repository = _normalize_required_value(
+            self.repository, "merge train admission decision requires repository"
+        )
+        self.base_branch = _normalize_required_value(
+            self.base_branch, "merge train admission decision requires base_branch"
+        )
+        self.requested_at = _normalize_required_value(
+            self.requested_at, "merge train admission decision requires requested_at"
+        )
+        self.next_allowed_at = _normalize_required_value(
+            self.next_allowed_at, "merge train admission decision requires next_allowed_at"
+        )
+        self.latest_run_id = self.latest_run_id.strip()
+        self.latest_run_status = self.latest_run_status.strip()
+        self.latest_run_recorded_at = self.latest_run_recorded_at.strip()
+        self.detail = _normalize_required_value(
+            self.detail, "merge train admission decision requires detail"
+        )
+        return self
+
+    @property
+    def admitted(self) -> bool:
+        return self.status == "admitted"
+
+
+def evaluate_merge_train_admission(
+    *,
+    repository: str,
+    base_branch: str,
+    requested_at: str,
+    latest_run: MergeTrainRunRecord | None,
+    poll_interval_seconds: int = 60,
+    backoff_seconds: int = 300,
+) -> MergeTrainAdmissionDecision:
+    normalized_repository = _normalize_required_value(
+        repository, "merge train admission requires repository"
+    )
+    normalized_base_branch = _normalize_required_value(
+        base_branch, "merge train admission requires base_branch"
+    )
+    requested_time = _parse_timestamp(requested_at)
+    normalized_requested_at = _format_timestamp(requested_time)
+    if poll_interval_seconds < 0:
+        raise ValueError("merge train poll interval cannot be negative")
+    if backoff_seconds < 0:
+        raise ValueError("merge train backoff interval cannot be negative")
+
+    if latest_run is None:
+        return _decision(
+            repository=normalized_repository,
+            base_branch=normalized_base_branch,
+            status="admitted",
+            reason_code="no_prior_run",
+            requested_at=normalized_requested_at,
+            next_allowed_at=normalized_requested_at,
+            detail="No prior merge-train run exists for this repository/base branch.",
+        )
+
+    _validate_latest_run_scope(
+        latest_run=latest_run,
+        repository=normalized_repository,
+        base_branch=normalized_base_branch,
+    )
+    if latest_run.mode == "dry_run":
+        return _decision(
+            repository=normalized_repository,
+            base_branch=normalized_base_branch,
+            status="admitted",
+            reason_code="dry_run_history_only",
+            requested_at=normalized_requested_at,
+            next_allowed_at=normalized_requested_at,
+            latest_run=latest_run,
+            detail="Latest merge-train record is dry-run evidence and does not throttle the scheduler.",
+        )
+
+    if latest_run.reread_required:
+        return _decision(
+            repository=normalized_repository,
+            base_branch=normalized_base_branch,
+            status="admitted",
+            reason_code="reread_required",
+            requested_at=normalized_requested_at,
+            next_allowed_at=normalized_requested_at,
+            latest_run=latest_run,
+            detail="Latest merge-train mutation requires a fresh read before another decision.",
+        )
+
+    if latest_run.poll_required:
+        return _interval_decision(
+            repository=normalized_repository,
+            base_branch=normalized_base_branch,
+            requested_time=requested_time,
+            requested_at=normalized_requested_at,
+            latest_run=latest_run,
+            interval_seconds=poll_interval_seconds,
+            elapsed_reason_code="poll_interval_elapsed",
+            pending_reason_code="poll_interval_pending",
+            elapsed_detail="Merge-train poll interval has elapsed for the latest wait boundary.",
+            pending_detail="Latest merge-train wait boundary is still inside the poll interval.",
+        )
+
+    return _interval_decision(
+        repository=normalized_repository,
+        base_branch=normalized_base_branch,
+        requested_time=requested_time,
+        requested_at=normalized_requested_at,
+        latest_run=latest_run,
+        interval_seconds=backoff_seconds,
+        elapsed_reason_code="backoff_elapsed",
+        pending_reason_code="backoff_pending",
+        elapsed_detail="Merge-train backoff interval has elapsed for the latest mutation result.",
+        pending_detail="Latest merge-train mutation result is still inside the backoff interval.",
+    )
+
+
+def _interval_decision(
+    *,
+    repository: str,
+    base_branch: str,
+    requested_time: datetime,
+    requested_at: str,
+    latest_run: MergeTrainRunRecord,
+    interval_seconds: int,
+    elapsed_reason_code: MergeTrainAdmissionReason,
+    pending_reason_code: MergeTrainAdmissionReason,
+    elapsed_detail: str,
+    pending_detail: str,
+) -> MergeTrainAdmissionDecision:
+    latest_time = _parse_timestamp(latest_run.recorded_at)
+    next_allowed_time = latest_time + timedelta(seconds=interval_seconds)
+    if requested_time >= next_allowed_time:
+        return _decision(
+            repository=repository,
+            base_branch=base_branch,
+            status="admitted",
+            reason_code=elapsed_reason_code,
+            requested_at=requested_at,
+            next_allowed_at=_format_timestamp(requested_time),
+            latest_run=latest_run,
+            detail=elapsed_detail,
+        )
+    return _decision(
+        repository=repository,
+        base_branch=base_branch,
+        status="deferred",
+        reason_code=pending_reason_code,
+        requested_at=requested_at,
+        next_allowed_at=_format_timestamp(next_allowed_time),
+        latest_run=latest_run,
+        detail=pending_detail,
+    )
+
+
+def _decision(
+    *,
+    repository: str,
+    base_branch: str,
+    status: MergeTrainAdmissionStatus,
+    reason_code: MergeTrainAdmissionReason,
+    requested_at: str,
+    next_allowed_at: str,
+    detail: str,
+    latest_run: MergeTrainRunRecord | None = None,
+) -> MergeTrainAdmissionDecision:
+    return MergeTrainAdmissionDecision(
+        repository=repository,
+        base_branch=base_branch,
+        status=status,
+        reason_code=reason_code,
+        requested_at=requested_at,
+        next_allowed_at=next_allowed_at,
+        latest_run_id=latest_run.run_id if latest_run is not None else "",
+        latest_run_status=latest_run.status if latest_run is not None else "",
+        latest_run_recorded_at=latest_run.recorded_at if latest_run is not None else "",
+        detail=detail,
+    )
+
+
+def _validate_latest_run_scope(
+    *, latest_run: MergeTrainRunRecord, repository: str, base_branch: str
+) -> None:
+    if latest_run.repository != repository or latest_run.base_branch != base_branch:
+        raise ValueError(
+            "latest merge train run scope does not match requested repository/base_branch"
+        )
+
+
+def _parse_timestamp(value: str) -> datetime:
+    normalized = _normalize_required_value(value, "merge train admission requires timestamp")
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _format_timestamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace(
+        "+00:00", "Z"
+    )
+
+
+def _normalize_required_value(value: str, error_message: str) -> str:
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise ValueError(error_message)
+    return normalized_value

--- a/control_plane/merge_train_admission.py
+++ b/control_plane/merge_train_admission.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from control_plane.contracts.merge_train_admission import MergeTrainAdmissionDecision
+from control_plane.contracts.merge_train_admission import evaluate_merge_train_admission
+from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
+
+
+class MergeTrainRunHistoryStore(Protocol):
+    def latest_merge_train_run_record(
+        self, *, repository: str, base_branch: str
+    ) -> MergeTrainRunRecord | None: ...
+
+
+def evaluate_merge_train_admission_from_store(
+    *,
+    store: MergeTrainRunHistoryStore,
+    repository: str,
+    base_branch: str,
+    requested_at: str,
+    poll_interval_seconds: int = 60,
+    backoff_seconds: int = 300,
+) -> MergeTrainAdmissionDecision:
+    return evaluate_merge_train_admission(
+        repository=repository,
+        base_branch=base_branch,
+        requested_at=requested_at,
+        latest_run=store.latest_merge_train_run_record(
+            repository=repository,
+            base_branch=base_branch,
+        ),
+        poll_interval_seconds=poll_interval_seconds,
+        backoff_seconds=backoff_seconds,
+    )

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -170,6 +170,16 @@ class FilesystemRecordStore:
             ).model_dump(mode="json")
         )
 
+    def latest_merge_train_run_record(
+        self, *, repository: str, base_branch: str
+    ) -> MergeTrainRunRecord | None:
+        records = self.list_merge_train_run_records(
+            repository=repository,
+            base_branch=base_branch,
+            limit=1,
+        )
+        return records[0] if records else None
+
     def list_merge_train_run_records(
         self,
         *,

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -1488,6 +1488,16 @@ class PostgresRecordStore(HumanSessionStore):
             filters=(LaunchplaneMergeTrainRunRow.run_id == run_id,),
         )
 
+    def latest_merge_train_run_record(
+        self, *, repository: str, base_branch: str
+    ) -> MergeTrainRunRecord | None:
+        records = self.list_merge_train_run_records(
+            repository=repository,
+            base_branch=base_branch,
+            limit=1,
+        )
+        return records[0] if records else None
+
     def list_merge_train_run_records(
         self,
         *,

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -157,6 +157,15 @@ result. Unsupported repository/base pairs, missing token configuration, and
 denied authorization all fail closed. Generic service code must not contain
 product repository conditionals.
 
+Scheduler admission is a deterministic decision over the latest stored
+`launchplane_merge_train_runs` record for the repository/base branch. Dry-run
+records do not throttle the scheduler. Mutation records with `reread_required`
+are admitted immediately because the next pass must re-read GitHub before any
+new decision. Mutation records with `poll_required` defer until the configured
+poll interval elapses. Other mutation records defer until the configured backoff
+interval elapses. Admission decisions are scheduling hints only; every admitted
+worker pass still reads a fresh GitHub snapshot before choosing an action.
+
 The merge step is allowed only from a fresh dry-run result whose next action is
 `merge`. The merge request must use the selected pull request's observed
 `head_sha` as the GitHub merge `sha` guard and the repository policy's

--- a/tests/test_merge_train_admission.py
+++ b/tests/test_merge_train_admission.py
@@ -1,0 +1,233 @@
+import unittest
+
+from control_plane.contracts.merge_train_admission import evaluate_merge_train_admission
+from control_plane.contracts.merge_train_policy import build_sellyouroutboard_main_merge_train_policy
+from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
+from control_plane.contracts.merge_train_run_record import build_merge_train_run_record
+from control_plane.merge_train import MergeTrainDryRunSnapshot
+from control_plane.merge_train import MergeTrainPullRequestSnapshot
+from control_plane.merge_train import MergeTrainCheckStatus
+from control_plane.merge_train import build_merge_train_dry_run_result
+from control_plane.merge_train_admission import evaluate_merge_train_admission_from_store
+from control_plane.workflows.merge_train_worker import MergeTrainWorkerClients
+from control_plane.workflows.merge_train_worker import run_merge_train_worker_step
+
+
+class _FakeMergeClient:
+    def merge_pull_request(
+        self,
+        *,
+        repository: str,
+        pull_request_number: int,
+        head_sha: str,
+        merge_method: str,
+    ) -> str:
+        return f"merge-{pull_request_number}"
+
+
+class _NoopClient:
+    def add_pull_request_label(
+        self, *, repository: str, pull_request_number: int, label: str
+    ) -> None:
+        return None
+
+    def update_pull_request_branch(
+        self, *, repository: str, pull_request_number: int, expected_head_sha: str
+    ) -> None:
+        return None
+
+
+class _RunHistoryStore:
+    def __init__(self, latest_run: MergeTrainRunRecord | None) -> None:
+        self.latest_run = latest_run
+        self.requests: list[tuple[str, str]] = []
+
+    def latest_merge_train_run_record(
+        self, *, repository: str, base_branch: str
+    ) -> MergeTrainRunRecord | None:
+        self.requests.append((repository, base_branch))
+        return self.latest_run
+
+
+class MergeTrainAdmissionTests(unittest.TestCase):
+    def test_admits_when_no_prior_run_exists(self) -> None:
+        decision = evaluate_merge_train_admission(
+            repository="cbusillo/sellyouroutboard",
+            base_branch="main",
+            requested_at="2026-05-09T02:10:00Z",
+            latest_run=None,
+        )
+
+        self.assertTrue(decision.admitted)
+        self.assertEqual(decision.reason_code, "no_prior_run")
+
+    def test_dry_run_history_does_not_throttle_scheduler(self) -> None:
+        latest_run = _run_record(recorded_at="2026-05-09T02:09:59Z")
+
+        decision = evaluate_merge_train_admission(
+            repository="cbusillo/sellyouroutboard",
+            base_branch="main",
+            requested_at="2026-05-09T02:10:00Z",
+            latest_run=latest_run,
+        )
+
+        self.assertTrue(decision.admitted)
+        self.assertEqual(decision.reason_code, "dry_run_history_only")
+        self.assertEqual(decision.latest_run_id, latest_run.run_id)
+
+    def test_reread_required_mutation_is_admitted_immediately(self) -> None:
+        latest_run = _run_record(
+            recorded_at="2026-05-09T02:09:59Z",
+            mutation="merge",
+        )
+
+        decision = evaluate_merge_train_admission(
+            repository="cbusillo/sellyouroutboard",
+            base_branch="main",
+            requested_at="2026-05-09T02:10:00Z",
+            latest_run=latest_run,
+        )
+
+        self.assertTrue(decision.admitted)
+        self.assertEqual(decision.reason_code, "reread_required")
+
+    def test_poll_required_mutation_defers_until_poll_interval_elapsed(self) -> None:
+        latest_run = _run_record(
+            recorded_at="2026-05-09T02:00:00Z",
+            mutation="wait",
+        )
+
+        pending_decision = evaluate_merge_train_admission(
+            repository="cbusillo/sellyouroutboard",
+            base_branch="main",
+            requested_at="2026-05-09T02:00:30Z",
+            latest_run=latest_run,
+            poll_interval_seconds=60,
+        )
+        elapsed_decision = evaluate_merge_train_admission(
+            repository="cbusillo/sellyouroutboard",
+            base_branch="main",
+            requested_at="2026-05-09T02:01:00Z",
+            latest_run=latest_run,
+            poll_interval_seconds=60,
+        )
+
+        self.assertFalse(pending_decision.admitted)
+        self.assertEqual(pending_decision.reason_code, "poll_interval_pending")
+        self.assertEqual(pending_decision.next_allowed_at, "2026-05-09T02:01:00Z")
+        self.assertTrue(elapsed_decision.admitted)
+        self.assertEqual(elapsed_decision.reason_code, "poll_interval_elapsed")
+
+    def test_non_reread_mutation_defers_until_backoff_elapsed(self) -> None:
+        latest_run = _run_record(
+            recorded_at="2026-05-09T02:00:00Z",
+            mutation="block",
+        )
+
+        pending_decision = evaluate_merge_train_admission(
+            repository="cbusillo/sellyouroutboard",
+            base_branch="main",
+            requested_at="2026-05-09T02:01:00Z",
+            latest_run=latest_run,
+            backoff_seconds=300,
+        )
+        elapsed_decision = evaluate_merge_train_admission(
+            repository="cbusillo/sellyouroutboard",
+            base_branch="main",
+            requested_at="2026-05-09T02:05:00Z",
+            latest_run=latest_run,
+            backoff_seconds=300,
+        )
+
+        self.assertFalse(pending_decision.admitted)
+        self.assertEqual(pending_decision.reason_code, "backoff_pending")
+        self.assertEqual(pending_decision.next_allowed_at, "2026-05-09T02:05:00Z")
+        self.assertTrue(elapsed_decision.admitted)
+        self.assertEqual(elapsed_decision.reason_code, "backoff_elapsed")
+
+    def test_rejects_latest_run_for_different_repository_scope(self) -> None:
+        latest_run = _run_record(recorded_at="2026-05-09T02:00:00Z")
+
+        with self.assertRaisesRegex(ValueError, "scope does not match"):
+            evaluate_merge_train_admission(
+                repository="cbusillo/other",
+                base_branch="main",
+                requested_at="2026-05-09T02:00:00Z",
+                latest_run=latest_run,
+            )
+
+    def test_reads_latest_run_from_store(self) -> None:
+        latest_run = _run_record(recorded_at="2026-05-09T02:00:00Z")
+        store = _RunHistoryStore(latest_run)
+
+        decision = evaluate_merge_train_admission_from_store(
+            store=store,
+            repository="cbusillo/sellyouroutboard",
+            base_branch="main",
+            requested_at="2026-05-09T02:01:00Z",
+        )
+
+        self.assertTrue(decision.admitted)
+        self.assertEqual(store.requests, [("cbusillo/sellyouroutboard", "main")])
+
+
+def _run_record(
+    *,
+    recorded_at: str,
+    mutation: str = "",
+) -> MergeTrainRunRecord:
+    policy = build_sellyouroutboard_main_merge_train_policy()
+    pull_request = _pull_request(42)
+    if mutation == "wait":
+        pull_request = _pull_request(42, required_checks_status="pending")
+    elif mutation == "block":
+        pull_request = _pull_request(42, required_checks_status="fail")
+    snapshot = MergeTrainDryRunSnapshot(
+        repository="cbusillo/sellyouroutboard",
+        base_branch="main",
+        pull_requests=(pull_request,),
+    )
+    dry_run_result = build_merge_train_dry_run_result(policy=policy, snapshot=snapshot)
+    worker_step_result = None
+    if mutation:
+        noop_client = _NoopClient()
+        worker_step_result = run_merge_train_worker_step(
+            policy=policy,
+            snapshot=snapshot,
+            clients=MergeTrainWorkerClients(
+                label_client=noop_client,
+                branch_client=noop_client,
+                merge_client=_FakeMergeClient(),
+            ),
+        )
+    return build_merge_train_run_record(
+        recorded_at=recorded_at,
+        trace_id="launchplane_req_admission_test",
+        policy_sha256=policy.policy_sha256,
+        snapshot=snapshot,
+        dry_run_result=dry_run_result,
+        worker_step_result=worker_step_result,
+    )
+
+
+def _pull_request(
+    number: int,
+    *,
+    required_checks_status: MergeTrainCheckStatus = "pass",
+) -> MergeTrainPullRequestSnapshot:
+    return MergeTrainPullRequestSnapshot(
+        number=number,
+        url=f"https://github.com/cbusillo/sellyouroutboard/pull/{number}",
+        title=f"Pull request {number}",
+        created_at="2026-05-09T01:00:00Z",
+        labels=("ready-to-merge",),
+        actor_role="repo_owner",
+        head_sha=f"head-{number}",
+        base_sha="base-main",
+        mergeable="mergeable",
+        required_checks_status=required_checks_status,
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1539,7 +1539,14 @@ class PostgresRecordStoreTests(unittest.TestCase):
             store.ensure_schema()
             record = _merge_train_run_record()
             store.write_merge_train_run_record(record)
+            store.write_merge_train_run_record(
+                _merge_train_run_record(recorded_at="2026-05-09T02:06:00Z")
+            )
             loaded_record = store.read_merge_train_run_record(record.run_id)
+            latest_record = store.latest_merge_train_run_record(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+            )
             listed_records = store.list_merge_train_run_records(
                 repository="cbusillo/sellyouroutboard",
                 base_branch="main",
@@ -1552,8 +1559,9 @@ class PostgresRecordStoreTests(unittest.TestCase):
         self.assertEqual(loaded_record.selected_pr_number, 42)
         self.assertEqual(loaded_record.selected_head_sha, "head-42")
         self.assertEqual(loaded_record.policy_key, "cbusillo/sellyouroutboard:main")
-        self.assertEqual(len(listed_records), 1)
-        self.assertEqual(listed_records[0].trace_id, "launchplane_req_merge_train_test")
+        self.assertEqual(latest_record.recorded_at if latest_record else "", "2026-05-09T02:06:00Z")
+        self.assertEqual(len(listed_records), 2)
+        self.assertEqual(listed_records[0].recorded_at, "2026-05-09T02:06:00Z")
 
     def test_write_and_list_dokploy_target_id_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add a typed merge-train admission decision contract over latest run history
- add storage helpers for latest merge-train run lookup
- document scheduler admission/backoff rules and cover the decision matrix in tests

Refs #410

## Validation
- uv run python -m unittest tests.test_merge_train_admission tests.test_postgres_store.PostgresRecordStoreTests.test_merge_train_run_records_round_trip
- uv run --extra dev ruff check --diff control_plane/contracts/merge_train_admission.py control_plane/merge_train_admission.py control_plane/storage/filesystem.py control_plane/storage/postgres.py tests/test_merge_train_admission.py tests/test_postgres_store.py docs/merge-train-policy.md
- uv run --extra dev ruff check control_plane/contracts/merge_train_admission.py control_plane/merge_train_admission.py control_plane/storage/filesystem.py control_plane/storage/postgres.py tests/test_merge_train_admission.py tests/test_postgres_store.py
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest