### PR TITLE
Add merge train admission endpoint

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -80,6 +80,7 @@ from control_plane.contracts.merge_train_policy import (
     build_sellyouroutboard_main_merge_train_policy,
 )
 from control_plane.contracts.merge_train_run_record import build_merge_train_run_record
+from control_plane.merge_train_admission import evaluate_merge_train_admission_from_store
 from control_plane.contracts.preview_mutation_request import (
     PreviewDestroyMutationRequest,
     PreviewGenerationMutationRequest,
@@ -305,6 +306,7 @@ from control_plane.workflows.verireel_preview_driver import (
 
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 _EVERY_CODE_GITHUB_WEBHOOK_ROUTE = "/v1/every-code/github-webhook"
+_MERGE_TRAIN_ADMISSION_ROUTE = "/v1/work-graph/merge-train/admission"
 _MERGE_TRAIN_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/run-once"
 _EVERY_CODE_GITHUB_WEBHOOK_SECRET_ENV_KEY = "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET"
 
@@ -329,6 +331,25 @@ class MergeTrainRunOnceEnvelope(BaseModel):
             raise ValueError("merge train repository must be owner/name")
         if not self.base_branch:
             raise ValueError("merge train run-once requires base_branch")
+        return self
+
+
+class MergeTrainAdmissionEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    repository: str
+    base_branch: str = "main"
+
+    @model_validator(mode="after")
+    def _validate_envelope(self) -> "MergeTrainAdmissionEnvelope":
+        self.repository = self.repository.strip()
+        self.base_branch = self.base_branch.strip()
+        if not self.repository:
+            raise ValueError("merge train admission requires repository")
+        if "/" not in self.repository:
+            raise ValueError("merge train repository must be owner/name")
+        if not self.base_branch:
+            raise ValueError("merge train admission requires base_branch")
         return self
 _GITHUB_CLOSING_REFERENCE_PATTERN = re.compile(
     r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+([^\n\r]+)", re.IGNORECASE
@@ -1776,6 +1797,8 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "operations.read", {"context": segments[2]}
     if len(segments) == 3 and segments == ["v1", "service", "runtime"]:
         return "launchplane_service.read", {}
+    if path == _MERGE_TRAIN_ADMISSION_ROUTE:
+        return "merge_train.admission", {}
     if len(segments) == 3 and segments == ["v1", "work-graph", "snapshot"]:
         return "work_graph.rank", {}
     if len(segments) == 2 and segments == ["v1", "repo-product-mapping"]:
@@ -5217,6 +5240,51 @@ def create_launchplane_service_app(
                         utc_now=_utc_now_timestamp,
                         json_response=_json_response,
                         start_response=start_response,
+                    )
+                if action == "merge_train.admission":
+                    admission_request = MergeTrainAdmissionEnvelope.model_validate(
+                        {
+                            "repository": str((query.get("repository") or [""])[0] or ""),
+                            "base_branch": str((query.get("base_branch") or ["main"])[0] or ""),
+                        }
+                    )
+                    policy = build_sellyouroutboard_main_merge_train_policy()
+                    repository_policy = policy.find_repository_policy(
+                        repository=admission_request.repository,
+                        base_branch=admission_request.base_branch,
+                    )
+                    if not authz_policy.allows(
+                        identity=identity,
+                        action=repository_policy.service_authz.action,
+                        product=repository_policy.service_authz.product,
+                        context=repository_policy.service_authz.context,
+                    ):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=403,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "authorization_denied",
+                                    "message": "Workflow cannot read the requested merge train admission decision.",
+                                },
+                            },
+                        )
+                    admission_decision = evaluate_merge_train_admission_from_store(
+                        store=record_store,
+                        repository=admission_request.repository,
+                        base_branch=admission_request.base_branch,
+                        requested_at=_utc_now_timestamp(),
+                    )
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=200,
+                        payload={
+                            "status": "ok",
+                            "trace_id": request_trace_id,
+                            "admission": admission_decision.model_dump(mode="json"),
+                        },
                     )
                 if action == "product_profile.read":
                     if "product" in params:

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -166,6 +166,12 @@ poll interval elapses. Other mutation records defer until the configured backoff
 interval elapses. Admission decisions are scheduling hints only; every admitted
 worker pass still reads a fresh GitHub snapshot before choosing an action.
 
+External schedulers can read the same decision from
+`GET /v1/work-graph/merge-train/admission?repository=owner/name&base_branch=main`.
+The route is policy-backed and authorized through the repository policy's
+`service_authz`, but it is store-only: it does not require a GitHub token, does
+not read GitHub, and does not write run records.
+
 The merge step is allowed only from a fresh dry-run result whose next action is
 `merge`. The merge request must use the selected pull request's observed
 `head_sha` as the GitHub merge `sha` guard and the repository policy's

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -195,6 +195,13 @@ repository policy, resolves its GitHub token from that policy's
 policy or token is available. The route is dry-run by default; `mutate: true`
 applies at most one worker transition from one fresh snapshot.
 
+`GET /v1/work-graph/merge-train/admission` returns the stored-history scheduler
+admission decision for a requested `repository` and `base_branch`. It uses the
+same merge-train repository policy and `service_authz` scope as `run-once`, but
+performs no GitHub reads and no storage writes. Schedulers use this route to
+pace calls into `run-once`; execution still re-reads GitHub before any dry-run or
+mutation.
+
 `GET /v1/repo-product-mapping` returns the repository ownership/awareness read
 model used by work graph and future agent context. The route requires
 `product_environment.read` for product/context `launchplane`, performs no

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -27,6 +27,9 @@ from control_plane.contracts.every_code_preview_gate_record import EveryCodePrev
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane.contracts.merge_train_policy import build_sellyouroutboard_main_merge_train_policy
+from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
+from control_plane.contracts.merge_train_run_record import build_merge_train_run_record
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
 from control_plane.contracts.preview_generation_record import (
     PreviewGenerationRecord,
@@ -53,6 +56,8 @@ from control_plane.contracts.runtime_key_safety_policy import (
 from control_plane.contracts.secret_record import SecretBinding
 from control_plane.contracts.work_graph_read_model import WorkGraphPlanningIssueFacts
 from control_plane.merge_train import MergeTrainDryRunSnapshot, MergeTrainPullRequestSnapshot
+from control_plane.merge_train import MergeTrainCheckStatus
+from control_plane.merge_train import build_merge_train_dry_run_result
 from control_plane.service import create_launchplane_service_app
 from control_plane.service_auth import (
     GitHubActionsIdentity,
@@ -81,6 +86,8 @@ from control_plane.workflows.verireel_app_maintenance import VeriReelAppMaintena
 from control_plane.workflows.verireel_prod_backup_gate import VeriReelProdBackupGateResult
 from control_plane.workflows.verireel_prod_promotion import VeriReelProdPromotionResult
 from control_plane.workflows.verireel_prod_rollback import VeriReelProdRollbackResult
+from control_plane.workflows.merge_train_worker import MergeTrainWorkerClients
+from control_plane.workflows.merge_train_worker import run_merge_train_worker_step
 from control_plane.workflows.verireel_stable_deploy import VeriReelStableDeployResult
 from control_plane.workflows.verireel_environment import VeriReelStableEnvironmentResult
 from control_plane.workflows.verireel_rollout import VeriReelRolloutVerificationResult
@@ -179,6 +186,28 @@ class _FakeMergeTrainGitHubClient:
         return f"merge-{pull_request_number}"
 
 
+class _NoopMergeTrainGitHubClient:
+    def add_pull_request_label(
+        self, *, repository: str, pull_request_number: int, label: str
+    ) -> None:
+        return None
+
+    def update_pull_request_branch(
+        self, *, repository: str, pull_request_number: int, expected_head_sha: str
+    ) -> None:
+        return None
+
+    def merge_pull_request(
+        self,
+        *,
+        repository: str,
+        pull_request_number: int,
+        head_sha: str,
+        merge_method: str,
+    ) -> str:
+        return f"merge-{pull_request_number}"
+
+
 class _FakeMergeTrainSnapshotReader:
     def __init__(self, *, transport: object) -> None:
         self.transport = transport
@@ -204,6 +233,81 @@ class _FakeMergeTrainSnapshotReader:
                 ),
             ),
         )
+
+
+def _merge_train_service_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "cbusillo/launchplane",
+                    "workflow_refs": [
+                        "cbusillo/launchplane/.github/workflows/merge-train.yml@refs/heads/main"
+                    ],
+                    "event_names": ["workflow_dispatch"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["merge_train.run_once"],
+                }
+            ]
+        }
+    )
+
+
+def _merge_train_service_identity() -> GitHubActionsIdentity:
+    return _identity(
+        repository="cbusillo/launchplane",
+        workflow_ref="cbusillo/launchplane/.github/workflows/merge-train.yml@refs/heads/main",
+        event_name="workflow_dispatch",
+    )
+
+
+def _merge_train_run_record(
+    *,
+    recorded_at: str,
+    required_checks_status: MergeTrainCheckStatus = "pass",
+    mutate: bool = False,
+) -> MergeTrainRunRecord:
+    policy = build_sellyouroutboard_main_merge_train_policy()
+    snapshot = MergeTrainDryRunSnapshot(
+        repository="cbusillo/sellyouroutboard",
+        base_branch="main",
+        pull_requests=(
+            MergeTrainPullRequestSnapshot(
+                number=1,
+                url="https://github.com/cbusillo/sellyouroutboard/pull/1",
+                title="Ready PR",
+                created_at="2026-05-08T10:00:00Z",
+                labels=("ready-to-merge",),
+                actor_role="repo_admin",
+                head_sha="head-1",
+                base_sha="base-main",
+                mergeable="mergeable",
+                required_checks_status=required_checks_status,
+            ),
+        ),
+    )
+    dry_run_result = build_merge_train_dry_run_result(policy=policy, snapshot=snapshot)
+    worker_step_result = None
+    if mutate:
+        noop_client = _NoopMergeTrainGitHubClient()
+        worker_step_result = run_merge_train_worker_step(
+            policy=policy,
+            snapshot=snapshot,
+            clients=MergeTrainWorkerClients(
+                label_client=noop_client,
+                branch_client=noop_client,
+                merge_client=noop_client,
+            ),
+        )
+    return build_merge_train_run_record(
+        recorded_at=recorded_at,
+        trace_id="launchplane_req_merge_train_service_test",
+        policy_sha256=policy.policy_sha256,
+        snapshot=snapshot,
+        dry_run_result=dry_run_result,
+        worker_step_result=worker_step_result,
+    )
 
 
 def _identity(
@@ -1223,6 +1327,80 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 400)
         self.assertEqual(payload["error"]["code"], "invalid_request")
+
+    def test_merge_train_admission_service_admits_without_prior_run(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                side_effect=AssertionError("admission must not read GitHub"),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/work-graph/merge-train/admission",
+                    query_string=(
+                        "repository=cbusillo/sellyouroutboard&base_branch=main"
+                    ),
+                )
+
+        self.assertEqual(status_code, 200)
+        self.assertEqual(payload["admission"]["status"], "admitted")
+        self.assertEqual(payload["admission"]["reason_code"], "no_prior_run")
+        self.assertEqual(payload["admission"]["latest_run_id"], "")
+
+    def test_merge_train_admission_service_defers_recent_wait_run(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir)
+            wait_record = _merge_train_run_record(
+                recorded_at="2999-01-01T00:00:00Z",
+                required_checks_status="pending",
+                mutate=True,
+            )
+            store.write_merge_train_run_record(wait_record)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/work-graph/merge-train/admission",
+                query_string="repository=cbusillo/sellyouroutboard&base_branch=main",
+            )
+
+        self.assertEqual(status_code, 200)
+        self.assertEqual(payload["admission"]["status"], "deferred")
+        self.assertEqual(payload["admission"]["reason_code"], "poll_interval_pending")
+        self.assertEqual(payload["admission"]["latest_run_id"], wait_record.run_id)
+        self.assertEqual(payload["admission"]["latest_run_status"], "waiting")
+        self.assertEqual(payload["admission"]["next_allowed_at"], "2999-01-01T00:01:00Z")
+
+    def test_merge_train_admission_service_rejects_unauthorized_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/work-graph/merge-train/admission",
+                query_string="repository=cbusillo/sellyouroutboard&base_branch=main",
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
 
     def test_every_code_github_webhook_creates_work_request(self) -> None:
         secret = "launchplane-every-code-webhook-secret"


### PR DESCRIPTION
## Summary
- add a read-only merge-train admission endpoint backed by stored run history
- authorize admission reads through the matching repository policy service_authz
- document the endpoint and cover admitted/deferred/unauthorized service cases

Refs #410

## Verification
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_merge_train_admission_service_admits_without_prior_run tests.test_service.LaunchplaneServiceTests.test_merge_train_admission_service_defers_recent_wait_run tests.test_service.LaunchplaneServiceTests.test_merge_train_admission_service_rejects_unauthorized_identity
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_service.py docs/service-boundary.md docs/merge-train-policy.md
- uv run --extra dev ruff check control_plane/service.py tests/test_service.py docs/service-boundary.md docs/merge-train-policy.md
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest