### PR TITLE
Harden merge train runner activation

### DIFF
--- a/.github/workflows/merge-train-runner.yml
+++ b/.github/workflows/merge-train-runner.yml
@@ -16,10 +16,12 @@ name: Merge Train Runner
         required: false
         default: main
       mutate:
-        description: Apply one worker mutation when admitted
+        description: >-
+          Apply one worker mutation when admitted. Scheduled runs use
+          LAUNCHPLANE_MERGE_TRAIN_MUTATE instead.
         type: boolean
         required: false
-        default: true
+        default: false
 
 permissions:
   contents: read
@@ -45,7 +47,17 @@ jobs:
       MERGE_TRAIN_REPOSITORY: >-
         ${{ inputs.repository || vars.LAUNCHPLANE_MERGE_TRAIN_REPOSITORY }}
       MERGE_TRAIN_BASE_BRANCH: ${{ inputs.base_branch || 'main' }}
-      MERGE_TRAIN_MUTATE: ${{ inputs.mutate && 'true' || 'false' }}
+      MERGE_TRAIN_MUTATE: >-
+        ${{
+          (
+            github.event_name == 'schedule' &&
+            vars.LAUNCHPLANE_MERGE_TRAIN_MUTATE == 'true'
+          ) && 'true' ||
+          (
+            github.event_name != 'schedule' && inputs.mutate
+          ) && 'true' ||
+          'false'
+        }}
     steps:
       - name: Request admission decision
         id: admission

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -207,7 +207,10 @@ mutation.
 this route. It mints a GitHub Actions OIDC token for the Launchplane service,
 reads admission, and calls `run-once` only when the decision is `admitted`.
 Repository and base-branch selection come from workflow inputs or repository
-variables, not service code.
+variables, not service code. Manual dispatch defaults to dry-run mode; scheduled
+runs also dry-run unless the repository variable `LAUNCHPLANE_MERGE_TRAIN_MUTATE`
+is set to `true`. This keeps activation explicit after setting
+`LAUNCHPLANE_MERGE_TRAIN_REPOSITORY`.
 
 `GET /v1/repo-product-mapping` returns the repository ownership/awareness read
 model used by work graph and future agent context. The route requires


### PR DESCRIPTION
## Summary
- default manual merge-train runner dispatches to dry-run mode
- require `LAUNCHPLANE_MERGE_TRAIN_MUTATE=true` before scheduled runs mutate
- document the dry-run-first activation contract

Refs #410

## Verification
- `docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`