### PR TITLE
Add read-only runner lane inventory

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -133,6 +133,7 @@ from control_plane.merge_train_github import (
     MergeTrainGitHubError,
     UrllibMergeTrainGitHubTransport,
 )
+from control_plane.runner_lane_github import GitHubRunnerLaneInventoryReader
 from control_plane.service import serve_launchplane_service
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.factory import build_record_store, resolve_database_url
@@ -9554,6 +9555,50 @@ def work_graph_merge_train_run_once(
     except (OSError, ValidationError, ValueError) as error:
         raise click.ClickException(str(error)) from error
     click.echo(json.dumps(payload, indent=2, sort_keys=True))
+
+
+@work_graph.command("runner-inventory")
+@click.option(
+    "--repository",
+    required=True,
+    help="owner/name repository whose self-hosted runner lanes should be listed.",
+)
+@click.option(
+    "--github-token-env",
+    default="GITHUB_TOKEN",
+    show_default=True,
+    help="Environment variable containing the GitHub token used for read-only runner inventory.",
+)
+@click.option(
+    "--github-api-base-url",
+    default="https://api.github.com",
+    show_default=True,
+    help="GitHub API base URL.",
+)
+def work_graph_runner_inventory(
+    repository: str, github_token_env: str, github_api_base_url: str
+) -> None:
+    try:
+        token_env = github_token_env.strip()
+        if not token_env:
+            raise click.ClickException("runner inventory requires --github-token-env.")
+        token = os.environ.get(token_env, "").strip()
+        if not token:
+            raise click.ClickException(f"Missing GitHub token in environment variable {token_env}.")
+        transport = UrllibMergeTrainGitHubTransport(
+            token=token, api_base_url=github_api_base_url
+        )
+        inventory = GitHubRunnerLaneInventoryReader(
+            transport=transport
+        ).read_runner_lane_inventory(repository=repository)
+    except MergeTrainGitHubError as error:
+        detail = str(error)
+        if error.status_code is not None:
+            detail = f"{detail} (HTTP {error.status_code})"
+        raise click.ClickException(f"GitHub runner inventory request failed: {detail}") from error
+    except (OSError, ValidationError, ValueError) as error:
+        raise click.ClickException(str(error)) from error
+    click.echo(json.dumps(inventory.model_dump(mode="json"), indent=2, sort_keys=True))
 
 
 @every_code.command("run-once")

--- a/control_plane/contracts/runner_lane_inventory.py
+++ b/control_plane/contracts/runner_lane_inventory.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class RunnerLaneRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    github_id: int = Field(ge=1)
+    name: str
+    repository: str
+    status: str
+    busy: bool
+    labels: tuple[str, ...] = ()
+    host_hint: str = ""
+    observed_at: str
+
+    @model_validator(mode="after")
+    def _normalize_record(self) -> "RunnerLaneRecord":
+        self.name = _required_text(self.name, "runner lane requires name")
+        self.repository = _required_text(
+            self.repository, "runner lane requires repository"
+        )
+        self.status = _required_text(self.status, "runner lane requires status").lower()
+        self.labels = tuple(sorted({label.strip() for label in self.labels if label.strip()}))
+        self.host_hint = self.host_hint.strip()
+        self.observed_at = _required_text(
+            self.observed_at, "runner lane requires observed_at"
+        )
+        return self
+
+
+class RunnerLaneInventory(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    repository: str
+    observed_at: str
+    lanes: tuple[RunnerLaneRecord, ...]
+    total_lanes: int = Field(ge=0)
+    online_lanes: int = Field(ge=0)
+    busy_lanes: int = Field(ge=0)
+    idle_lanes: int = Field(ge=0)
+    offline_lanes: int = Field(ge=0)
+    capacity_constrained: bool
+    capacity_reason: str
+
+    @model_validator(mode="after")
+    def _normalize_inventory(self) -> "RunnerLaneInventory":
+        self.repository = _required_text(
+            self.repository, "runner lane inventory requires repository"
+        )
+        self.observed_at = _required_text(
+            self.observed_at, "runner lane inventory requires observed_at"
+        )
+        self.lanes = tuple(sorted(self.lanes, key=lambda lane: (lane.name, lane.github_id)))
+        self.capacity_reason = self.capacity_reason.strip()
+        return self
+
+
+def build_runner_lane_inventory(
+    *, repository: str, observed_at: str, lanes: tuple[RunnerLaneRecord, ...]
+) -> RunnerLaneInventory:
+    online_lanes = tuple(lane for lane in lanes if lane.status == "online")
+    busy_lanes = tuple(lane for lane in online_lanes if lane.busy)
+    idle_lanes = tuple(lane for lane in online_lanes if not lane.busy)
+    offline_lanes = tuple(lane for lane in lanes if lane.status != "online")
+    capacity_constrained = not idle_lanes
+    capacity_reason = "idle lane available"
+    if not lanes:
+        capacity_reason = "no self-hosted runner lanes discovered"
+    elif not online_lanes:
+        capacity_reason = "no online self-hosted runner lanes discovered"
+    elif capacity_constrained:
+        capacity_reason = "all online self-hosted runner lanes are busy"
+    return RunnerLaneInventory(
+        repository=repository,
+        observed_at=observed_at,
+        lanes=lanes,
+        total_lanes=len(lanes),
+        online_lanes=len(online_lanes),
+        busy_lanes=len(busy_lanes),
+        idle_lanes=len(idle_lanes),
+        offline_lanes=len(offline_lanes),
+        capacity_constrained=capacity_constrained,
+        capacity_reason=capacity_reason,
+    )
+
+
+def _required_text(value: str, message: str) -> str:
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise ValueError(message)
+    return normalized_value

--- a/control_plane/runner_lane_github.py
+++ b/control_plane/runner_lane_github.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Protocol
+from urllib.parse import urlencode
+
+from control_plane.contracts.runner_lane_inventory import RunnerLaneInventory
+from control_plane.contracts.runner_lane_inventory import RunnerLaneRecord
+from control_plane.contracts.runner_lane_inventory import build_runner_lane_inventory
+from control_plane.merge_train_github import MergeTrainGitHubError
+from control_plane.merge_train_github import MergeTrainGitHubTransport
+
+
+class RunnerLaneClock(Protocol):
+    def now(self) -> datetime: ...
+
+
+class SystemRunnerLaneClock:
+    def now(self) -> datetime:
+        return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+class GitHubRunnerLaneInventoryReader:
+    def __init__(
+        self,
+        *,
+        transport: MergeTrainGitHubTransport,
+        clock: RunnerLaneClock | None = None,
+    ) -> None:
+        self.transport = transport
+        self.clock = clock or SystemRunnerLaneClock()
+
+    def read_runner_lane_inventory(self, *, repository: str) -> RunnerLaneInventory:
+        repository_path = _repository_path(repository)
+        observed_at = self.clock.now().isoformat().replace("+00:00", "Z")
+        lanes: list[RunnerLaneRecord] = []
+        page = 1
+        while True:
+            query = urlencode({"per_page": "100", "page": str(page)})
+            payload = self.transport.request(
+                method="GET", path=f"/repos/{repository_path}/actions/runners?{query}"
+            )
+            payload_object = _json_object(payload, "GitHub runner list response")
+            runners_payload = payload_object.get("runners")
+            if not isinstance(runners_payload, list):
+                raise MergeTrainGitHubError(
+                    "GitHub runner list response must include runners."
+                )
+            page_lanes = tuple(
+                _runner_lane_record(
+                    repository=repository,
+                    observed_at=observed_at,
+                    payload=_json_object(runner, "GitHub runner entry"),
+                )
+                for runner in runners_payload
+            )
+            lanes.extend(page_lanes)
+            if len(page_lanes) < 100:
+                return build_runner_lane_inventory(
+                    repository=repository,
+                    observed_at=observed_at,
+                    lanes=tuple(lanes),
+                )
+            page += 1
+
+
+def _runner_lane_record(
+    *, repository: str, observed_at: str, payload: dict[str, object]
+) -> RunnerLaneRecord:
+    return RunnerLaneRecord(
+        github_id=_required_int(payload.get("id"), "GitHub runner entry requires id."),
+        name=_required_text(payload.get("name"), "GitHub runner entry requires name."),
+        repository=repository,
+        status=_required_text(payload.get("status"), "GitHub runner entry requires status."),
+        busy=bool(payload.get("busy")),
+        labels=_runner_labels(payload.get("labels")),
+        host_hint=_host_hint_from_name(
+            _required_text(payload.get("name"), "GitHub runner entry requires name.")
+        ),
+        observed_at=observed_at,
+    )
+
+
+def _runner_labels(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise MergeTrainGitHubError("GitHub runner labels must be a JSON array.")
+    labels: list[str] = []
+    for item in value:
+        label = _json_object(item, "GitHub runner label")
+        labels.append(_required_text(label.get("name"), "GitHub runner label requires name."))
+    return tuple(labels)
+
+
+def _host_hint_from_name(name: str) -> str:
+    normalized_name = name.strip()
+    if not normalized_name:
+        return ""
+    for separator in (":", "/"):
+        if separator in normalized_name:
+            return normalized_name.split(separator, 1)[0].strip()
+    segments = [segment for segment in normalized_name.split("-") if segment]
+    if len(segments) >= 3:
+        return "-".join(segments[:2])
+    return normalized_name
+
+
+def _repository_path(repository: str) -> str:
+    normalized_repository = repository.strip()
+    if normalized_repository.count("/") != 1:
+        raise ValueError("GitHub repository must be formatted as owner/name.")
+    owner, repo = normalized_repository.split("/", 1)
+    if not owner or not repo:
+        raise ValueError("GitHub repository must be formatted as owner/name.")
+    return normalized_repository
+
+
+def _json_object(value: object, label: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise MergeTrainGitHubError(f"{label} must be a JSON object.")
+    return value
+
+
+def _required_text(value: object, message: str) -> str:
+    normalized_value = str(value or "").strip()
+    if not normalized_value:
+        raise MergeTrainGitHubError(message)
+    return normalized_value
+
+
+def _required_int(value: object, message: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise MergeTrainGitHubError(message)
+    return value

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -211,6 +211,11 @@ Dokploy-hosted.
   and the CI container scan pulls Trivy from GHCR so self-hosted runners do not
   fail closed on Docker Hub anonymous pull limits before Launchplane code is
   built or scanned.
+- Before adding or controlling self-hosted runner lanes, use
+  `uv run launchplane work-graph runner-inventory --repository owner/name` to
+  read GitHub's current repository runner list. The command is read-only and
+  reports lane count, online/busy/idle/offline counts, labels, host hints, and a
+  capacity-constrained heuristic from the observation timestamp.
 - Deploy verification should probe Launchplane's live health endpoint, currently
   `GET /v1/health`, after the Dokploy update.
 - When rollout health fails, deploy automation should restore the previous

--- a/tests/test_runner_lane_inventory.py
+++ b/tests/test_runner_lane_inventory.py
@@ -1,0 +1,160 @@
+from datetime import datetime, timezone
+import json
+import unittest
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from control_plane.cli import main
+from control_plane.contracts.runner_lane_inventory import RunnerLaneInventory
+from control_plane.runner_lane_github import GitHubRunnerLaneInventoryReader
+from control_plane.merge_train_github import MergeTrainGitHubError
+from control_plane.merge_train_github import RecordingMergeTrainGitHubTransport
+
+
+class _FixedClock:
+    def now(self) -> datetime:
+        return datetime(2026, 5, 9, 12, 45, tzinfo=timezone.utc)
+
+
+class GitHubRunnerLaneInventoryReaderTests(unittest.TestCase):
+    def test_reader_builds_capacity_summary_from_github_runners(self) -> None:
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                {
+                    "total_count": 3,
+                    "runners": [
+                        _runner(101, "chris-testing-syo-1", busy=True),
+                        _runner(102, "chris-testing-syo-2", busy=False),
+                        _runner(103, "chris-testing-syo-3", status="offline"),
+                    ],
+                },
+            )
+        )
+
+        inventory = GitHubRunnerLaneInventoryReader(
+            transport=transport, clock=_FixedClock()
+        ).read_runner_lane_inventory(repository="cbusillo/sellyouroutboard")
+
+        self.assertEqual(inventory.repository, "cbusillo/sellyouroutboard")
+        self.assertEqual(inventory.observed_at, "2026-05-09T12:45:00Z")
+        self.assertEqual(inventory.total_lanes, 3)
+        self.assertEqual(inventory.online_lanes, 2)
+        self.assertEqual(inventory.busy_lanes, 1)
+        self.assertEqual(inventory.idle_lanes, 1)
+        self.assertEqual(inventory.offline_lanes, 1)
+        self.assertFalse(inventory.capacity_constrained)
+        self.assertEqual(inventory.lanes[0].host_hint, "chris-testing")
+        self.assertEqual(
+            [request.path for request in transport.requests],
+            ["/repos/cbusillo/sellyouroutboard/actions/runners?per_page=100&page=1"],
+        )
+
+    def test_reader_marks_all_busy_online_lanes_as_capacity_constrained(self) -> None:
+        inventory = GitHubRunnerLaneInventoryReader(
+            transport=RecordingMergeTrainGitHubTransport(
+                responses=(
+                    {"total_count": 1, "runners": [_runner(201, "lane-1", busy=True)]},
+                )
+            ),
+            clock=_FixedClock(),
+        ).read_runner_lane_inventory(repository="cbusillo/repo")
+
+        self.assertTrue(inventory.capacity_constrained)
+        self.assertEqual(
+            inventory.capacity_reason, "all online self-hosted runner lanes are busy"
+        )
+
+    def test_reader_paginates_runner_results(self) -> None:
+        first_page = [_runner(number, f"lane-{number}") for number in range(1, 101)]
+        second_page = [_runner(101, "lane-101")]
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                {"total_count": 101, "runners": first_page},
+                {"total_count": 101, "runners": second_page},
+            )
+        )
+
+        inventory = GitHubRunnerLaneInventoryReader(
+            transport=transport, clock=_FixedClock()
+        ).read_runner_lane_inventory(repository="cbusillo/repo")
+
+        self.assertEqual(inventory.total_lanes, 101)
+        self.assertEqual(
+            [request.path for request in transport.requests],
+            [
+                "/repos/cbusillo/repo/actions/runners?per_page=100&page=1",
+                "/repos/cbusillo/repo/actions/runners?per_page=100&page=2",
+            ],
+        )
+
+    def test_reader_rejects_malformed_runner_response(self) -> None:
+        reader = GitHubRunnerLaneInventoryReader(
+            transport=RecordingMergeTrainGitHubTransport(responses=({"runners": {}},)),
+            clock=_FixedClock(),
+        )
+
+        with self.assertRaisesRegex(MergeTrainGitHubError, "must include runners"):
+            reader.read_runner_lane_inventory(repository="cbusillo/repo")
+
+
+class RunnerLaneInventoryCliTests(unittest.TestCase):
+    def test_cli_prints_runner_inventory_json(self) -> None:
+        class _FakeInventoryReader:
+            def __init__(self, *, transport: object) -> None:
+                self.transport = transport
+
+            def read_runner_lane_inventory(self, *, repository: str) -> RunnerLaneInventory:
+                return GitHubRunnerLaneInventoryReader(
+                    transport=RecordingMergeTrainGitHubTransport(
+                        responses=({"total_count": 1, "runners": [_runner(301, "lane-1")]},)
+                    ),
+                    clock=_FixedClock(),
+                ).read_runner_lane_inventory(repository=repository)
+
+        with (
+            patch("control_plane.cli.UrllibMergeTrainGitHubTransport", return_value=object()),
+            patch("control_plane.cli.GitHubRunnerLaneInventoryReader", _FakeInventoryReader),
+            patch.dict("os.environ", {"GITHUB_TOKEN": "token"}, clear=True),
+        ):
+            result = CliRunner().invoke(
+                main,
+                [
+                    "work-graph",
+                    "runner-inventory",
+                    "--repository",
+                    "cbusillo/repo",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["repository"], "cbusillo/repo")
+        self.assertEqual(payload["total_lanes"], 1)
+        self.assertEqual(payload["idle_lanes"], 1)
+
+    def test_cli_requires_github_token(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            result = CliRunner().invoke(
+                main,
+                ["work-graph", "runner-inventory", "--repository", "cbusillo/repo"],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Missing GitHub token", result.output)
+
+
+def _runner(
+    runner_id: int, name: str, *, status: str = "online", busy: bool = False
+) -> dict[str, object]:
+    return {
+        "id": runner_id,
+        "name": name,
+        "status": status,
+        "busy": busy,
+        "labels": [{"name": "self-hosted"}, {"name": "launchplane"}],
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a typed runner lane inventory read model with online/busy/idle/offline counts
- add a GitHub repository runner inventory reader with pagination and fail-closed shape validation
- expose `work-graph runner-inventory` as a read-only CLI command
- document using runner inventory before adding or controlling self-hosted lanes

Refs #413

## Verification
- `uv run python -m unittest tests.test_runner_lane_inventory`
- `uv run --extra dev ruff check --diff control_plane/contracts/runner_lane_inventory.py control_plane/runner_lane_github.py control_plane/cli.py tests/test_runner_lane_inventory.py`
- `uv run --extra dev ruff check control_plane/contracts/runner_lane_inventory.py control_plane/runner_lane_github.py control_plane/cli.py tests/test_runner_lane_inventory.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`
- `GITHUB_TOKEN="$(gh auth token)" uv run launchplane work-graph runner-inventory --repository cbusillo/launchplane`