### PR TITLE
Add Odoo preview adapter routes

### DIFF
--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -387,9 +387,12 @@ GENERIC_WEB_DRIVER = DriverDescriptor(
 
 ODOO_DRIVER = DriverDescriptor(
     driver_id="odoo",
+    base_driver_id="generic-web",
     label="Odoo",
     product="odoo",
-    description="Stable-lane Odoo artifact, deploy, backup, promotion, rollback, and settings driver.",
+    description=(
+        "Odoo artifact, deploy, preview, backup, promotion, rollback, and settings driver."
+    ),
     context_patterns=("cm", "opw"),
     provider_boundary=PROVIDER_BOUNDARY_NOTE,
     capabilities=(
@@ -413,6 +416,23 @@ ODOO_DRIVER = DriverDescriptor(
             description="Capture backup evidence, promote testing to prod, and roll back prod to stored artifacts.",
             actions=("prod_backup_gate", "prod_promotion", "prod_rollback"),
             panels=("lane_health", "deployment_evidence", "promotion_evidence", "backup_evidence"),
+        ),
+        DriverCapabilityDescriptor(
+            capability_id="previewable",
+            label="Previewable",
+            description=(
+                "Create, refresh, inventory, and destroy Odoo PR previews through the "
+                "generic-web preview lifecycle."
+            ),
+            actions=("preview_desired_state", "preview_refresh"),
+            panels=("preview_inventory", "deployment_evidence", "audit"),
+        ),
+        DriverCapabilityDescriptor(
+            capability_id="preview_inventory_managed",
+            label="Preview inventory managed",
+            description="Read provider inventory and reconcile current Odoo preview state.",
+            actions=("preview_inventory", "preview_destroy"),
+            panels=("preview_inventory", "deployment_evidence", "audit"),
         ),
     ),
     actions=(
@@ -444,6 +464,54 @@ ODOO_DRIVER = DriverDescriptor(
             route_path="/v1/drivers/odoo/post-deploy",
             authz_action="odoo_post_deploy.execute",
             writes_records=("odoo_instance_override",),
+        ),
+        _action(
+            "preview_desired_state",
+            "Discover desired previews",
+            "Discover labeled Odoo pull requests and record desired preview state.",
+            safety="safe_write",
+            scope="context",
+            route_path="/v1/drivers/odoo/preview-desired-state",
+            authz_action="preview_desired_state.discover",
+            writes_records=("preview_desired_state",),
+        ),
+        _action(
+            "preview_refresh",
+            "Refresh preview",
+            "Create or update an Odoo preview through the generic-web preview lifecycle.",
+            safety="mutation",
+            scope="preview",
+            route_path="/v1/drivers/odoo/preview-refresh",
+            authz_action="preview_refresh.execute",
+        ),
+        _action(
+            "preview_inventory",
+            "Read preview inventory",
+            "Scan provider state for active Odoo previews and record inventory evidence.",
+            safety="safe_write",
+            scope="context",
+            route_path="/v1/drivers/odoo/preview-inventory",
+            authz_action="preview_inventory.read",
+            writes_records=("preview_inventory_scan",),
+        ),
+        _action(
+            "preview_readiness",
+            "Evaluate preview readiness",
+            "Validate Odoo preview template settings before provider mutation.",
+            safety="read",
+            scope="context",
+            route_path="/v1/drivers/odoo/preview-readiness",
+            authz_action="preview_readiness.evaluate",
+        ),
+        _action(
+            "preview_destroy",
+            "Destroy preview",
+            "Destroy an Odoo preview application and record cleanup evidence.",
+            safety="destructive",
+            scope="preview",
+            route_path="/v1/drivers/odoo/preview-destroy",
+            authz_action="preview_destroy.execute",
+            writes_records=("preview",),
         ),
         _action(
             "prod_backup_gate",

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -664,6 +664,63 @@ _GENERIC_WEB_PREVIEW_DESTROY_ROUTE = _DriverRouteExecutionMetadata(
 )
 
 
+_ODOO_PREVIEW_DESIRED_STATE_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/odoo/preview-desired-state",
+    envelope_model=GenericWebPreviewDesiredStateEnvelope,
+    denial_message=(
+        "Workflow cannot discover Odoo preview desired state for the requested product/context."
+    ),
+)
+
+
+_ODOO_PREVIEW_REFRESH_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/odoo/preview-refresh",
+    envelope_model=GenericWebPreviewRefreshEnvelope,
+    denial_message="Workflow cannot refresh Odoo preview state for the requested product/context.",
+)
+
+
+_ODOO_PREVIEW_INVENTORY_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/odoo/preview-inventory",
+    envelope_model=GenericWebPreviewInventoryEnvelope,
+    denial_message="Workflow cannot read Odoo preview inventory for the requested product/context.",
+)
+
+
+_ODOO_PREVIEW_READINESS_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/odoo/preview-readiness",
+    envelope_model=GenericWebPreviewReadinessEnvelope,
+    denial_message="Workflow cannot evaluate Odoo preview readiness for the requested product/context.",
+)
+
+
+_ODOO_PREVIEW_DESTROY_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/odoo/preview-destroy",
+    envelope_model=GenericWebPreviewDestroyEnvelope,
+    denial_message="Workflow cannot destroy Odoo preview state for the requested product/context.",
+)
+
+
+_PREVIEW_DESIRED_STATE_ROUTE_PATHS = frozenset(
+    {
+        _GENERIC_WEB_PREVIEW_DESIRED_STATE_ROUTE.route_path,
+        _ODOO_PREVIEW_DESIRED_STATE_ROUTE.route_path,
+    }
+)
+_PREVIEW_INVENTORY_ROUTE_PATHS = frozenset(
+    {_GENERIC_WEB_PREVIEW_INVENTORY_ROUTE.route_path, _ODOO_PREVIEW_INVENTORY_ROUTE.route_path}
+)
+_PREVIEW_REFRESH_ROUTE_PATHS = frozenset(
+    {_GENERIC_WEB_PREVIEW_REFRESH_ROUTE.route_path, _ODOO_PREVIEW_REFRESH_ROUTE.route_path}
+)
+_PREVIEW_READINESS_ROUTE_PATHS = frozenset(
+    {_GENERIC_WEB_PREVIEW_READINESS_ROUTE.route_path, _ODOO_PREVIEW_READINESS_ROUTE.route_path}
+)
+_PREVIEW_DESTROY_ROUTE_PATHS = frozenset(
+    {_GENERIC_WEB_PREVIEW_DESTROY_ROUTE.route_path, _ODOO_PREVIEW_DESTROY_ROUTE.route_path}
+)
+
+
 class BackupGateEvidenceEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -1610,6 +1667,46 @@ def _authorize_generic_web_preview_route(
         trace_id=trace_id,
     )
     return request, profile, authorization_response
+
+
+def _generic_web_preview_desired_state_route_metadata(
+    path: str,
+) -> _DriverRouteExecutionMetadata[GenericWebPreviewDesiredStateEnvelope]:
+    if path == _ODOO_PREVIEW_DESIRED_STATE_ROUTE.route_path:
+        return _ODOO_PREVIEW_DESIRED_STATE_ROUTE
+    return _GENERIC_WEB_PREVIEW_DESIRED_STATE_ROUTE
+
+
+def _generic_web_preview_inventory_route_metadata(
+    path: str,
+) -> _DriverRouteExecutionMetadata[GenericWebPreviewInventoryEnvelope]:
+    if path == _ODOO_PREVIEW_INVENTORY_ROUTE.route_path:
+        return _ODOO_PREVIEW_INVENTORY_ROUTE
+    return _GENERIC_WEB_PREVIEW_INVENTORY_ROUTE
+
+
+def _generic_web_preview_refresh_route_metadata(
+    path: str,
+) -> _DriverRouteExecutionMetadata[GenericWebPreviewRefreshEnvelope]:
+    if path == _ODOO_PREVIEW_REFRESH_ROUTE.route_path:
+        return _ODOO_PREVIEW_REFRESH_ROUTE
+    return _GENERIC_WEB_PREVIEW_REFRESH_ROUTE
+
+
+def _generic_web_preview_readiness_route_metadata(
+    path: str,
+) -> _DriverRouteExecutionMetadata[GenericWebPreviewReadinessEnvelope]:
+    if path == _ODOO_PREVIEW_READINESS_ROUTE.route_path:
+        return _ODOO_PREVIEW_READINESS_ROUTE
+    return _GENERIC_WEB_PREVIEW_READINESS_ROUTE
+
+
+def _generic_web_preview_destroy_route_metadata(
+    path: str,
+) -> _DriverRouteExecutionMetadata[GenericWebPreviewDestroyEnvelope]:
+    if path == _ODOO_PREVIEW_DESTROY_ROUTE.route_path:
+        return _ODOO_PREVIEW_DESTROY_ROUTE
+    return _GENERIC_WEB_PREVIEW_DESTROY_ROUTE
 
 
 def _http_status_text(status_code: int) -> str:
@@ -2869,7 +2966,7 @@ def _request_fingerprint(payload: dict[str, object]) -> str:
 def _canonical_request_payload_for_idempotency(
     *, route_path: str, payload: dict[str, object]
 ) -> dict[str, object]:
-    if route_path != _GENERIC_WEB_PREVIEW_DESTROY_ROUTE.route_path:
+    if route_path not in _PREVIEW_DESTROY_ROUTE_PATHS:
         return payload
     canonical_payload = json.loads(json.dumps(payload))
     destroy_payload = canonical_payload.get("destroy")
@@ -6800,10 +6897,10 @@ def create_launchplane_service_app(
                     request=generic_web_workflow_request.workflow,
                 )
                 result = driver_result.model_dump(mode="json")
-            elif path == _GENERIC_WEB_PREVIEW_DESIRED_STATE_ROUTE.route_path:
+            elif path in _PREVIEW_DESIRED_STATE_ROUTE_PATHS:
                 generic_web_desired_state_request, profile, authorization_response = (
                     _authorize_generic_web_preview_route(
-                        route_metadata=_GENERIC_WEB_PREVIEW_DESIRED_STATE_ROUTE,
+                        route_metadata=_generic_web_preview_desired_state_route_metadata(path),
                         payload=payload,
                         record_store=record_store,
                         authz_policy=authz_policy,
@@ -6837,10 +6934,10 @@ def create_launchplane_service_app(
                     record=driver_result,
                 )
                 result = {"preview_desired_state_id": preview_desired_state_id}
-            elif path == _GENERIC_WEB_PREVIEW_INVENTORY_ROUTE.route_path:
+            elif path in _PREVIEW_INVENTORY_ROUTE_PATHS:
                 generic_web_inventory_request, profile, authorization_response = (
                     _authorize_generic_web_preview_route(
-                        route_metadata=_GENERIC_WEB_PREVIEW_INVENTORY_ROUTE,
+                        route_metadata=_generic_web_preview_inventory_route_metadata(path),
                         payload=payload,
                         record_store=record_store,
                         authz_policy=authz_policy,
@@ -6864,10 +6961,10 @@ def create_launchplane_service_app(
                     preview_slugs=tuple(item.previewSlug for item in driver_result.previews),
                 )
                 result = {"preview_inventory_scan_id": preview_inventory_scan_id}
-            elif path == _GENERIC_WEB_PREVIEW_REFRESH_ROUTE.route_path:
+            elif path in _PREVIEW_REFRESH_ROUTE_PATHS:
                 generic_web_refresh_request, profile, authorization_response = (
                     _authorize_generic_web_preview_route(
-                        route_metadata=_GENERIC_WEB_PREVIEW_REFRESH_ROUTE,
+                        route_metadata=_generic_web_preview_refresh_route_metadata(path),
                         payload=payload,
                         record_store=record_store,
                         authz_policy=authz_policy,
@@ -6907,10 +7004,10 @@ def create_launchplane_service_app(
                     driver_result=driver_result,
                     profile=profile,
                 )
-            elif path == _GENERIC_WEB_PREVIEW_READINESS_ROUTE.route_path:
+            elif path in _PREVIEW_READINESS_ROUTE_PATHS:
                 generic_web_readiness_request, profile, authorization_response = (
                     _authorize_generic_web_preview_route(
-                        route_metadata=_GENERIC_WEB_PREVIEW_READINESS_ROUTE,
+                        route_metadata=_generic_web_preview_readiness_route_metadata(path),
                         payload=payload,
                         record_store=record_store,
                         authz_policy=authz_policy,
@@ -6929,10 +7026,10 @@ def create_launchplane_service_app(
                     profile=profile,
                 )
                 result = {}
-            elif path == _GENERIC_WEB_PREVIEW_DESTROY_ROUTE.route_path:
+            elif path in _PREVIEW_DESTROY_ROUTE_PATHS:
                 generic_web_destroy_request, profile, authorization_response = (
                     _authorize_generic_web_preview_route(
-                        route_metadata=_GENERIC_WEB_PREVIEW_DESTROY_ROUTE,
+                        route_metadata=_generic_web_preview_destroy_route_metadata(path),
                         payload=payload,
                         record_store=record_store,
                         authz_policy=authz_policy,

--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -24,6 +24,7 @@ from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeKeySafetyTarget,
 )
 from control_plane.contracts.secret_record import SecretBinding
+from control_plane.drivers.registry import read_driver_descriptor
 from control_plane.runtime_key_safety import (
     evaluate_runtime_key_safety,
     latest_active_runtime_key_safety_policy,
@@ -560,9 +561,17 @@ def resolve_generic_web_preview_profile(
     *, record_store: GenericWebPreviewProfileStore, product: str
 ) -> LaunchplaneProductProfileRecord:
     profile = record_store.read_product_profile_record(product)
-    if profile.driver_id != "generic-web":
+    driver_id = profile.driver_id.strip()
+    driver_is_generic_web = driver_id == "generic-web"
+    if not driver_is_generic_web:
+        try:
+            driver_is_generic_web = read_driver_descriptor(driver_id).base_driver_id == "generic-web"
+        except FileNotFoundError:
+            driver_is_generic_web = False
+    if not driver_is_generic_web:
         raise click.ClickException(
-            f"Product {profile.product!r} is configured for driver {profile.driver_id!r}, not generic-web."
+            f"Product {profile.product!r} is configured for driver {profile.driver_id!r}, "
+            "not generic-web or a generic-web based driver."
         )
     if not profile.preview.enabled:
         raise click.ClickException(

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -134,6 +134,15 @@ generic web lifecycle and add named product-specific gates or runtime actions.
 The relationship is explicit metadata; product-specific capabilities are still
 declared directly on the product driver.
 
+Odoo declares `base_driver_id="generic-web"` and exposes Odoo-shaped preview
+routes for the same lifecycle: `POST /v1/drivers/odoo/preview-desired-state`,
+`POST /v1/drivers/odoo/preview-refresh`,
+`POST /v1/drivers/odoo/preview-inventory`,
+`POST /v1/drivers/odoo/preview-readiness`, and
+`POST /v1/drivers/odoo/preview-destroy`. These routes use the generic-web
+preview request schema and record writer so Odoo PR previews land in the same
+Launchplane preview and preview-generation records as generic-web previews.
+
 Driver action routes are owned by the base driver contract. The service accepts
 any product key on Odoo and VeriReel action envelopes, then authorizes the call
 against that product and verifies the product profile's `driver_id` or driver
@@ -158,6 +167,8 @@ Odoo exposes:
 
 - artifact publish handoff
 - post-deploy settings
+- PR preview desired state, refresh, readiness, inventory, and destroy through
+  the generic-web preview lifecycle
 - prod backup gate
 - testing-to-prod promotion
 - prod rollback

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -646,6 +646,15 @@ Any exported release-tuple catalog is seed/reference material now, not live
 runtime authority. Pull requests flow through Launchplane preview records
 instead of a tracked long-lived `dev` tuple lane.
 
+Odoo PR previews use Odoo-shaped Launchplane driver routes over the same
+generic-web preview lifecycle. Product workflows call
+`POST /v1/drivers/odoo/preview-refresh` with a preview slug, preview URL, and
+immutable image reference; Launchplane resolves the Odoo product profile preview
+context, verifies the profile is preview-enabled, runs generic-web readiness, and
+writes shared preview and preview-generation records. Cleanup calls
+`POST /v1/drivers/odoo/preview-destroy` and leaves the same cleanup/read-model
+history as generic-web previews.
+
 `launchplane-previews write-from-generation` and `launchplane-previews write-destroyed`
 are local preview-evidence ingest adapters that mirror the service ingress
 payload shape. VeriReel preview runtime now flows through Launchplane drivers:

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -866,6 +866,10 @@ retries do not collide. The regular cleanup workflow uses
   `generic-web-preview-refresh:<product>:<anchor_pr_number>:<sha>`
 - generic-web preview destroy driver:
   `generic-web-preview-destroy:<product>:<anchor_pr_number>`
+- Odoo preview refresh driver:
+  `odoo-preview-refresh:<product>:<anchor_pr_number>:<sha>`
+- Odoo preview destroy driver:
+  `odoo-preview-destroy:<product>:<anchor_pr_number>`
 
 Generic-web product workflow clients live in product repositories as thin
 Launchplane callers until Launchplane provides a shared distributable helper.
@@ -877,6 +881,12 @@ not retry `AbortError` or timeout aborts, and use stable idempotency keys for th
 same product operation. Generic-web preview destroy keys intentionally omit the
 free-form destroy reason so the same preview cleanup is idempotent even when the
 caller wording changes between cleanup paths.
+
+Odoo preview routes intentionally reuse the generic-web preview request schema,
+profile resolver, and record writer. Product repos call the Odoo-shaped routes
+so authz and driver views remain product-specific, while Launchplane still writes
+the shared preview and preview-generation records from DB-backed product profile
+preview configuration.
 
 - VeriReel testing deploy driver:
   `verireel-testing-deploy:<product>:<context>:<instance>:<artifact_id>:<source_git_ref>`

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -92,10 +92,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         descriptor = read_driver_descriptor("odoo")
         actions = {action.action_id: action for action in descriptor.actions}
 
+        self.assertEqual(descriptor.base_driver_id, "generic-web")
         self.assertEqual(actions["prod_backup_gate"].safety, "safe_write")
         self.assertEqual(actions["prod_promotion"].safety, "mutation")
         self.assertEqual(actions["prod_rollback"].safety, "destructive")
         self.assertEqual(actions["prod_rollback"].route_path, "/v1/drivers/odoo/prod-rollback")
+        self.assertEqual(actions["preview_refresh"].route_path, "/v1/drivers/odoo/preview-refresh")
+        self.assertEqual(actions["preview_refresh"].scope, "preview")
+        self.assertEqual(actions["preview_inventory"].safety, "safe_write")
+        self.assertEqual(actions["preview_destroy"].safety, "destructive")
 
     def test_verireel_descriptor_exposes_preview_and_stable_capabilities(self) -> None:
         descriptor = read_driver_descriptor("verireel")
@@ -285,6 +290,38 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
                     control_plane_service._ODOO_PROD_ROLLBACK_ROUTE,
                     control_plane_service.OdooProdRollbackEnvelope,
                     "prod rollback driver",
+                ),
+            },
+        )
+
+    def test_odoo_preview_execution_metadata_matches_descriptors(self) -> None:
+        self.assert_route_metadata_matches_descriptor(
+            driver_id="odoo",
+            route_metadata_by_action={
+                "preview_desired_state": (
+                    control_plane_service._ODOO_PREVIEW_DESIRED_STATE_ROUTE,
+                    control_plane_service.GenericWebPreviewDesiredStateEnvelope,
+                    "Odoo preview desired state",
+                ),
+                "preview_inventory": (
+                    control_plane_service._ODOO_PREVIEW_INVENTORY_ROUTE,
+                    control_plane_service.GenericWebPreviewInventoryEnvelope,
+                    "Odoo preview inventory",
+                ),
+                "preview_refresh": (
+                    control_plane_service._ODOO_PREVIEW_REFRESH_ROUTE,
+                    control_plane_service.GenericWebPreviewRefreshEnvelope,
+                    "refresh Odoo",
+                ),
+                "preview_readiness": (
+                    control_plane_service._ODOO_PREVIEW_READINESS_ROUTE,
+                    control_plane_service.GenericWebPreviewReadinessEnvelope,
+                    "Odoo preview readiness",
+                ),
+                "preview_destroy": (
+                    control_plane_service._ODOO_PREVIEW_DESTROY_ROUTE,
+                    control_plane_service.GenericWebPreviewDestroyEnvelope,
+                    "destroy Odoo",
                 ),
             },
         )

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -92,12 +92,14 @@ class _GenericWebPreviewStore:
         return bindings
 
 
-def _profile(*, preview_enabled: bool = True) -> LaunchplaneProductProfileRecord:
+def _profile(
+    *, preview_enabled: bool = True, driver_id: str = "generic-web"
+) -> LaunchplaneProductProfileRecord:
     return LaunchplaneProductProfileRecord(
         product="sellyouroutboard",
         display_name="SellYourOutboard.com",
         repository="cbusillo/sellyouroutboard",
-        driver_id="generic-web",
+        driver_id=driver_id,
         image=ProductImageProfile(repository="ghcr.io/cbusillo/sellyouroutboard"),
         runtime_port=3000,
         health_path="/api/health",
@@ -160,6 +162,25 @@ def _runtime_secret_binding(*, status: SecretStatus = "configured") -> SecretBin
 
 
 class GenericWebPreviewTests(unittest.TestCase):
+    def test_resolve_generic_web_preview_profile_accepts_based_driver(self) -> None:
+        profile = _profile(driver_id="odoo")
+
+        resolved = resolve_generic_web_preview_profile(
+            record_store=_GenericWebPreviewStore(profile),
+            product="sellyouroutboard",
+        )
+
+        self.assertEqual(resolved.driver_id, "odoo")
+
+    def test_resolve_generic_web_preview_profile_rejects_unbased_driver(self) -> None:
+        profile = _profile(driver_id="missing-driver")
+
+        with self.assertRaises(click.ClickException):
+            resolve_generic_web_preview_profile(
+                record_store=_GenericWebPreviewStore(profile),
+                product="sellyouroutboard",
+            )
+
     def test_render_preview_slug_uses_template_when_present(self) -> None:
         self.assertEqual(
             render_preview_slug(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -395,6 +395,35 @@ def _product_profile_payload(product: str = "sellyouroutboard") -> dict[str, obj
     }
 
 
+def _odoo_preview_profile_payload(product: str = "odoo-tenant-cm") -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "product": product,
+        "display_name": "CM Odoo",
+        "repository": f"cbusillo/{product}",
+        "driver_id": "odoo",
+        "image": {"repository": f"ghcr.io/cbusillo/{product}"},
+        "runtime_port": 8069,
+        "health_path": "/web/health",
+        "lanes": (
+            {
+                "instance": "testing",
+                "context": "cm",
+                "base_url": "https://cm-testing.example.com",
+                "health_url": "https://cm-testing.example.com/web/health",
+            },
+        ),
+        "preview": {
+            "enabled": True,
+            "context": "cm",
+            "slug_template": "pr-{number}",
+            "app_name_prefix": "cm-odoo-preview",
+        },
+        "updated_at": "2026-05-09T12:00:00Z",
+        "source": "test",
+    }
+
+
 def _product_profile_payload_with_prod(product: str = "sellyouroutboard") -> dict[str, object]:
     payload = _product_profile_payload(product)
     lanes = list(cast(tuple[dict[str, object], ...], payload["lanes"]))
@@ -8242,6 +8271,149 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     generation.failure_summary,
                     "Dokploy API POST /api/application.update failed (500): provider exploded",
                 )
+
+    def test_odoo_preview_refresh_route_reuses_generic_preview_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/odoo-tenant-cm",
+                            "workflow_refs": [
+                                "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["preview_refresh.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/odoo-tenant-cm",
+                        workflow_ref=(
+                            "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml"
+                            "@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_generic_web_preview_refresh",
+                return_value={
+                    "refresh_status": "pass",
+                    "refresh_started_at": "2026-05-09T15:00:00Z",
+                    "refresh_finished_at": "2026-05-09T15:05:00Z",
+                    "product": "odoo-tenant-cm",
+                    "context": "cm",
+                    "preview_slug": "pr-42",
+                    "application_name": "cm-odoo-preview-pr-42",
+                    "application_id": "app-odoo-preview",
+                    "preview_url": "https://pr-42.cm.example.test",
+                },
+            ) as refresh:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/preview-refresh",
+                    payload={
+                        "schema_version": 1,
+                        "product": "odoo-tenant-cm",
+                        "refresh": {
+                            "schema_version": 1,
+                            "product": "odoo-tenant-cm",
+                            "preview_slug": "pr-42",
+                            "preview_url": "https://pr-42.cm.example.test",
+                            "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm:sha",
+                        },
+                    },
+                    headers={"Idempotency-Key": "odoo-preview-refresh:cm:42:sha"},
+                )
+
+            self.assertEqual(status_code, 202)
+            self.assertEqual(payload["records"]["transition"], "verifying")
+            self.assertEqual(payload["result"]["application_id"], "app-odoo-preview")
+            preview = FilesystemRecordStore(state_dir=state_dir).read_preview_record(
+                "preview-cm-odoo-tenant-cm-pr-42"
+            )
+            self.assertEqual(preview.state, "pending")
+            refresh.assert_called_once()
+            _, kwargs = refresh.call_args
+            self.assertEqual(kwargs["profile"].driver_id, "odoo")
+            self.assertEqual(kwargs["profile"].preview.context, "cm")
+
+    def test_odoo_preview_refresh_route_fails_closed_when_preview_disabled(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            profile_payload = _odoo_preview_profile_payload()
+            profile_payload["preview"] = {"enabled": False}
+            FilesystemRecordStore(state_dir=state_dir).write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/odoo-tenant-cm",
+                        workflow_ref=(
+                            "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml"
+                            "@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate(
+                    {
+                        "github_actions": [
+                            {
+                                "repository": "cbusillo/odoo-tenant-cm",
+                                "workflow_refs": [
+                                    "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
+                                ],
+                                "event_names": ["pull_request"],
+                                "products": ["odoo-tenant-cm"],
+                                "contexts": ["cm"],
+                                "actions": ["preview_refresh.execute"],
+                            }
+                        ]
+                    }
+                ),
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/odoo/preview-refresh",
+                payload={
+                    "schema_version": 1,
+                    "product": "odoo-tenant-cm",
+                    "refresh": {
+                        "schema_version": 1,
+                        "product": "odoo-tenant-cm",
+                        "preview_slug": "pr-42",
+                        "preview_url": "https://pr-42.cm.example.test",
+                        "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm:sha",
+                    },
+                },
+                headers={"Idempotency-Key": "odoo-preview-refresh:cm:42:sha"},
+            )
+
+            self.assertEqual(status_code, 400)
+            self.assertEqual(payload["error"]["code"], "invalid_request")
 
     def test_generic_web_preview_refresh_route_keeps_blocked_result_non_mutating(
         self,


### PR DESCRIPTION
## Summary
- add Odoo-shaped preview desired-state, refresh, readiness, inventory, and destroy route metadata
- let generic-web preview profile resolution accept drivers whose descriptor is based on generic-web
- route Odoo preview calls through the existing generic-web preview lifecycle and shared preview/generation records
- document Odoo preview as a product-driver wrapper over generic-web preview records

Refs #488

## Validation
- uv run --extra dev ruff check control_plane/service.py control_plane/drivers/registry.py control_plane/workflows/generic_web_preview.py tests/test_driver_descriptors.py tests/test_generic_web_preview.py tests/test_service.py
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest tests.test_driver_descriptors tests.test_generic_web_preview tests.test_service.LaunchplaneServiceTests.test_odoo_preview_refresh_route_reuses_generic_preview_records tests.test_service.LaunchplaneServiceTests.test_odoo_preview_refresh_route_fails_closed_when_preview_disabled
- uv run python -m unittest