### PR TITLE
Grant CM Odoo preview workflow access

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -868,6 +868,24 @@ jobs:
               "syo-preview-destroy-manual-${suffix}"
           }
 
+          post_odoo_cm_preview_grant() {
+            local product_name="$1"
+            local action_name="$2"
+            local source_label="$3"
+            local idempotency_suffix="$4"
+            local event_name="${5:-pull_request}"
+            post_grant \
+              cbusillo/odoo-tenant-cm \
+              odoo-preview.yml \
+              "$product_name" \
+              cm \
+              "$action_name" \
+              "$source_label" \
+              "$idempotency_suffix" \
+              "$event_name" \
+              '*'
+          }
+
           apply_product_onboarding \
             discord-blue
           post_grant \
@@ -961,3 +979,29 @@ jobs:
           post_syo_preview_grants \
             sellyouroutboard \
             canonical-context
+          post_odoo_cm_preview_grant \
+            odoo \
+            odoo_artifact_publish_inputs.read \
+            deploy:odoo-cm-preview-artifact-publish-inputs-grant \
+            odoo-cm-preview-artifact-publish-inputs
+          post_odoo_cm_preview_grant \
+            odoo \
+            odoo_artifact_publish.write \
+            deploy:odoo-cm-preview-artifact-publish-grant \
+            odoo-cm-preview-artifact-publish
+          post_odoo_cm_preview_grant \
+            odoo-tenant-cm \
+            preview_refresh.execute \
+            deploy:odoo-cm-preview-refresh-grant \
+            odoo-cm-preview-refresh
+          post_odoo_cm_preview_grant \
+            odoo-tenant-cm \
+            preview_destroy.execute \
+            deploy:odoo-cm-preview-destroy-pr-grant \
+            odoo-cm-preview-destroy-pr
+          post_odoo_cm_preview_grant \
+            odoo-tenant-cm \
+            preview_destroy.execute \
+            deploy:odoo-cm-preview-destroy-manual-grant \
+            odoo-cm-preview-destroy-manual \
+            workflow_dispatch

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -888,6 +888,16 @@ so authz and driver views remain product-specific, while Launchplane still write
 the shared preview and preview-generation records from DB-backed product profile
 preview configuration.
 
+The CM tenant preview workflow uses two product scopes deliberately. Artifact
+publish input and publish evidence requests use product `odoo` for context `cm`,
+because the publish handoff is an Odoo driver contract. Preview refresh and
+destroy requests use product `odoo-tenant-cm`, because preview lifecycle records
+and product profile configuration are tenant-product scoped. Deploy-maintained
+GitHub Actions grants must include both scopes for
+`cbusillo/odoo-tenant-cm/.github/workflows/odoo-preview.yml`; granting only the
+tenant product lets preview mutation through but blocks the earlier build input
+resolution step.
+
 - VeriReel testing deploy driver:
   `verireel-testing-deploy:<product>:<context>:<instance>:<artifact_id>:<source_git_ref>`
 - VeriReel testing verification driver:


### PR DESCRIPTION
## Summary
- add deploy-maintained authz grants for the CM Odoo preview workflow
- grant Odoo artifact publish input/evidence actions under product `odoo` for context `cm`
- grant CM tenant preview refresh/destroy actions under product `odoo-tenant-cm`
- document the intentional product-scope split for CM preview

## Validation
- docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest

Refs cbusillo/odoo-tenant-cm#29