### PR TITLE
Seed Odoo CM preview product profile

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -74,6 +74,7 @@ jobs:
       LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN: ${{ secrets.LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN }}
       LAUNCHPLANE_TERMINAL_AGENT_SUBJECT: ${{ vars.LAUNCHPLANE_TERMINAL_AGENT_SUBJECT }}
       LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL: ${{ vars.LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL }}
+      ODOO_CM_TESTING_DOKPLOY_TARGET_ID: ${{ vars.ODOO_CM_TESTING_DOKPLOY_TARGET_ID }}
       LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST: ${{ secrets.LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST }}
       LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN: ${{ secrets.LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN }}
     steps:
@@ -738,6 +739,80 @@ jobs:
             return 1
           }
 
+          apply_odoo_cm_onboarding() {
+            local idempotency_suffix="odoo-cm-preview-profile"
+            local request_payload response_file status_code
+            local target_id="${ODOO_CM_TESTING_DOKPLOY_TARGET_ID:-}"
+
+            request_payload="$({
+              jq -n \
+                --arg target_id "$target_id" \
+                '{
+                  schema_version: 1,
+                  product: "launchplane",
+                  manifest: {
+                    product: "odoo-tenant-cm",
+                    display_name: "Odoo CM",
+                    repository: "cbusillo/odoo-tenant-cm",
+                    driver_id: "odoo",
+                    image_repository: "ghcr.io/cbusillo/odoo-tenant-cm",
+                    runtime_port: 8069,
+                    health_path: "/web/health",
+                    lanes: [
+                      {
+                        instance: "testing",
+                        context: "cm"
+                      }
+                    ],
+                    preview: {
+                      enabled: true,
+                      context: "cm",
+                      enable_label: "preview",
+                      slug_template: "pr-{number}",
+                      app_name_prefix: "cm-odoo-preview",
+                      template_instance: "testing",
+                      preview_url_env_keys: ["WEB_BASE_URL"],
+                      data_transport_mode: "bootstrap"
+                    },
+                    dokploy_targets: (
+                      if ($target_id | length) > 0 then
+                        [
+                          {
+                            context: "cm",
+                            instance: "testing",
+                            target_id: $target_id,
+                            target_type: "application",
+                            target_name: "cm-testing",
+                            healthcheck_path: "/web/health",
+                            healthcheck_enabled: true,
+                            deploy_timeout_seconds: 900
+                          }
+                        ]
+                      else [] end
+                    ),
+                    source_label: "deploy:odoo-cm-product-onboarding"
+                  }
+                }'
+            })"
+            response_file="$(mktemp)"
+            status_code="$(curl -sS \
+              -o "$response_file" \
+              -w '%{http_code}' \
+              -X POST \
+              -H "Authorization: Bearer ${oidc_token}" \
+              -H 'Content-Type: application/json' \
+              -H "Idempotency-Key: launchplane-product-onboarding:${idempotency_suffix}:${target_id}:${GITHUB_SHA}" \
+              --data "$request_payload" \
+              "${{ steps.service.outputs.service_url }}/v1/product-onboarding/apply")"
+            if [ "$status_code" = "200" ] || [ "$status_code" = "202" ]; then
+              cat "$response_file"
+              return 0
+            fi
+            cat "$response_file" >&2
+            echo "Launchplane Odoo CM product onboarding request failed with HTTP ${status_code}." >&2
+            return 1
+          }
+
           apply_runtime_key_safety_policy() {
             local idempotency_suffix="$1"
             local request_payload response_file status_code
@@ -888,6 +963,7 @@ jobs:
 
           apply_product_onboarding \
             discord-blue
+          apply_odoo_cm_onboarding
           post_grant \
             cbusillo/discord-blue \
             main.yml \


### PR DESCRIPTION
## Summary
- Adds deploy-time onboarding for the Odoo CM product profile so Launchplane can resolve `product=odoo-tenant-cm` during preview refresh/destroy.
- Keeps the CM testing Dokploy target ID optional through `ODOO_CM_TESTING_DOKPLOY_TARGET_ID`, so deploy can seed the profile now without inventing live target authority.
- Configures CM previews for the existing `preview` label, `cm` context, `pr-{number}` slugs, and bootstrap-mode preview data policy.

## Validation
- `docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest` (1048 tests)

Refs cbusillo/launchplane#488
Refs cbusillo/odoo-tenant-cm#29
