### PR TITLE
Support staged Odoo compose previews

### DIFF
--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -12,6 +12,7 @@ import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane import dokploy as control_plane_dokploy
+from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane import secrets as control_plane_secrets
 from control_plane.dokploy import JsonObject, JsonValue
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
@@ -34,6 +35,20 @@ from control_plane.workflows.ship import utc_now_timestamp
 
 
 _SECRET_SHAPED_RUNTIME_ENV_KEY_PARTS = {"PASSWORD", "TOKEN", "SECRET", "KEY"}
+_ODOO_COMPOSE_STAGE_PREVIEW_DRIVER_ID = "odoo"
+_ODOO_COMPOSE_STAGE_PREVIEW_MODE = "bootstrap"
+_ODOO_COMPOSE_STAGE_PREVIEW_TARGET_TYPE = "compose"
+_ARTIFACT_IMAGE_REFERENCE_ENV_KEY = "DOCKER_IMAGE_REFERENCE"
+_ODOO_COMPOSE_STAGE_PREVIEW_REQUIRED_ENV_KEYS = (
+    "ODOO_DB_NAME",
+    "ODOO_DB_USER",
+    "ODOO_DB_PASSWORD",
+    "ODOO_DATA_VOLUME",
+    "ODOO_LOG_VOLUME",
+    "ODOO_DB_VOLUME",
+    "ODOO_MASTER_PASSWORD",
+    "ODOO_ADMIN_PASSWORD",
+)
 
 
 class GenericWebPreviewProfileStore(Protocol):
@@ -608,7 +623,10 @@ def _is_blank(value: object) -> bool:
 
 
 def _read_template_payload(
-    *, control_plane_root: Path, template_lane: ProductLaneProfile
+    *,
+    control_plane_root: Path,
+    template_lane: ProductLaneProfile,
+    allow_compose_template: bool = False,
 ) -> tuple[control_plane_dokploy.DokployTargetDefinition | None, JsonObject | None, str]:
     source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
         control_plane_root=control_plane_root,
@@ -626,11 +644,18 @@ def _read_template_payload(
             None,
             f"No Dokploy target definition found for {template_lane.context}/{template_lane.instance}.",
         )
-    if target_definition.target_type != "application":
+    if target_definition.target_type == "compose" and not allow_compose_template:
         return (
             target_definition,
             None,
             "Generic web preview readiness requires the template lane to be a Dokploy application.",
+        )
+    if target_definition.target_type not in {"application", "compose"}:
+        return (
+            target_definition,
+            None,
+            "Generic web preview readiness requires the template lane to be a "
+            "Dokploy application or an explicitly supported staged Odoo compose target.",
         )
     if not target_definition.target_id.strip():
         return (
@@ -646,6 +671,27 @@ def _read_template_payload(
         target_id=target_definition.target_id,
     )
     return target_definition, payload, ""
+
+
+def _profile_allows_odoo_compose_stage_preview(
+    *, profile: LaunchplaneProductProfileRecord
+) -> bool:
+    return (
+        profile.driver_id.strip() == _ODOO_COMPOSE_STAGE_PREVIEW_DRIVER_ID
+        and profile.preview.data_transport_mode == _ODOO_COMPOSE_STAGE_PREVIEW_MODE
+    )
+
+
+def _uses_odoo_compose_stage_preview(
+    *,
+    profile: LaunchplaneProductProfileRecord,
+    target_definition: control_plane_dokploy.DokployTargetDefinition | None,
+) -> bool:
+    return (
+        _profile_allows_odoo_compose_stage_preview(profile=profile)
+        and target_definition is not None
+        and target_definition.target_type == _ODOO_COMPOSE_STAGE_PREVIEW_TARGET_TYPE
+    )
 
 
 def _transport_summary(
@@ -696,6 +742,58 @@ def _render_preview_env_text(
         "",
         updates=updates,
     )
+
+
+def _render_odoo_compose_stage_preview_env_text(
+    *,
+    control_plane_root: Path,
+    profile: LaunchplaneProductProfileRecord,
+    template_lane: ProductLaneProfile,
+    template_payload: JsonObject,
+    preview_url: str,
+    image_reference: str,
+) -> str:
+    template_env = control_plane_dokploy.parse_dokploy_env_text(
+        str(template_payload.get("env") or "")
+    )
+    desired_env = dict(template_env)
+    desired_env.update(
+        _optional_runtime_environment_values(
+            control_plane_root=control_plane_root,
+            context_name=template_lane.context,
+            instance_name=template_lane.instance,
+        )
+    )
+    desired_env.update(profile.preview.override_env)
+    desired_env[_ARTIFACT_IMAGE_REFERENCE_ENV_KEY] = image_reference
+    preview_host = _preview_host(preview_url)
+    for key in profile.preview.preview_url_env_keys:
+        desired_env[key] = preview_url
+    for key in profile.preview.preview_domain_env_keys:
+        desired_env[key] = preview_host
+    return control_plane_dokploy.serialize_dokploy_env_text(desired_env)
+
+
+def _optional_runtime_environment_values(
+    *, control_plane_root: Path, context_name: str, instance_name: str
+) -> dict[str, str]:
+    try:
+        return control_plane_runtime_environments.resolve_runtime_environment_values(
+            control_plane_root=control_plane_root,
+            context_name=context_name,
+            instance_name=instance_name,
+        )
+    except click.ClickException as exc:
+        message = str(exc)
+        if message.startswith("Missing Launchplane runtime environment authority"):
+            return {}
+        if message.startswith("Missing DB-backed Launchplane runtime environment records"):
+            return {}
+        if message.startswith("Runtime environments file has no context definition"):
+            return {}
+        if message.startswith("Runtime environments file has no instance definition"):
+            return {}
+        raise
 
 
 def _runtime_environment_key_requires_secret_store(key_name: str) -> bool:
@@ -860,6 +958,9 @@ def evaluate_generic_web_preview_readiness(
         target_definition, template_payload, target_error = _read_template_payload(
             control_plane_root=control_plane_root,
             template_lane=template_lane,
+            allow_compose_template=_profile_allows_odoo_compose_stage_preview(
+                profile=resolved_profile
+            ),
         )
     except click.ClickException as exc:
         target_error = str(exc)
@@ -896,21 +997,61 @@ def evaluate_generic_web_preview_readiness(
 
     assert target_definition is not None
     assert template_payload is not None
-    env_map = control_plane_dokploy.parse_dokploy_env_text(str(template_payload.get("env") or ""))
-    required_env_keys = tuple(
-        dict.fromkeys(
-            (
-                *resolved_profile.preview.required_template_env_keys,
-                *resolved_profile.preview.copied_env_keys,
+    uses_odoo_compose_stage_preview = _uses_odoo_compose_stage_preview(
+        profile=resolved_profile,
+        target_definition=target_definition,
+    )
+    if target_definition.target_type == "compose" and not uses_odoo_compose_stage_preview:
+        checks.append(
+            GenericWebPreviewReadinessCheck(
+                check_id="template_target",
+                status="blocked",
+                message=(
+                    "Compose template lanes are supported only for the staged Odoo "
+                    "bootstrap preview path."
+                ),
             )
         )
+        return GenericWebPreviewReadinessResult(
+            readiness_status="blocked",
+            checked_at=checked_at,
+            product=resolved_profile.product,
+            context=resolved_profile.preview.context,
+            template_context=template_lane.context,
+            template_instance=template_lane.instance,
+            template_target_type=target_definition.target_type,
+            template_target_id=target_definition.target_id,
+            template_target_name=target_definition.target_name,
+            source=request.source,
+            missing_template_env_keys=(),
+            missing_provider_fields=(),
+            transport=_transport_summary(profile=resolved_profile),
+            checks=tuple(checks),
+        )
+    env_map = control_plane_dokploy.parse_dokploy_env_text(str(template_payload.get("env") or ""))
+    if uses_odoo_compose_stage_preview:
+        env_map.update(
+            _optional_runtime_environment_values(
+                control_plane_root=control_plane_root,
+                context_name=template_lane.context,
+                instance_name=template_lane.instance,
+            )
+        )
+    required_env_parts = (
+        *resolved_profile.preview.required_template_env_keys,
+        *resolved_profile.preview.copied_env_keys,
     )
+    if uses_odoo_compose_stage_preview:
+        required_env_parts = (*required_env_parts, *_ODOO_COMPOSE_STAGE_PREVIEW_REQUIRED_ENV_KEYS)
+    required_env_keys = tuple(dict.fromkeys(required_env_parts))
     missing_env_keys = tuple(key for key in required_env_keys if not env_map.get(key, "").strip())
-    missing_provider_fields = tuple(
-        field
-        for field in resolved_profile.preview.required_provider_fields
-        if _is_blank(_field_value(template_payload, field))
-    )
+    missing_provider_fields: tuple[str, ...] = ()
+    if not uses_odoo_compose_stage_preview:
+        missing_provider_fields = tuple(
+            field
+            for field in resolved_profile.preview.required_provider_fields
+            if _is_blank(_field_value(template_payload, field))
+        )
 
     if missing_env_keys:
         checks.append(
@@ -943,7 +1084,11 @@ def evaluate_generic_web_preview_readiness(
             GenericWebPreviewReadinessCheck(
                 check_id="template_provider_fields",
                 status="pass",
-                message="Template lane includes required provider fields.",
+                message=(
+                    "Staged Odoo compose preview uses Launchplane-rendered compose source."
+                    if uses_odoo_compose_stage_preview
+                    else "Template lane includes required provider fields."
+                ),
             )
         )
     checks.append(
@@ -1032,10 +1177,39 @@ def execute_generic_web_preview_refresh(
         target_definition, template_application, target_error = _read_template_payload(
             control_plane_root=control_plane_root,
             template_lane=template_lane,
+            allow_compose_template=_profile_allows_odoo_compose_stage_preview(
+                profile=resolved_profile
+            ),
         )
         if target_error or template_application is None or target_definition is None:
             raise click.ClickException(
                 target_error or "Generic web preview template payload is unavailable."
+            )
+        if _uses_odoo_compose_stage_preview(
+            profile=resolved_profile,
+            target_definition=target_definition,
+        ):
+            application_id = _execute_odoo_compose_stage_preview_refresh(
+                control_plane_root=control_plane_root,
+                record_store=record_store,
+                request=request,
+                profile=resolved_profile,
+                template_lane=template_lane,
+                target_definition=target_definition,
+                template_payload=template_application,
+            )
+            finished_at = utc_now_timestamp()
+            return GenericWebPreviewRefreshResult(
+                refresh_status="pass",
+                refresh_started_at=started_at,
+                refresh_finished_at=finished_at,
+                product=resolved_profile.product,
+                context=resolved_profile.preview.context,
+                preview_slug=request.preview_slug,
+                application_name=application_name,
+                application_id=application_id,
+                preview_url=request.preview_url,
+                readiness=readiness,
             )
         _enforce_preview_copied_runtime_key_safety(
             record_store=record_store,
@@ -1146,6 +1320,85 @@ def execute_generic_web_preview_refresh(
         preview_url=request.preview_url,
         readiness=readiness,
     )
+
+
+def _execute_odoo_compose_stage_preview_refresh(
+    *,
+    control_plane_root: Path,
+    record_store: GenericWebPreviewProfileStore,
+    request: GenericWebPreviewRefreshRequest,
+    profile: LaunchplaneProductProfileRecord,
+    template_lane: ProductLaneProfile,
+    target_definition: control_plane_dokploy.DokployTargetDefinition,
+    template_payload: JsonObject,
+) -> str:
+    _enforce_preview_copied_runtime_key_safety(
+        record_store=record_store,
+        profile=profile,
+        template_lane=template_lane,
+        template_application=template_payload,
+        preview_slug=request.preview_slug,
+    )
+    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
+    compose_name = (
+        target_definition.target_name.strip()
+        or str(template_payload.get("name") or "").strip()
+        or f"{template_lane.context}-{template_lane.instance}"
+    )
+    compose_file = control_plane_dokploy.render_odoo_raw_compose_file(
+        image_reference=request.image_reference
+    )
+    control_plane_dokploy.sync_dokploy_compose_raw_source(
+        host=host,
+        token=token,
+        compose_id=target_definition.target_id,
+        compose_name=compose_name,
+        target_payload=template_payload,
+        compose_file=compose_file,
+    )
+    env_text = _render_odoo_compose_stage_preview_env_text(
+        control_plane_root=control_plane_root,
+        profile=profile,
+        template_lane=template_lane,
+        template_payload=template_payload,
+        preview_url=request.preview_url,
+        image_reference=request.image_reference,
+    )
+    control_plane_dokploy.update_dokploy_target_env(
+        host=host,
+        token=token,
+        target_type="compose",
+        target_id=target_definition.target_id,
+        target_payload=template_payload,
+        env_text=env_text,
+    )
+    latest_before = control_plane_dokploy.latest_deployment_for_target(
+        host=host,
+        token=token,
+        target_type="compose",
+        target_id=target_definition.target_id,
+    )
+    control_plane_dokploy.trigger_deployment(
+        host=host,
+        token=token,
+        target_type="compose",
+        target_id=target_definition.target_id,
+        no_cache=request.no_cache,
+    )
+    control_plane_dokploy.wait_for_target_deployment(
+        host=host,
+        token=token,
+        target_type="compose",
+        target_id=target_definition.target_id,
+        before_key=control_plane_dokploy.deployment_key(latest_before),
+        timeout_seconds=request.timeout_seconds,
+    )
+    _wait_for_preview_health(
+        preview_url=request.preview_url,
+        health_path=profile.health_path,
+        timeout_seconds=request.timeout_seconds,
+    )
+    return target_definition.target_id
 
 
 def discover_generic_web_preview_desired_state(

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -142,6 +142,14 @@ routes for the same lifecycle: `POST /v1/drivers/odoo/preview-desired-state`,
 `POST /v1/drivers/odoo/preview-destroy`. These routes use the generic-web
 preview request schema and record writer so Odoo PR previews land in the same
 Launchplane preview and preview-generation records as generic-web previews.
+Odoo is the only current generic-web-based driver allowed to use the staged
+compose preview MVP: if its product profile uses `preview.data_transport_mode =
+"bootstrap"` and its template lane is a Dokploy `compose` target, preview refresh
+updates and deploys that configured compose target instead of creating a
+generic-web application. This exception is route-scoped to Odoo preview refresh
+and readiness; it does not grant Odoo products access to stable generic-web
+deploy or promotion routes, and it does not make compose templates valid for
+generic-web products.
 
 Driver action routes are owned by the base driver contract. The service accepts
 any product key on Odoo and VeriReel action envelopes, then authorizes the call

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -655,6 +655,27 @@ writes shared preview and preview-generation records. Cleanup calls
 `POST /v1/drivers/odoo/preview-destroy` and leaves the same cleanup/read-model
 history as generic-web previews.
 
+Stage-MVP Odoo previews may point at a Dokploy `compose` template lane only when
+the product profile uses `driver_id="odoo"` and `preview.data_transport_mode` is
+`bootstrap`. In that mode Launchplane reuses the configured compose target,
+renders the Odoo raw compose file for the requested immutable image, overlays
+runtime-environment records when present, requires the Odoo raw-compose safety
+env keys already present on the live target, including non-default Odoo master
+and admin password values, applies preview URL env keys, deploys the compose
+target, and records the requested PR URL as the preview generation. This is
+intentionally not generic compose preview support:
+generic-web application previews still require application template lanes, and
+stable deploy/promotion routes do not inherit Odoo's compose preview behavior.
+Destroy for the staged compose MVP is a record/cleanup handoff only and must not
+delete the shared compose target.
+
+The long-term Odoo preview target is isolated per-PR runtime state, either by a
+provider-supported compose clone/create/delete path or by a dedicated
+application-backed template if Odoo can be safely reduced to an application
+shape. Until that follow-up lands, CM previews are a single active staged target
+behind pre-existing DNS/nginx routing and are intended to make the client-visible
+Odoo system usable before full ephemeral preview infrastructure exists.
+
 `launchplane-previews write-from-generation` and `launchplane-previews write-destroyed`
 are local preview-evidence ingest adapters that mirror the service ingress
 payload shape. VeriReel preview runtime now flows through Launchplane drivers:

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -129,6 +129,38 @@ def _profile(
     )
 
 
+def _odoo_compose_profile() -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord(
+        product="odoo-tenant-cm",
+        display_name="Odoo CM",
+        repository="cbusillo/odoo-tenant-cm",
+        driver_id="odoo",
+        image=ProductImageProfile(repository="ghcr.io/cbusillo/odoo-tenant-cm"),
+        runtime_port=8069,
+        health_path="/web/health",
+        lanes=(
+            ProductLaneProfile(
+                instance="testing",
+                context="cm",
+                base_url="https://testing.cm.example.test",
+                health_url="https://testing.cm.example.test/web/health",
+            ),
+        ),
+        preview=ProductPreviewProfile(
+            enabled=True,
+            context="cm",
+            enable_label="preview",
+            slug_template="pr-{number}",
+            app_name_prefix="cm-odoo-preview",
+            template_instance="testing",
+            preview_url_env_keys=("WEB_BASE_URL",),
+            data_transport_mode="bootstrap",
+        ),
+        updated_at="2026-05-09T15:00:00Z",
+        source="test",
+    )
+
+
 def _preview_runtime_policy(
     *, secret_class: RuntimeSecretClass = "preview"
 ) -> RuntimeKeySafetyPolicyRecord:
@@ -441,6 +473,234 @@ class GenericWebPreviewTests(unittest.TestCase):
         read_dokploy_config.assert_not_called()
         fetch_dokploy_target_payload.assert_not_called()
 
+    def test_evaluate_generic_web_preview_readiness_allows_odoo_compose_stage_template(
+        self,
+    ) -> None:
+        store = _GenericWebPreviewStore(_odoo_compose_profile())
+        source = DokploySourceOfTruth(
+            schema_version=1,
+            targets=(
+                DokployTargetDefinition(
+                    context="cm",
+                    instance="testing",
+                    target_type="compose",
+                    target_id="compose-cm-testing",
+                    target_name="cm-testing",
+                ),
+            ),
+        )
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                return_value=source,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "composeId": "compose-cm-testing",
+                    "name": "cm-testing",
+                    "environmentId": "env-1",
+                    "env": (
+                        "ODOO_DB_NAME=cm_preview\n"
+                        "ODOO_DB_USER=odoo\n"
+                        "ODOO_DB_PASSWORD=safe\n"
+                        "ODOO_DATA_VOLUME=cm_data\n"
+                        "ODOO_LOG_VOLUME=cm_logs\n"
+                        "ODOO_DB_VOLUME=cm_db\n"
+                        "ODOO_MASTER_PASSWORD=safe-master\n"
+                        "ODOO_ADMIN_PASSWORD=safe-admin\n"
+                    ),
+                },
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.resolve_runtime_environment_values",
+                return_value={},
+            ),
+        ):
+            result = evaluate_generic_web_preview_readiness(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebPreviewReadinessRequest(product="odoo-tenant-cm"),
+                checked_at="2026-05-09T15:00:00Z",
+            )
+
+        self.assertEqual(result.readiness_status, "pass")
+        self.assertEqual(result.template_target_type, "compose")
+        self.assertEqual(result.template_target_id, "compose-cm-testing")
+        self.assertEqual(result.transport.data_transport_mode, "bootstrap")
+        self.assertEqual(result.missing_provider_fields, ())
+        self.assertEqual(
+            result.checks[1].message,
+            "Staged Odoo compose preview uses Launchplane-rendered compose source.",
+        )
+
+    def test_evaluate_generic_web_preview_readiness_blocks_non_odoo_compose_template(
+        self,
+    ) -> None:
+        store = _GenericWebPreviewStore(_profile())
+        source = DokploySourceOfTruth(
+            schema_version=1,
+            targets=(
+                DokployTargetDefinition(
+                    context="sellyouroutboard-testing",
+                    instance="testing",
+                    target_type="compose",
+                    target_id="compose-testing",
+                    target_name="sellyouroutboard-testing",
+                ),
+            ),
+        )
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                return_value=source,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config"
+            ) as read_dokploy_config,
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.fetch_dokploy_target_payload"
+            ) as fetch_dokploy_target_payload,
+        ):
+            result = evaluate_generic_web_preview_readiness(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebPreviewReadinessRequest(product="sellyouroutboard"),
+                checked_at="2026-05-09T15:00:00Z",
+            )
+
+        self.assertEqual(result.readiness_status, "blocked")
+        self.assertEqual(result.template_target_type, "compose")
+        self.assertEqual(
+            result.checks[0].message,
+            "Generic web preview readiness requires the template lane to be a Dokploy application.",
+        )
+        read_dokploy_config.assert_not_called()
+        fetch_dokploy_target_payload.assert_not_called()
+
+    def test_evaluate_generic_web_preview_readiness_blocks_odoo_compose_missing_safe_env(
+        self,
+    ) -> None:
+        store = _GenericWebPreviewStore(_odoo_compose_profile())
+        source = DokploySourceOfTruth(
+            schema_version=1,
+            targets=(
+                DokployTargetDefinition(
+                    context="cm",
+                    instance="testing",
+                    target_type="compose",
+                    target_id="compose-cm-testing",
+                    target_name="cm-testing",
+                ),
+            ),
+        )
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                return_value=source,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "composeId": "compose-cm-testing",
+                    "name": "cm-testing",
+                    "environmentId": "env-1",
+                    "env": "ODOO_DB_NAME=cm_preview\nODOO_DB_USER=odoo\n",
+                },
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.resolve_runtime_environment_values",
+                return_value={},
+            ),
+        ):
+            result = evaluate_generic_web_preview_readiness(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebPreviewReadinessRequest(product="odoo-tenant-cm"),
+                checked_at="2026-05-09T15:00:00Z",
+            )
+
+        self.assertEqual(result.readiness_status, "blocked")
+        self.assertEqual(
+            result.missing_template_env_keys,
+            (
+                "ODOO_DB_PASSWORD",
+                "ODOO_DATA_VOLUME",
+                "ODOO_LOG_VOLUME",
+                "ODOO_DB_VOLUME",
+                "ODOO_MASTER_PASSWORD",
+                "ODOO_ADMIN_PASSWORD",
+            ),
+        )
+
+    def test_evaluate_generic_web_preview_readiness_accepts_odoo_compose_runtime_env(
+        self,
+    ) -> None:
+        store = _GenericWebPreviewStore(_odoo_compose_profile())
+        source = DokploySourceOfTruth(
+            schema_version=1,
+            targets=(
+                DokployTargetDefinition(
+                    context="cm",
+                    instance="testing",
+                    target_type="compose",
+                    target_id="compose-cm-testing",
+                    target_name="cm-testing",
+                ),
+            ),
+        )
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                return_value=source,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "composeId": "compose-cm-testing",
+                    "name": "cm-testing",
+                    "environmentId": "env-1",
+                    "env": "ODOO_DB_NAME=cm_preview\nODOO_DB_USER=odoo\n",
+                },
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.resolve_runtime_environment_values",
+                return_value={
+                    "ODOO_DB_PASSWORD": "safe",
+                    "ODOO_DATA_VOLUME": "cm_data",
+                    "ODOO_LOG_VOLUME": "cm_logs",
+                    "ODOO_DB_VOLUME": "cm_db",
+                    "ODOO_MASTER_PASSWORD": "safe-master",
+                    "ODOO_ADMIN_PASSWORD": "safe-admin",
+                },
+            ),
+        ):
+            result = evaluate_generic_web_preview_readiness(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebPreviewReadinessRequest(product="odoo-tenant-cm"),
+                checked_at="2026-05-09T15:00:00Z",
+            )
+
+        self.assertEqual(result.readiness_status, "pass")
+        self.assertEqual(result.missing_template_env_keys, ())
+
     def test_execute_generic_web_preview_refresh_blocks_before_provider_mutation(self) -> None:
         store = _GenericWebPreviewStore(_profile())
         source = DokploySourceOfTruth(
@@ -696,6 +956,136 @@ class GenericWebPreviewTests(unittest.TestCase):
         self.assertIn("runtime key-safety gate failed", result.error_message)
         self.assertIn("secret_class_not_allowed", result.error_message)
         dokploy_request.assert_not_called()
+
+    def test_execute_generic_web_preview_refresh_updates_odoo_compose_stage_target(
+        self,
+    ) -> None:
+        store = _GenericWebPreviewStore(_odoo_compose_profile())
+        source = DokploySourceOfTruth(
+            schema_version=1,
+            targets=(
+                DokployTargetDefinition(
+                    context="cm",
+                    instance="testing",
+                    target_type="compose",
+                    target_id="compose-cm-testing",
+                    target_name="cm-testing",
+                ),
+            ),
+        )
+        env_updates: list[str] = []
+
+        def _fake_fetch(**kwargs: object) -> dict[str, object]:
+            self.assertEqual(kwargs["target_type"], "compose")
+            self.assertEqual(kwargs["target_id"], "compose-cm-testing")
+            return {
+                "composeId": "compose-cm-testing",
+                "name": "cm-testing",
+                "environmentId": "env-1",
+                "sourceType": "raw",
+                "composePath": "docker-compose.yml",
+                "composeFile": "",
+                "env": (
+                    "ODOO_DB_NAME=cm_preview\n"
+                    "ODOO_DB_USER=odoo\n"
+                    "ODOO_DB_PASSWORD=safe\n"
+                    "ODOO_DATA_VOLUME=cm_data\n"
+                    "ODOO_LOG_VOLUME=cm_logs\n"
+                    "ODOO_DB_VOLUME=cm_db\n"
+                    "ODOO_MASTER_PASSWORD=safe-master\n"
+                    "ODOO_ADMIN_PASSWORD=safe-admin\n"
+                    "WEB_BASE_URL=https://testing.cm.example.test\n"
+                ),
+            }
+
+        def _fake_update_env(**kwargs: object) -> None:
+            env_updates.append(str(kwargs["env_text"]))
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                return_value=source,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.fetch_dokploy_target_payload",
+                side_effect=_fake_fetch,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.resolve_runtime_environment_values",
+                return_value={"ODOO_PROJECT_NAME": "cm-pr-28"},
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.sync_dokploy_compose_raw_source",
+            ) as sync_raw_source,
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.update_dokploy_target_env",
+                side_effect=_fake_update_env,
+            ) as update_env,
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.latest_deployment_for_target",
+                return_value={"deploymentId": "before"},
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.trigger_deployment",
+            ) as trigger_deployment,
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.wait_for_target_deployment",
+            ) as wait_for_deployment,
+            patch(
+                "control_plane.workflows.generic_web_preview._wait_for_preview_health"
+            ) as wait_health,
+            patch(
+                "control_plane.workflows.generic_web_preview.utc_now_timestamp",
+                side_effect=["2026-05-09T15:00:00Z", "2026-05-09T15:00:05Z"],
+            ),
+        ):
+            result = execute_generic_web_preview_refresh(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebPreviewRefreshRequest(
+                    product="odoo-tenant-cm",
+                    preview_slug="pr-28",
+                    preview_url="https://pr-28.cm-preview.shinycomputers.com",
+                    image_reference="ghcr.io/cbusillo/odoo-tenant-cm:sha",
+                ),
+            )
+
+        self.assertEqual(result.refresh_status, "pass")
+        self.assertEqual(result.application_id, "compose-cm-testing")
+        sync_raw_source.assert_called_once()
+        _, sync_kwargs = sync_raw_source.call_args
+        self.assertEqual(sync_kwargs["compose_id"], "compose-cm-testing")
+        self.assertIn(
+            "image: ghcr.io/cbusillo/odoo-tenant-cm:sha",
+            str(sync_kwargs["compose_file"]),
+        )
+        update_env.assert_called_once()
+        self.assertEqual(len(env_updates), 1)
+        self.assertIn("ODOO_DB_NAME=cm_preview", env_updates[0])
+        self.assertIn("ODOO_PROJECT_NAME=cm-pr-28", env_updates[0])
+        self.assertIn(
+            "WEB_BASE_URL=https://pr-28.cm-preview.shinycomputers.com", env_updates[0]
+        )
+        self.assertIn(
+            "DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/odoo-tenant-cm:sha", env_updates[0]
+        )
+        trigger_deployment.assert_called_once_with(
+            host="https://dokploy.example",
+            token="token",
+            target_type="compose",
+            target_id="compose-cm-testing",
+            no_cache=False,
+        )
+        wait_for_deployment.assert_called_once()
+        wait_health.assert_called_once_with(
+            preview_url="https://pr-28.cm-preview.shinycomputers.com",
+            health_path="/web/health",
+            timeout_seconds=300,
+        )
 
     def test_execute_generic_web_preview_refresh_allows_preview_safe_copied_secret_key(
         self,


### PR DESCRIPTION
## Summary
- Adds a route-scoped staged Odoo compose preview path for the CM bootstrap MVP while keeping generic-web application previews unchanged.
- Reuses the configured Odoo compose target, renders the Launchplane Odoo raw compose for the PR image, overlays optional runtime records plus preview URL/image env, deploys the compose target, and records the requested PR URL through existing preview-generation records.
- Documents the staged MVP boundary and opens #495 for the intended isolated per-PR preview runtime follow-up.

## Validation
- `uv run python -m unittest tests.test_generic_web_preview` (22 tests)
- `uv run --extra dev ruff check --diff control_plane/workflows/generic_web_preview.py tests/test_generic_web_preview.py docs/operations.md docs/driver-descriptors.md`
- `uv run --extra dev ruff check control_plane/workflows/generic_web_preview.py tests/test_generic_web_preview.py docs/operations.md docs/driver-descriptors.md`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest` (1053 tests)

Refs #488
Refs #495
Refs cbusillo/odoo-tenant-cm#29
