### PR TITLE
Bound staged Odoo preview wait budget

### DIFF
--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -49,6 +49,7 @@ _ODOO_COMPOSE_STAGE_PREVIEW_REQUIRED_ENV_KEYS = (
     "ODOO_MASTER_PASSWORD",
     "ODOO_ADMIN_PASSWORD",
 )
+_ODOO_COMPOSE_STAGE_PREVIEW_MIN_HEALTH_TIMEOUT_SECONDS = 30
 
 
 class GenericWebPreviewProfileStore(Protocol):
@@ -1385,18 +1386,25 @@ def _execute_odoo_compose_stage_preview_refresh(
         target_id=target_definition.target_id,
         no_cache=request.no_cache,
     )
+    deployment_timeout_seconds = max(
+        _ODOO_COMPOSE_STAGE_PREVIEW_MIN_HEALTH_TIMEOUT_SECONDS,
+        request.timeout_seconds - _ODOO_COMPOSE_STAGE_PREVIEW_MIN_HEALTH_TIMEOUT_SECONDS,
+    )
     control_plane_dokploy.wait_for_target_deployment(
         host=host,
         token=token,
         target_type="compose",
         target_id=target_definition.target_id,
         before_key=control_plane_dokploy.deployment_key(latest_before),
-        timeout_seconds=request.timeout_seconds,
+        timeout_seconds=deployment_timeout_seconds,
     )
     _wait_for_preview_health(
         preview_url=request.preview_url,
         health_path=profile.health_path,
-        timeout_seconds=request.timeout_seconds,
+        timeout_seconds=min(
+            request.timeout_seconds,
+            _ODOO_COMPOSE_STAGE_PREVIEW_MIN_HEALTH_TIMEOUT_SECONDS,
+        ),
     )
     return target_definition.target_id
 

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -1051,6 +1051,7 @@ class GenericWebPreviewTests(unittest.TestCase):
                     preview_slug="pr-28",
                     preview_url="https://pr-28.cm-preview.shinycomputers.com",
                     image_reference="ghcr.io/cbusillo/odoo-tenant-cm:sha",
+                    timeout_seconds=240,
                 ),
             )
 
@@ -1081,10 +1082,12 @@ class GenericWebPreviewTests(unittest.TestCase):
             no_cache=False,
         )
         wait_for_deployment.assert_called_once()
+        _, wait_kwargs = wait_for_deployment.call_args
+        self.assertEqual(wait_kwargs["timeout_seconds"], 210)
         wait_health.assert_called_once_with(
             preview_url="https://pr-28.cm-preview.shinycomputers.com",
             health_path="/web/health",
-            timeout_seconds=300,
+            timeout_seconds=30,
         )
 
     def test_execute_generic_web_preview_refresh_allows_preview_safe_copied_secret_key(


### PR DESCRIPTION
## Summary
- Splits the staged Odoo compose preview wait budget between provider deployment and preview health checks.
- Caps the health check wait at 30 seconds so Launchplane can return structured readiness failure before tenant workflow/proxy timeouts swallow the response.
- Pins the timeout split in the Odoo staged-preview workflow test.

## Validation
- `uv run python -m unittest tests.test_generic_web_preview`
- `uv run --extra dev ruff check --diff control_plane/workflows/generic_web_preview.py tests/test_generic_web_preview.py`
- `uv run --extra dev ruff check control_plane/workflows/generic_web_preview.py tests/test_generic_web_preview.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest` (1053 tests)

Refs #488
