### PR TITLE
Bind staged Odoo preview compose domain

### DIFF
--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -563,6 +563,66 @@ def _delete_domain(*, host: str, token: str, domain_id: str) -> None:
     )
 
 
+def _ensure_compose_domain(
+    *, host: str, token: str, compose_id: str, preview_host: str, runtime_port: int
+) -> tuple[str, tuple[str, ...]]:
+    raw_domains = control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/domain.byComposeId",
+        query={"composeId": compose_id},
+    )
+    domains = raw_domains if isinstance(raw_domains, list) else []
+    existing: JsonObject | None = None
+    stale_domain_ids: list[str] = []
+    for raw_domain in domains:
+        domain = control_plane_dokploy.as_json_object(raw_domain)
+        if domain is None:
+            continue
+        domain_host = str(domain.get("host") or "").strip()
+        domain_id = str(domain.get("domainId") or "").strip()
+        if domain_host == preview_host and domain_id:
+            existing = domain
+            continue
+        if domain_id:
+            stale_domain_ids.append(domain_id)
+    payload: JsonObject = {
+        "host": preview_host,
+        "path": "/",
+        "internalPath": "/",
+        "port": runtime_port,
+        "https": True,
+        "applicationId": None,
+        "certificateType": "none",
+        "customCertResolver": None,
+        "composeId": compose_id,
+        "serviceName": "web",
+        "domainType": "compose",
+        "previewDeploymentId": None,
+        "stripPath": False,
+    }
+    if existing is not None:
+        existing_domain_id = str(existing.get("domainId") or "").strip()
+        update_payload: JsonObject = {"domainId": existing_domain_id, **payload}
+        control_plane_dokploy.dokploy_request(
+            host=host,
+            token=token,
+            path="/api/domain.update",
+            method="POST",
+            payload=update_payload,
+        )
+        return "", tuple(stale_domain_ids)
+    created = control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/domain.create",
+        method="POST",
+        payload=payload,
+    )
+    created_domain = control_plane_dokploy.as_json_object(created)
+    return str((created_domain or {}).get("domainId") or "").strip(), tuple(stale_domain_ids)
+
+
 def _delete_application(*, host: str, token: str, application_id: str) -> None:
     control_plane_dokploy.dokploy_request(
         host=host,
@@ -1372,6 +1432,13 @@ def _execute_odoo_compose_stage_preview_refresh(
         target_id=target_definition.target_id,
         target_payload=template_payload,
         env_text=env_text,
+    )
+    _ensure_compose_domain(
+        host=host,
+        token=token,
+        compose_id=target_definition.target_id,
+        preview_host=_preview_host(request.preview_url),
+        runtime_port=profile.runtime_port,
     )
     latest_before = control_plane_dokploy.latest_deployment_for_target(
         host=host,

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -1001,6 +1001,25 @@ class GenericWebPreviewTests(unittest.TestCase):
         def _fake_update_env(**kwargs: object) -> None:
             env_updates.append(str(kwargs["env_text"]))
 
+        domain_requests: list[dict[str, object]] = []
+
+        def _fake_dokploy_request(**kwargs: object) -> object:
+            domain_requests.append(dict(kwargs))
+            path = kwargs["path"]
+            if path == "/api/domain.byComposeId":
+                return [
+                    {
+                        "domainId": "domain-testing",
+                        "host": "cm-testing.shinycomputers.com",
+                        "serviceName": "web",
+                        "port": 8069,
+                        "domainType": "compose",
+                    }
+                ]
+            if path == "/api/domain.create":
+                return {"domainId": "domain-preview"}
+            return {}
+
         with (
             patch(
                 "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
@@ -1025,6 +1044,10 @@ class GenericWebPreviewTests(unittest.TestCase):
                 "control_plane.workflows.generic_web_preview.control_plane_dokploy.update_dokploy_target_env",
                 side_effect=_fake_update_env,
             ) as update_env,
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.dokploy_request",
+                side_effect=_fake_dokploy_request,
+            ),
             patch(
                 "control_plane.workflows.generic_web_preview.control_plane_dokploy.latest_deployment_for_target",
                 return_value={"deploymentId": "before"},
@@ -1073,6 +1096,28 @@ class GenericWebPreviewTests(unittest.TestCase):
         )
         self.assertIn(
             "DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/odoo-tenant-cm:sha", env_updates[0]
+        )
+        self.assertEqual(
+            [request["path"] for request in domain_requests],
+            ["/api/domain.byComposeId", "/api/domain.create"],
+        )
+        self.assertEqual(
+            domain_requests[1]["payload"],
+            {
+                "host": "pr-28.cm-preview.shinycomputers.com",
+                "path": "/",
+                "internalPath": "/",
+                "port": 8069,
+                "https": True,
+                "applicationId": None,
+                "certificateType": "none",
+                "customCertResolver": None,
+                "composeId": "compose-cm-testing",
+                "serviceName": "web",
+                "domainType": "compose",
+                "previewDeploymentId": None,
+                "stripPath": False,
+            },
         )
         trigger_deployment.assert_called_once_with(
             host="https://dokploy.example",


### PR DESCRIPTION
## Summary
- Ensures staged Odoo compose previews bind the requested preview host to the Dokploy compose target before deploy.
- Uses Dokploy's compose-domain API (`domain.byComposeId` / `domain.create`) for the `web` service on the product profile runtime port.
- Pins the compose-domain payload in the staged Odoo preview test.

## Validation
- `uv run python -m unittest tests.test_generic_web_preview`
- `uv run --extra dev ruff check --diff control_plane/workflows/generic_web_preview.py tests/test_generic_web_preview.py`
- `uv run --extra dev ruff check control_plane/workflows/generic_web_preview.py tests/test_generic_web_preview.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest` (1053 tests)

Refs #488
Refs #498
