### PR TITLE
Install CM website addon in staged previews

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -771,6 +771,9 @@ jobs:
                       slug_template: "pr-{number}",
                       app_name_prefix: "cm-odoo-preview",
                       template_instance: "testing",
+                      override_env: {
+                        ODOO_INSTALL_MODULES: "cm_custom,cm_website"
+                      },
                       preview_url_env_keys: ["WEB_BASE_URL"],
                       data_transport_mode: "bootstrap"
                     },

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -661,7 +661,8 @@ the product profile uses `driver_id="odoo"` and `preview.data_transport_mode` is
 renders the Odoo raw compose file for the requested immutable image, overlays
 runtime-environment records when present, requires the Odoo raw-compose safety
 env keys already present on the live target, including non-default Odoo master
-and admin password values, applies preview URL env keys, deploys the compose
+and admin password values, applies profile-owned preview override env such as
+`ODOO_INSTALL_MODULES`, applies preview URL env keys, deploys the compose
 target, and records the requested PR URL as the preview generation. This is
 intentionally not generic compose preview support:
 generic-web application previews still require application template lanes, and

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -153,6 +153,7 @@ def _odoo_compose_profile() -> LaunchplaneProductProfileRecord:
             slug_template="pr-{number}",
             app_name_prefix="cm-odoo-preview",
             template_instance="testing",
+            override_env={"ODOO_INSTALL_MODULES": "cm_custom,cm_website"},
             preview_url_env_keys=("WEB_BASE_URL",),
             data_transport_mode="bootstrap",
         ),
@@ -1091,6 +1092,7 @@ class GenericWebPreviewTests(unittest.TestCase):
         self.assertEqual(len(env_updates), 1)
         self.assertIn("ODOO_DB_NAME=cm_preview", env_updates[0])
         self.assertIn("ODOO_PROJECT_NAME=cm-pr-28", env_updates[0])
+        self.assertIn("ODOO_INSTALL_MODULES=cm_custom,cm_website", env_updates[0])
         self.assertIn(
             "WEB_BASE_URL=https://pr-28.cm-preview.shinycomputers.com", env_updates[0]
         )


### PR DESCRIPTION
## Summary
- Configures the CM Odoo product profile's staged preview override env to install `cm_custom,cm_website` during Odoo startup.
- Pins the staged compose preview test so the rendered Dokploy env includes `ODOO_INSTALL_MODULES`.
- Documents that staged Odoo preview override env is profile-owned and intentionally part of the stage-MVP path.

## Validation
- `uv run python -m unittest tests.test_generic_web_preview`
- `uv run --extra dev ruff check --diff tests/test_generic_web_preview.py`
- `uv run --extra dev ruff check tests/test_generic_web_preview.py`
- `docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest` (1053 tests)

Refs #488
Refs cbusillo/odoo-tenant-cm#29
