### PR TITLE
Extend staged Odoo preview health wait

### DIFF
--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -49,7 +49,8 @@ _ODOO_COMPOSE_STAGE_PREVIEW_REQUIRED_ENV_KEYS = (
     "ODOO_MASTER_PASSWORD",
     "ODOO_ADMIN_PASSWORD",
 )
-_ODOO_COMPOSE_STAGE_PREVIEW_MIN_HEALTH_TIMEOUT_SECONDS = 30
+_ODOO_COMPOSE_STAGE_PREVIEW_MIN_DEPLOY_TIMEOUT_SECONDS = 30
+_ODOO_COMPOSE_STAGE_PREVIEW_HEALTH_TIMEOUT_SECONDS = 120
 
 
 class GenericWebPreviewProfileStore(Protocol):
@@ -1453,9 +1454,13 @@ def _execute_odoo_compose_stage_preview_refresh(
         target_id=target_definition.target_id,
         no_cache=request.no_cache,
     )
+    health_timeout_seconds = min(
+        request.timeout_seconds,
+        _ODOO_COMPOSE_STAGE_PREVIEW_HEALTH_TIMEOUT_SECONDS,
+    )
     deployment_timeout_seconds = max(
-        _ODOO_COMPOSE_STAGE_PREVIEW_MIN_HEALTH_TIMEOUT_SECONDS,
-        request.timeout_seconds - _ODOO_COMPOSE_STAGE_PREVIEW_MIN_HEALTH_TIMEOUT_SECONDS,
+        _ODOO_COMPOSE_STAGE_PREVIEW_MIN_DEPLOY_TIMEOUT_SECONDS,
+        request.timeout_seconds - health_timeout_seconds,
     )
     control_plane_dokploy.wait_for_target_deployment(
         host=host,
@@ -1468,10 +1473,7 @@ def _execute_odoo_compose_stage_preview_refresh(
     _wait_for_preview_health(
         preview_url=request.preview_url,
         health_path=profile.health_path,
-        timeout_seconds=min(
-            request.timeout_seconds,
-            _ODOO_COMPOSE_STAGE_PREVIEW_MIN_HEALTH_TIMEOUT_SECONDS,
-        ),
+        timeout_seconds=health_timeout_seconds,
     )
     return target_definition.target_id
 

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -1130,11 +1130,11 @@ class GenericWebPreviewTests(unittest.TestCase):
         )
         wait_for_deployment.assert_called_once()
         _, wait_kwargs = wait_for_deployment.call_args
-        self.assertEqual(wait_kwargs["timeout_seconds"], 210)
+        self.assertEqual(wait_kwargs["timeout_seconds"], 120)
         wait_health.assert_called_once_with(
             preview_url="https://pr-28.cm-preview.shinycomputers.com",
             health_path="/web/health",
-            timeout_seconds=30,
+            timeout_seconds=120,
         )
 
     def test_execute_generic_web_preview_refresh_allows_preview_safe_copied_secret_key(


### PR DESCRIPTION
## Summary
- Gives staged Odoo compose previews up to 120 seconds for `/web/health` after deployment, while preserving a minimum deploy wait.
- Updates the staged Odoo preview test to pin the new deploy/health timeout split.

## Context
PR #500 proved the profile-owned `ODOO_INSTALL_MODULES` path works: the live preview eventually returned 200 for `/web/health`, `/cm-website/health`, and `/cell-mechanic`, but the tenant workflow failed because the previous 30-second health wait ended while Odoo was still installing/updating modules.

## Validation
- `uv run python -m unittest tests.test_generic_web_preview`
- `uv run --extra dev ruff check --diff control_plane/workflows/generic_web_preview.py tests/test_generic_web_preview.py`
- `uv run --extra dev ruff check control_plane/workflows/generic_web_preview.py tests/test_generic_web_preview.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest` (1053 tests)

Refs #488
Refs cbusillo/odoo-tenant-cm#29
