### PR TITLE
Grant terminal agent LaunchPlane context reads

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -939,6 +939,30 @@ jobs:
             product_environment.read \
             deploy:syo-terminal-agent-product-environment-read-grant \
             syo-terminal-agent-product-environment-read
+          post_terminal_agent_grant \
+            launchplane \
+            launchplane \
+            product_environment.read \
+            deploy:terminal-agent-agent-context-product-read-grant \
+            terminal-agent-agent-context-product-read
+          post_terminal_agent_grant \
+            launchplane \
+            launchplane \
+            work_graph.rank \
+            deploy:terminal-agent-agent-context-work-graph-grant \
+            terminal-agent-agent-context-work-graph
+          post_terminal_agent_grant \
+            launchplane \
+            launchplane \
+            every_code_work_request.read \
+            deploy:terminal-agent-agent-context-every-code-grant \
+            terminal-agent-agent-context-every-code
+          post_terminal_agent_grant \
+            launchplane \
+            launchplane \
+            every_code_preview_gate.read \
+            deploy:terminal-agent-agent-context-preview-grant \
+            terminal-agent-agent-context-preview
           post_grant \
             "$GITHUB_REPOSITORY" \
             live-target-runtime.yml \

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -4194,6 +4194,81 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
 
+    def test_terminal_agent_read_token_can_read_agent_context(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "terminal_agents": [
+                    {
+                        "subjects": ["local-owner-agent"],
+                        "token_labels": ["local-owner-read"],
+                        "products": ["launchplane", "example-site"],
+                        "contexts": ["launchplane", "example-site"],
+                        "actions": [
+                            "product_environment.read",
+                            "work_graph.rank",
+                            "every_code_work_request.read",
+                            "every_code_preview_gate.read",
+                        ],
+                    }
+                ]
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
+            )
+            store.write_every_code_preview_gate_record(
+                EveryCodePreviewGateRecord(
+                    gate_id="every-code-preview-gate-every-example-site-190-abcdef",
+                    request_id="every-code-every-example-site-190-test",
+                    repository="every/example-site",
+                    issue_number=190,
+                    issue_url="https://github.com/every/example-site/issues/190",
+                    pr_number=191,
+                    pr_url="https://github.com/every/example-site/pull/191",
+                    head_sha="abcdef1234567890",
+                    status="ready",
+                    created_at="2026-05-08T18:00:00Z",
+                    updated_at="2026-05-08T18:01:00Z",
+                    ready_at="2026-05-08T18:01:00Z",
+                    last_checked_at="2026-05-08T18:01:00Z",
+                )
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN": "terminal-read-token",
+                    "LAUNCHPLANE_TERMINAL_AGENT_SUBJECT": "local-owner-agent",
+                    "LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL": "local-owner-read",
+                },
+                clear=True,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/agent/context",
+                    query_string="repository=every/example-site",
+                    authorization="Bearer terminal-read-token",
+                )
+
+        self.assertEqual(status_code, 200)
+        context = payload["context"]
+        self.assertEqual(context["repository"], "every/example-site")
+        sections = context["sections"]
+        self.assertEqual(sections["repo_product_mapping"]["status"], "available")
+        self.assertEqual(sections["work_graph_snapshot"]["status"], "available")
+        self.assertEqual(sections["every_code_summary"]["status"], "available")
+        self.assertEqual(sections["preview_readiness"]["status"], "available")
+
     def test_agent_context_marks_work_graph_unavailable_without_dropping_sections(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- add deploy-time terminal-agent authz grants for LaunchPlane agent context read actions
- cover terminal-agent bearer access to /v1/agent/context with a focused service test

## Validation
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_terminal_agent_read_token_can_read_agent_context
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-launchplane.yml"); puts "yaml=ok"'

## Notes
This keeps DB access behind the LaunchPlane service grant endpoint. The workflow uses OIDC to request DB-backed authz grants; it does not hardcode database URLs or credentials.