### PR TITLE
Fix Every Code worker maintenance auth

### DIFF
--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -119,6 +119,17 @@ class EveryCodeWorkerApiError(RuntimeError):
     pass
 
 
+def _try_every_code_worker_maintenance(
+    description: str,
+    operation: Callable[[], object],
+) -> str:
+    try:
+        operation()
+    except EveryCodeWorkerApiError as error:
+        return f"{description} failed: {error}"
+    return ""
+
+
 @dataclass(frozen=True)
 class EveryCodeWorkerApiStore:
     service_url: str
@@ -370,6 +381,22 @@ class EveryCodeWorkerHandoffResult:
     checkout_root: str = ""
     worktree_root: str = ""
     worktree_branch: str = ""
+
+    def with_detail_suffix(self, suffix: str) -> EveryCodeWorkerHandoffResult:
+        normalized_suffix = suffix.strip()
+        if not normalized_suffix:
+            return self
+        return self.__class__(
+            status=self.status,
+            detail=f"{self.detail} Maintenance warning: {normalized_suffix}",
+            request_id=self.request_id,
+            repository=self.repository,
+            issue_number=self.issue_number,
+            session_name=self.session_name,
+            checkout_root=self.checkout_root,
+            worktree_root=self.worktree_root,
+            worktree_branch=self.worktree_branch,
+        )
 
     def as_payload(self) -> dict[str, object]:
         return {
@@ -1165,35 +1192,53 @@ def run_every_code_worker_loop(
             tmux_binary=tmux_binary,
             runner=runner,
         )
-        apply_every_code_pr_feedback_for_host(
-            record_store=record_store,
-            host=host,
-            state_dir=state_dir,
-            database_url=database_url,
-            service_url=service_url,
-            worker_token_env=worker_token_env,
-            tmux_binary=tmux_binary,
-            runner=runner,
-        )
-        request_ready_every_code_pr_preview_labels(
-            record_store=record_store,
-            repository=repository,
-            runner=runner,
-        )
-        route_every_code_pr_check_failures(
-            record_store=record_store,
-            repository=repository,
-            runner=runner,
-        )
-        apply_every_code_pr_feedback_for_host(
-            record_store=record_store,
-            host=host,
-            state_dir=state_dir,
-            database_url=database_url,
-            service_url=service_url,
-            worker_token_env=worker_token_env,
-            tmux_binary=tmux_binary,
-            runner=runner,
+        maintenance_errors = tuple(
+            error
+            for error in (
+                _try_every_code_worker_maintenance(
+                    "Every Code PR feedback maintenance",
+                    lambda: apply_every_code_pr_feedback_for_host(
+                        record_store=record_store,
+                        host=host,
+                        state_dir=state_dir,
+                        database_url=database_url,
+                        service_url=service_url,
+                        worker_token_env=worker_token_env,
+                        tmux_binary=tmux_binary,
+                        runner=runner,
+                    ),
+                ),
+                _try_every_code_worker_maintenance(
+                    "Every Code preview readiness maintenance",
+                    lambda: request_ready_every_code_pr_preview_labels(
+                        record_store=record_store,
+                        repository=repository,
+                        runner=runner,
+                    ),
+                ),
+                _try_every_code_worker_maintenance(
+                    "Every Code check-failure maintenance",
+                    lambda: route_every_code_pr_check_failures(
+                        record_store=record_store,
+                        repository=repository,
+                        runner=runner,
+                    ),
+                ),
+                _try_every_code_worker_maintenance(
+                    "Every Code PR feedback follow-up maintenance",
+                    lambda: apply_every_code_pr_feedback_for_host(
+                        record_store=record_store,
+                        host=host,
+                        state_dir=state_dir,
+                        database_url=database_url,
+                        service_url=service_url,
+                        worker_token_env=worker_token_env,
+                        tmux_binary=tmux_binary,
+                        runner=runner,
+                    ),
+                ),
+            )
+            if error
         )
         last_result = run_every_code_worker_once(
             record_store=record_store,
@@ -1210,6 +1255,8 @@ def run_every_code_worker_loop(
             tmux_binary=tmux_binary,
             runner=runner,
         )
+        if maintenance_errors:
+            last_result = last_result.with_detail_suffix("; ".join(maintenance_errors))
         if last_result.status == "running":
             handed_off += 1
         elif last_result.status == "blocked":

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -103,6 +103,7 @@ from control_plane.contracts.preview_pr_feedback_record import (
 from control_plane.contracts.preview_readiness_read_model import (
     build_preview_readiness_read_model,
 )
+from control_plane.contracts.product_environment_read_model import ProductReadModelStore
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductLaneProfile,
@@ -3303,6 +3304,8 @@ def _terminal_agent_identity_from_bearer(
 
 
 def _is_every_code_worker_route(*, method: str, path: str) -> bool:
+    if method == "GET" and path == "/v1/product-profiles":
+        return True
     if method == "GET" and path == "/v1/previews/readiness":
         return True
     if method == "GET" and path == "/v1/every-code/summary":
@@ -3352,8 +3355,14 @@ def _every_code_read_payload(
     path: str,
     query: dict[str, list[str]],
 ) -> dict[str, object]:
-    every_code_store = _every_code_work_request_store(record_store)
     segments = [segment for segment in path.split("/") if segment]
+    if path == "/v1/product-profiles":
+        driver_id_filter = str((query.get("driver_id") or [""])[0] or "").strip()
+        return control_plane_product_read_service.build_product_profile_list_service_payload(
+            record_store=cast(ProductReadModelStore, record_store),
+            driver_id=driver_id_filter,
+        )
+    every_code_store = _every_code_work_request_store(record_store)
     if path == "/v1/previews/readiness":
         repository_filter = str((query.get("repository") or [""])[0] or "").strip()
         pr_number_value = str((query.get("pr_number") or [""])[0] or "").strip()

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -138,14 +138,12 @@ The Every Code worker read, claim, and status routes also accept a dedicated
 local-worker bearer token. Configure `LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN` on
 the Launchplane service and on the Mac worker host, then run the worker with
 `uv run launchplane every-code start --service-url https://...`. That token is
-scoped in code to `GET /v1/every-code/work-requests`,
-`GET /v1/every-code/work-requests/{request_id}`,
-`POST /v1/every-code/work-requests/claim`,
-`POST /v1/every-code/work-requests/rerun`, and
-`POST /v1/every-code/work-requests/status`. It cannot create webhook requests,
-write product records, or access other Launchplane service routes. This keeps
-remote DB credentials on the Launchplane host while still allowing visible local
-Code/tmux work sessions to claim, rerun terminal requests, and report progress.
+scoped in code to Every Code work-request, PR-feedback, preview-gate, preview
+readiness routes, plus read-only `GET /v1/product-profiles` for preview
+readiness projection. It cannot create webhook requests, write product records,
+or access other Launchplane service routes. This keeps remote DB credentials on
+the Launchplane host while still allowing visible local Code/tmux work sessions
+to claim, rerun terminal requests, reconcile preview state, and report progress.
 
 Local terminal agents that need Launchplane context use a separate read-only
 bearer credential, not the browser OAuth session cookie and not

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -22,6 +22,7 @@ from control_plane.contracts.product_profile_record import LaunchplaneProductPro
 from control_plane.contracts.product_profile_record import ProductImageProfile
 from control_plane.contracts.product_profile_record import ProductPreviewProfile
 from control_plane.every_code_worker import (
+    EveryCodeWorkerApiError,
     EveryCodeWorkerApiStore,
     apply_every_code_pr_feedback_for_host,
     build_every_code_worker_daemon_spec,
@@ -284,6 +285,13 @@ class _GoneSessionWithWorktreeProcessRunner(_GoneSessionRunner):
 class _Process:
     def __init__(self, pid: int) -> None:
         self.pid = pid
+
+
+class _MaintenanceFailingStore(FilesystemRecordStore):
+    def list_every_code_pr_feedback_records(self, **kwargs: object) -> tuple[EveryCodePrFeedbackRecord, ...]:
+        if kwargs.get("status") == "pending":
+            raise EveryCodeWorkerApiError("Launchplane API request failed with HTTP 401")
+        return super().list_every_code_pr_feedback_records(**kwargs)  # type: ignore[arg-type]
 
 
 class _EveryCodeApiHandler(BaseHTTPRequestHandler):
@@ -2272,6 +2280,34 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(result.blocked, 0)
         self.assertEqual(result.stopped_reason, "max_iterations")
         self.assertEqual(sleeps, [2.5])
+
+    def test_run_loop_claims_request_when_pr_feedback_maintenance_fails(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            store = _MaintenanceFailingStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            result = run_every_code_worker_loop(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "worker-state",
+                interval_seconds=0,
+                max_iterations=1,
+                runner=_Runner(),
+                sleeper=lambda _seconds: None,
+            )
+            record = store.read_every_code_work_request_record(
+                "every-code-cbusillo-code-123-test"
+            )
+
+        self.assertEqual(result.handed_off, 1)
+        self.assertEqual(result.blocked, 0)
+        self.assertEqual(record.state, "running")
+        self.assertIn("Maintenance warning", result.last_result.detail)
+        self.assertIn("HTTP 401", result.last_result.detail)
 
     def test_run_loop_rejects_negative_interval(self) -> None:
         with self.assertRaises(ValueError):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3534,6 +3534,88 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_status, 202)
         self.assertEqual(status_payload["result"]["request"]["state"], "done")
 
+    def test_every_code_worker_token_can_list_product_profiles_read_only(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main"
+                        ],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["product_profile.write"],
+                    }
+                ]
+            }
+        )
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
+            event_name="workflow_dispatch",
+        )
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "worker-token"},
+            ),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            FilesystemRecordStore(state_dir=state_dir).write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(identity),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            list_status, list_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/product-profiles",
+                query_string="driver_id=generic-web",
+                authorization="Bearer worker-token",
+            )
+            show_status, show_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/product-profiles/sellyouroutboard",
+                authorization="Bearer worker-token",
+            )
+            write_with_worker_status, write_with_worker_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/product-profiles",
+                payload=_product_profile_payload("verireel"),
+                authorization="Bearer worker-token",
+            )
+            unrelated_status, unrelated_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/products",
+                authorization="Bearer worker-token",
+            )
+
+        self.assertEqual(list_status, 200)
+        self.assertEqual(list_payload["driver_id"], "generic-web")
+        self.assertEqual(
+            [profile["product"] for profile in list_payload["profiles"]],
+            ["sellyouroutboard"],
+        )
+        self.assertEqual(show_status, 401)
+        self.assertEqual(show_payload["error"]["code"], "authentication_required")
+        self.assertEqual(write_with_worker_status, 400)
+        self.assertEqual(
+            write_with_worker_payload["error"]["code"],
+            "invalid_request",
+        )
+        self.assertEqual(unrelated_status, 401)
+        self.assertEqual(unrelated_payload["error"]["code"], "authentication_required")
+
     def test_every_code_worker_token_can_rerun_terminal_request(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(
             {


### PR DESCRIPTION
## Summary

- allow the Every Code worker token to perform the narrow read-only `GET /v1/product-profiles` call used by preview readiness projection
- isolate worker pre-claim maintenance API failures so queued work can still be claimed
- document the expanded worker-token read scope and add focused service/worker regression tests

Refs #490

## Verification

- `uv run python -m unittest tests.test_service tests.test_every_code_worker`
- `uv run python -m unittest`
- `uv run --extra dev ruff check --diff control_plane/service.py control_plane/every_code_worker.py tests/test_service.py tests/test_every_code_worker.py`
- `uv run --extra dev ruff check control_plane/service.py control_plane/every_code_worker.py tests/test_service.py tests/test_every_code_worker.py`
- `uv run --extra dev mypy control_plane tests`
