### PR TITLE
Trust Every Code feedback actors and reconcile preview gates

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -108,10 +108,12 @@ from control_plane.every_code_worker import (
     EveryCodeWorkerApiError,
     EveryCodeWorkerApiStore,
     EveryCodeWorkerStore,
+    apply_every_code_pr_feedback_for_host,
     build_every_code_worker_daemon_spec,
     every_code_worker_daemon_status,
     finish_every_code_work_request,
     request_ready_every_code_pr_preview_labels,
+    route_every_code_pr_check_failures,
     run_every_code_worker_loop,
     run_every_code_worker_once,
     start_every_code_worker_daemon,
@@ -9675,6 +9677,32 @@ def every_code_run_once(
         worker_token_env=worker_token_env,
     )
     try:
+        apply_every_code_pr_feedback_for_host(
+            record_store=record_store,
+            host=resolved_host,
+            state_dir=state_dir,
+            database_url=database_url,
+            service_url=service_url,
+            worker_token_env=worker_token_env,
+            tmux_binary=tmux_binary,
+        )
+        request_ready_every_code_pr_preview_labels(
+            record_store=record_store,
+            repository=repository,
+        )
+        route_every_code_pr_check_failures(
+            record_store=record_store,
+            repository=repository,
+        )
+        apply_every_code_pr_feedback_for_host(
+            record_store=record_store,
+            host=resolved_host,
+            state_dir=state_dir,
+            database_url=database_url,
+            service_url=service_url,
+            worker_token_env=worker_token_env,
+            tmux_binary=tmux_binary,
+        )
         result = run_every_code_worker_once(
             record_store=record_store,
             host=resolved_host,

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2125,6 +2125,81 @@ def _github_webhook_string(mapping: dict[str, object] | None, key: str) -> str:
     return value.strip() if isinstance(value, str) else ""
 
 
+def _github_login_normalized(login: str) -> str:
+    return login.strip().lstrip("@").casefold()
+
+
+def _github_actor_login(payload: dict[str, object]) -> str:
+    return _github_webhook_string(_github_webhook_mapping(payload, "sender"), "login")
+
+
+def _every_code_trusted_manager_logins(repository: str) -> frozenset[str]:
+    normalized_repository = repository.strip().casefold()
+    if not normalized_repository:
+        return frozenset()
+    config_paths = (
+        Path.home() / ".code" / "github-planning.json",
+        Path.home() / ".codex" / "github-planning.json",
+    )
+    for config_path in config_paths:
+        try:
+            payload = json.loads(config_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        workflow = payload.get("workflow")
+        if not isinstance(workflow, dict):
+            continue
+        managers: set[str] = set()
+        default_manager = workflow.get("default_manager")
+        if isinstance(default_manager, str) and default_manager.strip():
+            managers.add(_github_login_normalized(default_manager))
+        repo_managers = workflow.get("repo_managers")
+        if isinstance(repo_managers, dict):
+            repo_manager = repo_managers.get(repository) or repo_managers.get(normalized_repository)
+            if isinstance(repo_manager, str) and repo_manager.strip():
+                managers.add(_github_login_normalized(repo_manager))
+        return frozenset(manager for manager in managers if manager)
+    return frozenset()
+
+
+def _every_code_feedback_actor_is_trusted(
+    *,
+    repository: str,
+    actor: str,
+    source_issue_author: str = "",
+) -> bool:
+    normalized_actor = _github_login_normalized(actor)
+    if not normalized_actor:
+        return False
+    repository_owner = repository.strip().split("/", 1)[0]
+    trusted = {_github_login_normalized(repository_owner)}
+    if source_issue_author.strip():
+        trusted.add(_github_login_normalized(source_issue_author))
+    trusted.update(_every_code_trusted_manager_logins(repository))
+    return normalized_actor in trusted
+
+
+def _every_code_untrusted_feedback_response(
+    *,
+    start_response: _StartResponse,
+    trace_id: str,
+    delivery_id: str,
+) -> list[bytes]:
+    return _json_response(
+        start_response=start_response,
+        status_code=202,
+        payload={
+            "status": "accepted",
+            "trace_id": trace_id,
+            "skipped": True,
+            "reason": "untrusted_actor",
+            "github_delivery_id": delivery_id,
+        },
+    )
+
+
 def _handle_every_code_github_webhook(
     *,
     environ: dict[str, object],
@@ -2546,12 +2621,23 @@ def _handle_every_code_preview_validation_webhook(
         return None
     issue_author_payload = _github_webhook_mapping(issue_payload, "user")
     issue_author = _github_webhook_string(issue_author_payload, "login")
+    actor = _github_actor_login(payload)
     comment_payload = _github_webhook_mapping(payload, "comment")
     if comment_payload is None:
         return None
     comment_body = _github_webhook_string(comment_payload, "body")
     if not comment_body.strip().lower().startswith("/preview"):
         return None
+    if not _every_code_feedback_actor_is_trusted(
+        repository=repository,
+        actor=actor,
+        source_issue_author=issue_author,
+    ):
+        return _every_code_untrusted_feedback_response(
+            start_response=start_response,
+            trace_id=trace_id,
+            delivery_id=delivery_id,
+        )
     every_code_store = _every_code_work_request_store(record_store)
     context_name = launchplane_anchor_repo_context(
         record_store=cast(FilesystemRecordStore, record_store),
@@ -2571,7 +2657,7 @@ def _handle_every_code_preview_validation_webhook(
             issue_number=issue_number_value,
             issue_url=_github_webhook_string(issue_payload, "html_url"),
             issue_author=issue_author,
-            actor=_github_webhook_string(_github_webhook_mapping(payload, "sender"), "login"),
+            actor=actor,
             comment_body=comment_body,
             comment_id=str(comment_payload.get("id") or ""),
             comment_node_id=_github_webhook_string(comment_payload, "node_id"),
@@ -2724,14 +2810,38 @@ def _handle_every_code_pr_feedback_webhook(
             },
         )
 
+    sender_payload = _github_webhook_mapping(payload, "sender")
+    body_payload = _every_code_feedback_body_payload(event_name=event_name, payload=payload)
+    if _every_code_feedback_actor_is_automation(
+        sender_payload=sender_payload,
+        body_payload=body_payload,
+    ):
+        return _json_response(
+            start_response=start_response,
+            status_code=202,
+            payload={
+                "status": "accepted",
+                "trace_id": trace_id,
+                "skipped": True,
+                "reason": "automation_actor",
+                "github_delivery_id": delivery_id,
+            },
+        )
+
     repository_payload = _github_webhook_mapping(payload, "repository")
     repository = _github_webhook_string(repository_payload, "full_name")
+    actor = _github_webhook_string(sender_payload, "login")
+    if not _every_code_feedback_actor_is_trusted(repository=repository, actor=actor):
+        return _every_code_untrusted_feedback_response(
+            start_response=start_response,
+            trace_id=trace_id,
+            delivery_id=delivery_id,
+        )
     pr_number, pr_url = _every_code_feedback_pr_reference(
         event_name=event_name,
         payload=payload,
         repository=repository,
     )
-    body_payload = _every_code_feedback_body_payload(event_name=event_name, payload=payload)
     body = _github_webhook_string(body_payload, "body")
     if not body.strip():
         return _json_response(
@@ -2799,7 +2909,6 @@ def _handle_every_code_pr_feedback_webhook(
             },
         )
 
-    sender_payload = _github_webhook_mapping(payload, "sender")
     github_node_id = _github_webhook_string(body_payload, "node_id")
     github_id_value = body_payload.get("id") if body_payload is not None else ""
     github_id = str(github_id_value) if github_id_value is not None else ""
@@ -2843,7 +2952,7 @@ def _handle_every_code_pr_feedback_webhook(
         github_delivery_id=delivery_id,
         github_node_id=github_node_id,
         github_id=github_id,
-        actor=_github_webhook_string(sender_payload, "login"),
+        actor=actor,
         author_association=_github_webhook_string(body_payload, "author_association"),
         body=body,
         html_url=_github_webhook_string(body_payload, "html_url"),
@@ -2872,6 +2981,25 @@ def _every_code_pr_feedback_action_supported(*, event_name: str, action: str) ->
         return action == "submitted"
     if event_name == "pull_request_review_comment":
         return action == "created"
+    return False
+
+
+def _every_code_feedback_actor_is_automation(
+    *,
+    sender_payload: dict[str, object] | None,
+    body_payload: dict[str, object],
+) -> bool:
+    actors = [sender_payload]
+    user_payload = _github_webhook_mapping(body_payload, "user")
+    if user_payload is not None:
+        actors.append(user_payload)
+    for actor_payload in actors:
+        if actor_payload is None:
+            continue
+        actor_type = _github_webhook_string(actor_payload, "type").lower()
+        actor_login = _github_webhook_string(actor_payload, "login").lower()
+        if actor_type == "bot" or actor_login.endswith("[bot]"):
+            return True
     return False
 
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -560,10 +560,12 @@ preflights.
   queued request before reporting progress. Terminal states are immutable through
   the service status route.
 - The local worker handoff is `uv run launchplane every-code run` for polling or
-  `uv run launchplane every-code run-once` for a single scan. It claims queued
-  requests, opens or reuses deterministic visible tmux sessions for local
-  checkouts, records `running` or immediate `blocked` status, and wraps the
-  visible command so terminal success or failure calls
+  `uv run launchplane every-code run-once` for a single scan. Each pass applies
+  trusted PR feedback, reconciles preview gates and ready preview labels, routes
+  failed checks back to the owning session, then claims at most one queued
+  request. Request handoff opens or reuses deterministic visible tmux sessions
+  for local checkouts, records `running` or immediate `blocked` status, and
+  wraps the visible command so terminal success or failure calls
   `uv run launchplane every-code finish`.
 - A Mac host can leave the poller running with
   `uv run launchplane every-code start`, inspect it with
@@ -601,6 +603,14 @@ preflights.
   to linked issues. A single pull request can close multiple Every Code requests;
   queued matches are terminalized with service-owned claim metadata so terminal
   records still satisfy the work-request contract.
+- Every Code PR feedback webhooks and `/preview ok` or `/preview changes ...`
+  source-issue comments are actor-gated before they become pending work for a
+  local session. The repository owner is trusted, the source issue author is
+  trusted for preview validation, and configured managers from the local planning
+  manager map are accepted as a bootstrap policy source until Launchplane owns a
+  mutable repo trust-policy record. Bot-authored and untrusted human comments are
+  accepted-but-skipped so webhook delivery remains idempotent without sending
+  automation chatter to Every Code.
 - Agent callers should prefer `GET /v1/every-code/summary` over raw work-request
   reads when they only need status. The summary projection links back to the
   issue and result PR, reports whether work is active, stuck, complete, or

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -839,6 +839,10 @@ class EveryCodeWorkerTests(unittest.TestCase):
                 _done_record(
                     repository="cbusillo/sellyouroutboard",
                     result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/86",
+                ).model_copy(
+                    update={
+                        "issue_url": "https://github.com/cbusillo/sellyouroutboard/issues/123"
+                    }
                 )
             )
             runner = _Runner(
@@ -2310,6 +2314,76 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(payload["iterations"], 1)
         self.assertEqual(payload["empty"], 1)
         self.assertEqual(payload["stopped_reason"], "max_iterations")
+
+    def test_cli_run_once_reconciles_ready_preview_gate(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            state_dir = temporary_root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            _write_sellyouroutboard_preview_profile(store)
+            store.write_every_code_work_request_record(
+                _done_record(
+                    repository="cbusillo/sellyouroutboard",
+                    result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/86",
+                ).model_copy(
+                    update={
+                        "issue_url": "https://github.com/cbusillo/sellyouroutboard/issues/123"
+                    }
+                )
+            )
+            runner = _Runner(
+                pr_view_payload={
+                    "state": "OPEN",
+                    "headRefOid": "abcdef1234567890",
+                    "labels": [],
+                    "statusCheckRollup": [
+                        {
+                            "name": "static_checks",
+                            "status": "COMPLETED",
+                            "conclusion": "SUCCESS",
+                        },
+                    ],
+                }
+            )
+            with patch("control_plane.every_code_worker._run_subprocess", runner):
+                result = CliRunner().invoke(
+                    main,
+                    [
+                        "every-code",
+                        "run-once",
+                        "--state-dir",
+                        str(state_dir),
+                        "--workspace-root",
+                        str(temporary_root / "Developer"),
+                        "--host",
+                        "Chris-Studio",
+                        "--repository",
+                        "cbusillo/sellyouroutboard",
+                    ],
+                )
+            gate_records = store.list_every_code_preview_gate_records(
+                request_id="every-code-cbusillo-code-123-test",
+                pr_number=86,
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["status"], "empty")
+        self.assertEqual(len(gate_records), 1)
+        self.assertEqual(gate_records[0].status, "labeled")
+        self.assertIn(
+            (
+                "gh",
+                "pr",
+                "edit",
+                "86",
+                "--repo",
+                "cbusillo/sellyouroutboard",
+                "--add-label",
+                "preview",
+            ),
+            runner.calls,
+        )
 
     def test_cli_api_mode_requires_worker_token_env(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -4,6 +4,7 @@ import hmac
 import io
 import json
 import os
+import tempfile
 import unittest
 from collections.abc import Callable, Iterable, Mapping
 from pathlib import Path
@@ -679,6 +680,8 @@ def _every_code_github_pr_comment_payload(
     body: str = "Please tighten this wording before merge.",
     comment_id: int = 1001,
     issue_body: str = "",
+    sender: str = "cbusillo",
+    sender_type: str = "User",
 ) -> dict[str, object]:
     return {
         "action": "created",
@@ -695,8 +698,9 @@ def _every_code_github_pr_comment_payload(
             "html_url": f"https://github.com/{repository}/pull/{pr_number}#issuecomment-{comment_id}",
             "body": body,
             "author_association": "OWNER",
+            "user": {"login": sender, "type": sender_type},
         },
-        "sender": {"login": "cbusillo"},
+        "sender": {"login": sender, "type": sender_type},
     }
 
 
@@ -724,8 +728,9 @@ def _every_code_github_issue_comment_payload(
             "html_url": f"https://github.com/{repository}/issues/{issue_number}#issuecomment-{comment_id}",
             "body": body,
             "author_association": "CONTRIBUTOR",
+            "user": {"login": sender, "type": "User"},
         },
-        "sender": {"login": sender},
+        "sender": {"login": sender, "type": "User"},
     }
 
 
@@ -799,6 +804,28 @@ def _invoke_app(
     response_payload = json.loads(response_body.decode("utf-8"))
     assert isinstance(response_payload, dict)
     return int(captured_status.split(" ", 1)[0]), cast(dict[str, Any], response_payload)
+
+
+def _write_github_planning_config(
+    root: Path,
+    *,
+    repo_managers: dict[str, str] | None = None,
+    default_manager: str = "@cellmechanic",
+) -> Path:
+    config_path = root / ".code" / "github-planning.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "workflow": {
+                    "default_manager": default_manager,
+                    "repo_managers": repo_managers or {},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    return config_path
 
 
 def _invoke_raw_app(
@@ -2761,6 +2788,167 @@ class LaunchplaneServiceTests(unittest.TestCase):
         create_comment.assert_called_once()
         self.assertIn("@cbusillo", create_comment.call_args.kwargs["body"])
 
+    def test_every_code_preview_ok_allows_repo_owner_override(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        issue_payload = _every_code_github_issue_labeled_payload(
+            repository="cbusillo/sellyouroutboard",
+            issue_number=82,
+        )
+        comment_payload = _every_code_github_issue_comment_payload(
+            repository="cbusillo/sellyouroutboard",
+            issue_number=82,
+            issue_author="Mbanks89",
+            sender="cbusillo",
+            body="/preview ok",
+        )
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
+            ),
+            patch(
+                "control_plane.service.resolve_launchplane_github_token",
+                return_value="github-token",
+            ),
+            patch(
+                "control_plane.workflows.preview_pr_feedback.github_api_request",
+                side_effect=[
+                    [{"name": "preview-approved"}],
+                    {},
+                    {},
+                    [{"name": "ready-to-merge"}],
+                    {"owner": {"login": "cbusillo", "type": "User"}},
+                    {"assignees": [{"login": "cbusillo"}]},
+                ],
+            ),
+            patch(
+                "control_plane.workflows.preview_pr_feedback.find_github_issue_comment_by_marker",
+                return_value=None,
+            ),
+            patch(
+                "control_plane.workflows.preview_pr_feedback.create_github_issue_comment",
+                return_value={"id": 987},
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            issue_status, issue_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=issue_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-issue",
+                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                },
+            )
+            request_id = issue_response["records"]["request_id"]
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/claim",
+                payload={"request_id": request_id, "host": "Chris-Studio"},
+                authorization="Bearer dev-worker-token",
+            )
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/status",
+                payload={
+                    "request_id": request_id,
+                    "host": "Chris-Studio",
+                    "state": "done",
+                    "result_pr_url": "https://github.com/cbusillo/sellyouroutboard/pull/88",
+                    "result_summary": "Opened PR.",
+                    "updated_at": "2026-05-07T12:40:00Z",
+                },
+                authorization="Bearer dev-worker-token",
+            )
+            ok_status, ok_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=comment_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issue_comment",
+                    "X-GitHub-Delivery": "delivery-preview-owner-ok",
+                    "X-Hub-Signature-256": _github_webhook_signature(comment_payload, secret),
+                },
+            )
+
+        self.assertEqual(issue_status, 202)
+        self.assertEqual(ok_status, 202, ok_response)
+        self.assertEqual(ok_response["result"]["preview_validation"]["command"], "ok")
+
+    def test_every_code_preview_comment_skips_untrusted_actor(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        issue_payload = _every_code_github_issue_labeled_payload(
+            repository="cbusillo/sellyouroutboard",
+            issue_number=82,
+        )
+        comment_payload = _every_code_github_issue_comment_payload(
+            repository="cbusillo/sellyouroutboard",
+            issue_number=82,
+            issue_author="Mbanks89",
+            sender="random-user",
+            body="/preview ok",
+        )
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            _issue_status, _issue_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=issue_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-issue",
+                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                },
+            )
+            ok_status, ok_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=comment_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issue_comment",
+                    "X-GitHub-Delivery": "delivery-preview-untrusted-ok",
+                    "X-Hub-Signature-256": _github_webhook_signature(comment_payload, secret),
+                },
+            )
+
+        self.assertEqual(ok_status, 202, ok_response)
+        self.assertTrue(ok_response["skipped"])
+        self.assertEqual(ok_response["reason"], "untrusted_actor")
+
     def test_every_code_preview_changes_routes_feedback_to_session(self) -> None:
         secret = "launchplane-every-code-webhook-secret"
         issue_payload = _every_code_github_issue_labeled_payload(
@@ -2936,6 +3124,245 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(feedback["request_id"], request_id)
         self.assertEqual(feedback["pr_number"], 75)
         self.assertEqual(feedback["pr_url"], "https://github.com/cbusillo/code/pull/75")
+
+    def test_every_code_pr_comment_webhook_allows_configured_manager(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        issue_payload = _every_code_github_issue_labeled_payload(
+            repository="cbusillo/sellyouroutboard",
+            issue_number=67,
+        )
+        comment_payload = _every_code_github_pr_comment_payload(
+            repository="cbusillo/sellyouroutboard",
+            pr_number=75,
+            issue_body="Closes #67",
+            sender="Mbanks89",
+        )
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            tempfile.TemporaryDirectory() as home_directory_name,
+            patch.dict(
+                os.environ,
+                {
+                    "HOME": home_directory_name,
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
+            ),
+        ):
+            _write_github_planning_config(
+                Path(home_directory_name),
+                repo_managers={"cbusillo/sellyouroutboard": "@Mbanks89"},
+            )
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            issue_status, issue_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=issue_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-issue",
+                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                },
+            )
+            request_id = issue_response["records"]["request_id"]
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/claim",
+                payload={"request_id": request_id, "host": "Chris-Studio"},
+                authorization="Bearer dev-worker-token",
+            )
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/status",
+                payload={
+                    "request_id": request_id,
+                    "host": "Chris-Studio",
+                    "state": "running",
+                    "result_summary": "Visible tmux session.",
+                    "updated_at": "2026-05-06T16:00:00Z",
+                },
+                authorization="Bearer dev-worker-token",
+            )
+            feedback_status, feedback_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=comment_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issue_comment",
+                    "X-GitHub-Delivery": "delivery-comment-manager",
+                    "X-Hub-Signature-256": _github_webhook_signature(comment_payload, secret),
+                },
+            )
+
+        self.assertEqual(issue_status, 202)
+        self.assertEqual(feedback_status, 202, feedback_response)
+        self.assertEqual(feedback_response["records"]["request_id"], request_id)
+        self.assertEqual(feedback_response["result"]["feedback"]["actor"], "Mbanks89")
+
+    def test_every_code_pr_comment_webhook_skips_untrusted_actor(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        issue_payload = _every_code_github_issue_labeled_payload(issue_number=67)
+        comment_payload = _every_code_github_pr_comment_payload(
+            pr_number=75,
+            issue_body="Closes #67",
+            sender="random-user",
+        )
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            tempfile.TemporaryDirectory() as home_directory_name,
+            patch.dict(
+                os.environ,
+                {
+                    "HOME": home_directory_name,
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
+            ),
+        ):
+            _write_github_planning_config(Path(home_directory_name), repo_managers={})
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            issue_status, issue_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=issue_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-issue",
+                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                },
+            )
+            request_id = issue_response["records"]["request_id"]
+            feedback_status, feedback_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=comment_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issue_comment",
+                    "X-GitHub-Delivery": "delivery-comment-untrusted",
+                    "X-Hub-Signature-256": _github_webhook_signature(comment_payload, secret),
+                },
+            )
+            list_status, list_response = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/every-code/pr-feedback",
+                query_string=f"request_id={request_id}",
+                authorization="Bearer dev-worker-token",
+            )
+
+        self.assertEqual(issue_status, 202)
+        self.assertEqual(feedback_status, 202, feedback_response)
+        self.assertEqual(list_status, 200, list_response)
+        self.assertTrue(feedback_response["skipped"])
+        self.assertEqual(feedback_response["reason"], "untrusted_actor")
+        self.assertEqual(list_response["feedback"], [])
+
+    def test_every_code_pr_comment_webhook_ignores_bot_feedback(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        issue_payload = _every_code_github_issue_labeled_payload(issue_number=67)
+        comment_payload = _every_code_github_pr_comment_payload(
+            pr_number=75,
+            issue_body="Closes #67",
+            body="Odoo preview refresh started for PR #75.",
+            sender="github-actions[bot]",
+            sender_type="Bot",
+        )
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            issue_status, issue_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=issue_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-issue",
+                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                },
+            )
+            request_id = issue_response["records"]["request_id"]
+            _claim_status, _claim_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/claim",
+                payload={"request_id": request_id, "host": "Chris-Studio"},
+                authorization="Bearer dev-worker-token",
+            )
+            _running_status, _running_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/status",
+                payload={
+                    "request_id": request_id,
+                    "host": "Chris-Studio",
+                    "state": "running",
+                    "result_summary": "Visible tmux session.",
+                    "updated_at": "2026-05-06T16:00:00Z",
+                },
+                authorization="Bearer dev-worker-token",
+            )
+            feedback_status, feedback_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=comment_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issue_comment",
+                    "X-GitHub-Delivery": "delivery-comment-bot",
+                    "X-Hub-Signature-256": _github_webhook_signature(comment_payload, secret),
+                },
+            )
+
+            list_status, list_response = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/every-code/pr-feedback",
+                query_string=f"request_id={request_id}",
+                authorization="Bearer dev-worker-token",
+            )
+
+        self.assertEqual(issue_status, 202)
+        self.assertEqual(feedback_status, 202, feedback_response)
+        self.assertEqual(list_status, 200, list_response)
+        self.assertTrue(feedback_response["skipped"])
+        self.assertEqual(feedback_response["reason"], "automation_actor")
+        self.assertEqual(list_response["feedback"], [])
 
     def test_every_code_pr_comment_webhook_dedupes_feedback(self) -> None:
         secret = "launchplane-every-code-webhook-secret"


### PR DESCRIPTION
## Summary
- gate Every Code PR feedback and /preview commands to trusted actors: repo owner, source issue author for preview validation, and configured planning managers
- skip bot/untrusted comments without creating pending Every Code feedback
- make every-code run-once perform the same feedback, preview gate, and check-failure housekeeping pass as the polling worker before claiming queued work
- document trusted feedback and run-once preview reconciliation behavior

## Validation
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_every_code_preview_ok_comment_marks_pr_ready_to_merge tests.test_service.LaunchplaneServiceTests.test_every_code_preview_ok_allows_repo_owner_override tests.test_service.LaunchplaneServiceTests.test_every_code_preview_comment_skips_untrusted_actor tests.test_service.LaunchplaneServiceTests.test_every_code_preview_changes_routes_feedback_to_session tests.test_service.LaunchplaneServiceTests.test_every_code_pr_comment_webhook_matches_linked_issue tests.test_service.LaunchplaneServiceTests.test_every_code_pr_comment_webhook_allows_configured_manager tests.test_service.LaunchplaneServiceTests.test_every_code_pr_comment_webhook_skips_untrusted_actor tests.test_service.LaunchplaneServiceTests.test_every_code_pr_comment_webhook_ignores_bot_feedback tests.test_service.LaunchplaneServiceTests.test_every_code_pr_comment_webhook_dedupes_feedback tests.test_every_code_worker.EveryCodeWorkerTests.test_preview_gate_labels_done_pull_request_after_checks_pass tests.test_every_code_worker.EveryCodeWorkerTests.test_cli_run_once_reconciles_ready_preview_gate tests.test_every_code_worker.EveryCodeWorkerTests.test_cli_api_mode_requires_worker_token_env
- uv run --extra dev mypy control_plane/service.py control_plane/cli.py tests/test_service.py tests/test_every_code_worker.py
- uv run --extra dev ruff check control_plane/service.py control_plane/cli.py tests/test_service.py tests/test_every_code_worker.py

Refs #514