### PR TITLE
Handle Odoo compose preview domain cleanup

### DIFF
--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -1584,7 +1584,7 @@ def execute_generic_web_preview_inventory(
             profile=resolved_profile,
             target_definition=target_definition,
         ):
-            preview_items = []
+            compose_preview_items: list[GenericWebPreviewInventoryItem] = []
             for domain in _compose_preview_domains(
                 host=host,
                 token=token,
@@ -1592,7 +1592,7 @@ def execute_generic_web_preview_inventory(
                 profile=resolved_profile,
             ):
                 domain_host = str(domain.get("host") or "").strip()
-                preview_items.append(
+                compose_preview_items.append(
                     GenericWebPreviewInventoryItem(
                         applicationId=target_definition.target_id,
                         applicationName=target_definition.target_name,
@@ -1610,7 +1610,9 @@ def execute_generic_web_preview_inventory(
                 context=resolved_profile.preview.context,
                 source=request.source,
                 app_name_prefix=app_name_prefix,
-                previews=tuple(sorted(preview_items, key=lambda item: item.previewSlug)),
+                previews=tuple(
+                    sorted(compose_preview_items, key=lambda item: item.previewSlug)
+                ),
             )
 
     raw_projects = control_plane_dokploy.dokploy_request(
@@ -1683,7 +1685,7 @@ def execute_generic_web_preview_destroy(
             profile=resolved_profile,
             target_definition=target_definition,
         ):
-            cleanup_errors: list[str] = []
+            compose_cleanup_errors: list[str] = []
             deleted_domain_ids: list[str] = []
             for domain in _compose_preview_domains(
                 host=host,
@@ -1707,9 +1709,9 @@ def execute_generic_web_preview_destroy(
                     _delete_domain(host=host, token=token, domain_id=domain_id)
                     deleted_domain_ids.append(domain_id)
                 except click.ClickException as exc:
-                    cleanup_errors.append(f"domain cleanup failed: {exc}")
+                    compose_cleanup_errors.append(f"domain cleanup failed: {exc}")
             finished_at = utc_now_timestamp()
-            if cleanup_errors:
+            if compose_cleanup_errors:
                 return GenericWebPreviewDestroyResult(
                     destroy_status="fail",
                     destroy_started_at=started_at,
@@ -1721,7 +1723,7 @@ def execute_generic_web_preview_destroy(
                     application_id=target_definition.target_id,
                     provider_type="compose-domain",
                     domain_ids=tuple(deleted_domain_ids),
-                    error_message="; ".join(cleanup_errors),
+                    error_message="; ".join(compose_cleanup_errors),
                 )
             return GenericWebPreviewDestroyResult(
                 destroy_status="pass",
@@ -1753,10 +1755,10 @@ def execute_generic_web_preview_destroy(
             )
             if isinstance(raw_domains, list):
                 for raw_domain in raw_domains:
-                    domain = control_plane_dokploy.as_json_object(raw_domain)
-                    if domain is None:
+                    application_domain = control_plane_dokploy.as_json_object(raw_domain)
+                    if application_domain is None:
                         continue
-                    domain_id = str(domain.get("domainId") or "").strip()
+                    domain_id = str(application_domain.get("domainId") or "").strip()
                     if domain_id:
                         _delete_domain(host=host, token=token, domain_id=domain_id)
         except click.ClickException as exc:

--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -118,6 +118,9 @@ class GenericWebPreviewInventoryItem(BaseModel):
     applicationId: str
     applicationName: str
     previewSlug: str
+    providerType: Literal["application", "compose-domain"] = "application"
+    domainId: str = ""
+    domainHost: str = ""
 
 
 class GenericWebPreviewInventoryResult(BaseModel):
@@ -161,6 +164,8 @@ class GenericWebPreviewDestroyResult(BaseModel):
     preview_slug: str
     application_name: str
     application_id: str
+    provider_type: Literal["application", "compose-domain"] = "application"
+    domain_ids: tuple[str, ...] = ()
     error_message: str = ""
 
 
@@ -622,6 +627,48 @@ def _ensure_compose_domain(
     )
     created_domain = control_plane_dokploy.as_json_object(created)
     return str((created_domain or {}).get("domainId") or "").strip(), tuple(stale_domain_ids)
+
+
+def _preview_slug_from_compose_domain(
+    *, profile: LaunchplaneProductProfileRecord, domain_host: str
+) -> str:
+    host = domain_host.strip().split(":", 1)[0]
+    slug_prefix = _preview_slug_prefix(profile.preview.slug_template)
+    if not host.startswith(slug_prefix):
+        return ""
+    slug = host.split(".", 1)[0]
+    if preview_pr_number_from_slug(
+        preview_slug=slug,
+        slug_template=profile.preview.slug_template,
+    ) is None:
+        return ""
+    return slug
+
+
+def _compose_preview_domains(
+    *, host: str, token: str, compose_id: str, profile: LaunchplaneProductProfileRecord
+) -> tuple[JsonObject, ...]:
+    raw_domains = control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/domain.byComposeId",
+        query={"composeId": compose_id},
+    )
+    if not isinstance(raw_domains, list):
+        return ()
+    domains: list[JsonObject] = []
+    for raw_domain in raw_domains:
+        domain = control_plane_dokploy.as_json_object(raw_domain)
+        if domain is None:
+            continue
+        domain_host = str(domain.get("host") or "").strip()
+        domain_id = str(domain.get("domainId") or "").strip()
+        if domain_id and _preview_slug_from_compose_domain(
+            profile=profile,
+            domain_host=domain_host,
+        ):
+            domains.append(domain)
+    return tuple(domains)
 
 
 def _delete_application(*, host: str, token: str, application_id: str) -> None:
@@ -1522,6 +1569,50 @@ def execute_generic_web_preview_inventory(
         )
     app_name_prefix = effective_preview_app_name_prefix(profile=resolved_profile)
     host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
+    template_lane = _template_lane(profile=resolved_profile)
+    if template_lane is not None and _profile_allows_odoo_compose_stage_preview(
+        profile=resolved_profile
+    ):
+        target_definition, _template_payload, target_error = _read_template_payload(
+            control_plane_root=control_plane_root,
+            template_lane=template_lane,
+            allow_compose_template=True,
+        )
+        if target_error:
+            raise click.ClickException(target_error)
+        if target_definition is not None and _uses_odoo_compose_stage_preview(
+            profile=resolved_profile,
+            target_definition=target_definition,
+        ):
+            preview_items = []
+            for domain in _compose_preview_domains(
+                host=host,
+                token=token,
+                compose_id=target_definition.target_id,
+                profile=resolved_profile,
+            ):
+                domain_host = str(domain.get("host") or "").strip()
+                preview_items.append(
+                    GenericWebPreviewInventoryItem(
+                        applicationId=target_definition.target_id,
+                        applicationName=target_definition.target_name,
+                        previewSlug=_preview_slug_from_compose_domain(
+                            profile=resolved_profile,
+                            domain_host=domain_host,
+                        ),
+                        providerType="compose-domain",
+                        domainId=str(domain.get("domainId") or "").strip(),
+                        domainHost=domain_host,
+                    )
+                )
+            return GenericWebPreviewInventoryResult(
+                product=resolved_profile.product,
+                context=resolved_profile.preview.context,
+                source=request.source,
+                app_name_prefix=app_name_prefix,
+                previews=tuple(sorted(preview_items, key=lambda item: item.previewSlug)),
+            )
+
     raw_projects = control_plane_dokploy.dokploy_request(
         host=host,
         token=token,
@@ -1577,6 +1668,74 @@ def execute_generic_web_preview_destroy(
         preview_slug=request.preview_slug,
     )
     host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
+    template_lane = _template_lane(profile=resolved_profile)
+    if template_lane is not None and _profile_allows_odoo_compose_stage_preview(
+        profile=resolved_profile
+    ):
+        target_definition, _template_payload, target_error = _read_template_payload(
+            control_plane_root=control_plane_root,
+            template_lane=template_lane,
+            allow_compose_template=True,
+        )
+        if target_error:
+            raise click.ClickException(target_error)
+        if target_definition is not None and _uses_odoo_compose_stage_preview(
+            profile=resolved_profile,
+            target_definition=target_definition,
+        ):
+            cleanup_errors: list[str] = []
+            deleted_domain_ids: list[str] = []
+            for domain in _compose_preview_domains(
+                host=host,
+                token=token,
+                compose_id=target_definition.target_id,
+                profile=resolved_profile,
+            ):
+                domain_host = str(domain.get("host") or "").strip()
+                if (
+                    _preview_slug_from_compose_domain(
+                        profile=resolved_profile,
+                        domain_host=domain_host,
+                    )
+                    != request.preview_slug
+                ):
+                    continue
+                domain_id = str(domain.get("domainId") or "").strip()
+                if not domain_id:
+                    continue
+                try:
+                    _delete_domain(host=host, token=token, domain_id=domain_id)
+                    deleted_domain_ids.append(domain_id)
+                except click.ClickException as exc:
+                    cleanup_errors.append(f"domain cleanup failed: {exc}")
+            finished_at = utc_now_timestamp()
+            if cleanup_errors:
+                return GenericWebPreviewDestroyResult(
+                    destroy_status="fail",
+                    destroy_started_at=started_at,
+                    destroy_finished_at=finished_at,
+                    product=resolved_profile.product,
+                    context=resolved_profile.preview.context,
+                    preview_slug=request.preview_slug,
+                    application_name=application_name,
+                    application_id=target_definition.target_id,
+                    provider_type="compose-domain",
+                    domain_ids=tuple(deleted_domain_ids),
+                    error_message="; ".join(cleanup_errors),
+                )
+            return GenericWebPreviewDestroyResult(
+                destroy_status="pass",
+                destroy_started_at=started_at,
+                destroy_finished_at=finished_at,
+                product=resolved_profile.product,
+                context=resolved_profile.preview.context,
+                preview_slug=request.preview_slug,
+                application_name=application_name,
+                application_id=target_definition.target_id,
+                provider_type="compose-domain",
+                domain_ids=tuple(deleted_domain_ids),
+            )
+
     application = _find_application_by_name(
         host=host,
         token=token,

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -146,10 +146,12 @@ Odoo is the only current generic-web-based driver allowed to use the staged
 compose preview MVP: if its product profile uses `preview.data_transport_mode =
 "bootstrap"` and its template lane is a Dokploy `compose` target, preview refresh
 updates and deploys that configured compose target instead of creating a
-generic-web application. This exception is route-scoped to Odoo preview refresh
-and readiness; it does not grant Odoo products access to stable generic-web
-deploy or promotion routes, and it does not make compose templates valid for
-generic-web products.
+generic-web application. Odoo preview inventory and destroy read compose domains
+with `/api/domain.byComposeId` and delete only domains whose hostnames match the
+preview slug template. This exception is route-scoped to Odoo preview refresh,
+inventory, destroy, and readiness; it does not grant Odoo products access to
+stable generic-web deploy or promotion routes, and it does not make compose
+templates valid for generic-web products.
 
 Driver action routes are owned by the base driver contract. The service accepts
 any product key on Odoo and VeriReel action envelopes, then authorizes the call

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -667,8 +667,10 @@ target, and records the requested PR URL as the preview generation. This is
 intentionally not generic compose preview support:
 generic-web application previews still require application template lanes, and
 stable deploy/promotion routes do not inherit Odoo's compose preview behavior.
-Destroy for the staged compose MVP is a record/cleanup handoff only and must not
-delete the shared compose target.
+Inventory and destroy for the staged compose MVP inspect compose-attached domains
+whose hostnames match the product preview slug template. Destroy deletes only the
+matching preview domain and must not delete the shared compose target or stable
+hostnames.
 
 The long-term Odoo preview target is isolated per-PR runtime state, either by a
 provider-supported compose clone/create/delete path or by a dedicated

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -329,6 +329,70 @@ class GenericWebPreviewTests(unittest.TestCase):
         self.assertEqual(result.app_name_prefix, "syo-preview")
         self.assertEqual([item.previewSlug for item in result.previews], ["preview-42-site"])
 
+    def test_execute_generic_web_preview_inventory_lists_odoo_compose_domains(self) -> None:
+        store = _GenericWebPreviewStore(_odoo_compose_profile())
+        requests: list[dict[str, object]] = []
+
+        def _fake_dokploy_request(**kwargs: object) -> object:
+            requests.append(dict(kwargs))
+            path = kwargs["path"]
+            if path == "/api/domain.byComposeId":
+                return [
+                    {
+                        "domainId": "domain-stable",
+                        "host": "cm-testing.shinycomputers.com",
+                    },
+                    {
+                        "domainId": "domain-preview",
+                        "host": "pr-28.cm-preview.shinycomputers.com",
+                    },
+                ]
+            return {}
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "composeId": "compose-cm-testing",
+                    "name": "cm-testing",
+                    "env": "ODOO_DB_NAME=cm\nODOO_DB_USER=odoo\nODOO_DB_PASSWORD=password\nODOO_DATA_VOLUME=data\nODOO_LOG_VOLUME=logs\nODOO_DB_VOLUME=db\nODOO_MASTER_PASSWORD=master\nODOO_ADMIN_PASSWORD=admin\n",
+                },
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                return_value=DokploySourceOfTruth(
+                    schema_version=1,
+                    targets=(
+                        DokployTargetDefinition(
+                            context="cm",
+                            instance="testing",
+                            target_type="compose",
+                            target_id="compose-cm-testing",
+                            target_name="cm-testing",
+                        ),
+                    ),
+                ),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.dokploy_request",
+                side_effect=_fake_dokploy_request,
+            ),
+        ):
+            result = execute_generic_web_preview_inventory(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebPreviewInventoryRequest(product="odoo-tenant-cm"),
+            )
+
+        self.assertEqual([item.previewSlug for item in result.previews], ["pr-28"])
+        self.assertEqual(result.previews[0].providerType, "compose-domain")
+        self.assertEqual(result.previews[0].domainId, "domain-preview")
+        self.assertEqual([request["path"] for request in requests], ["/api/domain.byComposeId"])
+
     def test_evaluate_generic_web_preview_readiness_passes_with_template_contract(self) -> None:
         store = _GenericWebPreviewStore(_profile())
         source = DokploySourceOfTruth(
@@ -1312,6 +1376,87 @@ class GenericWebPreviewTests(unittest.TestCase):
                 "/api/application.delete",
             ],
         )
+
+    def test_execute_generic_web_preview_destroy_deletes_odoo_compose_domain(self) -> None:
+        store = _GenericWebPreviewStore(_odoo_compose_profile())
+        requests: list[dict[str, object]] = []
+
+        def _fake_dokploy_request(**kwargs: object) -> object:
+            requests.append(dict(kwargs))
+            path = kwargs["path"]
+            if path == "/api/domain.byComposeId":
+                return [
+                    {
+                        "domainId": "domain-stable",
+                        "host": "cm-testing.shinycomputers.com",
+                    },
+                    {
+                        "domainId": "domain-pr-28",
+                        "host": "pr-28.cm-preview.shinycomputers.com",
+                    },
+                    {
+                        "domainId": "domain-pr-29",
+                        "host": "pr-29.cm-preview.shinycomputers.com",
+                    },
+                ]
+            return {}
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "composeId": "compose-cm-testing",
+                    "name": "cm-testing",
+                    "env": "ODOO_DB_NAME=cm\nODOO_DB_USER=odoo\nODOO_DB_PASSWORD=password\nODOO_DATA_VOLUME=data\nODOO_LOG_VOLUME=logs\nODOO_DB_VOLUME=db\nODOO_MASTER_PASSWORD=master\nODOO_ADMIN_PASSWORD=admin\n",
+                },
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                return_value=DokploySourceOfTruth(
+                    schema_version=1,
+                    targets=(
+                        DokployTargetDefinition(
+                            context="cm",
+                            instance="testing",
+                            target_type="compose",
+                            target_id="compose-cm-testing",
+                            target_name="cm-testing",
+                        ),
+                    ),
+                ),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.dokploy_request",
+                side_effect=_fake_dokploy_request,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.utc_now_timestamp",
+                side_effect=["2026-05-09T22:00:00Z", "2026-05-09T22:00:01Z"],
+            ),
+        ):
+            result = execute_generic_web_preview_destroy(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebPreviewDestroyRequest(
+                    product="odoo-tenant-cm",
+                    preview_slug="pr-28",
+                    destroy_reason="test",
+                ),
+            )
+
+        self.assertEqual(result.destroy_status, "pass")
+        self.assertEqual(result.provider_type, "compose-domain")
+        self.assertEqual(result.application_id, "compose-cm-testing")
+        self.assertEqual(result.domain_ids, ("domain-pr-28",))
+        delete_requests = [
+            request for request in requests if request["path"] == "/api/domain.delete"
+        ]
+        self.assertEqual(len(delete_requests), 1)
+        self.assertEqual(delete_requests[0]["payload"], {"domainId": "domain-pr-28"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- teach Odoo compose-stage preview inventory to report PR domains attached to the template compose
- teach Odoo compose-stage preview destroy to delete only the matching preview domain via `/api/domain.byComposeId`
- document the staged-compose cleanup behavior while keeping isolated per-PR runtimes as the target architecture

Refs #495.

## Validation

- `uv run python -m unittest tests.test_generic_web_preview`
- `uv run --extra dev ruff check control_plane/workflows/generic_web_preview.py tests/test_generic_web_preview.py --diff`
- `uv run --extra dev ruff check control_plane/workflows/generic_web_preview.py tests/test_generic_web_preview.py`

## Notes

This is the safety repair needed before cleaning stale live compose preview domains like `pr-28.cm-preview.shinycomputers.com`. It does not finish the full isolated-runtime architecture from #495; it makes the staged MVP cleanup-compatible so live repair can be done through the same Launchplane destroy path.
