### PR TITLE
Add runtime identity breadcrumbs

### DIFF
--- a/control_plane/contracts/deployment_record.py
+++ b/control_plane/contracts/deployment_record.py
@@ -8,6 +8,7 @@ from control_plane.contracts.promotion_record import (
     HealthcheckEvidence,
     PostDeployUpdateEvidence,
 )
+from control_plane.contracts.runtime_identity import RuntimeIdentity
 
 DelegatedExecutor = Literal["control-plane.dokploy"]
 
@@ -43,6 +44,7 @@ class DeploymentRecord(BaseModel):
     delegated_executor: DelegatedExecutor = "control-plane.dokploy"
     resolved_target: ResolvedTargetEvidence | None = None
     runtime_source: dict[str, str] = Field(default_factory=dict)
+    runtime_identity: RuntimeIdentity | None = None
     deploy: DeploymentEvidence
     post_deploy_update: PostDeployUpdateEvidence = Field(default_factory=PostDeployUpdateEvidence)
     destination_health: HealthcheckEvidence = Field(default_factory=HealthcheckEvidence)

--- a/control_plane/contracts/environment_inventory.py
+++ b/control_plane/contracts/environment_inventory.py
@@ -6,6 +6,7 @@ from control_plane.contracts.promotion_record import (
     HealthcheckEvidence,
 )
 from control_plane.contracts.promotion_record import PostDeployUpdateEvidence
+from control_plane.contracts.runtime_identity import RuntimeIdentity
 
 
 class EnvironmentInventory(BaseModel):
@@ -17,6 +18,7 @@ class EnvironmentInventory(BaseModel):
     artifact_identity: ArtifactIdentityReference | None = None
     source_git_ref: str
     deploy: DeploymentEvidence
+    runtime_identity: RuntimeIdentity | None = None
     post_deploy_update: PostDeployUpdateEvidence = Field(default_factory=PostDeployUpdateEvidence)
     destination_health: HealthcheckEvidence = Field(default_factory=HealthcheckEvidence)
     updated_at: str

--- a/control_plane/contracts/runtime_identity.py
+++ b/control_plane/contracts/runtime_identity.py
@@ -1,0 +1,49 @@
+import json
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class RuntimeIdentity(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str = ""
+    context: str
+    instance: str
+    environment_kind: str = "stable"
+    deployment_record_id: str
+    artifact_id: str
+    source_git_ref: str
+    image_reference: str = ""
+    release_tuple_id: str = ""
+    preview_id: str = ""
+    preview_generation_id: str = ""
+    deployed_at: str = ""
+
+    @model_validator(mode="after")
+    def _validate_identity(self) -> "RuntimeIdentity":
+        if not self.context.strip():
+            raise ValueError("runtime identity requires context")
+        if not self.instance.strip():
+            raise ValueError("runtime identity requires instance")
+        if not self.deployment_record_id.strip():
+            raise ValueError("runtime identity requires deployment_record_id")
+        if not self.artifact_id.strip():
+            raise ValueError("runtime identity requires artifact_id")
+        if not self.source_git_ref.strip():
+            raise ValueError("runtime identity requires source_git_ref")
+        return self
+
+
+def runtime_identity_env(identity: RuntimeIdentity) -> dict[str, str]:
+    payload = identity.model_dump(mode="json", exclude_none=True)
+    return {
+        "LAUNCHPLANE_RUNTIME_IDENTITY_JSON": json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+        "LAUNCHPLANE_DEPLOYMENT_RECORD_ID": identity.deployment_record_id,
+        "LAUNCHPLANE_ARTIFACT_ID": identity.artifact_id,
+        "LAUNCHPLANE_SOURCE_GIT_REF": identity.source_git_ref,
+    }

--- a/control_plane/workflows/dokploy_deploy.py
+++ b/control_plane/workflows/dokploy_deploy.py
@@ -4,6 +4,7 @@ import click
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane.contracts.deployment_record import ResolvedTargetEvidence
+from control_plane.contracts.runtime_identity import RuntimeIdentity, runtime_identity_env
 from control_plane.contracts.ship_request import ShipRequest
 
 
@@ -14,6 +15,7 @@ def update_dokploy_target_artifact(
     target_type: str,
     target_id: str,
     artifact_id: str,
+    runtime_identity: RuntimeIdentity | None = None,
 ) -> None:
     target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
         host=host,
@@ -22,6 +24,19 @@ def update_dokploy_target_artifact(
         target_id=target_id,
     )
     if target_type == "application":
+        if runtime_identity is not None:
+            env_text = control_plane_dokploy.render_dokploy_env_text_with_overrides(
+                str(target_payload.get("env") or ""),
+                updates=runtime_identity_env(runtime_identity),
+            )
+            control_plane_dokploy.update_dokploy_target_env(
+                host=host,
+                token=token,
+                target_type=target_type,
+                target_id=target_id,
+                target_payload=target_payload,
+                env_text=env_text,
+            )
         control_plane_dokploy.dokploy_request(
             host=host,
             token=token,
@@ -40,7 +55,10 @@ def update_dokploy_target_artifact(
     if target_type == "compose":
         env_text = control_plane_dokploy.render_dokploy_env_text_with_overrides(
             str(target_payload.get("env") or ""),
-            updates={"DOCKER_IMAGE_REFERENCE": artifact_id},
+            updates={
+                "DOCKER_IMAGE_REFERENCE": artifact_id,
+                **(runtime_identity_env(runtime_identity) if runtime_identity is not None else {}),
+            },
         )
         control_plane_dokploy.update_dokploy_target_env(
             host=host,
@@ -62,6 +80,7 @@ def execute_dokploy_artifact_deploy(
     ship_request: ShipRequest,
     resolved_target: ResolvedTargetEvidence,
     deploy_timeout_seconds: int,
+    runtime_identity: RuntimeIdentity | None = None,
 ) -> None:
     latest_before = control_plane_dokploy.latest_deployment_for_target(
         host=host,
@@ -75,6 +94,7 @@ def execute_dokploy_artifact_deploy(
         target_type=resolved_target.target_type,
         target_id=resolved_target.target_id,
         artifact_id=ship_request.artifact_id,
+        runtime_identity=runtime_identity,
     )
     control_plane_dokploy.trigger_deployment(
         host=host,

--- a/control_plane/workflows/generic_web_deploy.py
+++ b/control_plane/workflows/generic_web_deploy.py
@@ -16,6 +16,7 @@ from control_plane.contracts.product_profile_record import (
     ProductLaneProfile,
 )
 from control_plane.contracts.promotion_record import HealthcheckEvidence
+from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.workflows.dokploy_deploy import execute_dokploy_artifact_deploy
 from control_plane.workflows.inventory import build_environment_inventory
@@ -121,6 +122,27 @@ def normalize_generic_web_artifact_id(
             f"{image_repository!r}, or be a bare image tag."
         )
     return f"{image_repository}:{normalized_artifact_id}"
+
+
+def _build_runtime_identity(
+    *,
+    profile: LaunchplaneProductProfileRecord,
+    lane: ProductLaneProfile,
+    ship_request: ShipRequest,
+    deployment_record_id: str,
+    deployed_at: str = "",
+) -> RuntimeIdentity:
+    return RuntimeIdentity(
+        product=profile.product,
+        context=lane.context,
+        instance=lane.instance,
+        environment_kind="stable",
+        deployment_record_id=deployment_record_id,
+        artifact_id=ship_request.artifact_id,
+        source_git_ref=ship_request.source_git_ref,
+        image_reference=ship_request.artifact_id,
+        deployed_at=deployed_at,
+    )
 
 
 def _fallback_ship_request(
@@ -280,6 +302,12 @@ def execute_generic_web_deploy(
             ship_request=ship_request,
             resolved_target=resolved_target,
             deploy_timeout_seconds=deploy_timeout_seconds,
+            runtime_identity=_build_runtime_identity(
+                profile=resolved_profile,
+                lane=resolved_lane,
+                ship_request=ship_request,
+                deployment_record_id=record_id,
+            ),
         )
     except click.ClickException as exc:
         finished_at = utc_now_timestamp()
@@ -317,6 +345,13 @@ def execute_generic_web_deploy(
         started_at=started_at,
         finished_at=finished_at,
         resolved_target=resolved_target,
+        runtime_identity=_build_runtime_identity(
+            profile=resolved_profile,
+            lane=resolved_lane,
+            ship_request=ship_request,
+            deployment_record_id=record_id,
+            deployed_at=finished_at,
+        ),
     )
     record_store.write_deployment_record(deployment_record)
     record_store.write_environment_inventory(

--- a/control_plane/workflows/inventory.py
+++ b/control_plane/workflows/inventory.py
@@ -19,6 +19,7 @@ def build_environment_inventory(
         artifact_identity=deployment_record.artifact_identity,
         source_git_ref=deployment_record.source_git_ref,
         deploy=deployment_record.deploy,
+        runtime_identity=deployment_record.runtime_identity,
         post_deploy_update=deployment_record.post_deploy_update,
         destination_health=deployment_record.destination_health,
         updated_at=updated_at,

--- a/control_plane/workflows/ship.py
+++ b/control_plane/workflows/ship.py
@@ -10,6 +10,7 @@ from control_plane.contracts.promotion_record import (
     PostDeployUpdateEvidence,
     ReleaseStatus,
 )
+from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.contracts.ship_request import ShipRequest
 
 
@@ -91,6 +92,7 @@ def build_deployment_record(
     resolved_target: ResolvedTargetEvidence | None = None,
     delegated_executor: DelegatedExecutor = "control-plane.dokploy",
     runtime_source: dict[str, str] | None = None,
+    runtime_identity: RuntimeIdentity | None = None,
     post_deploy_update: PostDeployUpdateEvidence | None = None,
     destination_health: HealthcheckEvidence | None = None,
 ) -> DeploymentRecord:
@@ -110,6 +112,7 @@ def build_deployment_record(
         delegated_executor=delegated_executor,
         resolved_target=resolved_target,
         runtime_source=runtime_source or {},
+        runtime_identity=runtime_identity,
         deploy=DeploymentEvidence(
             target_name=request.target_name,
             target_type=request.target_type,

--- a/docs/dokploy-service-deployments.md
+++ b/docs/dokploy-service-deployments.md
@@ -101,6 +101,13 @@ deploys. If a later slice adds generic artifact-manifest resolution for this
 path, the manifest must still resolve to the same `repository@sha256:digest`
 identity before Dokploy is mutated.
 
+Launchplane also injects a non-secret runtime identity into Dokploy env during
+Launchplane-owned deploys. The standard keys are
+`LAUNCHPLANE_RUNTIME_IDENTITY_JSON`, `LAUNCHPLANE_DEPLOYMENT_RECORD_ID`,
+`LAUNCHPLANE_ARTIFACT_ID`, and `LAUNCHPLANE_SOURCE_GIT_REF`. Product health
+endpoints should expose that identity when adopted so Launchplane can compare
+expected inventory against observed runtime state.
+
 ## Config, Secrets, And Volumes
 
 Non-secret runtime settings belong in Launchplane runtime-environment records.

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -202,7 +202,9 @@ When creating a new website repo for Launchplane:
 
 - Build the app as a normal product repo first.
 - Add a health endpoint that returns enough non-secret version data for
-  Launchplane to verify the deployed artifact.
+  Launchplane to verify the deployed artifact. New products should expose the
+  Launchplane runtime identity env payload from `LAUNCHPLANE_RUNTIME_IDENTITY_JSON`
+  or the equivalent discrete env keys.
 - Publish immutable container images or artifacts from GitHub Actions.
 - Apply an operator-owned Launchplane product onboarding manifest to seed the
   product profile, lane profiles, target records, runtime environment, disabled

--- a/docs/records.md
+++ b/docs/records.md
@@ -75,13 +75,15 @@ an ORM column/table or remains only in the evidence payload.
   `created_at`, and `status`. Concrete backup paths and provider-specific backup
   evidence stay payload-only.
 - Deployment: modeled fields are `record_id`, `context`, `instance`,
-  `artifact_id`, `source_git_ref`, and deploy timestamps. Resolved provider
-  evidence, health detail, and post-deploy product facts stay payload-only.
+  `artifact_id`, `source_git_ref`, deploy timestamps, and an optional structured
+  runtime identity. Resolved provider evidence, health detail, and post-deploy
+  product facts stay payload-only.
 - Promotion: modeled fields are `record_id`, `context`, `from_instance`,
   `to_instance`, `artifact_id`, and deploy timestamps. Rollback annotations,
   backup evidence detail, and provider health envelopes stay payload-only.
 - Inventory: modeled fields are `context`, `instance`, `artifact_id`,
-  `source_git_ref`, `updated_at`, and linked deployment/promotion ids. Full
+  `source_git_ref`, `updated_at`, linked deployment/promotion ids, and the
+  expected runtime identity copied from the current deployment record. Full
   deploy evidence and product-specific live facts stay payload-only.
 - Preview: modeled fields are `preview_id`, `context`, `anchor_repo`,
   `anchor_pr_number`, `state`, and `updated_at`. Canonical URLs, lifecycle

--- a/tests/test_dokploy_deploy.py
+++ b/tests/test_dokploy_deploy.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest.mock import patch
+
+from control_plane.contracts.runtime_identity import RuntimeIdentity
+from control_plane.workflows.dokploy_deploy import update_dokploy_target_artifact
+
+
+class DokployDeployTests(unittest.TestCase):
+    def test_update_application_injects_runtime_identity_env(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def _fake_request(**kwargs: object) -> object:
+            requests.append(dict(kwargs))
+            return {}
+
+        with (
+            patch(
+                "control_plane.workflows.dokploy_deploy.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={"env": "EXISTING=true", "username": "u", "password": "p"},
+            ),
+            patch(
+                "control_plane.workflows.dokploy_deploy.control_plane_dokploy.dokploy_request",
+                side_effect=_fake_request,
+            ),
+        ):
+            update_dokploy_target_artifact(
+                host="https://dokploy.example",
+                token="token",
+                target_type="application",
+                target_id="app-123",
+                artifact_id="ghcr.io/example/app@sha256:abc",
+                runtime_identity=RuntimeIdentity(
+                    product="example",
+                    context="example-testing",
+                    instance="testing",
+                    deployment_record_id="deployment-123",
+                    artifact_id="ghcr.io/example/app@sha256:abc",
+                    source_git_ref="abc",
+                ),
+            )
+
+        self.assertEqual(requests[0]["path"], "/api/application.saveEnvironment")
+        env_text = str(requests[0]["payload"]["env"])
+        self.assertIn("EXISTING=true", env_text)
+        self.assertIn("LAUNCHPLANE_DEPLOYMENT_RECORD_ID=deployment-123", env_text)
+        self.assertIn("LAUNCHPLANE_ARTIFACT_ID=ghcr.io/example/app@sha256:abc", env_text)
+        self.assertEqual(requests[1]["path"], "/api/application.saveDockerProvider")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dokploy_deploy.py
+++ b/tests/test_dokploy_deploy.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import Any
 from unittest.mock import patch
 
 from control_plane.contracts.runtime_identity import RuntimeIdentity
@@ -7,7 +8,7 @@ from control_plane.workflows.dokploy_deploy import update_dokploy_target_artifac
 
 class DokployDeployTests(unittest.TestCase):
     def test_update_application_injects_runtime_identity_env(self) -> None:
-        requests: list[dict[str, object]] = []
+        requests: list[dict[str, Any]] = []
 
         def _fake_request(**kwargs: object) -> object:
             requests.append(dict(kwargs))

--- a/tests/test_generic_web_deploy.py
+++ b/tests/test_generic_web_deploy.py
@@ -148,6 +148,18 @@ class GenericWebDeployTests(unittest.TestCase):
             store.inventories[0].deployment_record_id,
             store.deployments[0].record_id,
         )
+        runtime_identity = store.deployments[0].runtime_identity
+        assert runtime_identity is not None
+        self.assertEqual(runtime_identity.product, "sellyouroutboard")
+        self.assertEqual(runtime_identity.context, "sellyouroutboard-testing")
+        self.assertEqual(runtime_identity.instance, "testing")
+        self.assertEqual(runtime_identity.deployment_record_id, store.deployments[0].record_id)
+        self.assertEqual(
+            runtime_identity.artifact_id,
+            "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+        )
+        self.assertEqual(runtime_identity.source_git_ref, "abc123")
+        self.assertEqual(store.inventories[0].runtime_identity, runtime_identity)
         artifact_identity = store.deployments[0].artifact_identity
         assert artifact_identity is not None
         self.assertEqual(
@@ -159,6 +171,10 @@ class GenericWebDeployTests(unittest.TestCase):
         assert resolved_target is not None
         self.assertEqual(resolved_target.target_name, "sellyouroutboard-testing-app")
         deploy.assert_called_once()
+        self.assertEqual(
+            deploy.call_args.kwargs["runtime_identity"].deployment_record_id,
+            store.deployments[0].record_id,
+        )
 
     def test_execute_generic_web_deploy_uses_qualified_bare_tag(self) -> None:
         store = _GenericWebDeployStore(_profile())

--- a/tests/test_runtime_identity.py
+++ b/tests/test_runtime_identity.py
@@ -1,0 +1,35 @@
+import json
+import unittest
+
+from control_plane.contracts.runtime_identity import RuntimeIdentity, runtime_identity_env
+
+
+class RuntimeIdentityTests(unittest.TestCase):
+    def test_runtime_identity_env_serializes_non_secret_identity(self) -> None:
+        identity = RuntimeIdentity(
+            product="sellyouroutboard",
+            context="sellyouroutboard-testing",
+            instance="testing",
+            deployment_record_id="deployment-123",
+            artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+            source_git_ref="abc123",
+            image_reference="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+            deployed_at="2026-05-09T22:10:00Z",
+        )
+
+        env = runtime_identity_env(identity)
+
+        self.assertEqual(env["LAUNCHPLANE_DEPLOYMENT_RECORD_ID"], "deployment-123")
+        self.assertEqual(
+            env["LAUNCHPLANE_ARTIFACT_ID"],
+            "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+        )
+        self.assertEqual(env["LAUNCHPLANE_SOURCE_GIT_REF"], "abc123")
+        payload = json.loads(env["LAUNCHPLANE_RUNTIME_IDENTITY_JSON"])
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["product"], "sellyouroutboard")
+        self.assertEqual(payload["deployment_record_id"], "deployment-123")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a driver-neutral `RuntimeIdentity` contract and env serialization helper
- persist expected runtime identity on deployment and inventory payloads
- inject Launchplane runtime identity env during generic-web Dokploy deploys for applications and compose targets
- document the tenant adoption path for exposing the identity through health/version surfaces

Refs #516.

## Validation

- `uv run python -m unittest tests.test_runtime_identity tests.test_dokploy_deploy tests.test_generic_web_deploy`
- `uv run --extra dev ruff check control_plane/contracts/runtime_identity.py control_plane/contracts/deployment_record.py control_plane/contracts/environment_inventory.py control_plane/workflows/ship.py control_plane/workflows/inventory.py control_plane/workflows/dokploy_deploy.py control_plane/workflows/generic_web_deploy.py tests/test_runtime_identity.py tests/test_dokploy_deploy.py tests/test_generic_web_deploy.py --diff`
- `uv run --extra dev ruff check control_plane/contracts/runtime_identity.py control_plane/contracts/deployment_record.py control_plane/contracts/environment_inventory.py control_plane/workflows/ship.py control_plane/workflows/inventory.py control_plane/workflows/dokploy_deploy.py control_plane/workflows/generic_web_deploy.py tests/test_runtime_identity.py tests/test_dokploy_deploy.py tests/test_generic_web_deploy.py`

## Notes

This is the first breadcrumb slice: expected identity generation, persistence, and env injection. Observed runtime identity parsing/health verification can build on this contract in a follow-up.
