### PR TITLE
Add Every Code API PR feedback writes

### DIFF
--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -266,12 +266,8 @@ class EveryCodeWorkerApiStore:
     def write_every_code_pr_feedback_record(self, record: EveryCodePrFeedbackRecord) -> object:
         payload = self._request(
             "POST",
-            "/v1/every-code/pr-feedback/status",
-            body={
-                "feedback_id": record.feedback_id,
-                "request_id": record.request_id,
-                "status": record.status,
-            },
+            "/v1/every-code/pr-feedback",
+            body=record.model_dump(mode="json"),
             idempotency_key=f"every-code-pr-feedback-{record.feedback_id}-{record.status}",
         )
         return payload

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1475,6 +1475,10 @@ class EveryCodePrFeedbackStatusEnvelope(BaseModel):
         return self
 
 
+class EveryCodePrFeedbackEnvelope(EveryCodePrFeedbackRecord):
+    pass
+
+
 class EveryCodePreviewGateEnvelope(EveryCodePreviewGateRecord):
     pass
 
@@ -1980,6 +1984,7 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/every-code/work-requests/claim",
         "/v1/every-code/work-requests/rerun",
         "/v1/every-code/work-requests/status",
+        "/v1/every-code/pr-feedback",
         "/v1/every-code/pr-feedback/status",
         "/v1/every-code/preview-gates",
         "/v1/work-graph/rank",
@@ -2142,6 +2147,7 @@ def _every_code_trusted_manager_logins(repository: str) -> frozenset[str]:
         Path.home() / ".code" / "github-planning.json",
         Path.home() / ".codex" / "github-planning.json",
     )
+    managers: set[str] = set()
     for config_path in config_paths:
         try:
             payload = json.loads(config_path.read_text(encoding="utf-8"))
@@ -2152,7 +2158,6 @@ def _every_code_trusted_manager_logins(repository: str) -> frozenset[str]:
         workflow = payload.get("workflow")
         if not isinstance(workflow, dict):
             continue
-        managers: set[str] = set()
         default_manager = workflow.get("default_manager")
         if isinstance(default_manager, str) and default_manager.strip():
             managers.add(_github_login_normalized(default_manager))
@@ -2161,8 +2166,7 @@ def _every_code_trusted_manager_logins(repository: str) -> frozenset[str]:
             repo_manager = repo_managers.get(repository) or repo_managers.get(normalized_repository)
             if isinstance(repo_manager, str) and repo_manager.strip():
                 managers.add(_github_login_normalized(repo_manager))
-        return frozenset(manager for manager in managers if manager)
-    return frozenset()
+    return frozenset(manager for manager in managers if manager)
 
 
 def _every_code_feedback_actor_is_trusted(
@@ -3157,6 +3161,7 @@ def _accepted_payload(
                 "artifact_id",
                 "transition",
                 "request_id",
+                "feedback_id",
                 "state",
                 "merge_train_run_id",
             }
@@ -3450,6 +3455,7 @@ def _is_every_code_worker_route(*, method: str, path: str) -> bool:
         "/v1/every-code/work-requests/claim",
         "/v1/every-code/work-requests/rerun",
         "/v1/every-code/work-requests/status",
+        "/v1/every-code/pr-feedback",
         "/v1/every-code/pr-feedback/status",
         "/v1/every-code/preview-gates",
     }
@@ -3631,6 +3637,22 @@ def _handle_every_code_worker_write(
                     "status": gate_record.status,
                 },
                 driver_result={"gate": gate_record.model_dump(mode="json")},
+            ),
+        )
+    if path == "/v1/every-code/pr-feedback":
+        feedback_record = EveryCodePrFeedbackEnvelope.model_validate(payload)
+        every_code_store.write_every_code_pr_feedback_record(feedback_record)
+        return _json_response(
+            start_response=start_response,
+            status_code=202,
+            payload=_accepted_payload(
+                trace_id=trace_id,
+                result={
+                    "request_id": feedback_record.request_id,
+                    "feedback_id": feedback_record.feedback_id,
+                    "status": feedback_record.status,
+                },
+                driver_result={"feedback": feedback_record.model_dump(mode="json")},
             ),
         )
     if path == "/v1/every-code/pr-feedback/status":

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -68,6 +68,11 @@ VeriReel product paths:
   - `POST /v1/every-code/work-requests/claim`
   - `POST /v1/every-code/work-requests/rerun`
   - `POST /v1/every-code/work-requests/status`
+  - `GET /v1/every-code/pr-feedback`
+  - `POST /v1/every-code/pr-feedback`
+  - `POST /v1/every-code/pr-feedback/status`
+  - `GET /v1/every-code/preview-gates`
+  - `POST /v1/every-code/preview-gates`
 - work graph chooser route:
   - `GET /v1/agent/context`
   - `GET /v1/repo-product-mapping`
@@ -140,10 +145,14 @@ the Launchplane service and on the Mac worker host, then run the worker with
 `uv run launchplane every-code start --service-url https://...`. That token is
 scoped in code to Every Code work-request, PR-feedback, preview-gate, preview
 readiness routes, plus read-only `GET /v1/product-profiles` for preview
-readiness projection. It cannot create webhook requests, write product records,
-or access other Launchplane service routes. This keeps remote DB credentials on
-the Launchplane host while still allowing visible local Code/tmux work sessions
-to claim, rerun terminal requests, reconcile preview state, and report progress.
+readiness projection. The worker can create service-owned PR feedback records
+only for Launchplane-derived worker signals such as failed-check routing, while
+human PR feedback still enters through the signed webhook path and trusted-actor
+gate. It cannot create webhook requests, write product records, or access other
+Launchplane service routes. This keeps remote DB credentials on the Launchplane
+host while still allowing visible local Code/tmux work sessions to claim, rerun
+terminal requests, reconcile preview state, route failed checks, and report
+progress.
 
 Local terminal agents that need Launchplane context use a separate read-only
 bearer credential, not the browser OAuth session cookie and not

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -380,6 +380,22 @@ class _EveryCodeApiHandler(BaseHTTPRequestHandler):
                 },
             )
             return
+        if self.path == "/v1/every-code/pr-feedback":
+            feedback_record = EveryCodePrFeedbackRecord.model_validate(payload)
+            self.store.write_every_code_pr_feedback_record(feedback_record)
+            self._write_json(
+                202,
+                {
+                    "status": "accepted",
+                    "records": {
+                        "request_id": feedback_record.request_id,
+                        "feedback_id": feedback_record.feedback_id,
+                        "status": feedback_record.status,
+                    },
+                    "result": {"feedback": feedback_record.model_dump(mode="json")},
+                },
+            )
+            return
         if self.path == "/v1/every-code/pr-feedback/status":
             feedback_records = self.store.list_every_code_pr_feedback_records(
                 request_id=str(payload["request_id"]),
@@ -581,6 +597,29 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(len(feedback_records), 1)
         self.assertEqual(feedback_records[0].feedback_id, _feedback_record().feedback_id)
         self.assertEqual(listed_after_update[0].status, "applied")
+
+    def test_api_store_creates_pr_feedback_via_service(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            _EveryCodeApiHandler.store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            server = ThreadingHTTPServer(("127.0.0.1", 0), _EveryCodeApiHandler)
+            server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+            server_thread.start()
+            try:
+                store = EveryCodeWorkerApiStore(
+                    service_url=f"http://127.0.0.1:{server.server_port}",
+                    worker_token="worker-token",
+                )
+
+                store.write_every_code_pr_feedback_record(_feedback_record())
+                feedback_records = store.list_every_code_pr_feedback_records(status="pending")
+            finally:
+                server.shutdown()
+                server.server_close()
+                server_thread.join(timeout=5)
+
+        self.assertEqual(len(feedback_records), 1)
+        self.assertEqual(feedback_records[0].feedback_id, _feedback_record().feedback_id)
 
     def test_api_store_lists_and_writes_preview_gates_via_service(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -25,6 +25,7 @@ from control_plane.contracts.authz_policy_record import (
 )
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
+from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
@@ -811,8 +812,9 @@ def _write_github_planning_config(
     *,
     repo_managers: dict[str, str] | None = None,
     default_manager: str = "@cellmechanic",
+    path: str = ".code/github-planning.json",
 ) -> Path:
-    config_path = root / ".code" / "github-planning.json"
+    config_path = root / Path(path)
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config_path.write_text(
         json.dumps(
@@ -3210,6 +3212,94 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(feedback_response["records"]["request_id"], request_id)
         self.assertEqual(feedback_response["result"]["feedback"]["actor"], "Mbanks89")
 
+    def test_every_code_pr_comment_webhook_uses_second_planning_config_path(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        issue_payload = _every_code_github_issue_labeled_payload(
+            repository="cbusillo/sellyouroutboard",
+            issue_number=67,
+        )
+        comment_payload = _every_code_github_pr_comment_payload(
+            repository="cbusillo/sellyouroutboard",
+            pr_number=75,
+            issue_body="Closes #67",
+            sender="Mbanks89",
+        )
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            tempfile.TemporaryDirectory() as home_directory_name,
+            patch.dict(
+                os.environ,
+                {
+                    "HOME": home_directory_name,
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
+            ),
+        ):
+            _write_github_planning_config(Path(home_directory_name), repo_managers={})
+            _write_github_planning_config(
+                Path(home_directory_name),
+                path=".codex/github-planning.json",
+                repo_managers={"cbusillo/sellyouroutboard": "@Mbanks89"},
+            )
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            issue_status, issue_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=issue_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-issue-second-config",
+                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                },
+            )
+            request_id = issue_response["records"]["request_id"]
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/claim",
+                payload={"request_id": request_id, "host": "Chris-Studio"},
+                authorization="Bearer dev-worker-token",
+            )
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/status",
+                payload={
+                    "request_id": request_id,
+                    "host": "Chris-Studio",
+                    "state": "done",
+                    "result_pr_url": "https://github.com/cbusillo/sellyouroutboard/pull/75",
+                    "result_summary": "Opened PR.",
+                    "updated_at": "2026-05-07T12:40:00Z",
+                },
+                authorization="Bearer dev-worker-token",
+            )
+            feedback_status, feedback_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=comment_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issue_comment",
+                    "X-GitHub-Delivery": "delivery-comment-second-config",
+                    "X-Hub-Signature-256": _github_webhook_signature(comment_payload, secret),
+                },
+            )
+
+        self.assertEqual(issue_status, 202)
+        self.assertEqual(feedback_status, 202, feedback_response)
+        self.assertEqual(feedback_response["records"]["request_id"], request_id)
+        self.assertEqual(feedback_response["result"]["feedback"]["actor"], "Mbanks89")
+
     def test_every_code_pr_comment_webhook_skips_untrusted_actor(self) -> None:
         secret = "launchplane-every-code-webhook-secret"
         issue_payload = _every_code_github_issue_labeled_payload(issue_number=67)
@@ -3556,6 +3646,58 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_response["result"]["feedback"]["status"], "applied")
         self.assertEqual(second_status, 409)
         self.assertEqual(second_response["error"]["code"], "feedback_already_final")
+
+    def test_every_code_worker_token_writes_pr_feedback_record(self) -> None:
+        feedback_record = EveryCodePrFeedbackRecord(
+            feedback_id="every-code-pr-feedback-cbusillo-code-26-check-failure-build",
+            request_id="every-code-cbusillo-code-123-test",
+            repository="cbusillo/code",
+            pr_number=26,
+            pr_url="https://github.com/cbusillo/code/pull/26",
+            feedback_kind="issue_comment",
+            github_delivery_id="check-failure-build",
+            github_id="check-failure-build",
+            actor="github-actions[bot]",
+            body="GitHub check build failed on the Every Code PR branch.",
+            html_url="https://github.com/cbusillo/code/actions/runs/1001/job/2002",
+            received_at="2026-05-06T19:00:00Z",
+        )
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": "ignored",
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+            )
+            write_status, write_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/pr-feedback",
+                payload=feedback_record.model_dump(mode="json"),
+                authorization="Bearer dev-worker-token",
+            )
+            list_status, list_response = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/every-code/pr-feedback",
+                query_string=f"request_id={feedback_record.request_id}&status=pending",
+                authorization="Bearer dev-worker-token",
+            )
+
+        self.assertEqual(write_status, 202, write_response)
+        self.assertEqual(write_response["records"]["feedback_id"], feedback_record.feedback_id)
+        self.assertEqual(write_response["result"]["feedback"]["feedback_id"], feedback_record.feedback_id)
+        self.assertEqual(list_status, 200, list_response)
+        self.assertEqual(len(list_response["feedback"]), 1)
+        self.assertEqual(list_response["feedback"][0]["feedback_id"], feedback_record.feedback_id)
 
     def test_every_code_worker_token_reruns_terminal_request(self) -> None:
         secret = "launchplane-every-code-webhook-secret"


### PR DESCRIPTION
## Summary
- add a worker-token POST /v1/every-code/pr-feedback route for full PR-feedback record writes
- switch the API-backed Every Code worker store to create feedback through that route instead of the status-only endpoint
- document the worker-token PR-feedback API surface and add service/API-store regressions

## Validation
- uv run python -m unittest tests.test_every_code_worker.EveryCodeWorkerTests.test_api_store_lists_and_updates_pr_feedback_via_service tests.test_every_code_worker.EveryCodeWorkerTests.test_api_store_creates_pr_feedback_via_service tests.test_every_code_worker.EveryCodeWorkerTests.test_check_failure_route_records_app_failure_feedback tests.test_service.LaunchplaneServiceTests.test_every_code_worker_token_writes_pr_feedback_record tests.test_service.LaunchplaneServiceTests.test_every_code_worker_token_lists_and_marks_pr_feedback
- uv run --extra dev ruff check control_plane/every_code_worker.py control_plane/service.py tests/test_every_code_worker.py tests/test_service.py docs/service-boundary.md
- uv run python -m unittest tests.test_every_code_worker tests.test_service
- uv run --extra dev mypy control_plane tests