### PR TITLE
Restore signed-in operator product-config apply

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1323,6 +1323,7 @@ _HUMAN_IDENTITY_MUTATION_ROUTES = frozenset(
         "/v1/agent/write-intents/evaluate",
         _GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path,
         _GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.route_path,
+        "/v1/product-config/apply",
         "/v1/authz-policies/github-actions/grants",
         "/v1/authz-policies/github-humans/grants",
         "/v1/authz-policies/terminal-agents/grants",

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -437,11 +437,14 @@ Current derived-state behavior:
 - `POST /v1/product-config/apply` exposes the same planner/writer through the
   authenticated service API for operator UI use. Submit `mode: "dry-run"` to
   preview with `product_config.plan`, then `mode: "apply"` with
-  `product_config.apply` after review. The service response is redacted and the
-  route rejects nested runtime or secret targets that differ from the authorized
-  top-level context/instance. It fails closed when secret writes are requested
-  without the Launchplane master encryption key in the service runtime or when
-  no active runtime key-safety policy allows the requested binding.
+  `product_config.apply` after review. Signed-in GitHub human operators can use
+  this route when their session has the exact product/context/action grant;
+  terminal-agent bearer credentials stay read-only and cannot apply product
+  config. The service response is redacted and the route rejects nested runtime
+  or secret targets that differ from the authorized top-level context/instance.
+  It fails closed when secret writes are requested without the Launchplane master
+  encryption key in the service runtime or when no active runtime key-safety
+  policy allows the requested binding.
 - The operator UI uses the same service route. It requires a successful dry-run
   result before enabling apply, clears rendered secret input values after each
   submit, and shows only key/action/count metadata from Launchplane responses.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -562,16 +562,19 @@ Product config writes use `POST /v1/product-config/apply`. The request carries
 `mode: "dry-run"` or `mode: "apply"`, product/context/instance, non-secret
 runtime values, and write-only managed secret values. Dry-run requires the
 `product_config.plan` action; apply requires `product_config.apply`. The route
-authorizes the top-level product/context/instance target and rejects nested
-runtime or secret targets that try to broaden or change that authorized target.
-It reuses the same planner/writer as `launchplane product-config apply`, returns
-only actions, keys, counts, actor/source metadata, and secret IDs, uses generic
-validation messages for rejected requests, and fails closed when a secret bundle
-is submitted without `LAUNCHPLANE_MASTER_ENCRYPTION_KEY` in the trusted
-Launchplane runtime or without an active runtime key-safety policy that allows
-the requested managed secret binding for the target runtime class. Request
-bodies for this route must not be copied into logs, issues, docs, or workflow
-artifacts because they can contain plaintext secret values.
+accepts GitHub Actions OIDC callers and signed-in GitHub human sessions, but
+terminal-agent bearer credentials remain read-only and cannot execute the
+mutation. The route authorizes the top-level product/context/instance target and
+rejects nested runtime or secret targets that try to broaden or change that
+authorized target. It reuses the same planner/writer as
+`launchplane product-config apply`, returns only actions, keys, counts,
+actor/source metadata, and secret IDs, uses generic validation messages for
+rejected requests, and fails closed when a secret bundle is submitted without
+`LAUNCHPLANE_MASTER_ENCRYPTION_KEY` in the trusted Launchplane runtime or without
+an active runtime key-safety policy that allows the requested managed secret
+binding for the target runtime class. Request bodies for this route must not be
+copied into logs, issues, docs, or workflow artifacts because they can contain
+plaintext secret values.
 
 Runtime key-safety policy reconciliation uses
 `POST /v1/runtime-key-safety/policies/apply`. The route is restricted to

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -420,6 +420,7 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
                     control_plane_service._GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path,
                     control_plane_service._GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.route_path,
                     "/v1/agent/write-intents/evaluate",
+                    "/v1/product-config/apply",
                     "/v1/authz-policies/github-actions/grants",
                     "/v1/authz-policies/github-humans/grants",
                     "/v1/authz-policies/terminal-agents/grants",

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -507,7 +507,11 @@ def _sqlite_database_url(database_path: Path) -> str:
 
 
 def _write_runtime_key_safety_policy(
-    *, database_url: str, context_name: str = "sellyouroutboard-prod", instance_name: str = "prod"
+    *,
+    database_url: str,
+    context_name: str = "sellyouroutboard-prod",
+    instance_name: str = "prod",
+    rules: tuple[RuntimeSecretSafetyRule, ...] | None = None,
 ) -> None:
     store = PostgresRecordStore(database_url=database_url)
     store.ensure_schema()
@@ -518,7 +522,8 @@ def _write_runtime_key_safety_policy(
                 status="active",
                 source="test",
                 updated_at="2026-05-05T20:00:00Z",
-                rules=(
+                rules=rules
+                or (
                     RuntimeSecretSafetyRule(
                         binding_key="SMTP_PASSWORD",
                         secret_class="prod_only",
@@ -610,6 +615,32 @@ def _product_config_payload() -> dict[str, object]:
                 "value": "smtp-secret-value",
                 "scope": "context_instance",
                 "description": "SMTP password",
+            }
+        ],
+    }
+
+
+def _meta_product_config_payload(*, mode: str = "dry-run") -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "mode": mode,
+        "product": "sellyouroutboard",
+        "context": "sellyouroutboard",
+        "instance": "prod",
+        "source_label": "product-config-ui-test",
+        "runtime_env": {
+            "scope": "instance",
+            "env": {
+                "NEXT_PUBLIC_META_PIXEL_ID": "123456789012345",
+            },
+        },
+        "secrets": [
+            {
+                "name": "META_CONVERSIONS_API_TOKEN",
+                "binding_key": "META_CONVERSIONS_API_TOKEN",
+                "value": "meta-conversions-api-secret-value",
+                "scope": "context_instance",
+                "description": "Meta conversions API token",
             }
         ],
     }
@@ -7229,6 +7260,258 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(len(secret_records), 1)
         self.assertEqual(secret_records[0].name, "SMTP_PASSWORD")
         self.assertEqual(secret_binding.binding_key, "SMTP_PASSWORD")
+
+    def test_product_config_api_human_admin_dry_run_returns_redacted_meta_plan(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_humans": [
+                        {
+                            "logins": ["alice"],
+                            "roles": ["admin"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard"],
+                            "actions": ["product_config.plan"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=_StubGitHubOAuthClient(_human_identity(role="admin")),  # type: ignore[arg-type]
+            )
+            _write_runtime_key_safety_policy(
+                database_url=database_url,
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key="META_CONVERSIONS_API_TOKEN",
+                        secret_class="prod_only",
+                        allowed_contexts=("sellyouroutboard",),
+                        allowed_instances=("prod",),
+                    ),
+                ),
+            )
+            cookie = _signed_in_cookie(app)
+
+            with patch.dict(
+                os.environ,
+                {control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"},
+                clear=True,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/product-config/apply",
+                    payload=_meta_product_config_payload(),
+                    authorization="",
+                    headers={
+                        "Cookie": cookie,
+                        "Idempotency-Key": "product-config-human-dry-run-meta",
+                    },
+                )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                runtime_records = store.list_runtime_environment_records()
+                secret_records = store.list_secret_records()
+            finally:
+                store.close()
+
+        response_text = json.dumps(payload, sort_keys=True)
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "dry-run")
+        self.assertEqual(payload["result"]["runtime_environment"]["action"], "created")
+        self.assertEqual(
+            payload["result"]["runtime_environment"]["changed_keys"],
+            ["NEXT_PUBLIC_META_PIXEL_ID"],
+        )
+        self.assertEqual(payload["result"]["secrets"][0]["action"], "created")
+        self.assertEqual(
+            payload["result"]["secrets"][0]["binding_key"],
+            "META_CONVERSIONS_API_TOKEN",
+        )
+        self.assertEqual(payload["result"]["runtime_key_safety"]["status"], "pass")
+        self.assertNotIn("123456789012345", response_text)
+        self.assertNotIn("meta-conversions-api-secret-value", response_text)
+        self.assertEqual(runtime_records, ())
+        self.assertEqual(secret_records, ())
+
+    def test_product_config_api_human_admin_apply_writes_meta_config(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_humans": [
+                        {
+                            "logins": ["alice"],
+                            "roles": ["admin"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard"],
+                            "actions": ["product_config.apply"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=_StubGitHubOAuthClient(_human_identity(role="admin")),  # type: ignore[arg-type]
+            )
+            _write_runtime_key_safety_policy(
+                database_url=database_url,
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key="META_CONVERSIONS_API_TOKEN",
+                        secret_class="prod_only",
+                        allowed_contexts=("sellyouroutboard",),
+                        allowed_instances=("prod",),
+                    ),
+                ),
+            )
+            cookie = _signed_in_cookie(app)
+
+            with patch.dict(
+                os.environ,
+                {control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"},
+                clear=True,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/product-config/apply",
+                    payload=_meta_product_config_payload(mode="apply"),
+                    authorization="",
+                    headers={
+                        "Cookie": cookie,
+                        "Idempotency-Key": "product-config-human-apply-meta",
+                    },
+                )
+                store = PostgresRecordStore(database_url=database_url)
+                store.ensure_schema()
+                try:
+                    runtime_records = store.list_runtime_environment_records()
+                    secret_records = store.list_secret_records()
+                    secret_binding = store.list_secret_bindings(limit=None)[0]
+                finally:
+                    store.close()
+
+        response_text = json.dumps(payload, sort_keys=True)
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "apply")
+        self.assertEqual(payload["result"]["runtime_environment"]["action"], "created")
+        self.assertEqual(payload["result"]["secrets"][0]["action"], "created")
+        self.assertNotIn("123456789012345", response_text)
+        self.assertNotIn("meta-conversions-api-secret-value", response_text)
+        self.assertEqual(len(runtime_records), 1)
+        self.assertEqual(runtime_records[0].context, "sellyouroutboard")
+        self.assertEqual(runtime_records[0].instance, "prod")
+        self.assertEqual(runtime_records[0].env["NEXT_PUBLIC_META_PIXEL_ID"], "123456789012345")
+        self.assertEqual(len(secret_records), 1)
+        self.assertEqual(secret_records[0].name, "META_CONVERSIONS_API_TOKEN")
+        self.assertEqual(secret_binding.binding_key, "META_CONVERSIONS_API_TOKEN")
+
+    def test_product_config_api_human_read_only_cannot_apply_product_config(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_humans": [
+                        {
+                            "logins": ["alice"],
+                            "roles": ["read_only"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard"],
+                            "actions": ["product_config.apply"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=_StubGitHubOAuthClient(_human_identity(role="read_only")),  # type: ignore[arg-type]
+            )
+            cookie = _signed_in_cookie(app)
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/product-config/apply",
+                payload=_meta_product_config_payload(mode="apply"),
+                authorization="",
+                headers={
+                    "Cookie": cookie,
+                    "Idempotency-Key": "product-config-human-read-only-apply",
+                },
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_product_config_api_terminal_agent_remains_read_only(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "terminal_agents": [
+                        {
+                            "subjects": ["local-owner-agent"],
+                            "token_labels": ["local-owner-read"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard"],
+                            "actions": ["product_config.apply"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            with patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN": "terminal-read-token"},
+                clear=True,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/product-config/apply",
+                    payload=_meta_product_config_payload(mode="apply"),
+                    authorization="Bearer terminal-read-token",
+                    headers={"Idempotency-Key": "product-config-terminal-denied"},
+                )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertEqual(
+            payload["error"]["message"],
+            "Terminal agent credentials can only read redacted Launchplane context.",
+        )
 
     def test_product_config_api_rejects_missing_master_key_for_secret_bundle(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- Re-admit `/v1/product-config/apply` to signed-in human mutation routes while preserving exact product/context/action authz.
- Add Meta-shaped product-config regression tests for admin dry-run/apply, read-only denial, terminal-agent denial, and redaction.
- Update service/operations docs to clarify that GitHub human sessions and OIDC callers may use the route, while terminal-agent credentials remain read-only.

Refs #521

## Validation
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_product_config_api_human_admin_dry_run_returns_redacted_meta_plan tests.test_service.LaunchplaneServiceTests.test_product_config_api_human_admin_apply_writes_meta_config tests.test_service.LaunchplaneServiceTests.test_product_config_api_human_read_only_cannot_apply_product_config tests.test_service.LaunchplaneServiceTests.test_product_config_api_terminal_agent_remains_read_only tests.test_service.LaunchplaneServiceTests.test_product_config_api_dry_run_returns_redacted_plan_without_writes tests.test_service.LaunchplaneServiceTests.test_product_config_api_apply_writes_runtime_and_managed_secret`
- `uv run python -m unittest tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_route_policy_sets_use_execution_metadata`
- `uv run python -m unittest`
- `uv run --extra dev ruff check --diff control_plane/service.py tests/test_service.py tests/test_driver_descriptors.py`
- `uv run --extra dev ruff check control_plane/service.py tests/test_service.py tests/test_driver_descriptors.py`
- `git diff --check`
- `uv run --extra dev mypy control_plane tests`