### PR TITLE
Add Odoo stable target replacement dry-run plan

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -187,6 +187,10 @@ from control_plane.workflows.odoo_prod_rollback import (
     OdooProdRollbackRequest,
     execute_odoo_prod_rollback,
 )
+from control_plane.workflows.odoo_stable_target_replacement import (
+    OdooStableTargetReplacementRequest,
+    build_odoo_stable_target_replacement_plan,
+)
 from control_plane.workflows.promote import (
     build_executed_promotion_record,
     build_promotion_record,
@@ -14326,6 +14330,63 @@ def dokploy_targets_relabel(
 @main.group("odoo-overrides")
 def odoo_overrides() -> None:
     """Odoo instance override record commands."""
+
+
+@main.group("odoo-targets")
+def odoo_targets() -> None:
+    """Odoo stable target planning commands."""
+
+
+@odoo_targets.command("replacement-plan")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane Odoo target records.",
+)
+@click.option("--product", default="odoo-tenant-cm", show_default=True)
+@click.option("--instance", "instance_name", required=True)
+@click.option(
+    "--strategy",
+    type=click.Choice(["recreate-in-place", "replace-and-cutover"]),
+    default="recreate-in-place",
+    show_default=True,
+)
+@click.option(
+    "--allow-empty-data",
+    is_flag=True,
+    help="Allow missing volume env keys in the dry-run plan for an intentionally empty target.",
+)
+@click.option(
+    "--control-plane-root",
+    type=click.Path(path_type=Path, file_okay=False),
+    default=None,
+    help="Optional Launchplane repo root used to resolve Dokploy credentials.",
+)
+def odoo_targets_replacement_plan(
+    database_url: str,
+    product: str,
+    instance_name: str,
+    strategy: str,
+    allow_empty_data: bool,
+    control_plane_root: Path | None,
+) -> None:
+    launchplane_root = control_plane_root or _control_plane_root()
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    try:
+        plan = build_odoo_stable_target_replacement_plan(
+            control_plane_root=launchplane_root,
+            record_store=postgres_store,
+            request=OdooStableTargetReplacementRequest(
+                product=product,
+                instance=instance_name,
+                strategy=cast(Literal["recreate-in-place", "replace-and-cutover"], strategy),
+                allow_empty_data=allow_empty_data,
+            ),
+        )
+    finally:
+        postgres_store.close()
+    click.echo(json.dumps(plan.model_dump(mode="json"), indent=2, sort_keys=True))
 
 
 @odoo_overrides.command("put-config-param")

--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Literal, Protocol
+
+import click
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane import dokploy as control_plane_dokploy
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductLaneProfile,
+)
+from control_plane.dokploy import JsonObject, JsonValue
+
+
+class OdooStableTargetReplacementStore(Protocol):
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord: ...
+
+    def read_dokploy_target_record(
+        self, *, context_name: str, instance_name: str
+    ) -> DokployTargetRecord: ...
+
+    def read_dokploy_target_id_record(
+        self, *, context_name: str, instance_name: str
+    ) -> DokployTargetIdRecord: ...
+
+    def read_environment_inventory(
+        self, *, context_name: str, instance_name: str
+    ) -> EnvironmentInventory: ...
+
+
+DokployRequest = Callable[..., JsonValue]
+
+
+class OdooStableTargetReplacementRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    instance: str
+    strategy: Literal["recreate-in-place", "replace-and-cutover"] = "recreate-in-place"
+    allow_empty_data: bool = False
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "OdooStableTargetReplacementRequest":
+        self.product = self.product.strip()
+        self.instance = self.instance.strip().lower()
+        if not self.product:
+            raise ValueError("Odoo stable target replacement requires product.")
+        if not self.instance:
+            raise ValueError("Odoo stable target replacement requires instance.")
+        return self
+
+
+class OdooStableTargetRuntimeSnapshot(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    target_type: str
+    target_id: str
+    target_name: str
+    project_name: str = ""
+    source_type: str = ""
+    compose_path: str = ""
+    compose_file_sha256: str = ""
+    domain_hosts: tuple[str, ...] = ()
+    latest_deployment_status: str = ""
+    latest_deployment_id: str = ""
+    env_keys: tuple[str, ...] = ()
+    required_volume_keys_present: tuple[str, ...] = ()
+    required_volume_keys_missing: tuple[str, ...] = ()
+    runtime_identity_present: bool = False
+    runtime_identity_deployment_record_id: str = ""
+
+
+class OdooStableTargetReplacementStep(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    step_id: str
+    status: Literal["ready", "blocked", "manual"]
+    message: str
+
+
+class OdooStableTargetReplacementPlan(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    plan_status: Literal["ready", "blocked"]
+    product: str
+    context: str
+    instance: str
+    strategy: Literal["recreate-in-place", "replace-and-cutover"]
+    target_record_found: bool
+    target_id_record_found: bool
+    inventory_found: bool
+    current_target: OdooStableTargetRuntimeSnapshot | None = None
+    expected_next_target_name: str
+    expected_domain_hosts: tuple[str, ...] = ()
+    expected_artifact_id: str = ""
+    expected_source_git_ref: str = ""
+    blockers: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+    steps: tuple[OdooStableTargetReplacementStep, ...] = ()
+
+
+def _read_lane(
+    *, profile: LaunchplaneProductProfileRecord, instance: str
+) -> ProductLaneProfile:
+    for lane in profile.lanes:
+        if lane.instance == instance:
+            return lane
+    raise click.ClickException(
+        f"Product {profile.product!r} has no stable lane for instance {instance!r}."
+    )
+
+
+def _read_optional(call: Callable[[], object]) -> object | None:
+    try:
+        return call()
+    except FileNotFoundError:
+        return None
+
+
+def _domain_hosts_from_payload(raw_domains: JsonValue) -> tuple[str, ...]:
+    if not isinstance(raw_domains, list):
+        return ()
+    hosts: list[str] = []
+    for raw_domain in raw_domains:
+        domain = control_plane_dokploy.as_json_object(raw_domain)
+        if domain is None:
+            continue
+        host = str(domain.get("host") or "").strip()
+        if host:
+            hosts.append(host)
+    return tuple(sorted(hosts))
+
+
+def _domains_for_target(
+    *,
+    host: str,
+    token: str,
+    target_type: str,
+    target_id: str,
+    request: DokployRequest,
+) -> tuple[str, ...]:
+    if target_type == "compose":
+        return _domain_hosts_from_payload(
+            request(
+                host=host,
+                token=token,
+                path="/api/domain.byComposeId",
+                query={"composeId": target_id},
+            )
+        )
+    if target_type == "application":
+        return _domain_hosts_from_payload(
+            request(
+                host=host,
+                token=token,
+                path="/api/domain.byApplicationId",
+                query={"applicationId": target_id},
+            )
+        )
+    return ()
+
+
+def _deployment_value(deployment: JsonObject | None, *keys: str) -> str:
+    if deployment is None:
+        return ""
+    for key in keys:
+        value = str(deployment.get(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _runtime_identity_map(env_map: Mapping[str, str]) -> dict[str, str]:
+    raw_identity = env_map.get("LAUNCHPLANE_RUNTIME_IDENTITY_JSON", "").strip()
+    if not raw_identity:
+        return {}
+    try:
+        import json
+
+        payload = json.loads(raw_identity)
+    except ValueError:
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    return {str(key): str(value) for key, value in payload.items() if value is not None}
+
+
+def _snapshot_current_target(
+    *,
+    host: str,
+    token: str,
+    target_record: DokployTargetRecord,
+    target_id_record: DokployTargetIdRecord,
+    request: DokployRequest,
+) -> OdooStableTargetRuntimeSnapshot:
+    target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
+        host=host,
+        token=token,
+        target_type=target_record.target_type,
+        target_id=target_id_record.target_id,
+    )
+    env_map = control_plane_dokploy.parse_dokploy_env_text(
+        str(target_payload.get("env") or "")
+    )
+    required_volume_keys = ("ODOO_DATA_VOLUME", "ODOO_LOG_VOLUME", "ODOO_DB_VOLUME")
+    present_volume_keys = tuple(key for key in required_volume_keys if env_map.get(key, "").strip())
+    missing_volume_keys = tuple(key for key in required_volume_keys if key not in present_volume_keys)
+    latest_deployment = control_plane_dokploy.latest_deployment_for_target(
+        host=host,
+        token=token,
+        target_type=target_record.target_type,
+        target_id=target_id_record.target_id,
+    )
+    runtime_identity = _runtime_identity_map(env_map)
+    compose_file = str(target_payload.get("composeFile") or "")
+    return OdooStableTargetRuntimeSnapshot(
+        target_type=target_record.target_type,
+        target_id=target_id_record.target_id,
+        target_name=target_record.target_name or str(target_payload.get("name") or "").strip(),
+        project_name=target_record.project_name,
+        source_type=str(target_payload.get("sourceType") or target_record.source_type or "").strip(),
+        compose_path=str(target_payload.get("composePath") or target_record.compose_path or "").strip(),
+        compose_file_sha256=control_plane_dokploy.compose_file_sha256(compose_file)
+        if compose_file
+        else "",
+        domain_hosts=_domains_for_target(
+            host=host,
+            token=token,
+            target_type=target_record.target_type,
+            target_id=target_id_record.target_id,
+            request=request,
+        ),
+        latest_deployment_status=_deployment_value(latest_deployment, "status", "state"),
+        latest_deployment_id=_deployment_value(
+            latest_deployment, "deploymentId", "deployment_id", "id"
+        ),
+        env_keys=tuple(sorted(env_map.keys())),
+        required_volume_keys_present=present_volume_keys,
+        required_volume_keys_missing=missing_volume_keys,
+        runtime_identity_present=bool(runtime_identity),
+        runtime_identity_deployment_record_id=runtime_identity.get("deployment_record_id", ""),
+    )
+
+
+def _build_steps(
+    *,
+    current_target: OdooStableTargetRuntimeSnapshot | None,
+    blockers: tuple[str, ...],
+    plan_strategy: Literal["recreate-in-place", "replace-and-cutover"],
+) -> tuple[OdooStableTargetReplacementStep, ...]:
+    steps: list[OdooStableTargetReplacementStep] = []
+    steps.append(
+        OdooStableTargetReplacementStep(
+            step_id="inventory",
+            status="ready" if current_target is not None else "blocked",
+            message="Read current Launchplane target record and live Dokploy payload.",
+        )
+    )
+    steps.append(
+        OdooStableTargetReplacementStep(
+            step_id="volume-contract",
+            status="ready"
+            if current_target is not None and not current_target.required_volume_keys_missing
+            else "blocked",
+            message="Confirm Odoo data/log/database volume keys are explicit in target env.",
+        )
+    )
+    steps.append(
+        OdooStableTargetReplacementStep(
+            step_id="replacement-apply",
+            status="manual" if not blockers else "blocked",
+            message=(
+                "Future apply should create a replacement target and cut routes over."
+                if plan_strategy == "replace-and-cutover"
+                else "Future apply should recreate the target only after route and volume proof."
+            ),
+        )
+    )
+    steps.append(
+        OdooStableTargetReplacementStep(
+            step_id="post-deploy-verification",
+            status="manual" if not blockers else "blocked",
+            message="Run Odoo post-deploy, health, canonical URL, logo, and runtime identity checks.",
+        )
+    )
+    return tuple(steps)
+
+
+def build_odoo_stable_target_replacement_plan(
+    *,
+    control_plane_root: Path,
+    record_store: OdooStableTargetReplacementStore,
+    request: OdooStableTargetReplacementRequest,
+    dokploy_request: DokployRequest = control_plane_dokploy.dokploy_request,
+) -> OdooStableTargetReplacementPlan:
+    profile = record_store.read_product_profile_record(request.product)
+    if profile.driver_id != "odoo":
+        raise click.ClickException(
+            f"Product {profile.product!r} is configured for driver {profile.driver_id!r}, not odoo."
+        )
+    lane = _read_lane(profile=profile, instance=request.instance)
+    target_record = _read_optional(
+        lambda: record_store.read_dokploy_target_record(
+            context_name=lane.context, instance_name=lane.instance
+        )
+    )
+    target_id_record = _read_optional(
+        lambda: record_store.read_dokploy_target_id_record(
+            context_name=lane.context, instance_name=lane.instance
+        )
+    )
+    inventory = _read_optional(
+        lambda: record_store.read_environment_inventory(
+            context_name=lane.context, instance_name=lane.instance
+        )
+    )
+    blockers: list[str] = []
+    warnings: list[str] = []
+    current_target: OdooStableTargetRuntimeSnapshot | None = None
+    if target_record is None:
+        blockers.append("Launchplane has no Dokploy target record for this lane.")
+    if target_id_record is None:
+        blockers.append("Launchplane has no Dokploy target-id record for this lane.")
+    if inventory is None:
+        warnings.append("Launchplane has no current environment inventory for this lane.")
+    if isinstance(target_record, DokployTargetRecord) and target_record.target_type != "compose":
+        blockers.append("Odoo stable replacement currently requires a compose target.")
+    if isinstance(target_record, DokployTargetRecord) and isinstance(
+        target_id_record, DokployTargetIdRecord
+    ):
+        host, token = control_plane_dokploy.read_dokploy_config(
+            control_plane_root=control_plane_root
+        )
+        current_target = _snapshot_current_target(
+            host=host,
+            token=token,
+            target_record=target_record,
+            target_id_record=target_id_record,
+            request=dokploy_request,
+        )
+        if current_target.required_volume_keys_missing and not request.allow_empty_data:
+            blockers.append(
+                "Current target is missing required Odoo volume env keys: "
+                + ", ".join(current_target.required_volume_keys_missing)
+            )
+        if not current_target.domain_hosts:
+            blockers.append("Current target has no discoverable Dokploy domains to cut over.")
+        if not current_target.runtime_identity_present:
+            warnings.append("Current target does not expose a Launchplane runtime identity yet.")
+    expected_artifact_id = ""
+    expected_source_git_ref = ""
+    if isinstance(inventory, EnvironmentInventory):
+        expected_artifact_id = (
+            inventory.artifact_identity.artifact_id if inventory.artifact_identity else ""
+        )
+        expected_source_git_ref = inventory.source_git_ref
+    expected_target_name = (
+        target_record.target_name
+        if isinstance(target_record, DokployTargetRecord) and target_record.target_name
+        else f"{profile.product}-{lane.instance}"
+    )
+    blockers_tuple = tuple(blockers)
+    return OdooStableTargetReplacementPlan(
+        plan_status="blocked" if blockers_tuple else "ready",
+        product=profile.product,
+        context=lane.context,
+        instance=lane.instance,
+        strategy=request.strategy,
+        target_record_found=target_record is not None,
+        target_id_record_found=target_id_record is not None,
+        inventory_found=inventory is not None,
+        current_target=current_target,
+        expected_next_target_name=expected_target_name,
+        expected_domain_hosts=current_target.domain_hosts if current_target else (),
+        expected_artifact_id=expected_artifact_id,
+        expected_source_git_ref=expected_source_git_ref,
+        blockers=blockers_tuple,
+        warnings=tuple(warnings),
+        steps=_build_steps(
+            current_target=current_target,
+            blockers=blockers_tuple,
+            plan_strategy=request.strategy,
+        ),
+    )

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -679,6 +679,23 @@ shape. Until that follow-up lands, CM previews are a single active staged target
 behind pre-existing DNS/nginx routing and are intended to make the client-visible
 Odoo system usable before full ephemeral preview infrastructure exists.
 
+For stable Odoo target replacement planning, use the read-only dry-run command
+before considering any provider mutation:
+
+```sh
+uv run launchplane odoo-targets replacement-plan \
+  --database-url "$LAUNCHPLANE_DATABASE_URL" \
+  --product odoo-tenant-cm \
+  --instance testing
+```
+
+The plan reads the product profile, Launchplane Dokploy target/id records,
+current inventory, live Dokploy target payload, domains, volume env keys, latest
+deployment, and expected runtime identity. It does not create, delete, deploy,
+or change routes. Later apply workflows must build on this plan and keep the
+same explicit volume, route, post-deploy, health, canonical URL, logo, and
+runtime identity checks.
+
 `launchplane-previews write-from-generation` and `launchplane-previews write-destroyed`
 are local preview-evidence ingest adapters that mirror the service ingress
 payload shape. VeriReel preview runtime now flows through Launchplane drivers:

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -1,0 +1,246 @@
+import json
+import unittest
+from pathlib import Path
+from typing import cast
+from unittest.mock import patch
+
+import click
+
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductImageProfile,
+    ProductLaneProfile,
+    ProductPreviewProfile,
+)
+from control_plane.contracts.promotion_record import (
+    ArtifactIdentityReference,
+    DeploymentEvidence,
+)
+from control_plane.dokploy import JsonValue
+from control_plane.workflows.odoo_stable_target_replacement import (
+    DokployRequest,
+    OdooStableTargetReplacementRequest,
+    build_odoo_stable_target_replacement_plan,
+)
+
+
+class _Store:
+    def __init__(
+        self,
+        *,
+        profile: LaunchplaneProductProfileRecord | None = None,
+        target_record: DokployTargetRecord | None = None,
+        target_id_record: DokployTargetIdRecord | None = None,
+        inventory: EnvironmentInventory | None = None,
+    ) -> None:
+        self.profile = profile or _profile()
+        self.target_record = target_record
+        self.target_id_record = target_id_record
+        self.inventory = inventory
+
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
+        if product != self.profile.product:
+            raise FileNotFoundError(product)
+        return self.profile
+
+    def read_dokploy_target_record(
+        self, *, context_name: str, instance_name: str
+    ) -> DokployTargetRecord:
+        if self.target_record is None:
+            raise FileNotFoundError(f"{context_name}/{instance_name}")
+        return self.target_record
+
+    def read_dokploy_target_id_record(
+        self, *, context_name: str, instance_name: str
+    ) -> DokployTargetIdRecord:
+        if self.target_id_record is None:
+            raise FileNotFoundError(f"{context_name}/{instance_name}")
+        return self.target_id_record
+
+    def read_environment_inventory(
+        self, *, context_name: str, instance_name: str
+    ) -> EnvironmentInventory:
+        if self.inventory is None:
+            raise FileNotFoundError(f"{context_name}/{instance_name}")
+        return self.inventory
+
+
+def _profile(driver_id: str = "odoo") -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord(
+        product="odoo-tenant-cm",
+        display_name="Odoo CM",
+        repository="cbusillo/odoo-tenant-cm",
+        driver_id=driver_id,
+        image=ProductImageProfile(repository="ghcr.io/cbusillo/odoo-tenant-cm"),
+        runtime_port=8069,
+        health_path="/web/health",
+        lanes=(ProductLaneProfile(instance="testing", context="cm"),),
+        preview=ProductPreviewProfile(enabled=True, context="cm"),
+        updated_at="2026-05-09T00:00:00Z",
+        source="test",
+    )
+
+
+def _target_record(target_type: str = "compose") -> DokployTargetRecord:
+    return DokployTargetRecord(
+        context="cm",
+        instance="testing",
+        project_name="odoo",
+        target_type=target_type,  # type: ignore[arg-type]
+        target_name="cm-testing",
+        domains=("cm-testing.shinycomputers.com",),
+        updated_at="2026-05-09T00:00:00Z",
+    )
+
+
+def _target_id_record() -> DokployTargetIdRecord:
+    return DokployTargetIdRecord(
+        context="cm",
+        instance="testing",
+        target_id="compose-cm-testing",
+        updated_at="2026-05-09T00:00:00Z",
+    )
+
+
+def _inventory() -> EnvironmentInventory:
+    return EnvironmentInventory(
+        context="cm",
+        instance="testing",
+        artifact_identity=ArtifactIdentityReference(artifact_id="artifact-cm-testing"),
+        source_git_ref="abc123",
+        deploy=DeploymentEvidence(
+            status="pass",
+            target_type="compose",
+            target_name="cm-testing",
+            deploy_mode="dokploy-compose-api",
+        ),
+        updated_at="2026-05-09T00:00:00Z",
+        deployment_record_id="deployment-cm-testing",
+    )
+
+
+def _request(path: str, query: object | None = None, **_: object) -> JsonValue:
+    if path == "/api/domain.byComposeId" and query == {"composeId": "compose-cm-testing"}:
+        return [{"host": "cm-testing.shinycomputers.com", "domainId": "domain-cm"}]
+    return []
+
+
+class OdooStableTargetReplacementTests(unittest.TestCase):
+    def test_build_plan_reports_ready_when_records_and_volume_contract_exist(self) -> None:
+        identity = json.dumps(
+            {"deployment_record_id": "deployment-cm-testing", "artifact_id": "artifact"}
+        )
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.read_dokploy_config",
+                return_value=("host", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "name": "cm-testing",
+                    "sourceType": "raw",
+                    "composePath": "docker-compose.yml",
+                    "composeFile": "services: {}",
+                    "env": "\n".join(
+                        (
+                            "ODOO_DATA_VOLUME=cm_testing_odoo_data",
+                            "ODOO_LOG_VOLUME=cm_testing_odoo_logs",
+                            "ODOO_DB_VOLUME=cm_testing_odoo_db",
+                            f"LAUNCHPLANE_RUNTIME_IDENTITY_JSON={identity}",
+                        )
+                    ),
+                },
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.latest_deployment_for_target",
+                return_value={"deploymentId": "deploy-123", "status": "success"},
+            ),
+        ):
+            plan = build_odoo_stable_target_replacement_plan(
+                control_plane_root=Path("."),
+                record_store=_Store(
+                    target_record=_target_record(),
+                    target_id_record=_target_id_record(),
+                    inventory=_inventory(),
+                ),
+                request=OdooStableTargetReplacementRequest(
+                    product="odoo-tenant-cm", instance="testing"
+                ),
+                dokploy_request=cast(DokployRequest, _request),
+            )
+
+        self.assertEqual(plan.plan_status, "ready")
+        self.assertEqual(plan.context, "cm")
+        self.assertEqual(plan.expected_artifact_id, "artifact-cm-testing")
+        self.assertIsNotNone(plan.current_target)
+        assert plan.current_target is not None
+        self.assertEqual(plan.current_target.required_volume_keys_missing, ())
+        self.assertTrue(plan.current_target.runtime_identity_present)
+        self.assertEqual(plan.current_target.domain_hosts, ("cm-testing.shinycomputers.com",))
+
+    def test_build_plan_blocks_without_target_records(self) -> None:
+        plan = build_odoo_stable_target_replacement_plan(
+            control_plane_root=Path("."),
+            record_store=_Store(),
+            request=OdooStableTargetReplacementRequest(
+                product="odoo-tenant-cm", instance="testing"
+            ),
+        )
+
+        self.assertEqual(plan.plan_status, "blocked")
+        self.assertIn(
+            "Launchplane has no Dokploy target record for this lane.", plan.blockers
+        )
+        self.assertIn(
+            "Launchplane has no Dokploy target-id record for this lane.", plan.blockers
+        )
+
+    def test_build_plan_blocks_missing_volume_contract(self) -> None:
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.read_dokploy_config",
+                return_value=("host", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={"name": "cm-testing", "env": "ODOO_DATA_VOLUME=data"},
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.latest_deployment_for_target",
+                return_value=None,
+            ),
+        ):
+            plan = build_odoo_stable_target_replacement_plan(
+                control_plane_root=Path("."),
+                record_store=_Store(
+                    target_record=_target_record(),
+                    target_id_record=_target_id_record(),
+                ),
+                request=OdooStableTargetReplacementRequest(
+                    product="odoo-tenant-cm", instance="testing"
+                ),
+                dokploy_request=cast(DokployRequest, _request),
+            )
+
+        self.assertEqual(plan.plan_status, "blocked")
+        self.assertIn("ODOO_LOG_VOLUME", plan.blockers[0])
+        self.assertIn("ODOO_DB_VOLUME", plan.blockers[0])
+        self.assertIn("Current target does not expose a Launchplane runtime identity yet.", plan.warnings)
+
+    def test_build_plan_rejects_non_odoo_profile(self) -> None:
+        with self.assertRaises(click.ClickException):
+            build_odoo_stable_target_replacement_plan(
+                control_plane_root=Path("."),
+                record_store=_Store(profile=_profile(driver_id="generic-web")),
+                request=OdooStableTargetReplacementRequest(
+                    product="odoo-tenant-cm", instance="testing"
+                ),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a read-only Odoo stable target replacement planner
- add `launchplane odoo-targets replacement-plan` for CM/OPW target inventory and dry-run blocker reporting
- inspect Launchplane target/id records, current inventory, live Dokploy payload, domains, volume env keys, latest deployment, and runtime identity without mutating provider state
- document the dry-run command in operations docs

Refs #520

## Validation

- `uv run python -m unittest tests.test_odoo_stable_target_replacement`
- `uv run --extra dev ruff check control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_stable_target_replacement.py control_plane/cli.py --diff`
- `uv run --extra dev ruff check control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_stable_target_replacement.py control_plane/cli.py`
- `uv run --extra dev mypy control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_stable_target_replacement.py`