### PR TITLE
Add Odoo target replacement plan workflow

### DIFF
--- a/.github/workflows/odoo-target-replacement-plan.yml
+++ b/.github/workflows/odoo-target-replacement-plan.yml
@@ -1,0 +1,99 @@
+---
+name: Odoo Target Replacement Plan
+
+"on":
+  workflow_dispatch:
+    inputs:
+      product:
+        description: Odoo product profile key.
+        required: true
+        default: odoo-tenant-cm
+        type: string
+      instance:
+        description: Stable Odoo instance to inspect.
+        required: true
+        default: testing
+        type: choice
+        options:
+          - testing
+          - prod
+      strategy:
+        description: Future replacement strategy to plan around.
+        required: true
+        default: recreate-in-place
+        type: choice
+        options:
+          - recreate-in-place
+          - replace-and-cutover
+      allow_empty_data:
+        description: Allow missing volume env keys for intentionally empty targets.
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: odoo-target-replacement-plan-${{ inputs.product }}-${{ inputs.instance }}
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    env:
+      PRODUCT: ${{ inputs.product }}
+      INSTANCE: ${{ inputs.instance }}
+      STRATEGY: ${{ inputs.strategy }}
+      ALLOW_EMPTY_DATA: ${{ inputs.allow_empty_data }}
+      LAUNCHPLANE_DATABASE_URL: ${{ secrets.LAUNCHPLANE_DATABASE_URL }}
+      DOKPLOY_HOST: ${{ secrets.LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST }}
+      DOKPLOY_TOKEN: ${{ secrets.LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install Python
+        run: uv python install 3.13
+
+      - name: Validate runtime inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${PRODUCT:?Missing product input}"
+          : "${INSTANCE:?Missing instance input}"
+          : "${STRATEGY:?Missing strategy input}"
+          if [ -z "${LAUNCHPLANE_DATABASE_URL:-}" ]; then
+            echo 'Missing LAUNCHPLANE_DATABASE_URL repository secret.' >&2
+            exit 1
+          fi
+          if [ -z "${DOKPLOY_HOST:-}" ] || [ -z "${DOKPLOY_TOKEN:-}" ]; then
+            echo 'Missing Launchplane emergency Dokploy repository secrets.' >&2
+            exit 1
+          fi
+
+      - name: Build replacement plan
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(
+            --product "$PRODUCT"
+            --instance "$INSTANCE"
+            --strategy "$STRATEGY"
+          )
+          if [ "$ALLOW_EMPTY_DATA" = "true" ]; then
+            args+=(--allow-empty-data)
+          fi
+          uv run launchplane odoo-targets replacement-plan "${args[@]}" \
+            | tee odoo-target-replacement-plan.json
+
+      - name: Upload replacement plan
+        uses: actions/upload-artifact@v5
+        with:
+          name: odoo-target-replacement-plan-${{ inputs.product }}-${{ inputs.instance }}
+          path: odoo-target-replacement-plan.json


### PR DESCRIPTION
## Summary

- add a manual workflow wrapper for `launchplane odoo-targets replacement-plan`
- run the read-only Odoo stable target plan from the trusted runner environment
- upload the JSON plan as a workflow artifact

Refs #520

## Validation

- CI/Security workflow validation on PR

## Notes

The workflow requires the repository to expose `LAUNCHPLANE_DATABASE_URL` plus the emergency Dokploy secrets to this workflow. If those are unavailable, the dry-run will fail early with an explicit missing-secret message.