### PR TITLE
Grant Odoo CM unsupported preview feedback

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -1104,6 +1104,12 @@ jobs:
             odoo-cm-preview-pr-feedback
           post_odoo_cm_preview_grant \
             odoo-tenant-cm \
+            preview_pr_feedback.write \
+            deploy:odoo-cm-preview-unsupported-feedback-grant \
+            odoo-cm-preview-unsupported-feedback \
+            pull_request_target
+          post_odoo_cm_preview_grant \
+            odoo-tenant-cm \
             preview_destroy.execute \
             deploy:odoo-cm-preview-destroy-pr-grant \
             odoo-cm-preview-destroy-pr

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -912,7 +912,10 @@ The CM preview workflow also needs `preview_pr_feedback.write` for product
 `odoo-tenant-cm` and context `cm` before it can retire tenant-side preview
 comment rendering. Normal refresh and destroy outcomes can reuse lifecycle
 grants, but unsupported/fork and Dependabot notices sit outside those mutation
-paths and require the explicit feedback grant.
+paths and require the explicit feedback grant. Fork and Dependabot notices run
+from the base branch through `pull_request_target`, so the deploy-maintained
+grant set includes both `pull_request` and `pull_request_target` feedback
+writers for the same workflow file.
 
 - VeriReel testing deploy driver:
   `verireel-testing-deploy:<product>:<context>:<instance>:<artifact_id>:<source_git_ref>`

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -14156,6 +14156,69 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(feedback_records[0].status, "unsupported")
         self.assertIn("preview automation is unavailable", payload["result"]["comment_markdown"])
 
+    def test_preview_pr_feedback_endpoint_accepts_odoo_cm_pull_request_target_feedback_grant(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/odoo-tenant-cm",
+                            "workflow_refs": [
+                                "cbusillo/odoo-tenant-cm/.github/workflows/odoo-preview.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request_target"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["preview_pr_feedback.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/odoo-tenant-cm",
+                        workflow_ref=(
+                            "cbusillo/odoo-tenant-cm/.github/workflows/odoo-preview.yml"
+                            "@refs/heads/main"
+                        ),
+                        event_name="pull_request_target",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/pr-feedback",
+                payload={
+                    "product": "odoo-tenant-cm",
+                    "context": "cm",
+                    "source": "odoo-preview-unsupported",
+                    "repository": "cbusillo/odoo-tenant-cm",
+                    "anchor_repo": "odoo-tenant-cm",
+                    "anchor_pr_number": 27,
+                    "anchor_pr_url": "https://github.com/cbusillo/odoo-tenant-cm/pull/27",
+                    "status": "unsupported",
+                    "run_url": "https://github.com/cbusillo/odoo-tenant-cm/actions/runs/123",
+                    "failure_summary": "Preview automation is unavailable for forked pull requests.",
+                },
+            )
+
+            feedback_records = FilesystemRecordStore(
+                state_dir=root / "state"
+            ).list_preview_pr_feedback_records(context_name="cm")
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(feedback_records[0].status, "unsupported")
+
     def test_preview_pr_feedback_endpoint_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add a deploy-maintained pull_request_target preview feedback grant for Odoo CM unsupported notices
- document why the unsupported path needs a base-branch feedback grant in addition to the pull_request grant
- add a service regression for Odoo CM pull_request_target feedback writes

Refs #505

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-launchplane.yml"); puts "workflow yaml ok"'
- npx --yes markdownlint-cli2 docs/service-boundary.md
- uv run --extra dev ruff check tests/test_service.py
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_preview_pr_feedback_endpoint_accepts_odoo_cm_pull_request_target_feedback_grant tests.test_service.LaunchplaneServiceTests.test_preview_pr_feedback_endpoint_accepts_odoo_cm_unsupported_feedback_grant