### PR TITLE
Route Odoo replacement planning through service

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -1076,6 +1076,14 @@ jobs:
             live_target_runtime.apply \
             deploy:syo-live-target-runtime-apply-grant \
             syo-live-target-runtime-apply
+          post_grant \
+            "$GITHUB_REPOSITORY" \
+            odoo-target-replacement-plan.yml \
+            odoo-tenant-cm \
+            cm \
+            odoo_target_replacement_plan.read \
+            deploy:odoo-cm-target-replacement-plan-grant \
+            odoo-cm-target-replacement-plan
           post_syo_preview_grants \
             sellyouroutboard-testing \
             legacy-context

--- a/.github/workflows/odoo-target-replacement-plan.yml
+++ b/.github/workflows/odoo-target-replacement-plan.yml
@@ -33,6 +33,7 @@ name: Odoo Target Replacement Plan
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: odoo-target-replacement-plan-${{ inputs.product }}-${{ inputs.instance }}
@@ -48,19 +49,9 @@ jobs:
       INSTANCE: ${{ inputs.instance }}
       STRATEGY: ${{ inputs.strategy }}
       ALLOW_EMPTY_DATA: ${{ inputs.allow_empty_data }}
-      LAUNCHPLANE_DATABASE_URL: ${{ secrets.LAUNCHPLANE_DATABASE_URL }}
-      DOKPLOY_HOST: ${{ secrets.LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST }}
-      DOKPLOY_TOKEN: ${{ secrets.LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN }}
+      LAUNCHPLANE_SERVICE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+      LAUNCHPLANE_SERVICE_AUDIENCE: launchplane.shinycomputers.com
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Install Python
-        run: uv python install 3.13
-
       - name: Validate runtime inputs
         shell: bash
         run: |
@@ -68,12 +59,8 @@ jobs:
           : "${PRODUCT:?Missing product input}"
           : "${INSTANCE:?Missing instance input}"
           : "${STRATEGY:?Missing strategy input}"
-          if [ -z "${LAUNCHPLANE_DATABASE_URL:-}" ]; then
-            echo 'Missing LAUNCHPLANE_DATABASE_URL repository secret.' >&2
-            exit 1
-          fi
-          if [ -z "${DOKPLOY_HOST:-}" ] || [ -z "${DOKPLOY_TOKEN:-}" ]; then
-            echo 'Missing Launchplane emergency Dokploy repository secrets.' >&2
+          if [ -z "${LAUNCHPLANE_SERVICE_URL:-}" ] || [ -z "${LAUNCHPLANE_SERVICE_AUDIENCE:-}" ]; then
+            echo 'Missing Launchplane service URL or OIDC audience repository variable.' >&2
             exit 1
           fi
 
@@ -81,16 +68,46 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          args=(
-            --product "$PRODUCT"
-            --instance "$INSTANCE"
-            --strategy "$STRATEGY"
-          )
-          if [ "$ALLOW_EMPTY_DATA" = "true" ]; then
-            args+=(--allow-empty-data)
+          oidc_token="$({
+            curl -fsSL \
+              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${LAUNCHPLANE_SERVICE_AUDIENCE}" \
+            | jq -r '.value'
+          })"
+          payload="$({
+            jq -n \
+              --arg product "$PRODUCT" \
+              --arg instance "$INSTANCE" \
+              --arg strategy "$STRATEGY" \
+              --argjson allow_empty_data "$ALLOW_EMPTY_DATA" \
+              '{
+                schema_version: 1,
+                product: $product,
+                replacement: {
+                  schema_version: 1,
+                  product: $product,
+                  instance: $instance,
+                  strategy: $strategy,
+                  allow_empty_data: $allow_empty_data
+                }
+              }'
+          })"
+          status_code="$({
+            curl -sS \
+              -o odoo-target-replacement-plan.json \
+              -w '%{http_code}' \
+              -X POST \
+              -H "Authorization: Bearer ${oidc_token}" \
+              -H 'Content-Type: application/json' \
+              -H "Idempotency-Key: odoo-target-replacement-plan:${PRODUCT}:${INSTANCE}:${STRATEGY}:${ALLOW_EMPTY_DATA}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}" \
+              --data "$payload" \
+              "${LAUNCHPLANE_SERVICE_URL}/v1/drivers/odoo/target-replacement-plan"
+          })"
+          jq . odoo-target-replacement-plan.json
+          if [ "$status_code" != "202" ]; then
+            echo "Launchplane Odoo target replacement plan failed with HTTP ${status_code}." >&2
+            exit 1
           fi
-          uv run launchplane odoo-targets replacement-plan "${args[@]}" \
-            | tee odoo-target-replacement-plan.json
 
       - name: Upload replacement plan
         uses: actions/upload-artifact@v5

--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -543,6 +543,15 @@ ODOO_DRIVER = DriverDescriptor(
             authz_action="odoo_prod_rollback.execute",
             writes_records=("deployment", "promotion", "inventory", "release_tuple"),
         ),
+        _action(
+            "target_replacement_plan",
+            "Plan stable target replacement",
+            "Read Launchplane and provider evidence for a safe Odoo stable target replacement dry-run.",
+            safety="read",
+            scope="instance",
+            route_path="/v1/drivers/odoo/target-replacement-plan",
+            authz_action="odoo_target_replacement_plan.read",
+        ),
     ),
     setting_groups=(
         DriverSettingGroupDescriptor(

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -265,6 +265,11 @@ from control_plane.workflows.odoo_prod_rollback import (
     OdooProdRollbackRequest,
     execute_odoo_prod_rollback,
 )
+from control_plane.workflows.odoo_stable_target_replacement import (
+    OdooStableTargetReplacementStore,
+    OdooStableTargetReplacementRequest,
+    build_odoo_stable_target_replacement_plan,
+)
 from control_plane.workflows.verireel_stable_deploy import (
     VeriReelStableDeployRequest,
     execute_verireel_stable_deploy,
@@ -989,6 +994,27 @@ _ODOO_PROD_ROLLBACK_ROUTE = _DriverRouteExecutionMetadata(
     envelope_model=OdooProdRollbackEnvelope,
     denial_message=(
         "Workflow cannot execute the Odoo prod rollback driver for the requested product/context."
+    ),
+)
+
+
+class OdooTargetReplacementPlanEnvelope(_ProductRouteEnvelope):
+    schema_version: int = Field(default=1, ge=1)
+    replacement: OdooStableTargetReplacementRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "OdooTargetReplacementPlanEnvelope":
+        _validate_driver_envelope_product(self.product, label="Odoo target replacement plan")
+        if self.product.strip() != self.replacement.product.strip():
+            raise ValueError("Odoo target replacement plan requires matching product values.")
+        return self
+
+
+_ODOO_TARGET_REPLACEMENT_PLAN_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/odoo/target-replacement-plan",
+    envelope_model=OdooTargetReplacementPlanEnvelope,
+    denial_message=(
+        "Workflow cannot read the Odoo target replacement plan for the requested product/context."
     ),
 )
 
@@ -7447,6 +7473,42 @@ def create_launchplane_service_app(
                     "rollback_status": driver_result.rollback_status,
                     "rollback_health_status": driver_result.rollback_health_status,
                 }
+            elif path == _ODOO_TARGET_REPLACEMENT_PLAN_ROUTE.route_path:
+                odoo_replacement_plan_request = (
+                    _ODOO_TARGET_REPLACEMENT_PLAN_ROUTE.envelope_model.model_validate(payload)
+                )
+                profile = record_store.read_product_profile_record(
+                    odoo_replacement_plan_request.product
+                )
+                replacement_plan_lane = _find_product_profile_lane(
+                    profile=profile,
+                    context="",
+                    instance=odoo_replacement_plan_request.replacement.instance,
+                )
+                if replacement_plan_lane is None:
+                    raise click.ClickException(
+                        "Odoo target replacement plan requires a known product lane."
+                    )
+                _, authorization_response = _resolve_and_authorize_descriptor_route(
+                    route_metadata=_ODOO_TARGET_REPLACEMENT_PLAN_ROUTE,
+                    record_store=record_store,
+                    authz_policy=authz_policy,
+                    identity=identity,
+                    product=odoo_replacement_plan_request.product,
+                    authorization_context=replacement_plan_lane.context,
+                    descriptor_context=replacement_plan_lane.context,
+                    descriptor_instance=replacement_plan_lane.instance,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if authorization_response is not None:
+                    return authorization_response
+                driver_result = build_odoo_stable_target_replacement_plan(
+                    control_plane_root=resolved_root,
+                    record_store=cast(OdooStableTargetReplacementStore, record_store),
+                    request=odoo_replacement_plan_request.replacement,
+                )
+                result = {}
             elif path == _VERIREEL_TESTING_DEPLOY_ROUTE.route_path:
                 verireel_testing_deploy_request = (
                     _VERIREEL_TESTING_DEPLOY_ROUTE.envelope_model.model_validate(payload)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -692,6 +692,13 @@ uv run launchplane odoo-targets replacement-plan \
   --instance testing
 ```
 
+For live shared targets, prefer the trusted workflow
+`Odoo Target Replacement Plan`. It calls the deployed Launchplane service route
+`POST /v1/drivers/odoo/target-replacement-plan` with GitHub Actions OIDC so the
+service resolves DB-backed records and managed Dokploy secrets inside the normal
+runtime boundary. The local CLI form is for operator debugging from an already
+trusted runtime with `LAUNCHPLANE_DATABASE_URL` configured.
+
 The plan reads the product profile, Launchplane Dokploy target/id records,
 current inventory, live Dokploy target payload, domains, volume env keys, latest
 deployment, and expected runtime identity. It does not create, delete, deploy,

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -92,6 +92,7 @@ VeriReel product paths:
   - `POST /v1/drivers/odoo/artifact-publish-inputs`
   - `POST /v1/drivers/odoo/artifact-publish`
   - `POST /v1/drivers/odoo/post-deploy`
+  - `POST /v1/drivers/odoo/target-replacement-plan`
   - `POST /v1/drivers/odoo/prod-backup-gate`
   - `POST /v1/drivers/odoo/prod-promotion`
   - `POST /v1/drivers/odoo/prod-rollback`

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -98,6 +98,9 @@ from control_plane.workflows.odoo_post_deploy import OdooPostDeployResult
 from control_plane.workflows.odoo_prod_backup_gate import OdooProdBackupGateResult
 from control_plane.workflows.odoo_prod_promotion import OdooProdPromotionResult
 from control_plane.workflows.odoo_prod_rollback import OdooProdRollbackResult
+from control_plane.workflows.odoo_stable_target_replacement import (
+    OdooStableTargetReplacementPlan,
+)
 from control_plane.workflows.generic_web_promotion import GenericWebProdPromotionResult
 from control_plane.workflows.generic_web_promotion_workflow import GenericWebPromotionWorkflowResult
 from control_plane.workflows.generic_web_preview import GenericWebPreviewDestroyResult
@@ -14881,6 +14884,138 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     "product": "odoo",
                     "post_deploy": {
                         "context": "opw",
+                        "instance": "testing",
+                    },
+                },
+            )
+
+            self.assertEqual(status_code, 403)
+            self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_odoo_target_replacement_plan_driver_reads_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/odoo-target-replacement-plan.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["odoo_target_replacement_plan.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-target-replacement-plan.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.build_odoo_stable_target_replacement_plan",
+                return_value=OdooStableTargetReplacementPlan(
+                    plan_status="ready",
+                    product="odoo-tenant-cm",
+                    context="cm",
+                    instance="testing",
+                    strategy="recreate-in-place",
+                    target_record_found=True,
+                    target_id_record_found=True,
+                    inventory_found=True,
+                    expected_next_target_name="cm-testing",
+                ),
+            ) as plan_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/target-replacement-plan",
+                    payload={
+                        "product": "odoo-tenant-cm",
+                        "replacement": {
+                            "product": "odoo-tenant-cm",
+                            "instance": "testing",
+                            "strategy": "recreate-in-place",
+                            "allow_empty_data": True,
+                        },
+                    },
+                )
+
+            self.assertEqual(status_code, 202)
+            self.assertEqual(payload["status"], "accepted")
+            self.assertEqual(payload["result"]["plan_status"], "ready")
+            self.assertEqual(payload["result"]["context"], "cm")
+            plan_mock.assert_called_once()
+            request = plan_mock.call_args.kwargs["request"]
+            self.assertTrue(request.allow_empty_data)
+
+    def test_odoo_target_replacement_plan_driver_rejects_unauthorized_workflow(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-target-replacement-plan.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate(
+                    {
+                        "github_actions": [
+                            {
+                                "repository": "cbusillo/launchplane",
+                                "workflow_refs": [
+                                    "cbusillo/launchplane/.github/workflows/odoo-target-replacement-plan.yml@refs/heads/main"
+                                ],
+                                "event_names": ["workflow_dispatch"],
+                                "products": ["odoo-tenant-cm"],
+                                "contexts": ["cm"],
+                                "actions": ["deployment.write"],
+                            }
+                        ]
+                    }
+                ),
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/odoo/target-replacement-plan",
+                payload={
+                    "product": "odoo-tenant-cm",
+                    "replacement": {
+                        "product": "odoo-tenant-cm",
                         "instance": "testing",
                     },
                 },


### PR DESCRIPTION
## Summary
- add an authenticated Odoo target replacement plan driver route
- update the manual replacement-plan workflow to call Launchplane with OIDC instead of requiring a DB secret
- grant the workflow read authorization during Launchplane deploy and document the service boundary

Refs #520

## Validation
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_odoo_post_deploy_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_post_deploy_driver_rejects_unauthorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_plan_driver_reads_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_plan_driver_rejects_unauthorized_workflow`
- `uv run --extra dev ruff check --diff .github/workflows/deploy-launchplane.yml .github/workflows/odoo-target-replacement-plan.yml control_plane/drivers/registry.py control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/drivers/registry.py control_plane/service.py tests/test_service.py`
- `git diff --check`