### PR TITLE
Add local operator product-config apply path

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -74,6 +74,9 @@ jobs:
       LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN: ${{ secrets.LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN }}
       LAUNCHPLANE_TERMINAL_AGENT_SUBJECT: ${{ vars.LAUNCHPLANE_TERMINAL_AGENT_SUBJECT }}
       LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL: ${{ vars.LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL }}
+      LAUNCHPLANE_LOCAL_OPERATOR_TOKEN: ${{ secrets.LAUNCHPLANE_LOCAL_OPERATOR_TOKEN }}
+      LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT: ${{ vars.LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT }}
+      LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL: ${{ vars.LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL }}
       ODOO_CM_TESTING_DOKPLOY_TARGET_ID: ${{ vars.ODOO_CM_TESTING_DOKPLOY_TARGET_ID }}
       LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST: ${{ secrets.LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST }}
       LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN: ${{ secrets.LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN }}
@@ -250,6 +253,9 @@ jobs:
                 --arg terminal_agent_read_token "${LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN:-}" \
                 --arg terminal_agent_subject "${LAUNCHPLANE_TERMINAL_AGENT_SUBJECT:-}" \
                 --arg terminal_agent_token_label "${LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL:-}" \
+                --arg local_operator_token "${LAUNCHPLANE_LOCAL_OPERATOR_TOKEN:-}" \
+                --arg local_operator_subject "${LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT:-}" \
+                --arg local_operator_token_label "${LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL:-}" \
                 --argjson omit_every_code_env '${{ inputs.omit_every_code_env || false }}' \
                 --argjson omit_terminal_agent_env '${{ inputs.omit_terminal_agent_env != false }}' \
                 '(
@@ -266,7 +272,10 @@ jobs:
                       {
                         LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN: $terminal_agent_read_token,
                         LAUNCHPLANE_TERMINAL_AGENT_SUBJECT: $terminal_agent_subject,
-                        LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL: $terminal_agent_token_label
+                        LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL: $terminal_agent_token_label,
+                        LAUNCHPLANE_LOCAL_OPERATOR_TOKEN: $local_operator_token,
+                        LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT: $local_operator_subject,
+                        LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL: $local_operator_token_label
                       }
                     else
                       {}

--- a/control_plane/product_config_http.py
+++ b/control_plane/product_config_http.py
@@ -9,7 +9,11 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from control_plane import product_config as control_plane_product_config
 from control_plane import product_config_service as control_plane_product_config_service
 from control_plane.product_config import ProductConfigStore
-from control_plane.service_auth import LaunchplaneAuthzPolicy, LaunchplaneIdentity
+from control_plane.service_auth import (
+    LaunchplaneAuthzPolicy,
+    LaunchplaneIdentity,
+    LocalOperatorIdentity,
+)
 
 
 JsonResponse = Callable[..., list[bytes]]
@@ -25,6 +29,7 @@ class ProductConfigApplyEnvelope(BaseModel):
     context: str = ""
     instance: str = ""
     source_label: str = "product-config-api"
+    reason: str = ""
     runtime_env: dict[str, object] | None = None
     runtime_environment: dict[str, object] | None = None
     secrets: list[dict[str, object]] = Field(default_factory=list)
@@ -43,6 +48,7 @@ class ProductConfigApplyEnvelope(BaseModel):
         self.context = self.context.strip()
         self.instance = self.instance.strip()
         self.source_label = self.source_label.strip() or "product-config-api"
+        self.reason = self.reason.strip()
         if not self.product:
             raise ValueError("Product config apply requires product.")
         return self
@@ -77,6 +83,19 @@ def validate_product_config_apply_request(
     start_response: StartResponse,
 ) -> tuple[ProductConfigApplyEnvelope | None, list[bytes] | None]:
     request = ProductConfigApplyEnvelope.model_validate(payload)
+    if isinstance(identity, LocalOperatorIdentity) and not request.reason:
+        return None, json_response(
+            start_response=start_response,
+            status_code=400,
+            payload={
+                "status": "rejected",
+                "trace_id": trace_id,
+                "error": {
+                    "code": "reason_required",
+                    "message": "Local operator product-config requests require a reason.",
+                },
+            },
+        )
     action = "product_config.apply" if request.mode == "apply" else "product_config.plan"
     if authz_policy.allows(
         identity=identity,

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -143,6 +143,7 @@ from control_plane.service_auth import (
     GitHubHumanIdentity,
     LaunchplaneAuthzPolicy,
     LaunchplaneIdentity,
+    LocalOperatorIdentity,
     TerminalAgentIdentity,
     TokenVerifier,
     agent_authz_audit,
@@ -352,6 +353,8 @@ class MergeTrainAdmissionEnvelope(BaseModel):
         if not self.base_branch:
             raise ValueError("merge train admission requires base_branch")
         return self
+
+
 _GITHUB_CLOSING_REFERENCE_PATTERN = re.compile(
     r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+([^\n\r]+)", re.IGNORECASE
 )
@@ -2062,7 +2065,9 @@ class _EveryCodeWorkRequestStore(Protocol):
         offset: int = 0,
     ) -> tuple[EveryCodePrFeedbackRecord, ...]: ...
 
-    def write_every_code_preview_gate_record(self, record: EveryCodePreviewGateRecord) -> object: ...
+    def write_every_code_preview_gate_record(
+        self, record: EveryCodePreviewGateRecord
+    ) -> object: ...
 
     def list_every_code_preview_gate_records(
         self,
@@ -2689,7 +2694,9 @@ def _handle_every_code_preview_validation_webhook(
         return None
     accepted_payload = _accepted_payload(
         trace_id=trace_id,
-        result={"preview_validation": {key: value for key, value in result.items() if key != "handled"}},
+        result={
+            "preview_validation": {key: value for key, value in result.items() if key != "handled"}
+        },
         driver_result={"preview_validation": dict(result)},
     )
     if bool(result.get("skipped")):
@@ -3070,6 +3077,8 @@ def _idempotency_key(environ: dict[str, object]) -> str:
 def _identity_actor(identity: LaunchplaneIdentity) -> str:
     if isinstance(identity, GitHubHumanIdentity):
         return f"github:{identity.login}"
+    if isinstance(identity, LocalOperatorIdentity):
+        return f"local-operator:{identity.subject}"
     if isinstance(identity, TerminalAgentIdentity):
         return f"terminal-agent:{identity.subject}"
     return (
@@ -3080,6 +3089,8 @@ def _identity_actor(identity: LaunchplaneIdentity) -> str:
 def _idempotency_scope(identity: LaunchplaneIdentity) -> str:
     if isinstance(identity, GitHubHumanIdentity):
         return "|".join(("github-human", identity.login, str(identity.github_id)))
+    if isinstance(identity, LocalOperatorIdentity):
+        return "|".join(("local-operator", identity.subject, identity.token_label))
     if isinstance(identity, TerminalAgentIdentity):
         return "|".join(("terminal-agent", identity.subject, identity.token_label))
     workflow_ref = identity.workflow_ref or identity.job_workflow_ref or ""
@@ -3112,6 +3123,22 @@ def _canonical_request_payload_for_idempotency(
 def _idempotency_request_fingerprint(*, route_path: str, payload: dict[str, object]) -> str:
     return _request_fingerprint(
         _canonical_request_payload_for_idempotency(route_path=route_path, payload=payload)
+    )
+
+
+def _local_operator_product_config_continuity_payload(
+    *, payload: dict[str, object]
+) -> dict[str, object]:
+    canonical_payload = json.loads(json.dumps(payload))
+    if isinstance(canonical_payload, dict):
+        canonical_payload.pop("mode", None)
+        canonical_payload.pop("reason", None)
+    return cast(dict[str, object], canonical_payload)
+
+
+def _local_operator_product_config_dry_run_key(*, payload: dict[str, object]) -> str:
+    return "local-operator-product-config-dry-run:" + _request_fingerprint(
+        _local_operator_product_config_continuity_payload(payload=payload)
     )
 
 
@@ -3282,6 +3309,44 @@ def _write_idempotency_record(
     )
 
 
+def _write_local_operator_product_config_dry_run_record(
+    *,
+    record_store: object,
+    scope: str,
+    request_payload: dict[str, object],
+    response_trace_id: str,
+    response_payload: dict[str, object],
+) -> None:
+    _write_idempotency_record(
+        record_store=record_store,
+        scope=scope,
+        route_path="/v1/product-config/apply",
+        idempotency_key=_local_operator_product_config_dry_run_key(payload=request_payload),
+        request_fingerprint=_request_fingerprint(
+            _local_operator_product_config_continuity_payload(payload=request_payload)
+        ),
+        response_status_code=202,
+        response_trace_id=f"{response_trace_id}-local-operator-dry-run",
+        response_payload=response_payload,
+    )
+
+
+def _local_operator_product_config_dry_run_exists(
+    *, record_store: object, scope: str, request_payload: dict[str, object]
+) -> bool:
+    stored_record = _read_idempotency_record(
+        record_store=record_store,
+        scope=scope,
+        route_path="/v1/product-config/apply",
+        idempotency_key=_local_operator_product_config_dry_run_key(payload=request_payload),
+    )
+    if stored_record is None:
+        return False
+    return stored_record.request_fingerprint == _request_fingerprint(
+        _local_operator_product_config_continuity_payload(payload=request_payload)
+    )
+
+
 def _check_idempotent_request(
     *,
     record_store: object,
@@ -3420,8 +3485,37 @@ def _terminal_agent_token_label_from_env() -> str:
     return os.environ.get("LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL", "local-owner-read").strip()
 
 
+def _local_operator_token_from_env() -> str:
+    return os.environ.get("LAUNCHPLANE_LOCAL_OPERATOR_TOKEN", "").strip()
+
+
+def _local_operator_subject_from_env() -> str:
+    return os.environ.get("LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT", "local-owner-agent").strip()
+
+
+def _local_operator_token_label_from_env() -> str:
+    return os.environ.get("LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL", "local-owner-write").strip()
+
+
+def _local_operator_identity_from_bearer(
+    environ: dict[str, object],
+) -> LocalOperatorIdentity | None:
+    expected_token = _local_operator_token_from_env()
+    if not expected_token:
+        return None
+    try:
+        provided_token = _bearer_token(environ)
+    except PermissionError:
+        return None
+    if not secrets.compare_digest(provided_token, expected_token):
+        return None
+    subject = _local_operator_subject_from_env() or "local-owner-agent"
+    token_label = _local_operator_token_label_from_env() or "local-owner-write"
+    return LocalOperatorIdentity(subject=subject, token_label=token_label)
+
+
 def _terminal_agent_identity_from_bearer(
-    environ: dict[str, object]
+    environ: dict[str, object],
 ) -> TerminalAgentIdentity | None:
     expected_token = _terminal_agent_read_token_from_env()
     if not expected_token:
@@ -3811,6 +3905,9 @@ def _read_identity(
     human_identity = _session_identity(environ=environ, session_manager=session_manager)
     if human_identity is not None:
         return human_identity
+    local_operator_identity = _local_operator_identity_from_bearer(environ)
+    if local_operator_identity is not None:
+        return local_operator_identity
     terminal_agent_identity = _terminal_agent_identity_from_bearer(environ)
     if terminal_agent_identity is not None:
         return terminal_agent_identity
@@ -3854,6 +3951,12 @@ def _authz_diagnostic_payload(
     elif isinstance(identity, TerminalAgentIdentity):
         identity_payload = {
             "type": "terminal_agent",
+            "subject": identity.subject,
+            "token_label": identity.token_label,
+        }
+    elif isinstance(identity, LocalOperatorIdentity):
+        identity_payload = {
+            "type": "local_operator",
             "subject": identity.subject,
             "token_label": identity.token_label,
         }
@@ -5715,9 +5818,7 @@ def create_launchplane_service_app(
                                     },
                                 },
                             )
-                        repository_filter = str(
-                            (query.get("repository") or [""])[0] or ""
-                        ).strip()
+                        repository_filter = str((query.get("repository") or [""])[0] or "").strip()
                         agent_context = build_agent_context_service_payload(
                             generated_at=_utc_now_timestamp(),
                             repository=repository_filter,
@@ -5975,9 +6076,7 @@ def create_launchplane_service_app(
                     repository=merge_train_request.repository,
                     base_branch=merge_train_request.base_branch,
                 )
-                dry_run_result = build_merge_train_dry_run_result(
-                    policy=policy, snapshot=snapshot
-                )
+                dry_run_result = build_merge_train_dry_run_result(policy=policy, snapshot=snapshot)
                 result = {
                     "repository": merge_train_request.repository,
                     "base_branch": merge_train_request.base_branch,
@@ -6012,9 +6111,7 @@ def create_launchplane_service_app(
                 result["merge_train_run_id"] = run_record.run_id
             elif path == "/v1/agent/write-intents/evaluate":
                 intent_request = AgentWriteIntentRequest.model_validate(payload)
-                intent_authz_action = authz_action_for_agent_write_intent(
-                    intent_request.intent
-                )
+                intent_authz_action = authz_action_for_agent_write_intent(intent_request.intent)
                 authorized = authz_policy.allows(
                     identity=identity,
                     action=intent_authz_action,
@@ -6289,6 +6386,29 @@ def create_launchplane_service_app(
                 if product_config_response is not None:
                     return product_config_response
                 assert product_config_request is not None
+                if (
+                    isinstance(identity, LocalOperatorIdentity)
+                    and product_config_request.mode == "apply"
+                    and not _local_operator_product_config_dry_run_exists(
+                        record_store=record_store,
+                        scope=request_scope,
+                        request_payload=payload,
+                    )
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=409,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "matching_dry_run_required",
+                                "message": (
+                                    "Local operator product-config apply requires a prior matching dry-run."
+                                ),
+                            },
+                        },
+                    )
                 idempotent_response = _check_idempotent_request(
                     record_store=record_store,
                     scope=request_scope,
@@ -6317,6 +6437,21 @@ def create_launchplane_service_app(
                 if not isinstance(product_config_result, ProductConfigRouteResult):
                     return product_config_result
                 driver_result = product_config_result.driver_result
+                if (
+                    isinstance(identity, LocalOperatorIdentity)
+                    and product_config_request.mode == "dry-run"
+                ):
+                    _write_local_operator_product_config_dry_run_record(
+                        record_store=record_store,
+                        scope=request_scope,
+                        request_payload=payload,
+                        response_trace_id=request_trace_id,
+                        response_payload=_accepted_payload(
+                            trace_id=request_trace_id,
+                            result=result,
+                            driver_result=driver_result,
+                        ),
+                    )
             elif path == "/v1/authz-policies/github-actions/grants":
                 authz_grant_request = control_plane_authz_grant_service.AuthzPolicyGitHubActionsGrantEnvelope.model_validate(
                     payload

--- a/control_plane/service_auth.py
+++ b/control_plane/service_auth.py
@@ -46,8 +46,18 @@ class TerminalAgentIdentity:
     token_label: str
 
 
-LaunchplaneIdentity = GitHubActionsIdentity | GitHubHumanIdentity | TerminalAgentIdentity
-AgentConsumerSubjectType = Literal["github_actions", "github_human", "terminal_agent"]
+@dataclass(frozen=True)
+class LocalOperatorIdentity:
+    subject: str
+    token_label: str
+
+
+LaunchplaneIdentity = (
+    GitHubActionsIdentity | GitHubHumanIdentity | TerminalAgentIdentity | LocalOperatorIdentity
+)
+AgentConsumerSubjectType = Literal[
+    "github_actions", "github_human", "terminal_agent", "local_operator"
+]
 AgentConsumerAccessProfile = Literal[
     "automation_worker",
     "human_admin",
@@ -269,7 +279,7 @@ class AgentConsumerSubject(BaseModel):
     subject: str
     display_label: str
     access_profile: AgentConsumerAccessProfile
-    role: Literal["read_only", "admin", "worker"] = "read_only"
+    role: Literal["read_only", "admin", "worker", "operator"] = "read_only"
     product: str = ""
     context: str = ""
     action: str = ""
@@ -348,6 +358,20 @@ def agent_consumer_subject(
             read_only_context=True,
             approval_capable=False,
         )
+    if isinstance(identity, LocalOperatorIdentity):
+        return AgentConsumerSubject(
+            subject_type="local_operator",
+            subject=identity.subject,
+            display_label=identity.token_label,
+            access_profile="owner_local_agent",
+            role="operator",
+            product=product,
+            context=context,
+            action=action,
+            action_safety=safety,
+            read_only_context=safety == "read",
+            approval_capable=safety in {"mutation", "prod", "destructive", "secret_backed"},
+        )
     return AgentConsumerSubject(
         subject_type="github_actions",
         subject=identity.subject or identity.workflow_ref,
@@ -359,7 +383,8 @@ def agent_consumer_subject(
         action=action,
         action_safety=safety,
         read_only_context=safety == "read",
-        approval_capable=safety in {"mutation", "prod", "destructive", "secret_backed", "policy_admin"},
+        approval_capable=safety
+        in {"mutation", "prod", "destructive", "secret_backed", "policy_admin"},
     )
 
 
@@ -414,6 +439,8 @@ class LaunchplaneAuthzPolicy(BaseModel):
                 rule.allows(identity=identity, action=action, product=product, context=context)
                 for rule in self.terminal_agents
             )
+        if isinstance(identity, LocalOperatorIdentity):
+            return action_safety(action) != "policy_admin"
         return any(
             rule.allows(identity=identity, action=action, product=product, context=context)
             for rule in self.github_actions

--- a/docs/agent-context-boundary.md
+++ b/docs/agent-context-boundary.md
@@ -35,6 +35,12 @@ Agent context callers are identified as compact agent consumers:
 - `owner_local_agent`: trusted local terminal agent using
   `LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN`. The service admits this identity only
   on `GET` routes; policy still scopes products, contexts, and read actions.
+- `owner_local_agent`: trusted local operator using
+  `LAUNCHPLANE_LOCAL_OPERATOR_TOKEN` from
+  `~/.config/launchplane/local-operator.env`. This identity can submit
+  reason-bearing Launchplane mutations such as product-config dry-run/apply from
+  a trusted shell; product-config apply requires a previously recorded matching
+  dry-run, and authz policy administration remains out of scope.
 - `limited_remote_user`: authenticated GitHub human with read-only role. This
   profile fails closed to read and safe-write action families even if a policy
   rule is accidentally broad.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -438,13 +438,18 @@ Current derived-state behavior:
   authenticated service API for operator UI use. Submit `mode: "dry-run"` to
   preview with `product_config.plan`, then `mode: "apply"` with
   `product_config.apply` after review. Signed-in GitHub human operators can use
-  this route when their session has the exact product/context/action grant;
-  terminal-agent bearer credentials stay read-only and cannot apply product
-  config. The service response is redacted and the route rejects nested runtime
-  or secret targets that differ from the authorized top-level context/instance.
-  It fails closed when secret writes are requested without the Launchplane master
-  encryption key in the service runtime or when no active runtime key-safety
-  policy allows the requested binding.
+  this route when their session has the exact product/context/action grant.
+  Trusted owner terminals can also use the dedicated
+  `LAUNCHPLANE_LOCAL_OPERATOR_TOKEN` from
+  `~/.config/launchplane/local-operator.env`; local-operator requests must
+  include a non-empty `reason`, and local-operator apply is rejected until the
+  service has recorded a matching local-operator dry-run. Terminal-agent read
+  bearer credentials stay read-only and cannot apply product config. The service
+  response is redacted and the route rejects nested runtime or secret targets
+  that differ from the authorized top-level context/instance. It fails closed
+  when secret writes are requested without the Launchplane master encryption key
+  in the service runtime or when no active runtime key-safety policy allows the
+  requested binding.
 - The operator UI uses the same service route. It requires a successful dry-run
   result before enabling apply, clears rendered secret input values after each
   submit, and shows only key/action/count metadata from Launchplane responses.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -158,6 +158,13 @@ title: Secrets
   before any managed secret write starts. Runtime-environment secret bundles
   also require an active runtime key-safety policy that allows each requested
   binding for the target runtime class.
+- Trusted local agents that need to call the deployed service instead of a
+  browser session should source `~/.config/launchplane/local-operator.env` and
+  use `LAUNCHPLANE_LOCAL_OPERATOR_TOKEN`. Product-config requests sent with this
+  token must include a reason, and apply requires a previously recorded matching
+  dry-run. They must still send plaintext secret values only in the request body
+  over the Launchplane service API. Do not copy those request bodies into logs,
+  GitHub issues, PR bodies, or docs.
 - `uv run launchplane environments unset --scope <scope> --key KEY` removes
   stale keys from DB-backed runtime-environment records without reading or
   printing plaintext values.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -170,6 +170,22 @@ Policy still scopes which redacted read actions and product/context pairs the
 agent can access, such as `product_environment.read` for product environment and
 config-status diagnostics.
 
+Trusted owner terminals that need to make Launchplane-owned product config
+changes can use a separate local-operator bearer credential instead of a
+browser OAuth session. Configure `LAUNCHPLANE_LOCAL_OPERATOR_TOKEN` on the
+service and provide the same secret to trusted local agents through
+`~/.config/launchplane/local-operator.env`. Optional
+`LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT` and
+`LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL` values identify the actor in audit and
+idempotency records; the defaults are `local-owner-agent` and
+`local-owner-write`. Local-operator product-config requests must include a
+non-empty `reason`; apply is rejected until the service has recorded a matching
+local-operator dry-run for the same product config payload. These requests still
+use Launchplane records, redacted responses, runtime key-safety policy, and
+managed secret storage. The local-operator identity is not accepted for authz
+policy administration, so the credential cannot rewrite its own permission
+model.
+
 `GET /v1/every-code/summary` returns a compact agent-safe projection of Every
 Code work requests. It requires `every_code_work_request.read` for
 product/context `launchplane` and supports `repository`, `issue_number`,
@@ -465,6 +481,10 @@ subject model before diagnostics or downstream intent contracts consume them:
   read bearer token. These subjects are always read-only context consumers and
   cannot use POST routes, product mutations, authz policy changes, destructive
   cleanup, or secret-backed actions even if a policy rule is too broad.
+- `local_operator`: trusted owner terminal agents authenticated by the dedicated
+  write bearer token. These subjects can use Launchplane mutation routes such as
+  product-config apply from a trusted shell with a required reason, but cannot
+  administer authz policy.
 - `github_human`: browser-session humans with `read_only` or `admin` role from
   GitHub human policy rules or bootstrap admin email matching. Read-only humans
   are `limited_remote_user` consumers: even if a rule is accidentally broad,
@@ -562,9 +582,12 @@ Product config writes use `POST /v1/product-config/apply`. The request carries
 `mode: "dry-run"` or `mode: "apply"`, product/context/instance, non-secret
 runtime values, and write-only managed secret values. Dry-run requires the
 `product_config.plan` action; apply requires `product_config.apply`. The route
-accepts GitHub Actions OIDC callers and signed-in GitHub human sessions, but
-terminal-agent bearer credentials remain read-only and cannot execute the
-mutation. The route authorizes the top-level product/context/instance target and
+accepts GitHub Actions OIDC callers, signed-in GitHub human sessions, and the
+dedicated local-operator bearer credential with a non-empty `reason`, but
+terminal-agent read bearer credentials remain read-only and cannot execute the
+mutation. Local-operator apply requests additionally require a previously
+recorded matching local-operator dry-run. The route authorizes the top-level
+product/context/instance target and
 rejects nested runtime or secret targets that try to broaden or change that
 authorized target. It reuses the same planner/writer as
 `launchplane product-config apply`, returns only actions, keys, counts,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -29,7 +29,9 @@ from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFee
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
-from control_plane.contracts.merge_train_policy import build_sellyouroutboard_main_merge_train_policy
+from control_plane.contracts.merge_train_policy import (
+    build_sellyouroutboard_main_merge_train_policy,
+)
 from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
 from control_plane.contracts.merge_train_run_record import build_merge_train_run_record
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
@@ -620,8 +622,10 @@ def _product_config_payload() -> dict[str, object]:
     }
 
 
-def _meta_product_config_payload(*, mode: str = "dry-run") -> dict[str, object]:
-    return {
+def _meta_product_config_payload(
+    *, mode: str = "dry-run", reason: str | None = None
+) -> dict[str, object]:
+    payload: dict[str, object] = {
         "schema_version": 1,
         "mode": mode,
         "product": "sellyouroutboard",
@@ -644,6 +648,9 @@ def _meta_product_config_payload(*, mode: str = "dry-run") -> dict[str, object]:
             }
         ],
     }
+    if reason is not None:
+        payload["reason"] = reason
+    return payload
 
 
 def _github_webhook_signature(payload: Mapping[str, object], secret: str) -> str:
@@ -1433,9 +1440,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     app,
                     method="GET",
                     path="/v1/work-graph/merge-train/admission",
-                    query_string=(
-                        "repository=cbusillo/sellyouroutboard&base_branch=main"
-                    ),
+                    query_string=("repository=cbusillo/sellyouroutboard&base_branch=main"),
                 )
 
         self.assertEqual(status_code, 200)
@@ -2816,8 +2821,12 @@ class LaunchplaneServiceTests(unittest.TestCase):
         preview_validation = ok_response["result"]["preview_validation"]
         self.assertEqual(preview_validation["command"], "ok")
         self.assertEqual(preview_validation["merge_owner"], "cbusillo")
-        self.assertEqual(github_request.call_args_list[3].kwargs["body"], {"labels": ["ready-to-merge"]})
-        self.assertEqual(github_request.call_args_list[5].kwargs["body"], {"assignees": ["cbusillo"]})
+        self.assertEqual(
+            github_request.call_args_list[3].kwargs["body"], {"labels": ["ready-to-merge"]}
+        )
+        self.assertEqual(
+            github_request.call_args_list[5].kwargs["body"], {"assignees": ["cbusillo"]}
+        )
         create_comment.assert_called_once()
         self.assertIn("@cbusillo", create_comment.call_args.kwargs["body"])
 
@@ -3725,7 +3734,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(write_status, 202, write_response)
         self.assertEqual(write_response["records"]["feedback_id"], feedback_record.feedback_id)
-        self.assertEqual(write_response["result"]["feedback"]["feedback_id"], feedback_record.feedback_id)
+        self.assertEqual(
+            write_response["result"]["feedback"]["feedback_id"], feedback_record.feedback_id
+        )
         self.assertEqual(list_status, 200, list_response)
         self.assertEqual(len(list_response["feedback"]), 1)
         self.assertEqual(list_response["feedback"][0]["feedback_id"], feedback_record.feedback_id)
@@ -4988,9 +4999,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         sections = payload["context"]["sections"]
         self.assertEqual(sections["repo_product_mapping"]["status"], "available")
         self.assertEqual(sections["work_graph_snapshot"]["status"], "unavailable")
-        self.assertEqual(
-            sections["work_graph_snapshot"]["reason_code"], "work_graph_unavailable"
-        )
+        self.assertEqual(sections["work_graph_snapshot"]["reason_code"], "work_graph_unavailable")
         self.assertEqual(sections["every_code_summary"]["status"], "available")
 
     def test_health_endpoint_reports_storage_backend(self) -> None:
@@ -5897,8 +5906,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             item["key"]: item["status"] for item in config_status["runtime_settings"]
         }
         secret_statuses = {
-            item["binding_key"]: item["status"]
-            for item in config_status["managed_secrets"]
+            item["binding_key"]: item["status"] for item in config_status["managed_secrets"]
         }
         self.assertEqual(
             runtime_statuses,
@@ -6571,9 +6579,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertTrue(payload["authz"]["agent_consumer"]["read_only_context"])
         self.assertFalse(payload["authz"]["agent_consumer"]["approval_capable"])
         self.assertEqual(payload["authz"]["agent_audit"]["decision"], "denied")
-        self.assertEqual(
-            payload["authz"]["agent_audit"]["reason_code"], "authorization_denied"
-        )
+        self.assertEqual(payload["authz"]["agent_audit"]["reason_code"], "authorization_denied")
         self.assertEqual(payload["authz"]["agent_audit"]["subject"]["action_safety"], "read")
         self.assertEqual(payload["authz"]["policy_source"], "bootstrap_seeded_store")
 
@@ -6670,7 +6676,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(intent["audit"]["subject"]["action_safety"], "safe_write")
         self.assertEqual(record.evaluation.status, "allowed")
         self.assertEqual(record.evaluation.intent, "every_code_rerun")
-        self.assertEqual(record.request.source_url, "https://github.com/cbusillo/launchplane/issues/386")
+        self.assertEqual(
+            record.request.source_url, "https://github.com/cbusillo/launchplane/issues/386"
+        )
         self.assertEqual(record.trace_id, payload["trace_id"])
 
     def test_agent_write_intent_evaluate_denies_ungranted_intent(self) -> None:
@@ -7512,6 +7520,208 @@ class LaunchplaneServiceTests(unittest.TestCase):
             payload["error"]["message"],
             "Terminal agent credentials can only read redacted Launchplane context.",
         )
+
+    def test_product_config_api_local_operator_dry_run_returns_redacted_meta_plan(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            _write_runtime_key_safety_policy(
+                database_url=database_url,
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key="META_CONVERSIONS_API_TOKEN",
+                        secret_class="prod_only",
+                        allowed_contexts=("sellyouroutboard",),
+                        allowed_instances=("prod",),
+                    ),
+                ),
+            )
+
+            with patch.dict(
+                os.environ,
+                {
+                    control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
+                },
+                clear=True,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/product-config/apply",
+                    payload=_meta_product_config_payload(
+                        reason="Dry-run SellYourOutBoard Meta config from terminal operator."
+                    ),
+                    authorization="Bearer local-operator-token",
+                    headers={"Idempotency-Key": "product-config-local-operator-dry-run"},
+                )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                runtime_records = store.list_runtime_environment_records()
+                secret_records = store.list_secret_records()
+            finally:
+                store.close()
+
+        response_text = json.dumps(payload, sort_keys=True)
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "dry-run")
+        self.assertEqual(payload["result"]["runtime_environment"]["action"], "created")
+        self.assertEqual(payload["result"]["secrets"][0]["action"], "created")
+        self.assertNotIn("123456789012345", response_text)
+        self.assertNotIn("meta-conversions-api-secret-value", response_text)
+        self.assertEqual(runtime_records, ())
+        self.assertEqual(secret_records, ())
+
+    def test_product_config_api_local_operator_apply_requires_reason(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            with patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token"},
+                clear=True,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/product-config/apply",
+                    payload=_meta_product_config_payload(mode="apply"),
+                    authorization="Bearer local-operator-token",
+                    headers={"Idempotency-Key": "product-config-local-operator-no-reason"},
+                )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "reason_required")
+
+    def test_product_config_api_local_operator_apply_requires_matching_dry_run(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            with patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token"},
+                clear=True,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/product-config/apply",
+                    payload=_meta_product_config_payload(
+                        mode="apply",
+                        reason="Apply reviewed SellYourOutBoard Meta config from terminal operator.",
+                    ),
+                    authorization="Bearer local-operator-token",
+                    headers={"Idempotency-Key": "product-config-local-operator-no-dry-run"},
+                )
+
+        self.assertEqual(status_code, 409)
+        self.assertEqual(payload["error"]["code"], "matching_dry_run_required")
+
+    def test_product_config_api_local_operator_apply_writes_meta_config_after_dry_run(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            _write_runtime_key_safety_policy(
+                database_url=database_url,
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key="META_CONVERSIONS_API_TOKEN",
+                        secret_class="prod_only",
+                        allowed_contexts=("sellyouroutboard",),
+                        allowed_instances=("prod",),
+                    ),
+                ),
+            )
+
+            with patch.dict(
+                os.environ,
+                {
+                    control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
+                },
+                clear=True,
+            ):
+                dry_run_status_code, dry_run_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/product-config/apply",
+                    payload=_meta_product_config_payload(
+                        reason="Dry-run SellYourOutBoard Meta config from terminal operator."
+                    ),
+                    authorization="Bearer local-operator-token",
+                    headers={"Idempotency-Key": "product-config-local-operator-apply-dry-run"},
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/product-config/apply",
+                    payload=_meta_product_config_payload(
+                        mode="apply",
+                        reason="Apply reviewed SellYourOutBoard Meta config from terminal operator.",
+                    ),
+                    authorization="Bearer local-operator-token",
+                    headers={"Idempotency-Key": "product-config-local-operator-apply"},
+                )
+                store = PostgresRecordStore(database_url=database_url)
+                store.ensure_schema()
+                try:
+                    runtime_records = store.list_runtime_environment_records()
+                    secret_records = store.list_secret_records()
+                    secret_binding = store.list_secret_bindings(limit=None)[0]
+                finally:
+                    store.close()
+
+        response_text = json.dumps(payload, sort_keys=True)
+        self.assertEqual(dry_run_status_code, 202)
+        self.assertEqual(dry_run_payload["result"]["mode"], "dry-run")
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "apply")
+        self.assertEqual(payload["result"]["runtime_environment"]["action"], "created")
+        self.assertEqual(payload["result"]["secrets"][0]["action"], "created")
+        self.assertNotIn("123456789012345", response_text)
+        self.assertNotIn("meta-conversions-api-secret-value", response_text)
+        self.assertEqual(len(runtime_records), 1)
+        self.assertEqual(runtime_records[0].env["NEXT_PUBLIC_META_PIXEL_ID"], "123456789012345")
+        self.assertEqual(len(secret_records), 1)
+        self.assertEqual(secret_records[0].name, "META_CONVERSIONS_API_TOKEN")
+        self.assertEqual(secret_binding.binding_key, "META_CONVERSIONS_API_TOKEN")
 
     def test_product_config_api_rejects_missing_master_key_for_secret_bundle(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -9311,8 +9521,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     _identity(
                         repository="cbusillo/odoo-tenant-cm",
                         workflow_ref=(
-                            "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml"
-                            "@refs/heads/main"
+                            "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
                         ),
                     )
                 ),
@@ -9379,8 +9588,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     _identity(
                         repository="cbusillo/odoo-tenant-cm",
                         workflow_ref=(
-                            "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml"
-                            "@refs/heads/main"
+                            "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
                         ),
                     )
                 ),
@@ -11138,13 +11346,12 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 202)
         self.assertEqual(payload["result"]["changed"], True)
-        self.assertEqual(
-            payload["result"]["diff"]["new_github_humans_rule_count"], 2
+        self.assertEqual(payload["result"]["diff"]["new_github_humans_rule_count"], 2)
+        self.assertEqual(payload["result"]["audit"]["requested_grant_summary"]["login_count"], 1)
+        self.assertNotIn(
+            "alice",
+            json.dumps(payload["result"]["audit"]["requested_grant_summary"], sort_keys=True),
         )
-        self.assertEqual(
-            payload["result"]["audit"]["requested_grant_summary"]["login_count"], 1
-        )
-        self.assertNotIn("alice", json.dumps(payload["result"]["audit"]["requested_grant_summary"], sort_keys=True))
         self.assertEqual(repeat_status_code, 202)
         self.assertEqual(repeat_payload["result"]["changed"], False)
         self.assertTrue(
@@ -11347,12 +11554,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 202)
         self.assertEqual(payload["result"]["changed"], True)
-        self.assertEqual(
-            payload["result"]["diff"]["new_terminal_agents_rule_count"], 1
-        )
-        self.assertEqual(
-            payload["result"]["audit"]["requested_grant_summary"]["subject_count"], 1
-        )
+        self.assertEqual(payload["result"]["diff"]["new_terminal_agents_rule_count"], 1)
+        self.assertEqual(payload["result"]["audit"]["requested_grant_summary"]["subject_count"], 1)
         self.assertNotIn(
             "local-owner-agent",
             json.dumps(payload["result"]["audit"]["requested_grant_summary"], sort_keys=True),
@@ -14216,12 +14419,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["authz"]["request"]["product"], "verireel")
         self.assertEqual(payload["authz"]["request"]["context"], "verireel-testing")
         self.assertEqual(payload["authz"]["agent_audit"]["decision"], "denied")
-        self.assertEqual(
-            payload["authz"]["agent_audit"]["reason_code"], "authorization_denied"
-        )
-        self.assertEqual(
-            payload["authz"]["agent_audit"]["subject"]["action_safety"], "safe_write"
-        )
+        self.assertEqual(payload["authz"]["agent_audit"]["reason_code"], "authorization_denied")
+        self.assertEqual(payload["authz"]["agent_audit"]["subject"]["action_safety"], "safe_write")
         self.assertEqual(payload["authz"]["agent_audit"]["source_kind"], "authz_policy")
         self.assertIn("policy_sha256", payload["authz"])
         self.assertIn("policy_source", payload["authz"])

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -14,6 +14,7 @@ from control_plane.service_auth import (
     GitHubHumanPolicyRule,
     GitHubOidcVerifier,
     LaunchplaneAuthzPolicy,
+    LocalOperatorIdentity,
     TerminalAgentIdentity,
     TerminalAgentPolicyRule,
     action_safety,
@@ -89,6 +90,18 @@ def _terminal_agent_identity(**overrides: object) -> TerminalAgentIdentity:
     }
     values.update(overrides)
     return TerminalAgentIdentity(
+        subject=str(values["subject"]),
+        token_label=str(values["token_label"]),
+    )
+
+
+def _local_operator_identity(**overrides: object) -> LocalOperatorIdentity:
+    values: dict[str, object] = {
+        "subject": "local-owner-agent",
+        "token_label": "local-owner-write",
+    }
+    values.update(overrides)
+    return LocalOperatorIdentity(
         subject=str(values["subject"]),
         token_label=str(values["token_label"]),
     )
@@ -182,6 +195,23 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
         self.assertEqual(subject.action_safety, "read")
         self.assertTrue(subject.read_only_context)
         self.assertFalse(subject.approval_capable)
+
+    def test_agent_consumer_subject_classifies_local_operator_as_approval_capable(
+        self,
+    ) -> None:
+        subject = agent_consumer_subject(
+            identity=_local_operator_identity(),
+            action="product_config.apply",
+            product="sellyouroutboard",
+            context="sellyouroutboard",
+        )
+
+        self.assertEqual(subject.subject_type, "local_operator")
+        self.assertEqual(subject.access_profile, "owner_local_agent")
+        self.assertEqual(subject.role, "operator")
+        self.assertEqual(subject.action_safety, "mutation")
+        self.assertFalse(subject.read_only_context)
+        self.assertTrue(subject.approval_capable)
 
     def test_agent_consumer_subject_classifies_human_admin_as_approval_capable(self) -> None:
         subject = agent_consumer_subject(
@@ -483,11 +513,35 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
             )
         )
         denied_cases = (
-            ("subject", _terminal_agent_identity(subject="other-agent"), "sellyouroutboard", "sellyouroutboard-testing", "product_environment.read"),
-            ("token_label", _terminal_agent_identity(token_label="write-token"), "sellyouroutboard", "sellyouroutboard-testing", "product_environment.read"),
-            ("product", identity, "other-product", "sellyouroutboard-testing", "product_environment.read"),
+            (
+                "subject",
+                _terminal_agent_identity(subject="other-agent"),
+                "sellyouroutboard",
+                "sellyouroutboard-testing",
+                "product_environment.read",
+            ),
+            (
+                "token_label",
+                _terminal_agent_identity(token_label="write-token"),
+                "sellyouroutboard",
+                "sellyouroutboard-testing",
+                "product_environment.read",
+            ),
+            (
+                "product",
+                identity,
+                "other-product",
+                "sellyouroutboard-testing",
+                "product_environment.read",
+            ),
             ("context", identity, "sellyouroutboard", "other-context", "product_environment.read"),
-            ("action", identity, "sellyouroutboard", "sellyouroutboard-testing", "generic_web_prod_promotion.execute"),
+            (
+                "action",
+                identity,
+                "sellyouroutboard",
+                "sellyouroutboard-testing",
+                "generic_web_prod_promotion.execute",
+            ),
         )
         for name, case_identity, product, context, action in denied_cases:
             with self.subTest(name=name):
@@ -527,6 +581,27 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
                 action="product_environment.read",
                 product="sellyouroutboard",
                 context="sellyouroutboard-testing",
+            )
+        )
+
+    def test_local_operator_policy_allows_non_policy_admin_actions(self) -> None:
+        policy = LaunchplaneAuthzPolicy()
+        identity = _local_operator_identity()
+
+        self.assertTrue(
+            policy.allows(
+                identity=identity,
+                action="product_config.apply",
+                product="sellyouroutboard",
+                context="sellyouroutboard",
+            )
+        )
+        self.assertFalse(
+            policy.allows(
+                identity=identity,
+                action="authz_policy.grant_terminal_agent",
+                product="launchplane",
+                context="launchplane",
             )
         )
         self.assertFalse(


### PR DESCRIPTION
## Summary

- add a dedicated `local_operator` bearer identity via `LAUNCHPLANE_LOCAL_OPERATOR_TOKEN`
- allow local operators to dry-run/apply product config with required `reason`, redacted responses, and policy-admin blocked
- enforce local-operator apply only after a previously recorded matching dry-run
- wire the deployed Launchplane env to `LAUNCHPLANE_LOCAL_OPERATOR_*` secret/vars and document the local operator boundary

Refs #527

## Validation

- `uv run --extra dev ruff check control_plane/product_config_http.py control_plane/service.py control_plane/service_auth.py tests/test_service.py tests/test_service_auth.py`
- `uv run --extra dev ruff format --check control_plane/product_config_http.py control_plane/service.py control_plane/service_auth.py tests/test_service.py tests/test_service_auth.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`

## Operator Setup

- rotated `~/.config/launchplane/local-operator.env` locally
- set GitHub secret `LAUNCHPLANE_LOCAL_OPERATOR_TOKEN`
- set GitHub vars `LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT` and `LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL`
