### PR TITLE
Add reusable preview workflow contract

### DIFF
--- a/.github/github-repo-workflow.json
+++ b/.github/github-repo-workflow.json
@@ -8,6 +8,7 @@
     "serviceBoundary": "docs/service-boundary.md",
     "dokployServiceDeployments": "docs/dokploy-service-deployments.md",
     "driverDescriptors": "docs/driver-descriptors.md",
+    "previewWorkflowContract": "docs/preview-workflow-contract.md",
     "operatorExperience": "docs/operator-experience.md",
     "operations": "docs/operations.md",
     "records": "docs/records.md",

--- a/control_plane/contracts/preview_workflow_contract.py
+++ b/control_plane/contracts/preview_workflow_contract.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+PreviewWorkflowEventName = Literal["pull_request", "pull_request_target", "workflow_dispatch"]
+PreviewWorkflowPullRequestAction = Literal[
+    "opened",
+    "reopened",
+    "synchronize",
+    "edited",
+    "labeled",
+    "unlabeled",
+    "closed",
+]
+PreviewWorkflowOperation = Literal[
+    "refresh",
+    "destroy",
+    "unsupported_notice",
+    "ignore",
+]
+PreviewWorkflowExecutionTrust = Literal["same_repo", "fork", "dependabot"]
+
+
+class PreviewWorkflowEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event_name: PreviewWorkflowEventName
+    action: PreviewWorkflowPullRequestAction | str = ""
+    operation: Literal["refresh", "destroy", ""] = ""
+    repository: str
+    anchor_repo: str
+    anchor_pr_number: int = Field(ge=1)
+    actor: str = ""
+    base_repository: str
+    head_repository: str
+    head_sha: str = ""
+    label_names: tuple[str, ...] = ()
+    action_label: str = ""
+    preview_label: str = "preview"
+
+    @model_validator(mode="after")
+    def _validate_event(self) -> "PreviewWorkflowEvent":
+        if not self.repository.strip():
+            raise ValueError("preview workflow event requires repository")
+        if not self.anchor_repo.strip():
+            raise ValueError("preview workflow event requires anchor_repo")
+        if not self.base_repository.strip():
+            raise ValueError("preview workflow event requires base_repository")
+        if not self.head_repository.strip():
+            raise ValueError("preview workflow event requires head_repository")
+        if not self.preview_label.strip():
+            raise ValueError("preview workflow event requires preview_label")
+        if self.event_name in {"pull_request", "pull_request_target"} and not self.action.strip():
+            raise ValueError("pull request preview workflow events require action")
+        if self.event_name == "workflow_dispatch" and not self.operation.strip():
+            raise ValueError("workflow_dispatch preview workflow events require operation")
+        if self.action == "labeled" and not self.action_label.strip():
+            raise ValueError("labeled preview workflow events require action_label")
+        if self.event_name == "pull_request" and _is_dependabot_actor(self.actor):
+            raise ValueError("dependabot preview workflow events must use pull_request_target")
+        return self
+
+
+class PreviewWorkflowDecision(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    operation: PreviewWorkflowOperation
+    reason: str
+    execution_trust: PreviewWorkflowExecutionTrust
+    label_enabled: bool
+    launchplane_route_path: str = ""
+    feedback_status: Literal["pending", "destroyed", "unsupported", ""] = ""
+    checkout_untrusted_head: bool = False
+    product_build_required: bool = False
+    launchplane_feedback_required: bool = False
+
+
+def decide_preview_workflow_operation(event: PreviewWorkflowEvent) -> PreviewWorkflowDecision:
+    """Classify a thin product-repo preview trigger into the Launchplane contract."""
+
+    label_enabled = _preview_label_enabled(event)
+    execution_trust = _execution_trust(event)
+
+    if event.event_name == "workflow_dispatch":
+        if event.operation == "destroy":
+            return PreviewWorkflowDecision(
+                operation="destroy",
+                reason="manual_destroy_requested",
+                execution_trust=execution_trust,
+                label_enabled=label_enabled,
+                launchplane_route_path="/v1/drivers/generic-web/preview-destroy",
+                feedback_status="destroyed",
+                launchplane_feedback_required=True,
+            )
+        return PreviewWorkflowDecision(
+            operation="refresh",
+            reason="manual_refresh_requested",
+            execution_trust=execution_trust,
+            label_enabled=label_enabled,
+            launchplane_route_path="/v1/drivers/generic-web/preview-refresh",
+            feedback_status="pending",
+            checkout_untrusted_head=True,
+            product_build_required=True,
+            launchplane_feedback_required=True,
+        )
+
+    if event.event_name == "pull_request_target":
+        if _needs_unsupported_notice(event=event, label_enabled=label_enabled):
+            return PreviewWorkflowDecision(
+                operation="unsupported_notice",
+                reason=f"preview_not_supported_for_{execution_trust}",
+                execution_trust=execution_trust,
+                label_enabled=label_enabled,
+                launchplane_route_path="/v1/previews/pr-feedback",
+                feedback_status="unsupported",
+                launchplane_feedback_required=True,
+            )
+        return PreviewWorkflowDecision(
+            operation="ignore",
+            reason="pull_request_target_is_only_for_unsupported_notices",
+            execution_trust=execution_trust,
+            label_enabled=label_enabled,
+        )
+
+    if execution_trust != "same_repo":
+        return PreviewWorkflowDecision(
+            operation="ignore",
+            reason=f"pull_request_event_must_not_run_untrusted_{execution_trust}_preview",
+            execution_trust=execution_trust,
+            label_enabled=label_enabled,
+        )
+
+    if event.action == "closed":
+        return PreviewWorkflowDecision(
+            operation="destroy",
+            reason="pull_request_closed",
+            execution_trust=execution_trust,
+            label_enabled=label_enabled,
+            launchplane_route_path="/v1/drivers/generic-web/preview-destroy",
+            feedback_status="destroyed",
+            launchplane_feedback_required=True,
+        )
+
+    if event.action == "unlabeled" and event.action_label == event.preview_label:
+        return PreviewWorkflowDecision(
+            operation="destroy",
+            reason="preview_label_removed",
+            execution_trust=execution_trust,
+            label_enabled=False,
+            launchplane_route_path="/v1/drivers/generic-web/preview-destroy",
+            feedback_status="destroyed",
+            launchplane_feedback_required=True,
+        )
+
+    if not label_enabled:
+        return PreviewWorkflowDecision(
+            operation="ignore",
+            reason="preview_label_not_enabled",
+            execution_trust=execution_trust,
+            label_enabled=False,
+        )
+
+    if event.action in {"opened", "reopened", "synchronize", "edited"}:
+        return PreviewWorkflowDecision(
+            operation="refresh",
+            reason=f"pull_request_{event.action}",
+            execution_trust=execution_trust,
+            label_enabled=True,
+            launchplane_route_path="/v1/drivers/generic-web/preview-refresh",
+            feedback_status="pending",
+            checkout_untrusted_head=True,
+            product_build_required=True,
+            launchplane_feedback_required=True,
+        )
+
+    if event.action == "labeled" and event.action_label == event.preview_label:
+        return PreviewWorkflowDecision(
+            operation="refresh",
+            reason="preview_label_added",
+            execution_trust=execution_trust,
+            label_enabled=True,
+            launchplane_route_path="/v1/drivers/generic-web/preview-refresh",
+            feedback_status="pending",
+            checkout_untrusted_head=True,
+            product_build_required=True,
+            launchplane_feedback_required=True,
+        )
+
+    return PreviewWorkflowDecision(
+        operation="ignore",
+        reason=f"pull_request_{event.action}_does_not_change_preview",
+        execution_trust=execution_trust,
+        label_enabled=label_enabled,
+    )
+
+
+def preview_workflow_idempotency_key(
+    *,
+    product: str,
+    context: str,
+    operation: PreviewWorkflowOperation,
+    anchor_pr_number: int,
+    run_id: str,
+    run_attempt: str,
+) -> str:
+    if operation == "ignore":
+        raise ValueError("ignored preview workflow operations do not need idempotency keys")
+    normalized_product = _normalize_key_part(product, "product")
+    normalized_context = _normalize_key_part(context, "context")
+    normalized_run_id = _normalize_key_part(run_id, "run_id")
+    normalized_run_attempt = _normalize_key_part(run_attempt, "run_attempt")
+    return (
+        f"preview-workflow:{normalized_product}:{normalized_context}:{operation}:"
+        f"pr-{anchor_pr_number}:{normalized_run_id}:{normalized_run_attempt}"
+    )
+
+
+def _preview_label_enabled(event: PreviewWorkflowEvent) -> bool:
+    return event.preview_label.strip() in {label_name.strip() for label_name in event.label_names}
+
+
+def _execution_trust(event: PreviewWorkflowEvent) -> PreviewWorkflowExecutionTrust:
+    if _is_dependabot_actor(event.actor):
+        return "dependabot"
+    if event.base_repository.casefold() != event.head_repository.casefold():
+        return "fork"
+    return "same_repo"
+
+
+def _needs_unsupported_notice(*, event: PreviewWorkflowEvent, label_enabled: bool) -> bool:
+    if not label_enabled:
+        return False
+    if event.action not in {"opened", "reopened", "synchronize", "edited", "labeled"}:
+        return False
+    return _execution_trust(event) in {"fork", "dependabot"}
+
+
+def _is_dependabot_actor(actor: str) -> bool:
+    return actor.strip().casefold() in {"dependabot[bot]", "dependabot-preview[bot]"}
+
+
+def _normalize_key_part(value: str, label: str) -> str:
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise ValueError(f"preview workflow idempotency key requires {label}")
+    return normalized_value.replace("/", "-")

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ Use these docs as the source of truth for `launchplane`.
   website or service repo operated by Launchplane.
 - [product-repo-contract.md](product-repo-contract.md) — thin product repo
   approval gate and new website repo checklist.
+- [preview-workflow-contract.md](preview-workflow-contract.md) — reusable thin
+  preview workflow event, idempotency, feedback, and migration contract.
 - [driver-descriptors.md](driver-descriptors.md) — provider-neutral driver
   descriptor, action safety, registry, and read-model endpoint contract.
 - [driver-development.md](driver-development.md) — when and how to add a new

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -1,0 +1,131 @@
+---
+title: Reusable Preview Workflow Contract
+---
+
+## Purpose
+
+Product preview workflows should be thin event adapters. Product repos build and
+publish the product artifact; Launchplane owns preview event semantics,
+idempotency, provider mutation, durable records, unsupported notices, feedback
+comments, inventory, and cleanup.
+
+This contract is the migration target for preview-enabled product repos that
+currently carry bespoke preview-control-plane workflows.
+
+## Ownership Boundary
+
+Product repos own:
+
+- GitHub event wiring for `pull_request`, `pull_request_target`, and manual
+  `workflow_dispatch` entrypoints.
+- Product build, test, package, and immutable artifact publishing.
+- Product-specific smoke facts that Launchplane cannot derive from a product
+  profile.
+- The minimal Launchplane request payload containing product key, PR number,
+  source SHA, immutable artifact reference, run URL, and primitive smoke result.
+
+Launchplane owns:
+
+- Preview-request interpretation and idempotency conventions.
+- Preview refresh, destroy, inventory, readiness, and lifecycle cleanup routes.
+- Preview records, generation records, desired-state records, cleanup records,
+  and PR feedback records.
+- Unsupported notices for fork and Dependabot preview requests.
+- PR comment rendering, delivery, replacement, and cleanup.
+- Provider credentials, runtime settings, managed secrets, preview URL policy,
+  and preview slug policy.
+
+Product workflows must not render Launchplane preview comments directly or keep
+their own durable lifecycle truth once a matching Launchplane route exists.
+
+## Event Contract
+
+Use `PreviewWorkflowEvent` and `decide_preview_workflow_operation` from
+`control_plane.contracts.preview_workflow_contract` as the shared event contract.
+The decision is deliberately small:
+
+- `refresh`: build and publish the product artifact, then call the product
+  driver's preview-refresh route.
+- `destroy`: call the product driver's preview-destroy route.
+- `unsupported_notice`: call `POST /v1/previews/pr-feedback` with
+  `status="unsupported"` from a trusted base-branch workflow.
+- `ignore`: make no Launchplane mutation.
+
+The same contract applies to SYO, VeriReel, Odoo CM, and future products. Driver
+routes may differ by product family, but event interpretation stays the same.
+
+## Required Workflow Shape
+
+Same-repository PRs use `pull_request` because the workflow may check out and
+build the PR head:
+
+- `opened`, `reopened`, `synchronize`, `edited`, or adding the preview label
+  with the label present: `refresh`.
+- `closed`: `destroy`.
+- Removing the preview label: `destroy`.
+- Any PR without the preview label: `ignore`.
+
+Fork and Dependabot PRs use `pull_request_target` only for an unsupported notice.
+That job must run from the base branch, must not check out untrusted PR code, and
+must only call `POST /v1/previews/pr-feedback` with `status="unsupported"`.
+Launchplane will render and deliver the comment.
+
+Manual `workflow_dispatch` may request `refresh` or `destroy` when a product repo
+needs an operator retry path. Manual refresh still follows the same build,
+publish, and Launchplane-refresh handoff as a PR refresh.
+
+## Idempotency
+
+Every Launchplane mutation from a product preview workflow needs a stable
+idempotency key. Use `preview_workflow_idempotency_key` or the same shape:
+
+```text
+preview-workflow:<product>:<context>:<operation>:pr-<number>:<run-id>:<run-attempt>
+```
+
+Run-scoped keys make repeated HTTP attempts safe while preserving a distinct
+record for a later retry or GitHub rerun. Ignored decisions do not have
+idempotency keys.
+
+## Route Handoff
+
+Preview refresh routes receive only product-local facts:
+
+- product key and context when the route still requires them
+- PR number and source SHA
+- immutable image or artifact reference
+- run URL
+- primitive smoke/readiness facts when the check is product-specific
+
+Preview destroy routes receive the PR number, source/run metadata, and an
+explicit destroy reason such as `pull_request_closed`, `preview_label_removed`,
+or `manual_destroy_requested`.
+
+Preview feedback routes receive the status and primitive display facts.
+Launchplane derives the marker, rendered markdown, delivery behavior, and record
+id.
+
+Use `cbusillo/launchplane/.github/actions/launchplane-request@main` for the OIDC
+transport whenever a product workflow only needs to send JSON to Launchplane.
+
+## Migration Checklist
+
+- Replace product-rendered preview comments with `/v1/previews/pr-feedback`.
+- Move unsupported fork and Dependabot notices to a base-branch
+  `pull_request_target` job that does not check out PR code.
+- Replace bespoke refresh/destroy event branching with the shared decision
+  contract.
+- Keep product build/publish/smoke logic local until a Launchplane driver route
+  owns the equivalent facts.
+- Use run-scoped idempotency keys for every Launchplane mutation.
+- Keep product configuration, preview URL policy, provider credentials, and
+  cleanup truth in Launchplane records rather than product-repo files.
+- Verify one refresh, one destroy, and one unsupported-notice path per migrated
+  product repo.
+
+## Source Workflows
+
+This contract was shaped from the current preview paths in SYO, VeriReel, and
+Odoo CM. Odoo CM is the reference thin workflow after its preview feedback moved
+to Launchplane. SYO and VeriReel should migrate toward the same event contract
+before deleting their bespoke preview-control-plane logic.

--- a/tests/test_preview_workflow_contract.py
+++ b/tests/test_preview_workflow_contract.py
@@ -1,0 +1,135 @@
+import unittest
+
+from pydantic import ValidationError
+
+from control_plane.contracts.preview_workflow_contract import (
+    PreviewWorkflowEvent,
+    decide_preview_workflow_operation,
+    preview_workflow_idempotency_key,
+)
+
+
+def _event(**overrides: object) -> PreviewWorkflowEvent:
+    values: dict[str, object] = {
+        "event_name": "pull_request",
+        "action": "synchronize",
+        "repository": "cbusillo/sellyouroutboard",
+        "anchor_repo": "cbusillo/sellyouroutboard",
+        "anchor_pr_number": 105,
+        "actor": "cbusillo",
+        "base_repository": "cbusillo/sellyouroutboard",
+        "head_repository": "cbusillo/sellyouroutboard",
+        "head_sha": "abc123",
+        "label_names": ("preview",),
+        "preview_label": "preview",
+    }
+    values.update(overrides)
+    return PreviewWorkflowEvent.model_validate(values)
+
+
+class PreviewWorkflowContractTests(unittest.TestCase):
+    def test_same_repo_labeled_pr_refreshes_preview(self) -> None:
+        decision = decide_preview_workflow_operation(
+            _event(action="labeled", action_label="preview")
+        )
+
+        self.assertEqual(decision.operation, "refresh")
+        self.assertEqual(decision.reason, "preview_label_added")
+        self.assertEqual(decision.execution_trust, "same_repo")
+        self.assertEqual(decision.launchplane_route_path, "/v1/drivers/generic-web/preview-refresh")
+        self.assertEqual(decision.feedback_status, "pending")
+        self.assertTrue(decision.product_build_required)
+        self.assertTrue(decision.launchplane_feedback_required)
+
+    def test_same_repo_preview_label_removal_destroys_preview(self) -> None:
+        decision = decide_preview_workflow_operation(
+            _event(action="unlabeled", action_label="preview", label_names=("bug",))
+        )
+
+        self.assertEqual(decision.operation, "destroy")
+        self.assertEqual(decision.reason, "preview_label_removed")
+        self.assertEqual(decision.feedback_status, "destroyed")
+        self.assertTrue(decision.launchplane_feedback_required)
+
+    def test_same_repo_unlabeled_pr_is_ignored(self) -> None:
+        decision = decide_preview_workflow_operation(_event(label_names=("bug",)))
+
+        self.assertEqual(decision.operation, "ignore")
+        self.assertEqual(decision.reason, "preview_label_not_enabled")
+
+    def test_pull_request_target_fork_preview_writes_unsupported_notice_only(self) -> None:
+        decision = decide_preview_workflow_operation(
+            _event(
+                event_name="pull_request_target",
+                action="labeled",
+                action_label="preview",
+                head_repository="somebody/sellyouroutboard",
+            )
+        )
+
+        self.assertEqual(decision.operation, "unsupported_notice")
+        self.assertEqual(decision.execution_trust, "fork")
+        self.assertEqual(decision.launchplane_route_path, "/v1/previews/pr-feedback")
+        self.assertEqual(decision.feedback_status, "unsupported")
+        self.assertFalse(decision.checkout_untrusted_head)
+        self.assertFalse(decision.product_build_required)
+
+    def test_pull_request_target_same_repo_is_ignored(self) -> None:
+        decision = decide_preview_workflow_operation(_event(event_name="pull_request_target"))
+
+        self.assertEqual(decision.operation, "ignore")
+        self.assertEqual(decision.reason, "pull_request_target_is_only_for_unsupported_notices")
+
+    def test_dependabot_pull_request_event_fails_closed(self) -> None:
+        with self.assertRaises(ValidationError):
+            _event(actor="dependabot[bot]")
+
+    def test_dependabot_pull_request_target_writes_unsupported_notice_only(self) -> None:
+        decision = decide_preview_workflow_operation(
+            _event(
+                event_name="pull_request_target",
+                actor="dependabot[bot]",
+                action="synchronize",
+            )
+        )
+
+        self.assertEqual(decision.operation, "unsupported_notice")
+        self.assertEqual(decision.execution_trust, "dependabot")
+        self.assertEqual(decision.feedback_status, "unsupported")
+
+    def test_workflow_dispatch_destroy_uses_destroy_route(self) -> None:
+        decision = decide_preview_workflow_operation(
+            _event(event_name="workflow_dispatch", action="", operation="destroy")
+        )
+
+        self.assertEqual(decision.operation, "destroy")
+        self.assertEqual(decision.reason, "manual_destroy_requested")
+        self.assertEqual(decision.launchplane_route_path, "/v1/drivers/generic-web/preview-destroy")
+
+    def test_preview_workflow_idempotency_key_is_run_scoped(self) -> None:
+        self.assertEqual(
+            preview_workflow_idempotency_key(
+                product="sell-your-outboard",
+                context="sellyouroutboard-testing",
+                operation="refresh",
+                anchor_pr_number=105,
+                run_id="123456",
+                run_attempt="2",
+            ),
+            "preview-workflow:sell-your-outboard:sellyouroutboard-testing:refresh:pr-105:123456:2",
+        )
+
+    def test_ignored_preview_workflow_does_not_have_idempotency_key(self) -> None:
+        with self.assertRaises(ValueError):
+            preview_workflow_idempotency_key(
+                product="sell-your-outboard",
+                context="sellyouroutboard-testing",
+                operation="ignore",
+                anchor_pr_number=105,
+                run_id="123456",
+                run_attempt="2",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a typed preview workflow event/decision contract for product repos
- document the reusable thin preview workflow ownership boundary and migration checklist
- cover same-repo, fork, Dependabot, manual refresh/destroy, and idempotency behavior with unit tests

Refs #509

## Verification
- uv run python -m unittest tests.test_preview_workflow_contract tests.test_launchplane_previews tests.test_preview_pr_feedback
- uv run --extra dev ruff check control_plane/contracts/preview_workflow_contract.py tests/test_preview_workflow_contract.py
- uv run --extra dev ruff format --check control_plane/contracts/preview_workflow_contract.py tests/test_preview_workflow_contract.py
- uv run --extra dev mypy control_plane/contracts/preview_workflow_contract.py tests/test_preview_workflow_contract.py
- uv run python -m unittest