### PR TITLE
Allow Meta conversions token runtime safety

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -853,6 +853,12 @@ jobs:
                       secret_class: "prod_only",
                       allowed_contexts: ["sellyouroutboard"],
                       allowed_instances: ["prod"]
+                    },
+                    {
+                      binding_key: "META_CONVERSIONS_API_TOKEN",
+                      secret_class: "shared_safe",
+                      allowed_contexts: ["sellyouroutboard"],
+                      allowed_instances: ["testing", "prod"]
                     }
                   ]
                 }'


### PR DESCRIPTION
## Summary

- classify `META_CONVERSIONS_API_TOKEN` in the deploy-owned runtime key-safety policy
- scope the binding to `sellyouroutboard` for `testing` and `prod` so the product-config dry-run/apply path can pass for the Meta conversions API token

Follow-up to #527 / #532.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-launchplane.yml")'`
- `actionlint .github/workflows/deploy-launchplane.yml`
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_runtime_key_safety_policy_endpoint_reconciles_rules tests.test_service.LaunchplaneServiceTests.test_product_config_api_human_admin_dry_run_returns_redacted_meta_plan tests.test_service.LaunchplaneServiceTests.test_product_config_api_human_admin_apply_writes_meta_config`
- `uv run python -m unittest`
