### PR TITLE
Authorize SYO preview feedback requests

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -944,6 +944,24 @@ jobs:
               pull_request \
               '*'
             post_syo_grant \
+              preview-control-plane.yml \
+              sellyouroutboard \
+              "$context_name" \
+              preview_pr_feedback.write \
+              "deploy:syo-preview-pr-feedback-${suffix}-grant" \
+              "syo-preview-pr-feedback-${suffix}" \
+              pull_request \
+              '*'
+            post_syo_grant \
+              preview-control-plane.yml \
+              sellyouroutboard \
+              "$context_name" \
+              preview_pr_feedback.write \
+              "deploy:syo-preview-unsupported-feedback-${suffix}-grant" \
+              "syo-preview-unsupported-feedback-${suffix}" \
+              pull_request_target \
+              '*'
+            post_syo_grant \
               preview-cleanup.yml \
               sellyouroutboard \
               "$context_name" \


### PR DESCRIPTION
## Summary
- seed explicit SYO preview PR feedback write grants for the preview workflow
- authorize unsupported-preview feedback from pull_request_target for both legacy and canonical SYO contexts

## Validation
- actionlint .github/workflows/deploy-launchplane.yml
- uv run python -m unittest tests.test_service_auth