### PR TITLE
Add Odoo stable bootstrap workflow

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -1133,6 +1133,14 @@ jobs:
             odoo_config_parameter_override.write \
             deploy:odoo-cm-config-parameter-override-grant \
             odoo-cm-config-parameter-override
+          post_grant \
+            "$GITHUB_REPOSITORY" \
+            odoo-stable-bootstrap.yml \
+            odoo-tenant-cm \
+            cm \
+            odoo_stable_bootstrap.execute \
+            deploy:odoo-cm-stable-bootstrap-grant \
+            odoo-cm-stable-bootstrap
           post_syo_preview_grants \
             sellyouroutboard-testing \
             legacy-context

--- a/.github/workflows/odoo-stable-bootstrap.yml
+++ b/.github/workflows/odoo-stable-bootstrap.yml
@@ -1,0 +1,170 @@
+---
+name: Odoo Stable Bootstrap
+
+"on":
+  workflow_dispatch:
+    inputs:
+      product:
+        description: Odoo product profile key.
+        required: true
+        default: odoo-tenant-cm
+        type: string
+      context:
+        description: Launchplane Odoo context.
+        required: true
+        default: cm
+        type: choice
+        options:
+          - cm
+      instance:
+        description: Stable Odoo instance to bootstrap.
+        required: true
+        default: testing
+        type: choice
+        options:
+          - testing
+      confirmation:
+        description: Type "bootstrap cm testing" to confirm destructive bootstrap.
+        required: true
+        type: string
+      verify_health:
+        description: Verify the Odoo health endpoint after bootstrap.
+        required: true
+        default: true
+        type: boolean
+      verify_canonical:
+        description: Verify the stable URL canonical page after bootstrap.
+        required: true
+        default: true
+        type: boolean
+      verify_logo:
+        description: Verify the Odoo logo route after bootstrap.
+        required: true
+        default: true
+        type: boolean
+      timeout_seconds:
+        description: Optional Dokploy bootstrap timeout override in seconds.
+        required: false
+        default: ""
+        type: string
+      health_timeout_seconds:
+        description: Optional health/canonical/logo timeout override in seconds.
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: odoo-stable-bootstrap-${{ inputs.product }}-${{ inputs.context }}-${{ inputs.instance }}
+  cancel-in-progress: false
+
+jobs:
+  bootstrap:
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    env:
+      PRODUCT: ${{ inputs.product }}
+      CONTEXT: ${{ inputs.context }}
+      INSTANCE: ${{ inputs.instance }}
+      CONFIRMATION: ${{ inputs.confirmation }}
+      VERIFY_HEALTH: ${{ inputs.verify_health }}
+      VERIFY_CANONICAL: ${{ inputs.verify_canonical }}
+      VERIFY_LOGO: ${{ inputs.verify_logo }}
+      TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
+      HEALTH_TIMEOUT_SECONDS: ${{ inputs.health_timeout_seconds }}
+      LAUNCHPLANE_SERVICE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+      LAUNCHPLANE_SERVICE_AUDIENCE: launchplane.shinycomputers.com
+    steps:
+      - name: Validate runtime inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${PRODUCT:?Missing product input}"
+          : "${CONTEXT:?Missing context input}"
+          : "${INSTANCE:?Missing instance input}"
+          : "${CONFIRMATION:?Missing confirmation input}"
+          if [ "$PRODUCT" != "odoo-tenant-cm" ] || [ "$CONTEXT" != "cm" ] || [ "$INSTANCE" != "testing" ]; then
+            echo 'This workflow currently only bootstraps odoo-tenant-cm cm/testing.' >&2
+            exit 1
+          fi
+          if [ "$CONFIRMATION" != "bootstrap cm testing" ]; then
+            echo 'Confirmation must be exactly: bootstrap cm testing' >&2
+            exit 1
+          fi
+          for value in "$VERIFY_HEALTH" "$VERIFY_CANONICAL" "$VERIFY_LOGO"; do
+            if [ "$value" != "true" ] && [ "$value" != "false" ]; then
+              echo "Boolean input resolved to invalid value: ${value}" >&2
+              exit 1
+            fi
+          done
+          if [ -z "${LAUNCHPLANE_SERVICE_URL:-}" ] || [ -z "${LAUNCHPLANE_SERVICE_AUDIENCE:-}" ]; then
+            echo 'Missing Launchplane service URL or OIDC audience repository variable.' >&2
+            exit 1
+          fi
+
+      - name: Run bootstrap
+        shell: bash
+        run: |
+          set -euo pipefail
+          oidc_token="$({
+            curl -fsSL \
+              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${LAUNCHPLANE_SERVICE_AUDIENCE}" \
+            | jq -r '.value'
+          })"
+          payload="$({
+            jq -n \
+              --arg product "$PRODUCT" \
+              --arg context "$CONTEXT" \
+              --arg instance "$INSTANCE" \
+              --arg confirmation "$CONFIRMATION" \
+              --argjson verify_health "$VERIFY_HEALTH" \
+              --argjson verify_canonical "$VERIFY_CANONICAL" \
+              --argjson verify_logo "$VERIFY_LOGO" \
+              '{
+                schema_version: 1,
+                product: $product,
+                bootstrap: {
+                  schema_version: 1,
+                  product: $product,
+                  context: $context,
+                  instance: $instance,
+                  confirmation: $confirmation,
+                  verify_health: $verify_health,
+                  verify_canonical: $verify_canonical,
+                  verify_logo: $verify_logo
+                }
+              }'
+          })"
+          if [ -n "${TIMEOUT_SECONDS:-}" ]; then
+            payload="$(jq --argjson timeout_seconds "$TIMEOUT_SECONDS" '.bootstrap.timeout_seconds = $timeout_seconds' <<<"$payload")"
+          fi
+          if [ -n "${HEALTH_TIMEOUT_SECONDS:-}" ]; then
+            payload="$(jq --argjson health_timeout_seconds "$HEALTH_TIMEOUT_SECONDS" '.bootstrap.health_timeout_seconds = $health_timeout_seconds' <<<"$payload")"
+          fi
+          status_code="$({
+            curl -sS \
+              -o odoo-stable-bootstrap.json \
+              -w '%{http_code}' \
+              -X POST \
+              -H "Authorization: Bearer ${oidc_token}" \
+              -H 'Content-Type: application/json' \
+              -H "Idempotency-Key: odoo-stable-bootstrap:${PRODUCT}:${CONTEXT}:${INSTANCE}:${VERIFY_HEALTH}:${VERIFY_CANONICAL}:${VERIFY_LOGO}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}" \
+              --data "$payload" \
+              "${LAUNCHPLANE_SERVICE_URL}/v1/drivers/odoo/stable-bootstrap"
+          })"
+          jq . odoo-stable-bootstrap.json
+          if [ "$status_code" != "202" ]; then
+            echo "Launchplane Odoo stable bootstrap failed with HTTP ${status_code}." >&2
+            exit 1
+          fi
+
+      - name: Upload bootstrap result
+        uses: actions/upload-artifact@v5
+        with:
+          name: odoo-stable-bootstrap-${{ inputs.product }}-${{ inputs.context }}-${{ inputs.instance }}
+          path: odoo-stable-bootstrap.json

--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -30,6 +30,7 @@ DEFAULT_CONTROL_PLANE_DOKPLOY_SOURCE_FILE = Path("config/dokploy.toml")
 DEFAULT_CONTROL_PLANE_DOKPLOY_TARGET_IDS_FILE = Path("config/dokploy-targets.toml")
 DEFAULT_STABLE_REMOTE_INSTANCES = {"testing", "prod"}
 DOKPLOY_DATA_WORKFLOW_SCHEDULE_NAME = "platform-data-workflow"
+DOKPLOY_ODOO_BOOTSTRAP_SCHEDULE_NAME = "platform-odoo-bootstrap"
 DOKPLOY_ODOO_BACKUP_GATE_SCHEDULE_NAME = "platform-odoo-backup-gate"
 DOKPLOY_MANUAL_ONLY_CRON_EXPRESSION = "0 0 31 2 *"
 DOKPLOY_RUNNING_DEPLOYMENT_STATUSES = {"pending", "queued", "running", "in_progress", "starting"}
@@ -1411,6 +1412,165 @@ def run_compose_post_deploy_update(
     )
 
 
+def run_compose_odoo_stable_bootstrap(
+    *,
+    host: str,
+    token: str,
+    target_definition: DokployTargetDefinition,
+    env_file: Path | None,
+    workflow_environment_overrides: Mapping[str, str] | None = None,
+    required_workflow_environment_keys: tuple[str, ...] = (),
+    timeout_seconds: int | None = None,
+) -> None:
+    compose_id = target_definition.target_id.strip()
+    compose_name = (
+        target_definition.target_name.strip()
+        or f"{target_definition.context}-{target_definition.instance}"
+    )
+    if not compose_id:
+        raise click.ClickException(
+            f"Dokploy compose target {target_definition.context}/{target_definition.instance} requires target_id for Odoo bootstrap."
+        )
+    target_payload = fetch_dokploy_target_payload(
+        host=host,
+        token=token,
+        target_type="compose",
+        target_id=compose_id,
+    )
+    current_env_map = parse_dokploy_env_text(str(target_payload.get("env") or ""))
+    desired_env_map = _apply_post_deploy_env_file_overrides(
+        current_env_map=current_env_map,
+        env_file=env_file,
+    )
+    schedule_timeout_seconds = (
+        timeout_seconds
+        or target_definition.deploy_timeout_seconds
+        or DEFAULT_DOKPLOY_DEPLOY_TIMEOUT_SECONDS
+    )
+    if desired_env_map != current_env_map:
+        update_dokploy_target_env(
+            host=host,
+            token=token,
+            target_type="compose",
+            target_id=compose_id,
+            target_payload=target_payload,
+            env_text=serialize_dokploy_env_text(desired_env_map),
+        )
+        latest_compose_deployment = latest_deployment_for_target(
+            host=host,
+            token=token,
+            target_type="compose",
+            target_id=compose_id,
+        )
+        trigger_deployment(
+            host=host,
+            token=token,
+            target_type="compose",
+            target_id=compose_id,
+            no_cache=False,
+        )
+        wait_for_target_deployment(
+            host=host,
+            token=token,
+            target_type="compose",
+            target_id=compose_id,
+            before_key=deployment_key(latest_compose_deployment),
+            timeout_seconds=schedule_timeout_seconds,
+        )
+
+    database_name = desired_env_map.get("ODOO_DB_NAME", "").strip()
+    if not database_name:
+        raise click.ClickException(
+            "Odoo stable bootstrap requires ODOO_DB_NAME in the live target environment or explicit env file."
+        )
+    filestore_path = (
+        desired_env_map.get("ODOO_FILESTORE_PATH") or "/volumes/data/filestore"
+    ).strip() or "/volumes/data/filestore"
+    data_workflow_lock_path = (
+        desired_env_map.get("ODOO_DATA_WORKFLOW_LOCK_FILE") or DEFAULT_DATA_WORKFLOW_LOCK_PATH
+    ).strip() or DEFAULT_DATA_WORKFLOW_LOCK_PATH
+    schedule_type, schedule_lookup_id, compose_app_name, schedule_server_id = (
+        _resolve_dokploy_schedule_runtime(
+            host=host,
+            token=token,
+            compose_id=compose_id,
+            compose_name=compose_name,
+            target_payload=target_payload,
+        )
+    )
+    schedule_app_name = f"platform-{target_definition.context}-{target_definition.instance}-odoo-bootstrap"
+    existing_schedule = find_matching_dokploy_schedule(
+        host=host,
+        token=token,
+        target_id=schedule_lookup_id,
+        schedule_type=schedule_type,
+        schedule_name=DOKPLOY_ODOO_BOOTSTRAP_SCHEDULE_NAME,
+        app_name=schedule_app_name,
+    )
+    if _has_running_schedule_deployment(existing_schedule):
+        raise click.ClickException(
+            "Dokploy-managed Odoo bootstrap already has a running schedule deployment for "
+            f"{target_definition.context}/{target_definition.instance}."
+        )
+    schedule_script = _build_dokploy_data_workflow_script(
+        compose_app_name=compose_app_name,
+        database_name=database_name,
+        filestore_path=filestore_path,
+        clear_stale_lock=_should_clear_stale_data_workflow_lock(existing_schedule),
+        data_workflow_lock_path=data_workflow_lock_path,
+        workflow_mode="bootstrap",
+        workflow_environment_overrides=workflow_environment_overrides or {},
+        required_workflow_environment_keys=required_workflow_environment_keys,
+    )
+    schedule_payload: JsonObject = {
+        "name": DOKPLOY_ODOO_BOOTSTRAP_SCHEDULE_NAME,
+        "cronExpression": DOKPLOY_MANUAL_ONLY_CRON_EXPRESSION,
+        "appName": schedule_app_name,
+        "shellType": "bash",
+        "scheduleType": schedule_type,
+        "command": "control-plane odoo stable bootstrap",
+        "script": schedule_script,
+        "serverId": schedule_server_id,
+        "userId": schedule_lookup_id if schedule_type == "dokploy-server" else None,
+        "enabled": False,
+        "timezone": "UTC",
+    }
+    schedule = upsert_dokploy_schedule(
+        host=host,
+        token=token,
+        target_id=schedule_lookup_id,
+        schedule_type=schedule_type,
+        schedule_name=DOKPLOY_ODOO_BOOTSTRAP_SCHEDULE_NAME,
+        app_name=schedule_app_name,
+        schedule_payload=schedule_payload,
+    )
+    schedule_id = schedule_key(schedule)
+    if not schedule_id:
+        raise click.ClickException(
+            f"Dokploy Odoo bootstrap schedule for {target_definition.context}/{target_definition.instance} did not expose a schedule id."
+        )
+    latest_schedule_deployment = latest_deployment_for_schedule(
+        host=host,
+        token=token,
+        schedule_id=schedule_id,
+    )
+    dokploy_request(
+        host=host,
+        token=token,
+        path="/api/schedule.runManually",
+        method="POST",
+        payload={"scheduleId": schedule_id},
+        timeout_seconds=schedule_timeout_seconds,
+    )
+    wait_for_dokploy_schedule_deployment(
+        host=host,
+        token=token,
+        schedule_id=schedule_id,
+        before_key=deployment_key(latest_schedule_deployment),
+        timeout_seconds=schedule_timeout_seconds,
+    )
+
+
 def run_compose_odoo_backup_gate(
     *,
     host: str,
@@ -1722,6 +1882,7 @@ def _build_dokploy_data_workflow_script(
     filestore_path: str,
     clear_stale_lock: bool,
     data_workflow_lock_path: str,
+    workflow_mode: Literal["update", "bootstrap"] = "update",
     workflow_environment_overrides: Mapping[str, str] | None = None,
     required_workflow_environment_keys: tuple[str, ...] = (),
     protected_shopify_store_keys: tuple[str, ...] = (),
@@ -1741,6 +1902,8 @@ def _build_dokploy_data_workflow_script(
         "protected_shopify_store_keys",
         protected_shopify_store_keys,
     )
+    workflow_arguments = "--bootstrap" if workflow_mode == "bootstrap" else "--update-only"
+    workflow_label = "bootstrap" if workflow_mode == "bootstrap" else "post-deploy update"
     return f"""#!/usr/bin/env bash
 set -euo pipefail
 
@@ -1748,7 +1911,7 @@ compose_project={quoted_compose_app_name}
 database_name={quoted_database_name}
 filestore_root={quoted_filestore_path}
 workflow_ssh_dir=/tmp/platform-data-workflow-ssh
-workflow_arguments=(--update-only)
+workflow_arguments=({workflow_arguments})
 workflow_environment=()
 {workflow_environment_lines}
 required_workflow_environment_keys=()
@@ -1886,7 +2049,7 @@ workflow_identity_key=$(docker exec -u root \
         printf "%s" "$workflow_identity_key"
     ')
 
-echo "Running post-deploy update in container ${{script_runner_container_id}}"
+echo "Running Odoo {workflow_label} in container ${{script_runner_container_id}}"
 docker exec \
     -e DATA_WORKFLOW_SSH_DIR="${{workflow_ssh_dir}}" \
     -e DATA_WORKFLOW_SSH_KEY="$workflow_identity_key" \

--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -407,7 +407,7 @@ ODOO_DRIVER = DriverDescriptor(
             capability_id="post_deploy_settings",
             label="Post-deploy settings",
             description="Apply typed Odoo instance settings and managed secret bindings after deploy.",
-            actions=("post_deploy",),
+            actions=("post_deploy", "stable_bootstrap"),
             panels=("settings", "secret_bindings", "audit"),
         ),
         DriverCapabilityDescriptor(
@@ -474,6 +474,16 @@ ODOO_DRIVER = DriverDescriptor(
             route_path="/v1/drivers/odoo/config-parameter-override",
             authz_action="odoo_config_parameter_override.write",
             writes_records=("odoo_instance_override",),
+        ),
+        _action(
+            "stable_bootstrap",
+            "Bootstrap stable instance",
+            "Run a guarded Odoo stable bootstrap through Launchplane-owned provider scheduling.",
+            safety="destructive",
+            scope="instance",
+            route_path="/v1/drivers/odoo/stable-bootstrap",
+            authz_action="odoo_stable_bootstrap.execute",
+            writes_records=("deployment", "inventory"),
         ),
         _action(
             "preview_desired_state",

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -259,6 +259,11 @@ from control_plane.workflows.odoo_post_deploy import (
     OdooPostDeployRequest,
     execute_odoo_post_deploy,
 )
+from control_plane.workflows.odoo_stable_bootstrap import (
+    OdooStableBootstrapRequest,
+    OdooStableBootstrapStore,
+    execute_odoo_stable_bootstrap,
+)
 from control_plane.workflows.odoo_prod_backup_gate import (
     OdooProdBackupGateRequest,
     execute_odoo_prod_backup_gate,
@@ -951,6 +956,18 @@ class OdooConfigParameterOverrideEnvelope(_ProductRouteEnvelope):
         return self
 
 
+class OdooStableBootstrapEnvelope(_ProductRouteEnvelope):
+    schema_version: int = Field(default=1, ge=1)
+    bootstrap: OdooStableBootstrapRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "OdooStableBootstrapEnvelope":
+        _validate_driver_envelope_product(self.product, label="Odoo stable bootstrap")
+        if self.product.strip() != self.bootstrap.product.strip():
+            raise ValueError("Odoo stable bootstrap requires matching product values.")
+        return self
+
+
 class OdooArtifactPublishEnvelope(_ProductRouteEnvelope):
     schema_version: int = Field(default=1, ge=1)
     publish: OdooArtifactPublishEvidenceRequest
@@ -985,6 +1002,15 @@ _ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE = _DriverRouteExecutionMetadata(
     envelope_model=OdooConfigParameterOverrideEnvelope,
     denial_message=(
         "Workflow cannot write Odoo config-parameter overrides for the requested product/context."
+    ),
+)
+
+
+_ODOO_STABLE_BOOTSTRAP_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/odoo/stable-bootstrap",
+    envelope_model=OdooStableBootstrapEnvelope,
+    denial_message=(
+        "Workflow cannot execute Odoo stable bootstrap for the requested product/context."
     ),
 )
 
@@ -7591,6 +7617,41 @@ def create_launchplane_service_app(
                         override.key for override in override_record.config_parameters
                     ),
                 }
+            elif path == _ODOO_STABLE_BOOTSTRAP_ROUTE.route_path:
+                odoo_bootstrap_request = (
+                    _ODOO_STABLE_BOOTSTRAP_ROUTE.envelope_model.model_validate(payload)
+                )
+                _, authorization_response = _resolve_and_authorize_descriptor_route(
+                    route_metadata=_ODOO_STABLE_BOOTSTRAP_ROUTE,
+                    record_store=record_store,
+                    authz_policy=authz_policy,
+                    identity=identity,
+                    product=odoo_bootstrap_request.product,
+                    authorization_context=odoo_bootstrap_request.bootstrap.context,
+                    descriptor_context=odoo_bootstrap_request.bootstrap.context,
+                    descriptor_instance=odoo_bootstrap_request.bootstrap.instance,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if authorization_response is not None:
+                    return authorization_response
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                driver_result = execute_odoo_stable_bootstrap(
+                    control_plane_root=resolved_root,
+                    record_store=cast(OdooStableBootstrapStore, record_store),
+                    request=odoo_bootstrap_request.bootstrap,
+                )
+                result = {"deployment_record_id": driver_result.deployment_record_id}
             elif path == _ODOO_ARTIFACT_PUBLISH_ROUTE.route_path:
                 odoo_publish_request = _ODOO_ARTIFACT_PUBLISH_ROUTE.envelope_model.model_validate(
                     payload

--- a/control_plane/workflows/odoo_stable_bootstrap.py
+++ b/control_plane/workflows/odoo_stable_bootstrap.py
@@ -1,0 +1,429 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal, Protocol
+
+import click
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane import dokploy as control_plane_dokploy
+from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.promotion_record import HealthcheckEvidence, PostDeployUpdateEvidence
+from control_plane.contracts.ship_request import ShipRequest
+from control_plane.workflows.inventory import build_environment_inventory
+from control_plane.workflows.odoo_post_deploy import OdooPostDeployRequest, execute_odoo_post_deploy
+from control_plane.workflows.odoo_stable_target_replacement import (
+    _read_lane,
+    _target_base_url,
+    _target_health_url,
+    _verify_canonical_url,
+    _verify_health_url,
+    _verify_logo_route,
+)
+from control_plane.workflows.ship import (
+    build_deployment_record,
+    generate_deployment_record_id,
+    utc_now_timestamp,
+)
+
+ODOO_STABLE_BOOTSTRAP_CONFIRMATION = "bootstrap cm testing"
+
+
+class OdooStableBootstrapStore(Protocol):
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord: ...
+
+    def read_dokploy_target_record(
+        self, *, context_name: str, instance_name: str
+    ) -> DokployTargetRecord: ...
+
+    def read_dokploy_target_id_record(
+        self, *, context_name: str, instance_name: str
+    ) -> DokployTargetIdRecord: ...
+
+    def read_environment_inventory(
+        self, *, context_name: str, instance_name: str
+    ) -> EnvironmentInventory: ...
+
+    def write_deployment_record(self, record: DeploymentRecord) -> object: ...
+
+    def write_environment_inventory(self, record: EnvironmentInventory) -> object: ...
+
+
+class OdooStableBootstrapRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    context: str = "cm"
+    instance: str
+    confirmation: str
+    verify_health: bool = True
+    verify_canonical: bool = True
+    verify_logo: bool = True
+    timeout_seconds: int | None = Field(default=None, ge=1)
+    health_timeout_seconds: int | None = Field(default=None, ge=1)
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "OdooStableBootstrapRequest":
+        self.product = self.product.strip()
+        self.context = self.context.strip().lower()
+        self.instance = self.instance.strip().lower()
+        self.confirmation = self.confirmation.strip().lower()
+        if not self.product:
+            raise ValueError("Odoo stable bootstrap requires product.")
+        if not self.context:
+            raise ValueError("Odoo stable bootstrap requires context.")
+        if not self.instance:
+            raise ValueError("Odoo stable bootstrap requires instance.")
+        return self
+
+
+class OdooStableBootstrapResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    product: str
+    context: str
+    instance: str
+    deployment_record_id: str = ""
+    bootstrap_status: Literal["pass", "fail"]
+    post_deploy_status: Literal["pass", "fail", "skipped"] = "skipped"
+    health_status: Literal["pass", "fail", "skipped"] = "skipped"
+    canonical_status: Literal["pass", "fail", "skipped"] = "skipped"
+    logo_status: Literal["pass", "fail", "skipped"] = "skipped"
+    target_id: str = ""
+    target_name: str = ""
+    artifact_id: str = ""
+    source_git_ref: str = ""
+    error_message: str = ""
+
+
+def _assert_cm_testing_bootstrap_allowed(request: OdooStableBootstrapRequest) -> None:
+    if request.product != "odoo-tenant-cm" or request.context != "cm" or request.instance != "testing":
+        raise click.ClickException(
+            "Odoo stable bootstrap is currently limited to odoo-tenant-cm cm/testing."
+        )
+    if request.confirmation != ODOO_STABLE_BOOTSTRAP_CONFIRMATION:
+        raise click.ClickException(
+            f"Odoo stable bootstrap requires confirmation {ODOO_STABLE_BOOTSTRAP_CONFIRMATION!r}."
+        )
+
+
+def _build_bootstrap_ship_request(
+    *,
+    context: str,
+    instance: str,
+    target_record: DokployTargetRecord,
+    artifact_id: str,
+    source_git_ref: str,
+) -> ShipRequest:
+    return ShipRequest(
+        artifact_id=artifact_id,
+        context=context,
+        instance=instance,
+        source_git_ref=source_git_ref,
+        target_name=target_record.target_name or f"{context}-{instance}",
+        target_type="compose",
+        deploy_mode="dokploy-compose-schedule",
+        wait=True,
+        verify_health=False,
+        no_cache=False,
+        destination_health=HealthcheckEvidence(status="pending"),
+    )
+
+
+def _write_failed_bootstrap_deployment(
+    *,
+    record_store: OdooStableBootstrapStore,
+    ship_request: ShipRequest,
+    deployment_record_id: str,
+    started_at: str,
+    resolved_target: ResolvedTargetEvidence,
+    post_deploy_update: PostDeployUpdateEvidence | None = None,
+    destination_health: HealthcheckEvidence | None = None,
+) -> None:
+    record_store.write_deployment_record(
+        build_deployment_record(
+            request=ship_request,
+            record_id=deployment_record_id,
+            deployment_id="control-plane-dokploy-schedule",
+            deployment_status="fail",
+            started_at=started_at,
+            finished_at=utc_now_timestamp(),
+            resolved_target=resolved_target,
+            post_deploy_update=post_deploy_update,
+            destination_health=destination_health,
+        )
+    )
+
+
+def _base_result(
+    *,
+    request: OdooStableBootstrapRequest,
+    deployment_record_id: str,
+    target_record: DokployTargetRecord,
+    target_id_record: DokployTargetIdRecord,
+    inventory: EnvironmentInventory,
+    bootstrap_status: Literal["pass", "fail"],
+    post_deploy_status: Literal["pass", "fail", "skipped"] = "skipped",
+    health_status: Literal["pass", "fail", "skipped"] = "skipped",
+    canonical_status: Literal["pass", "fail", "skipped"] = "skipped",
+    logo_status: Literal["pass", "fail", "skipped"] = "skipped",
+    error_message: str = "",
+) -> OdooStableBootstrapResult:
+    artifact_id = ""
+    if inventory.artifact_identity is not None:
+        artifact_id = inventory.artifact_identity.artifact_id
+    return OdooStableBootstrapResult(
+        product=request.product,
+        context=request.context,
+        instance=request.instance,
+        deployment_record_id=deployment_record_id,
+        bootstrap_status=bootstrap_status,
+        post_deploy_status=post_deploy_status,
+        health_status=health_status,
+        canonical_status=canonical_status,
+        logo_status=logo_status,
+        target_id=target_id_record.target_id,
+        target_name=target_record.target_name,
+        artifact_id=artifact_id,
+        source_git_ref=inventory.source_git_ref,
+        error_message=error_message,
+    )
+
+
+def execute_odoo_stable_bootstrap(
+    *,
+    control_plane_root: Path,
+    record_store: OdooStableBootstrapStore,
+    request: OdooStableBootstrapRequest,
+    env_file: Path | None = None,
+) -> OdooStableBootstrapResult:
+    _assert_cm_testing_bootstrap_allowed(request)
+    profile = record_store.read_product_profile_record(request.product)
+    lane = _read_lane(profile=profile, instance=request.instance)
+    if lane.context.strip().lower() != request.context:
+        raise click.ClickException(
+            f"Product {request.product!r} lane {request.instance!r} belongs to context {lane.context!r}, not {request.context!r}."
+        )
+    target_record = record_store.read_dokploy_target_record(
+        context_name=request.context, instance_name=request.instance
+    )
+    target_id_record = record_store.read_dokploy_target_id_record(
+        context_name=request.context, instance_name=request.instance
+    )
+    if target_record.target_type != "compose":
+        raise click.ClickException("Odoo stable bootstrap requires a compose target.")
+    inventory = record_store.read_environment_inventory(
+        context_name=request.context, instance_name=request.instance
+    )
+    artifact_id = ""
+    if inventory.artifact_identity is not None:
+        artifact_id = inventory.artifact_identity.artifact_id
+    if not artifact_id.strip():
+        raise click.ClickException("Odoo stable bootstrap requires inventory artifact evidence.")
+    if not inventory.source_git_ref.strip():
+        raise click.ClickException("Odoo stable bootstrap requires inventory source git ref evidence.")
+
+    deployment_record_id = generate_deployment_record_id(
+        context_name=request.context, instance_name=request.instance
+    )
+    started_at = utc_now_timestamp()
+    ship_request = _build_bootstrap_ship_request(
+        context=request.context,
+        instance=request.instance,
+        target_record=target_record,
+        artifact_id=artifact_id,
+        source_git_ref=inventory.source_git_ref,
+    )
+    resolved_target = ResolvedTargetEvidence(
+        target_type="compose",
+        target_id=target_id_record.target_id,
+        target_name=target_record.target_name or f"{request.context}-{request.instance}",
+    )
+    record_store.write_deployment_record(
+        build_deployment_record(
+            request=ship_request,
+            record_id=deployment_record_id,
+            deployment_id="control-plane-dokploy-schedule",
+            deployment_status="pending",
+            started_at=started_at,
+            finished_at="",
+            resolved_target=resolved_target,
+            destination_health=HealthcheckEvidence(status="pending")
+            if request.verify_health
+            else HealthcheckEvidence(status="skipped"),
+        )
+    )
+
+    try:
+        host, token = control_plane_dokploy.read_dokploy_config(
+            control_plane_root=control_plane_root
+        )
+        target_definition = control_plane_dokploy.DokployTargetDefinition(
+            context=request.context,
+            instance=request.instance,
+            target_type="compose",
+            target_id=target_id_record.target_id,
+            target_name=target_record.target_name,
+            project_name=target_record.project_name,
+            deploy_timeout_seconds=target_record.deploy_timeout_seconds,
+            healthcheck_timeout_seconds=target_record.healthcheck_timeout_seconds,
+        )
+        control_plane_dokploy.run_compose_odoo_stable_bootstrap(
+            host=host,
+            token=token,
+            target_definition=target_definition,
+            env_file=env_file,
+            timeout_seconds=request.timeout_seconds,
+        )
+    except click.ClickException as error:
+        _write_failed_bootstrap_deployment(
+            record_store=record_store,
+            ship_request=ship_request,
+            deployment_record_id=deployment_record_id,
+            started_at=started_at,
+            resolved_target=resolved_target,
+            destination_health=HealthcheckEvidence(status="skipped"),
+        )
+        return _base_result(
+            request=request,
+            deployment_record_id=deployment_record_id,
+            target_record=target_record,
+            target_id_record=target_id_record,
+            inventory=inventory,
+            bootstrap_status="fail",
+            error_message=str(error),
+        )
+
+    post_deploy_result = execute_odoo_post_deploy(
+        control_plane_root=control_plane_root,
+        record_store=record_store,
+        request=OdooPostDeployRequest(
+            context=request.context, instance=request.instance, phase="manual"
+        ),
+    )
+    post_deploy_evidence = PostDeployUpdateEvidence(
+        attempted=True,
+        status=post_deploy_result.post_deploy_status,
+        detail=post_deploy_result.error_message
+        or "Odoo post-deploy completed after stable bootstrap.",
+    )
+    if post_deploy_result.post_deploy_status != "pass":
+        _write_failed_bootstrap_deployment(
+            record_store=record_store,
+            ship_request=ship_request,
+            deployment_record_id=deployment_record_id,
+            started_at=started_at,
+            resolved_target=resolved_target,
+            post_deploy_update=post_deploy_evidence,
+            destination_health=HealthcheckEvidence(status="skipped"),
+        )
+        return _base_result(
+            request=request,
+            deployment_record_id=deployment_record_id,
+            target_record=target_record,
+            target_id_record=target_id_record,
+            inventory=inventory,
+            bootstrap_status="fail",
+            post_deploy_status=post_deploy_result.post_deploy_status,
+            error_message=post_deploy_result.error_message or "Odoo post-deploy failed.",
+        )
+
+    base_url = _target_base_url(lane=lane, domains=())
+    health_url = _target_health_url(profile=profile, lane=lane, domains=())
+    health_timeout_seconds = (
+        request.health_timeout_seconds
+        or target_record.healthcheck_timeout_seconds
+        or control_plane_dokploy.DEFAULT_DOKPLOY_HEALTH_TIMEOUT_SECONDS
+    )
+    health_status: Literal["pass", "fail", "skipped"] = "skipped"
+    canonical_status: Literal["pass", "fail", "skipped"] = "skipped"
+    logo_status: Literal["pass", "fail", "skipped"] = "skipped"
+    try:
+        if request.verify_health:
+            if not health_url:
+                raise click.ClickException("Odoo stable bootstrap has no health URL.")
+            _verify_health_url(health_url=health_url, timeout_seconds=health_timeout_seconds)
+            health_status = "pass"
+        if request.verify_canonical:
+            if not base_url:
+                raise click.ClickException("Odoo stable bootstrap has no base URL.")
+            _verify_canonical_url(
+                base_url=base_url,
+                expected_base_url=base_url,
+                timeout_seconds=health_timeout_seconds,
+            )
+            canonical_status = "pass"
+        if request.verify_logo:
+            if not base_url:
+                raise click.ClickException("Odoo stable bootstrap has no base URL.")
+            _verify_logo_route(base_url=base_url, timeout_seconds=health_timeout_seconds)
+            logo_status = "pass"
+    except click.ClickException as error:
+        destination_health = HealthcheckEvidence(
+            verified=health_status == "pass",
+            urls=(health_url,) if health_url else (),
+            timeout_seconds=health_timeout_seconds if health_url else None,
+            status="fail",
+        )
+        _write_failed_bootstrap_deployment(
+            record_store=record_store,
+            ship_request=ship_request,
+            deployment_record_id=deployment_record_id,
+            started_at=started_at,
+            resolved_target=resolved_target,
+            post_deploy_update=post_deploy_evidence,
+            destination_health=destination_health,
+        )
+        return _base_result(
+            request=request,
+            deployment_record_id=deployment_record_id,
+            target_record=target_record,
+            target_id_record=target_id_record,
+            inventory=inventory,
+            bootstrap_status="fail",
+            post_deploy_status="pass",
+            health_status=health_status if health_status == "pass" else "fail",
+            canonical_status=canonical_status if canonical_status == "pass" else "fail",
+            logo_status=logo_status if logo_status == "pass" else "fail",
+            error_message=str(error),
+        )
+
+    finished_at = utc_now_timestamp()
+    destination_health = HealthcheckEvidence(
+        verified=request.verify_health,
+        urls=(health_url,) if request.verify_health and health_url else (),
+        timeout_seconds=health_timeout_seconds if request.verify_health and health_url else None,
+        status=health_status,
+    )
+    deployment_record = build_deployment_record(
+        request=ship_request,
+        record_id=deployment_record_id,
+        deployment_id="control-plane-dokploy-schedule",
+        deployment_status="pass",
+        started_at=started_at,
+        finished_at=finished_at,
+        resolved_target=resolved_target,
+        post_deploy_update=post_deploy_evidence,
+        destination_health=destination_health,
+    )
+    record_store.write_deployment_record(deployment_record)
+    record_store.write_environment_inventory(
+        build_environment_inventory(deployment_record=deployment_record, updated_at=finished_at)
+    )
+    return _base_result(
+        request=request,
+        deployment_record_id=deployment_record_id,
+        target_record=target_record,
+        target_id_record=target_id_record,
+        inventory=inventory,
+        bootstrap_status="pass",
+        post_deploy_status="pass",
+        health_status=health_status,
+        canonical_status=canonical_status,
+        logo_status=logo_status,
+    )

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -153,6 +153,13 @@ inventory, destroy, and readiness; it does not grant Odoo products access to
 stable generic-web deploy or promotion routes, and it does not make compose
 templates valid for generic-web products.
 
+Odoo also exposes `POST /v1/drivers/odoo/stable-bootstrap` as a destructive
+instance-scoped action. The first implementation is policy-limited to CM testing
+and reuses the existing devkit `--bootstrap` data workflow through a
+Launchplane-owned Dokploy schedule. It is separate from target replacement:
+replacement reconciles provider/runtime target state, while bootstrap rebuilds
+Odoo application data for lanes that are explicitly safe to recreate.
+
 Driver action routes are owned by the base driver contract. The service accepts
 any product key on Odoo and VeriReel action envelopes, then authorizes the call
 against that product and verifies the product profile's `driver_id` or driver

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -723,6 +723,18 @@ and writes deployment plus inventory records. Do not manually delete canonical
 stable targets as a replacement shortcut; add the missing Launchplane apply
 coverage first, then use the service-backed workflow.
 
+Target replacement only reconciles the provider target and runtime envelope. If
+an intentionally empty CM testing lane needs its Odoo database and filestore
+rebuilt, use the trusted `Odoo Stable Bootstrap` workflow instead of repairing
+state in Dokploy or a local checkout. The workflow calls
+`POST /v1/drivers/odoo/stable-bootstrap`, requires the exact confirmation
+`bootstrap cm testing`, and is currently limited to `odoo-tenant-cm` `cm/testing`.
+The service runs the existing compose-local devkit data workflow in `--bootstrap`
+mode through a dedicated manual Dokploy schedule, then runs Odoo post-deploy and
+verifies health, canonical URL, and logo routes before writing deployment and
+inventory evidence. Do not use this path for prod until Launchplane has explicit
+backup/restore policy evidence for that lane.
+
 `launchplane-previews write-from-generation` and `launchplane-previews write-destroyed`
 are local preview-evidence ingest adapters that mirror the service ingress
 payload shape. VeriReel preview runtime now flows through Launchplane drivers:

--- a/docs/records.md
+++ b/docs/records.md
@@ -335,6 +335,11 @@ state/
 - Deployment records make the native follow-up step explicit by
   recording whether the Odoo-specific compose post-deploy update was skipped,
   pending, passed, or failed.
+- Odoo stable bootstrap writes normal deployment and inventory records even
+  though the provider deploy step is a dedicated Dokploy schedule. The record's
+  deploy mode is `dokploy-compose-schedule`; post-deploy evidence captures the
+  typed Odoo settings apply, and destination health captures the public
+  verification outcome after bootstrap.
 - Odoo prod rollback writes a normal deployment record for the rollback deploy,
   refreshes prod inventory, mints the prod release tuple from the selected
   artifact manifest, and annotates the current prod promotion record's

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -1961,6 +1961,72 @@ protected_store_keys = ["yps-your-part-supplier"]
         self.assertIn("manifest.json", script)
         self.assertIn("/api/schedule.runManually", request_paths)
 
+    def test_run_compose_odoo_stable_bootstrap_uses_dedicated_manual_schedule(self) -> None:
+        target_definition = control_plane_dokploy.DokployTargetDefinition(
+            context="cm",
+            instance="testing",
+            target_id="compose-123",
+            target_name="cm-testing",
+        )
+        schedule_payloads: list[dict[str, object]] = []
+        request_paths: list[str] = []
+
+        def capture_schedule_payload(**kwargs: object) -> dict[str, str]:
+            schedule_payloads.append(cast("dict[str, object]", kwargs["schedule_payload"]))
+            return {"scheduleId": "schedule-123"}
+
+        def capture_request_path(**kwargs: object) -> dict[str, bool]:
+            request_paths.append(str(kwargs["path"]))
+            return {"ok": True}
+
+        with (
+            patch(
+                "control_plane.dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "env": "ODOO_DB_NAME=cm_testing\nODOO_FILESTORE_PATH=/volumes/data/filestore\n",
+                    "appName": "cm-testing-app",
+                    "serverId": "server-123",
+                },
+            ),
+            patch(
+                "control_plane.dokploy.find_matching_dokploy_schedule",
+                return_value=None,
+            ),
+            patch(
+                "control_plane.dokploy.upsert_dokploy_schedule",
+                side_effect=capture_schedule_payload,
+            ),
+            patch(
+                "control_plane.dokploy.latest_deployment_for_schedule",
+                return_value={"deploymentId": "schedule-before"},
+            ),
+            patch(
+                "control_plane.dokploy.wait_for_dokploy_schedule_deployment",
+                side_effect=lambda **_kwargs: None,
+            ),
+            patch(
+                "control_plane.dokploy.dokploy_request",
+                side_effect=capture_request_path,
+            ),
+        ):
+            control_plane_dokploy.run_compose_odoo_stable_bootstrap(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                target_definition=target_definition,
+                env_file=None,
+            )
+
+        self.assertEqual(len(schedule_payloads), 1)
+        self.assertEqual(
+            schedule_payloads[0]["name"],
+            control_plane_dokploy.DOKPLOY_ODOO_BOOTSTRAP_SCHEDULE_NAME,
+        )
+        self.assertEqual(schedule_payloads[0]["command"], "control-plane odoo stable bootstrap")
+        script = str(schedule_payloads[0]["script"])
+        self.assertIn("workflow_arguments=(--bootstrap)", script)
+        self.assertNotIn("workflow_arguments=(--update-only)", script)
+        self.assertIn("/api/schedule.runManually", request_paths)
+
     def test_run_compose_post_deploy_update_rejects_unsupported_env_overlay_keys(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             env_file = Path(temporary_directory_name) / "post-deploy.env"

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -101,6 +101,11 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         self.assertEqual(actions["preview_refresh"].scope, "preview")
         self.assertEqual(actions["preview_inventory"].safety, "safe_write")
         self.assertEqual(actions["preview_destroy"].safety, "destructive")
+        self.assertEqual(actions["stable_bootstrap"].safety, "destructive")
+        self.assertEqual(
+            actions["stable_bootstrap"].route_path,
+            "/v1/drivers/odoo/stable-bootstrap",
+        )
 
     def test_verireel_descriptor_exposes_preview_and_stable_capabilities(self) -> None:
         descriptor = read_driver_descriptor("verireel")
@@ -268,6 +273,11 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
                     control_plane_service._ODOO_POST_DEPLOY_ROUTE,
                     control_plane_service.OdooPostDeployEnvelope,
                     "post-deploy driver",
+                ),
+                "stable_bootstrap": (
+                    control_plane_service._ODOO_STABLE_BOOTSTRAP_ROUTE,
+                    control_plane_service.OdooStableBootstrapEnvelope,
+                    "stable bootstrap",
                 ),
             },
         )

--- a/tests/test_odoo_stable_bootstrap.py
+++ b/tests/test_odoo_stable_bootstrap.py
@@ -1,0 +1,246 @@
+import unittest
+from pathlib import Path
+from typing import cast
+from unittest.mock import patch
+
+import click
+
+from control_plane.contracts.deployment_record import DeploymentRecord
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductImageProfile,
+    ProductLaneProfile,
+)
+from control_plane.dokploy import DokployTargetDefinition
+from control_plane.contracts.promotion_record import ArtifactIdentityReference, DeploymentEvidence
+from control_plane.workflows.odoo_post_deploy import OdooPostDeployResult
+from control_plane.workflows.odoo_stable_bootstrap import (
+    ODOO_STABLE_BOOTSTRAP_CONFIRMATION,
+    OdooStableBootstrapRequest,
+    execute_odoo_stable_bootstrap,
+)
+
+
+class _Store:
+    def __init__(self) -> None:
+        self.profile = LaunchplaneProductProfileRecord(
+            product="odoo-tenant-cm",
+            display_name="Odoo CM",
+            repository="cbusillo/odoo-tenant-cm",
+            driver_id="odoo",
+            image=ProductImageProfile(repository="ghcr.io/cbusillo/odoo-tenant-cm"),
+            runtime_port=8069,
+            health_path="/web/health",
+            lanes=(
+                ProductLaneProfile(
+                    instance="testing",
+                    context="cm",
+                    base_url="https://cm-testing.shinycomputers.com",
+                    health_url="https://cm-testing.shinycomputers.com/web/health",
+                ),
+            ),
+            updated_at="2026-05-10T00:00:00Z",
+            source="test",
+        )
+        self.target_record = DokployTargetRecord(
+            context="cm",
+            instance="testing",
+            project_name="odoo",
+            target_type="compose",
+            target_name="cm-testing",
+            deploy_timeout_seconds=900,
+            healthcheck_timeout_seconds=30,
+            updated_at="2026-05-10T00:00:00Z",
+        )
+        self.target_id_record = DokployTargetIdRecord(
+            context="cm",
+            instance="testing",
+            target_id="compose-cm-testing",
+            updated_at="2026-05-10T00:00:00Z",
+        )
+        self.inventory = EnvironmentInventory(
+            context="cm",
+            instance="testing",
+            artifact_identity=ArtifactIdentityReference(artifact_id="artifact-cm-testing"),
+            source_git_ref="abc123",
+            deploy=DeploymentEvidence(
+                status="pass",
+                target_type="compose",
+                target_name="cm-testing",
+                deploy_mode="dokploy-compose-api",
+            ),
+            updated_at="2026-05-10T00:00:00Z",
+            deployment_record_id="deployment-cm-testing-old",
+        )
+        self.deployment_records: list[DeploymentRecord] = []
+        self.environment_inventories: list[EnvironmentInventory] = []
+
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
+        if product != self.profile.product:
+            raise FileNotFoundError(product)
+        return self.profile
+
+    def read_dokploy_target_record(
+        self, *, context_name: str, instance_name: str
+    ) -> DokployTargetRecord:
+        if (context_name, instance_name) != ("cm", "testing"):
+            raise FileNotFoundError(f"{context_name}/{instance_name}")
+        return self.target_record
+
+    def read_dokploy_target_id_record(
+        self, *, context_name: str, instance_name: str
+    ) -> DokployTargetIdRecord:
+        if (context_name, instance_name) != ("cm", "testing"):
+            raise FileNotFoundError(f"{context_name}/{instance_name}")
+        return self.target_id_record
+
+    def read_environment_inventory(
+        self, *, context_name: str, instance_name: str
+    ) -> EnvironmentInventory:
+        if (context_name, instance_name) != ("cm", "testing"):
+            raise FileNotFoundError(f"{context_name}/{instance_name}")
+        return self.inventory
+
+    def write_deployment_record(self, record: DeploymentRecord) -> None:
+        self.deployment_records.append(record)
+
+    def write_environment_inventory(self, record: EnvironmentInventory) -> None:
+        self.environment_inventories.append(record)
+
+
+class OdooStableBootstrapTests(unittest.TestCase):
+    def test_execute_runs_bootstrap_post_deploy_and_verification(self) -> None:
+        store = _Store()
+        captured_bootstrap_runs: list[dict[str, object]] = []
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example.com", "token-123"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.control_plane_dokploy.run_compose_odoo_stable_bootstrap",
+                side_effect=lambda **kwargs: captured_bootstrap_runs.append(kwargs),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.execute_odoo_post_deploy",
+                return_value=OdooPostDeployResult(
+                    context="cm",
+                    instance="testing",
+                    phase="manual",
+                    post_deploy_status="pass",
+                ),
+            ) as post_deploy_mock,
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap._verify_health_url",
+                side_effect=lambda **_kwargs: None,
+            ) as health_mock,
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap._verify_canonical_url",
+                side_effect=lambda **_kwargs: None,
+            ) as canonical_mock,
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap._verify_logo_route",
+                side_effect=lambda **_kwargs: None,
+            ) as logo_mock,
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.utc_now_timestamp",
+                side_effect=("2026-05-10T02:00:00Z", "2026-05-10T02:05:00Z"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.generate_deployment_record_id",
+                return_value="deployment-cm-testing-bootstrap",
+            ),
+        ):
+            result = execute_odoo_stable_bootstrap(
+                control_plane_root=Path("/tmp/launchplane"),
+                record_store=store,
+                request=OdooStableBootstrapRequest(
+                    product="odoo-tenant-cm",
+                    context="cm",
+                    instance="testing",
+                    confirmation=ODOO_STABLE_BOOTSTRAP_CONFIRMATION,
+                ),
+            )
+
+        self.assertEqual(result.bootstrap_status, "pass")
+        self.assertEqual(result.post_deploy_status, "pass")
+        self.assertEqual(result.health_status, "pass")
+        self.assertEqual(result.canonical_status, "pass")
+        self.assertEqual(result.logo_status, "pass")
+        self.assertEqual(len(captured_bootstrap_runs), 1)
+        target_definition = cast(
+            DokployTargetDefinition, captured_bootstrap_runs[0]["target_definition"]
+        )
+        self.assertEqual(target_definition.target_id, "compose-cm-testing")
+        self.assertEqual(captured_bootstrap_runs[0]["timeout_seconds"], None)
+        post_deploy_mock.assert_called_once()
+        self.assertEqual(post_deploy_mock.call_args.kwargs["request"].phase, "manual")
+        health_mock.assert_called_once()
+        canonical_mock.assert_called_once()
+        logo_mock.assert_called_once()
+        self.assertEqual(len(store.deployment_records), 2)
+        self.assertEqual(store.deployment_records[-1].deploy.status, "pass")
+        self.assertEqual(len(store.environment_inventories), 1)
+        self.assertEqual(
+            store.environment_inventories[0].deployment_record_id,
+            "deployment-cm-testing-bootstrap",
+        )
+
+    def test_execute_refuses_non_cm_testing(self) -> None:
+        store = _Store()
+        with self.assertRaises(click.ClickException) as raised_error:
+            execute_odoo_stable_bootstrap(
+                control_plane_root=Path("/tmp/launchplane"),
+                record_store=store,
+                request=OdooStableBootstrapRequest(
+                    product="odoo-tenant-cm",
+                    context="cm",
+                    instance="prod",
+                    confirmation=ODOO_STABLE_BOOTSTRAP_CONFIRMATION,
+                ),
+            )
+
+        self.assertIn("cm/testing", str(raised_error.exception))
+
+    def test_execute_records_failure_when_bootstrap_schedule_fails(self) -> None:
+        store = _Store()
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example.com", "token-123"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.control_plane_dokploy.run_compose_odoo_stable_bootstrap",
+                side_effect=click.ClickException("schedule failed"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.utc_now_timestamp",
+                side_effect=("2026-05-10T02:00:00Z", "2026-05-10T02:01:00Z"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.generate_deployment_record_id",
+                return_value="deployment-cm-testing-bootstrap",
+            ),
+        ):
+            result = execute_odoo_stable_bootstrap(
+                control_plane_root=Path("/tmp/launchplane"),
+                record_store=store,
+                request=OdooStableBootstrapRequest(
+                    product="odoo-tenant-cm",
+                    context="cm",
+                    instance="testing",
+                    confirmation=ODOO_STABLE_BOOTSTRAP_CONFIRMATION,
+                ),
+            )
+
+        self.assertEqual(result.bootstrap_status, "fail")
+        self.assertIn("schedule failed", result.error_message)
+        self.assertEqual(store.deployment_records[-1].deploy.status, "fail")
+        self.assertEqual(store.environment_inventories, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -97,6 +97,7 @@ from control_plane.workflows.verireel_environment import VeriReelStableEnvironme
 from control_plane.workflows.verireel_rollout import VeriReelRolloutVerificationResult
 from control_plane.workflows.odoo_artifact_publish import OdooArtifactPublishResult
 from control_plane.workflows.odoo_post_deploy import OdooPostDeployResult
+from control_plane.workflows.odoo_stable_bootstrap import OdooStableBootstrapResult
 from control_plane.workflows.odoo_prod_backup_gate import OdooProdBackupGateResult
 from control_plane.workflows.odoo_prod_promotion import OdooProdPromotionResult
 from control_plane.workflows.odoo_prod_rollback import OdooProdRollbackResult
@@ -15351,6 +15352,146 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
             self.assertEqual(status_code, 400)
             self.assertEqual(payload["error"]["code"], "invalid_request")
+
+    def test_odoo_stable_bootstrap_driver_runs_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/odoo-stable-bootstrap.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["odoo_stable_bootstrap.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-stable-bootstrap.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_odoo_stable_bootstrap",
+                return_value=OdooStableBootstrapResult(
+                    product="odoo-tenant-cm",
+                    context="cm",
+                    instance="testing",
+                    deployment_record_id="deployment-cm-testing-bootstrap",
+                    bootstrap_status="pass",
+                    post_deploy_status="pass",
+                    health_status="pass",
+                    canonical_status="pass",
+                    logo_status="pass",
+                ),
+            ) as bootstrap_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/stable-bootstrap",
+                    payload={
+                        "product": "odoo-tenant-cm",
+                        "bootstrap": {
+                            "product": "odoo-tenant-cm",
+                            "context": "cm",
+                            "instance": "testing",
+                            "confirmation": "bootstrap cm testing",
+                            "verify_health": True,
+                            "verify_canonical": True,
+                            "verify_logo": True,
+                        },
+                    },
+                    headers={"Idempotency-Key": "bootstrap-cm-testing"},
+                )
+
+            self.assertEqual(status_code, 202)
+            self.assertEqual(payload["status"], "accepted")
+            self.assertEqual(
+                payload["records"],
+                {"deployment_record_id": "deployment-cm-testing-bootstrap"},
+            )
+            self.assertEqual(payload["result"]["bootstrap_status"], "pass")
+            bootstrap_mock.assert_called_once()
+            request = bootstrap_mock.call_args.kwargs["request"]
+            self.assertEqual(request.confirmation, "bootstrap cm testing")
+
+    def test_odoo_stable_bootstrap_driver_rejects_unauthorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-stable-bootstrap.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate(
+                    {
+                        "github_actions": [
+                            {
+                                "repository": "cbusillo/launchplane",
+                                "workflow_refs": [
+                                    "cbusillo/launchplane/.github/workflows/odoo-stable-bootstrap.yml@refs/heads/main"
+                                ],
+                                "event_names": ["workflow_dispatch"],
+                                "products": ["odoo-tenant-cm"],
+                                "contexts": ["cm"],
+                                "actions": ["odoo_target_replacement_plan.read"],
+                            }
+                        ]
+                    }
+                ),
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/odoo/stable-bootstrap",
+                payload={
+                    "product": "odoo-tenant-cm",
+                    "bootstrap": {
+                        "product": "odoo-tenant-cm",
+                        "context": "cm",
+                        "instance": "testing",
+                        "confirmation": "bootstrap cm testing",
+                    },
+                },
+                headers={"Idempotency-Key": "bootstrap-cm-testing"},
+            )
+
+            self.assertEqual(status_code, 403)
+            self.assertEqual(payload["error"]["code"], "authorization_denied")
 
     def test_odoo_target_replacement_plan_driver_reads_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary

- add a dedicated Odoo stable bootstrap service driver limited to `odoo-tenant-cm` `cm/testing` with exact confirmation text
- run the existing compose-local data workflow in `--bootstrap` mode through a new Launchplane-owned Dokploy schedule, then post-deploy and verify health/canonical/logo
- expose a trusted `Odoo Stable Bootstrap` workflow and deploy-time auth grant, plus descriptor/docs/test coverage

Refs #542

## Verification

- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`
