### PR TITLE
Tighten Odoo bootstrap verification

### DIFF
--- a/.github/workflows/odoo-stable-bootstrap.yml
+++ b/.github/workflows/odoo-stable-bootstrap.yml
@@ -162,6 +162,31 @@ jobs:
             echo "Launchplane Odoo stable bootstrap failed with HTTP ${status_code}." >&2
             exit 1
           fi
+          bootstrap_status="$(jq -r '.result.bootstrap_status // ""' odoo-stable-bootstrap.json)"
+          post_deploy_status="$(jq -r '.result.post_deploy_status // ""' odoo-stable-bootstrap.json)"
+          health_status="$(jq -r '.result.health_status // ""' odoo-stable-bootstrap.json)"
+          canonical_status="$(jq -r '.result.canonical_status // ""' odoo-stable-bootstrap.json)"
+          logo_status="$(jq -r '.result.logo_status // ""' odoo-stable-bootstrap.json)"
+          if [ "$bootstrap_status" != "pass" ] || [ "$post_deploy_status" != "pass" ]; then
+            echo "Launchplane Odoo stable bootstrap did not pass: bootstrap=${bootstrap_status} post_deploy=${post_deploy_status}." >&2
+            jq -r '.result.error_message // ""' odoo-stable-bootstrap.json >&2
+            exit 1
+          fi
+          if [ "$VERIFY_HEALTH" = "true" ] && [ "$health_status" != "pass" ]; then
+            echo "Launchplane Odoo stable bootstrap health verification did not pass: ${health_status}." >&2
+            jq -r '.result.error_message // ""' odoo-stable-bootstrap.json >&2
+            exit 1
+          fi
+          if [ "$VERIFY_CANONICAL" = "true" ] && [ "$canonical_status" != "pass" ]; then
+            echo "Launchplane Odoo stable bootstrap canonical verification did not pass: ${canonical_status}." >&2
+            jq -r '.result.error_message // ""' odoo-stable-bootstrap.json >&2
+            exit 1
+          fi
+          if [ "$VERIFY_LOGO" = "true" ] && [ "$logo_status" != "pass" ]; then
+            echo "Launchplane Odoo stable bootstrap logo verification did not pass: ${logo_status}." >&2
+            jq -r '.result.error_message // ""' odoo-stable-bootstrap.json >&2
+            exit 1
+          fi
 
       - name: Upload bootstrap result
         uses: actions/upload-artifact@v5

--- a/control_plane/workflows/odoo_stable_bootstrap.py
+++ b/control_plane/workflows/odoo_stable_bootstrap.py
@@ -333,8 +333,10 @@ def execute_odoo_stable_bootstrap(
             error_message=post_deploy_result.error_message or "Odoo post-deploy failed.",
         )
 
-    base_url = _target_base_url(lane=lane, domains=())
-    health_url = _target_health_url(profile=profile, lane=lane, domains=())
+    base_url = _target_base_url(lane=lane, domains=target_record.domains)
+    health_url = _target_health_url(
+        profile=profile, lane=lane, domains=target_record.domains
+    )
     health_timeout_seconds = (
         request.health_timeout_seconds
         or target_record.healthcheck_timeout_seconds

--- a/tests/test_odoo_stable_bootstrap.py
+++ b/tests/test_odoo_stable_bootstrap.py
@@ -51,6 +51,7 @@ class _Store:
             project_name="odoo",
             target_type="compose",
             target_name="cm-testing",
+            domains=("cm-testing.shinycomputers.com",),
             deploy_timeout_seconds=900,
             healthcheck_timeout_seconds=30,
             updated_at="2026-05-10T00:00:00Z",
@@ -179,7 +180,15 @@ class OdooStableBootstrapTests(unittest.TestCase):
         post_deploy_mock.assert_called_once()
         self.assertEqual(post_deploy_mock.call_args.kwargs["request"].phase, "manual")
         health_mock.assert_called_once()
+        self.assertEqual(
+            health_mock.call_args.kwargs["health_url"],
+            "https://cm-testing.shinycomputers.com/web/health",
+        )
         canonical_mock.assert_called_once()
+        self.assertEqual(
+            canonical_mock.call_args.kwargs["base_url"],
+            "https://cm-testing.shinycomputers.com",
+        )
         logo_mock.assert_called_once()
         self.assertEqual(len(store.deployment_records), 2)
         self.assertEqual(store.deployment_records[-1].deploy.status, "pass")


### PR DESCRIPTION
## Summary

- derive Odoo stable bootstrap verification URLs from tracked target domains when lane URLs are not explicit
- make the GitHub workflow fail when Launchplane returns non-pass bootstrap/post-deploy/verification status
- cover domain-derived health/base URLs in the bootstrap workflow test

Refs #542

## Verification

- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`
