### PR TITLE
Honor configured local operator identity

### DIFF
--- a/control_plane/service_auth.py
+++ b/control_plane/service_auth.py
@@ -75,8 +75,6 @@ AgentConsumerActionSafety = Literal[
 ]
 AgentAuthzDecision = Literal["allowed", "denied"]
 LOCAL_OPERATOR_ALLOWED_ACTIONS = frozenset({"product_config.plan", "product_config.apply"})
-LOCAL_OPERATOR_DEFAULT_SUBJECT = "local-owner-agent"
-LOCAL_OPERATOR_DEFAULT_TOKEN_LABEL = "local-owner-write"
 
 
 class TokenVerifier(Protocol):
@@ -331,8 +329,8 @@ def limited_remote_user_action_allowed(action: str) -> bool:
 
 def local_operator_action_allowed(*, identity: LocalOperatorIdentity, action: str) -> bool:
     return (
-        identity.subject == LOCAL_OPERATOR_DEFAULT_SUBJECT
-        and identity.token_label == LOCAL_OPERATOR_DEFAULT_TOKEN_LABEL
+        bool(identity.subject.strip())
+        and bool(identity.token_label.strip())
         and action.strip() in LOCAL_OPERATOR_ALLOWED_ACTIONS
     )
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -7728,6 +7728,55 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(secret_records[0].name, "META_CONVERSIONS_API_TOKEN")
         self.assertEqual(secret_binding.binding_key, "META_CONVERSIONS_API_TOKEN")
 
+    def test_product_config_api_local_operator_allows_configured_identity(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            _write_runtime_key_safety_policy(
+                database_url=database_url,
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key="META_CONVERSIONS_API_TOKEN",
+                        secret_class="prod_only",
+                        allowed_contexts=("sellyouroutboard",),
+                        allowed_instances=("prod",),
+                    ),
+                ),
+            )
+
+            with patch.dict(
+                os.environ,
+                {
+                    control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "configured-local-owner",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "configured-write-token",
+                },
+                clear=True,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/product-config/apply",
+                    payload=_meta_product_config_payload(
+                        reason="Dry-run SellYourOutBoard Meta config from terminal operator."
+                    ),
+                    authorization="Bearer local-operator-token",
+                    headers={"Idempotency-Key": "product-config-configured-local-operator"},
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "dry-run")
+
     def test_product_config_api_rejects_missing_master_key_for_secret_bundle(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -630,22 +630,25 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
             )
         )
 
-    def test_local_operator_action_requires_expected_subject_and_label(self) -> None:
+    def test_local_operator_action_allows_configured_subject_and_label(self) -> None:
         self.assertTrue(
             local_operator_action_allowed(
-                identity=_local_operator_identity(),
+                identity=_local_operator_identity(
+                    subject="configured-local-operator",
+                    token_label="configured-write-token",
+                ),
                 action="product_config.apply",
             )
         )
         self.assertFalse(
             local_operator_action_allowed(
-                identity=_local_operator_identity(subject="different-owner"),
+                identity=_local_operator_identity(subject="  "),
                 action="product_config.apply",
             )
         )
         self.assertFalse(
             local_operator_action_allowed(
-                identity=_local_operator_identity(token_label="other-write-token"),
+                identity=_local_operator_identity(token_label="  "),
                 action="product_config.apply",
             )
         )


### PR DESCRIPTION
## Summary
- allow local-operator authz to use the configured subject/token-label identity produced by bearer authentication
- keep local-operator authorization limited to product-config plan/apply and reject blank identity fields
- add unit and service regressions for non-default local-operator identity configuration

## Validation
- uv run python -m unittest tests.test_service_auth tests.test_service.LaunchplaneServiceTests.test_product_config_api_local_operator_dry_run_returns_redacted_meta_plan tests.test_service.LaunchplaneServiceTests.test_product_config_api_local_operator_apply_requires_reason tests.test_service.LaunchplaneServiceTests.test_product_config_api_local_operator_apply_requires_matching_dry_run tests.test_service.LaunchplaneServiceTests.test_product_config_api_local_operator_apply_writes_meta_config_after_dry_run tests.test_service.LaunchplaneServiceTests.test_product_config_api_local_operator_allows_configured_identity
- uv run --extra dev ruff check control_plane/service_auth.py tests/test_service_auth.py tests/test_service.py
- uv run --extra dev mypy control_plane/service_auth.py tests/test_service_auth.py tests/test_service.py