### PR TITLE
Avoid long Odoo bootstrap verification timeouts

### DIFF
--- a/.github/workflows/odoo-stable-bootstrap.yml
+++ b/.github/workflows/odoo-stable-bootstrap.yml
@@ -157,11 +157,12 @@ jobs:
               --data "$payload" \
               "${LAUNCHPLANE_SERVICE_URL}/v1/drivers/odoo/stable-bootstrap"
           })"
-          jq . odoo-stable-bootstrap.json
           if [ "$status_code" != "202" ]; then
             echo "Launchplane Odoo stable bootstrap failed with HTTP ${status_code}." >&2
+            cat odoo-stable-bootstrap.json >&2
             exit 1
           fi
+          jq . odoo-stable-bootstrap.json
           bootstrap_status="$(jq -r '.result.bootstrap_status // ""' odoo-stable-bootstrap.json)"
           post_deploy_status="$(jq -r '.result.post_deploy_status // ""' odoo-stable-bootstrap.json)"
           health_status="$(jq -r '.result.health_status // ""' odoo-stable-bootstrap.json)"

--- a/control_plane/workflows/odoo_stable_bootstrap.py
+++ b/control_plane/workflows/odoo_stable_bootstrap.py
@@ -381,24 +381,16 @@ def execute_odoo_stable_bootstrap(
         if request.verify_canonical:
             if not base_url:
                 raise click.ClickException("Odoo stable bootstrap has no base URL.")
-            _run_verification_with_retry(
-                lambda: _verify_canonical_url(
-                    base_url=base_url,
-                    expected_base_url=base_url,
-                    timeout_seconds=health_timeout_seconds,
-                ),
+            _verify_canonical_url(
+                base_url=base_url,
+                expected_base_url=base_url,
                 timeout_seconds=health_timeout_seconds,
             )
             canonical_status = "pass"
         if request.verify_logo:
             if not base_url:
                 raise click.ClickException("Odoo stable bootstrap has no base URL.")
-            _run_verification_with_retry(
-                lambda: _verify_logo_route(
-                    base_url=base_url, timeout_seconds=health_timeout_seconds
-                ),
-                timeout_seconds=health_timeout_seconds,
-            )
+            _verify_logo_route(base_url=base_url, timeout_seconds=health_timeout_seconds)
             logo_status = "pass"
     except click.ClickException as error:
         destination_health = HealthcheckEvidence(


### PR DESCRIPTION
## Summary

- retry only the startup-sensitive health check during Odoo stable bootstrap verification
- avoid long synchronous canonical/logo retry loops that can exceed the service edge timeout
- report non-202 service responses before attempting to parse JSON in the workflow

Refs #542

## Verification

- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`
