### PR TITLE
Replay Odoo overrides during bootstrap deploy phase

### DIFF
--- a/control_plane/workflows/odoo_stable_bootstrap.py
+++ b/control_plane/workflows/odoo_stable_bootstrap.py
@@ -325,7 +325,7 @@ def execute_odoo_stable_bootstrap(
         control_plane_root=control_plane_root,
         record_store=record_store,
         request=OdooPostDeployRequest(
-            context=request.context, instance=request.instance, phase="manual"
+            context=request.context, instance=request.instance, phase="deploy"
         ),
     )
     post_deploy_evidence = PostDeployUpdateEvidence(

--- a/tests/test_odoo_stable_bootstrap.py
+++ b/tests/test_odoo_stable_bootstrap.py
@@ -131,7 +131,7 @@ class OdooStableBootstrapTests(unittest.TestCase):
                 return_value=OdooPostDeployResult(
                     context="cm",
                     instance="testing",
-                    phase="manual",
+                    phase="deploy",
                     post_deploy_status="pass",
                 ),
             ) as post_deploy_mock,
@@ -179,7 +179,7 @@ class OdooStableBootstrapTests(unittest.TestCase):
         self.assertEqual(target_definition.target_id, "compose-cm-testing")
         self.assertEqual(captured_bootstrap_runs[0]["timeout_seconds"], None)
         post_deploy_mock.assert_called_once()
-        self.assertEqual(post_deploy_mock.call_args.kwargs["request"].phase, "manual")
+        self.assertEqual(post_deploy_mock.call_args.kwargs["request"].phase, "deploy")
         health_mock.assert_called_once()
         self.assertEqual(
             health_mock.call_args.kwargs["health_url"],


### PR DESCRIPTION
## Summary
- run Odoo post-deploy replay with phase=deploy after stable bootstrap
- align stable bootstrap with default Odoo override apply_on phases so freshly written config parameter overrides are applied
- update the stable bootstrap regression to assert the deploy phase

## Validation
- uv run python -m unittest tests.test_odoo_stable_bootstrap tests.test_odoo_post_deploy
- uv run --extra dev ruff check control_plane/workflows/odoo_stable_bootstrap.py tests/test_odoo_stable_bootstrap.py
- uv run --extra dev mypy control_plane/workflows/odoo_stable_bootstrap.py tests/test_odoo_stable_bootstrap.py