### PR TITLE
Derive preview URLs in Launchplane

### DIFF
--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -5,7 +5,7 @@ import time
 from pathlib import Path
 from typing import Iterator, Literal, Protocol, runtime_checkable
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 from urllib.request import Request, urlopen
 
 import click
@@ -51,6 +51,7 @@ _ODOO_COMPOSE_STAGE_PREVIEW_REQUIRED_ENV_KEYS = (
 )
 _ODOO_COMPOSE_STAGE_PREVIEW_MIN_DEPLOY_TIMEOUT_SECONDS = 30
 _ODOO_COMPOSE_STAGE_PREVIEW_HEALTH_TIMEOUT_SECONDS = 120
+_PREVIEW_BASE_URL_ENV_KEY = "LAUNCHPLANE_PREVIEW_BASE_URL"
 
 
 class GenericWebPreviewProfileStore(Protocol):
@@ -175,7 +176,7 @@ class GenericWebPreviewRefreshRequest(BaseModel):
     schema_version: int = Field(default=1, ge=1)
     product: str
     preview_slug: str
-    preview_url: str
+    preview_url: str = ""
     image_reference: str
     anchor_pr_number: int | None = Field(default=None, ge=1)
     anchor_pr_url: str = ""
@@ -190,13 +191,12 @@ class GenericWebPreviewRefreshRequest(BaseModel):
             raise ValueError("Generic web preview refresh requires product.")
         if not self.preview_slug.strip():
             raise ValueError("Generic web preview refresh requires preview_slug.")
-        if not self.preview_url.strip():
-            raise ValueError("Generic web preview refresh requires preview_url.")
-        parsed = urlparse(self.preview_url.strip())
-        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-            raise ValueError(
-                "Generic web preview refresh preview_url must be an absolute http(s) URL."
-            )
+        if self.preview_url.strip():
+            parsed = urlparse(self.preview_url.strip())
+            if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+                raise ValueError(
+                    "Generic web preview refresh preview_url must be an absolute http(s) URL."
+                )
         if not self.image_reference.strip():
             raise ValueError("Generic web preview refresh requires image_reference.")
         if not self.source.strip():
@@ -827,6 +827,51 @@ def _preview_host(preview_url: str) -> str:
     return parsed.hostname
 
 
+def _preview_url_from_base_url(*, preview_slug: str, preview_base_url: str) -> str:
+    parsed = urlparse(preview_base_url.strip())
+    if parsed.scheme not in {"http", "https"}:
+        raise click.ClickException(f"{_PREVIEW_BASE_URL_ENV_KEY} must use http or https.")
+    if not parsed.hostname:
+        raise click.ClickException(f"{_PREVIEW_BASE_URL_ENV_KEY} requires a hostname.")
+    if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
+        raise click.ClickException(
+            f"{_PREVIEW_BASE_URL_ENV_KEY} must be a root URL without path, query, or fragment."
+        )
+    return urlunparse(
+        parsed._replace(
+            netloc=f"{preview_slug.strip()}.{parsed.hostname}",
+            path="",
+            params="",
+            query="",
+            fragment="",
+        )
+    )
+
+
+def resolve_generic_web_preview_url(
+    *,
+    control_plane_root: Path,
+    profile: LaunchplaneProductProfileRecord,
+    request: GenericWebPreviewRefreshRequest,
+) -> str:
+    explicit_preview_url = request.preview_url.strip()
+    if explicit_preview_url:
+        return explicit_preview_url
+    context_values = control_plane_runtime_environments.resolve_runtime_context_values(
+        control_plane_root=control_plane_root,
+        context_name=profile.preview.context,
+    )
+    preview_base_url = str(context_values.get(_PREVIEW_BASE_URL_ENV_KEY) or "").strip()
+    if not preview_base_url:
+        raise click.ClickException(
+            f"Missing {_PREVIEW_BASE_URL_ENV_KEY} in Launchplane runtime-environment records for {profile.preview.context}."
+        )
+    return _preview_url_from_base_url(
+        preview_slug=request.preview_slug,
+        preview_base_url=preview_base_url,
+    )
+
+
 def _render_preview_env_text(
     *,
     profile: LaunchplaneProductProfileRecord,
@@ -1244,6 +1289,11 @@ def execute_generic_web_preview_refresh(
             record_store=record_store,
             product=request.product,
         )
+    preview_url = resolve_generic_web_preview_url(
+        control_plane_root=control_plane_root,
+        profile=resolved_profile,
+        request=request,
+    )
     started_at = utc_now_timestamp()
     app_name_prefix = effective_preview_app_name_prefix(profile=resolved_profile)
     application_name = preview_application_name(
@@ -1267,7 +1317,7 @@ def execute_generic_web_preview_refresh(
             context=resolved_profile.preview.context,
             preview_slug=request.preview_slug,
             application_name=application_name,
-            preview_url=request.preview_url,
+            preview_url=preview_url,
             readiness=readiness,
             error_message="Generic web preview readiness blocked refresh.",
         )
@@ -1306,6 +1356,7 @@ def execute_generic_web_preview_refresh(
                 template_lane=template_lane,
                 target_definition=target_definition,
                 template_payload=template_application,
+                preview_url=preview_url,
             )
             finished_at = utc_now_timestamp()
             return GenericWebPreviewRefreshResult(
@@ -1317,7 +1368,7 @@ def execute_generic_web_preview_refresh(
                 preview_slug=request.preview_slug,
                 application_name=application_name,
                 application_id=application_id,
-                preview_url=request.preview_url,
+                preview_url=preview_url,
                 readiness=readiness,
             )
         _enforce_preview_copied_runtime_key_safety(
@@ -1330,7 +1381,7 @@ def execute_generic_web_preview_refresh(
         env_text = _render_preview_env_text(
             profile=resolved_profile,
             template_application=template_application,
-            preview_url=request.preview_url,
+            preview_url=preview_url,
         )
         application, created_application = _ensure_application(
             host=host,
@@ -1355,7 +1406,7 @@ def execute_generic_web_preview_refresh(
             host=host,
             token=token,
             application_id=application_id,
-            preview_host=_preview_host(request.preview_url),
+            preview_host=_preview_host(preview_url),
             runtime_port=resolved_profile.runtime_port,
         )
         latest_before = control_plane_dokploy.latest_deployment_for_target(
@@ -1380,7 +1431,7 @@ def execute_generic_web_preview_refresh(
             timeout_seconds=request.timeout_seconds,
         )
         _wait_for_preview_health(
-            preview_url=request.preview_url,
+            preview_url=preview_url,
             health_path=resolved_profile.health_path,
             timeout_seconds=request.timeout_seconds,
         )
@@ -1411,7 +1462,7 @@ def execute_generic_web_preview_refresh(
             preview_slug=request.preview_slug,
             application_name=application_name,
             application_id=application_id,
-            preview_url=request.preview_url,
+            preview_url=preview_url,
             readiness=readiness,
             error_message=message,
         )
@@ -1426,7 +1477,7 @@ def execute_generic_web_preview_refresh(
         preview_slug=request.preview_slug,
         application_name=application_name,
         application_id=application_id,
-        preview_url=request.preview_url,
+        preview_url=preview_url,
         readiness=readiness,
     )
 
@@ -1440,6 +1491,7 @@ def _execute_odoo_compose_stage_preview_refresh(
     template_lane: ProductLaneProfile,
     target_definition: control_plane_dokploy.DokployTargetDefinition,
     template_payload: JsonObject,
+    preview_url: str,
 ) -> str:
     _enforce_preview_copied_runtime_key_safety(
         record_store=record_store,
@@ -1470,7 +1522,7 @@ def _execute_odoo_compose_stage_preview_refresh(
         profile=profile,
         template_lane=template_lane,
         template_payload=template_payload,
-        preview_url=request.preview_url,
+        preview_url=preview_url,
         image_reference=request.image_reference,
     )
     control_plane_dokploy.update_dokploy_target_env(
@@ -1485,7 +1537,7 @@ def _execute_odoo_compose_stage_preview_refresh(
         host=host,
         token=token,
         compose_id=target_definition.target_id,
-        preview_host=_preview_host(request.preview_url),
+        preview_host=_preview_host(preview_url),
         runtime_port=profile.runtime_port,
     )
     latest_before = control_plane_dokploy.latest_deployment_for_target(
@@ -1518,7 +1570,7 @@ def _execute_odoo_compose_stage_preview_refresh(
         timeout_seconds=deployment_timeout_seconds,
     )
     _wait_for_preview_health(
-        preview_url=request.preview_url,
+        preview_url=preview_url,
         health_path=profile.health_path,
         timeout_seconds=health_timeout_seconds,
     )

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -125,9 +125,11 @@ The `preview_refresh`, `preview_inventory`, `preview_readiness`, and
 `POST /v1/drivers/generic-web/preview-readiness`, and
 `POST /v1/drivers/generic-web/preview-destroy`. Refresh runs readiness first,
 then creates or updates a stateless Dokploy application from the DB-backed
-template lane, applies explicit settings transport, deploys the submitted image,
-and checks the product health path. Inventory and destroy scan and delete
-Dokploy applications by the product profile's preview application-name prefix.
+template lane, derives the live preview URL from the context-level
+`LAUNCHPLANE_PREVIEW_BASE_URL` runtime-environment record plus the preview slug,
+applies explicit settings transport, deploys the submitted image, and checks the
+product health path. Inventory and destroy scan and delete Dokploy applications
+by the product profile's preview application-name prefix.
 
 Product drivers can declare `base_driver_id="generic-web"` when they reuse the
 generic web lifecycle and add named product-specific gates or runtime actions.
@@ -140,8 +142,9 @@ routes for the same lifecycle: `POST /v1/drivers/odoo/preview-desired-state`,
 `POST /v1/drivers/odoo/preview-inventory`,
 `POST /v1/drivers/odoo/preview-readiness`, and
 `POST /v1/drivers/odoo/preview-destroy`. These routes use the generic-web
-preview request schema and record writer so Odoo PR previews land in the same
-Launchplane preview and preview-generation records as generic-web previews.
+preview request schema, live URL derivation, and record writer so Odoo PR
+previews land in the same Launchplane preview and preview-generation records as
+generic-web previews.
 Odoo is the only current generic-web-based driver allowed to use the staged
 compose preview MVP: if its product profile uses `preview.data_transport_mode =
 "bootstrap"` and its template lane is a Dokploy `compose` target, preview refresh

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -737,10 +737,10 @@ backup/restore policy evidence for that lane.
 
 `launchplane-previews write-from-generation` and `launchplane-previews write-destroyed`
 are local preview-evidence ingest adapters that mirror the service ingress
-payload shape. VeriReel preview runtime now flows through Launchplane drivers:
-the app repo sends PR/image intent, Launchplane derives the live preview URL
-from `LAUNCHPLANE_PREVIEW_BASE_URL`, and evidence stores that returned URL with
-generation status and cleanup outcome.
+payload shape. Generic-web, Odoo, and VeriReel preview runtime now flow through
+Launchplane drivers: product repos send PR/image intent, Launchplane derives the
+live preview URL from `LAUNCHPLANE_PREVIEW_BASE_URL`, and evidence stores that
+returned URL with generation status and cleanup outcome.
 
 Launchplane now owns the preview lifecycle planning boundary. The scheduled
 Launchplane `Preview Lifecycle` workflow discovers desired preview anchors from

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -164,6 +164,12 @@ repo action instead:
       error_message=result.error_message
 ```
 
+The preview refresh payload should identify the product, preview slug, immutable
+image reference, and optional PR metadata. New product workflows should omit
+`preview_url`; Launchplane derives the live URL from the product preview context
+and `LAUNCHPLANE_PREVIEW_BASE_URL`. `preview_url` is reserved as a compatibility
+override for older callers.
+
 The action requests a GitHub OIDC token, sends the JSON request with a stable
 `Idempotency-Key`, exposes the raw response body, and can map response JSON paths
 to GitHub outputs. Product repos may still need small payload-builder scripts

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -662,16 +662,19 @@ DB-backed product profile before recording desired preview state.
 
 Generic web preview refresh uses
 `POST /v1/drivers/generic-web/preview-refresh`. The request names the product,
-preview slug, preview URL, and immutable image reference; Launchplane resolves
-the repository and preview context from the DB-backed product profile, derives
-the anchor pull request from the preview slug when possible, and records preview
-and generation evidence for both successful and failed provider results. Product
-workflows may send `anchor_pr_number`, `anchor_pr_url`, and `anchor_head_sha`
-when the preview slug cannot be parsed from the configured slug template or when
-the workflow has more precise anchor metadata than the image reference. Preview
-health failures that return Dokploy Dead Host are classified as public preview
-ingress failures so workflow output and persisted generation evidence point at
-DNS/ingress routing instead of a generic provider timeout.
+preview slug, and immutable image reference. Launchplane resolves the repository
+and preview context from the DB-backed product profile, derives the canonical
+live preview URL from the context-level `LAUNCHPLANE_PREVIEW_BASE_URL` runtime
+environment record plus the preview slug, derives the anchor pull request from
+the preview slug when possible, and records preview and generation evidence for
+both successful and failed provider results. Product workflows may send
+`anchor_pr_number`, `anchor_pr_url`, and `anchor_head_sha` when the preview slug
+cannot be parsed from the configured slug template or when the workflow has more
+precise anchor metadata than the image reference. `preview_url` remains accepted
+as a compatibility override but is not the product-repo authority for new
+workflows. Preview health failures that return Dokploy Dead Host are classified
+as public preview ingress failures so workflow output and persisted generation
+evidence point at DNS/ingress routing instead of a generic provider timeout.
 
 Generic web preview inventory and destroy use
 `POST /v1/drivers/generic-web/preview-inventory` and
@@ -920,10 +923,11 @@ free-form destroy reason so the same preview cleanup is idempotent even when the
 caller wording changes between cleanup paths.
 
 Odoo preview routes intentionally reuse the generic-web preview request schema,
-profile resolver, and record writer. Product repos call the Odoo-shaped routes
-so authz and driver views remain product-specific, while Launchplane still writes
-the shared preview and preview-generation records from DB-backed product profile
-preview configuration.
+profile resolver, URL derivation, and record writer. Product repos call the
+Odoo-shaped routes so authz and driver views remain product-specific, while
+Launchplane still derives the live preview URL from runtime-environment records
+and writes the shared preview and preview-generation records from DB-backed
+product profile preview configuration.
 
 The CM tenant preview workflow uses two product scopes deliberately. Artifact
 publish input and publish evidence requests use product `odoo` for context `cm`,

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -8,6 +8,7 @@ from urllib.error import HTTPError
 
 import click
 
+from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane.dokploy import DokploySourceOfTruth, DokployTargetDefinition
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
 from control_plane.contracts.product_profile_record import (
@@ -16,6 +17,7 @@ from control_plane.contracts.product_profile_record import (
     ProductLaneProfile,
     ProductPreviewProfile,
 )
+from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeKeySafetyPolicyRecord,
     RuntimeSecretClass,
@@ -35,6 +37,7 @@ from control_plane.workflows.generic_web_preview import (
     execute_generic_web_preview_refresh,
     preview_pr_number_from_slug,
     resolve_generic_web_preview_profile,
+    resolve_generic_web_preview_url,
     _wait_for_preview_health,
 )
 from control_plane.workflows.preview_desired_state import render_preview_slug
@@ -90,6 +93,25 @@ class _GenericWebPreviewStore:
         if limit is not None:
             return bindings[:limit]
         return bindings
+
+    def list_runtime_environment_records(
+        self, *, context_name: str = "", instance_name: str = ""
+    ) -> tuple[RuntimeEnvironmentRecord, ...]:
+        records = (
+            RuntimeEnvironmentRecord(
+                scope="context",
+                context=self.profile.preview.context,
+                env={"LAUNCHPLANE_PREVIEW_BASE_URL": "https://syo-preview.example.test"},
+                updated_at="2026-05-10T05:30:00Z",
+                source_label="test",
+            ),
+        )
+        return tuple(
+            record
+            for record in records
+            if (not context_name or record.context == context_name)
+            and (not instance_name or record.instance == instance_name)
+        )
 
 
 def _profile(
@@ -810,6 +832,118 @@ class GenericWebPreviewTests(unittest.TestCase):
         self.assertEqual(result.refresh_status, "blocked")
         dokploy_request.assert_not_called()
 
+    def test_resolve_preview_url_derives_from_runtime_context_base_url(self) -> None:
+        profile = _profile().model_copy(
+            update={
+                "preview": _profile().preview.model_copy(
+                    update={"slug_template": "pr-{number}"}
+                )
+            }
+        )
+        store = _GenericWebPreviewStore(profile)
+
+        with patch(
+            "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.load_runtime_environment_definition",
+            return_value=control_plane_runtime_environments.build_runtime_environment_definition_from_records(
+                tuple(store.list_runtime_environment_records())
+            ),
+        ):
+            preview_url = resolve_generic_web_preview_url(
+                control_plane_root=Path("."),
+                profile=profile,
+                request=GenericWebPreviewRefreshRequest(
+                    product="sellyouroutboard",
+                    preview_slug="pr-42",
+                    preview_url="",
+                    image_reference="ghcr.io/cbusillo/sellyouroutboard:sha",
+                ),
+            )
+
+        self.assertEqual(preview_url, "https://pr-42.syo-preview.example.test")
+
+    def test_resolve_preview_url_fails_closed_when_base_url_missing(self) -> None:
+        profile = _profile().model_copy(
+            update={
+                "preview": _profile().preview.model_copy(
+                    update={"slug_template": "pr-{number}"}
+                )
+            }
+        )
+        with patch(
+            "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.load_runtime_environment_definition",
+            return_value=control_plane_runtime_environments.build_runtime_environment_definition_from_records(
+                (
+                    RuntimeEnvironmentRecord(
+                        scope="context",
+                        context="sellyouroutboard-testing",
+                        env={"OTHER_KEY": "value"},
+                        updated_at="2026-05-10T05:30:00Z",
+                        source_label="test",
+                    ),
+                )
+            ),
+        ):
+            with self.assertRaisesRegex(click.ClickException, "Missing LAUNCHPLANE_PREVIEW_BASE_URL"):
+                resolve_generic_web_preview_url(
+                    control_plane_root=Path("."),
+                    profile=profile,
+                    request=GenericWebPreviewRefreshRequest(
+                        product="sellyouroutboard",
+                        preview_slug="pr-42",
+                        preview_url="",
+                        image_reference="ghcr.io/cbusillo/sellyouroutboard:sha",
+                    ),
+                )
+
+    def test_resolve_preview_url_rejects_non_root_base_url(self) -> None:
+        profile = _profile().model_copy(
+            update={
+                "preview": _profile().preview.model_copy(
+                    update={"slug_template": "pr-{number}"}
+                )
+            }
+        )
+        with patch(
+            "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.load_runtime_environment_definition",
+            return_value=control_plane_runtime_environments.build_runtime_environment_definition_from_records(
+                (
+                    RuntimeEnvironmentRecord(
+                        scope="context",
+                        context="sellyouroutboard-testing",
+                        env={"LAUNCHPLANE_PREVIEW_BASE_URL": "https://preview.example/path"},
+                        updated_at="2026-05-10T05:30:00Z",
+                        source_label="test",
+                    ),
+                )
+            ),
+        ):
+            with self.assertRaisesRegex(click.ClickException, "root URL"):
+                resolve_generic_web_preview_url(
+                    control_plane_root=Path("."),
+                    profile=profile,
+                    request=GenericWebPreviewRefreshRequest(
+                        product="sellyouroutboard",
+                        preview_slug="pr-42",
+                        preview_url="",
+                        image_reference="ghcr.io/cbusillo/sellyouroutboard:sha",
+                    ),
+                )
+
+    def test_resolve_preview_url_keeps_explicit_override_compatible(self) -> None:
+        profile = _profile()
+        preview_url = resolve_generic_web_preview_url(
+            control_plane_root=Path("."),
+            profile=profile,
+            request=GenericWebPreviewRefreshRequest(
+                product="sellyouroutboard",
+                preview_slug="pr-42",
+                preview_url="https://custom-preview.example.test",
+                image_reference="ghcr.io/cbusillo/sellyouroutboard:sha",
+            ),
+        )
+
+        self.assertEqual(preview_url, "https://custom-preview.example.test")
+
     def test_wait_for_preview_health_reports_dokploy_dead_host_as_ingress_failure(self) -> None:
         dead_host = HTTPError(
             url="https://preview-42.example.test/api/health",
@@ -1022,7 +1156,7 @@ class GenericWebPreviewTests(unittest.TestCase):
         self.assertIn("secret_class_not_allowed", result.error_message)
         dokploy_request.assert_not_called()
 
-    def test_execute_generic_web_preview_refresh_updates_odoo_compose_stage_target(
+    def test_execute_generic_web_preview_refresh_derives_odoo_compose_preview_url(
         self,
     ) -> None:
         store = _GenericWebPreviewStore(_odoo_compose_profile())
@@ -1103,6 +1237,10 @@ class GenericWebPreviewTests(unittest.TestCase):
                 return_value={"ODOO_PROJECT_NAME": "cm-pr-28"},
             ),
             patch(
+                "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.resolve_runtime_context_values",
+                return_value={"LAUNCHPLANE_PREVIEW_BASE_URL": "https://cm-preview.shinycomputers.com"},
+            ),
+            patch(
                 "control_plane.workflows.generic_web_preview.control_plane_dokploy.sync_dokploy_compose_raw_source",
             ) as sync_raw_source,
             patch(
@@ -1137,7 +1275,6 @@ class GenericWebPreviewTests(unittest.TestCase):
                 request=GenericWebPreviewRefreshRequest(
                     product="odoo-tenant-cm",
                     preview_slug="pr-28",
-                    preview_url="https://pr-28.cm-preview.shinycomputers.com",
                     image_reference="ghcr.io/cbusillo/odoo-tenant-cm:sha",
                     timeout_seconds=240,
                 ),

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -9452,6 +9452,83 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 refresh.assert_called_once()
                 _, kwargs = refresh.call_args
                 self.assertEqual(kwargs["profile"].product, "sellyouroutboard")
+                self.assertEqual(kwargs["request"].preview_url, "https://pr-42.example.test")
+
+    def test_generic_web_preview_refresh_route_accepts_omitted_preview_url(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["preview_refresh.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
+                            "@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_generic_web_preview_refresh",
+                return_value={
+                    "refresh_status": "pass",
+                    "refresh_started_at": "2026-05-03T15:00:00Z",
+                    "refresh_finished_at": "2026-05-03T15:05:00Z",
+                    "product": "sellyouroutboard",
+                    "context": "sellyouroutboard-testing",
+                    "preview_slug": "pr-42",
+                    "application_name": "sellyouroutboard-pr-42",
+                    "application_id": "app-preview",
+                    "preview_url": "https://pr-42.syo-preview.example.test",
+                },
+            ) as refresh:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/preview-refresh",
+                    payload={
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "refresh": {
+                            "schema_version": 1,
+                            "product": "sellyouroutboard",
+                            "preview_slug": "pr-42",
+                            "image_reference": "ghcr.io/cbusillo/sellyouroutboard:sha",
+                        },
+                    },
+                    headers={"Idempotency-Key": "generic-web-preview-refresh:syo:pr-42"},
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["preview_url"], "https://pr-42.syo-preview.example.test")
+        refresh.assert_called_once()
+        _, kwargs = refresh.call_args
+        self.assertEqual(kwargs["request"].preview_url, "")
 
     def test_generic_web_preview_refresh_route_persists_provider_failure_result(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -9608,7 +9685,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
                             "schema_version": 1,
                             "product": "odoo-tenant-cm",
                             "preview_slug": "pr-42",
-                            "preview_url": "https://pr-42.cm.example.test",
                             "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm:sha",
                         },
                     },
@@ -9626,6 +9702,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             _, kwargs = refresh.call_args
             self.assertEqual(kwargs["profile"].driver_id, "odoo")
             self.assertEqual(kwargs["profile"].preview.context, "cm")
+            self.assertEqual(kwargs["request"].preview_url, "")
 
     def test_odoo_preview_refresh_route_fails_closed_when_preview_disabled(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- allow generic-web/Odoo preview refresh callers to omit preview_url
- derive live preview URLs from the preview context's LAUNCHPLANE_PREVIEW_BASE_URL runtime record plus preview slug
- keep explicit preview_url as a compatibility override and update preview docs

Refs #507

## Validation
- uv run python -m unittest tests.test_generic_web_preview tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_refresh_route_returns_driver_result tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_refresh_route_accepts_omitted_preview_url tests.test_service.LaunchplaneServiceTests.test_odoo_preview_refresh_route_reuses_generic_preview_records tests.test_service.LaunchplaneServiceTests.test_odoo_preview_refresh_route_fails_closed_when_preview_disabled
- uv run --extra dev ruff check --diff control_plane/workflows/generic_web_preview.py tests/test_generic_web_preview.py tests/test_service.py
- uv run --extra dev ruff check control_plane/workflows/generic_web_preview.py tests/test_generic_web_preview.py tests/test_service.py
- uv run --extra dev mypy control_plane/workflows/generic_web_preview.py tests/test_generic_web_preview.py tests/test_service.py