### PR TITLE
Add Odoo preview smoke contract

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -4651,7 +4651,12 @@ def _apply_generic_web_preview_refresh_records(
     )
     finished_at = driver_result.refresh_finished_at.strip() or requested_at
     refresh_passed = driver_result.refresh_status == "pass"
+    smoke = driver_result.smoke
+    smoke_passed = smoke is not None and smoke.smoke_status == "pass"
+    smoke_failed = smoke is not None and smoke.smoke_status == "fail"
     failure_summary = driver_result.error_message.strip() or "Preview provisioning failed."
+    if smoke is not None and smoke_failed and smoke.failure_summary.strip():
+        failure_summary = smoke.failure_summary.strip()
     preview_request = PreviewMutationRequest(
         context=profile.preview.context,
         anchor_repo=_generic_web_preview_anchor_repo(profile),
@@ -4662,7 +4667,7 @@ def _apply_generic_web_preview_refresh_records(
             anchor_pr_number=anchor_pr_number,
         ),
         canonical_url=driver_result.preview_url.strip() or request.preview_url.strip(),
-        state="pending" if refresh_passed else "failed",
+        state=("active" if smoke_passed else "pending" if refresh_passed else "failed"),
         created_at=requested_at,
         updated_at=finished_at,
         eligible_at=requested_at,
@@ -4673,18 +4678,35 @@ def _apply_generic_web_preview_refresh_records(
         anchor_pr_number=anchor_pr_number,
         anchor_pr_url=preview_request.anchor_pr_url,
         anchor_head_sha=_generic_web_preview_anchor_head_sha(request),
-        state="verifying" if refresh_passed else "failed",
+        state=("ready" if smoke_passed else "verifying" if refresh_passed else "failed"),
         requested_reason="external_preview_refresh",
         requested_at=requested_at,
         started_at=requested_at,
-        finished_at="" if refresh_passed else finished_at,
-        failed_at="" if refresh_passed else finished_at,
+        ready_at=finished_at if smoke_passed else "",
+        finished_at=finished_at if smoke_passed or not refresh_passed else "",
+        failed_at=finished_at if not refresh_passed else "",
         resolved_manifest_fingerprint=_generic_web_preview_manifest_fingerprint(request),
         artifact_id=request.image_reference,
-        deploy_status="pass" if refresh_passed else "fail",
-        verify_status="pending" if refresh_passed else "skipped",
-        overall_health_status="pending" if refresh_passed else "fail",
-        failure_stage="" if refresh_passed else "provision",
+        deploy_status="pass" if refresh_passed or smoke_failed else "fail",
+        verify_status=(
+            "pass"
+            if smoke_passed
+            else "fail"
+            if smoke_failed
+            else "pending"
+            if refresh_passed
+            else "skipped"
+        ),
+        overall_health_status=(
+            "pass"
+            if smoke_passed
+            else "fail"
+            if smoke_failed
+            else "pending"
+            if refresh_passed
+            else "fail"
+        ),
+        failure_stage="" if refresh_passed else "verify" if smoke_failed else "provision",
         failure_summary="" if refresh_passed else failure_summary,
     )
     typed_record_store = cast(FilesystemRecordStore, record_store)
@@ -7618,8 +7640,8 @@ def create_launchplane_service_app(
                     ),
                 }
             elif path == _ODOO_STABLE_BOOTSTRAP_ROUTE.route_path:
-                odoo_bootstrap_request = (
-                    _ODOO_STABLE_BOOTSTRAP_ROUTE.envelope_model.model_validate(payload)
+                odoo_bootstrap_request = _ODOO_STABLE_BOOTSTRAP_ROUTE.envelope_model.model_validate(
+                    payload
                 )
                 _, authorization_response = _resolve_and_authorize_descriptor_route(
                     route_metadata=_ODOO_STABLE_BOOTSTRAP_ROUTE,

--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -52,6 +52,12 @@ _ODOO_COMPOSE_STAGE_PREVIEW_REQUIRED_ENV_KEYS = (
 _ODOO_COMPOSE_STAGE_PREVIEW_MIN_DEPLOY_TIMEOUT_SECONDS = 30
 _ODOO_COMPOSE_STAGE_PREVIEW_HEALTH_TIMEOUT_SECONDS = 120
 _PREVIEW_BASE_URL_ENV_KEY = "LAUNCHPLANE_PREVIEW_BASE_URL"
+_ODOO_COMPOSE_STAGE_PREVIEW_SMOKE_PATHS = (
+    ("web_health", "/web/health"),
+    ("cm_website_health", "/cm-website/health"),
+    ("cell_mechanic_page", "/cell-mechanic"),
+)
+_ODOO_COMPOSE_STAGE_PREVIEW_MODULE_KEYS = ("ODOO_INSTALL_MODULES", "ODOO_UPDATE_MODULES")
 
 
 class GenericWebPreviewProfileStore(Protocol):
@@ -223,6 +229,7 @@ class GenericWebPreviewRefreshResult(BaseModel):
     application_id: str = ""
     preview_url: str
     readiness: GenericWebPreviewReadinessResult | None = None
+    smoke: GenericWebPreviewSmokeResult | None = None
     error_message: str = ""
 
 
@@ -280,6 +287,23 @@ class GenericWebPreviewReadinessResult(BaseModel):
     missing_provider_fields: tuple[str, ...]
     transport: GenericWebPreviewTransportSummary
     checks: tuple[GenericWebPreviewReadinessCheck, ...]
+
+
+class GenericWebPreviewSmokeCheck(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    check_id: str
+    status: Literal["pass", "fail"]
+    message: str
+
+
+class GenericWebPreviewSmokeResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    smoke_status: Literal["pass", "fail"]
+    checked_at: str
+    checks: tuple[GenericWebPreviewSmokeCheck, ...]
+    failure_summary: str = ""
 
 
 def _anchor_repo(repository: str) -> str:
@@ -637,10 +661,13 @@ def _preview_slug_from_compose_domain(
     if not host.startswith(slug_prefix):
         return ""
     slug = host.split(".", 1)[0]
-    if preview_pr_number_from_slug(
-        preview_slug=slug,
-        slug_template=profile.preview.slug_template,
-    ) is None:
+    if (
+        preview_pr_number_from_slug(
+            preview_slug=slug,
+            slug_template=profile.preview.slug_template,
+        )
+        is None
+    ):
         return ""
     return slug
 
@@ -689,7 +716,9 @@ def resolve_generic_web_preview_profile(
     driver_is_generic_web = driver_id == "generic-web"
     if not driver_is_generic_web:
         try:
-            driver_is_generic_web = read_driver_descriptor(driver_id).base_driver_id == "generic-web"
+            driver_is_generic_web = (
+                read_driver_descriptor(driver_id).base_driver_id == "generic-web"
+            )
         except FileNotFoundError:
             driver_is_generic_web = False
     if not driver_is_generic_web:
@@ -782,9 +811,7 @@ def _read_template_payload(
     return target_definition, payload, ""
 
 
-def _profile_allows_odoo_compose_stage_preview(
-    *, profile: LaunchplaneProductProfileRecord
-) -> bool:
+def _profile_allows_odoo_compose_stage_preview(*, profile: LaunchplaneProductProfileRecord) -> bool:
     return (
         profile.driver_id.strip() == _ODOO_COMPOSE_STAGE_PREVIEW_DRIVER_ID
         and profile.preview.data_transport_mode == _ODOO_COMPOSE_STAGE_PREVIEW_MODE
@@ -1061,6 +1088,149 @@ def _wait_for_preview_health(*, preview_url: str, health_path: str, timeout_seco
         time.sleep(sleep_seconds)
         deadline -= sleep_seconds
     raise click.ClickException(f"Timed out waiting for {health_url} to report healthy.")
+
+
+def _preview_url_with_path(*, preview_url: str, path: str) -> str:
+    parsed = urlparse(preview_url.rstrip("/"))
+    return parsed._replace(path=path, params="", query="", fragment="").geturl()
+
+
+def _fetch_preview_smoke_path(*, preview_url: str, path: str, timeout_seconds: int) -> None:
+    smoke_url = _preview_url_with_path(preview_url=preview_url, path=path)
+    request = Request(
+        smoke_url,
+        headers={
+            "Accept": "application/json, text/html, text/plain, */*",
+            "Cache-Control": "no-store",
+        },
+    )
+    deadline = timeout_seconds
+    last_error = "is not reachable"
+    while deadline > 0:
+        try:
+            with urlopen(request, timeout=min(15, deadline)) as response:
+                response.read()
+            if 200 <= response.status < 400:
+                return
+            last_error = f"returned HTTP {response.status}"
+        except HTTPError as exc:
+            last_error = f"returned HTTP {exc.code}"
+        except (TimeoutError, URLError, ValueError):
+            last_error = "is not reachable"
+        sleep_seconds = min(5, deadline)
+        time.sleep(sleep_seconds)
+        deadline -= sleep_seconds
+    raise click.ClickException(f"Odoo preview smoke path {path} {last_error}.")
+
+
+def _pass_smoke_check(*, check_id: str, message: str) -> GenericWebPreviewSmokeCheck:
+    return GenericWebPreviewSmokeCheck(check_id=check_id, status="pass", message=message)
+
+
+def _fail_smoke_check(*, check_id: str, message: str) -> GenericWebPreviewSmokeCheck:
+    return GenericWebPreviewSmokeCheck(check_id=check_id, status="fail", message=message)
+
+
+def _failure_summary_from_smoke_checks(checks: tuple[GenericWebPreviewSmokeCheck, ...]) -> str:
+    for check in checks:
+        if check.status == "fail":
+            return f"Odoo preview smoke failed: {check.message}"
+    return "Odoo preview smoke failed."
+
+
+def _odoo_compose_stage_preview_smoke_result(
+    *,
+    checked_at: str,
+    request: GenericWebPreviewRefreshRequest,
+    env_text: str,
+    preview_url: str,
+    timeout_seconds: int,
+) -> GenericWebPreviewSmokeResult:
+    checks: list[GenericWebPreviewSmokeCheck] = []
+    if request.image_reference.strip():
+        checks.append(
+            _pass_smoke_check(
+                check_id="artifact_image_reference",
+                message="Preview image artifact reference is present.",
+            )
+        )
+    else:
+        checks.append(
+            _fail_smoke_check(
+                check_id="artifact_image_reference",
+                message="Preview image artifact reference is missing.",
+            )
+        )
+    if request.anchor_head_sha.strip():
+        checks.append(
+            _pass_smoke_check(
+                check_id="anchor_head_sha",
+                message="Preview source revision is present.",
+            )
+        )
+    else:
+        checks.append(
+            _fail_smoke_check(
+                check_id="anchor_head_sha",
+                message="Preview source revision is missing.",
+            )
+        )
+
+    rendered_env = control_plane_dokploy.parse_dokploy_env_text(env_text)
+    configured_module_keys = tuple(
+        key for key in _ODOO_COMPOSE_STAGE_PREVIEW_MODULE_KEYS if rendered_env.get(key, "").strip()
+    )
+    if configured_module_keys:
+        checks.append(
+            _pass_smoke_check(
+                check_id="module_install_update_evidence",
+                message="Odoo module install/update evidence is captured in rendered env.",
+            )
+        )
+    else:
+        checks.append(
+            _fail_smoke_check(
+                check_id="module_install_update_evidence",
+                message="Odoo module install/update evidence is missing.",
+            )
+        )
+
+    for check_id, path in _ODOO_COMPOSE_STAGE_PREVIEW_SMOKE_PATHS:
+        try:
+            if path == "/web/health":
+                _wait_for_preview_health(
+                    preview_url=preview_url,
+                    health_path=path,
+                    timeout_seconds=timeout_seconds,
+                )
+            else:
+                _fetch_preview_smoke_path(
+                    preview_url=preview_url,
+                    path=path,
+                    timeout_seconds=timeout_seconds,
+                )
+        except click.ClickException as exc:
+            checks.append(_fail_smoke_check(check_id=check_id, message=str(exc)))
+        else:
+            checks.append(
+                _pass_smoke_check(
+                    check_id=check_id,
+                    message=f"Odoo preview smoke path {path} responded successfully.",
+                )
+            )
+
+    smoke_checks = tuple(checks)
+    smoke_status: Literal["pass", "fail"] = (
+        "fail" if any(check.status == "fail" for check in smoke_checks) else "pass"
+    )
+    return GenericWebPreviewSmokeResult(
+        smoke_status=smoke_status,
+        checked_at=checked_at,
+        checks=smoke_checks,
+        failure_summary=""
+        if smoke_status == "pass"
+        else _failure_summary_from_smoke_checks(smoke_checks),
+    )
 
 
 def evaluate_generic_web_preview_readiness(
@@ -1348,7 +1518,7 @@ def execute_generic_web_preview_refresh(
             profile=resolved_profile,
             target_definition=target_definition,
         ):
-            application_id = _execute_odoo_compose_stage_preview_refresh(
+            application_id, smoke = _execute_odoo_compose_stage_preview_refresh(
                 control_plane_root=control_plane_root,
                 record_store=record_store,
                 request=request,
@@ -1359,8 +1529,11 @@ def execute_generic_web_preview_refresh(
                 preview_url=preview_url,
             )
             finished_at = utc_now_timestamp()
+            refresh_status: Literal["pass", "blocked", "fail"] = (
+                "pass" if smoke.smoke_status == "pass" else "fail"
+            )
             return GenericWebPreviewRefreshResult(
-                refresh_status="pass",
+                refresh_status=refresh_status,
                 refresh_started_at=started_at,
                 refresh_finished_at=finished_at,
                 product=resolved_profile.product,
@@ -1370,6 +1543,8 @@ def execute_generic_web_preview_refresh(
                 application_id=application_id,
                 preview_url=preview_url,
                 readiness=readiness,
+                smoke=smoke,
+                error_message="" if refresh_status == "pass" else smoke.failure_summary,
             )
         _enforce_preview_copied_runtime_key_safety(
             record_store=record_store,
@@ -1492,7 +1667,7 @@ def _execute_odoo_compose_stage_preview_refresh(
     target_definition: control_plane_dokploy.DokployTargetDefinition,
     template_payload: JsonObject,
     preview_url: str,
-) -> str:
+) -> tuple[str, GenericWebPreviewSmokeResult]:
     _enforce_preview_copied_runtime_key_safety(
         record_store=record_store,
         profile=profile,
@@ -1569,12 +1744,14 @@ def _execute_odoo_compose_stage_preview_refresh(
         before_key=control_plane_dokploy.deployment_key(latest_before),
         timeout_seconds=deployment_timeout_seconds,
     )
-    _wait_for_preview_health(
+    smoke = _odoo_compose_stage_preview_smoke_result(
+        checked_at=utc_now_timestamp(),
+        request=request,
+        env_text=env_text,
         preview_url=preview_url,
-        health_path=profile.health_path,
         timeout_seconds=health_timeout_seconds,
     )
-    return target_definition.target_id
+    return target_definition.target_id, smoke
 
 
 def discover_generic_web_preview_desired_state(
@@ -1662,9 +1839,7 @@ def execute_generic_web_preview_inventory(
                 context=resolved_profile.preview.context,
                 source=request.source,
                 app_name_prefix=app_name_prefix,
-                previews=tuple(
-                    sorted(compose_preview_items, key=lambda item: item.previewSlug)
-                ),
+                previews=tuple(sorted(compose_preview_items, key=lambda item: item.previewSlug)),
             )
 
     raw_projects = control_plane_dokploy.dokploy_request(

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -155,6 +155,13 @@ preview slug template. This exception is route-scoped to Odoo preview refresh,
 inventory, destroy, and readiness; it does not grant Odoo products access to
 stable generic-web deploy or promotion routes, and it does not make compose
 templates valid for generic-web products.
+For the CM staged preview contract, Odoo preview refresh also runs Launchplane-
+owned smoke before reporting `refresh_status="pass"`: image artifact evidence,
+source revision evidence, module install/update evidence from rendered Odoo env,
+`/web/health`, `/cm-website/health`, and `/cell-mechanic`. Passing smoke records
+the preview generation as `ready` with deploy, verify, and overall health status
+`pass`; failed smoke records a concise verification failure so PR feedback does
+not advertise ready before the checks pass.
 
 Odoo also exposes `POST /v1/drivers/odoo/stable-bootstrap` as a destructive
 instance-scoped action. The first implementation is policy-limited to CM testing

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -97,6 +97,13 @@ Preview refresh routes receive only product-local facts:
 - run URL
 - primitive smoke/readiness facts when the check is product-specific
 
+Odoo CM is the exception where Launchplane now owns the stage-preview smoke
+contract after refresh: `/web/health`, `/cm-website/health`, `/cell-mechanic`,
+artifact/revision evidence, and module install/update evidence. Product
+workflows should treat the Odoo refresh route's `refresh_status="pass"` as the
+ready-to-comment signal instead of independently deciding readiness from raw
+health checks.
+
 Preview destroy routes receive the PR number, source/run metadata, and an
 explicit destroy reason such as `pull_request_closed`, `preview_label_removed`,
 or `manual_destroy_requested`.

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -30,6 +30,7 @@ from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewInventoryRequest,
     GenericWebPreviewReadinessRequest,
     GenericWebPreviewRefreshRequest,
+    GenericWebPreviewRefreshResult,
     discover_generic_web_preview_desired_state,
     evaluate_generic_web_preview_readiness,
     execute_generic_web_preview_destroy,
@@ -835,9 +836,7 @@ class GenericWebPreviewTests(unittest.TestCase):
     def test_resolve_preview_url_derives_from_runtime_context_base_url(self) -> None:
         profile = _profile().model_copy(
             update={
-                "preview": _profile().preview.model_copy(
-                    update={"slug_template": "pr-{number}"}
-                )
+                "preview": _profile().preview.model_copy(update={"slug_template": "pr-{number}"})
             }
         )
         store = _GenericWebPreviewStore(profile)
@@ -864,9 +863,7 @@ class GenericWebPreviewTests(unittest.TestCase):
     def test_resolve_preview_url_fails_closed_when_base_url_missing(self) -> None:
         profile = _profile().model_copy(
             update={
-                "preview": _profile().preview.model_copy(
-                    update={"slug_template": "pr-{number}"}
-                )
+                "preview": _profile().preview.model_copy(update={"slug_template": "pr-{number}"})
             }
         )
         with patch(
@@ -883,7 +880,9 @@ class GenericWebPreviewTests(unittest.TestCase):
                 )
             ),
         ):
-            with self.assertRaisesRegex(click.ClickException, "Missing LAUNCHPLANE_PREVIEW_BASE_URL"):
+            with self.assertRaisesRegex(
+                click.ClickException, "Missing LAUNCHPLANE_PREVIEW_BASE_URL"
+            ):
                 resolve_generic_web_preview_url(
                     control_plane_root=Path("."),
                     profile=profile,
@@ -898,9 +897,7 @@ class GenericWebPreviewTests(unittest.TestCase):
     def test_resolve_preview_url_rejects_non_root_base_url(self) -> None:
         profile = _profile().model_copy(
             update={
-                "preview": _profile().preview.model_copy(
-                    update={"slug_template": "pr-{number}"}
-                )
+                "preview": _profile().preview.model_copy(update={"slug_template": "pr-{number}"})
             }
         )
         with patch(
@@ -1238,7 +1235,9 @@ class GenericWebPreviewTests(unittest.TestCase):
             ),
             patch(
                 "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.resolve_runtime_context_values",
-                return_value={"LAUNCHPLANE_PREVIEW_BASE_URL": "https://cm-preview.shinycomputers.com"},
+                return_value={
+                    "LAUNCHPLANE_PREVIEW_BASE_URL": "https://cm-preview.shinycomputers.com"
+                },
             ),
             patch(
                 "control_plane.workflows.generic_web_preview.control_plane_dokploy.sync_dokploy_compose_raw_source",
@@ -1265,8 +1264,15 @@ class GenericWebPreviewTests(unittest.TestCase):
                 "control_plane.workflows.generic_web_preview._wait_for_preview_health"
             ) as wait_health,
             patch(
+                "control_plane.workflows.generic_web_preview._fetch_preview_smoke_path"
+            ) as fetch_smoke_path,
+            patch(
                 "control_plane.workflows.generic_web_preview.utc_now_timestamp",
-                side_effect=["2026-05-09T15:00:00Z", "2026-05-09T15:00:05Z"],
+                side_effect=[
+                    "2026-05-09T15:00:00Z",
+                    "2026-05-09T15:00:04Z",
+                    "2026-05-09T15:00:05Z",
+                ],
             ),
         ):
             result = execute_generic_web_preview_refresh(
@@ -1276,11 +1282,14 @@ class GenericWebPreviewTests(unittest.TestCase):
                     product="odoo-tenant-cm",
                     preview_slug="pr-28",
                     image_reference="ghcr.io/cbusillo/odoo-tenant-cm:sha",
+                    anchor_head_sha="abc123",
                     timeout_seconds=240,
                 ),
             )
 
         self.assertEqual(result.refresh_status, "pass")
+        self.assertIsNotNone(result.smoke)
+        self.assertEqual(result.smoke.smoke_status if result.smoke else "", "pass")
         self.assertEqual(result.application_id, "compose-cm-testing")
         sync_raw_source.assert_called_once()
         _, sync_kwargs = sync_raw_source.call_args
@@ -1294,12 +1303,8 @@ class GenericWebPreviewTests(unittest.TestCase):
         self.assertIn("ODOO_DB_NAME=cm_preview", env_updates[0])
         self.assertIn("ODOO_PROJECT_NAME=cm-pr-28", env_updates[0])
         self.assertIn("ODOO_INSTALL_MODULES=cm_custom,cm_website", env_updates[0])
-        self.assertIn(
-            "WEB_BASE_URL=https://pr-28.cm-preview.shinycomputers.com", env_updates[0]
-        )
-        self.assertIn(
-            "DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/odoo-tenant-cm:sha", env_updates[0]
-        )
+        self.assertIn("WEB_BASE_URL=https://pr-28.cm-preview.shinycomputers.com", env_updates[0])
+        self.assertIn("DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/odoo-tenant-cm:sha", env_updates[0])
         self.assertEqual(
             [request["path"] for request in domain_requests],
             ["/api/domain.byComposeId", "/api/domain.create"],
@@ -1337,6 +1342,198 @@ class GenericWebPreviewTests(unittest.TestCase):
             health_path="/web/health",
             timeout_seconds=120,
         )
+        self.assertEqual(
+            [call.kwargs["path"] for call in fetch_smoke_path.call_args_list],
+            ["/cm-website/health", "/cell-mechanic"],
+        )
+
+    def test_execute_generic_web_preview_refresh_fails_odoo_health_smoke(self) -> None:
+        result = self._execute_odoo_compose_stage_preview_with_smoke_failure(
+            health_failure=click.ClickException("Timed out waiting for health."),
+            anchor_head_sha="abc123",
+        )
+
+        self.assertEqual(result.refresh_status, "fail")
+        self.assertIsNotNone(result.smoke)
+        self.assertEqual(result.smoke.smoke_status if result.smoke else "", "fail")
+        self.assertIn("Timed out waiting for health", result.error_message)
+
+    def test_execute_generic_web_preview_refresh_fails_odoo_page_smoke(self) -> None:
+        result = self._execute_odoo_compose_stage_preview_with_smoke_failure(
+            page_failures={"/cell-mechanic": click.ClickException("HTTP 404")},
+            anchor_head_sha="abc123",
+        )
+
+        self.assertEqual(result.refresh_status, "fail")
+        self.assertIsNotNone(result.smoke)
+        failed_checks = (
+            [check.check_id for check in result.smoke.checks if check.status == "fail"]
+            if result.smoke
+            else []
+        )
+        self.assertEqual(failed_checks, ["cell_mechanic_page"])
+
+    def test_execute_generic_web_preview_refresh_fails_odoo_missing_revision_evidence(
+        self,
+    ) -> None:
+        result = self._execute_odoo_compose_stage_preview_with_smoke_failure(anchor_head_sha="")
+
+        self.assertEqual(result.refresh_status, "fail")
+        self.assertIn("source revision is missing", result.error_message)
+
+    def test_execute_generic_web_preview_refresh_rejects_missing_artifact_evidence(self) -> None:
+        with self.assertRaises(ValueError):
+            GenericWebPreviewRefreshRequest(
+                product="odoo-tenant-cm",
+                preview_slug="pr-28",
+                image_reference="",
+            )
+
+    def test_execute_generic_web_preview_refresh_fails_odoo_missing_module_evidence(
+        self,
+    ) -> None:
+        base_profile = _odoo_compose_profile()
+        result = self._execute_odoo_compose_stage_preview_with_smoke_failure(
+            profile=base_profile.model_copy(
+                update={"preview": base_profile.preview.model_copy(update={"override_env": {}})}
+            ),
+            anchor_head_sha="abc123",
+        )
+
+        self.assertEqual(result.refresh_status, "fail")
+        self.assertIn("module install/update evidence is missing", result.error_message)
+
+    def _execute_odoo_compose_stage_preview_with_smoke_failure(
+        self,
+        *,
+        profile: LaunchplaneProductProfileRecord | None = None,
+        anchor_head_sha: str = "abc123",
+        health_failure: click.ClickException | None = None,
+        page_failures: dict[str, click.ClickException] | None = None,
+    ) -> GenericWebPreviewRefreshResult:
+        resolved_profile = profile or _odoo_compose_profile()
+        store = _GenericWebPreviewStore(resolved_profile)
+        source = DokploySourceOfTruth(
+            schema_version=1,
+            targets=(
+                DokployTargetDefinition(
+                    context="cm",
+                    instance="testing",
+                    target_type="compose",
+                    target_id="compose-cm-testing",
+                    target_name="cm-testing",
+                ),
+            ),
+        )
+
+        def _fake_fetch(**kwargs: object) -> dict[str, object]:
+            return {
+                "composeId": "compose-cm-testing",
+                "name": "cm-testing",
+                "environmentId": "env-1",
+                "sourceType": "raw",
+                "composePath": "docker-compose.yml",
+                "composeFile": "",
+                "env": (
+                    "ODOO_DB_NAME=cm_preview\n"
+                    "ODOO_DB_USER=odoo\n"
+                    "ODOO_DB_PASSWORD=safe\n"
+                    "ODOO_DATA_VOLUME=cm_data\n"
+                    "ODOO_LOG_VOLUME=cm_logs\n"
+                    "ODOO_DB_VOLUME=cm_db\n"
+                    "ODOO_MASTER_PASSWORD=safe-master\n"
+                    "ODOO_ADMIN_PASSWORD=safe-admin\n"
+                    "WEB_BASE_URL=https://testing.cm.example.test\n"
+                ),
+            }
+
+        def _fake_dokploy_request(**kwargs: object) -> object:
+            if kwargs["path"] == "/api/domain.byComposeId":
+                return []
+            if kwargs["path"] == "/api/domain.create":
+                return {"domainId": "domain-preview"}
+            return {}
+
+        def _fake_wait_health(**kwargs: object) -> None:
+            if health_failure is not None:
+                raise health_failure
+
+        def _fake_fetch_smoke_path(**kwargs: object) -> None:
+            failure = (page_failures or {}).get(str(kwargs["path"]))
+            if failure is not None:
+                raise failure
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                return_value=source,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.fetch_dokploy_target_payload",
+                side_effect=_fake_fetch,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.resolve_runtime_environment_values",
+                return_value={"ODOO_PROJECT_NAME": "cm-pr-28"},
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.resolve_runtime_context_values",
+                return_value={
+                    "LAUNCHPLANE_PREVIEW_BASE_URL": "https://cm-preview.shinycomputers.com"
+                },
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.sync_dokploy_compose_raw_source",
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.update_dokploy_target_env",
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.dokploy_request",
+                side_effect=_fake_dokploy_request,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.latest_deployment_for_target",
+                return_value={"deploymentId": "before"},
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.trigger_deployment",
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.wait_for_target_deployment",
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview._wait_for_preview_health",
+                side_effect=_fake_wait_health,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview._fetch_preview_smoke_path",
+                side_effect=_fake_fetch_smoke_path,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.utc_now_timestamp",
+                side_effect=[
+                    "2026-05-09T15:00:00Z",
+                    "2026-05-09T15:00:04Z",
+                    "2026-05-09T15:00:05Z",
+                ],
+            ),
+        ):
+            return execute_generic_web_preview_refresh(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebPreviewRefreshRequest(
+                    product="odoo-tenant-cm",
+                    preview_slug="pr-28",
+                    image_reference="ghcr.io/cbusillo/odoo-tenant-cm:sha",
+                    anchor_head_sha=anchor_head_sha,
+                    timeout_seconds=240,
+                ),
+            )
 
     def test_execute_generic_web_preview_refresh_allows_preview_safe_copied_secret_key(
         self,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -107,7 +107,12 @@ from control_plane.workflows.odoo_stable_target_replacement import (
 )
 from control_plane.workflows.generic_web_promotion import GenericWebProdPromotionResult
 from control_plane.workflows.generic_web_promotion_workflow import GenericWebPromotionWorkflowResult
-from control_plane.workflows.generic_web_preview import GenericWebPreviewDestroyResult
+from control_plane.workflows.generic_web_preview import (
+    GenericWebPreviewDestroyResult,
+    GenericWebPreviewRefreshResult,
+    GenericWebPreviewSmokeCheck,
+    GenericWebPreviewSmokeResult,
+)
 
 StartResponse = Callable[[str, list[tuple[str, str]]], None]
 WsgiApp = Callable[[dict[str, object], StartResponse], Iterable[bytes]]
@@ -9703,6 +9708,199 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(kwargs["profile"].driver_id, "odoo")
             self.assertEqual(kwargs["profile"].preview.context, "cm")
             self.assertEqual(kwargs["request"].preview_url, "")
+
+    def test_odoo_preview_refresh_route_records_smoke_ready_evidence(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/odoo-tenant-cm",
+                            "workflow_refs": [
+                                "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["preview_refresh.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/odoo-tenant-cm",
+                        workflow_ref=(
+                            "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_generic_web_preview_refresh",
+                return_value=GenericWebPreviewRefreshResult(
+                    refresh_status="pass",
+                    refresh_started_at="2026-05-09T15:00:00Z",
+                    refresh_finished_at="2026-05-09T15:05:00Z",
+                    product="odoo-tenant-cm",
+                    context="cm",
+                    preview_slug="pr-42",
+                    application_name="cm-odoo-preview-pr-42",
+                    application_id="compose-cm-testing",
+                    preview_url="https://pr-42.cm.example.test",
+                    smoke=GenericWebPreviewSmokeResult(
+                        smoke_status="pass",
+                        checked_at="2026-05-09T15:04:55Z",
+                        checks=(
+                            GenericWebPreviewSmokeCheck(
+                                check_id="web_health",
+                                status="pass",
+                                message="Odoo preview smoke path /web/health responded successfully.",
+                            ),
+                        ),
+                    ),
+                ),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/preview-refresh",
+                    payload={
+                        "schema_version": 1,
+                        "product": "odoo-tenant-cm",
+                        "refresh": {
+                            "schema_version": 1,
+                            "product": "odoo-tenant-cm",
+                            "preview_slug": "pr-42",
+                            "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm:sha",
+                            "anchor_head_sha": "abc123",
+                        },
+                    },
+                    headers={"Idempotency-Key": "odoo-preview-refresh:cm:42:sha"},
+                )
+
+            self.assertEqual(status_code, 202)
+            self.assertEqual(payload["records"]["transition"], "ready")
+            stored = FilesystemRecordStore(state_dir=state_dir)
+            preview = stored.read_preview_record("preview-cm-odoo-tenant-cm-pr-42")
+            generation = stored.read_preview_generation_record(
+                "preview-cm-odoo-tenant-cm-pr-42-generation-0001"
+            )
+            self.assertEqual(preview.state, "active")
+            self.assertEqual(generation.state, "ready")
+            self.assertEqual(generation.deploy_status, "pass")
+            self.assertEqual(generation.verify_status, "pass")
+            self.assertEqual(generation.overall_health_status, "pass")
+
+    def test_odoo_preview_refresh_route_records_smoke_failure_as_verify_failure(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/odoo-tenant-cm",
+                            "workflow_refs": [
+                                "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["preview_refresh.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/odoo-tenant-cm",
+                        workflow_ref=(
+                            "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_generic_web_preview_refresh",
+                return_value=GenericWebPreviewRefreshResult(
+                    refresh_status="fail",
+                    refresh_started_at="2026-05-09T15:00:00Z",
+                    refresh_finished_at="2026-05-09T15:05:00Z",
+                    product="odoo-tenant-cm",
+                    context="cm",
+                    preview_slug="pr-42",
+                    application_name="cm-odoo-preview-pr-42",
+                    application_id="compose-cm-testing",
+                    preview_url="https://pr-42.cm.example.test",
+                    smoke=GenericWebPreviewSmokeResult(
+                        smoke_status="fail",
+                        checked_at="2026-05-09T15:04:55Z",
+                        checks=(
+                            GenericWebPreviewSmokeCheck(
+                                check_id="cell_mechanic_page",
+                                status="fail",
+                                message="Odoo preview smoke path /cell-mechanic returned HTTP 404.",
+                            ),
+                        ),
+                        failure_summary=(
+                            "Odoo preview smoke failed: Odoo preview smoke path "
+                            "/cell-mechanic returned HTTP 404."
+                        ),
+                    ),
+                    error_message=(
+                        "Odoo preview smoke failed: Odoo preview smoke path "
+                        "/cell-mechanic returned HTTP 404."
+                    ),
+                ),
+            ):
+                status_code, _payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/preview-refresh",
+                    payload={
+                        "schema_version": 1,
+                        "product": "odoo-tenant-cm",
+                        "refresh": {
+                            "schema_version": 1,
+                            "product": "odoo-tenant-cm",
+                            "preview_slug": "pr-42",
+                            "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm:sha",
+                            "anchor_head_sha": "abc123",
+                        },
+                    },
+                    headers={"Idempotency-Key": "odoo-preview-refresh:cm:42:sha"},
+                )
+
+            self.assertEqual(status_code, 202)
+            generation = FilesystemRecordStore(state_dir=state_dir).read_preview_generation_record(
+                "preview-cm-odoo-tenant-cm-pr-42-generation-0001"
+            )
+            self.assertEqual(generation.deploy_status, "pass")
+            self.assertEqual(generation.verify_status, "fail")
+            self.assertEqual(generation.overall_health_status, "fail")
+            self.assertEqual(generation.failure_stage, "verify")
+            self.assertIn("/cell-mechanic", generation.failure_summary)
 
     def test_odoo_preview_refresh_route_fails_closed_when_preview_disabled(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add Launchplane-owned Odoo preview smoke results for artifact/revision/module evidence and CM HTTP paths
- record Odoo smoke pass as ready/pass preview-generation evidence and smoke failure as verify failure
- document the Odoo CM smoke contract and create browser-smoke follow-up #553

Refs #506

## Validation
- uv run python -m unittest
- uv run --extra dev ruff check control_plane/workflows/generic_web_preview.py control_plane/service.py tests/test_generic_web_preview.py tests/test_service.py
- uv run --extra dev mypy control_plane tests

Note: repo-wide ruff format --check still reports existing unrelated files; changed files were formatted surgically.