### PR TITLE
Add Odoo bootstrap lane policy proof

### DIFF
--- a/.github/workflows/odoo-stable-bootstrap.yml
+++ b/.github/workflows/odoo-stable-bootstrap.yml
@@ -13,18 +13,14 @@ name: Odoo Stable Bootstrap
         description: Launchplane Odoo context.
         required: true
         default: cm
-        type: choice
-        options:
-          - cm
+        type: string
       instance:
         description: Stable Odoo instance to bootstrap.
         required: true
         default: testing
-        type: choice
-        options:
-          - testing
+        type: string
       confirmation:
-        description: Type "bootstrap cm testing" to confirm destructive bootstrap.
+        description: Type the lane policy confirmation to confirm destructive bootstrap.
         required: true
         type: string
       verify_health:
@@ -87,14 +83,6 @@ jobs:
           : "${CONTEXT:?Missing context input}"
           : "${INSTANCE:?Missing instance input}"
           : "${CONFIRMATION:?Missing confirmation input}"
-          if [ "$PRODUCT" != "odoo-tenant-cm" ] || [ "$CONTEXT" != "cm" ] || [ "$INSTANCE" != "testing" ]; then
-            echo 'This workflow currently only bootstraps odoo-tenant-cm cm/testing.' >&2
-            exit 1
-          fi
-          if [ "$CONFIRMATION" != "bootstrap cm testing" ]; then
-            echo 'Confirmation must be exactly: bootstrap cm testing' >&2
-            exit 1
-          fi
           for value in "$VERIFY_HEALTH" "$VERIFY_CANONICAL" "$VERIFY_LOGO"; do
             if [ "$value" != "true" ] && [ "$value" != "false" ]; then
               echo "Boolean input resolved to invalid value: ${value}" >&2

--- a/control_plane/contracts/product_profile_record.py
+++ b/control_plane/contracts/product_profile_record.py
@@ -18,6 +18,50 @@ class ProductImageProfile(BaseModel):
         return self
 
 
+class ProductOdooStableBootstrapPolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    data_source_mode: Literal["empty"] = "empty"
+    confirmation: str = ""
+    expected_target_name: str = ""
+    expected_domains: tuple[str, ...] = ()
+    require_health_verification: bool = True
+    require_canonical_verification: bool = True
+    require_logo_verification: bool = True
+
+    @model_validator(mode="after")
+    def _validate_policy(self) -> "ProductOdooStableBootstrapPolicy":
+        self.confirmation = self.confirmation.strip().lower()
+        self.expected_target_name = self.expected_target_name.strip()
+        normalized_domains: list[str] = []
+        for raw_domain in self.expected_domains:
+            domain = (
+                raw_domain.strip()
+                .lower()
+                .removeprefix("https://")
+                .removeprefix("http://")
+                .rstrip("/")
+            )
+            if not domain:
+                raise ValueError(
+                    "Odoo stable bootstrap policy expected_domains values must be non-empty"
+                )
+            if domain not in normalized_domains:
+                normalized_domains.append(domain)
+        self.expected_domains = tuple(normalized_domains)
+        if self.enabled:
+            if not self.confirmation:
+                raise ValueError("enabled Odoo stable bootstrap policy requires confirmation")
+            if not self.expected_target_name:
+                raise ValueError(
+                    "enabled Odoo stable bootstrap policy requires expected_target_name"
+                )
+            if not self.expected_domains:
+                raise ValueError("enabled Odoo stable bootstrap policy requires expected_domains")
+        return self
+
+
 class ProductLaneProfile(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -25,6 +69,9 @@ class ProductLaneProfile(BaseModel):
     context: str
     base_url: str = ""
     health_url: str = ""
+    odoo_stable_bootstrap: ProductOdooStableBootstrapPolicy = Field(
+        default_factory=ProductOdooStableBootstrapPolicy
+    )
 
     @model_validator(mode="after")
     def _validate_lane(self) -> "ProductLaneProfile":

--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -1437,6 +1437,12 @@ def run_compose_odoo_stable_bootstrap(
         target_type="compose",
         target_id=compose_id,
     )
+    observed_compose_name = str(target_payload.get("name") or "").strip()
+    if observed_compose_name and observed_compose_name != compose_name:
+        raise click.ClickException(
+            "Odoo stable bootstrap target proof failed: live Dokploy compose name "
+            f"{observed_compose_name!r} does not match expected {compose_name!r}."
+        )
     current_env_map = parse_dokploy_env_text(str(target_payload.get("env") or ""))
     desired_env_map = _apply_post_deploy_env_file_overrides(
         current_env_map=current_env_map,
@@ -1498,7 +1504,9 @@ def run_compose_odoo_stable_bootstrap(
             target_payload=target_payload,
         )
     )
-    schedule_app_name = f"platform-{target_definition.context}-{target_definition.instance}-odoo-bootstrap"
+    schedule_app_name = (
+        f"platform-{target_definition.context}-{target_definition.instance}-odoo-bootstrap"
+    )
     existing_schedule = find_matching_dokploy_schedule(
         host=host,
         token=token,

--- a/control_plane/workflows/odoo_stable_bootstrap.py
+++ b/control_plane/workflows/odoo_stable_bootstrap.py
@@ -12,7 +12,10 @@ from control_plane.contracts.deployment_record import DeploymentRecord, Resolved
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
-from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductLaneProfile,
+)
 from control_plane.contracts.promotion_record import HealthcheckEvidence, PostDeployUpdateEvidence
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.workflows.inventory import build_environment_inventory
@@ -31,7 +34,6 @@ from control_plane.workflows.ship import (
     utc_now_timestamp,
 )
 
-ODOO_STABLE_BOOTSTRAP_CONFIRMATION = "bootstrap cm testing"
 ODOO_STABLE_BOOTSTRAP_VERIFY_RETRY_INTERVAL_SECONDS = 5
 
 
@@ -103,15 +105,51 @@ class OdooStableBootstrapResult(BaseModel):
     error_message: str = ""
 
 
-def _assert_cm_testing_bootstrap_allowed(request: OdooStableBootstrapRequest) -> None:
-    if request.product != "odoo-tenant-cm" or request.context != "cm" or request.instance != "testing":
+def _normalize_domain(raw_domain: str) -> str:
+    return raw_domain.strip().lower().removeprefix("https://").removeprefix("http://").rstrip("/")
+
+
+def _assert_bootstrap_policy_allows_request(
+    *,
+    request: OdooStableBootstrapRequest,
+    lane: ProductLaneProfile,
+    target_record: DokployTargetRecord,
+) -> None:
+    policy = lane.odoo_stable_bootstrap
+    if not policy.enabled:
         raise click.ClickException(
-            "Odoo stable bootstrap is currently limited to odoo-tenant-cm cm/testing."
+            f"Odoo stable bootstrap is not enabled for {request.product} {request.context}/{request.instance}."
         )
-    if request.confirmation != ODOO_STABLE_BOOTSTRAP_CONFIRMATION:
+    if request.confirmation != policy.confirmation:
         raise click.ClickException(
-            f"Odoo stable bootstrap requires confirmation {ODOO_STABLE_BOOTSTRAP_CONFIRMATION!r}."
+            f"Odoo stable bootstrap requires confirmation {policy.confirmation!r}."
         )
+    if policy.data_source_mode != "empty":
+        raise click.ClickException(
+            f"Unsupported Odoo stable bootstrap data source mode {policy.data_source_mode!r}."
+        )
+    if policy.expected_target_name and target_record.target_name != policy.expected_target_name:
+        raise click.ClickException(
+            "Odoo stable bootstrap target proof failed: expected target "
+            f"{policy.expected_target_name!r}, observed {target_record.target_name!r}."
+        )
+    target_domains = {
+        _normalize_domain(domain) for domain in target_record.domains if domain.strip()
+    }
+    missing_domains = tuple(
+        domain for domain in policy.expected_domains if domain not in target_domains
+    )
+    if missing_domains:
+        raise click.ClickException(
+            "Odoo stable bootstrap target proof failed: missing expected domain(s) "
+            + ", ".join(missing_domains)
+        )
+    if policy.require_health_verification and not request.verify_health:
+        raise click.ClickException("Odoo stable bootstrap policy requires health verification.")
+    if policy.require_canonical_verification and not request.verify_canonical:
+        raise click.ClickException("Odoo stable bootstrap policy requires canonical verification.")
+    if policy.require_logo_verification and not request.verify_logo:
+        raise click.ClickException("Odoo stable bootstrap policy requires logo verification.")
 
 
 def _build_bootstrap_ship_request(
@@ -221,9 +259,7 @@ def _read_bootstrap_target_record(
     *, record_store: OdooStableBootstrapStore, context: str, instance: str
 ) -> DokployTargetRecord:
     try:
-        return record_store.read_dokploy_target_record(
-            context_name=context, instance_name=instance
-        )
+        return record_store.read_dokploy_target_record(context_name=context, instance_name=instance)
     except FileNotFoundError as error:
         raise click.ClickException(
             f"Odoo stable bootstrap requires a Launchplane Dokploy target record for {context}/{instance}."
@@ -247,9 +283,7 @@ def _read_bootstrap_inventory(
     *, record_store: OdooStableBootstrapStore, context: str, instance: str
 ) -> EnvironmentInventory:
     try:
-        return record_store.read_environment_inventory(
-            context_name=context, instance_name=instance
-        )
+        return record_store.read_environment_inventory(context_name=context, instance_name=instance)
     except FileNotFoundError as error:
         raise click.ClickException(
             f"Odoo stable bootstrap requires current Launchplane environment inventory for {context}/{instance}."
@@ -263,7 +297,6 @@ def execute_odoo_stable_bootstrap(
     request: OdooStableBootstrapRequest,
     env_file: Path | None = None,
 ) -> OdooStableBootstrapResult:
-    _assert_cm_testing_bootstrap_allowed(request)
     profile = record_store.read_product_profile_record(request.product)
     lane = _read_lane(profile=profile, instance=request.instance)
     if lane.context.strip().lower() != request.context:
@@ -278,6 +311,7 @@ def execute_odoo_stable_bootstrap(
     )
     if target_record.target_type != "compose":
         raise click.ClickException("Odoo stable bootstrap requires a compose target.")
+    _assert_bootstrap_policy_allows_request(request=request, lane=lane, target_record=target_record)
     inventory = _read_bootstrap_inventory(
         record_store=record_store, context=request.context, instance=request.instance
     )
@@ -287,7 +321,9 @@ def execute_odoo_stable_bootstrap(
     if not artifact_id.strip():
         raise click.ClickException("Odoo stable bootstrap requires inventory artifact evidence.")
     if not inventory.source_git_ref.strip():
-        raise click.ClickException("Odoo stable bootstrap requires inventory source git ref evidence.")
+        raise click.ClickException(
+            "Odoo stable bootstrap requires inventory source git ref evidence."
+        )
 
     deployment_record_id = generate_deployment_record_id(
         context_name=request.context, instance_name=request.instance
@@ -395,9 +431,7 @@ def execute_odoo_stable_bootstrap(
         )
 
     base_url = _target_base_url(lane=lane, domains=target_record.domains)
-    health_url = _target_health_url(
-        profile=profile, lane=lane, domains=target_record.domains
-    )
+    health_url = _target_health_url(profile=profile, lane=lane, domains=target_record.domains)
     health_timeout_seconds = (
         request.health_timeout_seconds
         or target_record.healthcheck_timeout_seconds

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -164,11 +164,14 @@ the preview generation as `ready` with deploy, verify, and overall health status
 not advertise ready before the checks pass.
 
 Odoo also exposes `POST /v1/drivers/odoo/stable-bootstrap` as a destructive
-instance-scoped action. The first implementation is policy-limited to CM testing
-and reuses the existing devkit `--bootstrap` data workflow through a
-Launchplane-owned Dokploy schedule. It is separate from target replacement:
-replacement reconciles provider/runtime target state, while bootstrap rebuilds
-Odoo application data for lanes that are explicitly safe to recreate.
+instance-scoped action. It is enabled per product-profile lane through
+`odoo_stable_bootstrap` policy rather than driver code literals. The policy
+defines the destructive confirmation phrase, allowed data-source mode, expected
+target name/domains, and required verification checks before Launchplane reuses
+the existing devkit `--bootstrap` data workflow through a Launchplane-owned
+Dokploy schedule. It is separate from target replacement: replacement reconciles
+provider/runtime target state, while bootstrap rebuilds Odoo application data for
+lanes that are explicitly safe to recreate.
 
 Driver action routes are owned by the base driver contract. The service accepts
 any product key on Odoo and VeriReel action envelopes, then authorizes the call

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -727,13 +727,17 @@ Target replacement only reconciles the provider target and runtime envelope. If
 an intentionally empty CM testing lane needs its Odoo database and filestore
 rebuilt, use the trusted `Odoo Stable Bootstrap` workflow instead of repairing
 state in Dokploy or a local checkout. The workflow calls
-`POST /v1/drivers/odoo/stable-bootstrap`, requires the exact confirmation
-`bootstrap cm testing`, and is currently limited to `odoo-tenant-cm` `cm/testing`.
-The service runs the existing compose-local devkit data workflow in `--bootstrap`
-mode through a dedicated manual Dokploy schedule, then runs Odoo post-deploy and
-verifies health, canonical URL, and logo routes before writing deployment and
-inventory evidence. Do not use this path for prod until Launchplane has explicit
-backup/restore policy evidence for that lane.
+`POST /v1/drivers/odoo/stable-bootstrap` and requires the lane's product-profile
+`odoo_stable_bootstrap` policy to be enabled. That policy carries the destructive
+confirmation phrase, expected Dokploy target name, expected domain set, data
+source mode, and required verification checks. The service proves the request,
+product lane, stored target record, and target domains before contacting Dokploy;
+the Dokploy runner also refuses if the live compose name no longer matches the
+expected target. After proof passes, Launchplane runs the existing compose-local
+devkit data workflow in `--bootstrap` mode through a dedicated manual Dokploy
+schedule, then runs Odoo post-deploy and verifies health, canonical URL, and logo
+routes before writing deployment and inventory evidence. Do not use this path for
+prod until Launchplane has explicit backup/restore policy evidence for that lane.
 
 `launchplane-previews write-from-generation` and `launchplane-previews write-destroyed`
 are local preview-evidence ingest adapters that mirror the service ingress

--- a/docs/records.md
+++ b/docs/records.md
@@ -220,6 +220,13 @@ directly with `uv run launchplane product-profiles upsert --database-url ...`.
 That command is an operator tool for creating the Launchplane record; it is not
 a repo-local manifest and should not become product repo authority.
 
+Odoo stable bootstrap eligibility is lane-owned product-profile data. A lane's
+`odoo_stable_bootstrap` policy defaults to disabled and must explicitly carry
+the destructive confirmation phrase, `data_source_mode`, expected Dokploy target
+name, expected domains, and required verification checks. Launchplane treats the
+policy plus stored/observed target proof as the authority for whether a bootstrap
+can proceed; request product/context/instance alone is not sufficient.
+
 This file layout describes today's local Launchplane implementation, not the
 final cross-product communication boundary. The stable long-term contract should
 be Launchplane's authenticated service ingress plus the durable record semantics

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -1983,6 +1983,7 @@ protected_store_keys = ["yps-your-part-supplier"]
             patch(
                 "control_plane.dokploy.fetch_dokploy_target_payload",
                 return_value={
+                    "name": "cm-testing",
                     "env": "ODOO_DB_NAME=cm_testing\nODOO_FILESTORE_PATH=/volumes/data/filestore\n",
                     "appName": "cm-testing-app",
                     "serverId": "server-123",
@@ -2026,6 +2027,33 @@ protected_store_keys = ["yps-your-part-supplier"]
         self.assertIn("workflow_arguments=(--bootstrap)", script)
         self.assertNotIn("workflow_arguments=(--update-only)", script)
         self.assertIn("/api/schedule.runManually", request_paths)
+
+    def test_run_compose_odoo_stable_bootstrap_refuses_live_name_mismatch(self) -> None:
+        target_definition = control_plane_dokploy.DokployTargetDefinition(
+            context="cm",
+            instance="testing",
+            target_id="compose-123",
+            target_name="cm-testing",
+        )
+
+        with patch(
+            "control_plane.dokploy.fetch_dokploy_target_payload",
+            return_value={
+                "name": "cm-prod",
+                "env": "ODOO_DB_NAME=cm_testing\n",
+                "appName": "cm-testing-app",
+                "serverId": "server-123",
+            },
+        ):
+            with self.assertRaises(click.ClickException) as raised_error:
+                control_plane_dokploy.run_compose_odoo_stable_bootstrap(
+                    host="https://dokploy.example.com",
+                    token="secret-token",
+                    target_definition=target_definition,
+                    env_file=None,
+                )
+
+        self.assertIn("target proof failed", str(raised_error.exception))
 
     def test_run_compose_post_deploy_update_rejects_unsupported_env_overlay_keys(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_odoo_stable_bootstrap.py
+++ b/tests/test_odoo_stable_bootstrap.py
@@ -11,6 +11,7 @@ from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
+    ProductOdooStableBootstrapPolicy,
     ProductImageProfile,
     ProductLaneProfile,
 )
@@ -18,11 +19,13 @@ from control_plane.dokploy import DokployTargetDefinition
 from control_plane.contracts.promotion_record import ArtifactIdentityReference, DeploymentEvidence
 from control_plane.workflows.odoo_post_deploy import OdooPostDeployResult
 from control_plane.workflows.odoo_stable_bootstrap import (
-    ODOO_STABLE_BOOTSTRAP_CONFIRMATION,
     OdooStableBootstrapRequest,
     execute_odoo_stable_bootstrap,
     _run_verification_with_retry,
 )
+
+
+_BOOTSTRAP_CONFIRMATION = "bootstrap cm testing"
 
 
 class _Store:
@@ -41,6 +44,12 @@ class _Store:
                     context="cm",
                     base_url="https://cm-testing.shinycomputers.com",
                     health_url="https://cm-testing.shinycomputers.com/web/health",
+                    odoo_stable_bootstrap=ProductOdooStableBootstrapPolicy(
+                        enabled=True,
+                        confirmation=_BOOTSTRAP_CONFIRMATION,
+                        expected_target_name="cm-testing",
+                        expected_domains=("cm-testing.shinycomputers.com",),
+                    ),
                 ),
             ),
             updated_at="2026-05-10T00:00:00Z",
@@ -172,7 +181,7 @@ class OdooStableBootstrapTests(unittest.TestCase):
                     product="odoo-tenant-cm",
                     context="cm",
                     instance="testing",
-                    confirmation=ODOO_STABLE_BOOTSTRAP_CONFIRMATION,
+                    confirmation=_BOOTSTRAP_CONFIRMATION,
                 ),
             )
 
@@ -208,7 +217,35 @@ class OdooStableBootstrapTests(unittest.TestCase):
             "deployment-cm-testing-bootstrap",
         )
 
-    def test_execute_refuses_non_cm_testing(self) -> None:
+    def test_execute_refuses_lane_without_bootstrap_policy(self) -> None:
+        store = _Store()
+        store.profile = store.profile.model_copy(
+            update={
+                "lanes": (
+                    ProductLaneProfile(
+                        instance="testing",
+                        context="cm",
+                        base_url="https://cm-testing.shinycomputers.com",
+                        health_url="https://cm-testing.shinycomputers.com/web/health",
+                    ),
+                )
+            }
+        )
+        with self.assertRaises(click.ClickException) as raised_error:
+            execute_odoo_stable_bootstrap(
+                control_plane_root=Path("/tmp/launchplane"),
+                record_store=store,
+                request=OdooStableBootstrapRequest(
+                    product="odoo-tenant-cm",
+                    context="cm",
+                    instance="testing",
+                    confirmation=_BOOTSTRAP_CONFIRMATION,
+                ),
+            )
+
+        self.assertIn("not enabled", str(raised_error.exception))
+
+    def test_execute_refuses_wrong_confirmation(self) -> None:
         store = _Store()
         with self.assertRaises(click.ClickException) as raised_error:
             execute_odoo_stable_bootstrap(
@@ -217,19 +254,72 @@ class OdooStableBootstrapTests(unittest.TestCase):
                 request=OdooStableBootstrapRequest(
                     product="odoo-tenant-cm",
                     context="cm",
-                    instance="prod",
-                    confirmation=ODOO_STABLE_BOOTSTRAP_CONFIRMATION,
+                    instance="testing",
+                    confirmation="bootstrap prod",
                 ),
             )
 
-        self.assertIn("cm/testing", str(raised_error.exception))
+        self.assertIn("requires confirmation", str(raised_error.exception))
+
+    def test_execute_refuses_mismatched_target_name(self) -> None:
+        store = _Store()
+        store.target_record = store.target_record.model_copy(update={"target_name": "cm-prod"})
+        with self.assertRaises(click.ClickException) as raised_error:
+            execute_odoo_stable_bootstrap(
+                control_plane_root=Path("/tmp/launchplane"),
+                record_store=store,
+                request=OdooStableBootstrapRequest(
+                    product="odoo-tenant-cm",
+                    context="cm",
+                    instance="testing",
+                    confirmation=_BOOTSTRAP_CONFIRMATION,
+                ),
+            )
+
+        self.assertIn("target proof failed", str(raised_error.exception))
+
+    def test_execute_refuses_mismatched_domain(self) -> None:
+        store = _Store()
+        store.target_record = store.target_record.model_copy(
+            update={"domains": ("cm-prod.shinycomputers.com",)}
+        )
+        with self.assertRaises(click.ClickException) as raised_error:
+            execute_odoo_stable_bootstrap(
+                control_plane_root=Path("/tmp/launchplane"),
+                record_store=store,
+                request=OdooStableBootstrapRequest(
+                    product="odoo-tenant-cm",
+                    context="cm",
+                    instance="testing",
+                    confirmation=_BOOTSTRAP_CONFIRMATION,
+                ),
+            )
+
+        self.assertIn("missing expected domain", str(raised_error.exception))
+
+    def test_execute_refuses_disabled_required_verification(self) -> None:
+        store = _Store()
+        with self.assertRaises(click.ClickException) as raised_error:
+            execute_odoo_stable_bootstrap(
+                control_plane_root=Path("/tmp/launchplane"),
+                record_store=store,
+                request=OdooStableBootstrapRequest(
+                    product="odoo-tenant-cm",
+                    context="cm",
+                    instance="testing",
+                    confirmation=_BOOTSTRAP_CONFIRMATION,
+                    verify_logo=False,
+                ),
+            )
+
+        self.assertIn("requires logo verification", str(raised_error.exception))
 
     def test_execute_reports_missing_target_records_as_controlled_errors(self) -> None:
         request = OdooStableBootstrapRequest(
             product="odoo-tenant-cm",
             context="cm",
             instance="testing",
-            confirmation=ODOO_STABLE_BOOTSTRAP_CONFIRMATION,
+            confirmation=_BOOTSTRAP_CONFIRMATION,
         )
 
         for missing_attribute, expected_message in (
@@ -276,7 +366,7 @@ class OdooStableBootstrapTests(unittest.TestCase):
                     product="odoo-tenant-cm",
                     context="cm",
                     instance="testing",
-                    confirmation=ODOO_STABLE_BOOTSTRAP_CONFIRMATION,
+                    confirmation=_BOOTSTRAP_CONFIRMATION,
                 ),
             )
 


### PR DESCRIPTION
## Summary

- add an explicit lane-level `odoo_stable_bootstrap` policy to product profiles
- require bootstrap policy, confirmation, expected target name/domains, and required verification flags before contacting Dokploy
- add a live Dokploy compose-name proof inside the bootstrap runner
- remove hard-coded CM/testing validation from the workflow and document policy-owned bootstrap eligibility

Refs #555.

## Validation

- `uv run python -m unittest tests.test_odoo_stable_bootstrap tests.test_dokploy`
- `uv run python -m unittest tests.test_service tests.test_filesystem_store tests.test_postgres_store tests.test_product_context_cutover tests.test_product_profile_context_audit`
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`

## Notes

- Broad `ruff format --check .` still reports pre-existing repository-wide formatting drift; only changed Python files were formatted in this branch.
- This is the first #555 slice. Runtime identity as strict target proof still depends on #516 adoption.