### PR TITLE
Track Odoo bootstrap provenance status

### DIFF
--- a/control_plane/contracts/deployment_record.py
+++ b/control_plane/contracts/deployment_record.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
+    BootstrapEvidence,
     DeploymentEvidence,
     HealthcheckEvidence,
     PostDeployUpdateEvidence,
@@ -46,6 +47,7 @@ class DeploymentRecord(BaseModel):
     runtime_source: dict[str, str] = Field(default_factory=dict)
     runtime_identity: RuntimeIdentity | None = None
     deploy: DeploymentEvidence
+    bootstrap: BootstrapEvidence = Field(default_factory=BootstrapEvidence)
     post_deploy_update: PostDeployUpdateEvidence = Field(default_factory=PostDeployUpdateEvidence)
     destination_health: HealthcheckEvidence = Field(default_factory=HealthcheckEvidence)
 

--- a/control_plane/contracts/environment_inventory.py
+++ b/control_plane/contracts/environment_inventory.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
+    BootstrapEvidence,
     DeploymentEvidence,
     HealthcheckEvidence,
 )
@@ -18,11 +19,13 @@ class EnvironmentInventory(BaseModel):
     artifact_identity: ArtifactIdentityReference | None = None
     source_git_ref: str
     deploy: DeploymentEvidence
+    bootstrap: BootstrapEvidence = Field(default_factory=BootstrapEvidence)
     runtime_identity: RuntimeIdentity | None = None
     post_deploy_update: PostDeployUpdateEvidence = Field(default_factory=PostDeployUpdateEvidence)
     destination_health: HealthcheckEvidence = Field(default_factory=HealthcheckEvidence)
     updated_at: str
     deployment_record_id: str
+    bootstrap_record_id: str = ""
     promotion_record_id: str = ""
     promoted_from_instance: str = ""
 

--- a/control_plane/contracts/promotion_record.py
+++ b/control_plane/contracts/promotion_record.py
@@ -69,6 +69,36 @@ class PostDeployUpdateEvidence(BaseModel):
         return self
 
 
+BootstrapReadinessStatus = Literal[
+    "pending",
+    "pass",
+    "fail",
+    "verification_failed",
+    "skipped",
+]
+
+
+class BootstrapEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    attempted: bool = False
+    run_status: ReleaseStatus = "skipped"
+    readiness_status: BootstrapReadinessStatus = "skipped"
+    detail: str = ""
+
+    @model_validator(mode="after")
+    def _validate_attempted_bootstrap(self) -> "BootstrapEvidence":
+        if not self.attempted:
+            if self.run_status != "skipped" or self.readiness_status != "skipped":
+                raise ValueError("non-attempted bootstrap evidence must use skipped statuses")
+            return self
+        if self.run_status == "skipped" or self.readiness_status == "skipped":
+            raise ValueError("attempted bootstrap evidence must not use skipped statuses")
+        if self.run_status == "fail" and self.readiness_status not in {"fail", "pending"}:
+            raise ValueError("failed bootstrap execution must use fail or pending readiness")
+        return self
+
+
 class RollbackExecutionEvidence(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/control_plane/workflows/inventory.py
+++ b/control_plane/workflows/inventory.py
@@ -10,6 +10,7 @@ def build_environment_inventory(
     *,
     deployment_record: DeploymentRecord,
     updated_at: str,
+    bootstrap_record_id: str = "",
     promotion_record_id: str = "",
     promoted_from_instance: str = "",
 ) -> EnvironmentInventory:
@@ -19,11 +20,13 @@ def build_environment_inventory(
         artifact_identity=deployment_record.artifact_identity,
         source_git_ref=deployment_record.source_git_ref,
         deploy=deployment_record.deploy,
+        bootstrap=deployment_record.bootstrap,
         runtime_identity=deployment_record.runtime_identity,
         post_deploy_update=deployment_record.post_deploy_update,
         destination_health=deployment_record.destination_health,
         updated_at=updated_at,
         deployment_record_id=deployment_record.record_id,
+        bootstrap_record_id=bootstrap_record_id,
         promotion_record_id=promotion_record_id,
         promoted_from_instance=promoted_from_instance,
     )

--- a/control_plane/workflows/odoo_stable_bootstrap.py
+++ b/control_plane/workflows/odoo_stable_bootstrap.py
@@ -16,7 +16,11 @@ from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductLaneProfile,
 )
-from control_plane.contracts.promotion_record import HealthcheckEvidence, PostDeployUpdateEvidence
+from control_plane.contracts.promotion_record import (
+    BootstrapEvidence,
+    HealthcheckEvidence,
+    PostDeployUpdateEvidence,
+)
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.workflows.inventory import build_environment_inventory
 from control_plane.workflows.odoo_post_deploy import OdooPostDeployRequest, execute_odoo_post_deploy
@@ -94,6 +98,8 @@ class OdooStableBootstrapResult(BaseModel):
     instance: str
     deployment_record_id: str = ""
     bootstrap_status: Literal["pass", "fail"]
+    bootstrap_run_status: Literal["pass", "fail", "skipped"] = "skipped"
+    readiness_status: Literal["pass", "fail", "verification_failed", "skipped"] = "skipped"
     post_deploy_status: Literal["pass", "fail", "skipped"] = "skipped"
     health_status: Literal["pass", "fail", "skipped"] = "skipped"
     canonical_status: Literal["pass", "fail", "skipped"] = "skipped"
@@ -182,6 +188,7 @@ def _write_failed_bootstrap_deployment(
     deployment_record_id: str,
     started_at: str,
     resolved_target: ResolvedTargetEvidence,
+    bootstrap: BootstrapEvidence | None = None,
     post_deploy_update: PostDeployUpdateEvidence | None = None,
     destination_health: HealthcheckEvidence | None = None,
 ) -> None:
@@ -194,9 +201,21 @@ def _write_failed_bootstrap_deployment(
             started_at=started_at,
             finished_at=utc_now_timestamp(),
             resolved_target=resolved_target,
+            bootstrap=bootstrap,
             post_deploy_update=post_deploy_update,
             destination_health=destination_health,
         )
+    )
+
+
+def _write_bootstrap_inventory_pointer(
+    *,
+    record_store: OdooStableBootstrapStore,
+    inventory: EnvironmentInventory,
+    bootstrap_record_id: str,
+) -> None:
+    record_store.write_environment_inventory(
+        inventory.model_copy(update={"bootstrap_record_id": bootstrap_record_id})
     )
 
 
@@ -228,6 +247,8 @@ def _base_result(
     target_id_record: DokployTargetIdRecord,
     inventory: EnvironmentInventory,
     bootstrap_status: Literal["pass", "fail"],
+    bootstrap_run_status: Literal["pass", "fail", "skipped"] = "skipped",
+    readiness_status: Literal["pass", "fail", "verification_failed", "skipped"] = "skipped",
     post_deploy_status: Literal["pass", "fail", "skipped"] = "skipped",
     health_status: Literal["pass", "fail", "skipped"] = "skipped",
     canonical_status: Literal["pass", "fail", "skipped"] = "skipped",
@@ -243,6 +264,8 @@ def _base_result(
         instance=request.instance,
         deployment_record_id=deployment_record_id,
         bootstrap_status=bootstrap_status,
+        bootstrap_run_status=bootstrap_run_status,
+        readiness_status=readiness_status,
         post_deploy_status=post_deploy_status,
         health_status=health_status,
         canonical_status=canonical_status,
@@ -350,6 +373,12 @@ def execute_odoo_stable_bootstrap(
             started_at=started_at,
             finished_at="",
             resolved_target=resolved_target,
+            bootstrap=BootstrapEvidence(
+                attempted=True,
+                run_status="pending",
+                readiness_status="pending",
+                detail="Odoo stable bootstrap schedule is pending.",
+            ),
             destination_health=HealthcheckEvidence(status="pending")
             if request.verify_health
             else HealthcheckEvidence(status="skipped"),
@@ -384,7 +413,18 @@ def execute_odoo_stable_bootstrap(
             deployment_record_id=deployment_record_id,
             started_at=started_at,
             resolved_target=resolved_target,
+            bootstrap=BootstrapEvidence(
+                attempted=True,
+                run_status="fail",
+                readiness_status="fail",
+                detail=str(error),
+            ),
             destination_health=HealthcheckEvidence(status="skipped"),
+        )
+        _write_bootstrap_inventory_pointer(
+            record_store=record_store,
+            inventory=inventory,
+            bootstrap_record_id=deployment_record_id,
         )
         return _base_result(
             request=request,
@@ -393,6 +433,8 @@ def execute_odoo_stable_bootstrap(
             target_id_record=target_id_record,
             inventory=inventory,
             bootstrap_status="fail",
+            bootstrap_run_status="fail",
+            readiness_status="fail",
             error_message=str(error),
         )
 
@@ -416,8 +458,19 @@ def execute_odoo_stable_bootstrap(
             deployment_record_id=deployment_record_id,
             started_at=started_at,
             resolved_target=resolved_target,
+            bootstrap=BootstrapEvidence(
+                attempted=True,
+                run_status="pass",
+                readiness_status="fail",
+                detail=post_deploy_result.error_message or "Odoo post-deploy failed.",
+            ),
             post_deploy_update=post_deploy_evidence,
             destination_health=HealthcheckEvidence(status="skipped"),
+        )
+        _write_bootstrap_inventory_pointer(
+            record_store=record_store,
+            inventory=inventory,
+            bootstrap_record_id=deployment_record_id,
         )
         return _base_result(
             request=request,
@@ -426,6 +479,8 @@ def execute_odoo_stable_bootstrap(
             target_id_record=target_id_record,
             inventory=inventory,
             bootstrap_status="fail",
+            bootstrap_run_status="pass",
+            readiness_status="fail",
             post_deploy_status=post_deploy_result.post_deploy_status,
             error_message=post_deploy_result.error_message or "Odoo post-deploy failed.",
         )
@@ -478,8 +533,19 @@ def execute_odoo_stable_bootstrap(
             deployment_record_id=deployment_record_id,
             started_at=started_at,
             resolved_target=resolved_target,
+            bootstrap=BootstrapEvidence(
+                attempted=True,
+                run_status="pass",
+                readiness_status="verification_failed",
+                detail=str(error),
+            ),
             post_deploy_update=post_deploy_evidence,
             destination_health=destination_health,
+        )
+        _write_bootstrap_inventory_pointer(
+            record_store=record_store,
+            inventory=inventory,
+            bootstrap_record_id=deployment_record_id,
         )
         return _base_result(
             request=request,
@@ -488,6 +554,8 @@ def execute_odoo_stable_bootstrap(
             target_id_record=target_id_record,
             inventory=inventory,
             bootstrap_status="fail",
+            bootstrap_run_status="pass",
+            readiness_status="verification_failed",
             post_deploy_status="pass",
             health_status=health_status if health_status == "pass" else "fail",
             canonical_status=canonical_status if canonical_status == "pass" else "fail",
@@ -510,12 +578,22 @@ def execute_odoo_stable_bootstrap(
         started_at=started_at,
         finished_at=finished_at,
         resolved_target=resolved_target,
+        bootstrap=BootstrapEvidence(
+            attempted=True,
+            run_status="pass",
+            readiness_status="pass",
+            detail="Odoo stable bootstrap, post-deploy, and verification completed.",
+        ),
         post_deploy_update=post_deploy_evidence,
         destination_health=destination_health,
     )
     record_store.write_deployment_record(deployment_record)
     record_store.write_environment_inventory(
-        build_environment_inventory(deployment_record=deployment_record, updated_at=finished_at)
+        build_environment_inventory(
+            deployment_record=deployment_record,
+            updated_at=finished_at,
+            bootstrap_record_id=deployment_record_id,
+        )
     )
     return _base_result(
         request=request,
@@ -524,6 +602,8 @@ def execute_odoo_stable_bootstrap(
         target_id_record=target_id_record,
         inventory=inventory,
         bootstrap_status="pass",
+        bootstrap_run_status="pass",
+        readiness_status="pass",
         post_deploy_status="pass",
         health_status=health_status,
         canonical_status=canonical_status,

--- a/control_plane/workflows/ship.py
+++ b/control_plane/workflows/ship.py
@@ -5,6 +5,7 @@ from control_plane.contracts.deployment_record import DelegatedExecutor
 from control_plane.contracts.deployment_record import ResolvedTargetEvidence
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
+    BootstrapEvidence,
     DeploymentEvidence,
     HealthcheckEvidence,
     PostDeployUpdateEvidence,
@@ -93,6 +94,7 @@ def build_deployment_record(
     delegated_executor: DelegatedExecutor = "control-plane.dokploy",
     runtime_source: dict[str, str] | None = None,
     runtime_identity: RuntimeIdentity | None = None,
+    bootstrap: BootstrapEvidence | None = None,
     post_deploy_update: PostDeployUpdateEvidence | None = None,
     destination_health: HealthcheckEvidence | None = None,
 ) -> DeploymentRecord:
@@ -122,6 +124,7 @@ def build_deployment_record(
             started_at=started_at,
             finished_at=finished_at,
         ),
+        bootstrap=bootstrap or BootstrapEvidence(),
         post_deploy_update=post_deploy_update
         or _resolve_post_deploy_update(
             request,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -736,8 +736,12 @@ the Dokploy runner also refuses if the live compose name no longer matches the
 expected target. After proof passes, Launchplane runs the existing compose-local
 devkit data workflow in `--bootstrap` mode through a dedicated manual Dokploy
 schedule, then runs Odoo post-deploy and verifies health, canonical URL, and logo
-routes before writing deployment and inventory evidence. Do not use this path for
-prod until Launchplane has explicit backup/restore policy evidence for that lane.
+routes before writing deployment and inventory evidence. Bootstrap evidence keeps
+the destructive data workflow status separate from public readiness: if the
+bootstrap runs but post-deploy or verification fails, inventory keeps its prior
+current deployment pointer and records the failed attempt in `bootstrap_record_id`.
+Do not use this path for prod until Launchplane has explicit backup/restore
+policy evidence for that lane.
 
 `launchplane-previews write-from-generation` and `launchplane-previews write-destroyed`
 are local preview-evidence ingest adapters that mirror the service ingress

--- a/docs/records.md
+++ b/docs/records.md
@@ -342,11 +342,15 @@ state/
 - Deployment records make the native follow-up step explicit by
   recording whether the Odoo-specific compose post-deploy update was skipped,
   pending, passed, or failed.
-- Odoo stable bootstrap writes normal deployment and inventory records even
-  though the provider deploy step is a dedicated Dokploy schedule. The record's
-  deploy mode is `dokploy-compose-schedule`; post-deploy evidence captures the
-  typed Odoo settings apply, and destination health captures the public
-  verification outcome after bootstrap.
+- Odoo stable bootstrap writes normal deployment records with additional
+  `bootstrap` evidence because the provider action is a dedicated data workflow
+  schedule, not a fresh artifact deploy. `bootstrap.run_status` captures whether
+  the destructive bootstrap schedule ran, while `bootstrap.readiness_status`
+  separates post-deploy/public verification failures from bootstrap execution.
+  Successful bootstrap refreshes inventory and sets `bootstrap_record_id` to the
+  same record as `deployment_record_id`; failed or partially verified bootstrap
+  attempts leave the current deployment inventory unchanged and update only
+  `bootstrap_record_id` so operators can see the latest bootstrap attempt.
 - Odoo prod rollback writes a normal deployment record for the rollback deploy,
   refreshes prod inventory, mints the prod release tuple from the selected
   artifact manifest, and annotates the current prod promotion record's

--- a/tests/test_odoo_stable_bootstrap.py
+++ b/tests/test_odoo_stable_bootstrap.py
@@ -186,6 +186,8 @@ class OdooStableBootstrapTests(unittest.TestCase):
             )
 
         self.assertEqual(result.bootstrap_status, "pass")
+        self.assertEqual(result.bootstrap_run_status, "pass")
+        self.assertEqual(result.readiness_status, "pass")
         self.assertEqual(result.post_deploy_status, "pass")
         self.assertEqual(result.health_status, "pass")
         self.assertEqual(result.canonical_status, "pass")
@@ -210,12 +212,19 @@ class OdooStableBootstrapTests(unittest.TestCase):
         )
         logo_mock.assert_called_once()
         self.assertEqual(len(store.deployment_records), 2)
+        self.assertEqual(store.deployment_records[-1].bootstrap.run_status, "pass")
+        self.assertEqual(store.deployment_records[-1].bootstrap.readiness_status, "pass")
         self.assertEqual(store.deployment_records[-1].deploy.status, "pass")
         self.assertEqual(len(store.environment_inventories), 1)
         self.assertEqual(
             store.environment_inventories[0].deployment_record_id,
             "deployment-cm-testing-bootstrap",
         )
+        self.assertEqual(
+            store.environment_inventories[0].bootstrap_record_id,
+            "deployment-cm-testing-bootstrap",
+        )
+        self.assertEqual(store.environment_inventories[0].bootstrap.run_status, "pass")
 
     def test_execute_refuses_lane_without_bootstrap_policy(self) -> None:
         store = _Store()
@@ -371,9 +380,148 @@ class OdooStableBootstrapTests(unittest.TestCase):
             )
 
         self.assertEqual(result.bootstrap_status, "fail")
+        self.assertEqual(result.bootstrap_run_status, "fail")
+        self.assertEqual(result.readiness_status, "fail")
         self.assertIn("schedule failed", result.error_message)
         self.assertEqual(store.deployment_records[-1].deploy.status, "fail")
-        self.assertEqual(store.environment_inventories, [])
+        self.assertEqual(store.deployment_records[-1].bootstrap.run_status, "fail")
+        self.assertEqual(store.deployment_records[-1].bootstrap.readiness_status, "fail")
+        self.assertEqual(len(store.environment_inventories), 1)
+        self.assertEqual(
+            store.environment_inventories[0].deployment_record_id,
+            "deployment-cm-testing-old",
+        )
+        self.assertEqual(
+            store.environment_inventories[0].bootstrap_record_id,
+            "deployment-cm-testing-bootstrap",
+        )
+
+    def test_execute_records_bootstrap_success_when_post_deploy_fails(self) -> None:
+        store = _Store()
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example.com", "token-123"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.control_plane_dokploy.run_compose_odoo_stable_bootstrap",
+                side_effect=lambda **_kwargs: None,
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.execute_odoo_post_deploy",
+                return_value=OdooPostDeployResult(
+                    context="cm",
+                    instance="testing",
+                    phase="deploy",
+                    post_deploy_status="fail",
+                    error_message="override failed",
+                ),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.utc_now_timestamp",
+                side_effect=("2026-05-10T02:00:00Z", "2026-05-10T02:01:00Z"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.generate_deployment_record_id",
+                return_value="deployment-cm-testing-bootstrap",
+            ),
+        ):
+            result = execute_odoo_stable_bootstrap(
+                control_plane_root=Path("/tmp/launchplane"),
+                record_store=store,
+                request=OdooStableBootstrapRequest(
+                    product="odoo-tenant-cm",
+                    context="cm",
+                    instance="testing",
+                    confirmation=_BOOTSTRAP_CONFIRMATION,
+                ),
+            )
+
+        self.assertEqual(result.bootstrap_status, "fail")
+        self.assertEqual(result.bootstrap_run_status, "pass")
+        self.assertEqual(result.readiness_status, "fail")
+        self.assertEqual(result.post_deploy_status, "fail")
+        self.assertEqual(store.deployment_records[-1].deploy.status, "fail")
+        self.assertEqual(store.deployment_records[-1].bootstrap.run_status, "pass")
+        self.assertEqual(store.deployment_records[-1].bootstrap.readiness_status, "fail")
+        self.assertEqual(len(store.environment_inventories), 1)
+        self.assertEqual(
+            store.environment_inventories[0].deployment_record_id,
+            "deployment-cm-testing-old",
+        )
+        self.assertEqual(
+            store.environment_inventories[0].bootstrap_record_id,
+            "deployment-cm-testing-bootstrap",
+        )
+
+    def test_execute_records_verification_failure_without_hiding_bootstrap_success(self) -> None:
+        store = _Store()
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example.com", "token-123"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.control_plane_dokploy.run_compose_odoo_stable_bootstrap",
+                side_effect=lambda **_kwargs: None,
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.execute_odoo_post_deploy",
+                return_value=OdooPostDeployResult(
+                    context="cm",
+                    instance="testing",
+                    phase="deploy",
+                    post_deploy_status="pass",
+                ),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap._verify_health_url",
+                side_effect=lambda **_kwargs: None,
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap._verify_canonical_url",
+                side_effect=click.ClickException("canonical failed"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.utc_now_timestamp",
+                side_effect=("2026-05-10T02:00:00Z", "2026-05-10T02:01:00Z"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.generate_deployment_record_id",
+                return_value="deployment-cm-testing-bootstrap",
+            ),
+        ):
+            result = execute_odoo_stable_bootstrap(
+                control_plane_root=Path("/tmp/launchplane"),
+                record_store=store,
+                request=OdooStableBootstrapRequest(
+                    product="odoo-tenant-cm",
+                    context="cm",
+                    instance="testing",
+                    confirmation=_BOOTSTRAP_CONFIRMATION,
+                ),
+            )
+
+        self.assertEqual(result.bootstrap_status, "fail")
+        self.assertEqual(result.bootstrap_run_status, "pass")
+        self.assertEqual(result.readiness_status, "verification_failed")
+        self.assertEqual(result.health_status, "pass")
+        self.assertEqual(result.canonical_status, "fail")
+        self.assertEqual(store.deployment_records[-1].deploy.status, "fail")
+        self.assertEqual(store.deployment_records[-1].bootstrap.run_status, "pass")
+        self.assertEqual(
+            store.deployment_records[-1].bootstrap.readiness_status,
+            "verification_failed",
+        )
+        self.assertEqual(len(store.environment_inventories), 1)
+        self.assertEqual(
+            store.environment_inventories[0].deployment_record_id,
+            "deployment-cm-testing-old",
+        )
+        self.assertEqual(
+            store.environment_inventories[0].bootstrap_record_id,
+            "deployment-cm-testing-bootstrap",
+        )
 
     def test_verification_retry_allows_transient_startup_failure(self) -> None:
         attempts = 0


### PR DESCRIPTION
## Summary

- add bootstrap-specific evidence on deployment records and inventory payloads
- expose `bootstrap_run_status` and `readiness_status` in Odoo stable bootstrap results
- keep current inventory deployment pointers unchanged on failed/partial bootstrap attempts while recording `bootstrap_record_id`
- document bootstrap execution vs public readiness semantics

Refs #557.
Stacked on #559.

## Validation

- `uv run python -m unittest tests.test_odoo_stable_bootstrap tests.test_filesystem_store tests.test_postgres_store`
- `uv run --extra dev ruff format control_plane/contracts/promotion_record.py control_plane/contracts/deployment_record.py control_plane/contracts/environment_inventory.py control_plane/workflows/inventory.py control_plane/workflows/ship.py control_plane/workflows/odoo_stable_bootstrap.py tests/test_odoo_stable_bootstrap.py`
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`