### PR TITLE
Preserve failed Odoo bootstrap artifacts

### DIFF
--- a/.github/workflows/odoo-stable-bootstrap.yml
+++ b/.github/workflows/odoo-stable-bootstrap.yml
@@ -178,7 +178,9 @@ jobs:
           fi
 
       - name: Upload bootstrap result
+        if: always()
         uses: actions/upload-artifact@v5
         with:
           name: odoo-stable-bootstrap-${{ inputs.product }}-${{ inputs.context }}-${{ inputs.instance }}
           path: odoo-stable-bootstrap.json
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

- upload the Odoo stable bootstrap result artifact even when the bootstrap step fails
- ignore missing artifact files for pre-curl/setup failures so the upload step does not mask the original failure

Refs #556.

## Validation

- `git diff --check`
- `uv run --extra dev ruff check .`

## Notes

- This is a small #556 evidence-preservation slice, not the full async operation record implementation.