### PR TITLE
Wire Every Code rerun write-intent execution

### DIFF
--- a/control_plane/contracts/agent_write_intent.py
+++ b/control_plane/contracts/agent_write_intent.py
@@ -24,7 +24,7 @@ AgentWriteIntentStatus = Literal["allowed", "denied"]
 AgentWriteIntentSecretStatus = Literal["not_required", "pass", "fail", "unavailable"]
 
 _INTENT_AUTHZ_ACTIONS: dict[AgentWriteIntentKind, str] = {
-    "every_code_rerun": "every_code_work_request.write",
+    "every_code_rerun": "every_code_work_request.rerun",
     "preview_refresh": "preview_refresh.execute",
     "preview_cleanup": "preview_lifecycle.cleanup",
     "preview_request": "preview_generation.write",

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import base64
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import hashlib
 import json
 import logging
@@ -381,6 +381,7 @@ _GITHUB_ISSUE_REFERENCE_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _EVERY_CODE_TRIGGER_LABEL = "every-code"
+_AGENT_WRITE_INTENT_MAX_AGE = timedelta(hours=24)
 
 
 @dataclass(frozen=True)
@@ -1592,11 +1593,17 @@ class EveryCodeWorkRequestRerunEnvelope(BaseModel):
 
     request_id: str
     trigger_actor: str = ""
+    source_url: str = ""
+    agent_write_intent_record_id: str = ""
 
     @model_validator(mode="after")
     def _validate_rerun(self) -> "EveryCodeWorkRequestRerunEnvelope":
         if not self.request_id.strip():
             raise ValueError("Every Code work request rerun requires request_id")
+        self.request_id = self.request_id.strip()
+        self.trigger_actor = self.trigger_actor.strip()
+        self.source_url = self.source_url.strip()
+        self.agent_write_intent_record_id = self.agent_write_intent_record_id.strip()
         return self
 
 
@@ -1875,6 +1882,16 @@ def _trace_id() -> str:
 
 def _utc_now_timestamp() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_utc_timestamp(value: str) -> datetime:
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 def _not_found_response(
@@ -3371,6 +3388,7 @@ def _accepted_payload(
                 "request_id",
                 "feedback_id",
                 "state",
+                "agent_write_intent_record_id",
                 "merge_train_run_id",
             }
         },
@@ -3896,6 +3914,7 @@ def _handle_every_code_worker_write(
     record_store: object,
     path: str,
     payload: dict[str, object],
+    idempotency_key: str = "",
 ) -> list[bytes]:
     every_code_store = _every_code_work_request_store(record_store)
     if path == "/v1/every-code/preview-gates":
@@ -4019,9 +4038,41 @@ def _handle_every_code_worker_write(
         )
     if path == "/v1/every-code/work-requests/rerun":
         rerun_request = EveryCodeWorkRequestRerunEnvelope.model_validate(payload)
+        rerun_checked_at = datetime.now(timezone.utc)
+        intent_record, intent_response = _validate_every_code_rerun_write_intent(
+            record_store=record_store,
+            rerun_request=rerun_request,
+            idempotency_key=idempotency_key,
+            now=rerun_checked_at,
+            trace_id=trace_id,
+            start_response=start_response,
+        )
+        if intent_response is not None:
+            return intent_response
         existing_record = every_code_store.read_every_code_work_request_record(
             rerun_request.request_id.strip()
         )
+        if intent_record is None:
+            intent_record = _matching_every_code_rerun_intent_record(
+                record_store=record_store,
+                source_url=existing_record.issue_url,
+                now=rerun_checked_at,
+            )
+            if intent_record is None:
+                return _reject_agent_write_intent(
+                    start_response=start_response,
+                    trace_id=trace_id,
+                    code="agent_write_intent_required",
+                    message="Every Code rerun requires matching approved write-intent evidence.",
+                )
+        if rerun_request.source_url and rerun_request.source_url != existing_record.issue_url:
+            return _reject_agent_write_intent(
+                start_response=start_response,
+                trace_id=trace_id,
+                code="agent_write_intent_source_mismatch",
+                message="Every Code rerun source_url does not match the work-request issue URL.",
+                record_id=intent_record.record_id,
+            )
         requeued_record = requeue_every_code_work_request(
             existing_record,
             queued_at=_utc_now_timestamp(),
@@ -4033,7 +4084,15 @@ def _handle_every_code_worker_write(
             status_code=202,
             payload=_accepted_payload(
                 trace_id=trace_id,
-                result={"request_id": requeued_record.request_id, "state": requeued_record.state},
+                result={
+                    "request_id": requeued_record.request_id,
+                    "state": requeued_record.state,
+                    **(
+                        {"agent_write_intent_record_id": intent_record.record_id}
+                        if intent_record is not None
+                        else {}
+                    ),
+                },
                 driver_result={"request": requeued_record.model_dump(mode="json")},
             ),
         )
@@ -4065,6 +4124,161 @@ def _handle_every_code_worker_write(
             driver_result={"request": updated_work_request_record.model_dump(mode="json")},
         ),
     )
+
+
+def _agent_write_intent_rejection_payload(
+    *, trace_id: str, code: str, message: str, record_id: str = ""
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "status": "rejected",
+        "trace_id": trace_id,
+        "error": {"code": code, "message": message},
+    }
+    if record_id:
+        payload["records"] = {"agent_write_intent_record_id": record_id}
+    return payload
+
+
+def _reject_agent_write_intent(
+    *,
+    start_response: _StartResponse,
+    trace_id: str,
+    code: str,
+    message: str,
+    record_id: str = "",
+) -> list[bytes]:
+    status_code = 404 if code == "agent_write_intent_not_found" else 409
+    return _json_response(
+        start_response=start_response,
+        status_code=status_code,
+        payload=_agent_write_intent_rejection_payload(
+            trace_id=trace_id,
+            code=code,
+            message=message,
+            record_id=record_id,
+        ),
+    )
+
+
+def _validate_every_code_rerun_write_intent(
+    *,
+    record_store: object,
+    rerun_request: EveryCodeWorkRequestRerunEnvelope,
+    idempotency_key: str,
+    now: datetime,
+    trace_id: str,
+    start_response: _StartResponse,
+) -> tuple[AgentWriteIntentRecord | None, list[bytes] | None]:
+    record_id = rerun_request.agent_write_intent_record_id.strip()
+    if not record_id:
+        return None, None
+    try:
+        record = _agent_write_intent_record_store(
+            record_store
+        ).read_agent_write_intent_record(record_id)
+    except FileNotFoundError:
+        return None, _reject_agent_write_intent(
+            start_response=start_response,
+            trace_id=trace_id,
+            code="agent_write_intent_not_found",
+            message="Agent write-intent evidence record was not found.",
+            record_id=record_id,
+        )
+    if (
+        record.evaluation.status != "allowed"
+        or record.evaluation.intent != "every_code_rerun"
+        or record.evaluation.mode != "apply"
+        or not record.evaluation.safe_to_execute
+    ):
+        return record, _reject_agent_write_intent(
+            start_response=start_response,
+            trace_id=trace_id,
+            code="agent_write_intent_not_executable",
+            message="Every Code rerun requires an allowed apply-mode every_code_rerun intent record.",
+            record_id=record.record_id,
+        )
+    if record.evaluation.product != "launchplane" or record.evaluation.context != _LAUNCHPLANE_SERVICE_CONTEXT:
+        return record, _reject_agent_write_intent(
+            start_response=start_response,
+            trace_id=trace_id,
+            code="agent_write_intent_scope_mismatch",
+            message="Agent write-intent evidence does not match the Every Code rerun product/context.",
+            record_id=record.record_id,
+        )
+    if record.evaluation.authz_action != "every_code_work_request.rerun":
+        return record, _reject_agent_write_intent(
+            start_response=start_response,
+            trace_id=trace_id,
+            code="agent_write_intent_action_mismatch",
+            message="Agent write-intent evidence was evaluated for a different route action.",
+            record_id=record.record_id,
+        )
+    if rerun_request.source_url and rerun_request.source_url != record.request.source_url:
+        return record, _reject_agent_write_intent(
+            start_response=start_response,
+            trace_id=trace_id,
+            code="agent_write_intent_source_mismatch",
+            message="Every Code rerun source_url does not match the write-intent source_url.",
+            record_id=record.record_id,
+        )
+    if idempotency_key and record.idempotency_key and idempotency_key != record.idempotency_key:
+        return record, _reject_agent_write_intent(
+            start_response=start_response,
+            trace_id=trace_id,
+            code="agent_write_intent_idempotency_mismatch",
+            message="Every Code rerun idempotency key does not match the write-intent evidence.",
+            record_id=record.record_id,
+        )
+    try:
+        recorded_at = _parse_utc_timestamp(record.recorded_at)
+    except ValueError:
+        return record, _reject_agent_write_intent(
+            start_response=start_response,
+            trace_id=trace_id,
+            code="agent_write_intent_stale",
+            message="Agent write-intent evidence timestamp is invalid or stale.",
+            record_id=record.record_id,
+        )
+    if recorded_at > now or now - recorded_at > _AGENT_WRITE_INTENT_MAX_AGE:
+        return record, _reject_agent_write_intent(
+            start_response=start_response,
+            trace_id=trace_id,
+            code="agent_write_intent_stale",
+            message="Agent write-intent evidence is too old for Every Code rerun execution.",
+            record_id=record.record_id,
+        )
+    return record, None
+
+
+def _matching_every_code_rerun_intent_record(
+    *,
+    record_store: object,
+    source_url: str,
+    now: datetime,
+) -> AgentWriteIntentRecord | None:
+    for record in _agent_write_intent_record_store(
+        record_store
+    ).list_agent_write_intent_records(
+        product="launchplane",
+        context_name=_LAUNCHPLANE_SERVICE_CONTEXT,
+        status="allowed",
+        limit=50,
+    ):
+        if record.evaluation.intent != "every_code_rerun":
+            continue
+        if record.evaluation.mode != "apply" or not record.evaluation.safe_to_execute:
+            continue
+        if record.evaluation.authz_action != "every_code_work_request.rerun":
+            continue
+        if record.request.source_url != source_url:
+            continue
+        try:
+            recorded_at = _parse_utc_timestamp(record.recorded_at)
+        except ValueError:
+            continue
+        if recorded_at <= now and now - recorded_at <= _AGENT_WRITE_INTENT_MAX_AGE:
+            return record
+    return None
 
 
 def _session_identity(
@@ -5297,6 +5511,7 @@ def create_launchplane_service_app(
                     record_store=record_store,
                     path=path,
                     payload=payload,
+                    idempotency_key=_idempotency_key(environ),
                 )
             except ValueError as error:
                 return _json_response(
@@ -6409,11 +6624,12 @@ def create_launchplane_service_app(
                     record_store=record_store,
                     path=path,
                     payload=payload,
+                    idempotency_key=request_idempotency_key,
                 )
             elif path == "/v1/every-code/work-requests/rerun":
                 if not authz_policy.allows(
                     identity=identity,
-                    action="every_code_work_request.write",
+                    action="every_code_work_request.rerun",
                     product="launchplane",
                     context=_LAUNCHPLANE_SERVICE_CONTEXT,
                 ):
@@ -6446,6 +6662,7 @@ def create_launchplane_service_app(
                     record_store=record_store,
                     path=path,
                     payload=payload,
+                    idempotency_key=request_idempotency_key,
                 )
             elif path == "/v1/every-code/work-requests/status":
                 if not authz_policy.allows(
@@ -6483,6 +6700,7 @@ def create_launchplane_service_app(
                     record_store=record_store,
                     path=path,
                     payload=payload,
+                    idempotency_key=request_idempotency_key,
                 )
             elif path == "/v1/work-graph/rank":
                 work_graph_rank_result = rank_work_graph_snapshot(

--- a/docs/agent-context-boundary.md
+++ b/docs/agent-context-boundary.md
@@ -95,9 +95,14 @@ caller, applies dry-run-first and secret-backed evidence rules, persists a
 record id. The evaluation route does not execute product/runtime mutations and
 does not return reusable credentials.
 
-Follow-on execution routes should require a route-specific policy action. They
-should link back to the durable write-intent record rather than treating the
-record as a bearer capability.
+Follow-on execution routes require a route-specific policy action. They may
+consume the durable write-intent record as evidence, but the record is not a
+bearer capability: execution routes must revalidate the intent family, mode,
+allowed status, safe-to-execute decision, product, context, route action,
+freshness, and any route-specific source or idempotency binding before mutating.
+For example, Every Code rerun execution consumes an approved `every_code_rerun`
+record and still requires `every_code_work_request.rerun` authorization before
+requeueing the work request.
 
 ## Redaction And Provenance
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -649,6 +649,12 @@ preflights.
   `launchplane_agent_write_intents` records. Each record stores the request,
   evaluation result, `agent_audit` envelope, trace id, optional idempotency key,
   and recorded timestamp so later action routes can link to durable evidence.
+  Execution routes treat these records as provenance, not credentials: they must
+  perform their normal route-specific authorization and fail closed when the
+  linked record is denied, stale, the wrong intent family, or mismatched on
+  product, context, route action, source, or idempotency binding. The first
+  consumer is Every Code rerun, which requires approved `every_code_rerun`
+  evidence before requeueing a terminal work request.
 - Merge train service runs are persisted as `launchplane_merge_train_runs`
   records. Each record stores the repository/base branch, mode, status, policy
   key and digest, fresh GitHub snapshot, dry-run decision, selected pull request

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3754,6 +3754,22 @@ class LaunchplaneServiceTests(unittest.TestCase):
     def test_every_code_worker_token_reruns_terminal_request(self) -> None:
         secret = "launchplane-every-code-webhook-secret"
         issue_payload = _every_code_github_issue_labeled_payload()
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "every/verireel",
+                        "workflow_refs": [
+                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                        ],
+                        "event_names": ["pull_request"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["every_code_work_request.rerun"],
+                    }
+                ]
+            }
+        )
         with (
             TemporaryDirectory() as temporary_directory_name,
             patch.dict(
@@ -3767,7 +3783,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             app = create_launchplane_service_app(
                 state_dir=Path(temporary_directory_name) / "state",
                 verifier=_StubVerifier(_identity()),
-                authz_policy=LaunchplaneAuthzPolicy(),
+                authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
             )
             _issue_status, issue_response = _invoke_app(
@@ -3803,15 +3819,34 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
                 authorization="Bearer dev-worker-token",
             )
+            intent_status, intent_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/agent/write-intents/evaluate",
+                payload={
+                    "intent": "every_code_rerun",
+                    "mode": "apply",
+                    "product": "launchplane",
+                    "context": "launchplane",
+                    "source_url": "https://github.com/cbusillo/code/issues/123",
+                    "reason": "Approved rerun for blocked Every Code request.",
+                },
+            )
+            intent_record_id = intent_payload["result"]["record"]["record_id"]
 
             rerun_status, rerun_response = _invoke_app(
                 app,
                 method="POST",
                 path="/v1/every-code/work-requests/rerun",
-                payload={"request_id": request_id, "trigger_actor": "ops"},
+                payload={
+                    "request_id": request_id,
+                    "trigger_actor": "ops",
+                    "agent_write_intent_record_id": intent_record_id,
+                },
                 authorization="Bearer dev-worker-token",
             )
 
+        self.assertEqual(intent_status, 202)
         self.assertEqual(rerun_status, 202)
         request = rerun_response["result"]["request"]
         self.assertEqual(request["state"], "queued")
@@ -3822,6 +3857,22 @@ class LaunchplaneServiceTests(unittest.TestCase):
     def test_every_code_worker_token_cannot_rerun_active_request(self) -> None:
         secret = "launchplane-every-code-webhook-secret"
         issue_payload = _every_code_github_issue_labeled_payload()
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "every/verireel",
+                        "workflow_refs": [
+                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                        ],
+                        "event_names": ["pull_request"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["every_code_work_request.rerun"],
+                    }
+                ]
+            }
+        )
         with (
             TemporaryDirectory() as temporary_directory_name,
             patch.dict(
@@ -3835,7 +3886,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             app = create_launchplane_service_app(
                 state_dir=Path(temporary_directory_name) / "state",
                 verifier=_StubVerifier(_identity()),
-                authz_policy=LaunchplaneAuthzPolicy(),
+                authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
             )
             _issue_status, issue_response = _invoke_app(
@@ -3851,15 +3902,34 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = issue_response["records"]["request_id"]
+            intent_status, intent_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/agent/write-intents/evaluate",
+                payload={
+                    "intent": "every_code_rerun",
+                    "mode": "apply",
+                    "product": "launchplane",
+                    "context": "launchplane",
+                    "source_url": "https://github.com/cbusillo/code/issues/123",
+                    "reason": "Approved rerun for active Every Code request.",
+                },
+            )
+            intent_record_id = intent_payload["result"]["record"]["record_id"]
 
             rerun_status, rerun_response = _invoke_app(
                 app,
                 method="POST",
                 path="/v1/every-code/work-requests/rerun",
-                payload={"request_id": request_id, "trigger_actor": "ops"},
+                payload={
+                    "request_id": request_id,
+                    "trigger_actor": "ops",
+                    "agent_write_intent_record_id": intent_record_id,
+                },
                 authorization="Bearer dev-worker-token",
             )
 
+        self.assertEqual(intent_status, 202)
         self.assertEqual(rerun_status, 400)
         self.assertEqual(rerun_response["error"]["code"], "invalid_payload")
 
@@ -4080,7 +4150,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "event_names": ["workflow_dispatch"],
                         "products": ["launchplane"],
                         "contexts": ["launchplane"],
-                        "actions": ["every_code_work_request.write"],
+                        "actions": [
+                            "every_code_work_request.write",
+                            "every_code_work_request.rerun",
+                        ],
                     }
                 ]
             }
@@ -4249,7 +4322,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "event_names": ["workflow_dispatch"],
                         "products": ["launchplane"],
                         "contexts": ["launchplane"],
-                        "actions": ["every_code_work_request.write"],
+                        "actions": [
+                            "every_code_work_request.write",
+                            "every_code_work_request.rerun",
+                        ],
                     }
                 ]
             }
@@ -4310,21 +4386,301 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
                 authorization="Bearer worker-token",
             )
+            intent_status, intent_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/agent/write-intents/evaluate",
+                payload={
+                    "intent": "every_code_rerun",
+                    "mode": "apply",
+                    "product": "launchplane",
+                    "context": "launchplane",
+                    "source_url": "https://github.com/cbusillo/code/issues/123",
+                    "reason": "Approved rerun for blocked Every Code request.",
+                },
+                headers={"Idempotency-Key": "every-code-rerun-intent:123"},
+            )
+            intent_record_id = intent_payload["result"]["record"]["record_id"]
             rerun_status, rerun_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/rerun",
+                payload={
+                    "request_id": request_id,
+                    "trigger_actor": "cbusillo",
+                    "source_url": "https://github.com/cbusillo/code/issues/123",
+                    "agent_write_intent_record_id": intent_record_id,
+                },
+                authorization="Bearer worker-token",
+                headers={"Idempotency-Key": "every-code-rerun-intent:123"},
+            )
+
+        self.assertEqual(create_status, 202)
+        self.assertEqual(intent_status, 202)
+        self.assertEqual(rerun_status, 202)
+        self.assertEqual(
+            rerun_payload["records"]["agent_write_intent_record_id"], intent_record_id
+        )
+        self.assertEqual(rerun_payload["records"]["state"], "queued")
+        self.assertEqual(rerun_payload["result"]["request"]["trigger_actor"], "cbusillo")
+        self.assertEqual(rerun_payload["result"]["request"]["claimed_by_host"], "")
+        self.assertEqual(rerun_payload["result"]["request"]["result_pr_url"], "")
+        self.assertEqual(rerun_payload["result"]["request"]["error_message"], "")
+
+    def test_every_code_rerun_requires_matching_write_intent_evidence(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main"
+                        ],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": [
+                            "every_code_work_request.write",
+                            "every_code_work_request.rerun",
+                        ],
+                    }
+                ]
+            }
+        )
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
+            event_name="workflow_dispatch",
+        )
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "worker-token"},
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(identity),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            _create_status, create_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/create",
+                payload={
+                    "repository": "cbusillo/code",
+                    "issue_number": 123,
+                    "issue_url": "https://github.com/cbusillo/code/issues/123",
+                    "issue_title": "Wire local automation",
+                    "trigger_actor": "cbusillo",
+                    "source": "manual",
+                    "queued_at": "2026-05-05T22:00:00Z",
+                },
+            )
+            request_id = str(create_payload["records"]["request_id"])
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/claim",
+                payload={"request_id": request_id, "host": "Chris-Studio"},
+                authorization="Bearer worker-token",
+            )
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/status",
+                payload={
+                    "request_id": request_id,
+                    "host": "Chris-Studio",
+                    "state": "blocked",
+                    "error_message": "Needs another pass.",
+                    "updated_at": "2026-05-05T22:05:00Z",
+                },
+                authorization="Bearer worker-token",
+            )
+
+            missing_status, missing_payload = _invoke_app(
                 app,
                 method="POST",
                 path="/v1/every-code/work-requests/rerun",
                 payload={"request_id": request_id, "trigger_actor": "cbusillo"},
                 authorization="Bearer worker-token",
             )
+            wrong_source_status, wrong_source_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/agent/write-intents/evaluate",
+                payload={
+                    "intent": "every_code_rerun",
+                    "mode": "apply",
+                    "product": "launchplane",
+                    "context": "launchplane",
+                    "source_url": "https://github.com/cbusillo/code/issues/999",
+                    "reason": "Approved rerun for a different Every Code request.",
+                },
+            )
+            wrong_source_record_id = wrong_source_payload["result"]["record"]["record_id"]
+            mismatched_status, mismatched_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/rerun",
+                payload={
+                    "request_id": request_id,
+                    "trigger_actor": "cbusillo",
+                    "source_url": "https://github.com/cbusillo/code/issues/123",
+                    "agent_write_intent_record_id": wrong_source_record_id,
+                },
+                authorization="Bearer worker-token",
+            )
 
-        self.assertEqual(create_status, 202)
-        self.assertEqual(rerun_status, 202)
-        self.assertEqual(rerun_payload["records"]["state"], "queued")
-        self.assertEqual(rerun_payload["result"]["request"]["trigger_actor"], "cbusillo")
-        self.assertEqual(rerun_payload["result"]["request"]["claimed_by_host"], "")
-        self.assertEqual(rerun_payload["result"]["request"]["result_pr_url"], "")
-        self.assertEqual(rerun_payload["result"]["request"]["error_message"], "")
+        self.assertEqual(missing_status, 409)
+        self.assertEqual(
+            missing_payload["error"]["code"], "agent_write_intent_required"
+        )
+        self.assertEqual(wrong_source_status, 202)
+        self.assertEqual(mismatched_status, 409)
+        self.assertEqual(
+            mismatched_payload["error"]["code"], "agent_write_intent_source_mismatch"
+        )
+
+    def test_every_code_rerun_rejects_stale_and_wrong_context_write_intents(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main"
+                        ],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane", "other-context"],
+                        "actions": [
+                            "every_code_work_request.write",
+                            "every_code_work_request.rerun",
+                        ],
+                    }
+                ]
+            }
+        )
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
+            event_name="workflow_dispatch",
+        )
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "worker-token"},
+            ),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(identity),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            _create_status, create_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/create",
+                payload={
+                    "repository": "cbusillo/code",
+                    "issue_number": 123,
+                    "issue_url": "https://github.com/cbusillo/code/issues/123",
+                    "issue_title": "Wire local automation",
+                    "trigger_actor": "cbusillo",
+                    "source": "manual",
+                    "queued_at": "2026-05-05T22:00:00Z",
+                },
+            )
+            request_id = str(create_payload["records"]["request_id"])
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/claim",
+                payload={"request_id": request_id, "host": "Chris-Studio"},
+                authorization="Bearer worker-token",
+            )
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/status",
+                payload={
+                    "request_id": request_id,
+                    "host": "Chris-Studio",
+                    "state": "blocked",
+                    "error_message": "Needs another pass.",
+                    "updated_at": "2026-05-05T22:05:00Z",
+                },
+                authorization="Bearer worker-token",
+            )
+            _wrong_context_status, wrong_context_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/agent/write-intents/evaluate",
+                payload={
+                    "intent": "every_code_rerun",
+                    "mode": "apply",
+                    "product": "launchplane",
+                    "context": "other-context",
+                    "source_url": "https://github.com/cbusillo/code/issues/123",
+                    "reason": "Approved rerun in the wrong context.",
+                },
+            )
+            wrong_context_record_id = wrong_context_payload["result"]["record"]["record_id"]
+            wrong_context_status, wrong_context_rerun_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/rerun",
+                payload={
+                    "request_id": request_id,
+                    "agent_write_intent_record_id": wrong_context_record_id,
+                },
+                authorization="Bearer worker-token",
+            )
+
+            _intent_status, intent_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/agent/write-intents/evaluate",
+                payload={
+                    "intent": "every_code_rerun",
+                    "mode": "apply",
+                    "product": "launchplane",
+                    "context": "launchplane",
+                    "source_url": "https://github.com/cbusillo/code/issues/123",
+                    "reason": "Approved rerun for a blocked Every Code request.",
+                },
+            )
+            stale_record_id = intent_payload["result"]["record"]["record_id"]
+            store = FilesystemRecordStore(state_dir)
+            stale_record = store.read_agent_write_intent_record(stale_record_id)
+            store.write_agent_write_intent_record(
+                stale_record.model_copy(update={"recorded_at": "2026-01-01T00:00:00Z"})
+            )
+            stale_status, stale_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/rerun",
+                payload={
+                    "request_id": request_id,
+                    "agent_write_intent_record_id": stale_record_id,
+                },
+                authorization="Bearer worker-token",
+            )
+
+        self.assertEqual(wrong_context_status, 409)
+        self.assertEqual(
+            wrong_context_rerun_payload["error"]["code"],
+            "agent_write_intent_scope_mismatch",
+        )
+        self.assertEqual(stale_status, 409)
+        self.assertEqual(stale_payload["error"]["code"], "agent_write_intent_stale")
 
     def test_every_code_worker_token_is_required_for_unauthenticated_request(self) -> None:
         with (
@@ -6645,7 +7001,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                             "event_names": ["pull_request"],
                             "products": ["launchplane"],
                             "contexts": ["launchplane"],
-                            "actions": ["every_code_work_request.write"],
+                            "actions": ["every_code_work_request.rerun"],
                         }
                     ]
                 }
@@ -6679,7 +7035,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 202)
         intent = payload["result"]["intent"]
         self.assertEqual(intent["status"], "allowed")
-        self.assertEqual(intent["authz_action"], "every_code_work_request.write")
+        self.assertEqual(intent["authz_action"], "every_code_work_request.rerun")
         self.assertFalse(intent["safe_to_execute"])
         self.assertEqual(intent["reason_code"], "authorized")
         self.assertEqual(intent["audit"]["decision"], "allowed")
@@ -6705,7 +7061,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                             "event_names": ["pull_request"],
                             "products": ["launchplane"],
                             "contexts": ["launchplane"],
-                            "actions": ["every_code_work_request.write"],
+                            "actions": ["every_code_work_request.rerun"],
                         }
                     ]
                 }
@@ -6797,7 +7153,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                             "token_labels": ["local-owner-read"],
                             "products": ["launchplane"],
                             "contexts": ["launchplane"],
-                            "actions": ["every_code_work_request.write"],
+                            "actions": ["every_code_work_request.rerun"],
                         }
                     ]
                 }

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -368,7 +368,7 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
 
         self.assertEqual(
             authz_action_for_agent_write_intent("every_code_rerun"),
-            "every_code_work_request.write",
+            "every_code_work_request.rerun",
         )
         self.assertEqual(
             authz_action_for_agent_write_intent("preview_refresh"),


### PR DESCRIPTION
## Summary
- require route-specific `every_code_work_request.rerun` authorization for Every Code reruns
- consume approved `every_code_rerun` write-intent records as provenance before requeueing terminal work requests
- reject missing, denied, stale, wrong-context, wrong-action, source-mismatched, and idempotency-mismatched intent evidence
- document that write-intent records are execution evidence, not bearer credentials

Refs #531

## Verification
- `uv run python -m unittest tests.test_service tests.test_service_auth`
- `uv run --extra dev ruff check --diff control_plane/contracts/agent_write_intent.py control_plane/service.py tests/test_service.py tests/test_service_auth.py`
- `uv run --extra dev ruff check control_plane/contracts/agent_write_intent.py control_plane/service.py tests/test_service.py tests/test_service_auth.py`
- `uv run python -m unittest`