### PR TITLE
Fix preview cleanup backstop

### DIFF
--- a/.github/workflows/preview-lifecycle.yml
+++ b/.github/workflows/preview-lifecycle.yml
@@ -17,8 +17,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: >-
-    launchplane-preview-lifecycle-${{ vars.LAUNCHPLANE_PREVIEW_LIFECYCLE_CONTEXT || 'default' }}
+  group: launchplane-preview-lifecycle
   cancel-in-progress: false
 
 jobs:
@@ -30,13 +29,7 @@ jobs:
       APPLY: ${{ github.event_name == 'workflow_dispatch' && inputs.apply || false }}
       LAUNCHPLANE_AUDIENCE: ${{ vars.LAUNCHPLANE_PREVIEW_LIFECYCLE_AUDIENCE }}
       LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PREVIEW_LIFECYCLE_URL }}
-      PRODUCT: ${{ vars.LAUNCHPLANE_PREVIEW_LIFECYCLE_PRODUCT }}
-      CONTEXT: ${{ vars.LAUNCHPLANE_PREVIEW_LIFECYCLE_CONTEXT }}
       SOURCE: ${{ vars.LAUNCHPLANE_PREVIEW_LIFECYCLE_SOURCE || 'launchplane-preview-lifecycle' }}
-      REPOSITORY: ${{ vars.LAUNCHPLANE_PREVIEW_LIFECYCLE_REPOSITORY }}
-      ANCHOR_REPO: ${{ vars.LAUNCHPLANE_PREVIEW_LIFECYCLE_ANCHOR_REPO }}
-      PREVIEW_LABEL: ${{ vars.LAUNCHPLANE_PREVIEW_LIFECYCLE_LABEL || 'preview' }}
-      INVENTORY_ROUTE: ${{ vars.LAUNCHPLANE_PREVIEW_LIFECYCLE_INVENTORY_ROUTE }}
 
     steps:
       - name: Validate preview lifecycle configuration
@@ -44,11 +37,6 @@ jobs:
           set -euo pipefail
           : "${LAUNCHPLANE_AUDIENCE:?Missing LAUNCHPLANE_PREVIEW_LIFECYCLE_AUDIENCE variable}"
           : "${LAUNCHPLANE_URL:?Missing LAUNCHPLANE_PREVIEW_LIFECYCLE_URL variable}"
-          : "${PRODUCT:?Missing LAUNCHPLANE_PREVIEW_LIFECYCLE_PRODUCT variable}"
-          : "${CONTEXT:?Missing LAUNCHPLANE_PREVIEW_LIFECYCLE_CONTEXT variable}"
-          : "${REPOSITORY:?Missing LAUNCHPLANE_PREVIEW_LIFECYCLE_REPOSITORY variable}"
-          : "${ANCHOR_REPO:?Missing LAUNCHPLANE_PREVIEW_LIFECYCLE_ANCHOR_REPO variable}"
-          : "${INVENTORY_ROUTE:?Missing LAUNCHPLANE_PREVIEW_LIFECYCLE_INVENTORY_ROUTE variable}"
 
       - name: Run Launchplane-owned preview lifecycle
         run: |
@@ -83,76 +71,22 @@ jobs:
             apply_json='true'
           fi
 
-          inventory_payload="$(jq -nc \
-            --arg product "$PRODUCT" \
-            --arg context "$CONTEXT" \
-            '{schema_version: 1, product: $product, inventory: {context: $context}}')"
-          inventory_response="$(post_launchplane_json \
-            "$INVENTORY_ROUTE" \
-            "preview-inventory:${CONTEXT}:${run_identity}" \
-            "$inventory_payload")"
-          echo "$inventory_response" | jq .
-
-          desired_payload="$(jq -nc \
-            --arg product "$PRODUCT" \
-            --arg context "$CONTEXT" \
+          sweep_payload="$(jq -nc \
             --arg source "$SOURCE" \
-            --arg repository "$REPOSITORY" \
-            --arg label "$PREVIEW_LABEL" \
-            --arg anchor_repo "$ANCHOR_REPO" \
-            '{schema_version: 1, product: $product, context: $context, source: $source, repository: $repository, label: $label, anchor_repo: $anchor_repo}')"
-          desired_response="$(post_launchplane_json \
-            '/v1/previews/desired-state' \
-            "preview-desired-state:${CONTEXT}:${run_identity}" \
-            "$desired_payload")"
-          echo "$desired_response" | jq .
-          desired_status="$(jq -r '.result.status // empty' <<< "$desired_response")"
-          if [ "$desired_status" != 'pass' ]; then
-            echo 'Preview desired-state discovery did not pass.' >&2
-            exit 1
-          fi
-
-          desired_previews="$(jq -c '.result.desired_previews // []' <<< "$desired_response")"
-          desired_state_id="$(jq -r '.records.preview_desired_state_id // empty' <<< "$desired_response")"
-          plan_payload="$(jq -nc \
-            --arg product "$PRODUCT" \
-            --arg context "$CONTEXT" \
-            --arg source "$SOURCE" \
-            --arg desired_state_id "$desired_state_id" \
-            --argjson desired_previews "$desired_previews" \
-            '{schema_version: 1, product: $product, context: $context, source: $source, desired_state_id: $desired_state_id, desired_previews: $desired_previews}')"
-          plan_response="$(post_launchplane_json \
-            '/v1/previews/lifecycle-plan' \
-            "preview-lifecycle-plan:${CONTEXT}:${run_identity}" \
-            "$plan_payload")"
-          echo "$plan_response" | jq .
-          plan_id="$(jq -r '.records.preview_lifecycle_plan_id // empty' <<< "$plan_response")"
-          if [ -z "$plan_id" ]; then
-            echo 'Preview lifecycle plan response did not include a plan id.' >&2
-            exit 1
-          fi
-
-          cleanup_payload="$(jq -nc \
-            --arg product "$PRODUCT" \
-            --arg context "$CONTEXT" \
-            --arg source "$SOURCE" \
-            --arg plan_id "$plan_id" \
             --argjson apply "$apply_json" \
-            '{schema_version: 1, product: $product, context: $context, source: $source, plan_id: $plan_id, apply: $apply, destroy_reason: "launchplane_preview_lifecycle_cleanup", timeout_seconds: 300}')"
-          cleanup_response="$(post_launchplane_json \
-            '/v1/previews/lifecycle-cleanup' \
-            "preview-lifecycle-cleanup:${CONTEXT}:${run_identity}:${apply_json}" \
-            "$cleanup_payload")"
-          echo "$cleanup_response" | jq .
+            '{schema_version: 1, source: $source, apply: $apply, destroy_reason: "launchplane_preview_lifecycle_cleanup", timeout_seconds: 300}')"
+          sweep_response="$(post_launchplane_json \
+            '/v1/previews/lifecycle-sweep' \
+            "preview-lifecycle-sweep:${run_identity}:${apply_json}" \
+            "$sweep_payload")"
+          echo "$sweep_response" | jq .
 
           {
             echo '## Launchplane preview lifecycle'
             echo
-            echo "- Desired state: $(jq -r '.records.preview_desired_state_id // empty' <<< "$desired_response")"
-            echo "- Lifecycle plan: ${plan_id}"
-            echo "- Cleanup: $(jq -r '.records.preview_lifecycle_cleanup_id // empty' <<< "$cleanup_response")"
             echo "- Apply: ${apply_json}"
-            echo "- Desired previews: $(jq -r '.result.desired_count // 0' <<< "$desired_response")"
-            echo "- Orphaned previews: $(jq -r '.result.orphaned_slugs | length' <<< "$plan_response")"
-            echo "- Cleanup status: $(jq -r '.result.status // empty' <<< "$cleanup_response")"
+            echo "- Sweep status: $(jq -r '.result.status // empty' <<< "$sweep_response")"
+            echo "- Profiles: $(jq -r '.result.profile_count // 0' <<< "$sweep_response")"
+            echo
+            jq -r '.result.profiles[]? | "- \(.product) / \(.context): \(.status) (orphaned: \((.orphaned_slugs // []) | length), destroyed: \((.destroyed_slugs // []) | length), failed: \((.failed_slugs // []) | length))"' <<< "$sweep_response"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -839,6 +839,26 @@ class PreviewLifecycleCleanupEnvelope(BaseModel):
         return self
 
 
+class PreviewLifecycleSweepEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    source: str = "launchplane-preview-lifecycle"
+    product: str = ""
+    apply: bool = False
+    destroy_reason: str = "launchplane_preview_lifecycle_cleanup"
+    timeout_seconds: int = Field(default=300, ge=1)
+    max_pages: int = Field(default=10, ge=1, le=20)
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "PreviewLifecycleSweepEnvelope":
+        if not self.source.strip():
+            raise ValueError("preview lifecycle sweep requires source")
+        if not self.destroy_reason.strip():
+            raise ValueError("preview lifecycle sweep requires destroy_reason")
+        return self
+
+
 class PreviewPrFeedbackEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -2146,6 +2166,7 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/previews/pr-feedback",
         "/v1/previews/lifecycle-cleanup",
         "/v1/previews/lifecycle-plan",
+        "/v1/previews/lifecycle-sweep",
         "/v1/product-profiles",
         "/v1/evidence/promotions",
         "/v1/drivers/launchplane/self-deploy",
@@ -4531,6 +4552,183 @@ def _latest_preview_lifecycle_plan(
         limit=None,
     )
     return next((record for record in records if record.plan_id == plan_id), None)
+
+
+def _preview_lifecycle_cleanup_driver_id(profile: LaunchplaneProductProfileRecord) -> str:
+    if profile.driver_id == "verireel":
+        return "verireel"
+    try:
+        generic_web_compatible = _product_driver_compatible(
+            profile=profile,
+            expected_driver_id="generic-web",
+        )
+    except FileNotFoundError:
+        generic_web_compatible = False
+    if generic_web_compatible:
+        return "generic-web"
+    return ""
+
+
+def _preview_lifecycle_sweep_profiles(
+    *, record_store: object, product: str = ""
+) -> tuple[LaunchplaneProductProfileRecord, ...]:
+    if not hasattr(record_store, "list_product_profile_records"):
+        return ()
+    records = getattr(record_store, "list_product_profile_records")()
+    requested_product = product.strip()
+    profiles: list[LaunchplaneProductProfileRecord] = []
+    for record in records:
+        profile = LaunchplaneProductProfileRecord.model_validate(record)
+        if requested_product and profile.product != requested_product:
+            continue
+        if not profile.preview.enabled:
+            continue
+        if not profile.preview.context.strip():
+            continue
+        profiles.append(profile)
+    return tuple(sorted(profiles, key=lambda profile: profile.product))
+
+
+def _build_preview_lifecycle_sweep(
+    *,
+    control_plane_root: Path,
+    record_store: object,
+    request: PreviewLifecycleSweepEnvelope,
+) -> dict[str, object]:
+    profiles = _preview_lifecycle_sweep_profiles(
+        record_store=record_store,
+        product=request.product,
+    )
+    entries: list[dict[str, object]] = []
+    for profile in profiles:
+        cleanup_driver_id = _preview_lifecycle_cleanup_driver_id(profile)
+        entry: dict[str, object] = {
+            "product": profile.product,
+            "context": profile.preview.context,
+            "driver_id": profile.driver_id,
+            "cleanup_driver_id": cleanup_driver_id,
+        }
+        if not cleanup_driver_id:
+            entry.update(
+                {
+                    "status": "skipped",
+                    "error_message": (
+                        "Preview lifecycle cleanup is not implemented for this product driver."
+                    ),
+                }
+            )
+            entries.append(entry)
+            continue
+        if cleanup_driver_id == "verireel":
+            verireel_inventory_result = execute_verireel_preview_inventory(
+                control_plane_root=control_plane_root,
+                request=VeriReelPreviewInventoryRequest(context=profile.preview.context),
+            )
+            inventory_context = verireel_inventory_result.context
+            inventory_source = request.source
+            inventory_slugs = tuple(
+                item.previewSlug for item in verireel_inventory_result.previews
+            )
+        else:
+            generic_web_inventory_result = execute_generic_web_preview_inventory(
+                control_plane_root=control_plane_root,
+                record_store=cast(GenericWebPreviewProfileStore, record_store),
+                request=GenericWebPreviewInventoryRequest(
+                    product=profile.product,
+                    source=request.source,
+                ),
+                profile=profile,
+            )
+            inventory_context = generic_web_inventory_result.context
+            inventory_source = generic_web_inventory_result.source
+            inventory_slugs = tuple(
+                item.previewSlug for item in generic_web_inventory_result.previews
+            )
+        inventory_scan_id = _write_preview_inventory_scan_if_supported(
+            record_store=record_store,
+            context=inventory_context,
+            source=inventory_source,
+            preview_slugs=inventory_slugs,
+        )
+        desired_state = discover_generic_web_preview_desired_state(
+            control_plane_root=control_plane_root,
+            record_store=cast(GenericWebPreviewProfileStore, record_store),
+            request=GenericWebPreviewDesiredStateRequest(
+                product=profile.product,
+                source=request.source,
+                label=profile.preview.enable_label,
+                max_pages=request.max_pages,
+            ),
+            discovered_at=_utc_now_timestamp(),
+            profile=profile,
+        )
+        desired_state_id = _write_preview_desired_state_if_supported(
+            record_store=record_store,
+            record=desired_state,
+        )
+        lifecycle_plan = build_preview_lifecycle_plan(
+            product=profile.product,
+            context=profile.preview.context,
+            planned_at=_utc_now_timestamp(),
+            source=request.source,
+            desired_previews=desired_state.desired_previews,
+            desired_state_id=desired_state_id,
+            latest_inventory_scan=_latest_preview_inventory_scan(
+                record_store=record_store,
+                context_name=profile.preview.context,
+            ),
+        )
+        lifecycle_plan_id = _write_preview_lifecycle_plan_if_supported(
+            record_store=record_store,
+            record=lifecycle_plan,
+        )
+        cleanup_record = build_preview_lifecycle_cleanup_record(
+            plan=lifecycle_plan,
+            requested_at=_utc_now_timestamp(),
+            source=request.source,
+            apply=request.apply,
+            destroy_reason=request.destroy_reason,
+            control_plane_root=control_plane_root,
+            record_store=record_store,
+            timeout_seconds=request.timeout_seconds,
+            driver_id=cleanup_driver_id,
+            preview_slug_template=profile.preview.slug_template,
+        )
+        cleanup_id = _write_preview_lifecycle_cleanup_if_supported(
+            record_store=record_store,
+            record=cleanup_record,
+        )
+        entry.update(
+            {
+                "status": cleanup_record.status,
+                "preview_inventory_scan_id": inventory_scan_id,
+                "preview_desired_state_id": desired_state_id,
+                "preview_lifecycle_plan_id": lifecycle_plan_id,
+                "preview_lifecycle_cleanup_id": cleanup_id,
+                "desired_count": desired_state.desired_count,
+                "actual_count": len(lifecycle_plan.actual_slugs),
+                "orphaned_slugs": lifecycle_plan.orphaned_slugs,
+                "missing_slugs": lifecycle_plan.missing_slugs,
+                "destroyed_slugs": cleanup_record.destroyed_slugs,
+                "failed_slugs": cleanup_record.failed_slugs,
+                "blocked_slugs": cleanup_record.blocked_slugs,
+                "error_message": cleanup_record.error_message,
+            }
+        )
+        entries.append(entry)
+    status = "pass"
+    for entry in entries:
+        if entry.get("status") in {"fail", "blocked"}:
+            status = "fail"
+            break
+        if entry.get("status") == "skipped" and status != "fail":
+            status = "partial"
+    return {
+        "status": status,
+        "apply": request.apply,
+        "profile_count": len(entries),
+        "profiles": entries,
+    }
 
 
 def _write_preview_lifecycle_cleanup_if_supported(
@@ -8990,6 +9188,87 @@ def create_launchplane_service_app(
                     record=driver_result,
                 )
                 result = {"preview_lifecycle_cleanup_id": preview_lifecycle_cleanup_id}
+            elif path == "/v1/previews/lifecycle-sweep":
+                preview_lifecycle_sweep_request = PreviewLifecycleSweepEnvelope.model_validate(
+                    payload
+                )
+                requested_sweep_profiles = _preview_lifecycle_sweep_profiles(
+                    record_store=record_store,
+                    product=preview_lifecycle_sweep_request.product,
+                )
+                if preview_lifecycle_sweep_request.product.strip() and not requested_sweep_profiles:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=404,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "not_found",
+                                "message": "Preview lifecycle sweep found no enabled preview profile for the requested product.",
+                            },
+                        },
+                    )
+                denied_profile = next(
+                    (
+                        profile
+                        for profile in requested_sweep_profiles
+                        if not authz_policy.allows(
+                            identity=identity,
+                            action="preview_lifecycle.plan",
+                            product=profile.product,
+                            context=profile.preview.context,
+                        )
+                        or not authz_policy.allows(
+                            identity=identity,
+                            action="preview_lifecycle.cleanup",
+                            product=profile.product,
+                            context=profile.preview.context,
+                        )
+                    ),
+                    None,
+                )
+                if denied_profile is not None:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot sweep preview lifecycle for one or more"
+                                    " enabled product profiles."
+                                ),
+                            },
+                            "authz": _authz_diagnostic_payload(
+                                identity=identity,
+                                authz_policy_sha256_value=resolved_authz_policy_sha256,
+                                authz_policy_source=resolved_authz_policy_source,
+                                action="preview_lifecycle.cleanup",
+                                product=denied_profile.product,
+                                context=denied_profile.preview.context,
+                            ),
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                driver_result = _build_preview_lifecycle_sweep(
+                    control_plane_root=resolved_root,
+                    record_store=record_store,
+                    request=preview_lifecycle_sweep_request,
+                )
+                result = {}
             else:
                 preview_destroyed_request = PreviewDestroyedEvidenceEnvelope.model_validate(payload)
                 if not authz_policy.allows(

--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -1972,28 +1972,40 @@ def execute_generic_web_preview_destroy(
     )
     application_id = str((application or {}).get("applicationId") or "").strip()
     cleanup_errors: list[str] = []
-    if application_id:
-        try:
-            raw_domains = control_plane_dokploy.dokploy_request(
-                host=host,
-                token=token,
-                path="/api/domain.byApplicationId",
-                query={"applicationId": application_id},
-            )
-            if isinstance(raw_domains, list):
-                for raw_domain in raw_domains:
-                    application_domain = control_plane_dokploy.as_json_object(raw_domain)
-                    if application_domain is None:
-                        continue
-                    domain_id = str(application_domain.get("domainId") or "").strip()
-                    if domain_id:
-                        _delete_domain(host=host, token=token, domain_id=domain_id)
-        except click.ClickException as exc:
-            cleanup_errors.append(f"domain cleanup failed: {exc}")
-        try:
-            _delete_application(host=host, token=token, application_id=application_id)
-        except click.ClickException as exc:
-            cleanup_errors.append(f"application cleanup failed: {exc}")
+    if not application_id:
+        finished_at = utc_now_timestamp()
+        return GenericWebPreviewDestroyResult(
+            destroy_status="fail",
+            destroy_started_at=started_at,
+            destroy_finished_at=finished_at,
+            product=resolved_profile.product,
+            context=resolved_profile.preview.context,
+            preview_slug=request.preview_slug,
+            application_name=application_name,
+            application_id="",
+            error_message=f"Preview application {application_name!r} was not found.",
+        )
+    try:
+        raw_domains = control_plane_dokploy.dokploy_request(
+            host=host,
+            token=token,
+            path="/api/domain.byApplicationId",
+            query={"applicationId": application_id},
+        )
+        if isinstance(raw_domains, list):
+            for raw_domain in raw_domains:
+                application_domain = control_plane_dokploy.as_json_object(raw_domain)
+                if application_domain is None:
+                    continue
+                domain_id = str(application_domain.get("domainId") or "").strip()
+                if domain_id:
+                    _delete_domain(host=host, token=token, domain_id=domain_id)
+    except click.ClickException as exc:
+        cleanup_errors.append(f"domain cleanup failed: {exc}")
+    try:
+        _delete_application(host=host, token=token, application_id=application_id)
+    except click.ClickException as exc:
+        cleanup_errors.append(f"application cleanup failed: {exc}")
     finished_at = utc_now_timestamp()
     if cleanup_errors:
         return GenericWebPreviewDestroyResult(

--- a/control_plane/workflows/preview_lifecycle_cleanup.py
+++ b/control_plane/workflows/preview_lifecycle_cleanup.py
@@ -141,7 +141,7 @@ def _build_generic_web_cleanup_record(
                 timeout_seconds=timeout_seconds,
             ),
         )
-        if destroy_result.destroy_status == "pass":
+        if destroy_result.destroy_status == "pass" and destroy_result.application_id.strip():
             try:
                 apply_launchplane_destroy_preview(
                     record_store=record_store,
@@ -179,6 +179,9 @@ def _build_generic_web_cleanup_record(
                 )
             continue
         failed_slugs.append(preview_slug)
+        error_message = destroy_result.error_message
+        if destroy_result.destroy_status == "pass":
+            error_message = "Preview destroy returned pass without a provider application id."
         results.append(
             PreviewLifecycleCleanupResult(
                 preview_slug=preview_slug,
@@ -187,7 +190,7 @@ def _build_generic_web_cleanup_record(
                 status="failed",
                 application_name=destroy_result.application_name,
                 application_id=destroy_result.application_id,
-                error_message=destroy_result.error_message,
+                error_message=error_message,
             )
         )
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -747,19 +747,19 @@ live preview URL from `LAUNCHPLANE_PREVIEW_BASE_URL`, and evidence stores that
 returned URL with generation status and cleanup outcome.
 
 Launchplane now owns the preview lifecycle planning boundary. The scheduled
-Launchplane `Preview Lifecycle` workflow discovers desired preview anchors from
-GitHub PR label state through `POST /v1/previews/desired-state`, refreshes the
-provider inventory, calls `POST /v1/previews/lifecycle-plan`, then records
-cleanup through `POST /v1/previews/lifecycle-cleanup`. Cleanup defaults to
-report-only and destructive provider cleanup still requires explicit
-`apply=true` from an authorized GitHub Actions workflow. PR feedback goes
-through `POST /v1/previews/pr-feedback`; Launchplane renders and upserts the
-anchored PR comment when runtime GitHub credentials are available, then records
-delivery status. Refresh-capable workflows can publish neutral pending feedback
-before preview publish/provision/verify outcomes are known, then replace it with
-ready or failed feedback after the actual result. Product repos remain thin
-adapters for labels, artifact build facts, and product-specific health/config
-hints.
+Launchplane `Preview Lifecycle` workflow calls `POST /v1/previews/lifecycle-sweep`;
+the service derives the participating products from product profiles where
+`preview.enabled=true`, refreshes provider inventory, discovers desired preview
+anchors from GitHub PR label state, writes lifecycle plans, and records cleanup
+results. Cleanup defaults to report-only and destructive provider cleanup still
+requires explicit `apply=true` from an authorized GitHub Actions workflow.
+Preview-disabled products are excluded from the sweep. PR feedback goes through
+`POST /v1/previews/pr-feedback`; Launchplane renders and upserts the anchored PR
+comment when runtime GitHub credentials are available, then records delivery
+status. Refresh-capable workflows can publish neutral pending feedback before
+preview publish/provision/verify outcomes are known, then replace it with ready
+or failed feedback after the actual result. Product repos remain thin adapters
+for labels, artifact build facts, and product-specific health/config hints.
 
 ### VeriReel Preview Evidence Handoff
 

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -28,6 +28,8 @@ Launchplane owns:
 
 - Preview-request interpretation and idempotency conventions.
 - Preview refresh, destroy, inventory, readiness, and lifecycle cleanup routes.
+- Scheduled lifecycle sweeps for every product profile where
+  `preview.enabled=true`.
 - Preview records, generation records, desired-state records, cleanup records,
   and PR feedback records.
 - Unsupported notices for fork and Dependabot preview requests.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -405,19 +405,17 @@ allowed actions:
   - preview_destroyed.write
 ```
 
-Janitor backstop example:
+Launchplane preview lifecycle sweep example:
 
 ```text
-repository: example-org/verireel
-workflow_ref: example-org/verireel/.github/workflows/preview-janitor.yml@refs/heads/main
+repository: example-org/launchplane
+workflow_ref: example-org/launchplane/.github/workflows/preview-lifecycle.yml@refs/heads/main
 event_name: schedule or workflow_dispatch
-allowed product: verireel
-allowed contexts: verireel-testing
+allowed products: all preview-enabled products
+allowed contexts: each preview-enabled product preview context
 allowed actions:
   - preview_lifecycle.plan
   - preview_lifecycle.cleanup
-  - verireel_preview_destroy.execute
-  - preview_destroyed.write
 ```
 
 Stable-lane examples:

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -1711,6 +1711,59 @@ class GenericWebPreviewTests(unittest.TestCase):
             ],
         )
 
+    def test_execute_generic_web_preview_destroy_fails_when_application_missing(self) -> None:
+        store = _GenericWebPreviewStore(_profile())
+        requests: list[dict[str, object]] = []
+
+        def _fake_dokploy_request(**kwargs: object) -> object:
+            requests.append(dict(kwargs))
+            path = kwargs["path"]
+            if path == "/api/project.all":
+                return [
+                    {
+                        "environments": [
+                            {
+                                "applications": [
+                                    {
+                                        "applicationId": "app-99",
+                                        "name": "syo-preview-preview-99-site",
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            return {}
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.dokploy_request",
+                side_effect=_fake_dokploy_request,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.utc_now_timestamp",
+                side_effect=["2026-04-30T21:00:00Z", "2026-04-30T21:00:02Z"],
+            ),
+        ):
+            result = execute_generic_web_preview_destroy(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebPreviewDestroyRequest(
+                    product="sellyouroutboard",
+                    preview_slug="preview-42-site",
+                    destroy_reason="test",
+                ),
+            )
+
+        self.assertEqual(result.destroy_status, "fail")
+        self.assertEqual(result.application_id, "")
+        self.assertIn("syo-preview-preview-42-site", result.error_message)
+        self.assertEqual([request["path"] for request in requests], ["/api/project.all"])
+
     def test_execute_generic_web_preview_destroy_deletes_odoo_compose_domain(self) -> None:
         store = _GenericWebPreviewStore(_odoo_compose_profile())
         requests: list[dict[str, object]] = []

--- a/tests/test_preview_lifecycle_cleanup.py
+++ b/tests/test_preview_lifecycle_cleanup.py
@@ -104,6 +104,68 @@ class PreviewLifecycleCleanupTests(unittest.TestCase):
         self.assertEqual(record.status, "blocked")
         self.assertEqual(record.blocked_slugs, ("bad-slug",))
 
+    def test_generic_web_cleanup_fails_pass_without_application_id(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_preview_record(
+                PreviewRecord(
+                    preview_id="preview-syo-testing-sellyouroutboard-pr-42",
+                    context="sellyouroutboard-testing",
+                    anchor_repo="sellyouroutboard",
+                    anchor_pr_number=42,
+                    anchor_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/42",
+                    preview_label="sellyouroutboard/pr-42",
+                    canonical_url="https://preview-42-site.example.com",
+                    state="active",
+                    created_at="2026-04-30T21:00:00Z",
+                    updated_at="2026-04-30T21:00:00Z",
+                    eligible_at="2026-04-30T21:00:00Z",
+                )
+            )
+            plan = PreviewLifecyclePlanRecord(
+                plan_id="preview-lifecycle-plan-syo-testing-1",
+                product="sellyouroutboard",
+                context="sellyouroutboard-testing",
+                planned_at="2026-04-30T21:00:00Z",
+                source="test",
+                status="pass",
+                inventory_scan_id="preview-inventory-scan-syo-testing-1",
+                orphaned_slugs=("preview-42-site",),
+            )
+
+            with patch(
+                "control_plane.workflows.preview_lifecycle_cleanup.execute_generic_web_preview_destroy",
+                return_value=GenericWebPreviewDestroyResult(
+                    destroy_status="pass",
+                    destroy_started_at="2026-04-30T21:01:00Z",
+                    destroy_finished_at="2026-04-30T21:01:02Z",
+                    product="sellyouroutboard",
+                    context="sellyouroutboard-testing",
+                    preview_slug="preview-42-site",
+                    application_name="syo-preview-preview-42-site",
+                    application_id="",
+                ),
+            ):
+                record = build_preview_lifecycle_cleanup_record(
+                    plan=plan,
+                    requested_at="2026-04-30T21:02:00Z",
+                    source="test",
+                    apply=True,
+                    destroy_reason="test_cleanup",
+                    control_plane_root=root,
+                    record_store=store,
+                    timeout_seconds=300,
+                    driver_id="generic-web",
+                    preview_slug_template="preview-{number}-site",
+                )
+
+            self.assertEqual(record.status, "fail")
+            self.assertEqual(record.failed_slugs, ("preview-42-site",))
+            self.assertIn("provider application id", record.results[0].error_message)
+            preview = store.read_preview_record("preview-syo-testing-sellyouroutboard-pr-42")
+            self.assertEqual(preview.state, "active")
+
     def test_verireel_cleanup_uses_plan_product_as_anchor_repo(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -109,6 +109,8 @@ from control_plane.workflows.generic_web_promotion import GenericWebProdPromotio
 from control_plane.workflows.generic_web_promotion_workflow import GenericWebPromotionWorkflowResult
 from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewDestroyResult,
+    GenericWebPreviewInventoryItem,
+    GenericWebPreviewInventoryResult,
     GenericWebPreviewRefreshResult,
     GenericWebPreviewSmokeCheck,
     GenericWebPreviewSmokeResult,
@@ -14265,6 +14267,181 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_preview_lifecycle_sweep_uses_enabled_product_profiles(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            enabled_profile = LaunchplaneProductProfileRecord.model_validate(
+                _generic_site_profile_payload(product="syo")
+            )
+            disabled_payload = _generic_site_profile_payload(product="discord-blue")
+            disabled_payload["preview"] = {"enabled": False}
+            disabled_profile = LaunchplaneProductProfileRecord.model_validate(disabled_payload)
+            store.write_product_profile_record(enabled_profile)
+            store.write_product_profile_record(disabled_profile)
+            store.write_preview_record(
+                PreviewRecord(
+                    preview_id="preview-syo-syo-pr-41",
+                    context="syo",
+                    anchor_repo="syo",
+                    anchor_pr_number=41,
+                    anchor_pr_url="https://github.example/every/syo/pull/41",
+                    preview_label="syo/syo#41",
+                    canonical_url="https://pr-41.syo.example",
+                    state="active",
+                    created_at="2026-04-20T10:00:00Z",
+                    updated_at="2026-04-20T10:00:00Z",
+                    eligible_at="2026-04-20T10:00:00Z",
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/launchplane",
+                            "workflow_refs": [
+                                "every/launchplane/.github/workflows/preview-lifecycle.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["syo"],
+                            "contexts": ["syo"],
+                            "actions": ["preview_lifecycle.plan", "preview_lifecycle.cleanup"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="every/launchplane",
+                        workflow_ref=(
+                            "every/launchplane/.github/workflows/preview-lifecycle.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with (
+                patch(
+                    "control_plane.service.execute_generic_web_preview_inventory",
+                    return_value=GenericWebPreviewInventoryResult(
+                        product="syo",
+                        context="syo",
+                        source="launchplane-preview-lifecycle",
+                        app_name_prefix="syo-preview",
+                        previews=(
+                            GenericWebPreviewInventoryItem(
+                                applicationId="app-41",
+                                applicationName="syo-preview-pr-41",
+                                previewSlug="pr-41",
+                            ),
+                        ),
+                    ),
+                ) as inventory_mock,
+                patch(
+                    "control_plane.service.discover_generic_web_preview_desired_state",
+                    return_value=PreviewDesiredStateRecord(
+                        desired_state_id="preview-desired-state-syo-20260510T120000Z",
+                        product="syo",
+                        context="syo",
+                        source="launchplane-preview-lifecycle",
+                        discovered_at="2026-05-10T12:00:00Z",
+                        repository="every/syo",
+                        label="preview",
+                        anchor_repo="syo",
+                        preview_slug_prefix="pr-",
+                        status="pass",
+                        desired_count=0,
+                        desired_previews=(),
+                    ),
+                ) as desired_mock,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/previews/lifecycle-sweep",
+                    payload={
+                        "source": "launchplane-preview-lifecycle",
+                        "apply": False,
+                    },
+                )
+
+            records = FilesystemRecordStore(state_dir=state_dir)
+            plan_records = records.list_preview_lifecycle_plan_records(context_name="syo")
+            cleanup_records = records.list_preview_lifecycle_cleanup_records(context_name="syo")
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["status"], "pass")
+        self.assertEqual(payload["result"]["profile_count"], 1)
+        self.assertEqual(payload["result"]["profiles"][0]["product"], "syo")
+        self.assertEqual(payload["result"]["profiles"][0]["orphaned_slugs"], ["pr-41"])
+        self.assertEqual(plan_records[0].orphaned_slugs, ("pr-41",))
+        self.assertEqual(cleanup_records[0].status, "report_only")
+        inventory_mock.assert_called_once()
+        desired_mock.assert_called_once()
+
+    def test_preview_lifecycle_sweep_rejects_missing_product_authorization(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(
+                    _generic_site_profile_payload(product="syo")
+                )
+            )
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(
+                    _generic_site_profile_payload(product="verireel")
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/launchplane",
+                            "workflow_refs": [
+                                "every/launchplane/.github/workflows/preview-lifecycle.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["syo"],
+                            "contexts": ["syo"],
+                            "actions": ["preview_lifecycle.plan", "preview_lifecycle.cleanup"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="every/launchplane",
+                        workflow_ref=(
+                            "every/launchplane/.github/workflows/preview-lifecycle.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/lifecycle-sweep",
+                payload={"source": "launchplane-preview-lifecycle"},
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertEqual(payload["authz"]["request"]["product"], "verireel")
 
     def test_preview_pr_feedback_endpoint_records_skipped_delivery_without_token(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- fail generic-web preview destroy when the expected provider application cannot be resolved
- add a Launchplane-owned `/v1/previews/lifecycle-sweep` route that derives lifecycle cleanup participants from `preview.enabled=true` product profiles
- thin the scheduled Preview Lifecycle workflow to one Launchplane sweep call and document the new ownership/authz shape

Refs #558
Refs #508

## Validation
- `uv run python -m unittest tests.test_generic_web_preview tests.test_preview_lifecycle_cleanup tests.test_service`
- `uv run python -m unittest`
- `uv run --extra dev ruff check control_plane/service.py control_plane/workflows/generic_web_preview.py control_plane/workflows/preview_lifecycle_cleanup.py tests/test_generic_web_preview.py tests/test_preview_lifecycle_cleanup.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- `actionlint .github/workflows/preview-lifecycle.yml`