### PR TITLE
Handle Odoo bootstrap post-deploy exceptions

### DIFF
--- a/control_plane/workflows/odoo_stable_bootstrap.py
+++ b/control_plane/workflows/odoo_stable_bootstrap.py
@@ -438,13 +438,53 @@ def execute_odoo_stable_bootstrap(
             error_message=str(error),
         )
 
-    post_deploy_result = execute_odoo_post_deploy(
-        control_plane_root=control_plane_root,
-        record_store=record_store,
-        request=OdooPostDeployRequest(
-            context=request.context, instance=request.instance, phase="deploy"
-        ),
-    )
+    try:
+        post_deploy_result = execute_odoo_post_deploy(
+            control_plane_root=control_plane_root,
+            record_store=record_store,
+            request=OdooPostDeployRequest(
+                context=request.context, instance=request.instance, phase="deploy"
+            ),
+        )
+    except click.ClickException as error:
+        post_deploy_evidence = PostDeployUpdateEvidence(
+            attempted=True,
+            status="fail",
+            detail=str(error),
+        )
+        _write_failed_bootstrap_deployment(
+            record_store=record_store,
+            ship_request=ship_request,
+            deployment_record_id=deployment_record_id,
+            started_at=started_at,
+            resolved_target=resolved_target,
+            bootstrap=BootstrapEvidence(
+                attempted=True,
+                run_status="pass",
+                readiness_status="fail",
+                detail=str(error),
+            ),
+            post_deploy_update=post_deploy_evidence,
+            destination_health=HealthcheckEvidence(status="skipped"),
+        )
+        _write_bootstrap_inventory_pointer(
+            record_store=record_store,
+            inventory=inventory,
+            bootstrap_record_id=deployment_record_id,
+        )
+        return _base_result(
+            request=request,
+            deployment_record_id=deployment_record_id,
+            target_record=target_record,
+            target_id_record=target_id_record,
+            inventory=inventory,
+            bootstrap_status="fail",
+            bootstrap_run_status="pass",
+            readiness_status="fail",
+            post_deploy_status="fail",
+            error_message=str(error),
+        )
+
     post_deploy_evidence = PostDeployUpdateEvidence(
         attempted=True,
         status=post_deploy_result.post_deploy_status,

--- a/tests/test_odoo_stable_bootstrap.py
+++ b/tests/test_odoo_stable_bootstrap.py
@@ -454,6 +454,60 @@ class OdooStableBootstrapTests(unittest.TestCase):
             "deployment-cm-testing-bootstrap",
         )
 
+    def test_execute_records_bootstrap_success_when_post_deploy_raises(self) -> None:
+        store = _Store()
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example.com", "token-123"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.control_plane_dokploy.run_compose_odoo_stable_bootstrap",
+                side_effect=lambda **_kwargs: None,
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.execute_odoo_post_deploy",
+                side_effect=click.ClickException("post-deploy exploded"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.utc_now_timestamp",
+                side_effect=("2026-05-10T02:00:00Z", "2026-05-10T02:01:00Z"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.generate_deployment_record_id",
+                return_value="deployment-cm-testing-bootstrap",
+            ),
+        ):
+            result = execute_odoo_stable_bootstrap(
+                control_plane_root=Path("/tmp/launchplane"),
+                record_store=store,
+                request=OdooStableBootstrapRequest(
+                    product="odoo-tenant-cm",
+                    context="cm",
+                    instance="testing",
+                    confirmation=_BOOTSTRAP_CONFIRMATION,
+                ),
+            )
+
+        self.assertEqual(result.bootstrap_status, "fail")
+        self.assertEqual(result.bootstrap_run_status, "pass")
+        self.assertEqual(result.readiness_status, "fail")
+        self.assertEqual(result.post_deploy_status, "fail")
+        self.assertIn("post-deploy exploded", result.error_message)
+        self.assertEqual(store.deployment_records[-1].deploy.status, "fail")
+        self.assertEqual(store.deployment_records[-1].bootstrap.run_status, "pass")
+        self.assertEqual(store.deployment_records[-1].bootstrap.readiness_status, "fail")
+        self.assertEqual(store.deployment_records[-1].post_deploy_update.status, "fail")
+        self.assertEqual(len(store.environment_inventories), 1)
+        self.assertEqual(
+            store.environment_inventories[0].deployment_record_id,
+            "deployment-cm-testing-old",
+        )
+        self.assertEqual(
+            store.environment_inventories[0].bootstrap_record_id,
+            "deployment-cm-testing-bootstrap",
+        )
+
     def test_execute_records_verification_failure_without_hiding_bootstrap_success(self) -> None:
         store = _Store()
         with (


### PR DESCRIPTION
## Summary
- catch post-deploy ClickException failures during Odoo stable bootstrap
- record bootstrap as run successfully while readiness/post-deploy fail structurally
- keep the previous deployment pointer and write the bootstrap evidence pointer for operator diagnosis

Refs #556
Refs #557

## Verification
- uv run python -m unittest tests.test_odoo_stable_bootstrap
- uv run --extra dev ruff check .
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest