### PR TITLE
Allow Odoo apply to deploy explicit artifacts

### DIFF
--- a/.github/workflows/odoo-target-replacement-apply.yml
+++ b/.github/workflows/odoo-target-replacement-apply.yml
@@ -23,8 +23,23 @@ name: Odoo Target Replacement Apply
         type: choice
         options:
           - recreate-in-place
+      artifact_id:
+        description: >-
+          Optional stored Launchplane artifact ID to deploy instead of the
+          current inventory artifact.
+        required: false
+        default: ""
+        type: string
+      source_git_ref:
+        description: >-
+          Required when artifact_id is set; must match the stored artifact
+          manifest source commit.
+        required: false
+        default: ""
+        type: string
       allow_empty_data:
-        description: Allow missing volume env keys for intentionally empty targets.
+        description: >-
+          Allow missing volume env keys for intentionally empty targets.
         required: true
         default: false
         type: boolean
@@ -64,7 +79,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: odoo-target-replacement-apply-${{ inputs.product }}-${{ inputs.instance }}
+  group: >-
+    odoo-target-replacement-apply-${{ inputs.product }}-${{ inputs.instance }}
   cancel-in-progress: false
 
 jobs:
@@ -76,6 +92,8 @@ jobs:
       PRODUCT: ${{ inputs.product }}
       INSTANCE: ${{ inputs.instance }}
       STRATEGY: ${{ inputs.strategy }}
+      ARTIFACT_ID: ${{ inputs.artifact_id }}
+      SOURCE_GIT_REF: ${{ inputs.source_git_ref }}
       ALLOW_EMPTY_DATA: ${{ inputs.allow_empty_data }}
       VERIFY_HEALTH: ${{ inputs.verify_health }}
       VERIFY_CANONICAL: ${{ inputs.verify_canonical }}
@@ -101,14 +119,22 @@ jobs:
             echo 'Only recreate-in-place is currently supported.' >&2
             exit 1
           fi
-          for value in "$ALLOW_EMPTY_DATA" "$VERIFY_HEALTH" "$VERIFY_CANONICAL" "$VERIFY_LOGO" "$NO_CACHE"; do
+          for value in \
+            "$ALLOW_EMPTY_DATA" \
+            "$VERIFY_HEALTH" \
+            "$VERIFY_CANONICAL" \
+            "$VERIFY_LOGO" \
+            "$NO_CACHE"; do
             if [ "$value" != "true" ] && [ "$value" != "false" ]; then
               echo "Boolean input resolved to invalid value: ${value}" >&2
               exit 1
             fi
           done
-          if [ -z "${LAUNCHPLANE_SERVICE_URL:-}" ] || [ -z "${LAUNCHPLANE_SERVICE_AUDIENCE:-}" ]; then
-            echo 'Missing Launchplane service URL or OIDC audience repository variable.' >&2
+          if [ -z "${LAUNCHPLANE_SERVICE_URL:-}" ] || \
+             [ -z "${LAUNCHPLANE_SERVICE_AUDIENCE:-}" ]; then
+            echo \
+              'Missing Launchplane service URL or OIDC audience variable.' \
+              >&2
             exit 1
           fi
 
@@ -117,9 +143,10 @@ jobs:
         run: |
           set -euo pipefail
           oidc_token="$({
+            token_url="${ACTIONS_ID_TOKEN_REQUEST_URL}"
             curl -fsSL \
               -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${LAUNCHPLANE_SERVICE_AUDIENCE}" \
+              "${token_url}&audience=${LAUNCHPLANE_SERVICE_AUDIENCE}" \
             | jq -r '.value'
           })"
           payload="$({
@@ -127,6 +154,8 @@ jobs:
               --arg product "$PRODUCT" \
               --arg instance "$INSTANCE" \
               --arg strategy "$STRATEGY" \
+              --arg artifact_id "$ARTIFACT_ID" \
+              --arg source_git_ref "$SOURCE_GIT_REF" \
               --argjson allow_empty_data "$ALLOW_EMPTY_DATA" \
               --argjson verify_health "$VERIFY_HEALTH" \
               --argjson verify_canonical "$VERIFY_CANONICAL" \
@@ -140,6 +169,8 @@ jobs:
                   product: $product,
                   instance: $instance,
                   strategy: $strategy,
+                  artifact_id: $artifact_id,
+                  source_git_ref: $source_git_ref,
                   allow_empty_data: $allow_empty_data,
                   verify_health: $verify_health,
                   verify_canonical: $verify_canonical,
@@ -149,11 +180,31 @@ jobs:
               }'
           })"
           if [ -n "${TIMEOUT_SECONDS:-}" ]; then
-            payload="$(jq --argjson timeout_seconds "$TIMEOUT_SECONDS" '.replacement.timeout_seconds = $timeout_seconds' <<<"$payload")"
+            payload="$({
+              jq \
+                --argjson timeout_seconds "$TIMEOUT_SECONDS" \
+                '.replacement.timeout_seconds = $timeout_seconds' \
+                <<<"$payload"
+            })"
           fi
           if [ -n "${HEALTH_TIMEOUT_SECONDS:-}" ]; then
-            payload="$(jq --argjson health_timeout_seconds "$HEALTH_TIMEOUT_SECONDS" '.replacement.health_timeout_seconds = $health_timeout_seconds' <<<"$payload")"
+            payload="$({
+              filter='.replacement.health_timeout_seconds = '
+              filter="${filter}\$health_timeout_seconds"
+              jq \
+                --argjson health_timeout_seconds "$HEALTH_TIMEOUT_SECONDS" \
+                "$filter" \
+                <<<"$payload"
+            })"
           fi
+          idempotency_key="$({
+            printf '%s' \
+              "odoo-target-replacement-apply:${PRODUCT}:${INSTANCE}:" \
+              "${STRATEGY}:${ARTIFACT_ID}:${SOURCE_GIT_REF}:" \
+              "${ALLOW_EMPTY_DATA}:${VERIFY_HEALTH}:${VERIFY_CANONICAL}:" \
+              "${VERIFY_LOGO}:${NO_CACHE}:${GITHUB_RUN_ID}:" \
+              "${GITHUB_RUN_ATTEMPT}"
+          })"
           status_code="$({
             curl -sS \
               -o odoo-target-replacement-apply.json \
@@ -161,18 +212,20 @@ jobs:
               -X POST \
               -H "Authorization: Bearer ${oidc_token}" \
               -H 'Content-Type: application/json' \
-              -H "Idempotency-Key: odoo-target-replacement-apply:${PRODUCT}:${INSTANCE}:${STRATEGY}:${ALLOW_EMPTY_DATA}:${VERIFY_HEALTH}:${VERIFY_CANONICAL}:${VERIFY_LOGO}:${NO_CACHE}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}" \
+              -H "Idempotency-Key: ${idempotency_key}" \
               --data "$payload" \
               "${LAUNCHPLANE_SERVICE_URL}/v1/drivers/odoo/target-replacement-apply"
           })"
           jq . odoo-target-replacement-apply.json
           if [ "$status_code" != "202" ]; then
-            echo "Launchplane Odoo target replacement apply failed with HTTP ${status_code}." >&2
+            echo \
+              "Odoo target replacement apply failed with HTTP ${status_code}." \
+              >&2
             exit 1
           fi
 
       - name: Upload replacement apply result
         uses: actions/upload-artifact@v5
         with:
-          name: odoo-target-replacement-apply-${{ inputs.product }}-${{ inputs.instance }}
+          name: odoo-target-replacement-apply
           path: odoo-target-replacement-apply.json

--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -129,6 +129,8 @@ class OdooStableTargetReplacementPlan(BaseModel):
 
 
 class OdooStableTargetReplacementApplyRequest(OdooStableTargetReplacementRequest):
+    artifact_id: str = ""
+    source_git_ref: str = ""
     verify_health: bool = True
     verify_canonical: bool = True
     verify_logo: bool = True
@@ -138,9 +140,15 @@ class OdooStableTargetReplacementApplyRequest(OdooStableTargetReplacementRequest
 
     @model_validator(mode="after")
     def _validate_apply_request(self) -> "OdooStableTargetReplacementApplyRequest":
+        self.artifact_id = self.artifact_id.strip()
+        self.source_git_ref = self.source_git_ref.strip()
         if self.strategy != "recreate-in-place":
             raise ValueError(
                 "Odoo target replacement apply currently supports recreate-in-place only."
+            )
+        if bool(self.artifact_id) != bool(self.source_git_ref):
+            raise ValueError(
+                "Odoo target replacement apply requires artifact_id and source_git_ref together."
             )
         return self
 
@@ -691,7 +699,14 @@ def execute_odoo_stable_target_replacement_apply(
             "Odoo target replacement apply requires inventory source git ref evidence."
         )
 
-    artifact_manifest = record_store.read_artifact_manifest(plan.expected_artifact_id)
+    artifact_id = request.artifact_id or plan.expected_artifact_id
+    source_git_ref = request.source_git_ref or plan.expected_source_git_ref
+    artifact_manifest = record_store.read_artifact_manifest(artifact_id)
+    if artifact_manifest.source_commit != source_git_ref:
+        raise click.ClickException(
+            "Odoo target replacement apply source ref does not match stored artifact manifest. "
+            f"Request={source_git_ref} manifest={artifact_manifest.source_commit}."
+        )
     image_reference = _artifact_image_reference(artifact_manifest)
     target_name = (
         plan.current_target.target_name
@@ -711,8 +726,8 @@ def execute_odoo_stable_target_replacement_apply(
     ship_request = _build_ship_request(
         plan=plan,
         target_name=target_name,
-        artifact_id=plan.expected_artifact_id,
-        source_git_ref=plan.expected_source_git_ref,
+        artifact_id=artifact_id,
+        source_git_ref=source_git_ref,
         timeout_seconds=deploy_timeout_seconds,
         no_cache=request.no_cache,
     )
@@ -728,7 +743,7 @@ def execute_odoo_stable_target_replacement_apply(
     runtime_identity = _build_runtime_identity(
         plan=plan,
         deployment_record_id=deployment_record_id,
-        artifact_id=plan.expected_artifact_id,
+        artifact_id=artifact_id,
         image_reference=image_reference,
     )
 
@@ -755,7 +770,7 @@ def execute_odoo_stable_target_replacement_apply(
         deployment_record_id=deployment_record_id,
         target_id=target_id_record.target_id,
         target_name=resolved_target.target_name,
-        artifact_id=plan.expected_artifact_id,
+        artifact_id=artifact_id,
         image_reference=image_reference,
     )
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -719,9 +719,13 @@ call `POST /v1/drivers/odoo/target-replacement-apply` for the guarded
 existing compose target, domains, and explicit Odoo volume env keys; it re-syncs
 the Launchplane-rendered compose source, injects the runtime identity breadcrumb,
 triggers Dokploy deploy, runs Odoo post-deploy, verifies health/canonical/logo,
-and writes deployment plus inventory records. Do not manually delete canonical
-stable targets as a replacement shortcut; add the missing Launchplane apply
-coverage first, then use the service-backed workflow.
+and writes deployment plus inventory records. By default it deploys the artifact
+already recorded in current inventory. Operators may supply both `artifact_id`
+and `source_git_ref` to deploy a newly published stored artifact before it has
+become inventory; the service refuses mismatches against the stored artifact
+manifest. Do not manually delete canonical stable targets as a replacement
+shortcut; add the missing Launchplane apply coverage first, then use the
+service-backed workflow.
 
 Target replacement only reconciles the provider target and runtime envelope. If
 an intentionally empty CM testing lane needs its Odoo database and filestore

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -44,12 +44,16 @@ class _Store:
         target_id_record: DokployTargetIdRecord | None = None,
         inventory: EnvironmentInventory | None = None,
         artifact_manifest: ArtifactIdentityManifest | None = None,
+        artifact_manifests: tuple[ArtifactIdentityManifest, ...] = (),
     ) -> None:
         self.profile = profile or _profile()
         self.target_record = target_record
         self.target_id_record = target_id_record
         self.inventory = inventory
-        self.artifact_manifest = artifact_manifest or _artifact_manifest()
+        self.artifact_manifests = {
+            manifest.artifact_id: manifest
+            for manifest in (artifact_manifests or (artifact_manifest or _artifact_manifest(),))
+        }
         self.deployment_records: list[DeploymentRecord] = []
         self.environment_inventories: list[EnvironmentInventory] = []
 
@@ -80,9 +84,9 @@ class _Store:
         return self.inventory
 
     def read_artifact_manifest(self, artifact_id: str) -> ArtifactIdentityManifest:
-        if artifact_id != self.artifact_manifest.artifact_id:
+        if artifact_id not in self.artifact_manifests:
             raise FileNotFoundError(artifact_id)
-        return self.artifact_manifest
+        return self.artifact_manifests[artifact_id]
 
     def write_deployment_record(self, record: DeploymentRecord) -> None:
         self.deployment_records.append(record)
@@ -145,14 +149,19 @@ def _inventory() -> EnvironmentInventory:
     )
 
 
-def _artifact_manifest() -> ArtifactIdentityManifest:
+def _artifact_manifest(
+    *,
+    artifact_id: str = "artifact-cm-testing",
+    source_commit: str = "abc123",
+    digest: str = "sha256:artifact",
+) -> ArtifactIdentityManifest:
     return ArtifactIdentityManifest(
-        artifact_id="artifact-cm-testing",
-        source_commit="abc123",
+        artifact_id=artifact_id,
+        source_commit=source_commit,
         enterprise_base_digest="sha256:enterprise",
         image=ArtifactImageReference(
             repository="ghcr.io/cbusillo/odoo-tenant-cm",
-            digest="sha256:artifact",
+            digest=digest,
             tags=("testing",),
         ),
     )
@@ -401,6 +410,156 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
             store.environment_inventories[0].deployment_record_id,
             final_deployment.record_id,
         )
+
+    def test_apply_can_deploy_explicit_stored_artifact(self) -> None:
+        fresh_manifest = _artifact_manifest(
+            artifact_id="artifact-cm-fresh",
+            source_commit="fresh-sha",
+            digest="sha256:fresh",
+        )
+        store = _Store(
+            target_record=_target_record(),
+            target_id_record=_target_id_record(),
+            inventory=_inventory(),
+            artifact_manifests=(_artifact_manifest(), fresh_manifest),
+        )
+        persisted_env = ""
+
+        def _fetch_target_payload(**_: object) -> JsonValue:
+            return {
+                "name": "cm-testing",
+                "sourceType": "raw",
+                "composePath": "docker-compose.yml",
+                "composeFile": "services: {}",
+                "env": persisted_env
+                or "\n".join(
+                    (
+                        "ODOO_DATA_VOLUME=cm_testing_odoo_data",
+                        "ODOO_LOG_VOLUME=cm_testing_odoo_logs",
+                        "ODOO_DB_VOLUME=cm_testing_odoo_db",
+                    )
+                ),
+            }
+
+        def _update_env(*, env_text: str, **_: object) -> None:
+            nonlocal persisted_env
+            persisted_env = env_text
+
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.read_dokploy_config",
+                return_value=("host", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.fetch_dokploy_target_payload",
+                side_effect=_fetch_target_payload,
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.latest_deployment_for_target",
+                return_value={"deploymentId": "deploy-123", "status": "success"},
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_runtime_environments.resolve_runtime_environment_values",
+                return_value={},
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.sync_dokploy_compose_raw_source"
+            ) as sync_source,
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.update_dokploy_target_env",
+                side_effect=_update_env,
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.trigger_deployment"
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.wait_for_target_deployment"
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.execute_odoo_post_deploy",
+                return_value=OdooPostDeployResult(
+                    context="cm",
+                    instance="testing",
+                    phase="deploy",
+                    post_deploy_status="pass",
+                ),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement._verify_health_url"
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement._verify_canonical_url"
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement._verify_logo_route"
+            ),
+        ):
+            result = execute_odoo_stable_target_replacement_apply(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=OdooStableTargetReplacementApplyRequest(
+                    product="odoo-tenant-cm",
+                    instance="testing",
+                    artifact_id="artifact-cm-fresh",
+                    source_git_ref="fresh-sha",
+                ),
+                dokploy_request=cast(DokployRequest, _request),
+            )
+
+        self.assertEqual(result.deploy_status, "pass")
+        self.assertEqual(result.artifact_id, "artifact-cm-fresh")
+        self.assertEqual(
+            result.image_reference,
+            "ghcr.io/cbusillo/odoo-tenant-cm@sha256:fresh",
+        )
+        self.assertIn("LAUNCHPLANE_ARTIFACT_ID=artifact-cm-fresh", persisted_env)
+        final_deployment = store.deployment_records[-1]
+        self.assertEqual(final_deployment.source_git_ref, "fresh-sha")
+        assert final_deployment.runtime_identity is not None
+        self.assertEqual(final_deployment.runtime_identity.artifact_id, "artifact-cm-fresh")
+        self.assertEqual(sync_source.call_args.kwargs["compose_name"], "cm-testing")
+
+    def test_apply_refuses_explicit_artifact_source_mismatch(self) -> None:
+        store = _Store(
+            target_record=_target_record(),
+            target_id_record=_target_id_record(),
+            inventory=_inventory(),
+        )
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.read_dokploy_config",
+                return_value=("host", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "name": "cm-testing",
+                    "env": "\n".join(
+                        (
+                            "ODOO_DATA_VOLUME=cm_testing_odoo_data",
+                            "ODOO_LOG_VOLUME=cm_testing_odoo_logs",
+                            "ODOO_DB_VOLUME=cm_testing_odoo_db",
+                        )
+                    ),
+                },
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.latest_deployment_for_target",
+                return_value={"deploymentId": "deploy-123", "status": "success"},
+            ),
+        ):
+            with self.assertRaisesRegex(click.ClickException, "source ref does not match"):
+                execute_odoo_stable_target_replacement_apply(
+                    control_plane_root=Path("."),
+                    record_store=store,
+                    request=OdooStableTargetReplacementApplyRequest(
+                        product="odoo-tenant-cm",
+                        instance="testing",
+                        artifact_id="artifact-cm-testing",
+                        source_git_ref="wrong-sha",
+                    ),
+                    dokploy_request=cast(DokployRequest, _request),
+                )
 
     def test_apply_refuses_blocked_plan(self) -> None:
         with self.assertRaises(click.ClickException):


### PR DESCRIPTION
## Summary
- Add optional artifact_id/source_git_ref inputs to Odoo target replacement apply
- Validate explicit source refs against stored artifact manifests before deploy
- Expose workflow dispatch inputs for deploying a freshly published artifact

Refs #520
Refs #542

## Validation
- uv run python -m unittest tests.test_odoo_stable_target_replacement
- uv run python -m unittest tests.test_odoo_stable_target_replacement tests.test_service
- uv run --extra dev ruff check --diff control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_stable_target_replacement.py
- uv run --extra dev ruff check control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_stable_target_replacement.py