### PR TITLE
Expose Odoo web ports in rendered compose

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -139,6 +139,9 @@ services:
     volumes:
       - odoo_data:/volumes/data
       - odoo_logs:/volumes/logs
+    ports:
+      - "${{ODOO_WEB_HOST_PORT:-8069}}:8069"
+      - "${{ODOO_LONGPOLL_HOST_PORT:-8072}}:8072"
     environment:
       <<: *odoo-env
     healthcheck:

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -2124,6 +2124,8 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
 
         self.assertIn("image: ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123", compose_file)
         self.assertIn("\n  web:", compose_file)
+        self.assertIn('- "${ODOO_WEB_HOST_PORT:-8069}:8069"', compose_file)
+        self.assertIn('- "${ODOO_LONGPOLL_HOST_PORT:-8072}:8072"', compose_file)
         self.assertIn("\n  database:", compose_file)
         self.assertIn("\n  script-runner:", compose_file)
         self.assertIn("name: ${ODOO_PROJECT_NAME:-odoo}", compose_file)


### PR DESCRIPTION
## Summary
- Preserve Odoo web and longpoll port mappings in Launchplane-rendered raw compose
- Cover the rendered compose contract in the existing Dokploy tests

Refs #520
Refs #542

## Validation
- uv run python -m unittest tests.test_dokploy.LaunchplaneServiceDeployTests.test_render_odoo_raw_compose_file_pins_artifact_image_and_services tests.test_odoo_stable_target_replacement
- uv run --extra dev ruff check --diff control_plane/dokploy.py tests/test_dokploy.py
- uv run --extra dev ruff check control_plane/dokploy.py tests/test_dokploy.py