### PR TITLE
Reconcile Odoo compose domain routes

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -1071,6 +1071,85 @@ def sync_dokploy_compose_raw_source(
     )
 
 
+def ensure_compose_web_domain_route(
+    *,
+    host: str,
+    token: str,
+    compose_id: str,
+    domain_host: str,
+    runtime_port: int,
+) -> str:
+    normalized_compose_id = compose_id.strip()
+    normalized_domain_host = domain_host.strip()
+    if not normalized_compose_id:
+        raise click.ClickException("Compose domain route reconciliation requires a compose id.")
+    if not normalized_domain_host:
+        raise click.ClickException("Compose domain route reconciliation requires a domain host.")
+    if runtime_port <= 0:
+        raise click.ClickException("Compose domain route reconciliation requires a positive port.")
+
+    raw_domains = dokploy_request(
+        host=host,
+        token=token,
+        path="/api/domain.byComposeId",
+        query={"composeId": normalized_compose_id},
+    )
+    domains = raw_domains if isinstance(raw_domains, list) else []
+    existing: JsonObject | None = None
+    for raw_domain in domains:
+        domain = as_json_object(raw_domain)
+        if domain is None:
+            continue
+        if str(domain.get("host") or "").strip() == normalized_domain_host:
+            existing = domain
+            break
+
+    payload: JsonObject = {
+        "host": normalized_domain_host,
+        "path": "/",
+        "internalPath": "/",
+        "port": runtime_port,
+        "https": True,
+        "applicationId": None,
+        "certificateType": "none",
+        "customCertResolver": None,
+        "composeId": normalized_compose_id,
+        "serviceName": "web",
+        "domainType": "compose",
+        "previewDeploymentId": None,
+        "stripPath": False,
+    }
+    if existing is not None:
+        domain_id = str(existing.get("domainId") or "").strip()
+        if not domain_id:
+            raise click.ClickException(
+                f"Dokploy domain {normalized_domain_host} is missing domainId."
+            )
+        dokploy_request(
+            host=host,
+            token=token,
+            path="/api/domain.update",
+            method="POST",
+            payload={"domainId": domain_id, **payload},
+        )
+        return domain_id
+
+    created = dokploy_request(
+        host=host,
+        token=token,
+        path="/api/domain.create",
+        method="POST",
+        payload=payload,
+    )
+    created_domain = as_json_object(created)
+    domain_id = str((created_domain or {}).get("domainId") or "").strip()
+    if not domain_id:
+        raise click.ClickException(
+            f"Dokploy domain create returned no domainId for {normalized_domain_host}."
+        )
+    return domain_id
+
+
 def _build_raw_compose_evidence(
     *, source_type: str, compose_file: str, changed: bool
 ) -> dict[str, str]:

--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -802,6 +802,15 @@ def execute_odoo_stable_target_replacement_apply(
             target_payload=target_payload,
             compose_file=compose_file,
         )
+        runtime_port = profile.runtime_port or 8069
+        for domain_host in plan.expected_domain_hosts:
+            control_plane_dokploy.ensure_compose_web_domain_route(
+                host=host,
+                token=token,
+                compose_id=target_id_record.target_id,
+                domain_host=domain_host,
+                runtime_port=runtime_port,
+            )
         current_env_map = control_plane_dokploy.parse_dokploy_env_text(
             str(target_payload.get("env") or "")
         )

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -716,16 +716,17 @@ or change routes.
 When a plan is `ready`, the trusted `Odoo Target Replacement Apply` workflow can
 call `POST /v1/drivers/odoo/target-replacement-apply` for the guarded
 `recreate-in-place` path. The first apply surface is testing-only and keeps the
-existing compose target, domains, and explicit Odoo volume env keys; it re-syncs
-the Launchplane-rendered compose source, injects the runtime identity breadcrumb,
-triggers Dokploy deploy, runs Odoo post-deploy, verifies health/canonical/logo,
-and writes deployment plus inventory records. By default it deploys the artifact
-already recorded in current inventory. Operators may supply both `artifact_id`
-and `source_git_ref` to deploy a newly published stored artifact before it has
-become inventory; the service refuses mismatches against the stored artifact
-manifest. Do not manually delete canonical stable targets as a replacement
-shortcut; add the missing Launchplane apply coverage first, then use the
-service-backed workflow.
+existing compose target, explicit Odoo volume env keys, and expected hostnames;
+it re-syncs the Launchplane-rendered compose source, reconciles each expected
+Dokploy compose domain route to the `web` service on the product runtime port,
+injects the runtime identity breadcrumb, triggers Dokploy deploy, runs Odoo
+post-deploy, verifies health/canonical/logo, and writes deployment plus
+inventory records. By default it deploys the artifact already recorded in
+current inventory. Operators may supply both `artifact_id` and `source_git_ref`
+to deploy a newly published stored artifact before it has become inventory; the
+service refuses mismatches against the stored artifact manifest. Do not manually
+delete canonical stable targets as a replacement shortcut; add the missing
+Launchplane apply coverage first, then use the service-backed workflow.
 
 Target replacement only reconciles the provider target and runtime envelope. If
 an intentionally empty CM testing lane needs its Odoo database and filestore

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -2180,6 +2180,74 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
         )
         self.assertEqual(evidence["changed"], "true")
 
+    def test_ensure_compose_web_domain_route_updates_existing_route(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def fake_dokploy_request(**kwargs: object) -> object:
+            requests.append(dict(kwargs))
+            if kwargs["path"] == "/api/domain.byComposeId":
+                return [
+                    {
+                        "domainId": "domain-cm-testing",
+                        "host": "cm-testing.shinycomputers.com",
+                        "serviceName": "old-service",
+                        "port": 3000,
+                    }
+                ]
+            return {"domainId": "domain-cm-testing"}
+
+        with patch("control_plane.dokploy.dokploy_request", side_effect=fake_dokploy_request):
+            domain_id = control_plane_dokploy.ensure_compose_web_domain_route(
+                host="https://dokploy.example.com",
+                token="token-123",
+                compose_id="compose-cm-testing",
+                domain_host="cm-testing.shinycomputers.com",
+                runtime_port=8069,
+            )
+
+        self.assertEqual(domain_id, "domain-cm-testing")
+        self.assertEqual(
+            [request["path"] for request in requests],
+            ["/api/domain.byComposeId", "/api/domain.update"],
+        )
+        update_payload = cast("dict[str, object]", requests[1]["payload"])
+        self.assertEqual(update_payload["domainId"], "domain-cm-testing")
+        self.assertEqual(update_payload["composeId"], "compose-cm-testing")
+        self.assertEqual(update_payload["domainType"], "compose")
+        self.assertEqual(update_payload["serviceName"], "web")
+        self.assertEqual(update_payload["port"], 8069)
+        self.assertEqual(update_payload["path"], "/")
+        self.assertEqual(update_payload["internalPath"], "/")
+
+    def test_ensure_compose_web_domain_route_creates_missing_route(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def fake_dokploy_request(**kwargs: object) -> object:
+            requests.append(dict(kwargs))
+            if kwargs["path"] == "/api/domain.byComposeId":
+                return []
+            return {"domainId": "domain-created"}
+
+        with patch("control_plane.dokploy.dokploy_request", side_effect=fake_dokploy_request):
+            domain_id = control_plane_dokploy.ensure_compose_web_domain_route(
+                host="https://dokploy.example.com",
+                token="token-123",
+                compose_id="compose-cm-testing",
+                domain_host="cm-testing.shinycomputers.com",
+                runtime_port=8069,
+            )
+
+        self.assertEqual(domain_id, "domain-created")
+        self.assertEqual(
+            [request["path"] for request in requests],
+            ["/api/domain.byComposeId", "/api/domain.create"],
+        )
+        create_payload = cast("dict[str, object]", requests[1]["payload"])
+        self.assertEqual(create_payload["host"], "cm-testing.shinycomputers.com")
+        self.assertEqual(create_payload["composeId"], "compose-cm-testing")
+        self.assertEqual(create_payload["serviceName"], "web")
+        self.assertEqual(create_payload["port"], 8069)
+
     def test_service_render_authz_policy_uses_explicit_policy_source(self) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -340,6 +340,9 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                 "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.sync_dokploy_compose_raw_source"
             ) as sync_source,
             patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.ensure_compose_web_domain_route"
+            ) as ensure_domain,
+            patch(
                 "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.update_dokploy_target_env",
                 side_effect=_update_env,
             ) as update_env,
@@ -385,6 +388,13 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         )
         sync_source.assert_called_once()
         self.assertEqual(sync_source.call_args.kwargs["compose_name"], "cm-testing")
+        ensure_domain.assert_called_once_with(
+            host="host",
+            token="token",
+            compose_id="compose-cm-testing",
+            domain_host="cm-testing.shinycomputers.com",
+            runtime_port=8069,
+        )
         update_env.assert_called_once()
         trigger_deploy.assert_called_once()
         wait_deploy.assert_called_once()
@@ -465,6 +475,9 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
             patch(
                 "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.sync_dokploy_compose_raw_source"
             ) as sync_source,
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.ensure_compose_web_domain_route"
+            ),
             patch(
                 "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.update_dokploy_target_env",
                 side_effect=_update_env,


### PR DESCRIPTION
## Summary
- add a Dokploy compose-domain reconciliation helper for stable Odoo routes
- make target replacement apply ensure expected domains route to the web service on the product runtime port before deploy
- document that target replacement reconciles compose domain routes

## Tests
- uv run python -m unittest tests.test_dokploy tests.test_odoo_stable_target_replacement
- uv run --extra dev ruff check --diff control_plane/dokploy.py control_plane/workflows/odoo_stable_target_replacement.py tests/test_dokploy.py tests/test_odoo_stable_target_replacement.py
- uv run --extra dev ruff check control_plane/dokploy.py control_plane/workflows/odoo_stable_target_replacement.py tests/test_dokploy.py tests/test_odoo_stable_target_replacement.py

## Live follow-up
After merge/deploy, rerun Odoo Target Replacement Apply for artifact-cm-48094d7cee46aa28, then Odoo Stable Bootstrap for odoo-tenant-cm cm/testing.