### PR TITLE
Render Odoo compose Traefik routes

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -80,12 +80,62 @@ class DokployTargetRecordStore(Protocol):
     def list_dokploy_target_id_records(self) -> tuple[DokployTargetIdRecord, ...]: ...
 
 
-def render_odoo_raw_compose_file(*, image_reference: str) -> str:
+def _traefik_route_name(*, domain_host: str) -> str:
+    normalized_host = domain_host.strip().lower()
+    host_slug = re.sub(r"[^a-z0-9]+", "-", normalized_host).strip("-")
+    if not host_slug:
+        raise click.ClickException("Traefik route rendering requires a domain host.")
+    host_hash = hashlib.sha1(normalized_host.encode("utf-8")).hexdigest()[:8]
+    return f"launchplane-odoo-web-{host_slug[:48]}-{host_hash}"
+
+
+def _render_odoo_web_traefik_labels(*, domain_hosts: tuple[str, ...], runtime_port: int) -> str:
+    if not domain_hosts:
+        return ""
+    if runtime_port <= 0:
+        raise click.ClickException("Odoo Traefik label rendering requires a positive port.")
+    lines: list[str] = [
+        "    networks:",
+        "      - default",
+        "      - dokploy-network",
+        "    labels:",
+        '      - "traefik.enable=true"',
+        '      - "traefik.docker.network=dokploy-network"',
+    ]
+    seen_hosts: set[str] = set()
+    for raw_domain_host in domain_hosts:
+        domain_host = raw_domain_host.strip().lower()
+        if not domain_host or domain_host in seen_hosts:
+            continue
+        if "`" in domain_host:
+            raise click.ClickException(
+                f"Odoo Traefik label rendering received an invalid domain host: {domain_host}"
+            )
+        seen_hosts.add(domain_host)
+        route_name = _traefik_route_name(domain_host=domain_host)
+        lines.extend(
+            (
+                f'      - "traefik.http.routers.{route_name}.rule=Host(`{domain_host}`)"',
+                f'      - "traefik.http.routers.{route_name}.entrypoints=websecure"',
+                f'      - "traefik.http.routers.{route_name}.tls.certResolver=letsencrypt"',
+                f'      - "traefik.http.routers.{route_name}.service={route_name}"',
+                f'      - "traefik.http.services.{route_name}.loadbalancer.server.port={runtime_port}"',
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def render_odoo_raw_compose_file(
+    *, image_reference: str, domain_hosts: tuple[str, ...] = (), runtime_port: int = 8069
+) -> str:
     normalized_image_reference = image_reference.strip()
     if not normalized_image_reference:
         raise click.ClickException(
             "Odoo raw compose rendering requires a non-empty image reference."
         )
+    web_route_labels = _render_odoo_web_traefik_labels(
+        domain_hosts=domain_hosts, runtime_port=runtime_port
+    )
     # Keep this intentionally close to odoo-devkit/docker-compose.yml. Launchplane
     # renders the image reference directly so Dokploy git checkout state cannot
     # decide what Odoo artifact is deployed.
@@ -152,6 +202,7 @@ services:
       start_period: 20s
     extra_hosts:
       - "host.docker.internal:host-gateway"
+{web_route_labels}
 
   database:
     image: postgres:17
@@ -236,6 +287,10 @@ volumes:
 secrets:
   github_token:
     environment: GITHUB_TOKEN
+
+networks:
+  dokploy-network:
+    external: true
 """
 
 

--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -792,7 +792,9 @@ def execute_odoo_stable_target_replacement_apply(
             )
         )
         compose_file = control_plane_dokploy.render_odoo_raw_compose_file(
-            image_reference=image_reference
+            image_reference=image_reference,
+            domain_hosts=plan.expected_domain_hosts,
+            runtime_port=profile.runtime_port,
         )
         control_plane_dokploy.sync_dokploy_compose_raw_source(
             host=host,
@@ -802,14 +804,13 @@ def execute_odoo_stable_target_replacement_apply(
             target_payload=target_payload,
             compose_file=compose_file,
         )
-        runtime_port = profile.runtime_port or 8069
         for domain_host in plan.expected_domain_hosts:
             control_plane_dokploy.ensure_compose_web_domain_route(
                 host=host,
                 token=token,
                 compose_id=target_id_record.target_id,
                 domain_host=domain_host,
-                runtime_port=runtime_port,
+                runtime_port=profile.runtime_port,
             )
         current_env_map = control_plane_dokploy.parse_dokploy_env_text(
             str(target_payload.get("env") or "")

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -719,14 +719,15 @@ call `POST /v1/drivers/odoo/target-replacement-apply` for the guarded
 existing compose target, explicit Odoo volume env keys, and expected hostnames;
 it re-syncs the Launchplane-rendered compose source, reconciles each expected
 Dokploy compose domain route to the `web` service on the product runtime port,
-injects the runtime identity breadcrumb, triggers Dokploy deploy, runs Odoo
-post-deploy, verifies health/canonical/logo, and writes deployment plus
-inventory records. By default it deploys the artifact already recorded in
-current inventory. Operators may supply both `artifact_id` and `source_git_ref`
-to deploy a newly published stored artifact before it has become inventory; the
-service refuses mismatches against the stored artifact manifest. Do not manually
-delete canonical stable targets as a replacement shortcut; add the missing
-Launchplane apply coverage first, then use the service-backed workflow.
+renders the matching Traefik router labels into the raw compose, injects the
+runtime identity breadcrumb, triggers Dokploy deploy, runs Odoo post-deploy,
+verifies health/canonical/logo, and writes deployment plus inventory records. By
+default it deploys the artifact already recorded in current inventory. Operators
+may supply both `artifact_id` and `source_git_ref` to deploy a newly published
+stored artifact before it has become inventory; the service refuses mismatches
+against the stored artifact manifest. Do not manually delete canonical stable
+targets as a replacement shortcut; add the missing Launchplane apply coverage
+first, then use the service-backed workflow.
 
 Target replacement only reconciles the provider target and runtime envelope. If
 an intentionally empty CM testing lane needs its Odoo database and filestore

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -2119,7 +2119,9 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
 
     def test_render_odoo_raw_compose_file_pins_artifact_image_and_services(self) -> None:
         compose_file = control_plane_dokploy.render_odoo_raw_compose_file(
-            image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123"
+            image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+            domain_hosts=("cm-testing.shinycomputers.com",),
+            runtime_port=8069,
         )
 
         self.assertIn("image: ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123", compose_file)
@@ -2129,6 +2131,23 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
         self.assertIn("\n  database:", compose_file)
         self.assertIn("\n  script-runner:", compose_file)
         self.assertIn("name: ${ODOO_PROJECT_NAME:-odoo}", compose_file)
+        self.assertIn("dokploy-network:", compose_file)
+        self.assertIn('traefik.enable=true', compose_file)
+        self.assertIn(
+            "traefik.http.routers.launchplane-odoo-web-cm-testing-shinycomputers-com-",
+            compose_file,
+        )
+        self.assertIn(".rule=Host(`cm-testing.shinycomputers.com`)", compose_file)
+        self.assertIn(".entrypoints=websecure", compose_file)
+        self.assertIn(".loadbalancer.server.port=8069", compose_file)
+
+    def test_render_odoo_raw_compose_file_omits_traefik_labels_without_domains(self) -> None:
+        compose_file = control_plane_dokploy.render_odoo_raw_compose_file(
+            image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123"
+        )
+
+        self.assertNotIn("traefik.http.routers", compose_file)
+        self.assertIn("dokploy-network:", compose_file)
 
     def test_sync_dokploy_compose_raw_source_updates_and_verifies_hash(self) -> None:
         compose_file = control_plane_dokploy.render_odoo_raw_compose_file(

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -340,6 +340,10 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                 "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.sync_dokploy_compose_raw_source"
             ) as sync_source,
             patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.render_odoo_raw_compose_file",
+                return_value="services:\n  web:\n",
+            ) as render_compose,
+            patch(
                 "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.ensure_compose_web_domain_route"
             ) as ensure_domain,
             patch(
@@ -385,6 +389,11 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         self.assertEqual(
             result.image_reference,
             "ghcr.io/cbusillo/odoo-tenant-cm@sha256:artifact",
+        )
+        render_compose.assert_called_once_with(
+            image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:artifact",
+            domain_hosts=("cm-testing.shinycomputers.com",),
+            runtime_port=8069,
         )
         sync_source.assert_called_once()
         self.assertEqual(sync_source.call_args.kwargs["compose_name"], "cm-testing")


### PR DESCRIPTION
## Summary
- render explicit Traefik routers for Odoo raw compose stable domains
- pass expected target domains and runtime port into raw compose rendering during target replacement apply
- document that stable Odoo target replacement renders matching Traefik route labels

## Tests
- uv run python -m unittest tests.test_dokploy tests.test_odoo_stable_target_replacement
- uv run --extra dev ruff check --diff control_plane/dokploy.py control_plane/workflows/odoo_stable_target_replacement.py tests/test_dokploy.py tests/test_odoo_stable_target_replacement.py
- uv run --extra dev ruff check control_plane/dokploy.py control_plane/workflows/odoo_stable_target_replacement.py tests/test_dokploy.py tests/test_odoo_stable_target_replacement.py

## Evidence
After #571 deployed, Odoo Target Replacement Apply run 25635086335 still deployed artifact-cm-48094d7cee46aa28 with runtime identity but failed public verification with Traefik plain 404 for https://cm-testing.shinycomputers.com/web/health. This adds explicit compose labels instead of relying only on Dokploy compose-domain injection.