### PR TITLE
Require issue-backed Odoo bootstrap approval

### DIFF
--- a/control_plane/contracts/product_profile_record.py
+++ b/control_plane/contracts/product_profile_record.py
@@ -22,6 +22,7 @@ class ProductOdooStableBootstrapPolicy(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     enabled: bool = False
+    approval_issue_url: str = ""
     data_source_mode: Literal["empty"] = "empty"
     confirmation: str = ""
     expected_target_name: str = ""
@@ -32,6 +33,7 @@ class ProductOdooStableBootstrapPolicy(BaseModel):
 
     @model_validator(mode="after")
     def _validate_policy(self) -> "ProductOdooStableBootstrapPolicy":
+        self.approval_issue_url = self.approval_issue_url.strip()
         self.confirmation = self.confirmation.strip().lower()
         self.expected_target_name = self.expected_target_name.strip()
         normalized_domains: list[str] = []
@@ -51,6 +53,10 @@ class ProductOdooStableBootstrapPolicy(BaseModel):
                 normalized_domains.append(domain)
         self.expected_domains = tuple(normalized_domains)
         if self.enabled:
+            if not self.approval_issue_url:
+                raise ValueError(
+                    "enabled Odoo stable bootstrap policy requires approval_issue_url"
+                )
             if not self.confirmation:
                 raise ValueError("enabled Odoo stable bootstrap policy requires confirmation")
             if not self.expected_target_name:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -735,16 +735,19 @@ rebuilt, use the trusted `Odoo Stable Bootstrap` workflow instead of repairing
 state in Dokploy or a local checkout. The workflow calls
 `POST /v1/drivers/odoo/stable-bootstrap` and requires the lane's product-profile
 `odoo_stable_bootstrap` policy to be enabled. That policy carries the destructive
-confirmation phrase, expected Dokploy target name, expected domain set, data
-source mode, and required verification checks. The service proves the request,
-product lane, stored target record, and target domains before contacting Dokploy;
-the Dokploy runner also refuses if the live compose name no longer matches the
-expected target. After proof passes, Launchplane runs the existing compose-local
-devkit data workflow in `--bootstrap` mode through a dedicated manual Dokploy
-schedule, then runs Odoo post-deploy and verifies health, canonical URL, and logo
-routes before writing deployment and inventory evidence. Bootstrap evidence keeps
-the destructive data workflow status separate from public readiness: if the
-bootstrap runs but post-deploy or verification fails, inventory keeps its prior
+confirmation phrase, issue-backed approval URL, expected Dokploy target name,
+expected domain set, data source mode, and required verification checks. The
+approval issue is the operator signal to encode prelaunch/resettable policy; it
+should close after the policy lands, while launch or cutover retirement belongs
+in a separate follow-up. The service proves the request, product lane, stored
+target record, and target domains before contacting Dokploy. The Dokploy runner
+also refuses if the live compose name no longer matches the expected target. After
+proof passes, Launchplane runs the existing compose-local devkit data workflow in
+`--bootstrap` mode through a dedicated manual Dokploy schedule, then runs Odoo
+post-deploy and verifies health, canonical URL, and logo routes before writing
+deployment and inventory evidence. Bootstrap evidence keeps the destructive data
+workflow status separate from public readiness: if the bootstrap runs but
+post-deploy or verification fails, inventory keeps its prior
 current deployment pointer and records the failed attempt in `bootstrap_record_id`.
 Do not use this path for prod until Launchplane has explicit backup/restore
 policy evidence for that lane.

--- a/docs/records.md
+++ b/docs/records.md
@@ -222,10 +222,14 @@ a repo-local manifest and should not become product repo authority.
 
 Odoo stable bootstrap eligibility is lane-owned product-profile data. A lane's
 `odoo_stable_bootstrap` policy defaults to disabled and must explicitly carry
-the destructive confirmation phrase, `data_source_mode`, expected Dokploy target
-name, expected domains, and required verification checks. Launchplane treats the
-policy plus stored/observed target proof as the authority for whether a bootstrap
-can proceed; request product/context/instance alone is not sufficient.
+an issue-backed approval URL, the destructive confirmation phrase,
+`data_source_mode`, expected Dokploy target name, expected domains, and required
+verification checks. Launchplane treats the policy plus stored/observed target
+proof as the authority for whether a bootstrap can proceed; request
+product/context/instance alone is not sufficient. The approval issue is the
+implementation signal, not a launch tracker: close it when the policy is encoded
+and keep launch/cutover retirement in a separate issue or explicit expiration
+record.
 
 This file layout describes today's local Launchplane implementation, not the
 final cross-product communication boundary. The stable long-term contract should

--- a/tests/test_odoo_stable_bootstrap.py
+++ b/tests/test_odoo_stable_bootstrap.py
@@ -46,6 +46,7 @@ class _Store:
                     health_url="https://cm-testing.shinycomputers.com/web/health",
                     odoo_stable_bootstrap=ProductOdooStableBootstrapPolicy(
                         enabled=True,
+                        approval_issue_url="https://github.com/cbusillo/launchplane/issues/573",
                         confirmation=_BOOTSTRAP_CONFIRMATION,
                         expected_target_name="cm-testing",
                         expected_domains=("cm-testing.shinycomputers.com",),
@@ -253,6 +254,17 @@ class OdooStableBootstrapTests(unittest.TestCase):
             )
 
         self.assertIn("not enabled", str(raised_error.exception))
+
+    def test_enabled_bootstrap_policy_requires_issue_backed_approval(self) -> None:
+        with self.assertRaises(ValueError) as raised_error:
+            ProductOdooStableBootstrapPolicy(
+                enabled=True,
+                confirmation=_BOOTSTRAP_CONFIRMATION,
+                expected_target_name="cm-testing",
+                expected_domains=("cm-testing.shinycomputers.com",),
+            )
+
+        self.assertIn("approval_issue_url", str(raised_error.exception))
 
     def test_execute_refuses_wrong_confirmation(self) -> None:
         store = _Store()


### PR DESCRIPTION
## Summary
- require enabled Odoo stable bootstrap policies to carry an `approval_issue_url`
- add targeted coverage for the issue-backed approval requirement
- document that the approval issue is the implementation signal and should close once encoded; launch/cutover retirement belongs in a separate follow-up

## Tests
- `uv run python -m unittest tests.test_odoo_stable_bootstrap tests.test_product_read_service tests.test_filesystem_store tests.test_postgres_store.PostgresRecordStoreTests.test_product_profile_records_round_trip`
- `uv run --extra dev ruff check --diff control_plane/contracts/product_profile_record.py tests/test_odoo_stable_bootstrap.py`
- `uv run --extra dev ruff check control_plane/contracts/product_profile_record.py tests/test_odoo_stable_bootstrap.py`
- `git diff --check`

## Notes
This is the contract guard for #573. It does not keep #573 open until CM/OPW launch; #573 should close when the policy is encoded. A separate launch/cutover retirement issue should remove or expire the prelaunch approval when those lanes become authoritative.
