### PR TITLE
Encode CM issue-backed bootstrap policy

### DIFF
--- a/.github/workflows/odoo-target-replacement-apply.yml
+++ b/.github/workflows/odoo-target-replacement-apply.yml
@@ -16,6 +16,7 @@ name: Odoo Target Replacement Apply
         type: choice
         options:
           - testing
+          - prod
       strategy:
         description: Replacement strategy to apply.
         required: true
@@ -43,6 +44,20 @@ name: Odoo Target Replacement Apply
         required: true
         default: false
         type: boolean
+      data_source_mode:
+        description: Prelaunch rebuild data authority for resettable targets.
+        required: true
+        default: existing
+        type: choice
+        options:
+          - existing
+          - empty
+          - upstream_restore
+      confirmation:
+        description: Confirmation phrase for lane prelaunch rebuild policy.
+        required: false
+        default: ""
+        type: string
       verify_health:
         description: Verify the Odoo health endpoint after deploy.
         required: true
@@ -95,6 +110,8 @@ jobs:
       ARTIFACT_ID: ${{ inputs.artifact_id }}
       SOURCE_GIT_REF: ${{ inputs.source_git_ref }}
       ALLOW_EMPTY_DATA: ${{ inputs.allow_empty_data }}
+      DATA_SOURCE_MODE: ${{ inputs.data_source_mode }}
+      CONFIRMATION: ${{ inputs.confirmation }}
       VERIFY_HEALTH: ${{ inputs.verify_health }}
       VERIFY_CANONICAL: ${{ inputs.verify_canonical }}
       VERIFY_LOGO: ${{ inputs.verify_logo }}
@@ -111,10 +128,6 @@ jobs:
           : "${PRODUCT:?Missing product input}"
           : "${INSTANCE:?Missing instance input}"
           : "${STRATEGY:?Missing strategy input}"
-          if [ "$INSTANCE" != "testing" ]; then
-            echo 'This workflow only applies testing target replacement.' >&2
-            exit 1
-          fi
           if [ "$STRATEGY" != "recreate-in-place" ]; then
             echo 'Only recreate-in-place is currently supported.' >&2
             exit 1
@@ -156,6 +169,8 @@ jobs:
               --arg strategy "$STRATEGY" \
               --arg artifact_id "$ARTIFACT_ID" \
               --arg source_git_ref "$SOURCE_GIT_REF" \
+              --arg data_source_mode "$DATA_SOURCE_MODE" \
+              --arg confirmation "$CONFIRMATION" \
               --argjson allow_empty_data "$ALLOW_EMPTY_DATA" \
               --argjson verify_health "$VERIFY_HEALTH" \
               --argjson verify_canonical "$VERIFY_CANONICAL" \
@@ -172,6 +187,8 @@ jobs:
                   artifact_id: $artifact_id,
                   source_git_ref: $source_git_ref,
                   allow_empty_data: $allow_empty_data,
+                  data_source_mode: $data_source_mode,
+                  confirmation: $confirmation,
                   verify_health: $verify_health,
                   verify_canonical: $verify_canonical,
                   verify_logo: $verify_logo,
@@ -201,10 +218,12 @@ jobs:
             printf '%s' \
               "odoo-target-replacement-apply:${PRODUCT}:${INSTANCE}:" \
               "${STRATEGY}:${ARTIFACT_ID}:${SOURCE_GIT_REF}:" \
-              "${ALLOW_EMPTY_DATA}:${VERIFY_HEALTH}:${VERIFY_CANONICAL}:" \
-              "${VERIFY_LOGO}:${NO_CACHE}:${GITHUB_RUN_ID}:" \
+              "${ALLOW_EMPTY_DATA}:${DATA_SOURCE_MODE}:${CONFIRMATION}:" \
+              "${VERIFY_HEALTH}:${VERIFY_CANONICAL}:${VERIFY_LOGO}:" \
+              "${NO_CACHE}:${GITHUB_RUN_ID}:" \
               "${GITHUB_RUN_ATTEMPT}"
           })"
+          route="${LAUNCHPLANE_SERVICE_URL}/v1/drivers/odoo"
           status_code="$({
             curl -sS \
               -o odoo-target-replacement-apply.json \
@@ -214,12 +233,12 @@ jobs:
               -H 'Content-Type: application/json' \
               -H "Idempotency-Key: ${idempotency_key}" \
               --data "$payload" \
-              "${LAUNCHPLANE_SERVICE_URL}/v1/drivers/odoo/target-replacement-apply"
+              "${route}/target-replacement-apply"
           })"
           jq . odoo-target-replacement-apply.json
           if [ "$status_code" != "202" ]; then
             echo \
-              "Odoo target replacement apply failed with HTTP ${status_code}." \
+              "Odoo target replacement apply failed: ${status_code}." \
               >&2
             exit 1
           fi

--- a/.github/workflows/odoo-target-replacement-plan.yml
+++ b/.github/workflows/odoo-target-replacement-plan.yml
@@ -26,17 +26,32 @@ name: Odoo Target Replacement Plan
           - recreate-in-place
           - replace-and-cutover
       allow_empty_data:
-        description: Allow missing volume env keys for intentionally empty targets.
+        description: Allow missing Odoo volume env keys.
         required: true
         default: false
         type: boolean
+      data_source_mode:
+        description: Prelaunch rebuild data authority for resettable targets.
+        required: true
+        default: existing
+        type: choice
+        options:
+          - existing
+          - empty
+          - upstream_restore
+      confirmation:
+        description: Confirmation phrase for lane prelaunch rebuild policy.
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
   id-token: write
 
 concurrency:
-  group: odoo-target-replacement-plan-${{ inputs.product }}-${{ inputs.instance }}
+  group: >-
+    odoo-target-replacement-plan-${{ inputs.product }}-${{ inputs.instance }}
   cancel-in-progress: false
 
 jobs:
@@ -49,6 +64,8 @@ jobs:
       INSTANCE: ${{ inputs.instance }}
       STRATEGY: ${{ inputs.strategy }}
       ALLOW_EMPTY_DATA: ${{ inputs.allow_empty_data }}
+      DATA_SOURCE_MODE: ${{ inputs.data_source_mode }}
+      CONFIRMATION: ${{ inputs.confirmation }}
       LAUNCHPLANE_SERVICE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
       LAUNCHPLANE_SERVICE_AUDIENCE: launchplane.shinycomputers.com
     steps:
@@ -59,8 +76,11 @@ jobs:
           : "${PRODUCT:?Missing product input}"
           : "${INSTANCE:?Missing instance input}"
           : "${STRATEGY:?Missing strategy input}"
-          if [ -z "${LAUNCHPLANE_SERVICE_URL:-}" ] || [ -z "${LAUNCHPLANE_SERVICE_AUDIENCE:-}" ]; then
-            echo 'Missing Launchplane service URL or OIDC audience repository variable.' >&2
+          if [ -z "${LAUNCHPLANE_SERVICE_URL:-}" ] || \
+             [ -z "${LAUNCHPLANE_SERVICE_AUDIENCE:-}" ]; then
+            echo \
+              'Missing Launchplane service URL or OIDC audience variable.' \
+              >&2
             exit 1
           fi
 
@@ -69,9 +89,10 @@ jobs:
         run: |
           set -euo pipefail
           oidc_token="$({
+            token_url="${ACTIONS_ID_TOKEN_REQUEST_URL}"
             curl -fsSL \
               -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${LAUNCHPLANE_SERVICE_AUDIENCE}" \
+              "${token_url}&audience=${LAUNCHPLANE_SERVICE_AUDIENCE}" \
             | jq -r '.value'
           })"
           payload="$({
@@ -79,6 +100,8 @@ jobs:
               --arg product "$PRODUCT" \
               --arg instance "$INSTANCE" \
               --arg strategy "$STRATEGY" \
+              --arg data_source_mode "$DATA_SOURCE_MODE" \
+              --arg confirmation "$CONFIRMATION" \
               --argjson allow_empty_data "$ALLOW_EMPTY_DATA" \
               '{
                 schema_version: 1,
@@ -88,10 +111,19 @@ jobs:
                   product: $product,
                   instance: $instance,
                   strategy: $strategy,
-                  allow_empty_data: $allow_empty_data
+                  allow_empty_data: $allow_empty_data,
+                  data_source_mode: $data_source_mode,
+                  confirmation: $confirmation
                 }
               }'
           })"
+          idempotency_key="$({
+            printf '%s' \
+              "odoo-target-replacement-plan:${PRODUCT}:${INSTANCE}:" \
+              "${STRATEGY}:${ALLOW_EMPTY_DATA}:${DATA_SOURCE_MODE}:" \
+              "${CONFIRMATION}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
+          })"
+          route="${LAUNCHPLANE_SERVICE_URL}/v1/drivers/odoo"
           status_code="$({
             curl -sS \
               -o odoo-target-replacement-plan.json \
@@ -99,18 +131,20 @@ jobs:
               -X POST \
               -H "Authorization: Bearer ${oidc_token}" \
               -H 'Content-Type: application/json' \
-              -H "Idempotency-Key: odoo-target-replacement-plan:${PRODUCT}:${INSTANCE}:${STRATEGY}:${ALLOW_EMPTY_DATA}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}" \
+              -H "Idempotency-Key: ${idempotency_key}" \
               --data "$payload" \
-              "${LAUNCHPLANE_SERVICE_URL}/v1/drivers/odoo/target-replacement-plan"
+              "${route}/target-replacement-plan"
           })"
           jq . odoo-target-replacement-plan.json
           if [ "$status_code" != "202" ]; then
-            echo "Launchplane Odoo target replacement plan failed with HTTP ${status_code}." >&2
+            echo \
+              "Odoo replacement plan failed: ${status_code}." \
+              >&2
             exit 1
           fi
 
       - name: Upload replacement plan
         uses: actions/upload-artifact@v5
         with:
-          name: odoo-target-replacement-plan-${{ inputs.product }}-${{ inputs.instance }}
+          name: odoo-target-replacement-plan
           path: odoo-target-replacement-plan.json

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -14358,6 +14358,18 @@ def odoo_targets() -> None:
     help="Allow missing volume env keys in the dry-run plan for an intentionally empty target.",
 )
 @click.option(
+    "--data-source-mode",
+    type=click.Choice(["existing", "empty", "upstream_restore"]),
+    default="existing",
+    show_default=True,
+    help="Prelaunch rebuild data authority for intentionally resettable targets.",
+)
+@click.option(
+    "--confirmation",
+    default="",
+    help="Confirmation phrase required by the lane prelaunch rebuild policy.",
+)
+@click.option(
     "--control-plane-root",
     type=click.Path(path_type=Path, file_okay=False),
     default=None,
@@ -14369,6 +14381,8 @@ def odoo_targets_replacement_plan(
     instance_name: str,
     strategy: str,
     allow_empty_data: bool,
+    data_source_mode: str,
+    confirmation: str,
     control_plane_root: Path | None,
 ) -> None:
     launchplane_root = control_plane_root or _control_plane_root()
@@ -14382,6 +14396,10 @@ def odoo_targets_replacement_plan(
                 instance=instance_name,
                 strategy=cast(Literal["recreate-in-place", "replace-and-cutover"], strategy),
                 allow_empty_data=allow_empty_data,
+                data_source_mode=cast(
+                    Literal["existing", "empty", "upstream_restore"], data_source_mode
+                ),
+                confirmation=confirmation,
             ),
         )
     finally:

--- a/control_plane/contracts/product_environment_read_model.py
+++ b/control_plane/contracts/product_environment_read_model.py
@@ -139,6 +139,9 @@ class ProductEnvironmentSummary(BaseModel):
     context: str
     base_url: str = ""
     health_url: str = ""
+    prelaunch_rebuild_allowed: bool = False
+    prelaunch_rebuild_data_source_mode: str = ""
+    prelaunch_rebuild_approval_issue_url: str = ""
     trust_state: FreshnessStatus
     provenance: DataProvenance
     warnings: tuple[str, ...] = ()
@@ -191,6 +194,9 @@ class ProductEnvironmentDetail(BaseModel):
     context: str
     base_url: str = ""
     health_url: str = ""
+    prelaunch_rebuild_allowed: bool = False
+    prelaunch_rebuild_data_source_mode: str = ""
+    prelaunch_rebuild_approval_issue_url: str = ""
     target: ProductTargetSummary
     runtime_settings: tuple[ProductRuntimeSettingSummary, ...] = ()
     managed_secrets: tuple[ProductSecretBindingSummary, ...] = ()
@@ -365,6 +371,11 @@ def build_product_environment_detail(
         context=lane.context,
         base_url=lane.base_url,
         health_url=lane.health_url,
+        prelaunch_rebuild_allowed=lane.odoo_prelaunch_rebuild.enabled,
+        prelaunch_rebuild_data_source_mode=lane.odoo_prelaunch_rebuild.data_source_mode
+        if lane.odoo_prelaunch_rebuild.enabled
+        else "",
+        prelaunch_rebuild_approval_issue_url=lane.odoo_prelaunch_rebuild.approval_issue_url,
         target=_target_summary(lane_summary),
         runtime_settings=_runtime_setting_summaries(lane_summary),
         managed_secrets=_secret_binding_summaries(lane_summary),
@@ -1014,6 +1025,11 @@ def _build_environment_summary(
         context=lane.context,
         base_url=lane.base_url,
         health_url=lane.health_url,
+        prelaunch_rebuild_allowed=lane.odoo_prelaunch_rebuild.enabled,
+        prelaunch_rebuild_data_source_mode=lane.odoo_prelaunch_rebuild.data_source_mode
+        if lane.odoo_prelaunch_rebuild.enabled
+        else "",
+        prelaunch_rebuild_approval_issue_url=lane.odoo_prelaunch_rebuild.approval_issue_url,
         trust_state=provenance.freshness_status,
         provenance=provenance,
         available_actions=_action_availability(

--- a/control_plane/contracts/product_onboarding_manifest.py
+++ b/control_plane/contracts/product_onboarding_manifest.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from control_plane.contracts.dokploy_target_record import DokployTargetType
 from control_plane.contracts.product_profile_record import (
     PRODUCT_PREVIEW_DEFAULT_ENABLE_LABEL,
+    ProductOdooStableBootstrapPolicy,
     ProductExpectedConfigProfile,
     ProductPreviewProfile,
     ProductPromotionWorkflowProfile,
@@ -20,6 +21,9 @@ class ProductOnboardingLaneManifest(BaseModel):
     context: str
     base_url: str = ""
     health_url: str = ""
+    odoo_stable_bootstrap: ProductOdooStableBootstrapPolicy = Field(
+        default_factory=ProductOdooStableBootstrapPolicy
+    )
 
     @model_validator(mode="after")
     def _validate_lane(self) -> "ProductOnboardingLaneManifest":

--- a/control_plane/contracts/product_onboarding_manifest.py
+++ b/control_plane/contracts/product_onboarding_manifest.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from control_plane.contracts.dokploy_target_record import DokployTargetType
 from control_plane.contracts.product_profile_record import (
     PRODUCT_PREVIEW_DEFAULT_ENABLE_LABEL,
+    ProductOdooPrelaunchRebuildPolicy,
     ProductOdooStableBootstrapPolicy,
     ProductExpectedConfigProfile,
     ProductPreviewProfile,
@@ -23,6 +24,9 @@ class ProductOnboardingLaneManifest(BaseModel):
     health_url: str = ""
     odoo_stable_bootstrap: ProductOdooStableBootstrapPolicy = Field(
         default_factory=ProductOdooStableBootstrapPolicy
+    )
+    odoo_prelaunch_rebuild: ProductOdooPrelaunchRebuildPolicy = Field(
+        default_factory=ProductOdooPrelaunchRebuildPolicy
     )
 
     @model_validator(mode="after")

--- a/control_plane/contracts/product_profile_record.py
+++ b/control_plane/contracts/product_profile_record.py
@@ -68,6 +68,55 @@ class ProductOdooStableBootstrapPolicy(BaseModel):
         return self
 
 
+class ProductOdooPrelaunchRebuildPolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    approval_issue_url: str = ""
+    data_source_mode: Literal["empty", "upstream_restore"] = "empty"
+    confirmation: str = ""
+    expected_target_name: str = ""
+    expected_domains: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_policy(self) -> "ProductOdooPrelaunchRebuildPolicy":
+        self.approval_issue_url = self.approval_issue_url.strip()
+        self.confirmation = self.confirmation.strip().lower()
+        self.expected_target_name = self.expected_target_name.strip()
+        normalized_domains: list[str] = []
+        for raw_domain in self.expected_domains:
+            domain = (
+                raw_domain.strip()
+                .lower()
+                .removeprefix("https://")
+                .removeprefix("http://")
+                .rstrip("/")
+            )
+            if not domain:
+                raise ValueError(
+                    "Odoo prelaunch rebuild policy expected_domains values must be non-empty"
+                )
+            if domain not in normalized_domains:
+                normalized_domains.append(domain)
+        self.expected_domains = tuple(normalized_domains)
+        if self.enabled:
+            if not self.approval_issue_url:
+                raise ValueError(
+                    "enabled Odoo prelaunch rebuild policy requires approval_issue_url"
+                )
+            if not self.confirmation:
+                raise ValueError("enabled Odoo prelaunch rebuild policy requires confirmation")
+            if not self.expected_target_name:
+                raise ValueError(
+                    "enabled Odoo prelaunch rebuild policy requires expected_target_name"
+                )
+            if not self.expected_domains:
+                raise ValueError(
+                    "enabled Odoo prelaunch rebuild policy requires expected_domains"
+                )
+        return self
+
+
 class ProductLaneProfile(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -77,6 +126,9 @@ class ProductLaneProfile(BaseModel):
     health_url: str = ""
     odoo_stable_bootstrap: ProductOdooStableBootstrapPolicy = Field(
         default_factory=ProductOdooStableBootstrapPolicy
+    )
+    odoo_prelaunch_rebuild: ProductOdooPrelaunchRebuildPolicy = Field(
+        default_factory=ProductOdooPrelaunchRebuildPolicy
     )
 
     @model_validator(mode="after")

--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -67,11 +67,14 @@ class OdooStableTargetReplacementRequest(BaseModel):
     instance: str
     strategy: Literal["recreate-in-place", "replace-and-cutover"] = "recreate-in-place"
     allow_empty_data: bool = False
+    data_source_mode: Literal["existing", "empty", "upstream_restore"] = "existing"
+    confirmation: str = ""
 
     @model_validator(mode="after")
     def _validate_request(self) -> "OdooStableTargetReplacementRequest":
         self.product = self.product.strip()
         self.instance = self.instance.strip().lower()
+        self.confirmation = self.confirmation.strip().lower()
         if not self.product:
             raise ValueError("Odoo stable target replacement requires product.")
         if not self.instance:
@@ -123,6 +126,9 @@ class OdooStableTargetReplacementPlan(BaseModel):
     expected_domain_hosts: tuple[str, ...] = ()
     expected_artifact_id: str = ""
     expected_source_git_ref: str = ""
+    allow_empty_data: bool = False
+    data_source_mode: Literal["existing", "empty", "upstream_restore"] = "existing"
+    approval_issue_url: str = ""
     blockers: tuple[str, ...] = ()
     warnings: tuple[str, ...] = ()
     steps: tuple[OdooStableTargetReplacementStep, ...] = ()
@@ -378,6 +384,51 @@ def _verify_logo_route(*, base_url: str, timeout_seconds: int) -> None:
         raise click.ClickException(f"Logo check {logo_url} returned an HTML 404 body.")
 
 
+def _normalize_domain(raw_domain: str) -> str:
+    return raw_domain.strip().lower().removeprefix("https://").removeprefix("http://").rstrip("/")
+
+
+def _assert_prelaunch_rebuild_policy_allows_request(
+    *,
+    request: OdooStableTargetReplacementRequest,
+    lane: ProductLaneProfile,
+    target_record: DokployTargetRecord,
+) -> str:
+    if request.data_source_mode == "existing":
+        return ""
+    policy = lane.odoo_prelaunch_rebuild
+    if not policy.enabled:
+        raise click.ClickException(
+            f"Odoo prelaunch rebuild is not enabled for {request.product} {lane.context}/{lane.instance}."
+        )
+    if policy.data_source_mode != request.data_source_mode:
+        raise click.ClickException(
+            "Odoo prelaunch rebuild data source mode mismatch: "
+            f"request={request.data_source_mode!r} policy={policy.data_source_mode!r}."
+        )
+    if request.confirmation != policy.confirmation:
+        raise click.ClickException(
+            f"Odoo prelaunch rebuild requires confirmation {policy.confirmation!r}."
+        )
+    if target_record.target_name != policy.expected_target_name:
+        raise click.ClickException(
+            "Odoo prelaunch rebuild target proof failed: expected target "
+            f"{policy.expected_target_name!r}, observed {target_record.target_name!r}."
+        )
+    target_domains = {
+        _normalize_domain(domain) for domain in target_record.domains if domain.strip()
+    }
+    missing_domains = tuple(
+        domain for domain in policy.expected_domains if domain not in target_domains
+    )
+    if missing_domains:
+        raise click.ClickException(
+            "Odoo prelaunch rebuild target proof failed: missing expected domain(s) "
+            + ", ".join(missing_domains)
+        )
+    return policy.approval_issue_url
+
+
 def _build_ship_request(
     *,
     plan: OdooStableTargetReplacementPlan,
@@ -595,6 +646,20 @@ def build_odoo_stable_target_replacement_plan(
         warnings.append("Launchplane has no current environment inventory for this lane.")
     if isinstance(target_record, DokployTargetRecord) and target_record.target_type != "compose":
         blockers.append("Odoo stable replacement currently requires a compose target.")
+    approval_issue_url = ""
+    if isinstance(target_record, DokployTargetRecord):
+        try:
+            approval_issue_url = _assert_prelaunch_rebuild_policy_allows_request(
+                request=request,
+                lane=lane,
+                target_record=target_record,
+            )
+        except click.ClickException as error:
+            blockers.append(str(error))
+    if request.data_source_mode != "existing" and not request.allow_empty_data:
+        blockers.append(
+            "Odoo prelaunch rebuild requests must explicitly set allow_empty_data."
+        )
     if isinstance(target_record, DokployTargetRecord) and isinstance(
         target_id_record, DokployTargetIdRecord
     ):
@@ -644,6 +709,9 @@ def build_odoo_stable_target_replacement_plan(
         expected_domain_hosts=current_target.domain_hosts if current_target else (),
         expected_artifact_id=expected_artifact_id,
         expected_source_git_ref=expected_source_git_ref,
+        allow_empty_data=request.allow_empty_data,
+        data_source_mode=request.data_source_mode,
+        approval_issue_url=approval_issue_url,
         blockers=blockers_tuple,
         warnings=tuple(warnings),
         steps=_build_steps(
@@ -669,6 +737,8 @@ def execute_odoo_stable_target_replacement_apply(
             instance=request.instance,
             strategy=request.strategy,
             allow_empty_data=request.allow_empty_data,
+            data_source_mode=request.data_source_mode,
+            confirmation=request.confirmation,
         ),
         dokploy_request=dokploy_request,
     )

--- a/control_plane/workflows/product_onboarding.py
+++ b/control_plane/workflows/product_onboarding.py
@@ -61,6 +61,7 @@ def build_product_profile_record(
                 context=lane.context,
                 base_url=lane.base_url,
                 health_url=lane.health_url or _health_url(lane.base_url, manifest.health_path),
+                odoo_stable_bootstrap=lane.odoo_stable_bootstrap,
             )
             for lane in manifest.lanes
         ),

--- a/control_plane/workflows/product_onboarding.py
+++ b/control_plane/workflows/product_onboarding.py
@@ -62,6 +62,7 @@ def build_product_profile_record(
                 base_url=lane.base_url,
                 health_url=lane.health_url or _health_url(lane.base_url, manifest.health_path),
                 odoo_stable_bootstrap=lane.odoo_stable_bootstrap,
+                odoo_prelaunch_rebuild=lane.odoo_prelaunch_rebuild,
             )
             for lane in manifest.lanes
         ),

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -752,6 +752,15 @@ current deployment pointer and records the failed attempt in `bootstrap_record_i
 Do not use this path for prod until Launchplane has explicit backup/restore
 policy evidence for that lane.
 
+For OPW prelaunch lanes that should be rebuilt from the current upstream
+non-Docker source, encode `odoo_prelaunch_rebuild` on the product profile lane
+with `data_source_mode="upstream_restore"`, the approval issue URL, expected
+target name, expected domains, and the confirmation phrase. Target replacement
+plan/apply requests must set the matching `data_source_mode`, confirmation, and
+`allow_empty_data=true` before Launchplane treats absent Odoo data/log/database
+volume keys as intentional. Unknown lanes, mismatched target proof, missing issue
+approval, or plain `prod` names still fail closed.
+
 `launchplane-previews write-from-generation` and `launchplane-previews write-destroyed`
 are local preview-evidence ingest adapters that mirror the service ingress
 payload shape. Generic-web, Odoo, and VeriReel preview runtime now flow through

--- a/docs/records.md
+++ b/docs/records.md
@@ -231,6 +231,16 @@ implementation signal, not a launch tracker: close it when the policy is encoded
 and keep launch/cutover retirement in a separate issue or explicit expiration
 record.
 
+Odoo prelaunch rebuild eligibility is also lane-owned product-profile data. A
+lane's `odoo_prelaunch_rebuild` policy defaults to disabled and must explicitly
+carry an issue-backed approval URL, confirmation phrase, data source mode,
+expected Dokploy target name, and expected domains. The initial data source
+modes are `empty` and `upstream_restore`. Target replacement plan/apply requests
+that set a prelaunch data source must match this policy before Launchplane will
+treat missing Odoo volume keys as intentional. This keeps provisional lanes such
+as OPW testing/prod auditable without making environment names like `prod`
+destructive authority by themselves.
+
 This file layout describes today's local Launchplane implementation, not the
 final cross-product communication boundary. The stable long-term contract should
 be Launchplane's authenticated service ingress plus the durable record semantics

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -208,10 +208,12 @@ apply_odoo_cm_onboarding() {
   local idempotency_suffix="odoo-cm-preview-profile"
   local request_payload response_file status_code
   local target_id="${ODOO_CM_TESTING_DOKPLOY_TARGET_ID:-}"
+  local prod_target_id="${ODOO_CM_PROD_DOKPLOY_TARGET_ID:-}"
 
   request_payload="$({
     jq -n \
       --arg target_id "$target_id" \
+      --arg prod_target_id "$prod_target_id" \
       '{
         schema_version: 1,
         product: "launchplane",
@@ -226,7 +228,33 @@ apply_odoo_cm_onboarding() {
           lanes: [
             {
               instance: "testing",
-              context: "cm"
+              context: "cm",
+              odoo_stable_bootstrap: {
+                enabled: true,
+                approval_issue_url: "https://github.com/cbusillo/launchplane/issues/573",
+                data_source_mode: "empty",
+                confirmation: "bootstrap cm testing",
+                expected_target_name: "cm-testing",
+                expected_domains: ["cm-testing.shinycomputers.com"],
+                require_health_verification: true,
+                require_canonical_verification: true,
+                require_logo_verification: true
+              }
+            },
+            {
+              instance: "prod",
+              context: "cm",
+              odoo_stable_bootstrap: {
+                enabled: true,
+                approval_issue_url: "https://github.com/cbusillo/launchplane/issues/573",
+                data_source_mode: "empty",
+                confirmation: "bootstrap cm prod",
+                expected_target_name: "cm-prod",
+                expected_domains: ["cellmechanic.com"],
+                require_health_verification: true,
+                require_canonical_verification: true,
+                require_logo_verification: true
+              }
             }
           ],
           preview: {
@@ -243,20 +271,34 @@ apply_odoo_cm_onboarding() {
             data_transport_mode: "bootstrap"
           },
           dokploy_targets: (
-            if ($target_id | length) > 0 then
+            (if ($target_id | length) > 0 then
               [
                 {
                   context: "cm",
                   instance: "testing",
                   target_id: $target_id,
-                  target_type: "application",
+                  target_type: "compose",
                   target_name: "cm-testing",
                   healthcheck_path: "/web/health",
                   healthcheck_enabled: true,
                   deploy_timeout_seconds: 900
                 }
               ]
-            else [] end
+            else [] end) +
+            (if ($prod_target_id | length) > 0 then
+              [
+                {
+                  context: "cm",
+                  instance: "prod",
+                  target_id: $prod_target_id,
+                  target_type: "compose",
+                  target_name: "cm-prod",
+                  healthcheck_path: "/web/health",
+                  healthcheck_enabled: true,
+                  deploy_timeout_seconds: 900
+                }
+              ]
+            else [] end)
           ),
           source_label: "deploy:odoo-cm-product-onboarding"
         }

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -323,6 +323,106 @@ apply_odoo_cm_onboarding() {
   return 1
 }
 
+apply_odoo_opw_onboarding() {
+  local idempotency_suffix="odoo-opw-prelaunch-profile"
+  local request_payload response_file status_code
+  local testing_target_id="${ODOO_OPW_TESTING_DOKPLOY_TARGET_ID:-}"
+  local prod_target_id="${ODOO_OPW_PROD_DOKPLOY_TARGET_ID:-}"
+
+  request_payload="$({
+    jq -n \
+      --arg testing_target_id "$testing_target_id" \
+      --arg prod_target_id "$prod_target_id" \
+      '{
+        schema_version: 1,
+        product: "launchplane",
+        manifest: {
+          product: "odoo-tenant-opw",
+          display_name: "Odoo OPW",
+          repository: "cbusillo/odoo-tenant-opw",
+          driver_id: "odoo",
+          image_repository: "ghcr.io/cbusillo/odoo-tenant-opw",
+          runtime_port: 8069,
+          health_path: "/web/health",
+          lanes: [
+            {
+              instance: "testing",
+              context: "opw",
+              odoo_prelaunch_rebuild: {
+                enabled: true,
+                approval_issue_url: "https://github.com/cbusillo/launchplane/issues/573",
+                data_source_mode: "upstream_restore",
+                confirmation: "restore opw upstream",
+                expected_target_name: "opw-testing",
+                expected_domains: ["opw-testing.shinycomputers.com"]
+              }
+            },
+            {
+              instance: "prod",
+              context: "opw",
+              odoo_prelaunch_rebuild: {
+                enabled: true,
+                approval_issue_url: "https://github.com/cbusillo/launchplane/issues/573",
+                data_source_mode: "upstream_restore",
+                confirmation: "restore opw upstream",
+                expected_target_name: "opw-prod",
+                expected_domains: ["openwater.pro"]
+              }
+            }
+          ],
+          dokploy_targets: (
+            (if ($testing_target_id | length) > 0 then
+              [
+                {
+                  context: "opw",
+                  instance: "testing",
+                  target_id: $testing_target_id,
+                  target_type: "compose",
+                  target_name: "opw-testing",
+                  healthcheck_path: "/web/health",
+                  healthcheck_enabled: true,
+                  deploy_timeout_seconds: 900
+                }
+              ]
+            else [] end) +
+            (if ($prod_target_id | length) > 0 then
+              [
+                {
+                  context: "opw",
+                  instance: "prod",
+                  target_id: $prod_target_id,
+                  target_type: "compose",
+                  target_name: "opw-prod",
+                  healthcheck_path: "/web/health",
+                  healthcheck_enabled: true,
+                  deploy_timeout_seconds: 900
+                }
+              ]
+            else [] end)
+          ),
+          source_label: "deploy:odoo-opw-product-onboarding"
+        }
+      }'
+  })"
+  response_file="$(mktemp)"
+  status_code="$(curl -sS \
+    -o "$response_file" \
+    -w '%{http_code}' \
+    -X POST \
+    -H "Authorization: Bearer ${oidc_token}" \
+    -H 'Content-Type: application/json' \
+    -H "Idempotency-Key: launchplane-product-onboarding:${idempotency_suffix}:${testing_target_id}:${prod_target_id}:${GITHUB_SHA}" \
+    --data "$request_payload" \
+    "${LAUNCHPLANE_SERVICE_URL}/v1/product-onboarding/apply")"
+  if [ "$status_code" = "200" ] || [ "$status_code" = "202" ]; then
+    cat "$response_file"
+    return 0
+  fi
+  cat "$response_file" >&2
+  echo "Launchplane Odoo OPW product onboarding request failed with HTTP ${status_code}." >&2
+  return 1
+}
+
 apply_runtime_key_safety_policy() {
   local idempotency_suffix="$1"
   local request_payload response_file status_code
@@ -559,6 +659,7 @@ post_odoo_cm_preview_grant() {
 apply_product_onboarding \
   discord-blue
 apply_odoo_cm_onboarding
+apply_odoo_opw_onboarding
 post_grant \
   cbusillo/discord-blue \
   main.yml \
@@ -678,12 +779,28 @@ post_grant \
   odoo-cm-target-replacement-plan
 post_grant \
   "$GITHUB_REPOSITORY" \
+  odoo-target-replacement-plan.yml \
+  odoo-tenant-opw \
+  opw \
+  odoo_target_replacement_plan.read \
+  deploy:odoo-opw-target-replacement-plan-grant \
+  odoo-opw-target-replacement-plan
+post_grant \
+  "$GITHUB_REPOSITORY" \
   odoo-target-replacement-apply.yml \
   odoo-tenant-cm \
   cm \
   odoo_target_replacement_apply.execute \
   deploy:odoo-cm-target-replacement-apply-grant \
   odoo-cm-target-replacement-apply
+post_grant \
+  "$GITHUB_REPOSITORY" \
+  odoo-target-replacement-apply.yml \
+  odoo-tenant-opw \
+  opw \
+  odoo_target_replacement_apply.execute \
+  deploy:odoo-opw-target-replacement-apply-grant \
+  odoo-opw-target-replacement-apply
 post_grant \
   "$GITHUB_REPOSITORY" \
   odoo-config-parameter-override.yml \

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -18,6 +18,7 @@ from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductImageProfile,
     ProductLaneProfile,
+    ProductOdooPrelaunchRebuildPolicy,
     ProductPreviewProfile,
 )
 from control_plane.contracts.promotion_record import (
@@ -111,6 +112,36 @@ def _profile(driver_id: str = "odoo") -> LaunchplaneProductProfileRecord:
     )
 
 
+def _opw_profile_with_prelaunch_policy(*, enabled: bool) -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord(
+        product="odoo-tenant-opw",
+        display_name="Odoo OPW",
+        repository="cbusillo/odoo-tenant-opw",
+        driver_id="odoo",
+        image=ProductImageProfile(repository="ghcr.io/cbusillo/odoo-tenant-opw"),
+        runtime_port=8069,
+        health_path="/web/health",
+        lanes=(
+            ProductLaneProfile(
+                instance="prod",
+                context="opw",
+                odoo_prelaunch_rebuild=ProductOdooPrelaunchRebuildPolicy(
+                    enabled=enabled,
+                    approval_issue_url="https://github.com/cbusillo/launchplane/issues/573"
+                    if enabled
+                    else "",
+                    data_source_mode="upstream_restore",
+                    confirmation="restore opw upstream" if enabled else "",
+                    expected_target_name="opw-prod" if enabled else "",
+                    expected_domains=("openwater.pro",) if enabled else (),
+                ),
+            ),
+        ),
+        updated_at="2026-05-10T00:00:00Z",
+        source="test",
+    )
+
+
 def _target_record(target_type: str = "compose") -> DokployTargetRecord:
     return DokployTargetRecord(
         context="cm",
@@ -120,6 +151,27 @@ def _target_record(target_type: str = "compose") -> DokployTargetRecord:
         target_name="cm-testing",
         domains=("cm-testing.shinycomputers.com",),
         updated_at="2026-05-09T00:00:00Z",
+    )
+
+
+def _opw_target_record() -> DokployTargetRecord:
+    return DokployTargetRecord(
+        context="opw",
+        instance="prod",
+        project_name="odoo",
+        target_type="compose",
+        target_name="opw-prod",
+        domains=("openwater.pro",),
+        updated_at="2026-05-10T00:00:00Z",
+    )
+
+
+def _opw_target_id_record() -> DokployTargetIdRecord:
+    return DokployTargetIdRecord(
+        context="opw",
+        instance="prod",
+        target_id="compose-opw-prod",
+        updated_at="2026-05-10T00:00:00Z",
     )
 
 
@@ -170,10 +222,99 @@ def _artifact_manifest(
 def _request(path: str, query: object | None = None, **_: object) -> JsonValue:
     if path == "/api/domain.byComposeId" and query == {"composeId": "compose-cm-testing"}:
         return [{"host": "cm-testing.shinycomputers.com", "domainId": "domain-cm"}]
+    if path == "/api/domain.byComposeId" and query == {"composeId": "compose-opw-prod"}:
+        return [{"host": "openwater.pro", "domainId": "domain-opw"}]
     return []
 
 
 class OdooStableTargetReplacementTests(unittest.TestCase):
+    def test_build_plan_allows_issue_backed_opw_upstream_restore_policy(self) -> None:
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.read_dokploy_config",
+                return_value=("host", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "name": "opw-prod",
+                    "sourceType": "raw",
+                    "composePath": "docker-compose.yml",
+                    "composeFile": "services: {}",
+                    "env": "",
+                },
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.latest_deployment_for_target",
+                return_value={"deploymentId": "deploy-opw", "status": "success"},
+            ),
+        ):
+            plan = build_odoo_stable_target_replacement_plan(
+                control_plane_root=Path("."),
+                record_store=_Store(
+                    profile=_opw_profile_with_prelaunch_policy(enabled=True),
+                    target_record=_opw_target_record(),
+                    target_id_record=_opw_target_id_record(),
+                ),
+                request=OdooStableTargetReplacementRequest(
+                    product="odoo-tenant-opw",
+                    instance="prod",
+                    allow_empty_data=True,
+                    data_source_mode="upstream_restore",
+                    confirmation="restore opw upstream",
+                ),
+                dokploy_request=cast(DokployRequest, _request),
+            )
+
+        self.assertEqual(plan.plan_status, "ready")
+        self.assertTrue(plan.allow_empty_data)
+        self.assertEqual(plan.data_source_mode, "upstream_restore")
+        self.assertEqual(
+            plan.approval_issue_url,
+            "https://github.com/cbusillo/launchplane/issues/573",
+        )
+
+    def test_build_plan_blocks_upstream_restore_without_issue_backed_policy(self) -> None:
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.read_dokploy_config",
+                return_value=("host", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "name": "opw-prod",
+                    "sourceType": "raw",
+                    "composePath": "docker-compose.yml",
+                    "composeFile": "services: {}",
+                    "env": "",
+                },
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.latest_deployment_for_target",
+                return_value={"deploymentId": "deploy-opw", "status": "success"},
+            ),
+        ):
+            plan = build_odoo_stable_target_replacement_plan(
+                control_plane_root=Path("."),
+                record_store=_Store(
+                    profile=_opw_profile_with_prelaunch_policy(enabled=False),
+                    target_record=_opw_target_record(),
+                    target_id_record=_opw_target_id_record(),
+                ),
+                request=OdooStableTargetReplacementRequest(
+                    product="odoo-tenant-opw",
+                    instance="prod",
+                    allow_empty_data=True,
+                    data_source_mode="upstream_restore",
+                    confirmation="restore opw upstream",
+                ),
+                dokploy_request=cast(DokployRequest, _request),
+            )
+
+        self.assertEqual(plan.plan_status, "blocked")
+        self.assertIn("prelaunch rebuild is not enabled", "; ".join(plan.blockers))
+
     def test_build_plan_reports_ready_when_records_and_volume_contract_exist(self) -> None:
         identity = json.dumps(
             {"deployment_record_id": "deployment-cm-testing", "artifact_id": "artifact"}

--- a/tests/test_product_environment_read_model.py
+++ b/tests/test_product_environment_read_model.py
@@ -49,6 +49,14 @@ def _site_profile_payload(
                 "context": prod_context,
                 "base_url": f"https://{product}.example",
                 "health_url": f"https://{product}.example/healthz",
+                "odoo_prelaunch_rebuild": {
+                    "enabled": True,
+                    "approval_issue_url": "https://github.com/cbusillo/launchplane/issues/573",
+                    "data_source_mode": "upstream_restore",
+                    "confirmation": "restore opw upstream",
+                    "expected_target_name": f"{product}-prod",
+                    "expected_domains": [f"{product}.example"],
+                },
             },
         ),
         "preview": {
@@ -652,6 +660,37 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
 
         self.assertEqual(detail.managed_secrets[0].status, "disabled")
         self.assertEqual(detail.managed_secrets[0].trust_state, "disabled")
+
+    def test_product_read_model_exposes_prelaunch_rebuild_policy(self) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(
+            _site_profile_payload(product="odoo-tenant-opw", preview_enabled=False)
+        )
+        store = _PreviewRecordStore(profile, ())
+
+        overview = build_product_site_overview(
+            record_store=store,
+            product="odoo-tenant-opw",
+            action_allowed=lambda *_: False,
+        )
+        detail = build_product_environment_detail(
+            record_store=store,
+            product="odoo-tenant-opw",
+            environment="prod",
+            action_allowed=lambda *_: False,
+        )
+
+        prod_summary = {summary.environment: summary for summary in overview.environments}["prod"]
+        self.assertTrue(prod_summary.prelaunch_rebuild_allowed)
+        self.assertEqual(
+            prod_summary.prelaunch_rebuild_data_source_mode,
+            "upstream_restore",
+        )
+        self.assertEqual(
+            prod_summary.prelaunch_rebuild_approval_issue_url,
+            "https://github.com/cbusillo/launchplane/issues/573",
+        )
+        self.assertTrue(detail.prelaunch_rebuild_allowed)
+        self.assertEqual(detail.prelaunch_rebuild_data_source_mode, "upstream_restore")
 
     def test_product_environment_config_status_reports_expected_key_states(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -45,6 +45,14 @@ def _manifest_payload() -> dict[str, object]:
                 "context": "example-site-prod",
                 "base_url": "https://example.invalid",
                 "health_url": "https://example.invalid/status",
+                "odoo_prelaunch_rebuild": {
+                    "enabled": True,
+                    "approval_issue_url": "https://github.com/cbusillo/launchplane/issues/573",
+                    "data_source_mode": "upstream_restore",
+                    "confirmation": "restore example upstream",
+                    "expected_target_name": "example-site-prod",
+                    "expected_domains": ["example.invalid"],
+                },
             },
         ],
         "preview": {
@@ -226,6 +234,104 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             ],
         )
 
+    def test_deploy_odoo_opw_onboarding_manifest_encodes_upstream_restore_policy(
+        self,
+    ) -> None:
+        script_path = Path("scripts/deploy/ensure-authz-grants.sh")
+        extractor = """
+set -euo pipefail
+PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
+"""
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            captured_bin_directory = temporary_directory / "bin"
+            captured_bin_directory.mkdir()
+            (captured_bin_directory / "curl").write_text(
+                "#!/usr/bin/env bash\n"
+                "case \"$*\" in\n"
+                "  *github.invalid/oidc*) printf '{\"value\":\"oidc-token\"}' ;;\n"
+                "  *)\n"
+                "    idempotency_key=''\n"
+                "    output_file=''\n"
+                "    request_payload=''\n"
+                "    while [ \"$#\" -gt 0 ]; do\n"
+                "      case \"$1\" in\n"
+                "        -o) shift; output_file=\"$1\" ;;\n"
+                "        -H)\n"
+                "          shift\n"
+                "          case \"$1\" in\n"
+                "            Idempotency-Key:*) idempotency_key=\"$1\" ;;\n"
+                "          esac\n"
+                "          ;;\n"
+                "        --data) shift; request_payload=\"$1\" ;;\n"
+                "      esac\n"
+                "      shift || true\n"
+                "    done\n"
+                "    case \"$idempotency_key\" in\n"
+                "      *launchplane-product-onboarding:odoo-opw-prelaunch-profile*)\n"
+                "        printf '%s' \"$request_payload\" > \"$CAPTURED_REQUEST_PAYLOAD\"\n"
+                "        ;;\n"
+                "    esac\n"
+                "    if [ -n \"$output_file\" ]; then\n"
+                "      printf '{\"status\":\"ok\"}' > \"$output_file\"\n"
+                "    fi\n"
+                "    printf '200'\n"
+                "    ;;\n"
+                "esac\n"
+            )
+            (captured_bin_directory / "mktemp").write_text(
+                "#!/usr/bin/env bash\n"
+                "printf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
+            )
+            (captured_bin_directory / "curl").chmod(0o755)
+            (captured_bin_directory / "mktemp").chmod(0o755)
+            captured_request_payload = temporary_directory / "request.json"
+            captured_response_file = temporary_directory / "response.json"
+            env = {
+                **os.environ,
+                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
+                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://github.invalid/oidc",
+                "GITHUB_REPOSITORY": "cbusillo/launchplane",
+                "GITHUB_SHA": "test-sha",
+                "LAUNCHPLANE_SERVICE_AUDIENCE": "launchplane-service",
+                "LAUNCHPLANE_SERVICE_URL": "https://launchplane.example.invalid",
+                "DISCORD_BLUE_DOKPLOY_TARGET_ID": "app-discord-blue",
+                "ODOO_CM_TESTING_DOKPLOY_TARGET_ID": "compose-cm-testing",
+                "ODOO_CM_PROD_DOKPLOY_TARGET_ID": "compose-cm-prod",
+                "ODOO_OPW_TESTING_DOKPLOY_TARGET_ID": "compose-opw-testing",
+                "ODOO_OPW_PROD_DOKPLOY_TARGET_ID": "compose-opw-prod",
+                "CAPTURED_REQUEST_PAYLOAD": str(captured_request_payload),
+                "CAPTURED_RESPONSE_FILE": str(captured_response_file),
+                "CAPTURED_BIN_DIR": str(captured_bin_directory),
+            }
+
+            result = subprocess.run(
+                ["bash", "-c", extractor],
+                check=False,
+                cwd=script_path.parent.parent.parent,
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            request_payload = json.loads(captured_request_payload.read_text())
+
+        manifest = ProductOnboardingManifest.model_validate(request_payload["manifest"])
+
+        self.assertEqual(manifest.product, "odoo-tenant-opw")
+        policies = {lane.instance: lane.odoo_prelaunch_rebuild for lane in manifest.lanes}
+        for instance in ("testing", "prod"):
+            self.assertTrue(policies[instance].enabled)
+            self.assertEqual(policies[instance].data_source_mode, "upstream_restore")
+            self.assertEqual(policies[instance].confirmation, "restore opw upstream")
+            self.assertEqual(
+                policies[instance].approval_issue_url,
+                "https://github.com/cbusillo/launchplane/issues/573",
+            )
+        self.assertEqual(policies["testing"].expected_target_name, "opw-testing")
+        self.assertEqual(policies["prod"].expected_target_name, "opw-prod")
+
     def test_apply_product_onboarding_manifest_writes_canonical_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(
@@ -264,6 +370,11 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             "bootstrap example testing",
         )
         self.assertEqual(profile.lanes[1].health_url, "https://example.invalid/status")
+        self.assertTrue(profile.lanes[1].odoo_prelaunch_rebuild.enabled)
+        self.assertEqual(
+            profile.lanes[1].odoo_prelaunch_rebuild.data_source_mode,
+            "upstream_restore",
+        )
         self.assertEqual(profile.preview.enable_label, "preview-requested")
         self.assertEqual(profile.expected_config.runtime_environment_keys[0].key, "PUBLIC_BASE_URL")
         self.assertEqual(

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1,6 +1,9 @@
 import json
+import os
 from pathlib import Path
+import subprocess
 from tempfile import TemporaryDirectory
+from typing import cast
 import unittest
 
 from click.testing import CliRunner
@@ -29,6 +32,13 @@ def _manifest_payload() -> dict[str, object]:
                 "instance": "testing",
                 "context": "example-site-testing",
                 "base_url": "https://testing.example.invalid",
+                "odoo_stable_bootstrap": {
+                    "enabled": True,
+                    "approval_issue_url": "https://github.com/cbusillo/launchplane/issues/573",
+                    "confirmation": "bootstrap example testing",
+                    "expected_target_name": "example-site-testing",
+                    "expected_domains": ["testing.example.invalid"],
+                },
             },
             {
                 "instance": "prod",
@@ -99,6 +109,123 @@ def _manifest_payload() -> dict[str, object]:
 
 
 class ProductOnboardingTests(unittest.TestCase):
+    def test_deploy_odoo_cm_onboarding_manifest_encodes_issue_backed_bootstrap_policy(
+        self,
+    ) -> None:
+        script_path = Path("scripts/deploy/ensure-authz-grants.sh")
+        extractor = """
+set -euo pipefail
+PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
+"""
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            captured_bin_directory = temporary_directory / "bin"
+            captured_bin_directory.mkdir()
+            (captured_bin_directory / "curl").write_text(
+                "#!/usr/bin/env bash\n"
+                "case \"$*\" in\n"
+                "  *github.invalid/oidc*) printf '{\"value\":\"oidc-token\"}' ;;\n"
+                "  *)\n"
+                "    idempotency_key=''\n"
+                "    output_file=''\n"
+                "    request_payload=''\n"
+                "    while [ \"$#\" -gt 0 ]; do\n"
+                "      case \"$1\" in\n"
+                "        -o)\n"
+                "          shift\n"
+                "          output_file=\"$1\"\n"
+                "          ;;\n"
+                "        -H)\n"
+                "          shift\n"
+                "          case \"$1\" in\n"
+                "            Idempotency-Key:*) idempotency_key=\"$1\" ;;\n"
+                "          esac\n"
+                "          ;;\n"
+                "        --data)\n"
+                "          shift\n"
+                "          request_payload=\"$1\"\n"
+                "          ;;\n"
+                "      esac\n"
+                "      shift || true\n"
+                "    done\n"
+                "    case \"$idempotency_key\" in\n"
+                "      *launchplane-product-onboarding:odoo-cm-preview-profile*)\n"
+                "        printf '%s' \"$request_payload\" > \"$CAPTURED_REQUEST_PAYLOAD\"\n"
+                "        ;;\n"
+                "    esac\n"
+                "    if [ -n \"$output_file\" ]; then\n"
+                "      printf '{\"status\":\"ok\"}' > \"$output_file\"\n"
+                "    fi\n"
+                "    printf '200'\n"
+                "    ;;\n"
+                "esac\n"
+            )
+            (captured_bin_directory / "mktemp").write_text(
+                "#!/usr/bin/env bash\n"
+                "printf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
+            )
+            (captured_bin_directory / "curl").chmod(0o755)
+            (captured_bin_directory / "mktemp").chmod(0o755)
+            captured_curl_args = temporary_directory / "curl-args.txt"
+            captured_response_file = temporary_directory / "response.json"
+            env = {
+                **os.environ,
+                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
+                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://github.invalid/oidc",
+                "GITHUB_REPOSITORY": "cbusillo/launchplane",
+                "GITHUB_SHA": "test-sha",
+                "LAUNCHPLANE_SERVICE_AUDIENCE": "launchplane-service",
+                "LAUNCHPLANE_SERVICE_URL": "https://launchplane.example.invalid",
+                "DISCORD_BLUE_DOKPLOY_TARGET_ID": "app-discord-blue",
+                "ODOO_CM_TESTING_DOKPLOY_TARGET_ID": "compose-cm-testing",
+                "ODOO_CM_PROD_DOKPLOY_TARGET_ID": "compose-cm-prod",
+                "CAPTURED_REQUEST_PAYLOAD": str(captured_curl_args),
+                "CAPTURED_RESPONSE_FILE": str(captured_response_file),
+                "CAPTURED_BIN_DIR": str(captured_bin_directory),
+            }
+
+            result = subprocess.run(
+                ["bash", "-c", extractor],
+                check=False,
+                cwd=script_path.parent.parent.parent,
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            request_payload = json.loads(captured_curl_args.read_text())
+
+        manifest = ProductOnboardingManifest.model_validate(request_payload["manifest"])
+
+        self.assertEqual(manifest.product, "odoo-tenant-cm")
+        self.assertEqual([lane.instance for lane in manifest.lanes], ["testing", "prod"])
+        policies = {lane.instance: lane.odoo_stable_bootstrap for lane in manifest.lanes}
+        self.assertEqual(
+            policies["testing"].approval_issue_url,
+            "https://github.com/cbusillo/launchplane/issues/573",
+        )
+        self.assertEqual(policies["testing"].confirmation, "bootstrap cm testing")
+        self.assertEqual(policies["testing"].expected_target_name, "cm-testing")
+        self.assertEqual(policies["testing"].expected_domains, ("cm-testing.shinycomputers.com",))
+        self.assertEqual(
+            policies["prod"].approval_issue_url,
+            "https://github.com/cbusillo/launchplane/issues/573",
+        )
+        self.assertEqual(policies["prod"].confirmation, "bootstrap cm prod")
+        self.assertEqual(policies["prod"].expected_target_name, "cm-prod")
+        self.assertEqual(policies["prod"].expected_domains, ("cellmechanic.com",))
+        self.assertEqual(
+            [
+                (target.context, target.instance, target.target_type, target.target_id)
+                for target in manifest.dokploy_targets
+            ],
+            [
+                ("cm", "testing", "compose", "compose-cm-testing"),
+                ("cm", "prod", "compose", "compose-cm-prod"),
+            ],
+        )
+
     def test_apply_product_onboarding_manifest_writes_canonical_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(
@@ -127,6 +254,15 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertEqual(second_result.product_profile.updated_at, "2026-05-03T01:30:00Z")
         self.assertEqual(profile.driver_id, "generic-web")
         self.assertEqual(profile.lanes[0].health_url, "https://testing.example.invalid/api/health")
+        self.assertTrue(profile.lanes[0].odoo_stable_bootstrap.enabled)
+        self.assertEqual(
+            profile.lanes[0].odoo_stable_bootstrap.approval_issue_url,
+            "https://github.com/cbusillo/launchplane/issues/573",
+        )
+        self.assertEqual(
+            profile.lanes[0].odoo_stable_bootstrap.confirmation,
+            "bootstrap example testing",
+        )
         self.assertEqual(profile.lanes[1].health_url, "https://example.invalid/status")
         self.assertEqual(profile.preview.enable_label, "preview-requested")
         self.assertEqual(profile.expected_config.runtime_environment_keys[0].key, "PUBLIC_BASE_URL")
@@ -167,6 +303,22 @@ class ProductOnboardingTests(unittest.TestCase):
         ]
 
         with self.assertRaisesRegex(ValueError, "target requires target_id"):
+            ProductOnboardingManifest.model_validate(payload)
+
+    def test_product_onboarding_manifest_rejects_enabled_bootstrap_without_issue(
+        self,
+    ) -> None:
+        payload = _manifest_payload()
+        lanes = cast(list[dict[str, object]], payload["lanes"])
+        first_lane = lanes[0]
+        first_lane["odoo_stable_bootstrap"] = {
+            "enabled": True,
+            "confirmation": "bootstrap example testing",
+            "expected_target_name": "example-site-testing",
+            "expected_domains": ["testing.example.invalid"],
+        }
+
+        with self.assertRaisesRegex(ValueError, "approval_issue_url"):
             ProductOnboardingManifest.model_validate(payload)
 
     def test_product_onboarding_manifest_rejects_duplicate_expected_config_keys(


### PR DESCRIPTION
## Summary
- let product onboarding lane manifests carry issue-backed Odoo rebuild policy into product profile records
- encode issue #573 approval on CM testing/prod empty-bootstrap lanes and OPW testing/prod upstream-restore prelaunch lanes
- require target replacement prelaunch rebuild requests to match lane policy before `allow_empty_data` is treated as intentional
- expose the prelaunch rebuild policy in product environment read models and update replacement workflows to carry data-source/confirmation inputs

## Tests
- `uv run python -m unittest tests.test_product_onboarding tests.test_product_environment_read_model tests.test_odoo_stable_target_replacement tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_plan_driver_reads_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_apply_driver_runs_for_authorized_workflow tests.test_postgres_store.PostgresRecordStoreTests.test_product_profile_records_round_trip`
- `uv run --extra dev ruff check --diff control_plane/contracts/product_profile_record.py control_plane/contracts/product_onboarding_manifest.py control_plane/workflows/product_onboarding.py control_plane/workflows/odoo_stable_target_replacement.py control_plane/contracts/product_environment_read_model.py control_plane/cli.py tests/test_product_onboarding.py tests/test_product_environment_read_model.py tests/test_odoo_stable_target_replacement.py`
- `uv run --extra dev ruff check control_plane/contracts/product_profile_record.py control_plane/contracts/product_onboarding_manifest.py control_plane/workflows/product_onboarding.py control_plane/workflows/odoo_stable_target_replacement.py control_plane/contracts/product_environment_read_model.py control_plane/cli.py tests/test_product_onboarding.py tests/test_product_environment_read_model.py tests/test_odoo_stable_target_replacement.py`
- `bash -n scripts/deploy/ensure-authz-grants.sh`
- `git diff --check`

## Notes
Refs #573. This now encodes both requested prelaunch policy families: CM empty bootstrap and OPW upstream restore. #573 can close after this lands and deploy-time onboarding records are applied.
