### PR TITLE
Record metadata validation evidence

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -86,7 +86,21 @@
     "cbusillo/odoo-tenant-cm",
     "cbusillo/odoo-tenant-opw"
   ],
-  "validatedThrough": [],
+  "validatedThrough": [
+    {
+      "date": "2026-05-10",
+      "source": "cbusillo/launchplane#575",
+      "checks": [
+        "jq empty .github/github.json",
+        "rg github-repo-workflow\\.json",
+        "codex-skills github-repo-snapshot.sh --json",
+        "GitHub Actions CI, Security, and CodeQL checks from config-path migration"
+      ],
+      "caveats": [
+        "Container/runtime deployment gates were not triggered for this metadata-only change."
+      ]
+    }
+  ],
   "githubSignals": {
     "postMerge": {
       "waitForActions": true,


### PR DESCRIPTION
## Summary
- add a compact `validatedThrough` evidence record to `.github/github.json`
- point the record at the config-path migration PR and checks used to validate the metadata
- keep runtime/deploy caveats explicit for gates not triggered by the metadata-only change

## Validation
- `jq` shape check for non-empty `validatedThrough`
- codex-skills `github-repo-snapshot.sh --json` confirms `.github/github.json` and non-empty `validatedThrough`
- `git diff --check`

Part of cbusillo/codex-skills#23.
