### PR TITLE
Align OPW prelaunch domain proof

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -764,6 +764,9 @@ plan/apply requests must set the matching `data_source_mode`, confirmation, and
 `allow_empty_data=true` before Launchplane treats absent Odoo data/log/database
 volume keys as intentional. Unknown lanes, mismatched target proof, missing issue
 approval, or plain `prod` names still fail closed.
+During OPW prelaunch, the prod proof follows the temporary Dokploy host
+`opw-prod.shinycomputers.com`; update the issue-backed policy to the final
+public hostname only after the live target actually exposes that domain.
 
 `launchplane-previews write-from-generation` and `launchplane-previews write-destroyed`
 are local preview-evidence ingest adapters that mirror the service ingress

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -366,7 +366,7 @@ apply_odoo_opw_onboarding() {
                 data_source_mode: "upstream_restore",
                 confirmation: "restore opw upstream",
                 expected_target_name: "opw-prod",
-                expected_domains: ["openwater.pro"]
+                expected_domains: ["opw-prod.shinycomputers.com"]
               }
             }
           ],

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -133,7 +133,7 @@ def _opw_profile_with_prelaunch_policy(*, enabled: bool) -> LaunchplaneProductPr
                     data_source_mode="upstream_restore",
                     confirmation="restore opw upstream" if enabled else "",
                     expected_target_name="opw-prod" if enabled else "",
-                    expected_domains=("openwater.pro",) if enabled else (),
+                    expected_domains=("opw-prod.shinycomputers.com",) if enabled else (),
                 ),
             ),
         ),
@@ -161,7 +161,7 @@ def _opw_target_record() -> DokployTargetRecord:
         project_name="odoo",
         target_type="compose",
         target_name="opw-prod",
-        domains=("openwater.pro",),
+        domains=("opw-prod.shinycomputers.com",),
         updated_at="2026-05-10T00:00:00Z",
     )
 
@@ -223,7 +223,7 @@ def _request(path: str, query: object | None = None, **_: object) -> JsonValue:
     if path == "/api/domain.byComposeId" and query == {"composeId": "compose-cm-testing"}:
         return [{"host": "cm-testing.shinycomputers.com", "domainId": "domain-cm"}]
     if path == "/api/domain.byComposeId" and query == {"composeId": "compose-opw-prod"}:
-        return [{"host": "openwater.pro", "domainId": "domain-opw"}]
+        return [{"host": "opw-prod.shinycomputers.com", "domainId": "domain-opw"}]
     return []
 
 

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -331,6 +331,10 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             )
         self.assertEqual(policies["testing"].expected_target_name, "opw-testing")
         self.assertEqual(policies["prod"].expected_target_name, "opw-prod")
+        self.assertEqual(
+            policies["prod"].expected_domains,
+            ("opw-prod.shinycomputers.com",),
+        )
 
     def test_apply_product_onboarding_manifest_writes_canonical_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- align OPW prod prelaunch rebuild proof with the current Dokploy host
- document that the final public hostname should replace it only once live
- cover the seeded OPW policy domain in tests

## Tests
- bash -n scripts/deploy/ensure-authz-grants.sh
- uv run python -m unittest tests.test_product_onboarding tests.test_odoo_stable_target_replacement
- git diff --check