### PR TITLE
Use live domains for Odoo prelaunch proof

### DIFF
--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -392,7 +392,8 @@ def _assert_prelaunch_rebuild_policy_allows_request(
     *,
     request: OdooStableTargetReplacementRequest,
     lane: ProductLaneProfile,
-    target_record: DokployTargetRecord,
+    target_name: str,
+    domain_hosts: tuple[str, ...],
 ) -> str:
     if request.data_source_mode == "existing":
         return ""
@@ -410,14 +411,12 @@ def _assert_prelaunch_rebuild_policy_allows_request(
         raise click.ClickException(
             f"Odoo prelaunch rebuild requires confirmation {policy.confirmation!r}."
         )
-    if target_record.target_name != policy.expected_target_name:
+    if target_name != policy.expected_target_name:
         raise click.ClickException(
             "Odoo prelaunch rebuild target proof failed: expected target "
-            f"{policy.expected_target_name!r}, observed {target_record.target_name!r}."
+            f"{policy.expected_target_name!r}, observed {target_name!r}."
         )
-    target_domains = {
-        _normalize_domain(domain) for domain in target_record.domains if domain.strip()
-    }
+    target_domains = {_normalize_domain(domain) for domain in domain_hosts if domain.strip()}
     missing_domains = tuple(
         domain for domain in policy.expected_domains if domain not in target_domains
     )
@@ -647,15 +646,6 @@ def build_odoo_stable_target_replacement_plan(
     if isinstance(target_record, DokployTargetRecord) and target_record.target_type != "compose":
         blockers.append("Odoo stable replacement currently requires a compose target.")
     approval_issue_url = ""
-    if isinstance(target_record, DokployTargetRecord):
-        try:
-            approval_issue_url = _assert_prelaunch_rebuild_policy_allows_request(
-                request=request,
-                lane=lane,
-                target_record=target_record,
-            )
-        except click.ClickException as error:
-            blockers.append(str(error))
     if request.data_source_mode != "existing" and not request.allow_empty_data:
         blockers.append(
             "Odoo prelaunch rebuild requests must explicitly set allow_empty_data."
@@ -673,6 +663,15 @@ def build_odoo_stable_target_replacement_plan(
             target_id_record=target_id_record,
             request=dokploy_request,
         )
+        try:
+            approval_issue_url = _assert_prelaunch_rebuild_policy_allows_request(
+                request=request,
+                lane=lane,
+                target_name=current_target.target_name,
+                domain_hosts=current_target.domain_hosts,
+            )
+        except click.ClickException as error:
+            blockers.append(str(error))
         if current_target.required_volume_keys_missing and not request.allow_empty_data:
             blockers.append(
                 "Current target is missing required Odoo volume env keys: "
@@ -682,6 +681,16 @@ def build_odoo_stable_target_replacement_plan(
             blockers.append("Current target has no discoverable Dokploy domains to cut over.")
         if not current_target.runtime_identity_present:
             warnings.append("Current target does not expose a Launchplane runtime identity yet.")
+    elif isinstance(target_record, DokployTargetRecord):
+        try:
+            approval_issue_url = _assert_prelaunch_rebuild_policy_allows_request(
+                request=request,
+                lane=lane,
+                target_name=target_record.target_name,
+                domain_hosts=target_record.domains,
+            )
+        except click.ClickException as error:
+            blockers.append(str(error))
     expected_artifact_id = ""
     expected_source_git_ref = ""
     if isinstance(inventory, EnvironmentInventory):

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -166,6 +166,18 @@ def _opw_target_record() -> DokployTargetRecord:
     )
 
 
+def _opw_target_record_with_stale_domain() -> DokployTargetRecord:
+    return DokployTargetRecord(
+        context="opw",
+        instance="prod",
+        project_name="odoo",
+        target_type="compose",
+        target_name="opw-prod",
+        domains=("openwater.pro",),
+        updated_at="2026-05-10T00:00:00Z",
+    )
+
+
 def _opw_target_id_record() -> DokployTargetIdRecord:
     return DokployTargetIdRecord(
         context="opw",
@@ -272,6 +284,50 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         self.assertEqual(
             plan.approval_issue_url,
             "https://github.com/cbusillo/launchplane/issues/573",
+        )
+
+    def test_build_plan_proves_prelaunch_domain_from_live_target(self) -> None:
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.read_dokploy_config",
+                return_value=("host", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "name": "opw-prod",
+                    "sourceType": "raw",
+                    "composePath": "docker-compose.yml",
+                    "composeFile": "services: {}",
+                    "env": "",
+                },
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.latest_deployment_for_target",
+                return_value={"deploymentId": "deploy-opw", "status": "success"},
+            ),
+        ):
+            plan = build_odoo_stable_target_replacement_plan(
+                control_plane_root=Path("."),
+                record_store=_Store(
+                    profile=_opw_profile_with_prelaunch_policy(enabled=True),
+                    target_record=_opw_target_record_with_stale_domain(),
+                    target_id_record=_opw_target_id_record(),
+                ),
+                request=OdooStableTargetReplacementRequest(
+                    product="odoo-tenant-opw",
+                    instance="prod",
+                    allow_empty_data=True,
+                    data_source_mode="upstream_restore",
+                    confirmation="restore opw upstream",
+                ),
+                dokploy_request=cast(DokployRequest, _request),
+            )
+
+        self.assertEqual(plan.plan_status, "ready")
+        self.assertEqual(
+            plan.expected_domain_hosts,
+            ("opw-prod.shinycomputers.com",),
         )
 
     def test_build_plan_blocks_upstream_restore_without_issue_backed_policy(self) -> None:


### PR DESCRIPTION
## Summary
- prove Odoo prelaunch rebuild domains from the live Dokploy target snapshot
- keep stored Launchplane target records as the target lookup authority
- add a regression for stale stored domains with correct live Dokploy domains

## Tests
- uv run python -m unittest tests.test_odoo_stable_target_replacement
- uv run --extra dev ruff check control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_stable_target_replacement.py
- uv run --extra dev mypy control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_stable_target_replacement.py
- git diff --check