### PR TITLE
Persist CI Buildx cache on self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          name: launchplane-ci
+          keep-state: true
 
       - name: Log in to GHCR for build cache
         uses: docker/login-action@v4


### PR DESCRIPTION
## Summary
- keep Buildx state on the persistent self-hosted CI builder for the container scan image build
- keep the existing GHCR buildcache as a fallback cache source

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml-ok"'`
- `actionlint .github/workflows/ci.yml`

## Timing Note
The goal is to let the new GitHub CLI source-build layer stay warm on the self-hosted runner. I will compare the `container_scan` job duration after this PR runs.
