### PR TITLE
Pin CI image build to persistent Buildx builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v4
         with:
           name: launchplane-ci
@@ -88,6 +89,7 @@ jobs:
       - name: Build runtime image
         uses: docker/build-push-action@v7
         with:
+          builder: ${{ steps.buildx.outputs.name }}
           context: .
           load: true
           tags: launchplane-ci:test


### PR DESCRIPTION
## Summary
- pin the CI runtime image build to the Buildx builder created in the same job
- keep the persistent self-hosted builder cache from being affected by another concurrent job's current builder selection

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml-ok"'`
- `actionlint .github/workflows/ci.yml`
