### PR TITLE
Record Odoo artifact build provenance

### DIFF
--- a/control_plane/contracts/artifact_identity.py
+++ b/control_plane/contracts/artifact_identity.py
@@ -1,4 +1,8 @@
-from pydantic import BaseModel, ConfigDict, Field
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+ArtifactBaseImageRole = Literal["runtime", "devtools"]
 
 
 class ArtifactAddonSource(BaseModel):
@@ -37,6 +41,77 @@ class ArtifactImageReference(BaseModel):
     digest: str
     tags: tuple[str, ...] = ()
 
+    @field_validator("repository", "digest", mode="after")
+    @classmethod
+    def _validate_required_string(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("artifact image reference requires repository and digest")
+        return value.strip()
+
+
+class ArtifactBaseImageProvenance(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    role: ArtifactBaseImageRole
+    image: ArtifactImageReference
+    source_repository: str = ""
+    source_ref: str = ""
+
+    @model_validator(mode="after")
+    def _validate_source_pair(self) -> "ArtifactBaseImageProvenance":
+        self.source_repository = self.source_repository.strip()
+        self.source_ref = self.source_ref.strip()
+        if bool(self.source_repository) != bool(self.source_ref):
+            raise ValueError(
+                "artifact base image provenance requires source_repository and source_ref together"
+            )
+        return self
+
+
+class ArtifactBuildToolProvenance(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    version: str = ""
+    source_repository: str = ""
+    source_ref: str = ""
+
+    @model_validator(mode="after")
+    def _validate_build_tool(self) -> "ArtifactBuildToolProvenance":
+        self.name = self.name.strip()
+        self.version = self.version.strip()
+        self.source_repository = self.source_repository.strip()
+        self.source_ref = self.source_ref.strip()
+        if not self.name:
+            raise ValueError("artifact build tool provenance requires name")
+        if bool(self.source_repository) != bool(self.source_ref):
+            raise ValueError(
+                "artifact build tool provenance requires source_repository and source_ref together"
+            )
+        if not self.version and not self.source_ref:
+            raise ValueError(
+                "artifact build tool provenance requires version or source_repository/source_ref"
+            )
+        return self
+
+
+class ArtifactBuildProvenance(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    base_images: tuple[ArtifactBaseImageProvenance, ...] = ()
+    build_tools: tuple[ArtifactBuildToolProvenance, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_build_provenance(self) -> "ArtifactBuildProvenance":
+        roles: set[ArtifactBaseImageRole] = set()
+        for base_image in self.base_images:
+            if base_image.role in roles:
+                raise ValueError(
+                    f"artifact build provenance cannot contain duplicate base image role {base_image.role!r}"
+                )
+            roles.add(base_image.role)
+        return self
+
 
 class ArtifactIdentityManifest(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -49,4 +124,5 @@ class ArtifactIdentityManifest(BaseModel):
     addon_selectors: tuple[ArtifactAddonSelector, ...] = ()
     openupgrade_inputs: ArtifactOpenUpgradeInputs = Field(default_factory=ArtifactOpenUpgradeInputs)
     build_flags: ArtifactBuildFlags = Field(default_factory=ArtifactBuildFlags)
+    build_provenance: ArtifactBuildProvenance = Field(default_factory=ArtifactBuildProvenance)
     image: ArtifactImageReference

--- a/docs/records.md
+++ b/docs/records.md
@@ -68,9 +68,10 @@ state. Use this audit when deciding whether a new GUI or driver field belongs in
 an ORM column/table or remains only in the evidence payload.
 
 - Artifact manifest: modeled fields are `artifact_id`, `source_commit`,
-  `image_repository`, and `image_digest`. Source input details, addon selectors,
-  and provider/build evidence stay payload-only until they become normal query
-  or action fields.
+  `image_repository`, and `image_digest`. The payload also carries typed Odoo
+  build provenance for base images and build tools such as `odoo-devkit`.
+  Source input details, addon selectors, support-repo provenance, and provider
+  evidence stay payload-only until they become normal query or action fields.
 - Backup gate: modeled fields are `record_id`, `context`, `instance`,
   `created_at`, and `status`. Concrete backup paths and provider-specific backup
   evidence stay payload-only.
@@ -376,6 +377,12 @@ state/
 - Artifact manifests may also carry `addon_selectors` metadata so operators can
   inspect the original selector intent, but `addon_sources` remains the exact
   SHA-backed release truth used for tuple minting and deploy execution.
+- Artifact manifests may carry `build_provenance` metadata for Odoo runtime and
+  devtools base images plus build tools such as `odoo-devkit`. That provenance
+  is artifact evidence, not addon ownership: `odoo-docker`, `odoo-devkit`,
+  `odoo-shared-addons`, and `disable_odoo_online` stay support/dependency repos,
+  while Launchplane records the immutable image/build refs used to produce an
+  artifact.
 - For a second product such as VeriReel, the first Launchplane onboarding slice
   should ingest deployment evidence from that product's existing release
   workflows into this record shape before Launchplane owns the deploy execution.
@@ -388,6 +395,9 @@ state/
 - Tuple minting requires artifact manifest source refs to be exact git SHAs;
   branch names such as `main` or `origin/testing` are rejected instead of being
   written as release truth.
+- Tuple minting uses tenant and addon source SHAs only. Base-image and build-tool
+  provenance remains on the artifact manifest payload and does not expand the
+  release tuple `repo_shas` map.
 - Promotion execution copies the source channel tuple to the destination
   channel after the destination deploy passes, retaining the promotion and
   deployment record ids that established the promoted state.

--- a/tests/test_odoo_artifact_publish.py
+++ b/tests/test_odoo_artifact_publish.py
@@ -28,6 +28,36 @@ def _artifact_payload() -> dict[str, object]:
         "artifact_id": "artifact-cm-005c291b63b6",
         "source_commit": "005c291b63b61971ba6b1b29a3a49913cb5975a6",
         "enterprise_base_digest": "sha256:enterprise",
+        "build_provenance": {
+            "base_images": [
+                {
+                    "role": "runtime",
+                    "image": {
+                        "repository": "ghcr.io/cbusillo/odoo-runtime",
+                        "digest": "sha256:runtime",
+                        "tags": ["19.0-stable"],
+                    },
+                    "source_repository": "cbusillo/odoo-docker",
+                    "source_ref": "1111111111111111111111111111111111111111",
+                },
+                {
+                    "role": "devtools",
+                    "image": {
+                        "repository": "ghcr.io/cbusillo/odoo-devtools",
+                        "digest": "sha256:devtools",
+                    },
+                    "source_repository": "cbusillo/odoo-docker",
+                    "source_ref": "2222222222222222222222222222222222222222",
+                },
+            ],
+            "build_tools": [
+                {
+                    "name": "odoo-devkit",
+                    "source_repository": "cbusillo/odoo-devkit",
+                    "source_ref": "3333333333333333333333333333333333333333",
+                }
+            ],
+        },
         "image": {
             "repository": "ghcr.io/cbusillo/odoo-tenant-cm",
             "digest": "sha256:005c291b63b61971ba6b1b29a3a49913cb5975a6005c291b63b6",
@@ -82,6 +112,57 @@ class OdooArtifactPublishWorkflowTests(unittest.TestCase):
                 ),
             ),
         )
+
+    def test_artifact_manifest_keeps_build_provenance(self) -> None:
+        manifest = _artifact_manifest()
+
+        self.assertEqual(len(manifest.build_provenance.base_images), 2)
+        self.assertEqual(manifest.build_provenance.base_images[0].role, "runtime")
+        self.assertEqual(
+            manifest.build_provenance.base_images[0].image.repository,
+            "ghcr.io/cbusillo/odoo-runtime",
+        )
+        self.assertEqual(manifest.build_provenance.build_tools[0].name, "odoo-devkit")
+        self.assertEqual(
+            manifest.build_provenance.build_tools[0].source_repository,
+            "cbusillo/odoo-devkit",
+        )
+
+    def test_artifact_manifest_accepts_legacy_payload_without_build_provenance(self) -> None:
+        payload = _artifact_payload()
+        payload.pop("build_provenance")
+
+        manifest = ArtifactIdentityManifest.model_validate(payload)
+
+        self.assertEqual(manifest.build_provenance.base_images, ())
+        self.assertEqual(manifest.build_provenance.build_tools, ())
+
+    def test_artifact_manifest_rejects_duplicate_base_image_roles(self) -> None:
+        payload = _artifact_payload()
+        build_provenance = payload["build_provenance"]
+        assert isinstance(build_provenance, dict)
+        base_images = build_provenance["base_images"]
+        assert isinstance(base_images, list)
+        duplicate_runtime = dict(base_images[0])
+        duplicate_runtime["image"] = {
+            "repository": "ghcr.io/cbusillo/other-runtime",
+            "digest": "sha256:other",
+        }
+        base_images.append(duplicate_runtime)
+
+        with self.assertRaisesRegex(ValidationError, "duplicate base image role"):
+            ArtifactIdentityManifest.model_validate(payload)
+
+    def test_artifact_manifest_rejects_incomplete_build_tool_provenance(self) -> None:
+        payload = _artifact_payload()
+        build_provenance = payload["build_provenance"]
+        assert isinstance(build_provenance, dict)
+        build_tools = build_provenance["build_tools"]
+        assert isinstance(build_tools, list)
+        build_tools[0] = {"name": "odoo-devkit"}
+
+        with self.assertRaisesRegex(ValidationError, "requires version or source_repository"):
+            ArtifactIdentityManifest.model_validate(payload)
 
     def test_publish_requests_accept_profile_owned_contexts(self) -> None:
         publish_request = OdooArtifactPublishRequest(

--- a/tests/test_release_tuples.py
+++ b/tests/test_release_tuples.py
@@ -9,6 +9,9 @@ from unittest.mock import patch
 from control_plane import release_tuples as control_plane_release_tuples
 from control_plane.contracts.artifact_identity import ArtifactAddonSelector
 from control_plane.contracts.artifact_identity import ArtifactAddonSource
+from control_plane.contracts.artifact_identity import ArtifactBaseImageProvenance
+from control_plane.contracts.artifact_identity import ArtifactBuildProvenance
+from control_plane.contracts.artifact_identity import ArtifactBuildToolProvenance
 from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
 from control_plane.contracts.artifact_identity import ArtifactImageReference
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
@@ -256,6 +259,26 @@ class ReleaseTupleTests(unittest.TestCase):
             artifact_id="artifact-sha256-image456",
             source_commit="abc1234",
             enterprise_base_digest="sha256:enterprise123",
+            build_provenance=ArtifactBuildProvenance(
+                base_images=(
+                    ArtifactBaseImageProvenance(
+                        role="runtime",
+                        image=ArtifactImageReference(
+                            repository="ghcr.io/cbusillo/odoo-runtime",
+                            digest="sha256:runtime",
+                        ),
+                        source_repository="cbusillo/odoo-docker",
+                        source_ref="1111111111111111111111111111111111111111",
+                    ),
+                ),
+                build_tools=(
+                    ArtifactBuildToolProvenance(
+                        name="odoo-devkit",
+                        source_repository="cbusillo/odoo-devkit",
+                        source_ref="2222222222222222222222222222222222222222",
+                    ),
+                ),
+            ),
             addon_sources=(
                 ArtifactAddonSource(
                     repository="cbusillo/odoo-shared-addons",
@@ -278,6 +301,8 @@ class ReleaseTupleTests(unittest.TestCase):
         self.assertEqual(release_tuple.tuple_id, "opw-testing-artifact-sha256-image456")
         self.assertEqual(release_tuple.repo_shas["tenant-opw"], "abc1234")
         self.assertEqual(release_tuple.repo_shas["shared-addons"], "def5678")
+        self.assertNotIn("odoo-docker", release_tuple.repo_shas)
+        self.assertNotIn("odoo-devkit", release_tuple.repo_shas)
         self.assertEqual(release_tuple.provenance, "ship")
 
     def test_build_release_tuple_record_ignores_addon_selector_metadata(self) -> None:


### PR DESCRIPTION
## Summary
- add typed Odoo artifact build provenance for runtime/devtools base images and build tools such as `odoo-devkit`
- keep legacy artifact manifests valid when build provenance is absent
- keep release tuples focused on tenant/addon release truth instead of adding support-repo build refs to `repo_shas`
- document the artifact-manifest vs release-tuple ownership boundary

Refs #513.

## Validation
- `uv run python -m unittest tests.test_odoo_artifact_publish tests.test_release_tuples`
- `uv run --extra dev mypy control_plane/contracts/artifact_identity.py tests/test_odoo_artifact_publish.py tests/test_release_tuples.py`
- `uv run --extra dev ruff check control_plane/contracts/artifact_identity.py tests/test_odoo_artifact_publish.py tests/test_release_tuples.py`
- `uv run --extra dev ruff format --check control_plane/contracts/artifact_identity.py tests/test_odoo_artifact_publish.py tests/test_release_tuples.py`
- `uv run python -m unittest`
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff check .`
- `git diff --check`
