### PR TITLE
Harden Odoo target replacement verification

### DIFF
--- a/.github/workflows/odoo-target-replacement-apply.yml
+++ b/.github/workflows/odoo-target-replacement-apply.yml
@@ -242,6 +242,15 @@ jobs:
               >&2
             exit 1
           fi
+          deploy_status="$(jq -r '.result.deploy_status // ""' odoo-target-replacement-apply.json)"
+          post_deploy_status="$(jq -r '.result.post_deploy_status // ""' odoo-target-replacement-apply.json)"
+          if [ "$deploy_status" != "pass" ] || [ "$post_deploy_status" != "pass" ]; then
+            echo \
+              "Odoo target replacement apply did not pass: deploy=${deploy_status} post_deploy=${post_deploy_status}." \
+              >&2
+            jq -r '.result.error_message // ""' odoo-target-replacement-apply.json >&2
+            exit 1
+          fi
 
       - name: Upload replacement apply result
         uses: actions/upload-artifact@v5

--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 import json
 from pathlib import Path
+import time
 from typing import Literal, Protocol
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
@@ -57,6 +58,7 @@ class OdooStableTargetReplacementStore(Protocol):
 
 
 DokployRequest = Callable[..., JsonValue]
+ODOO_STABLE_TARGET_REPLACEMENT_VERIFY_RETRY_INTERVAL_SECONDS = 5
 
 
 class OdooStableTargetReplacementRequest(BaseModel):
@@ -382,6 +384,26 @@ def _verify_logo_route(*, base_url: str, timeout_seconds: int) -> None:
         raise click.ClickException(f"Logo check {logo_url} returned HTTP {status_code}.")
     if "text/html" in content_type.lower() and "404" in body[:500].lower():
         raise click.ClickException(f"Logo check {logo_url} returned an HTML 404 body.")
+
+
+def _run_verification_with_retry(
+    verification: Callable[[], None],
+    *,
+    timeout_seconds: int,
+    retry_interval_seconds: int = ODOO_STABLE_TARGET_REPLACEMENT_VERIFY_RETRY_INTERVAL_SECONDS,
+) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    last_error: click.ClickException | None = None
+    while True:
+        try:
+            verification()
+            return
+        except click.ClickException as error:
+            last_error = error
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                raise last_error
+            time.sleep(min(retry_interval_seconds, remaining_seconds))
 
 
 def _normalize_domain(raw_domain: str) -> str:
@@ -999,16 +1021,25 @@ def execute_odoo_stable_target_replacement_apply(
                 raise click.ClickException(
                     "Odoo target replacement health verification has no health URL."
                 )
-            _verify_health_url(health_url=health_url, timeout_seconds=health_timeout_seconds)
+            _run_verification_with_retry(
+                lambda: _verify_health_url(
+                    health_url=health_url,
+                    timeout_seconds=health_timeout_seconds,
+                ),
+                timeout_seconds=health_timeout_seconds,
+            )
             health_status = "pass"
         if request.verify_canonical:
             if not base_url:
                 raise click.ClickException(
                     "Odoo target replacement canonical verification has no base URL."
                 )
-            _verify_canonical_url(
-                base_url=base_url,
-                expected_base_url=base_url,
+            _run_verification_with_retry(
+                lambda: _verify_canonical_url(
+                    base_url=base_url,
+                    expected_base_url=base_url,
+                    timeout_seconds=health_timeout_seconds,
+                ),
                 timeout_seconds=health_timeout_seconds,
             )
             canonical_status = "pass"
@@ -1017,7 +1048,13 @@ def execute_odoo_stable_target_replacement_apply(
                 raise click.ClickException(
                     "Odoo target replacement logo verification has no base URL."
                 )
-            _verify_logo_route(base_url=base_url, timeout_seconds=health_timeout_seconds)
+            _run_verification_with_retry(
+                lambda: _verify_logo_route(
+                    base_url=base_url,
+                    timeout_seconds=health_timeout_seconds,
+                ),
+                timeout_seconds=health_timeout_seconds,
+            )
             logo_status = "pass"
     except click.ClickException as error:
         destination_health = HealthcheckEvidence(

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -31,6 +31,7 @@ from control_plane.workflows.odoo_stable_target_replacement import (
     DokployRequest,
     OdooStableTargetReplacementApplyRequest,
     OdooStableTargetReplacementRequest,
+    _run_verification_with_retry,
     build_odoo_stable_target_replacement_plan,
     execute_odoo_stable_target_replacement_apply,
 )
@@ -779,6 +780,28 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                     ),
                     dokploy_request=cast(DokployRequest, _request),
                 )
+
+    def test_verification_retry_allows_transient_startup_failure(self) -> None:
+        attempts = 0
+
+        def flaky_verification() -> None:
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise click.ClickException("temporary health 404")
+
+        with patch(
+            "control_plane.workflows.odoo_stable_target_replacement.time.sleep",
+            side_effect=lambda _seconds: None,
+        ) as sleep_mock:
+            _run_verification_with_retry(
+                flaky_verification,
+                timeout_seconds=30,
+                retry_interval_seconds=5,
+            )
+
+        self.assertEqual(attempts, 2)
+        sleep_mock.assert_called_once()
 
     def test_apply_refuses_blocked_plan(self) -> None:
         with self.assertRaises(click.ClickException):


### PR DESCRIPTION
## Summary
- retry Odoo target replacement health/canonical/logo verification for transient startup 404s
- make the target replacement workflow fail when the accepted driver result reports failed deploy/post-deploy status
- add regression coverage for the retry helper

## Context
This came out of `cbusillo/odoo-devkit#34` live verification. Target replacement was accepted by Launchplane but returned `deploy_status: fail` after a transient `/web/health` 404, while the GitHub Actions job still appeared successful. That prevented inventory from advancing to the newer CM artifact, so stable bootstrap kept using stale artifact `artifact-cm-56978ff75c57c6a0` from source `f358c2d`.

## Tests
- `uv run python -m unittest tests.test_odoo_stable_target_replacement`
- `uv run --extra dev ruff check --diff control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_stable_target_replacement.py`
- `uv run --extra dev ruff check control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_stable_target_replacement.py`
- `ruby -e 'require "yaml"; data = YAML.load_file(".github/workflows/odoo-target-replacement-apply.yml"); abort("bad name") unless data["name"] == "Odoo Target Replacement Apply"; puts "yaml ok"'`

## Notes
- `actionlint .github/workflows/odoo-target-replacement-apply.yml` still reports the existing workflow-dispatch input-count warning for this workflow.
