### PR TITLE
Pass Odoo overrides into stable bootstrap

### DIFF
--- a/control_plane/workflows/odoo_stable_bootstrap.py
+++ b/control_plane/workflows/odoo_stable_bootstrap.py
@@ -8,10 +8,12 @@ import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane import dokploy as control_plane_dokploy
+from control_plane import odoo_instance_overrides as control_plane_odoo_instance_overrides
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductLaneProfile,
@@ -44,6 +46,10 @@ ODOO_STABLE_BOOTSTRAP_VERIFY_RETRY_INTERVAL_SECONDS = 5
 
 
 class OdooStableBootstrapStore(Protocol):
+    def read_odoo_instance_override_record(
+        self, *, context_name: str, instance_name: str
+    ) -> OdooInstanceOverrideRecord: ...
+
     def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord: ...
 
     def read_dokploy_target_record(
@@ -318,6 +324,18 @@ def _read_bootstrap_inventory(
         ) from error
 
 
+def _read_odoo_instance_override_record(
+    *, record_store: OdooStableBootstrapStore, context: str, instance: str
+) -> OdooInstanceOverrideRecord | None:
+    try:
+        return record_store.read_odoo_instance_override_record(
+            context_name=context,
+            instance_name=instance,
+        )
+    except FileNotFoundError:
+        return None
+
+
 def execute_odoo_stable_bootstrap(
     *,
     control_plane_root: Path,
@@ -337,6 +355,11 @@ def execute_odoo_stable_bootstrap(
     )
     target_id_record = _read_bootstrap_target_id_record(
         record_store=record_store, context=request.context, instance=request.instance
+    )
+    odoo_override_record = _read_odoo_instance_override_record(
+        record_store=record_store,
+        context=request.context,
+        instance=request.instance,
     )
     if target_record.target_type != "compose":
         raise click.ClickException("Odoo stable bootstrap requires a compose target.")
@@ -424,11 +447,26 @@ def execute_odoo_stable_bootstrap(
             deploy_timeout_seconds=target_record.deploy_timeout_seconds,
             healthcheck_timeout_seconds=target_record.healthcheck_timeout_seconds,
         )
+        workflow_environment_overrides: dict[str, str] = {}
+        required_workflow_environment_keys: tuple[str, ...] = ()
+        if odoo_override_record is not None and "deploy" in odoo_override_record.apply_on:
+            post_deploy_environment = control_plane_odoo_instance_overrides.build_post_deploy_environment(
+                odoo_override_record,
+                protected_shopify_store_keys=control_plane_dokploy.protected_shopify_store_keys_for_target_definition(
+                    target_definition
+                ),
+            )
+            workflow_environment_overrides = post_deploy_environment.inline_environment
+            required_workflow_environment_keys = (
+                post_deploy_environment.required_container_environment_keys
+            )
         control_plane_dokploy.run_compose_odoo_stable_bootstrap(
             host=host,
             token=token,
             target_definition=target_definition,
             env_file=env_file,
+            workflow_environment_overrides=workflow_environment_overrides,
+            required_workflow_environment_keys=required_workflow_environment_keys,
             timeout_seconds=request.timeout_seconds,
         )
     except click.ClickException as error:

--- a/tests/test_odoo_stable_bootstrap.py
+++ b/tests/test_odoo_stable_bootstrap.py
@@ -9,6 +9,11 @@ from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.odoo_instance_override_record import (
+    OdooConfigParameterOverride,
+    OdooInstanceOverrideRecord,
+    OdooOverrideValue,
+)
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductOdooStableBootstrapPolicy,
@@ -146,6 +151,11 @@ class _Store:
     def write_environment_inventory(self, record: EnvironmentInventory) -> None:
         self.environment_inventories.append(record)
 
+    def read_odoo_instance_override_record(
+        self, *, context_name: str, instance_name: str
+    ) -> OdooInstanceOverrideRecord:
+        raise FileNotFoundError(f"{context_name}/{instance_name}")
+
 
 class OdooStableBootstrapTests(unittest.TestCase):
     def test_execute_runs_bootstrap_post_deploy_and_verification(self) -> None:
@@ -237,6 +247,79 @@ class OdooStableBootstrapTests(unittest.TestCase):
             store.environment_inventories[0].deployment_record_id,
             "deployment-cm-testing-bootstrap",
         )
+
+    def test_execute_passes_override_payload_to_bootstrap_runner(self) -> None:
+        class OverrideStore(_Store):
+            def read_odoo_instance_override_record(
+                self, *, context_name: str, instance_name: str
+            ) -> OdooInstanceOverrideRecord:
+                if (context_name, instance_name) != ("cm", "testing"):
+                    raise FileNotFoundError(f"{context_name}/{instance_name}")
+                return OdooInstanceOverrideRecord(
+                    context="cm",
+                    instance="testing",
+                    apply_on=("deploy",),
+                    config_parameters=(
+                        OdooConfigParameterOverride(
+                            key="web.base.url",
+                            value=OdooOverrideValue(
+                                source="literal",
+                                value="https://cm-testing.shinycomputers.com",
+                            ),
+                        ),
+                    ),
+                    updated_at="2026-05-10T00:00:00Z",
+                )
+
+        store = OverrideStore()
+        captured_bootstrap_runs: list[dict[str, object]] = []
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example.com", "token-123"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.control_plane_dokploy.run_compose_odoo_stable_bootstrap",
+                side_effect=lambda **kwargs: captured_bootstrap_runs.append(kwargs),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.execute_odoo_post_deploy",
+                return_value=OdooPostDeployResult(
+                    context="cm",
+                    instance="testing",
+                    phase="deploy",
+                    post_deploy_status="pass",
+                ),
+            ),
+            patch("control_plane.workflows.odoo_stable_bootstrap._verify_health_url"),
+            patch("control_plane.workflows.odoo_stable_bootstrap._verify_canonical_url"),
+            patch("control_plane.workflows.odoo_stable_bootstrap._verify_logo_route"),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.utc_now_timestamp",
+                side_effect=("2026-05-10T02:00:00Z", "2026-05-10T02:01:00Z"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.generate_deployment_record_id",
+                return_value="deployment-cm-testing-bootstrap",
+            ),
+        ):
+            result = execute_odoo_stable_bootstrap(
+                control_plane_root=Path("/tmp/launchplane"),
+                record_store=store,
+                request=OdooStableBootstrapRequest(
+                    product="odoo-tenant-cm",
+                    context="cm",
+                    instance="testing",
+                    confirmation=_BOOTSTRAP_CONFIRMATION,
+                ),
+                dokploy_request=cast(DokployRequest, _dokploy_request),
+            )
+
+        self.assertEqual(result.bootstrap_status, "pass")
+        workflow_environment = cast(
+            "dict[str, str]", captured_bootstrap_runs[0]["workflow_environment_overrides"]
+        )
+        self.assertIn("ODOO_INSTANCE_OVERRIDES_PAYLOAD_B64", workflow_environment)
         self.assertEqual(
             store.environment_inventories[0].bootstrap_record_id,
             "deployment-cm-testing-bootstrap",


### PR DESCRIPTION
## Summary
- read the Odoo instance override record before stable bootstrap scheduling
- pass the encoded override payload and required env keys into the bootstrap data workflow
- add regression coverage proving stable bootstrap forwards `ODOO_INSTANCE_OVERRIDES_PAYLOAD_B64`

## Context
Follow-up from `cbusillo/odoo-devkit#34` live verification after #590 landed. Target replacement successfully advanced CM testing to `artifact-cm-d86025a089905522` / `ff348ec8df2de651e4d1a36a62e6c134374b4531`, but stable bootstrap still left the public page as `My Website` with canonical `http://localhost:8069/cell-mechanic`.

Root cause: post-deploy passed Odoo override environment into the data workflow, but stable bootstrap did not. That meant devkit's `website_bootstrap` payload was never available to `apply_website_bootstrap` during the bootstrap schedule.

## Tests
- `uv run python -m unittest tests.test_odoo_stable_bootstrap`
- `uv run --extra dev ruff check --diff control_plane/workflows/odoo_stable_bootstrap.py tests/test_odoo_stable_bootstrap.py`
- `uv run --extra dev ruff check control_plane/workflows/odoo_stable_bootstrap.py tests/test_odoo_stable_bootstrap.py`
