### PR TITLE
Report live target runtime follow-up after product config apply

### DIFF
--- a/control_plane/product_config_http.py
+++ b/control_plane/product_config_http.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import cast
+from typing import Protocol, cast
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from control_plane import product_config as control_plane_product_config
 from control_plane import product_config_service as control_plane_product_config_service
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.product_config import ProductConfigStore
 from control_plane.service_auth import (
     LaunchplaneAuthzPolicy,
@@ -18,6 +19,10 @@ from control_plane.service_auth import (
 
 JsonResponse = Callable[..., list[bytes]]
 StartResponse = Callable[[str, list[tuple[str, str]]], None]
+
+
+class ProductConfigRouteStore(ProductConfigStore, Protocol):
+    def list_dokploy_target_records(self) -> tuple[DokployTargetRecord, ...]: ...
 
 
 class ProductConfigApplyEnvelope(BaseModel):
@@ -73,6 +78,62 @@ class ProductConfigRouteResult:
     driver_result: dict[str, object] | None
 
 
+def product_config_live_target_next_actions(
+    *,
+    request: ProductConfigApplyEnvelope,
+    driver_result: dict[str, object] | None,
+    tracked_targets: tuple[DokployTargetRecord, ...],
+) -> list[dict[str, object]]:
+    if request.mode != "apply" or not driver_result:
+        return []
+    runtime_environment = driver_result.get("runtime_environment")
+    if not isinstance(runtime_environment, dict):
+        return []
+    changed_keys = runtime_environment.get("changed_keys")
+    if not isinstance(changed_keys, list) or not changed_keys:
+        return []
+    context_name = str(runtime_environment.get("context") or "")
+    instance_name = str(runtime_environment.get("instance") or "")
+    target = next(
+        (
+            record
+            for record in tracked_targets
+            if record.context == context_name and record.instance == instance_name
+        ),
+        None,
+    )
+    if target is None:
+        return []
+    return [
+        {
+            "kind": "live_target_runtime_apply",
+            "required": True,
+            "status": "live_sync_required",
+            "target": {
+                "context": context_name,
+                "instance": instance_name,
+                "target_type": target.target_type,
+                "target_name": target.target_name,
+            },
+            "changed_keys": sorted(str(key) for key in changed_keys),
+            "dry_run": {
+                "method": "POST",
+                "endpoint": "/v1/live-target-runtime/apply",
+                "mode": "dry-run",
+            },
+            "apply": {
+                "method": "POST",
+                "endpoint": "/v1/live-target-runtime/apply",
+                "mode": "apply",
+            },
+            "instruction": (
+                "Run live-target-runtime dry-run, then apply with a concrete reason. "
+                "Redeploying the same app image does not sync the live Dokploy target environment."
+            ),
+        }
+    ]
+
+
 def validate_product_config_apply_request(
     *,
     authz_policy: LaunchplaneAuthzPolicy,
@@ -123,7 +184,7 @@ def validate_product_config_apply_request(
 
 def apply_product_config_route(
     *,
-    record_store: ProductConfigStore,
+    record_store: ProductConfigRouteStore,
     request: ProductConfigApplyEnvelope,
     actor: str,
     trace_id: str,
@@ -152,6 +213,17 @@ def apply_product_config_route(
                 },
             },
         )
+    next_actions = product_config_live_target_next_actions(
+        request=request,
+        driver_result=driver_result,
+        tracked_targets=record_store.list_dokploy_target_records(),
+    )
+    if next_actions and driver_result is not None:
+        driver_result = {
+            **driver_result,
+            "status": "records_applied_live_sync_required",
+            "next_actions": next_actions,
+        }
     return ProductConfigRouteResult(driver_result=driver_result)
 
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -453,7 +453,12 @@ Current derived-state behavior:
   that differ from the authorized top-level context/instance. It fails closed
   when secret writes are requested without the Launchplane master encryption key
   in the service runtime or when no active runtime key-safety policy allows the
-  requested binding.
+  requested binding. When apply changes runtime-environment keys for a tracked
+  Dokploy target, the response includes a required `live_target_runtime_apply`
+  `next_actions` item. Treat product-config apply as a record mutation only
+  until that next action has been dry-run and applied through
+  `/v1/live-target-runtime/apply`; redeploying the same app image does not sync
+  the live Dokploy target environment.
 - The operator UI uses the same service route. It requires a successful dry-run
   result before enabling apply, clears rendered secret input values after each
   submit, and shows only key/action/count metadata from Launchplane responses.

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -4420,9 +4420,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(create_status, 202)
         self.assertEqual(intent_status, 202)
         self.assertEqual(rerun_status, 202)
-        self.assertEqual(
-            rerun_payload["records"]["agent_write_intent_record_id"], intent_record_id
-        )
+        self.assertEqual(rerun_payload["records"]["agent_write_intent_record_id"], intent_record_id)
         self.assertEqual(rerun_payload["records"]["state"], "queued")
         self.assertEqual(rerun_payload["result"]["request"]["trigger_actor"], "cbusillo")
         self.assertEqual(rerun_payload["result"]["request"]["claimed_by_host"], "")
@@ -4538,14 +4536,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
 
         self.assertEqual(missing_status, 409)
-        self.assertEqual(
-            missing_payload["error"]["code"], "agent_write_intent_required"
-        )
+        self.assertEqual(missing_payload["error"]["code"], "agent_write_intent_required")
         self.assertEqual(wrong_source_status, 202)
         self.assertEqual(mismatched_status, 409)
-        self.assertEqual(
-            mismatched_payload["error"]["code"], "agent_write_intent_source_mismatch"
-        )
+        self.assertEqual(mismatched_payload["error"]["code"], "agent_write_intent_source_mismatch")
 
     def test_every_code_rerun_rejects_stale_and_wrong_context_write_intents(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(
@@ -7636,6 +7630,76 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(len(secret_records), 1)
         self.assertEqual(secret_records[0].name, "SMTP_PASSWORD")
         self.assertEqual(secret_binding.binding_key, "SMTP_PASSWORD")
+
+    def test_product_config_api_apply_reports_live_target_runtime_next_action(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-prod"],
+                            "actions": ["product_config.apply"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            _write_runtime_key_safety_policy(database_url=database_url)
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="sellyouroutboard-prod",
+                instance="prod",
+                target_id="application-syo-prod",
+                target_type="application",
+                target_name="syo-prod-app",
+            )
+            request_payload = {**_product_config_payload(), "mode": "apply"}
+
+            with patch.dict(
+                os.environ,
+                {control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"},
+                clear=True,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/product-config/apply",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "product-config-apply-live-sync"},
+                )
+
+        self.assertEqual(status_code, 202, msg=json.dumps(payload, indent=2, sort_keys=True))
+        result = payload["result"]
+        self.assertEqual(result["status"], "records_applied_live_sync_required")
+        next_actions = result["next_actions"]
+        self.assertEqual(len(next_actions), 1)
+        next_action = next_actions[0]
+        self.assertEqual(next_action["kind"], "live_target_runtime_apply")
+        self.assertTrue(next_action["required"])
+        self.assertEqual(next_action["dry_run"]["endpoint"], "/v1/live-target-runtime/apply")
+        self.assertEqual(next_action["dry_run"]["mode"], "dry-run")
+        self.assertEqual(next_action["apply"]["endpoint"], "/v1/live-target-runtime/apply")
+        self.assertEqual(next_action["apply"]["mode"], "apply")
+        self.assertEqual(next_action["target"]["target_type"], "application")
+        self.assertEqual(next_action["target"]["target_name"], "syo-prod-app")
+        self.assertIn("Redeploying the same app image", next_action["instruction"])
+        self.assertNotIn("smtp-secret-value", json.dumps(payload, sort_keys=True))
 
     def test_product_config_api_human_admin_dry_run_returns_redacted_meta_plan(
         self,


### PR DESCRIPTION
## Summary
- Add `records_applied_live_sync_required` status and `next_actions` guidance when product-config apply changes runtime env for a tracked Dokploy target.
- Include live-target-runtime dry-run/apply endpoint instructions and warn that redeploying the same app image does not sync live env.
- Document the record-vs-live-target boundary and add regression coverage.

## Validation
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_product_config_api_dry_run_returns_redacted_plan_without_writes tests.test_service.LaunchplaneServiceTests.test_product_config_api_apply_writes_runtime_and_managed_secret tests.test_service.LaunchplaneServiceTests.test_product_config_api_apply_reports_live_target_runtime_next_action tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_api_dry_run_returns_redacted_delta tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_api_apply_updates_env_and_verifies`
- `uv run --extra dev ruff check --diff control_plane/product_config_http.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/product_config_http.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/product_config_http.py tests/test_service.py`
- `uv run --extra dev mypy control_plane/product_config_http.py`
