### PR TITLE
Apply Odoo config overrides during deploy

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2225,12 +2225,19 @@ def _write_odoo_config_parameter_override(
         key=request.key,
         value=OdooOverrideValue(source="literal", value=request.value),
     )
+    apply_on = tuple(
+        dict.fromkeys(
+            (
+                *(existing_record.apply_on if existing_record is not None else ()),
+                "deploy",
+                "promotion",
+            )
+        )
+    )
     record = OdooInstanceOverrideRecord(
         context=request.context,
         instance=request.instance,
-        apply_on=existing_record.apply_on
-        if existing_record is not None
-        else ("deploy", "promotion"),
+        apply_on=apply_on,
         config_parameters=tuple(config_parameters[key] for key in sorted(config_parameters)),
         addon_settings=addon_settings,
         updated_at=_utc_now_timestamp(),

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -573,6 +573,9 @@ context only, and `context_instance` has both context and instance.
   workflow instead of local CLI writes. It calls
   `POST /v1/drivers/odoo/config-parameter-override` with GitHub Actions OIDC and
   is currently limited to the non-secret `web.base.url` key for `cm/testing`.
+  Service-written `web.base.url` records are always marked for `deploy` and
+  `promotion` application so Odoo post-deploy and stable-bootstrap drivers can
+  apply the canonical URL before verification.
 - `odoo-overrides put-addon-setting` writes addon-shaped Odoo override intent
   such as Authentik or Shopify settings for a context and instance.
 - Secret-shaped override names, including `*_TOKEN`, `*_PASSWORD`, and

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -32,6 +32,9 @@ from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.merge_train_policy import (
     build_sellyouroutboard_main_merge_train_policy,
 )
+from control_plane.contracts.odoo_instance_override_record import OdooConfigParameterOverride
+from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
+from control_plane.contracts.odoo_instance_override_record import OdooOverrideValue
 from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
 from control_plane.contracts.merge_train_run_record import build_merge_train_run_record
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
@@ -16151,6 +16154,93 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 context_name="cm", instance_name="testing"
             )
             self.assertEqual(stored_record.config_parameters[0].key, "web.base.url")
+            self.assertEqual(
+                stored_record.config_parameters[0].value.value,
+                "https://cm-testing.shinycomputers.com",
+            )
+            self.assertEqual(stored_record.apply_on, ("deploy", "promotion"))
+
+    def test_odoo_config_parameter_override_driver_keeps_existing_phases_and_adds_deploy(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            store.write_odoo_instance_override_record(
+                OdooInstanceOverrideRecord(
+                    context="cm",
+                    instance="testing",
+                    apply_on=("manual",),
+                    config_parameters=(
+                        OdooConfigParameterOverride(
+                            key="web.base.url",
+                            value=OdooOverrideValue(
+                                source="literal",
+                                value="https://old.example.com",
+                            ),
+                        ),
+                    ),
+                    updated_at="2026-05-10T20:00:00Z",
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "schema_version": 1,
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/odoo-config-parameter-override.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["odoo_config_parameter_override.write"],
+                        }
+                    ],
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-config-parameter-override.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, _payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/odoo/config-parameter-override",
+                payload={
+                    "product": "odoo-tenant-cm",
+                    "override": {
+                        "product": "odoo-tenant-cm",
+                        "context": "cm",
+                        "instance": "testing",
+                        "key": "web.base.url",
+                        "value": "https://cm-testing.shinycomputers.com",
+                    },
+                },
+                headers={"Idempotency-Key": "odoo-cm-testing-web-base-url"},
+            )
+
+            self.assertEqual(status_code, 202)
+            stored_record = store.read_odoo_instance_override_record(
+                context_name="cm", instance_name="testing"
+            )
+            self.assertEqual(stored_record.apply_on, ("manual", "deploy", "promotion"))
             self.assertEqual(
                 stored_record.config_parameters[0].value.value,
                 "https://cm-testing.shinycomputers.com",


### PR DESCRIPTION
## Summary
- make service-written Odoo `web.base.url` overrides apply during deploy and promotion even when updating older override records
- keep existing apply phases instead of replacing operator intent
- document that config-parameter override workflow records are deploy/promotion scoped so stable bootstrap can apply canonical URL before verification

Refs #573.
Refs #542.

## Validation
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_odoo_config_parameter_override_driver_writes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_config_parameter_override_driver_keeps_existing_phases_and_adds_deploy tests.test_odoo_stable_bootstrap`
- `uv run --extra dev mypy control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/service.py tests/test_service.py`
- `uv run python -m unittest`
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff check .`
- `git diff --check`

## Live Evidence
- `https://cm-testing.shinycomputers.com/` now returns 200 and advertises canonical `https://cm-testing.shinycomputers.com/cell-mechanic`.
- The CM page serves tenant static assets from `/cm_website/static/...`.
- Odoo website logo/favicon routes under `/web/image/website/1/...` still return 404, so the logo issue appears to be website/logo bootstrap state rather than missing tenant static assets.
