### PR TITLE
Fix merge train service token source

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -220,7 +220,7 @@ _RUNTIME_CONTRACT_ENV_KEYS = (
 _DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
 _EVERY_CODE_WORKER_TOKEN_ENV_KEY = "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN"
 _EVERY_CODE_WEBHOOK_URL_ENV_KEY = "LAUNCHPLANE_EVERY_CODE_WEBHOOK_URL"
-_MERGE_TRAIN_GITHUB_TOKEN_ENV_KEY = "GITHUB_TOKEN"
+_MERGE_TRAIN_GITHUB_TOKEN_ENV_KEY = "GH_TOKEN"
 _MASTER_ENCRYPTION_KEY_ENV_KEYS = ("LAUNCHPLANE_MASTER_ENCRYPTION_KEY",)
 _LAUNCHPLANE_SERVICE_POLICY_ENV_KEYS = (
     "LAUNCHPLANE_POLICY_TOML",
@@ -792,12 +792,16 @@ def _relative_href(*, from_file: Path, to_file: Path) -> str:
     return os.path.relpath(to_file, start=from_file.parent)
 
 
-def _launchplane_preview_profile_rows(record_store: FilesystemRecordStore) -> tuple[tuple[str, str], ...]:
+def _launchplane_preview_profile_rows(
+    record_store: FilesystemRecordStore,
+) -> tuple[tuple[str, str], ...]:
     rows: list[tuple[str, str]] = []
     for profile in record_store.list_product_profile_records():
         if not profile.preview.enabled or not profile.preview.context.strip():
             continue
-        rows.append((profile.repository.strip().rsplit("/", maxsplit=1)[-1], profile.preview.context))
+        rows.append(
+            (profile.repository.strip().rsplit("/", maxsplit=1)[-1], profile.preview.context)
+        )
     return tuple(sorted(rows))
 
 
@@ -9454,9 +9458,7 @@ def work_graph_merge_train_policy(
     default=None,
     help="Optional merge-train policy TOML to validate instead of the bundled smoke policy.",
 )
-def work_graph_merge_train_dry_run(
-    snapshot_file: Path, policy_file: Path | None
-) -> None:
+def work_graph_merge_train_dry_run(snapshot_file: Path, policy_file: Path | None) -> None:
     try:
         snapshot_payload = json.loads(snapshot_file.read_text(encoding="utf-8"))
         snapshot = MergeTrainDryRunSnapshot.model_validate(snapshot_payload)
@@ -9524,9 +9526,7 @@ def work_graph_merge_train_run_once(
         token = os.environ.get(token_env, "").strip()
         if not token:
             raise click.ClickException(f"Missing GitHub token in environment variable {token_env}.")
-        transport = UrllibMergeTrainGitHubTransport(
-            token=token, api_base_url=github_api_base_url
-        )
+        transport = UrllibMergeTrainGitHubTransport(token=token, api_base_url=github_api_base_url)
         snapshot_reader = GitHubMergeTrainSnapshotReader(transport=transport)
         snapshot = snapshot_reader.read_merge_train_snapshot(
             repository=repository, base_branch=base_branch
@@ -9591,12 +9591,10 @@ def work_graph_runner_inventory(
         token = os.environ.get(token_env, "").strip()
         if not token:
             raise click.ClickException(f"Missing GitHub token in environment variable {token_env}.")
-        transport = UrllibMergeTrainGitHubTransport(
-            token=token, api_base_url=github_api_base_url
+        transport = UrllibMergeTrainGitHubTransport(token=token, api_base_url=github_api_base_url)
+        inventory = GitHubRunnerLaneInventoryReader(transport=transport).read_runner_lane_inventory(
+            repository=repository
         )
-        inventory = GitHubRunnerLaneInventoryReader(
-            transport=transport
-        ).read_runner_lane_inventory(repository=repository)
     except MergeTrainGitHubError as error:
         detail = str(error)
         if error.status_code is not None:
@@ -13317,9 +13315,7 @@ def authz_policies_grant_workflow(
     help="Launchplane browser session cookie. Use instead of --bearer-token-env.",
 )
 @click.option("--login", "logins", multiple=True, help="Allowed GitHub login.")
-@click.option(
-    "--organization", "organizations", multiple=True, help="Allowed GitHub organization."
-)
+@click.option("--organization", "organizations", multiple=True, help="Allowed GitHub organization.")
 @click.option("--team", "teams", multiple=True, help="Allowed GitHub team.")
 @click.option(
     "--role",
@@ -13415,7 +13411,9 @@ def authz_policies_grant_human(
     default="",
     help="Launchplane browser session cookie. Use instead of --bearer-token-env.",
 )
-@click.option("--subject", "subjects", multiple=True, required=True, help="Allowed terminal-agent subject.")
+@click.option(
+    "--subject", "subjects", multiple=True, required=True, help="Allowed terminal-agent subject."
+)
 @click.option(
     "--token-label",
     "token_labels",

--- a/control_plane/contracts/merge_train_policy.py
+++ b/control_plane/contracts/merge_train_policy.py
@@ -85,9 +85,7 @@ class MergeTrainRepositoryPolicy(BaseModel):
     enqueue: MergeTrainEnqueuePolicy
     merge_identity: MergeTrainIdentity
     service_authz: MergeTrainServiceAuthz = Field(default_factory=MergeTrainServiceAuthz)
-    github_token: MergeTrainGitHubTokenSource = Field(
-        default_factory=MergeTrainGitHubTokenSource
-    )
+    github_token: MergeTrainGitHubTokenSource = Field(default_factory=MergeTrainGitHubTokenSource)
 
     @model_validator(mode="after")
     def _validate_repository_policy(self) -> "MergeTrainRepositoryPolicy":
@@ -151,8 +149,7 @@ class MergeTrainPolicy(BaseModel):
             ):
                 return repository_policy
         raise ValueError(
-            "merge train policy not found for "
-            f"{normalized_repository}:{normalized_base_branch}"
+            f"merge train policy not found for {normalized_repository}:{normalized_base_branch}"
         )
 
 
@@ -180,7 +177,7 @@ product = "launchplane"
 context = "launchplane"
 
 [policies.github_token]
-env_var = "GITHUB_TOKEN"
+env_var = "GH_TOKEN"
 """
 
 

--- a/docs/config-boundary.md
+++ b/docs/config-boundary.md
@@ -54,7 +54,7 @@ handoff path. Leave it unset for normal deploys after the service accepts both
 terminal-agent and local-operator keys.
 
 | Work graph GitHub Project read source | `LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER`, `LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER`, optional `LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT`, optional `LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT`, optional `LAUNCHPLANE_WORK_GRAPH_GH_BINARY` | Service target env | Opt-in read source for compact Project fields plus bounded dependency, subissue, and PR check signals. Deploy automation forwards these values only when the GitHub Project token secret is present. Requires a `gh` credential with the GitHub CLI `project` scope. Does not store copied issue bodies. |
-| Work graph GitHub Project token | `GH_TOKEN` from deploy secret `LAUNCHPLANE_WORK_GRAPH_GH_TOKEN` | Platform secret projected into service target env | Authenticates the service's non-interactive `gh` reads. The token must have enough GitHub access for the configured Project and issue/PR signal reads. |
+| Work graph and merge-train GitHub token | `GH_TOKEN` from deploy secret `LAUNCHPLANE_WORK_GRAPH_GH_TOKEN` | Platform secret projected into service target env | Authenticates the service's non-interactive `gh` reads and merge-train GitHub API calls. The token must have enough GitHub access for the configured Project, issue/PR signal reads, and the configured merge-train repository. |
 
 ### DB Authoritative
 

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -69,7 +69,7 @@ product = "launchplane"
 context = "launchplane"
 
 [policies.github_token]
-env_var = "GITHUB_TOKEN"
+env_var = "GH_TOKEN"
 ```
 
 ## Discoverability
@@ -107,8 +107,12 @@ repository/base branch and reports the same worker-step intent without mutating
 by default:
 
 ```sh
-GITHUB_TOKEN=... uv run launchplane work-graph merge-train-run-once
+GH_TOKEN=... uv run launchplane work-graph merge-train-run-once
 ```
+
+The deployed Launchplane service projects the work-graph GitHub credential into
+`GH_TOKEN` from the `LAUNCHPLANE_WORK_GRAPH_GH_TOKEN` deployment secret, so the
+bundled smoke policy uses that same service-host token source.
 
 Passing `--mutate` applies exactly one worker transition from that fresh
 snapshot. Use it only from the intended operator environment for the smoke

--- a/tests/test_merge_train.py
+++ b/tests/test_merge_train.py
@@ -56,9 +56,7 @@ class _FakeMergeClient:
         head_sha: str,
         merge_method: str,
     ) -> str:
-        self.merged_pull_requests.append(
-            (repository, pull_request_number, head_sha, merge_method)
-        )
+        self.merged_pull_requests.append((repository, pull_request_number, head_sha, merge_method))
         return f"merge-{pull_request_number}"
 
 
@@ -162,8 +160,9 @@ class MergeTrainDryRunTests(unittest.TestCase):
                         "repository": "cbusillo/sellyouroutboard",
                         "base_branch": "main",
                         "pull_requests": [
-                            _pull_request(22, created_at="2026-05-08T22:00:00Z")
-                            .model_dump(mode="json")
+                            _pull_request(22, created_at="2026-05-08T22:00:00Z").model_dump(
+                                mode="json"
+                            )
                         ],
                     }
                 ),
@@ -204,7 +203,7 @@ class MergeTrainDryRunTests(unittest.TestCase):
                 "control_plane.cli.GitHubMergeTrainSnapshotReader",
                 return_value=snapshot_reader,
             ) as reader_class,
-            patch.dict("os.environ", {"GITHUB_TOKEN": "token"}, clear=True),
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
         ):
             result = CliRunner().invoke(
                 main,
@@ -271,7 +270,7 @@ class MergeTrainDryRunTests(unittest.TestCase):
                 return_value=snapshot_reader,
             ),
             patch("control_plane.cli.GitHubMergeTrainClient", _FakeGitHubClient),
-            patch.dict("os.environ", {"GITHUB_TOKEN": "token"}, clear=True),
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
         ):
             result = CliRunner().invoke(
                 main,
@@ -317,7 +316,7 @@ class MergeTrainDryRunTests(unittest.TestCase):
                 "control_plane.cli.GitHubMergeTrainSnapshotReader",
                 return_value=snapshot_reader,
             ),
-            patch.dict("os.environ", {"GITHUB_TOKEN": "token"}, clear=True),
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
         ):
             result = CliRunner().invoke(
                 main,
@@ -548,9 +547,7 @@ class MergeTrainWaitTests(unittest.TestCase):
             snapshot=MergeTrainDryRunSnapshot(
                 repository="cbusillo/sellyouroutboard",
                 base_branch="main",
-                pull_requests=(
-                    _pull_request(61, required_checks_status="pending"),
-                ),
+                pull_requests=(_pull_request(61, required_checks_status="pending"),),
             ),
         )
 
@@ -570,9 +567,7 @@ class MergeTrainWaitTests(unittest.TestCase):
             snapshot=MergeTrainDryRunSnapshot(
                 repository="cbusillo/sellyouroutboard",
                 base_branch="main",
-                pull_requests=(
-                    _pull_request(62, mergeable="unknown"),
-                ),
+                pull_requests=(_pull_request(62, mergeable="unknown"),),
             ),
         )
 

--- a/tests/test_merge_train_policy.py
+++ b/tests/test_merge_train_policy.py
@@ -33,7 +33,7 @@ class MergeTrainPolicyTests(unittest.TestCase):
         self.assertEqual(repository_policy.service_authz.action, "merge_train.run_once")
         self.assertEqual(repository_policy.service_authz.product, "launchplane")
         self.assertEqual(repository_policy.service_authz.context, "launchplane")
-        self.assertEqual(repository_policy.github_token.env_var, "GITHUB_TOKEN")
+        self.assertEqual(repository_policy.github_token.env_var, "GH_TOKEN")
         self.assertEqual(len(policy.policy_sha256), 64)
 
     def test_parse_rejects_duplicate_repository_branch_policy(self) -> None:
@@ -115,9 +115,7 @@ class MergeTrainPolicyTests(unittest.TestCase):
         payload = json.loads(result.output)
         self.assertEqual(payload["status"], "ok")
         self.assertEqual(payload["repository_count"], 1)
-        self.assertEqual(
-            payload["selected_policy"]["repository"], "cbusillo/sellyouroutboard"
-        )
+        self.assertEqual(payload["selected_policy"]["repository"], "cbusillo/sellyouroutboard")
         self.assertEqual(payload["selected_policy"]["base_branch"], "main")
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1227,7 +1227,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         with (
             TemporaryDirectory() as temporary_directory_name,
-            patch.dict("os.environ", {"GITHUB_TOKEN": "token"}, clear=True),
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
         ):
             app = create_launchplane_service_app(
                 state_dir=Path(temporary_directory_name) / "state",
@@ -1291,7 +1291,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         with (
             TemporaryDirectory() as temporary_directory_name,
-            patch.dict("os.environ", {"GITHUB_TOKEN": "token"}, clear=True),
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
         ):
             app = create_launchplane_service_app(
                 state_dir=Path(temporary_directory_name) / "state",
@@ -1346,7 +1346,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     "control_plane.service.GitHubMergeTrainSnapshotReader",
                     _FakeMergeTrainSnapshotReader,
                 ),
-                patch.dict("os.environ", {"GITHUB_TOKEN": "token"}, clear=True),
+                patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
             ):
                 status_code, payload = _invoke_app(
                     app,


### PR DESCRIPTION
## Summary
- point the bundled merge-train policy and CLI default at `GH_TOKEN`, which deploy already projects from `LAUNCHPLANE_WORK_GRAPH_GH_TOKEN`
- update merge-train docs and config-boundary docs to describe the shared service token source
- update merge-train/service tests for the deployed token env name

## Verification
- `uv run python -m unittest tests.test_merge_train tests.test_merge_train_worker tests.test_merge_train_policy tests.test_merge_train_admission tests.test_merge_train_github tests.test_service.LaunchplaneServiceTests.test_merge_train_run_once_service_returns_dry_run_from_policy tests.test_service.LaunchplaneServiceTests.test_merge_train_run_once_service_mutates_one_worker_step tests.test_service.LaunchplaneServiceTests.test_merge_train_run_once_service_rejects_unauthorized_identity tests.test_service.LaunchplaneServiceTests.test_merge_train_run_once_service_rejects_missing_token tests.test_service.LaunchplaneServiceTests.test_merge_train_run_once_service_rejects_unsupported_policy`
- `uv run --extra dev ruff check control_plane/contracts/merge_train_policy.py control_plane/cli.py tests/test_merge_train.py tests/test_merge_train_policy.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/contracts/merge_train_policy.py control_plane/cli.py tests/test_merge_train.py tests/test_merge_train_policy.py tests/test_service.py`
- `GH_TOKEN=$(gh auth token) uv run launchplane work-graph merge-train-run-once --repository cbusillo/sellyouroutboard --base-branch main --dry-run`

## Live finding
Manual dispatch of `Merge Train Runner` before this fix admitted the run, then failed closed at `run-once` with `github_token_not_configured` because the deployed service had no `GITHUB_TOKEN` env var.