### PR TITLE
Load merge train policies from Launchplane config

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -64,6 +64,8 @@ jobs:
       LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT: ${{ vars.LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT }}
       LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT: ${{ vars.LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT }}
       LAUNCHPLANE_WORK_GRAPH_GH_BINARY: ${{ vars.LAUNCHPLANE_WORK_GRAPH_GH_BINARY }}
+      LAUNCHPLANE_MERGE_TRAIN_POLICY_TOML: ${{ vars.LAUNCHPLANE_MERGE_TRAIN_POLICY_TOML }}
+      LAUNCHPLANE_MERGE_TRAIN_POLICY_FILE: ${{ vars.LAUNCHPLANE_MERGE_TRAIN_POLICY_FILE }}
       LAUNCHPLANE_ENABLE_EVERY_CODE_RUNTIME_SECRETS: ${{ vars.LAUNCHPLANE_ENABLE_EVERY_CODE_RUNTIME_SECRETS }}
       DISCORD_BLUE_DOKPLOY_TARGET_ID: ${{ vars.DISCORD_BLUE_DOKPLOY_TARGET_ID }}
       LAUNCHPLANE_GITHUB_CLIENT_SECRET: ${{ secrets.LAUNCHPLANE_GITHUB_CLIENT_SECRET }}
@@ -250,6 +252,8 @@ jobs:
                 --arg work_graph_project_signal_limit "${LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT:-}" \
                 --arg work_graph_gh_binary "${LAUNCHPLANE_WORK_GRAPH_GH_BINARY:-}" \
                 --arg work_graph_gh_token "${LAUNCHPLANE_WORK_GRAPH_GH_TOKEN:-}" \
+                --arg merge_train_policy_toml "${LAUNCHPLANE_MERGE_TRAIN_POLICY_TOML:-}" \
+                --arg merge_train_policy_file "${LAUNCHPLANE_MERGE_TRAIN_POLICY_FILE:-}" \
                 --arg enable_every_code_runtime_secrets "${LAUNCHPLANE_ENABLE_EVERY_CODE_RUNTIME_SECRETS:-}" \
                 --arg every_code_worker_token "${LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN:-}" \
                 --arg every_code_webhook_secret "${LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET:-}" \
@@ -305,6 +309,15 @@ jobs:
                         LAUNCHPLANE_WORK_GRAPH_GH_BINARY: $work_graph_gh_binary,
                         GH_TOKEN: $work_graph_gh_token
                       }
+                    else
+                      {}
+                    end
+                  )
+                  + (
+                    if $merge_train_policy_toml != "" then
+                      {LAUNCHPLANE_MERGE_TRAIN_POLICY_TOML: $merge_train_policy_toml}
+                    elif $merge_train_policy_file != "" then
+                      {LAUNCHPLANE_MERGE_TRAIN_POLICY_FILE: $merge_train_policy_file}
                     else
                       {}
                     end

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -42,7 +42,6 @@ from control_plane.contracts.every_code_work_request import build_every_code_wor
 from control_plane.contracts.github_pull_request_event import GitHubPullRequestEvent
 from control_plane.contracts.github_webhook_replay_envelope import GitHubWebhookReplayEnvelope
 from control_plane.contracts.merge_train_policy import (
-    build_sellyouroutboard_main_merge_train_policy,
     load_merge_train_policy,
 )
 from control_plane.contracts.odoo_instance_override_record import OdooAddonSettingOverride
@@ -135,6 +134,7 @@ from control_plane.merge_train_github import (
     MergeTrainGitHubError,
     UrllibMergeTrainGitHubTransport,
 )
+from control_plane.merge_train_policy_source import load_launchplane_merge_train_policy
 from control_plane.runner_lane_github import GitHubRunnerLaneInventoryReader
 from control_plane.service import serve_launchplane_service
 from control_plane.storage.filesystem import FilesystemRecordStore
@@ -9412,7 +9412,7 @@ def work_graph_rank(snapshot_file: Path, limit: int) -> None:
     "--policy-file",
     type=click.Path(path_type=Path, exists=True, dir_okay=False),
     default=None,
-    help="Optional merge-train policy TOML to validate instead of the bundled smoke policy.",
+    help="Optional merge-train policy TOML to validate instead of Launchplane service policy.",
 )
 @click.option("--repository", default="", help="Optional owner/name repository lookup.")
 @click.option("--base-branch", default="main", show_default=True)
@@ -9423,7 +9423,7 @@ def work_graph_merge_train_policy(
         policy = (
             load_merge_train_policy(policy_file)
             if policy_file is not None
-            else build_sellyouroutboard_main_merge_train_policy()
+            else load_launchplane_merge_train_policy()
         )
         selected_policy = None
         if repository.strip():
@@ -9456,7 +9456,7 @@ def work_graph_merge_train_policy(
     "--policy-file",
     type=click.Path(path_type=Path, exists=True, dir_okay=False),
     default=None,
-    help="Optional merge-train policy TOML to validate instead of the bundled smoke policy.",
+    help="Optional merge-train policy TOML to validate instead of Launchplane service policy.",
 )
 def work_graph_merge_train_dry_run(snapshot_file: Path, policy_file: Path | None) -> None:
     try:
@@ -9465,7 +9465,7 @@ def work_graph_merge_train_dry_run(snapshot_file: Path, policy_file: Path | None
         policy = (
             load_merge_train_policy(policy_file)
             if policy_file is not None
-            else build_sellyouroutboard_main_merge_train_policy()
+            else load_launchplane_merge_train_policy()
         )
         result = build_merge_train_dry_run_result(policy=policy, snapshot=snapshot)
     except (OSError, JSONDecodeError, ValidationError, ValueError) as error:
@@ -9478,11 +9478,11 @@ def work_graph_merge_train_dry_run(snapshot_file: Path, policy_file: Path | None
     "--policy-file",
     type=click.Path(path_type=Path, exists=True, dir_okay=False),
     default=None,
-    help="Optional merge-train policy TOML to validate instead of the bundled smoke policy.",
+    help="Optional merge-train policy TOML to validate instead of Launchplane service policy.",
 )
 @click.option(
     "--repository",
-    default="cbusillo/sellyouroutboard",
+    default="cbusillo/codex-skills",
     show_default=True,
     help="owner/name repository whose policy should run once.",
 )
@@ -9517,7 +9517,7 @@ def work_graph_merge_train_run_once(
         policy = (
             load_merge_train_policy(policy_file)
             if policy_file is not None
-            else build_sellyouroutboard_main_merge_train_policy()
+            else load_launchplane_merge_train_policy()
         )
         policy.find_repository_policy(repository=repository, base_branch=base_branch)
         token_env = github_token_env.strip()

--- a/control_plane/config/merge-train-policies.toml
+++ b/control_plane/config/merge-train-policies.toml
@@ -1,0 +1,49 @@
+schema_version = 1
+
+[[policies]]
+repository = "cbusillo/sellyouroutboard"
+base_branch = "main"
+enqueue_label = "ready-to-merge"
+blocked_label = "merge-blocked"
+merge_method = "merge"
+failure_policy = "pause_train"
+
+[policies.enqueue]
+label_required = true
+allowed_actor_roles = ["repo_owner", "repo_admin"]
+
+[policies.merge_identity]
+kind = "github_actions_oidc"
+name = "launchplane-merge-train"
+
+[policies.service_authz]
+action = "merge_train.run_once"
+product = "launchplane"
+context = "launchplane"
+
+[policies.github_token]
+env_var = "GH_TOKEN"
+
+[[policies]]
+repository = "cbusillo/codex-skills"
+base_branch = "main"
+enqueue_label = "ready-to-merge"
+blocked_label = "merge-blocked"
+merge_method = "merge"
+failure_policy = "pause_train"
+
+[policies.enqueue]
+label_required = true
+allowed_actor_roles = ["repo_owner", "repo_admin"]
+
+[policies.merge_identity]
+kind = "github_actions_oidc"
+name = "launchplane-merge-train"
+
+[policies.service_authz]
+action = "merge_train.run_once"
+product = "launchplane"
+context = "launchplane"
+
+[policies.github_token]
+env_var = "GH_TOKEN"

--- a/control_plane/contracts/merge_train_policy.py
+++ b/control_plane/contracts/merge_train_policy.py
@@ -189,8 +189,16 @@ def load_merge_train_policy(policy_file: Path) -> MergeTrainPolicy:
     return parse_merge_train_policy_toml(policy_file.read_text(encoding="utf-8"))
 
 
+def load_merge_train_policy_from_default_config() -> MergeTrainPolicy:
+    return load_merge_train_policy(default_merge_train_policy_path())
+
+
 def build_sellyouroutboard_main_merge_train_policy() -> MergeTrainPolicy:
     return parse_merge_train_policy_toml(SELLYOUROUTBOARD_MAIN_POLICY_TOML)
+
+
+def default_merge_train_policy_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "config" / "merge-train-policies.toml"
 
 
 def merge_train_policy_sha256(policy: MergeTrainPolicy) -> str:

--- a/control_plane/merge_train_policy_source.py
+++ b/control_plane/merge_train_policy_source.py
@@ -1,0 +1,23 @@
+import os
+from pathlib import Path
+
+from control_plane.contracts.merge_train_policy import MergeTrainPolicy
+from control_plane.contracts.merge_train_policy import default_merge_train_policy_path
+from control_plane.contracts.merge_train_policy import load_merge_train_policy
+from control_plane.contracts.merge_train_policy import parse_merge_train_policy_toml
+
+
+_MERGE_TRAIN_POLICY_TOML_ENV_KEY = "LAUNCHPLANE_MERGE_TRAIN_POLICY_TOML"
+_MERGE_TRAIN_POLICY_FILE_ENV_KEY = "LAUNCHPLANE_MERGE_TRAIN_POLICY_FILE"
+
+
+def load_launchplane_merge_train_policy() -> MergeTrainPolicy:
+    policy_toml = os.environ.get(_MERGE_TRAIN_POLICY_TOML_ENV_KEY, "").strip()
+    if policy_toml:
+        return parse_merge_train_policy_toml(policy_toml)
+
+    policy_file = os.environ.get(_MERGE_TRAIN_POLICY_FILE_ENV_KEY, "").strip()
+    if policy_file:
+        return load_merge_train_policy(Path(policy_file))
+
+    return load_merge_train_policy(default_merge_train_policy_path())

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -76,11 +76,9 @@ from control_plane.contracts.every_code_summary_read_model import (
 )
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.idempotency_record import build_launchplane_idempotency_record_id
-from control_plane.contracts.merge_train_policy import (
-    build_sellyouroutboard_main_merge_train_policy,
-)
 from control_plane.contracts.merge_train_run_record import build_merge_train_run_record
 from control_plane.merge_train_admission import evaluate_merge_train_admission_from_store
+from control_plane.merge_train_policy_source import load_launchplane_merge_train_policy
 from control_plane.contracts.odoo_instance_override_record import (
     OdooConfigParameterOverride,
     OdooInstanceOverrideRecord,
@@ -455,6 +453,8 @@ _LAUNCHPLANE_SELF_DEPLOY_OAUTH_ENV_KEYS = frozenset(
         "LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT",
         "LAUNCHPLANE_WORK_GRAPH_GH_BINARY",
         "GH_TOKEN",
+        "LAUNCHPLANE_MERGE_TRAIN_POLICY_TOML",
+        "LAUNCHPLANE_MERGE_TRAIN_POLICY_FILE",
     }
 )
 
@@ -6242,7 +6242,7 @@ def create_launchplane_service_app(
                             "base_branch": str((query.get("base_branch") or ["main"])[0] or ""),
                         }
                     )
-                    policy = build_sellyouroutboard_main_merge_train_policy()
+                    policy = load_launchplane_merge_train_policy()
                     repository_policy = policy.find_repository_policy(
                         repository=admission_request.repository,
                         base_branch=admission_request.base_branch,
@@ -6649,7 +6649,7 @@ def create_launchplane_service_app(
                 driver_result = {"request": record.model_dump(mode="json")}
             elif path == _MERGE_TRAIN_RUN_ONCE_ROUTE:
                 merge_train_request = MergeTrainRunOnceEnvelope.model_validate(payload)
-                policy = build_sellyouroutboard_main_merge_train_policy()
+                policy = load_launchplane_merge_train_policy()
                 repository_policy = policy.find_repository_policy(
                     repository=merge_train_request.repository,
                     base_branch=merge_train_request.base_branch,

--- a/docs/config-boundary.md
+++ b/docs/config-boundary.md
@@ -55,6 +55,13 @@ terminal-agent and local-operator keys.
 
 | Work graph GitHub Project read source | `LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER`, `LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER`, optional `LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT`, optional `LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT`, optional `LAUNCHPLANE_WORK_GRAPH_GH_BINARY` | Service target env | Opt-in read source for compact Project fields plus bounded dependency, subissue, and PR check signals. Deploy automation forwards these values only when the GitHub Project token secret is present. Requires a `gh` credential with the GitHub CLI `project` scope. Does not store copied issue bodies. |
 | Work graph and merge-train GitHub token | `GH_TOKEN` from deploy secret `LAUNCHPLANE_WORK_GRAPH_GH_TOKEN` | Platform secret projected into service target env | Authenticates the service's non-interactive `gh` reads and merge-train GitHub API calls. The token must have enough GitHub access for the configured Project, issue/PR signal reads, and the configured merge-train repository. |
+| Merge-train policy source | `control_plane/config/merge-train-policies.toml`, optional `LAUNCHPLANE_MERGE_TRAIN_POLICY_TOML`, optional `LAUNCHPLANE_MERGE_TRAIN_POLICY_FILE` | Launchplane-owned repo config or explicit deploy override | Defines supported repository/base branch merge-train policies. The service fails closed for unsupported pairs before GitHub calls. Env overrides replace the checked-in policy set for operator-managed deployments. |
+
+`LAUNCHPLANE_MERGE_TRAIN_POLICY_TOML` takes precedence over
+`LAUNCHPLANE_MERGE_TRAIN_POLICY_FILE` when both are present. Deploy automation
+forwards either override even when the work-graph GitHub token secret is absent,
+but accepted live merge-train runs still require the configured `github_token`
+environment variable to resolve at request time.
 
 ### DB Authoritative
 

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -1,13 +1,15 @@
 # Merge Train Policy Contract
 
 Launchplane merge trains use an explicit repository policy before any worker is
-allowed to enqueue, update, or merge pull requests. The policy is a bootstrap
-contract for the sequential merge train work in #410; it is not a live tracked
-`config/*.toml` authority.
+allowed to enqueue, update, or merge pull requests. The default Launchplane-owned
+policy set lives at `control_plane/config/merge-train-policies.toml`. Deployments
+may override it with `LAUNCHPLANE_MERGE_TRAIN_POLICY_TOML` or
+`LAUNCHPLANE_MERGE_TRAIN_POLICY_FILE`; when neither env var is set, service
+routes and CLI tools load the checked-in default policy file.
 
-The first live smoke target is SellYourOutboard `main`. The policy is bundled in
-code for CLI and worker dry-runs so the next implementation slice can discover a
-stable contract without adding repo-local runtime config.
+The default policy set keeps the SellYourOutboard `main` smoke policy available
+as seed/test data and opts `cbusillo/codex-skills:main` into the merge train as
+the first real target.
 
 ## Fields
 
@@ -42,7 +44,7 @@ request with `blocked_label` and stops processing later queued pull requests.
 higher throughput over strict ordering. A worker must still mark the failed pull
 request with `blocked_label` before considering later entries.
 
-## Initial Smoke Policy
+## Default Policy Entries
 
 ```toml
 schema_version = 1
@@ -70,7 +72,45 @@ context = "launchplane"
 
 [policies.github_token]
 env_var = "GH_TOKEN"
+
+[[policies]]
+repository = "cbusillo/codex-skills"
+base_branch = "main"
+enqueue_label = "ready-to-merge"
+blocked_label = "merge-blocked"
+merge_method = "merge"
+failure_policy = "pause_train"
+
+[policies.enqueue]
+label_required = true
+allowed_actor_roles = ["repo_owner", "repo_admin"]
+
+[policies.merge_identity]
+kind = "github_actions_oidc"
+name = "launchplane-merge-train"
+
+[policies.service_authz]
+action = "merge_train.run_once"
+product = "launchplane"
+context = "launchplane"
+
+[policies.github_token]
+env_var = "GH_TOKEN"
 ```
+
+## Operator Changes
+
+To add or change a repository policy without editing generic service logic,
+update the TOML policy source and deploy Launchplane. The service resolves
+repository/base branch requests from that typed policy before authorization,
+token lookup, or GitHub calls, so unsupported pairs fail closed.
+
+Use `LAUNCHPLANE_MERGE_TRAIN_POLICY_TOML` for a deploy-projected inline TOML
+payload or `LAUNCHPLANE_MERGE_TRAIN_POLICY_FILE` for an operator-managed file on
+the service host. `LAUNCHPLANE_MERGE_TRAIN_POLICY_TOML` takes precedence when
+both are set. The payload must include every policy the service should support;
+env overrides replace the default checked-in policy set rather than merging with
+it.
 
 ## Discoverability
 
@@ -78,12 +118,12 @@ The contract is available to dry-run tooling with:
 
 ```sh
 uv run launchplane work-graph merge-train-policy \
-  --repository cbusillo/sellyouroutboard \
+  --repository cbusillo/codex-skills \
   --base-branch main
 ```
 
-Operators can validate an external bootstrap TOML without treating it as live
-authority:
+Operators can validate an external TOML before projecting it into deployment
+configuration:
 
 ```sh
 uv run launchplane work-graph merge-train-policy \
@@ -102,7 +142,7 @@ uv run launchplane work-graph merge-train-dry-run \
   --snapshot-file path/to/merge-train-snapshot.json
 ```
 
-The smoke-target run-once command reads a live GitHub snapshot for the selected
+The run-once command reads a live GitHub snapshot for the selected
 repository/base branch and reports the same worker-step intent without mutating
 by default:
 
@@ -112,12 +152,12 @@ GH_TOKEN=... uv run launchplane work-graph merge-train-run-once
 
 The deployed Launchplane service projects the work-graph GitHub credential into
 `GH_TOKEN` from the `LAUNCHPLANE_WORK_GRAPH_GH_TOKEN` deployment secret, so the
-bundled smoke policy uses that same service-host token source.
+default policies use that same service-host token source.
 
 Passing `--mutate` applies exactly one worker transition from that fresh
-snapshot. Use it only from the intended operator environment for the smoke
-target; the command is a narrow bootstrap surface, not a long-running train
-scheduler.
+snapshot. Use it only from the intended operator environment for the smoke or
+configured target; the command is a narrow bootstrap surface, not a long-running
+train scheduler.
 
 The dry-run orders eligible pull requests by `created_at` and then PR number. It
 excludes draft, closed, unlabeled, or unauthorized entries and fails closed when

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -279,10 +279,13 @@ bodies, and must preserve the lower-level redaction/provenance rules.
 
 `POST /v1/work-graph/merge-train/run-once` is the authenticated service ingress
 for one merge-train read or mutation pass. It resolves repository/base policy
-before authorization, token lookup, or GitHub reads, authorizes against the
-policy's `service_authz`, reads a fresh GitHub snapshot, and writes a
-`launchplane_merge_train_runs` record for accepted dry-run and mutate calls.
-Mutation mode still applies at most one worker transition from that snapshot.
+from `control_plane/config/merge-train-policies.toml`, or from
+`LAUNCHPLANE_MERGE_TRAIN_POLICY_TOML` / `LAUNCHPLANE_MERGE_TRAIN_POLICY_FILE`
+when the deployment projects an override, before authorization, token lookup, or
+GitHub reads. It authorizes against the policy's `service_authz`, reads a fresh
+GitHub snapshot, and writes a `launchplane_merge_train_runs` record for accepted
+dry-run and mutate calls. Mutation mode still applies at most one worker
+transition from that snapshot.
 
 ## Host Assumption
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ launchplane = "control_plane.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["control_plane"]
+artifacts = ["control_plane/config/*.toml"]
 
 [tool.ruff]
 line-length = 100

--- a/tests/test_merge_train.py
+++ b/tests/test_merge_train.py
@@ -207,7 +207,12 @@ class MergeTrainDryRunTests(unittest.TestCase):
         ):
             result = CliRunner().invoke(
                 main,
-                ["work-graph", "merge-train-run-once"],
+                [
+                    "work-graph",
+                    "merge-train-run-once",
+                    "--repository",
+                    "cbusillo/sellyouroutboard",
+                ],
             )
 
         self.assertEqual(result.exit_code, 0, result.output)
@@ -274,7 +279,13 @@ class MergeTrainDryRunTests(unittest.TestCase):
         ):
             result = CliRunner().invoke(
                 main,
-                ["work-graph", "merge-train-run-once", "--mutate"],
+                [
+                    "work-graph",
+                    "merge-train-run-once",
+                    "--repository",
+                    "cbusillo/sellyouroutboard",
+                    "--mutate",
+                ],
             )
 
         self.assertEqual(result.exit_code, 0, result.output)
@@ -291,7 +302,12 @@ class MergeTrainDryRunTests(unittest.TestCase):
         with patch.dict("os.environ", {}, clear=True):
             result = CliRunner().invoke(
                 main,
-                ["work-graph", "merge-train-run-once"],
+                [
+                    "work-graph",
+                    "merge-train-run-once",
+                    "--repository",
+                    "cbusillo/sellyouroutboard",
+                ],
             )
 
         self.assertNotEqual(result.exit_code, 0)

--- a/tests/test_merge_train_policy.py
+++ b/tests/test_merge_train_policy.py
@@ -1,6 +1,10 @@
 import json
+import os
 import textwrap
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from click.testing import CliRunner
 from pydantic import ValidationError
@@ -8,8 +12,10 @@ from pydantic import ValidationError
 from control_plane.cli import main
 from control_plane.contracts.merge_train_policy import (
     build_sellyouroutboard_main_merge_train_policy,
+    load_merge_train_policy_from_default_config,
     parse_merge_train_policy_toml,
 )
+from control_plane.merge_train_policy_source import load_launchplane_merge_train_policy
 
 
 class MergeTrainPolicyTests(unittest.TestCase):
@@ -35,6 +41,50 @@ class MergeTrainPolicyTests(unittest.TestCase):
         self.assertEqual(repository_policy.service_authz.context, "launchplane")
         self.assertEqual(repository_policy.github_token.env_var, "GH_TOKEN")
         self.assertEqual(len(policy.policy_sha256), 64)
+
+    def test_default_config_includes_smoke_and_codex_skills_policies(self) -> None:
+        policy = load_merge_train_policy_from_default_config()
+
+        self.assertEqual(len(policy.policies), 2)
+        self.assertEqual(
+            {repository_policy.policy_key for repository_policy in policy.policies},
+            {"cbusillo/sellyouroutboard:main", "cbusillo/codex-skills:main"},
+        )
+        codex_skills_policy = policy.find_repository_policy(
+            repository="cbusillo/codex-skills", base_branch="main"
+        )
+        self.assertEqual(codex_skills_policy.enqueue_label, "ready-to-merge")
+        self.assertEqual(codex_skills_policy.blocked_label, "merge-blocked")
+        self.assertEqual(codex_skills_policy.merge_method, "merge")
+        self.assertEqual(codex_skills_policy.github_token.env_var, "GH_TOKEN")
+        self.assertEqual(codex_skills_policy.service_authz.action, "merge_train.run_once")
+        self.assertEqual(codex_skills_policy.service_authz.product, "launchplane")
+        self.assertEqual(codex_skills_policy.service_authz.context, "launchplane")
+
+    def test_launchplane_policy_source_prefers_env_toml(self) -> None:
+        with patch.dict(
+            os.environ,
+            {"LAUNCHPLANE_MERGE_TRAIN_POLICY_TOML": _policy_toml("example/app")},
+            clear=True,
+        ):
+            policy = load_launchplane_merge_train_policy()
+
+        self.assertEqual(len(policy.policies), 1)
+        self.assertEqual(policy.policies[0].policy_key, "example/app:main")
+
+    def test_launchplane_policy_source_uses_env_file(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            policy_file = Path(temporary_directory_name) / "merge-train-policies.toml"
+            policy_file.write_text(_policy_toml("example/file-app"), encoding="utf-8")
+            with patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_MERGE_TRAIN_POLICY_FILE": str(policy_file)},
+                clear=True,
+            ):
+                policy = load_launchplane_merge_train_policy()
+
+        self.assertEqual(len(policy.policies), 1)
+        self.assertEqual(policy.policies[0].policy_key, "example/file-app:main")
 
     def test_parse_rejects_duplicate_repository_branch_policy(self) -> None:
         policy_toml = textwrap.dedent(
@@ -114,9 +164,33 @@ class MergeTrainPolicyTests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         payload = json.loads(result.output)
         self.assertEqual(payload["status"], "ok")
-        self.assertEqual(payload["repository_count"], 1)
+        self.assertEqual(payload["repository_count"], 2)
         self.assertEqual(payload["selected_policy"]["repository"], "cbusillo/sellyouroutboard")
         self.assertEqual(payload["selected_policy"]["base_branch"], "main")
+
+
+def _policy_toml(repository: str) -> str:
+    return textwrap.dedent(
+        f"""
+        schema_version = 1
+
+        [[policies]]
+        repository = "{repository}"
+        base_branch = "main"
+        enqueue_label = "ready-to-merge"
+        blocked_label = "merge-blocked"
+        merge_method = "merge"
+        failure_policy = "pause_train"
+        [policies.enqueue]
+        label_required = true
+        allowed_actor_roles = ["repo_owner"]
+        [policies.merge_identity]
+        kind = "github_app"
+        name = "launchplane"
+        [policies.github_token]
+        env_var = "GH_TOKEN"
+        """
+    ).strip()
 
 
 if __name__ == "__main__":

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1439,6 +1439,59 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 400)
         self.assertEqual(payload["error"]["code"], "invalid_request")
 
+    def test_merge_train_run_once_service_uses_configured_codex_skills_policy(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                _FakeMergeTrainSnapshotReader,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/codex-skills",
+                        "base_branch": "main",
+                    },
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["repository"], "cbusillo/codex-skills")
+        self.assertEqual(payload["result"]["base_branch"], "main")
+        self.assertEqual(
+            payload["result"]["dry_run_result"]["policy_key"], "cbusillo/codex-skills:main"
+        )
+
+    def test_merge_train_admission_service_uses_configured_codex_skills_policy(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/work-graph/merge-train/admission",
+                query_string="repository=cbusillo/codex-skills&base_branch=main",
+            )
+
+        self.assertEqual(status_code, 200)
+        self.assertEqual(payload["admission"]["repository"], "cbusillo/codex-skills")
+        self.assertEqual(payload["admission"]["base_branch"], "main")
+        self.assertEqual(payload["admission"]["status"], "admitted")
+
     def test_merge_train_admission_service_admits_without_prior_run(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             app = create_launchplane_service_app(


### PR DESCRIPTION
## Summary

- load merge-train policies from Launchplane-owned TOML config/env policy sources instead of the bundled single smoke policy
- configure both `cbusillo/sellyouroutboard:main` and `cbusillo/codex-skills:main`, with `codex-skills` as the CLI run-once default target
- document operator policy updates and forward deploy-time merge-train policy overrides

Closes #597.

## Validation

- `uv run python -m unittest tests.test_merge_train tests.test_merge_train_admission tests.test_merge_train_policy tests.test_merge_train_worker tests.test_service.LaunchplaneServiceTests`
- `uv run python -m unittest`
- `uv run --extra dev ruff check control_plane/cli.py control_plane/contracts/merge_train_policy.py control_plane/merge_train_policy_source.py control_plane/service.py tests/test_merge_train.py tests/test_merge_train_policy.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/cli.py control_plane/contracts/merge_train_policy.py control_plane/merge_train_policy_source.py control_plane/service.py tests/test_merge_train.py tests/test_merge_train_policy.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests/test_merge_train.py tests/test_merge_train_policy.py tests/test_service.py`
- `uv run launchplane work-graph merge-train-policy --repository cbusillo/codex-skills --base-branch main`
- `uv build`
- package artifact check for `control_plane/config/merge-train-policies.toml` in sdist and wheel
- JetBrains changed-file inspection: completed; warnings are existing-style weak/test warnings, with command-line gates clean
