### PR TITLE
Add merge train policy import workflow

### DIFF
--- a/.github/workflows/merge-train-policy-import.yml
+++ b/.github/workflows/merge-train-policy-import.yml
@@ -1,0 +1,252 @@
+---
+name: Merge Train Policy Import
+
+"on":
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: owner/name repository to configure for the merge train
+        required: true
+        type: string
+      base_branch:
+        description: Base branch protected by the merge train
+        required: false
+        default: main
+        type: string
+      enqueue_label:
+        description: Label required before a pull request can enter the train
+        required: false
+        default: ready-to-merge
+        type: string
+      blocked_label:
+        description: Label Launchplane applies when a pull request blocks
+        required: false
+        default: merge-blocked
+        type: string
+      merge_method:
+        description: GitHub merge method
+        required: false
+        default: merge
+        type: choice
+        options:
+          - merge
+          - squash
+          - rebase
+      failure_policy:
+        description: Worker behavior after a blocking pull request
+        required: false
+        default: pause_train
+        type: choice
+        options:
+          - pause_train
+          - continue_after_blocking_pr
+      source_label:
+        description: Source label stored on the policy record
+        required: false
+        default: workflow:merge-train-policy-import
+        type: string
+      reason:
+        description: Audit reason used when apply is true
+        required: false
+        default: Configure merge train policy for requested repository.
+        type: string
+      apply:
+        description: Apply after the service dry-run succeeds
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: merge-train-policy-import
+  cancel-in-progress: false
+
+jobs:
+  import:
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    env:
+      LAUNCHPLANE_URL: >-
+        ${{ vars.LAUNCHPLANE_PUBLIC_URL ||
+        'https://launchplane.shinycomputers.com' }}
+      APPLY_POLICY: ${{ inputs.apply && 'true' || 'false' }}
+      POLICY_REPOSITORY: ${{ inputs.repository }}
+      POLICY_BASE_BRANCH: ${{ inputs.base_branch }}
+      POLICY_ENQUEUE_LABEL: ${{ inputs.enqueue_label }}
+      POLICY_BLOCKED_LABEL: ${{ inputs.blocked_label }}
+      POLICY_MERGE_METHOD: ${{ inputs.merge_method }}
+      POLICY_FAILURE_POLICY: ${{ inputs.failure_policy }}
+      POLICY_SOURCE_LABEL: ${{ inputs.source_label }}
+      POLICY_REASON: ${{ inputs.reason }}
+    steps:
+      - name: Resolve service endpoint
+        id: service
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${LAUNCHPLANE_URL:?Missing LAUNCHPLANE_PUBLIC_URL variable}"
+
+          python3 - <<'PY'
+          import os
+          from urllib.parse import urlsplit
+
+          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"].strip())
+          if not parsed.scheme or not parsed.netloc or not parsed.hostname:
+              raise SystemExit("LAUNCHPLANE_URL must be an absolute URL.")
+          output_path = os.environ["GITHUB_OUTPUT"]
+          with open(output_path, "a", encoding="utf-8") as handle:
+              handle.write(f"origin={parsed.scheme}://{parsed.netloc}\n")
+              handle.write(f"audience={parsed.hostname}\n")
+          PY
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install Python
+        run: uv python install 3.13
+
+      - name: Build policy payload
+        id: policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          policy_file="${RUNNER_TEMP}/merge-train-policy.toml"
+          python3 - <<'PY' > "$policy_file"
+          import os
+
+          values = {
+              "repository": os.environ["POLICY_REPOSITORY"].strip(),
+              "base_branch": os.environ["POLICY_BASE_BRANCH"].strip(),
+              "enqueue_label": os.environ["POLICY_ENQUEUE_LABEL"].strip(),
+              "blocked_label": os.environ["POLICY_BLOCKED_LABEL"].strip(),
+              "merge_method": os.environ["POLICY_MERGE_METHOD"].strip(),
+              "failure_policy": os.environ["POLICY_FAILURE_POLICY"].strip(),
+          }
+          for key, value in values.items():
+              if not value:
+                  raise SystemExit(f"{key} is required")
+              if "\n" in value or "\r" in value:
+                  raise SystemExit(f"{key} must be a single line")
+          if "/" not in values["repository"]:
+              raise SystemExit("repository must be owner/name")
+          if values["enqueue_label"] == values["blocked_label"]:
+              raise SystemExit("enqueue_label and blocked_label must differ")
+          print("schema_version = 1")
+          print()
+          print("[[policies]]")
+          for key in (
+              "repository",
+              "base_branch",
+              "enqueue_label",
+              "blocked_label",
+              "merge_method",
+              "failure_policy",
+          ):
+              print(f'{key} = "{values[key]}"')
+          print()
+          print("[policies.enqueue]")
+          print("label_required = true")
+          print('allowed_actor_roles = ["repo_owner", "repo_admin"]')
+          print()
+          print("[policies.merge_identity]")
+          print('kind = "github_actions_oidc"')
+          print('name = "launchplane-merge-train"')
+          print()
+          print("[policies.service_authz]")
+          print('action = "merge_train.run_once"')
+          print('product = "launchplane"')
+          print('context = "launchplane"')
+          print()
+          print("[policies.github_token]")
+          print('env_var = "GH_TOKEN"')
+          PY
+          uv run launchplane work-graph merge-train-policy \
+            --policy-file "$policy_file" \
+            --repository "$POLICY_REPOSITORY" \
+            --base-branch "$POLICY_BASE_BRANCH" \
+            | tee merge-train-policy-validation.json
+          policy_sha256="$(
+            jq -r '.policy_sha256' merge-train-policy-validation.json
+          )"
+          echo "file=${policy_file}" >> "$GITHUB_OUTPUT"
+          echo "sha256=${policy_sha256}" >> "$GITHUB_OUTPUT"
+
+      - name: Request policy import dry-run
+        id: dry_run
+        shell: bash
+        env:
+          SERVICE_ORIGIN: ${{ steps.service.outputs.origin }}
+          SERVICE_AUDIENCE: ${{ steps.service.outputs.audience }}
+          POLICY_FILE: ${{ steps.policy.outputs.file }}
+        run: |
+          set -euo pipefail
+          oidc_token="$({
+            curl -fsSL \
+              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
+            | jq -r '.value'
+          })"
+          LAUNCHPLANE_SERVICE_TOKEN="$oidc_token" \
+            uv run launchplane merge-train-policies import-policy \
+              --service-url "$SERVICE_ORIGIN" \
+              --policy-file "$POLICY_FILE" \
+              --source-label "$POLICY_SOURCE_LABEL" \
+              --dry-run \
+              | tee merge-train-policy-dry-run.json
+
+      - name: Apply policy import
+        if: env.APPLY_POLICY == 'true'
+        shell: bash
+        env:
+          SERVICE_ORIGIN: ${{ steps.service.outputs.origin }}
+          SERVICE_AUDIENCE: ${{ steps.service.outputs.audience }}
+          POLICY_FILE: ${{ steps.policy.outputs.file }}
+        run: |
+          set -euo pipefail
+          reason="$POLICY_REASON"
+          if [ -z "$(printf '%s' "$reason" | xargs)" ]; then
+            echo "reason is required when apply is true" >&2
+            exit 1
+          fi
+          oidc_token="$({
+            curl -fsSL \
+              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
+            | jq -r '.value'
+          })"
+          LAUNCHPLANE_SERVICE_TOKEN="$oidc_token" \
+            uv run launchplane merge-train-policies import-policy \
+              --service-url "$SERVICE_ORIGIN" \
+              --policy-file "$POLICY_FILE" \
+              --source-label "$POLICY_SOURCE_LABEL" \
+              --reason "$reason" \
+              --idempotency-key "$({
+                printf 'merge-train-policy-import:%s:%s:%s:%s:%s' \
+                  "$POLICY_REPOSITORY" \
+                  "$POLICY_BASE_BRANCH" \
+                  '${{ steps.policy.outputs.sha256 }}' \
+                  "$GITHUB_RUN_ID" \
+                  "$GITHUB_RUN_ATTEMPT"
+              })" \
+              --apply \
+              | tee merge-train-policy-apply.json
+
+      - name: Summarize
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo '## Merge train policy import'
+            echo
+            echo "- Repository: ${POLICY_REPOSITORY}"
+            echo "- Base branch: ${POLICY_BASE_BRANCH}"
+            echo "- Policy SHA256: ${{ steps.policy.outputs.sha256 }}"
+            echo "- Applied: ${APPLY_POLICY}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -715,6 +715,14 @@ post_grant \
   merge-train-runner
 post_grant \
   "$GITHUB_REPOSITORY" \
+  merge-train-policy-import.yml \
+  launchplane \
+  launchplane \
+  launchplane_service_deploy.execute \
+  deploy:merge-train-policy-import-grant \
+  merge-train-policy-import
+post_grant \
+  "$GITHUB_REPOSITORY" \
   deploy-launchplane.yml \
   launchplane \
   launchplane \


### PR DESCRIPTION
Adds a reusable workflow_dispatch path for DB-backed merge-train policy imports through the deployed Launchplane service using GitHub OIDC. The workflow builds policy TOML from dispatch inputs, validates it locally, dry-runs the service import, and applies only when explicitly requested. Also grants this workflow launchplane_service_deploy.execute via the existing deploy authz grant script.