### PR TITLE
Define batch merge train records

### DIFF
--- a/control_plane/contracts/merge_train_batch.py
+++ b/control_plane/contracts/merge_train_batch.py
@@ -12,6 +12,7 @@ from control_plane.contracts.merge_train_policy import MergeTrainMergeMethod
 MergeTrainBatchCandidateStatus = Literal[
     "planned", "building", "ready_for_checks", "passed", "failed", "stale", "blocked"
 ]
+MergeTrainBatchRecordStatus = Literal["active", "superseded"]
 MergeTrainBatchLandingStatus = Literal[
     "planned", "merging", "merged", "blocked", "stale", "skipped"
 ]
@@ -158,6 +159,56 @@ class MergeTrainBatchLandingPlan(BaseModel):
         positions = [entry.position for entry in self.entries]
         if positions != list(range(1, len(positions) + 1)):
             raise ValueError("merge train batch landing plan positions must be contiguous")
+        return self
+
+
+class MergeTrainBatchCandidateRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    record_id: str
+    status: MergeTrainBatchRecordStatus = "active"
+    source: str
+    updated_at: str
+    candidate: MergeTrainBatchCandidate
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "MergeTrainBatchCandidateRecord":
+        self.record_id = _normalize_required_value(
+            self.record_id, "merge train batch candidate record requires record_id"
+        )
+        self.source = _normalize_required_value(
+            self.source, "merge train batch candidate record requires source"
+        )
+        self.updated_at = _normalize_required_value(
+            self.updated_at,
+            "merge train batch candidate record requires updated_at",
+        )
+        return self
+
+
+class MergeTrainBatchLandingPlanRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    record_id: str
+    status: MergeTrainBatchRecordStatus = "active"
+    source: str
+    updated_at: str
+    landing_plan: MergeTrainBatchLandingPlan
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "MergeTrainBatchLandingPlanRecord":
+        self.record_id = _normalize_required_value(
+            self.record_id, "merge train batch landing plan record requires record_id"
+        )
+        self.source = _normalize_required_value(
+            self.source, "merge train batch landing plan record requires source"
+        )
+        self.updated_at = _normalize_required_value(
+            self.updated_at,
+            "merge train batch landing plan record requires updated_at",
+        )
         return self
 
 

--- a/control_plane/contracts/merge_train_batch.py
+++ b/control_plane/contracts/merge_train_batch.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.merge_train_policy import MergeTrainMergeMethod
+
+
+MergeTrainBatchCandidateStatus = Literal[
+    "planned", "building", "ready_for_checks", "passed", "failed", "stale", "blocked"
+]
+MergeTrainBatchLandingStatus = Literal[
+    "planned", "merging", "merged", "blocked", "stale", "skipped"
+]
+
+
+class MergeTrainBatchEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    pull_request_number: int = Field(gt=0)
+    position: int = Field(gt=0)
+    head_sha: str
+    title: str = ""
+    url: str = ""
+
+    @model_validator(mode="after")
+    def _validate_entry(self) -> "MergeTrainBatchEntry":
+        self.head_sha = _normalize_required_value(
+            self.head_sha, "merge train batch entry requires head_sha"
+        )
+        self.title = self.title.strip()
+        self.url = self.url.strip()
+        return self
+
+
+class MergeTrainBatchCandidate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    batch_id: str
+    repository: str
+    base_branch: str
+    base_sha: str
+    policy_key: str
+    policy_sha256: str
+    candidate_ref: str
+    candidate_sha: str = ""
+    status: MergeTrainBatchCandidateStatus = "planned"
+    entries: tuple[MergeTrainBatchEntry, ...]
+    required_checks_status: Literal["unknown", "pending", "pass", "fail"] = "unknown"
+    created_at: str
+    updated_at: str
+
+    @model_validator(mode="after")
+    def _validate_candidate(self) -> "MergeTrainBatchCandidate":
+        self.batch_id = _normalize_required_value(
+            self.batch_id, "merge train batch candidate requires batch_id"
+        )
+        self.repository = _normalize_repository(self.repository)
+        self.base_branch = _normalize_required_value(
+            self.base_branch, "merge train batch candidate requires base_branch"
+        )
+        self.base_sha = _normalize_required_value(
+            self.base_sha, "merge train batch candidate requires base_sha"
+        )
+        self.policy_key = _normalize_required_value(
+            self.policy_key, "merge train batch candidate requires policy_key"
+        )
+        self.policy_sha256 = _normalize_required_value(
+            self.policy_sha256,
+            "merge train batch candidate requires policy_sha256",
+        )
+        self.candidate_ref = _normalize_required_value(
+            self.candidate_ref, "merge train batch candidate requires candidate_ref"
+        )
+        self.candidate_sha = self.candidate_sha.strip()
+        self.created_at = _normalize_required_value(
+            self.created_at, "merge train batch candidate requires created_at"
+        )
+        self.updated_at = _normalize_required_value(
+            self.updated_at, "merge train batch candidate requires updated_at"
+        )
+        self.entries = _normalize_entries(self.entries)
+        return self
+
+
+class MergeTrainBatchLandingEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    pull_request_number: int = Field(gt=0)
+    position: int = Field(gt=0)
+    expected_head_sha: str
+    expected_base_sha: str
+    merge_method: MergeTrainMergeMethod
+    status: MergeTrainBatchLandingStatus = "planned"
+    merge_commit_sha: str = ""
+
+    @model_validator(mode="after")
+    def _validate_landing_entry(self) -> "MergeTrainBatchLandingEntry":
+        self.expected_head_sha = _normalize_required_value(
+            self.expected_head_sha,
+            "merge train batch landing entry requires expected_head_sha",
+        )
+        self.expected_base_sha = _normalize_required_value(
+            self.expected_base_sha,
+            "merge train batch landing entry requires expected_base_sha",
+        )
+        self.merge_commit_sha = self.merge_commit_sha.strip()
+        return self
+
+
+class MergeTrainBatchLandingPlan(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    plan_id: str
+    batch_id: str
+    repository: str
+    base_branch: str
+    candidate_ref: str
+    candidate_sha: str
+    policy_key: str
+    policy_sha256: str
+    entries: tuple[MergeTrainBatchLandingEntry, ...]
+    created_at: str
+
+    @model_validator(mode="after")
+    def _validate_plan(self) -> "MergeTrainBatchLandingPlan":
+        self.plan_id = _normalize_required_value(
+            self.plan_id, "merge train batch landing plan requires plan_id"
+        )
+        self.batch_id = _normalize_required_value(
+            self.batch_id, "merge train batch landing plan requires batch_id"
+        )
+        self.repository = _normalize_repository(self.repository)
+        self.base_branch = _normalize_required_value(
+            self.base_branch, "merge train batch landing plan requires base_branch"
+        )
+        self.candidate_ref = _normalize_required_value(
+            self.candidate_ref, "merge train batch landing plan requires candidate_ref"
+        )
+        self.candidate_sha = _normalize_required_value(
+            self.candidate_sha, "merge train batch landing plan requires candidate_sha"
+        )
+        self.policy_key = _normalize_required_value(
+            self.policy_key, "merge train batch landing plan requires policy_key"
+        )
+        self.policy_sha256 = _normalize_required_value(
+            self.policy_sha256,
+            "merge train batch landing plan requires policy_sha256",
+        )
+        self.created_at = _normalize_required_value(
+            self.created_at, "merge train batch landing plan requires created_at"
+        )
+        if not self.entries:
+            raise ValueError("merge train batch landing plan requires entries")
+        positions = [entry.position for entry in self.entries]
+        if positions != list(range(1, len(positions) + 1)):
+            raise ValueError("merge train batch landing plan positions must be contiguous")
+        return self
+
+
+def build_merge_train_batch_id(
+    *, repository: str, base_branch: str, base_sha: str, entry_head_shas: tuple[str, ...]
+) -> str:
+    normalized_repository = _normalize_repository(repository).replace("/", "-")
+    normalized_base_branch = _normalize_required_value(
+        base_branch, "merge train batch id requires base_branch"
+    ).replace("/", "-")
+    digest = hashlib.sha256(
+        json.dumps(
+            {
+                "base_sha": _normalize_required_value(
+                    base_sha, "merge train batch id requires base_sha"
+                ),
+                "entry_head_shas": [
+                    _normalize_required_value(sha, "merge train batch id requires head sha")
+                    for sha in entry_head_shas
+                ],
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+    return f"merge-train-batch-{normalized_repository}-{normalized_base_branch}-{digest}"
+
+
+def build_merge_train_batch_candidate_ref(
+    *, repository: str, base_branch: str, batch_id: str
+) -> str:
+    owner, name = _normalize_repository(repository).split("/", maxsplit=1)
+    normalized_base_branch = _normalize_required_value(
+        base_branch, "merge train batch candidate ref requires base_branch"
+    ).replace("/", "-")
+    normalized_batch_id = _normalize_required_value(
+        batch_id, "merge train batch candidate ref requires batch_id"
+    )
+    return f"refs/heads/launchplane/train/{owner}/{name}/{normalized_base_branch}/{normalized_batch_id}"
+
+
+def build_merge_train_batch_landing_plan(
+    *,
+    candidate: MergeTrainBatchCandidate,
+    merge_method: MergeTrainMergeMethod,
+    created_at: str,
+) -> MergeTrainBatchLandingPlan:
+    if candidate.status != "passed":
+        raise ValueError("merge train batch landing plan requires passed candidate")
+    if not candidate.candidate_sha:
+        raise ValueError("merge train batch landing plan requires candidate_sha")
+    entries = tuple(
+        MergeTrainBatchLandingEntry(
+            pull_request_number=entry.pull_request_number,
+            position=entry.position,
+            expected_head_sha=entry.head_sha,
+            expected_base_sha=candidate.base_sha,
+            merge_method=merge_method,
+        )
+        for entry in candidate.entries
+    )
+    plan_without_id = MergeTrainBatchLandingPlan(
+        plan_id="pending",
+        batch_id=candidate.batch_id,
+        repository=candidate.repository,
+        base_branch=candidate.base_branch,
+        candidate_ref=candidate.candidate_ref,
+        candidate_sha=candidate.candidate_sha,
+        policy_key=candidate.policy_key,
+        policy_sha256=candidate.policy_sha256,
+        entries=entries,
+        created_at=created_at,
+    )
+    return plan_without_id.model_copy(
+        update={"plan_id": build_merge_train_batch_landing_plan_id(plan_without_id)}
+    )
+
+
+def build_merge_train_batch_landing_plan_id(plan: MergeTrainBatchLandingPlan) -> str:
+    digest_payload = plan.model_dump(mode="json", exclude={"plan_id"})
+    digest = hashlib.sha256(
+        json.dumps(digest_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:16]
+    return f"merge-train-landing-plan-{plan.batch_id}-{digest}"
+
+
+def _normalize_entries(
+    entries: tuple[MergeTrainBatchEntry, ...],
+) -> tuple[MergeTrainBatchEntry, ...]:
+    if not entries:
+        raise ValueError("merge train batch candidate requires entries")
+    positions = [entry.position for entry in entries]
+    if positions != list(range(1, len(positions) + 1)):
+        raise ValueError("merge train batch candidate positions must be contiguous")
+    seen_pr_numbers: set[int] = set()
+    for entry in entries:
+        if entry.pull_request_number in seen_pr_numbers:
+            raise ValueError("merge train batch candidate PR numbers must be unique")
+        seen_pr_numbers.add(entry.pull_request_number)
+    return entries
+
+
+def _normalize_repository(repository: str) -> str:
+    normalized = _normalize_required_value(repository, "merge train batch requires repository")
+    if "/" not in normalized:
+        raise ValueError("merge train batch repository must be owner/name")
+    return normalized
+
+
+def _normalize_required_value(value: str, error_message: str) -> str:
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise ValueError(error_message)
+    return normalized_value

--- a/control_plane/contracts/merge_train_batch.py
+++ b/control_plane/contracts/merge_train_batch.py
@@ -7,6 +7,7 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane.contracts.merge_train_policy import MergeTrainMergeMethod
+from control_plane.merge_train import MergeTrainDryRunResult
 
 
 MergeTrainBatchCandidateStatus = Literal[
@@ -210,6 +211,60 @@ class MergeTrainBatchLandingPlanRecord(BaseModel):
             "merge train batch landing plan record requires updated_at",
         )
         return self
+
+
+def build_merge_train_batch_candidate(
+    *,
+    dry_run_result: MergeTrainDryRunResult,
+    base_sha: str,
+    policy_sha256: str,
+    created_at: str,
+) -> MergeTrainBatchCandidate:
+    if dry_run_result.intended_next_action not in ("merge", "idle"):
+        raise ValueError("merge train batch candidate requires a queue without blocking actions")
+    queue_by_number = {entry.number: entry for entry in dry_run_result.queue}
+    entries: list[MergeTrainBatchEntry] = []
+    for pull_request_number in dry_run_result.queue_order:
+        queue_entry = queue_by_number[pull_request_number]
+        if not queue_entry.eligible:
+            raise ValueError("merge train batch candidate requires eligible queue entries")
+        entries.append(
+            MergeTrainBatchEntry(
+                pull_request_number=queue_entry.number,
+                position=len(entries) + 1,
+                head_sha=queue_entry.head_sha,
+                title=queue_entry.title,
+                url=queue_entry.url,
+            )
+        )
+    if not entries:
+        raise ValueError("merge train batch candidate requires at least one eligible PR")
+    normalized_base_sha = _normalize_required_value(
+        base_sha, "merge train batch candidate builder requires base_sha"
+    )
+    batch_id = build_merge_train_batch_id(
+        repository=dry_run_result.repository,
+        base_branch=dry_run_result.base_branch,
+        base_sha=normalized_base_sha,
+        entry_head_shas=tuple(entry.head_sha for entry in entries),
+    )
+    return MergeTrainBatchCandidate(
+        batch_id=batch_id,
+        repository=dry_run_result.repository,
+        base_branch=dry_run_result.base_branch,
+        base_sha=normalized_base_sha,
+        policy_key=dry_run_result.policy_key,
+        policy_sha256=policy_sha256,
+        candidate_ref=build_merge_train_batch_candidate_ref(
+            repository=dry_run_result.repository,
+            base_branch=dry_run_result.base_branch,
+            batch_id=batch_id,
+        ),
+        status="planned",
+        entries=tuple(entries),
+        created_at=created_at,
+        updated_at=created_at,
+    )
 
 
 def build_merge_train_batch_id(

--- a/control_plane/merge_train_github.py
+++ b/control_plane/merge_train_github.py
@@ -107,6 +107,28 @@ class GitHubMergeTrainClient:
             update={"candidate_sha": candidate_sha, "status": "ready_for_checks"}
         )
 
+    def observe_batch_candidate_checks(
+        self, *, candidate: MergeTrainBatchCandidate
+    ) -> MergeTrainBatchCandidate:
+        repository_path = _repository_path(candidate.repository)
+        candidate_sha = _required_value(
+            candidate.candidate_sha,
+            "Merge train batch candidate SHA is required before observing checks.",
+        )
+        check_status = _required_checks_status(
+            transport=self.transport,
+            repository_path=repository_path,
+            encoded_head_sha=quote(candidate_sha, safe=""),
+        )
+        candidate_status = "ready_for_checks"
+        if check_status == "pass":
+            candidate_status = "passed"
+        elif check_status == "fail":
+            candidate_status = "failed"
+        return candidate.model_copy(
+            update={"required_checks_status": check_status, "status": candidate_status}
+        )
+
     def add_pull_request_label(
         self, *, repository: str, pull_request_number: int, label: str
     ) -> None:
@@ -302,48 +324,18 @@ class GitHubMergeTrainSnapshotReader:
         self, *, repository_path: str, head_sha: str
     ) -> MergeTrainCheckStatus:
         encoded_head_sha = quote(head_sha, safe="")
-        status_payload = _json_object(
-            self.transport.request(
-                method="GET", path=f"/repos/{repository_path}/commits/{encoded_head_sha}/status"
-            ),
-            "GitHub combined status response",
-        )
-        check_runs_payload = self._list_check_runs(
-            repository_path=repository_path, encoded_head_sha=encoded_head_sha
-        )
-        return _combine_check_statuses(
-            _combined_status_state(status_payload), _check_runs_status(check_runs_payload)
+        return _required_checks_status(
+            transport=self.transport,
+            repository_path=repository_path,
+            encoded_head_sha=encoded_head_sha,
         )
 
     def _list_check_runs(self, *, repository_path: str, encoded_head_sha: str) -> dict[str, object]:
-        check_runs: list[object] = []
-        page = 1
-        total_count: int | None = None
-        while True:
-            query = urlencode({"per_page": "100", "page": str(page)})
-            payload = _json_object(
-                self.transport.request(
-                    method="GET",
-                    path=(
-                        f"/repos/{repository_path}/commits/{encoded_head_sha}/check-runs?{query}"
-                    ),
-                ),
-                "GitHub check runs response",
-            )
-            raw_check_runs = payload.get("check_runs")
-            if not isinstance(raw_check_runs, list):
-                raise MergeTrainGitHubError("GitHub check runs response must include check_runs.")
-            raw_total_count = payload.get("total_count")
-            if isinstance(raw_total_count, int):
-                total_count = raw_total_count
-            check_runs.extend(raw_check_runs)
-            if len(raw_check_runs) < 100:
-                break
-            page += 1
-        return {
-            "total_count": total_count if total_count is not None else len(check_runs),
-            "check_runs": check_runs,
-        }
+        return _list_check_runs(
+            transport=self.transport,
+            repository_path=repository_path,
+            encoded_head_sha=encoded_head_sha,
+        )
 
 
 class MergeTrainGitHubRequest(BaseModel):
@@ -487,6 +479,62 @@ def _check_runs_status(payload: dict[str, object]) -> MergeTrainCheckStatus:
         check_run = _json_object(item, "GitHub check run")
         statuses.append(_check_run_status(check_run))
     return _combine_check_statuses(*statuses)
+
+
+def _required_checks_status(
+    *,
+    transport: MergeTrainGitHubTransport,
+    repository_path: str,
+    encoded_head_sha: str,
+) -> MergeTrainCheckStatus:
+    status_payload = _json_object(
+        transport.request(
+            method="GET", path=f"/repos/{repository_path}/commits/{encoded_head_sha}/status"
+        ),
+        "GitHub combined status response",
+    )
+    check_runs_payload = _list_check_runs(
+        transport=transport,
+        repository_path=repository_path,
+        encoded_head_sha=encoded_head_sha,
+    )
+    return _combine_check_statuses(
+        _combined_status_state(status_payload), _check_runs_status(check_runs_payload)
+    )
+
+
+def _list_check_runs(
+    *,
+    transport: MergeTrainGitHubTransport,
+    repository_path: str,
+    encoded_head_sha: str,
+) -> dict[str, object]:
+    check_runs: list[object] = []
+    page = 1
+    total_count: int | None = None
+    while True:
+        query = urlencode({"per_page": "100", "page": str(page)})
+        payload = _json_object(
+            transport.request(
+                method="GET",
+                path=(f"/repos/{repository_path}/commits/{encoded_head_sha}/check-runs?{query}"),
+            ),
+            "GitHub check runs response",
+        )
+        raw_check_runs = payload.get("check_runs")
+        if not isinstance(raw_check_runs, list):
+            raise MergeTrainGitHubError("GitHub check runs response must include check_runs.")
+        raw_total_count = payload.get("total_count")
+        if isinstance(raw_total_count, int):
+            total_count = raw_total_count
+        check_runs.extend(raw_check_runs)
+        if len(raw_check_runs) < 100:
+            break
+        page += 1
+    return {
+        "total_count": total_count if total_count is not None else len(check_runs),
+        "check_runs": check_runs,
+    }
 
 
 def _check_run_status(check_run: dict[str, object]) -> MergeTrainCheckStatus:

--- a/control_plane/merge_train_github.py
+++ b/control_plane/merge_train_github.py
@@ -6,6 +6,7 @@ from urllib.request import Request, urlopen
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
+from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidate
 from control_plane.contracts.merge_train_policy import MergeTrainMergeMethod
 from control_plane.merge_train import MergeTrainCheckStatus
 from control_plane.merge_train import MergeTrainDryRunSnapshot
@@ -33,13 +34,11 @@ class MergeTrainGitHubTransport(Protocol):
 class UrllibMergeTrainGitHubTransport:
     def __init__(self, *, token: str, api_base_url: str = "https://api.github.com") -> None:
         self.token = _required_value(token, "GitHub token is required.")
-        self.api_base_url = _required_value(api_base_url, "GitHub API base URL is required.").rstrip(
-            "/"
-        )
+        self.api_base_url = _required_value(
+            api_base_url, "GitHub API base URL is required."
+        ).rstrip("/")
 
-    def request(
-        self, *, method: str, path: str, body: dict[str, object] | None = None
-    ) -> object:
+    def request(self, *, method: str, path: str, body: dict[str, object] | None = None) -> object:
         request_body = None
         headers = {
             "Accept": "application/vnd.github+json",
@@ -72,6 +71,41 @@ class UrllibMergeTrainGitHubTransport:
 class GitHubMergeTrainClient:
     def __init__(self, *, transport: MergeTrainGitHubTransport) -> None:
         self.transport = transport
+
+    def build_batch_candidate(
+        self, *, candidate: MergeTrainBatchCandidate
+    ) -> MergeTrainBatchCandidate:
+        repository_path = _repository_path(candidate.repository)
+        candidate_branch = _branch_name_from_ref(candidate.candidate_ref)
+        self._create_or_reset_reference(
+            repository_path=repository_path,
+            reference=candidate.candidate_ref,
+            sha=candidate.base_sha,
+        )
+        candidate_sha = candidate.base_sha
+        for entry in candidate.entries:
+            payload = self.transport.request(
+                method="POST",
+                path=f"/repos/{repository_path}/merges",
+                body={
+                    "base": candidate_branch,
+                    "head": entry.head_sha,
+                    "commit_message": (
+                        f"Launchplane merge train {candidate.batch_id}: "
+                        f"merge PR #{entry.pull_request_number}"
+                    ),
+                },
+            )
+            if payload is None:
+                continue
+            if not isinstance(payload, dict):
+                raise MergeTrainGitHubError("GitHub merge response must be a JSON object.")
+            candidate_sha = _required_text(
+                payload.get("sha"), "GitHub merge response requires sha."
+            )
+        return candidate.model_copy(
+            update={"candidate_sha": candidate_sha, "status": "ready_for_checks"}
+        )
 
     def add_pull_request_label(
         self, *, repository: str, pull_request_number: int, label: str
@@ -126,6 +160,24 @@ class GitHubMergeTrainClient:
             )
         return merge_commit_sha
 
+    def _create_or_reset_reference(self, *, repository_path: str, reference: str, sha: str) -> None:
+        normalized_sha = _required_value(sha, "GitHub reference SHA is required.")
+        try:
+            self.transport.request(
+                method="POST",
+                path=f"/repos/{repository_path}/git/refs",
+                body={"ref": reference, "sha": normalized_sha},
+            )
+        except MergeTrainGitHubError as error:
+            if error.status_code != 409:
+                raise
+            reference_path = _reference_path(reference)
+            self.transport.request(
+                method="PATCH",
+                path=f"/repos/{repository_path}/git/refs/{reference_path}",
+                body={"sha": normalized_sha, "force": True},
+            )
+
 
 class GitHubMergeTrainSnapshotReader:
     def __init__(self, *, transport: MergeTrainGitHubTransport) -> None:
@@ -177,7 +229,9 @@ class GitHubMergeTrainSnapshotReader:
                 raise MergeTrainGitHubError(
                     "GitHub pull request list response must be a JSON array."
                 )
-            page_pull_requests = [_json_object(item, "GitHub pull request entry") for item in payload]
+            page_pull_requests = [
+                _json_object(item, "GitHub pull request entry") for item in payload
+            ]
             pull_requests.extend(page_pull_requests)
             if len(page_pull_requests) < 100:
                 return tuple(pull_requests)
@@ -261,9 +315,7 @@ class GitHubMergeTrainSnapshotReader:
             _combined_status_state(status_payload), _check_runs_status(check_runs_payload)
         )
 
-    def _list_check_runs(
-        self, *, repository_path: str, encoded_head_sha: str
-    ) -> dict[str, object]:
+    def _list_check_runs(self, *, repository_path: str, encoded_head_sha: str) -> dict[str, object]:
         check_runs: list[object] = []
         page = 1
         total_count: int | None = None
@@ -288,7 +340,10 @@ class GitHubMergeTrainSnapshotReader:
             if len(raw_check_runs) < 100:
                 break
             page += 1
-        return {"total_count": total_count if total_count is not None else len(check_runs), "check_runs": check_runs}
+        return {
+            "total_count": total_count if total_count is not None else len(check_runs),
+            "check_runs": check_runs,
+        }
 
 
 class MergeTrainGitHubRequest(BaseModel):
@@ -312,13 +367,9 @@ class RecordingMergeTrainGitHubTransport:
         self.responses = list(responses)
         self.requests: list[MergeTrainGitHubRequest] = []
 
-    def request(
-        self, *, method: str, path: str, body: dict[str, object] | None = None
-    ) -> object:
+    def request(self, *, method: str, path: str, body: dict[str, object] | None = None) -> object:
         self.requests.append(
-            MergeTrainGitHubRequest.model_validate(
-                {"method": method, "path": path, "body": body}
-            )
+            MergeTrainGitHubRequest.model_validate({"method": method, "path": path, "body": body})
         )
         if self.responses:
             response = self.responses.pop(0)
@@ -334,6 +385,22 @@ def _repository_path(repository: str) -> str:
     if len(parts) != 2 or not all(part.strip() for part in parts):
         raise ValueError("GitHub repository must be formatted as owner/name.")
     return "/".join(quote(part.strip(), safe="") for part in parts)
+
+
+def _branch_name_from_ref(reference: str) -> str:
+    normalized = _required_value(reference, "GitHub branch ref is required.")
+    prefix = "refs/heads/"
+    if not normalized.startswith(prefix):
+        raise ValueError("GitHub branch ref must start with refs/heads/.")
+    return normalized.removeprefix(prefix)
+
+
+def _reference_path(reference: str) -> str:
+    normalized = _required_value(reference, "GitHub reference is required.")
+    prefix = "refs/"
+    if not normalized.startswith(prefix):
+        raise ValueError("GitHub reference must start with refs/.")
+    return "/".join(quote(part, safe="") for part in normalized.removeprefix(prefix).split("/"))
 
 
 def _json_object(value: object, label: str) -> dict[str, object]:

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -17,6 +17,8 @@ from control_plane.contracts.every_code_work_request import (
 )
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
+from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidateRecord
+from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlanRecord
 from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
@@ -164,6 +166,66 @@ class FilesystemRecordStore:
 
     def write_merge_train_policy_record(self, record: MergeTrainPolicyRecord) -> Path:
         return self._write_model("launchplane_merge_train_policies", record.record_id, record)
+
+    def write_merge_train_batch_candidate_record(
+        self, record: MergeTrainBatchCandidateRecord
+    ) -> Path:
+        return self._write_model(
+            "launchplane_merge_train_batch_candidates", record.record_id, record
+        )
+
+    def list_merge_train_batch_candidate_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeTrainBatchCandidateRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                MergeTrainBatchCandidateRecord,
+                "launchplane_merge_train_batch_candidates",
+            )
+            if (not repository or record.candidate.repository == repository)
+            and (not base_branch or record.candidate.base_branch == base_branch)
+            and (not status or record.status == status)
+        ]
+        records.sort(key=lambda record: (record.updated_at, record.record_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def write_merge_train_batch_landing_plan_record(
+        self, record: MergeTrainBatchLandingPlanRecord
+    ) -> Path:
+        return self._write_model(
+            "launchplane_merge_train_batch_landing_plans", record.record_id, record
+        )
+
+    def list_merge_train_batch_landing_plan_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeTrainBatchLandingPlanRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                MergeTrainBatchLandingPlanRecord,
+                "launchplane_merge_train_batch_landing_plans",
+            )
+            if (not repository or record.landing_plan.repository == repository)
+            and (not base_branch or record.landing_plan.base_branch == base_branch)
+            and (not status or record.status == status)
+        ]
+        records.sort(key=lambda record: (record.updated_at, record.record_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
 
     def list_merge_train_policy_records(
         self,

--- a/control_plane/storage/migrations/versions/c178d29af012_add_merge_train_batch_records.py
+++ b/control_plane/storage/migrations/versions/c178d29af012_add_merge_train_batch_records.py
@@ -1,0 +1,97 @@
+"""add merge train batch records
+
+Revision ID: c178d29af012
+Revises: b067c189ef01
+Create Date: 2026-05-13 23:50:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "c178d29af012"
+down_revision: str | None = "b067c189ef01"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "launchplane_merge_train_batch_candidates",
+        sa.Column("record_id", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("source", sa.String(), nullable=False),
+        sa.Column("updated_at", sa.String(), nullable=False),
+        sa.Column("repository", sa.String(), nullable=False),
+        sa.Column("base_branch", sa.String(), nullable=False),
+        sa.Column("batch_id", sa.String(), nullable=False),
+        sa.Column("candidate_status", sa.String(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("record_id"),
+    )
+    op.create_index(
+        "launchplane_merge_train_batch_candidates_repository_base_idx",
+        "launchplane_merge_train_batch_candidates",
+        ["repository", "base_branch", sa.text("updated_at DESC")],
+    )
+    op.create_index(
+        "launchplane_merge_train_batch_candidates_status_idx",
+        "launchplane_merge_train_batch_candidates",
+        ["status", sa.text("updated_at DESC")],
+    )
+    op.create_table(
+        "launchplane_merge_train_batch_landing_plans",
+        sa.Column("record_id", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("source", sa.String(), nullable=False),
+        sa.Column("updated_at", sa.String(), nullable=False),
+        sa.Column("repository", sa.String(), nullable=False),
+        sa.Column("base_branch", sa.String(), nullable=False),
+        sa.Column("batch_id", sa.String(), nullable=False),
+        sa.Column("plan_id", sa.String(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("record_id"),
+    )
+    op.create_index(
+        "launchplane_merge_train_batch_landing_plans_repository_base_idx",
+        "launchplane_merge_train_batch_landing_plans",
+        ["repository", "base_branch", sa.text("updated_at DESC")],
+    )
+    op.create_index(
+        "launchplane_merge_train_batch_landing_plans_status_idx",
+        "launchplane_merge_train_batch_landing_plans",
+        ["status", sa.text("updated_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "launchplane_merge_train_batch_landing_plans_status_idx",
+        table_name="launchplane_merge_train_batch_landing_plans",
+    )
+    op.drop_index(
+        "launchplane_merge_train_batch_landing_plans_repository_base_idx",
+        table_name="launchplane_merge_train_batch_landing_plans",
+    )
+    op.drop_table("launchplane_merge_train_batch_landing_plans")
+    op.drop_index(
+        "launchplane_merge_train_batch_candidates_status_idx",
+        table_name="launchplane_merge_train_batch_candidates",
+    )
+    op.drop_index(
+        "launchplane_merge_train_batch_candidates_repository_base_idx",
+        table_name="launchplane_merge_train_batch_candidates",
+    )
+    op.drop_table("launchplane_merge_train_batch_candidates")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -37,6 +37,10 @@ from control_plane.contracts.every_code_work_request import (
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
+from control_plane.contracts.merge_train_batch import (
+    MergeTrainBatchCandidateRecord,
+    MergeTrainBatchLandingPlanRecord,
+)
 from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
@@ -604,6 +608,60 @@ class LaunchplaneMergeTrainPolicyRow(Base):
     source: Mapped[str] = mapped_column(String, nullable=False)
     updated_at: Mapped[str] = mapped_column(String, nullable=False)
     policy_sha256: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneMergeTrainBatchCandidateRow(Base):
+    __tablename__ = "launchplane_merge_train_batch_candidates"
+    __table_args__ = (
+        Index(
+            "launchplane_merge_train_batch_candidates_repository_base_idx",
+            "repository",
+            "base_branch",
+            desc("updated_at"),
+        ),
+        Index(
+            "launchplane_merge_train_batch_candidates_status_idx",
+            "status",
+            desc("updated_at"),
+        ),
+    )
+
+    record_id: Mapped[str] = mapped_column(String, primary_key=True)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    source: Mapped[str] = mapped_column(String, nullable=False)
+    updated_at: Mapped[str] = mapped_column(String, nullable=False)
+    repository: Mapped[str] = mapped_column(String, nullable=False)
+    base_branch: Mapped[str] = mapped_column(String, nullable=False)
+    batch_id: Mapped[str] = mapped_column(String, nullable=False)
+    candidate_status: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneMergeTrainBatchLandingPlanRow(Base):
+    __tablename__ = "launchplane_merge_train_batch_landing_plans"
+    __table_args__ = (
+        Index(
+            "launchplane_merge_train_batch_landing_plans_repository_base_idx",
+            "repository",
+            "base_branch",
+            desc("updated_at"),
+        ),
+        Index(
+            "launchplane_merge_train_batch_landing_plans_status_idx",
+            "status",
+            desc("updated_at"),
+        ),
+    )
+
+    record_id: Mapped[str] = mapped_column(String, primary_key=True)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    source: Mapped[str] = mapped_column(String, nullable=False)
+    updated_at: Mapped[str] = mapped_column(String, nullable=False)
+    repository: Mapped[str] = mapped_column(String, nullable=False)
+    base_branch: Mapped[str] = mapped_column(String, nullable=False)
+    batch_id: Mapped[str] = mapped_column(String, nullable=False)
+    plan_id: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -1510,6 +1568,92 @@ class PostgresRecordStore(HumanSessionStore):
                 policy_sha256=record.policy_sha256,
                 payload=self._payload_dict(record),
             )
+        )
+
+    def write_merge_train_batch_candidate_record(
+        self, record: MergeTrainBatchCandidateRecord
+    ) -> None:
+        self._write_row(
+            LaunchplaneMergeTrainBatchCandidateRow(
+                record_id=record.record_id,
+                status=record.status,
+                source=record.source,
+                updated_at=record.updated_at,
+                repository=record.candidate.repository,
+                base_branch=record.candidate.base_branch,
+                batch_id=record.candidate.batch_id,
+                candidate_status=record.candidate.status,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def list_merge_train_batch_candidate_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeTrainBatchCandidateRecord, ...]:
+        filters: list[object] = []
+        if repository:
+            filters.append(LaunchplaneMergeTrainBatchCandidateRow.repository == repository)
+        if base_branch:
+            filters.append(LaunchplaneMergeTrainBatchCandidateRow.base_branch == base_branch)
+        if status:
+            filters.append(LaunchplaneMergeTrainBatchCandidateRow.status == status)
+        return self._list_models(
+            model_type=MergeTrainBatchCandidateRecord,
+            orm_model=LaunchplaneMergeTrainBatchCandidateRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneMergeTrainBatchCandidateRow.updated_at.desc(),
+                LaunchplaneMergeTrainBatchCandidateRow.record_id.desc(),
+            ),
+            limit=limit,
+        )
+
+    def write_merge_train_batch_landing_plan_record(
+        self, record: MergeTrainBatchLandingPlanRecord
+    ) -> None:
+        self._write_row(
+            LaunchplaneMergeTrainBatchLandingPlanRow(
+                record_id=record.record_id,
+                status=record.status,
+                source=record.source,
+                updated_at=record.updated_at,
+                repository=record.landing_plan.repository,
+                base_branch=record.landing_plan.base_branch,
+                batch_id=record.landing_plan.batch_id,
+                plan_id=record.landing_plan.plan_id,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def list_merge_train_batch_landing_plan_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeTrainBatchLandingPlanRecord, ...]:
+        filters: list[object] = []
+        if repository:
+            filters.append(LaunchplaneMergeTrainBatchLandingPlanRow.repository == repository)
+        if base_branch:
+            filters.append(LaunchplaneMergeTrainBatchLandingPlanRow.base_branch == base_branch)
+        if status:
+            filters.append(LaunchplaneMergeTrainBatchLandingPlanRow.status == status)
+        return self._list_models(
+            model_type=MergeTrainBatchLandingPlanRecord,
+            orm_model=LaunchplaneMergeTrainBatchLandingPlanRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneMergeTrainBatchLandingPlanRow.updated_at.desc(),
+                LaunchplaneMergeTrainBatchLandingPlanRow.record_id.desc(),
+            ),
+            limit=limit,
         )
 
     def list_merge_train_policy_records(
@@ -2477,6 +2621,8 @@ class PostgresRecordStore(HumanSessionStore):
             "preview_pr_feedback": 0,
             "every_code_preview_gates": 0,
             "agent_write_intents": 0,
+            "merge_train_batch_candidates": 0,
+            "merge_train_batch_landing_plans": 0,
             "merge_train_policies": 0,
             "merge_train_runs": 0,
             "release_tuples": 0,
@@ -2547,6 +2693,14 @@ class PostgresRecordStore(HumanSessionStore):
             for run_record in filesystem_store.list_merge_train_run_records():
                 self.write_merge_train_run_record(run_record)
                 counts["merge_train_runs"] += 1
+        if hasattr(filesystem_store, "list_merge_train_batch_candidate_records"):
+            for candidate_record in filesystem_store.list_merge_train_batch_candidate_records():
+                self.write_merge_train_batch_candidate_record(candidate_record)
+                counts["merge_train_batch_candidates"] += 1
+        if hasattr(filesystem_store, "list_merge_train_batch_landing_plan_records"):
+            for plan_record in filesystem_store.list_merge_train_batch_landing_plan_records():
+                self.write_merge_train_batch_landing_plan_record(plan_record)
+                counts["merge_train_batch_landing_plans"] += 1
         if hasattr(filesystem_store, "list_merge_train_policy_records"):
             for merge_train_policy_record in filesystem_store.list_merge_train_policy_records():
                 self.write_merge_train_policy_record(merge_train_policy_record)

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -1,5 +1,28 @@
 # Merge Train Policy Contract
 
+## Terminology
+
+Launchplane currently ships a Level 1 ordered merge queue baseline. It reads a
+fresh GitHub snapshot, orders eligible pull requests, selects the first eligible
+entry, and applies at most one worker transition per service call. That baseline
+is useful for fail-closed ordering, but it is not the full batch merge train
+target.
+
+The full Launchplane merge train target is a batch-validating train:
+
+1. Collect eligible queued pull requests for one repository/base branch.
+2. Build one combined batch candidate from the base branch plus queued pull
+   requests in train order.
+3. Run required checks against that exact candidate commit.
+4. If the candidate passes, land the original pull requests in train order using
+   GitHub's normal pull request merge path so repository UI and audit hints stay
+   attached to each PR.
+5. If the candidate fails or cannot be built, split or reduce the batch to
+   isolate blockers, then mark or requeue entries according to policy.
+
+Until the batch candidate and landing records exist, docs and operators should
+describe the live implementation as the ordered merge queue baseline.
+
 Launchplane merge trains use an explicit repository policy before any worker is
 allowed to enqueue, update, or merge pull requests. Live service routes resolve
 the active `launchplane_merge_train_policies` record from Launchplane storage.
@@ -40,6 +63,61 @@ the blocking pull request with `blocked_label` before stopping.
 `continue_after_blocking_pr` is reserved for repositories that explicitly choose
 higher throughput over strict ordering. A worker must still mark the failed pull
 request with `blocked_label` before considering later entries.
+
+## Batch Train Target
+
+The batch train is the first full-train implementation target because it proves
+that many queued pull requests are compatible together while preserving normal
+GitHub pull request UX. It differs from merging every individually green PR: the
+batch candidate must pass required checks as a combined tree before Launchplane
+starts landing the original pull requests.
+
+### Candidate Construction
+
+A batch candidate represents:
+
+```text
+base branch + queued PR #1 + queued PR #2 + ... + queued PR #N
+```
+
+The candidate is built in deterministic queue order. If any pull request cannot
+be applied cleanly, candidate construction stops at that pull request and the
+worker records a blocker. The first implementation should use an explicit
+temporary candidate ref or branch so GitHub Actions can run checks against a
+real commit SHA. The exact ref naming and cleanup policy are part of the batch
+train implementation, not the repository policy TOML.
+
+### Candidate Validation
+
+Required checks must pass on the candidate commit that includes the queued PRs
+being considered for the batch. Checks on each PR's own head are useful
+screening evidence, but they do not prove the combined tree is safe to land.
+Launchplane must fail closed when candidate check evidence is missing, pending,
+failed, stale, or attached to a different commit SHA.
+
+### PR-Native Landing
+
+After a batch candidate passes, Launchplane lands the original pull requests in
+queue order using GitHub's pull request merge API and the configured
+`merge_method`. Before each PR merge, Launchplane must verify that the PR still
+matches the candidate evidence it is about to rely on. At minimum, the PR head
+SHA, base branch, queue position, policy digest, and candidate batch identity
+must match the recorded landing plan. If GitHub state changes, Launchplane must
+stop, re-read, and rebuild or requeue rather than continuing from stale batch
+evidence.
+
+Directly merging the candidate branch into the protected base branch is not the
+preferred first implementation because it hides the normal PR-by-PR merge UX and
+can make repository history and GitHub review state harder to inspect. It should
+remain a separate, explicit future decision if ever needed.
+
+### Blocker Isolation
+
+When the combined candidate fails checks, Launchplane must not assume all queued
+entries are bad. The first implementation may split the batch or fall back to
+smaller batches/one-at-a-time validation to identify the blocking PR. Once a
+blocker is identified, Launchplane applies `blocked_label` and either pauses or
+reflows later entries according to `failure_policy`.
 
 ## Example Policy Entries
 
@@ -164,8 +242,8 @@ Workers should load the same typed contract before enqueuing or merging. A
 missing policy for a repository/base branch is a hard failure, not a fallback to
 implicit behavior.
 
-The sequential train dry-run accepts a JSON snapshot of candidate pull requests
-and reports queue order plus the next intended action without mutating GitHub:
+The ordered queue dry-run accepts a JSON snapshot of candidate pull requests and
+reports queue order plus the next intended action without mutating GitHub:
 
 ```sh
 uv run launchplane work-graph merge-train-dry-run \
@@ -186,10 +264,10 @@ The deployed Launchplane service projects the work-graph GitHub credential into
 `GH_TOKEN` from the `LAUNCHPLANE_WORK_GRAPH_GH_TOKEN` deployment secret, so the
 imported policies normally reference that same service-host token source.
 
-Passing `--mutate` applies exactly one worker transition from that fresh
-snapshot. Use it only from the intended operator environment for the smoke or
-configured target; the command is a narrow bootstrap surface, not a long-running
-train scheduler.
+Passing `--mutate` applies exactly one ordered-queue worker transition from that
+fresh snapshot. Use it only from the intended operator environment for the smoke
+or configured target; the command is a narrow bootstrap surface, not the full
+batch train scheduler.
 
 The dry-run orders eligible pull requests by `created_at` and then PR number. It
 excludes draft, closed, unlabeled, or unauthorized entries and fails closed when
@@ -216,10 +294,12 @@ merge or mutate GitHub. A later worker pass must read a fresh snapshot for the
 same repository/base branch and continue only when that fresh dry-run result
 selects `merge`.
 
-A worker pass applies at most one transition from one fresh snapshot. It may add
-the block label, request a branch refresh, record a wait boundary, perform one
-guarded merge, or report an idle queue; it must not chain follow-up reads or
-mutations in the same pass.
+A Level 1 ordered-queue worker pass applies at most one transition from one
+fresh snapshot. It may add the block label, request a branch refresh, record a
+wait boundary, perform one guarded merge, or report an idle queue; it must not
+chain follow-up reads or mutations in the same pass. The full batch train will
+use separate batch candidate and landing-plan records instead of treating a
+single selected PR as the whole train state.
 
 The service endpoint `POST /v1/work-graph/merge-train/run-once` uses the same
 policy. Request payloads name `repository`, `base_branch`, and optional
@@ -231,7 +311,8 @@ result or applies exactly one worker step. Accepted calls write a
 dry-run decision, selected pull request metadata, and optional worker mutation
 result. Unsupported repository/base pairs, missing token configuration, and
 denied authorization all fail closed. Generic service code must not contain
-product repository conditionals.
+product repository conditionals. Future batch train service routes must preserve
+that same policy-backed, DB-backed, fail-closed boundary.
 
 Scheduler admission is a deterministic decision over the latest stored
 `launchplane_merge_train_runs` record for the repository/base branch. Dry-run

--- a/docs/records.md
+++ b/docs/records.md
@@ -702,11 +702,22 @@ preflights.
   metadata, trace id, recorded timestamp, and optional one-step worker result.
   The record is evidence for a single Level 1 ordered-queue service call, not
   queue authority for a later pass.
-- The full batch train will need additional persisted records for durable queue
-  entries, batch candidates, candidate check evidence, and PR-native landing
-  plans. Those records must preserve the same DB-backed authority boundary:
-  runtime train state belongs in Launchplane storage, not checked-in config,
-  service-host env, logs, or product-repo conditionals.
+- Full batch train candidates are persisted as
+  `launchplane_merge_train_batch_candidates` records. Each record stores the
+  repository/base branch, observed base SHA, ordered PR entries, candidate ref,
+  candidate SHA when available, policy key and digest, candidate status, check
+  status summary, source, and update timestamp. These records are the durable
+  evidence for a speculative batch candidate, not checked-in configuration.
+- Full batch train landing plans are persisted as
+  `launchplane_merge_train_batch_landing_plans` records. Each record stores the
+  candidate identity, repository/base branch, candidate SHA, policy key and
+  digest, and ordered PR-native landing entries with expected head/base SHAs,
+  merge method, and per-entry landing status.
+- The full batch train may add more persisted records for explicit queue entries
+  and detailed candidate check evidence. Those records must preserve the same
+  DB-backed authority boundary: runtime train state belongs in Launchplane
+  storage, not checked-in config, service-host env, logs, or product-repo
+  conditionals.
 - Scoped agent write-intent evaluation is exposed at
   `POST /v1/agent/write-intents/evaluate`. It validates intent shape, maps the
   intent to an exact existing policy action, evaluates authorization, and returns

--- a/docs/records.md
+++ b/docs/records.md
@@ -700,8 +700,13 @@ preflights.
   records. Each record stores the repository/base branch, mode, status, policy
   key and digest, fresh GitHub snapshot, dry-run decision, selected pull request
   metadata, trace id, recorded timestamp, and optional one-step worker result.
-  The record is evidence for a single service call, not queue authority for a
-  later pass.
+  The record is evidence for a single Level 1 ordered-queue service call, not
+  queue authority for a later pass.
+- The full batch train will need additional persisted records for durable queue
+  entries, batch candidates, candidate check evidence, and PR-native landing
+  plans. Those records must preserve the same DB-backed authority boundary:
+  runtime train state belongs in Launchplane storage, not checked-in config,
+  service-host env, logs, or product-repo conditionals.
 - Scoped agent write-intent evaluation is exposed at
   `POST /v1/agent/write-intents/evaluate`. It validates intent shape, maps the
   intent to an exact existing policy action, evaluates authorization, and returns

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -214,13 +214,14 @@ returns the queue payload under `result.queue`. The route requires the
 writes, and does not make Launchplane authoritative for copied GitHub or Code
 Plans state.
 
-`POST /v1/work-graph/merge-train/run-once` executes one policy-backed
-merge-train pass for a requested repository/base branch. It requires the
+`POST /v1/work-graph/merge-train/run-once` executes one policy-backed Level 1
+ordered-queue pass for a requested repository/base branch. It requires the
 `service_authz` action/product/context declared by the matching merge-train
 repository policy, resolves its GitHub token from that policy's
 `github_token.env_var`, and fails closed before GitHub calls when no matching
 policy or token is available. The route is dry-run by default; `mutate: true`
-applies at most one worker transition from one fresh snapshot.
+applies at most one worker transition from one fresh snapshot. This route is the
+deployed sequential baseline, not the full batch train target.
 
 `GET /v1/work-graph/merge-train/admission` returns the stored-history scheduler
 admission decision for a requested `repository` and `base_branch`. It uses the
@@ -278,7 +279,7 @@ silently omitting the failure. The endpoint writes no records, fetches no issue
 bodies, and must preserve the lower-level redaction/provenance rules.
 
 `POST /v1/work-graph/merge-train/run-once` is the authenticated service ingress
-for one merge-train read or mutation pass. It resolves repository/base policy
+for one ordered-queue read or mutation pass. It resolves repository/base policy
 from the active DB-backed `launchplane_merge_train_policies` record before
 authorization, token lookup, or GitHub reads. If no active record exists, the
 service fails closed with `merge_train_policy_not_configured`; policy creation
@@ -287,6 +288,12 @@ service-host env overrides. It authorizes against the policy's `service_authz`,
 reads a fresh GitHub snapshot, and writes a `launchplane_merge_train_runs` record
 for accepted dry-run and mutate calls. Mutation mode still applies at most one
 worker transition from that snapshot.
+
+The full batch train will use additional service contracts and records rather
+than overloading `run-once`. Its target behavior is to build one combined
+candidate from the base branch plus multiple queued PRs, run required checks on
+that candidate commit, and then land the original PRs in queue order through
+GitHub's normal PR merge path after pre-merge invariants are rechecked.
 
 `POST /v1/merge-train/policies/import` is the service-owned write path for merge
 train policy records. It requires database storage and

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -16,6 +16,16 @@ from control_plane.contracts.deployment_record import DeploymentRecord, Resolved
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
+from control_plane.contracts.merge_train_batch import (
+    MergeTrainBatchCandidate,
+    MergeTrainBatchCandidateRecord,
+    MergeTrainBatchEntry,
+    MergeTrainBatchRecordStatus,
+    MergeTrainBatchLandingPlanRecord,
+    build_merge_train_batch_candidate_ref,
+    build_merge_train_batch_id,
+    build_merge_train_batch_landing_plan,
+)
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
 from control_plane.contracts.odoo_instance_override_record import OdooAddonSettingOverride
 from control_plane.contracts.odoo_instance_override_record import OdooConfigParameterOverride
@@ -69,6 +79,84 @@ def _health_pass() -> HealthcheckEvidence:
         urls=("https://prod.example.com/web/health",),
         timeout_seconds=45,
         status="pass",
+    )
+
+
+def _merge_train_batch_candidate_record(
+    *,
+    record_id: str = "merge-train-batch-candidate-20260514T010000Z-active",
+    status: MergeTrainBatchRecordStatus = "active",
+    updated_at: str = "2026-05-14T01:00:00Z",
+) -> MergeTrainBatchCandidateRecord:
+    repository = "example/merge-train-repo"
+    base_branch = "main"
+    base_sha = "base-main"
+    entries = (
+        MergeTrainBatchEntry(
+            pull_request_number=10,
+            position=1,
+            head_sha="head-10",
+            title="First queued change",
+            url="https://github.com/example/merge-train-repo/pull/10",
+        ),
+        MergeTrainBatchEntry(
+            pull_request_number=11,
+            position=2,
+            head_sha="head-11",
+            title="Second queued change",
+            url="https://github.com/example/merge-train-repo/pull/11",
+        ),
+    )
+    batch_id = build_merge_train_batch_id(
+        repository=repository,
+        base_branch=base_branch,
+        base_sha=base_sha,
+        entry_head_shas=tuple(entry.head_sha for entry in entries),
+    )
+    return MergeTrainBatchCandidateRecord(
+        record_id=record_id,
+        status=status,
+        source="test",
+        updated_at=updated_at,
+        candidate=MergeTrainBatchCandidate(
+            batch_id=batch_id,
+            repository=repository,
+            base_branch=base_branch,
+            base_sha=base_sha,
+            policy_key=f"{repository}:{base_branch}",
+            policy_sha256="policy-digest",
+            candidate_ref=build_merge_train_batch_candidate_ref(
+                repository=repository,
+                base_branch=base_branch,
+                batch_id=batch_id,
+            ),
+            candidate_sha="candidate-sha",
+            status="passed",
+            entries=entries,
+            required_checks_status="pass",
+            created_at="2026-05-14T00:59:00Z",
+            updated_at=updated_at,
+        ),
+    )
+
+
+def _merge_train_batch_landing_plan_record(
+    *,
+    record_id: str = "merge-train-batch-landing-plan-20260514T010500Z-active",
+    status: MergeTrainBatchRecordStatus = "active",
+    updated_at: str = "2026-05-14T01:05:00Z",
+) -> MergeTrainBatchLandingPlanRecord:
+    landing_plan = build_merge_train_batch_landing_plan(
+        candidate=_merge_train_batch_candidate_record(updated_at=updated_at).candidate,
+        merge_method="squash",
+        created_at=updated_at,
+    )
+    return MergeTrainBatchLandingPlanRecord(
+        record_id=record_id,
+        status=status,
+        source="test",
+        updated_at=updated_at,
+        landing_plan=landing_plan,
     )
 
 
@@ -275,6 +363,60 @@ class FilesystemRecordStoreTests(unittest.TestCase):
             .enqueue_label,
             "ready-to-merge",
         )
+
+    def test_write_and_list_merge_train_batch_candidate_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            older_record = _merge_train_batch_candidate_record(
+                record_id="merge-train-batch-candidate-20260514T005900Z-old",
+                status="superseded",
+                updated_at="2026-05-14T00:59:00Z",
+            )
+            active_record = _merge_train_batch_candidate_record()
+
+            store.write_merge_train_batch_candidate_record(older_record)
+            written_path = store.write_merge_train_batch_candidate_record(active_record)
+            listed_records = store.list_merge_train_batch_candidate_records(
+                repository="example/merge-train-repo",
+                base_branch="main",
+                status="active",
+            )
+
+        self.assertEqual(
+            written_path.relative_to(state_dir).as_posix(),
+            "launchplane_merge_train_batch_candidates/"
+            "merge-train-batch-candidate-20260514T010000Z-active.json",
+        )
+        self.assertEqual([record.record_id for record in listed_records], [active_record.record_id])
+        self.assertEqual(listed_records[0].candidate.entries[1].pull_request_number, 11)
+
+    def test_write_and_list_merge_train_batch_landing_plan_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            older_record = _merge_train_batch_landing_plan_record(
+                record_id="merge-train-batch-landing-plan-20260514T005900Z-old",
+                status="superseded",
+                updated_at="2026-05-14T00:59:00Z",
+            )
+            active_record = _merge_train_batch_landing_plan_record()
+
+            store.write_merge_train_batch_landing_plan_record(older_record)
+            written_path = store.write_merge_train_batch_landing_plan_record(active_record)
+            listed_records = store.list_merge_train_batch_landing_plan_records(
+                repository="example/merge-train-repo",
+                base_branch="main",
+                status="active",
+            )
+
+        self.assertEqual(
+            written_path.relative_to(state_dir).as_posix(),
+            "launchplane_merge_train_batch_landing_plans/"
+            "merge-train-batch-landing-plan-20260514T010500Z-active.json",
+        )
+        self.assertEqual([record.record_id for record in listed_records], [active_record.record_id])
+        self.assertEqual(listed_records[0].landing_plan.entries[0].merge_method, "squash")
 
     def test_write_and_read_artifact_manifest(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_merge_train_batch.py
+++ b/tests/test_merge_train_batch.py
@@ -4,15 +4,20 @@ from pydantic import ValidationError
 
 from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidate
 from control_plane.contracts.merge_train_batch import MergeTrainBatchEntry
+from control_plane.contracts.merge_train_batch import build_merge_train_batch_candidate
 from control_plane.contracts.merge_train_batch import build_merge_train_batch_candidate_ref
 from control_plane.contracts.merge_train_batch import build_merge_train_batch_id
 from control_plane.contracts.merge_train_batch import build_merge_train_batch_landing_plan
+from control_plane.merge_train import MergeTrainDryRunSnapshot
+from control_plane.merge_train import MergeTrainPullRequestSnapshot
+from control_plane.merge_train import build_merge_train_dry_run_result
+from tests.merge_train_policy_fixtures import build_test_merge_train_policy
 
 
 class MergeTrainBatchContractTests(unittest.TestCase):
     def test_batch_id_and_candidate_ref_are_deterministic(self) -> None:
         batch_id = build_merge_train_batch_id(
-            repository="cbusillo/codex-skills",
+            repository="example/merge-train-repo",
             base_branch="main",
             base_sha="base-sha",
             entry_head_shas=("head-a", "head-b"),
@@ -21,20 +26,20 @@ class MergeTrainBatchContractTests(unittest.TestCase):
         self.assertEqual(
             batch_id,
             build_merge_train_batch_id(
-                repository="cbusillo/codex-skills",
+                repository="example/merge-train-repo",
                 base_branch="main",
                 base_sha="base-sha",
                 entry_head_shas=("head-a", "head-b"),
             ),
         )
-        self.assertTrue(batch_id.startswith("merge-train-batch-cbusillo-codex-skills-main-"))
+        self.assertTrue(batch_id.startswith("merge-train-batch-example-merge-train-repo-main-"))
         self.assertEqual(
             build_merge_train_batch_candidate_ref(
-                repository="cbusillo/codex-skills",
+                repository="example/merge-train-repo",
                 base_branch="main",
                 batch_id=batch_id,
             ),
-            f"refs/heads/launchplane/train/cbusillo/codex-skills/main/{batch_id}",
+            f"refs/heads/launchplane/train/example/merge-train-repo/main/{batch_id}",
         )
 
     def test_candidate_requires_contiguous_positions(self) -> None:
@@ -88,6 +93,71 @@ class MergeTrainBatchContractTests(unittest.TestCase):
         self.assertEqual({entry.expected_base_sha for entry in plan.entries}, {"base-sha"})
         self.assertEqual({entry.merge_method for entry in plan.entries}, {"merge"})
 
+    def test_candidate_builder_uses_all_eligible_queue_entries(self) -> None:
+        dry_run_result = build_merge_train_dry_run_result(
+            policy=build_test_merge_train_policy(repository="example/merge-train-repo"),
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="example/merge-train-repo",
+                base_branch="main",
+                pull_requests=(
+                    _pull_request(2, created_at="2026-05-13T10:02:00Z"),
+                    _pull_request(1, created_at="2026-05-13T10:01:00Z"),
+                ),
+            ),
+        )
+
+        candidate = build_merge_train_batch_candidate(
+            dry_run_result=dry_run_result,
+            base_sha="base-main",
+            policy_sha256="policy-sha",
+            created_at="2026-05-13T23:00:00Z",
+        )
+
+        self.assertEqual(candidate.status, "planned")
+        self.assertEqual(candidate.base_sha, "base-main")
+        self.assertEqual(candidate.policy_key, "example/merge-train-repo:main")
+        self.assertEqual(
+            [entry.pull_request_number for entry in candidate.entries],
+            [1, 2],
+        )
+        self.assertEqual([entry.head_sha for entry in candidate.entries], ["head-1", "head-2"])
+
+    def test_candidate_builder_rejects_blocking_queue_state(self) -> None:
+        dry_run_result = build_merge_train_dry_run_result(
+            policy=build_test_merge_train_policy(repository="example/merge-train-repo"),
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="example/merge-train-repo",
+                base_branch="main",
+                pull_requests=(_pull_request(1, required_checks_status="fail"),),
+            ),
+        )
+
+        with self.assertRaisesRegex(ValueError, "without blocking actions"):
+            build_merge_train_batch_candidate(
+                dry_run_result=dry_run_result,
+                base_sha="base-main",
+                policy_sha256="policy-sha",
+                created_at="2026-05-13T23:00:00Z",
+            )
+
+    def test_candidate_builder_rejects_empty_queue(self) -> None:
+        dry_run_result = build_merge_train_dry_run_result(
+            policy=build_test_merge_train_policy(repository="example/merge-train-repo"),
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="example/merge-train-repo",
+                base_branch="main",
+                pull_requests=(),
+            ),
+        )
+
+        with self.assertRaisesRegex(ValueError, "requires at least one eligible PR"):
+            build_merge_train_batch_candidate(
+                dry_run_result=dry_run_result,
+                base_sha="base-main",
+                policy_sha256="policy-sha",
+                created_at="2026-05-13T23:00:00Z",
+            )
+
 
 def _candidate(
     *,
@@ -100,20 +170,20 @@ def _candidate(
         _entry(2, position=2, head_sha="head-b"),
     )
     batch_id = build_merge_train_batch_id(
-        repository="cbusillo/codex-skills",
+        repository="example/merge-train-repo",
         base_branch="main",
         base_sha="base-sha",
         entry_head_shas=tuple(entry.head_sha for entry in resolved_entries),
     )
     return MergeTrainBatchCandidate(
         batch_id=batch_id,
-        repository="cbusillo/codex-skills",
+        repository="example/merge-train-repo",
         base_branch="main",
         base_sha="base-sha",
-        policy_key="cbusillo/codex-skills:main",
+        policy_key="example/merge-train-repo:main",
         policy_sha256="policy-sha",
         candidate_ref=build_merge_train_batch_candidate_ref(
-            repository="cbusillo/codex-skills",
+            repository="example/merge-train-repo",
             base_branch="main",
             batch_id=batch_id,
         ),
@@ -131,7 +201,29 @@ def _entry(pull_request_number: int, *, position: int, head_sha: str) -> MergeTr
         position=position,
         head_sha=head_sha,
         title=f"PR {pull_request_number}",
-        url=f"https://github.com/cbusillo/codex-skills/pull/{pull_request_number}",
+        url=f"https://github.com/example/merge-train-repo/pull/{pull_request_number}",
+    )
+
+
+def _pull_request(
+    number: int,
+    *,
+    created_at: str = "2026-05-13T10:00:00Z",
+    required_checks_status: str = "pass",
+) -> MergeTrainPullRequestSnapshot:
+    return MergeTrainPullRequestSnapshot.model_validate(
+        {
+            "number": number,
+            "url": f"https://github.com/example/merge-train-repo/pull/{number}",
+            "title": f"PR {number}",
+            "created_at": created_at,
+            "labels": ("ready-to-merge",),
+            "actor_role": "repo_admin",
+            "head_sha": f"head-{number}",
+            "base_sha": "base-main",
+            "mergeable": "mergeable",
+            "required_checks_status": required_checks_status,
+        }
     )
 
 

--- a/tests/test_merge_train_batch.py
+++ b/tests/test_merge_train_batch.py
@@ -1,0 +1,139 @@
+import unittest
+
+from pydantic import ValidationError
+
+from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidate
+from control_plane.contracts.merge_train_batch import MergeTrainBatchEntry
+from control_plane.contracts.merge_train_batch import build_merge_train_batch_candidate_ref
+from control_plane.contracts.merge_train_batch import build_merge_train_batch_id
+from control_plane.contracts.merge_train_batch import build_merge_train_batch_landing_plan
+
+
+class MergeTrainBatchContractTests(unittest.TestCase):
+    def test_batch_id_and_candidate_ref_are_deterministic(self) -> None:
+        batch_id = build_merge_train_batch_id(
+            repository="cbusillo/codex-skills",
+            base_branch="main",
+            base_sha="base-sha",
+            entry_head_shas=("head-a", "head-b"),
+        )
+
+        self.assertEqual(
+            batch_id,
+            build_merge_train_batch_id(
+                repository="cbusillo/codex-skills",
+                base_branch="main",
+                base_sha="base-sha",
+                entry_head_shas=("head-a", "head-b"),
+            ),
+        )
+        self.assertTrue(batch_id.startswith("merge-train-batch-cbusillo-codex-skills-main-"))
+        self.assertEqual(
+            build_merge_train_batch_candidate_ref(
+                repository="cbusillo/codex-skills",
+                base_branch="main",
+                batch_id=batch_id,
+            ),
+            f"refs/heads/launchplane/train/cbusillo/codex-skills/main/{batch_id}",
+        )
+
+    def test_candidate_requires_contiguous_positions(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "positions must be contiguous"):
+            _candidate(
+                entries=(
+                    _entry(1, position=1, head_sha="head-a"),
+                    _entry(2, position=3, head_sha="head-b"),
+                )
+            )
+
+    def test_candidate_rejects_duplicate_pull_requests(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "PR numbers must be unique"):
+            _candidate(
+                entries=(
+                    _entry(1, position=1, head_sha="head-a"),
+                    _entry(1, position=2, head_sha="head-b"),
+                )
+            )
+
+    def test_landing_plan_requires_passed_candidate(self) -> None:
+        candidate = _candidate(status="ready_for_checks", candidate_sha="candidate-sha")
+
+        with self.assertRaisesRegex(ValueError, "requires passed candidate"):
+            build_merge_train_batch_landing_plan(
+                candidate=candidate,
+                merge_method="merge",
+                created_at="2026-05-13T23:00:00Z",
+            )
+
+    def test_landing_plan_preserves_pr_native_merge_invariants(self) -> None:
+        candidate = _candidate(status="passed", candidate_sha="candidate-sha")
+
+        plan = build_merge_train_batch_landing_plan(
+            candidate=candidate,
+            merge_method="merge",
+            created_at="2026-05-13T23:00:00Z",
+        )
+
+        self.assertTrue(plan.plan_id.startswith(f"merge-train-landing-plan-{candidate.batch_id}-"))
+        self.assertEqual(plan.batch_id, candidate.batch_id)
+        self.assertEqual(plan.candidate_sha, "candidate-sha")
+        self.assertEqual(
+            [entry.pull_request_number for entry in plan.entries],
+            [1, 2],
+        )
+        self.assertEqual(
+            [entry.expected_head_sha for entry in plan.entries],
+            ["head-a", "head-b"],
+        )
+        self.assertEqual({entry.expected_base_sha for entry in plan.entries}, {"base-sha"})
+        self.assertEqual({entry.merge_method for entry in plan.entries}, {"merge"})
+
+
+def _candidate(
+    *,
+    status: str = "planned",
+    candidate_sha: str = "",
+    entries: tuple[MergeTrainBatchEntry, ...] | None = None,
+) -> MergeTrainBatchCandidate:
+    resolved_entries = entries or (
+        _entry(1, position=1, head_sha="head-a"),
+        _entry(2, position=2, head_sha="head-b"),
+    )
+    batch_id = build_merge_train_batch_id(
+        repository="cbusillo/codex-skills",
+        base_branch="main",
+        base_sha="base-sha",
+        entry_head_shas=tuple(entry.head_sha for entry in resolved_entries),
+    )
+    return MergeTrainBatchCandidate(
+        batch_id=batch_id,
+        repository="cbusillo/codex-skills",
+        base_branch="main",
+        base_sha="base-sha",
+        policy_key="cbusillo/codex-skills:main",
+        policy_sha256="policy-sha",
+        candidate_ref=build_merge_train_batch_candidate_ref(
+            repository="cbusillo/codex-skills",
+            base_branch="main",
+            batch_id=batch_id,
+        ),
+        candidate_sha=candidate_sha,
+        status=status,  # type: ignore[arg-type]
+        entries=resolved_entries,
+        created_at="2026-05-13T23:00:00Z",
+        updated_at="2026-05-13T23:00:00Z",
+    )
+
+
+def _entry(pull_request_number: int, *, position: int, head_sha: str) -> MergeTrainBatchEntry:
+    return MergeTrainBatchEntry(
+        pull_request_number=pull_request_number,
+        position=position,
+        head_sha=head_sha,
+        title=f"PR {pull_request_number}",
+        url=f"https://github.com/cbusillo/codex-skills/pull/{pull_request_number}",
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_merge_train_github.py
+++ b/tests/test_merge_train_github.py
@@ -3,6 +3,10 @@ from email.message import Message
 from unittest.mock import patch
 from urllib.error import HTTPError
 
+from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidate
+from control_plane.contracts.merge_train_batch import MergeTrainBatchEntry
+from control_plane.contracts.merge_train_batch import build_merge_train_batch_candidate_ref
+from control_plane.contracts.merge_train_batch import build_merge_train_batch_id
 from control_plane.merge_train_github import GitHubMergeTrainClient
 from control_plane.merge_train_github import GitHubMergeTrainSnapshotReader
 from control_plane.merge_train_github import MergeTrainGitHubError
@@ -25,9 +29,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
         self.assertEqual(len(transport.requests), 1)
         request = transport.requests[0]
         self.assertEqual(request.method, "POST")
-        self.assertEqual(
-            request.path, "/repos/cbusillo/sellyouroutboard/issues/42/labels"
-        )
+        self.assertEqual(request.path, "/repos/cbusillo/sellyouroutboard/issues/42/labels")
         self.assertEqual(request.body, {"labels": ["merge-blocked"]})
 
     def test_update_pull_request_branch_uses_expected_head_sha(self) -> None:
@@ -43,15 +45,11 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
         self.assertEqual(len(transport.requests), 1)
         request = transport.requests[0]
         self.assertEqual(request.method, "PUT")
-        self.assertEqual(
-            request.path, "/repos/cbusillo/sellyouroutboard/pulls/42/update-branch"
-        )
+        self.assertEqual(request.path, "/repos/cbusillo/sellyouroutboard/pulls/42/update-branch")
         self.assertEqual(request.body, {"expected_head_sha": "head-42"})
 
     def test_merge_pull_request_uses_sha_guard_and_policy_method(self) -> None:
-        transport = RecordingMergeTrainGitHubTransport(
-            responses=({"sha": "merge-sha-42"},)
-        )
+        transport = RecordingMergeTrainGitHubTransport(responses=({"sha": "merge-sha-42"},))
         client = GitHubMergeTrainClient(transport=transport)
 
         merge_commit_sha = client.merge_pull_request(
@@ -79,6 +77,91 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 head_sha="head-42",
                 merge_method="merge",
             )
+
+    def test_build_batch_candidate_creates_ref_and_merges_heads_in_order(self) -> None:
+        candidate = _batch_candidate()
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                {"ref": candidate.candidate_ref, "object": {"sha": "base-main"}},
+                {"sha": "candidate-after-1"},
+                {"sha": "candidate-after-2"},
+            )
+        )
+
+        built_candidate = GitHubMergeTrainClient(transport=transport).build_batch_candidate(
+            candidate=candidate
+        )
+
+        self.assertEqual(built_candidate.status, "ready_for_checks")
+        self.assertEqual(built_candidate.candidate_sha, "candidate-after-2")
+        self.assertEqual(
+            [(request.method, request.path, request.body) for request in transport.requests],
+            [
+                (
+                    "POST",
+                    "/repos/example/merge-train-repo/git/refs",
+                    {"ref": candidate.candidate_ref, "sha": "base-main"},
+                ),
+                (
+                    "POST",
+                    "/repos/example/merge-train-repo/merges",
+                    {
+                        "base": "launchplane/train/example/merge-train-repo/main/"
+                        f"{candidate.batch_id}",
+                        "head": "head-1",
+                        "commit_message": f"Launchplane merge train {candidate.batch_id}: merge PR #1",
+                    },
+                ),
+                (
+                    "POST",
+                    "/repos/example/merge-train-repo/merges",
+                    {
+                        "base": "launchplane/train/example/merge-train-repo/main/"
+                        f"{candidate.batch_id}",
+                        "head": "head-2",
+                        "commit_message": f"Launchplane merge train {candidate.batch_id}: merge PR #2",
+                    },
+                ),
+            ],
+        )
+
+    def test_build_batch_candidate_resets_existing_ref(self) -> None:
+        candidate = _batch_candidate()
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                MergeTrainGitHubError("reference exists", status_code=409),
+                {"ref": candidate.candidate_ref, "object": {"sha": "base-main"}},
+                {"sha": "candidate-after-1"},
+                {"sha": "candidate-after-2"},
+            )
+        )
+
+        GitHubMergeTrainClient(transport=transport).build_batch_candidate(candidate=candidate)
+
+        self.assertEqual(transport.requests[1].method, "PATCH")
+        self.assertEqual(
+            transport.requests[1].path,
+            "/repos/example/merge-train-repo/git/refs/heads/launchplane/train/example/merge-train-repo/main/"
+            f"{candidate.batch_id}",
+        )
+        self.assertEqual(transport.requests[1].body, {"sha": "base-main", "force": True})
+
+    def test_build_batch_candidate_reports_conflict_without_landing_prs(self) -> None:
+        candidate = _batch_candidate()
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                {"ref": candidate.candidate_ref, "object": {"sha": "base-main"}},
+                {"sha": "candidate-after-1"},
+                MergeTrainGitHubStaleHeadError("conflict", status_code=409),
+            )
+        )
+
+        with self.assertRaises(MergeTrainGitHubStaleHeadError):
+            GitHubMergeTrainClient(transport=transport).build_batch_candidate(candidate=candidate)
+
+        self.assertEqual(
+            [request.method for request in transport.requests], ["POST", "POST", "POST"]
+        )
 
     def test_repository_must_be_owner_name(self) -> None:
         client = GitHubMergeTrainClient(transport=RecordingMergeTrainGitHubTransport())
@@ -312,6 +395,38 @@ def _check_run(status: str, conclusion: str | None) -> dict[str, object]:
     if conclusion is not None:
         payload["conclusion"] = conclusion
     return payload
+
+
+def _batch_candidate() -> MergeTrainBatchCandidate:
+    repository = "example/merge-train-repo"
+    base_branch = "main"
+    base_sha = "base-main"
+    entries = (
+        MergeTrainBatchEntry(pull_request_number=1, position=1, head_sha="head-1"),
+        MergeTrainBatchEntry(pull_request_number=2, position=2, head_sha="head-2"),
+    )
+    batch_id = build_merge_train_batch_id(
+        repository=repository,
+        base_branch=base_branch,
+        base_sha=base_sha,
+        entry_head_shas=tuple(entry.head_sha for entry in entries),
+    )
+    return MergeTrainBatchCandidate(
+        batch_id=batch_id,
+        repository=repository,
+        base_branch=base_branch,
+        base_sha=base_sha,
+        policy_key=f"{repository}:{base_branch}",
+        policy_sha256="policy-sha",
+        candidate_ref=build_merge_train_batch_candidate_ref(
+            repository=repository,
+            base_branch=base_branch,
+            batch_id=batch_id,
+        ),
+        entries=entries,
+        created_at="2026-05-13T23:00:00Z",
+        updated_at="2026-05-13T23:00:00Z",
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_merge_train_github.py
+++ b/tests/test_merge_train_github.py
@@ -163,6 +163,49 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
             [request.method for request in transport.requests], ["POST", "POST", "POST"]
         )
 
+    def test_observe_batch_candidate_checks_marks_passed_candidate(self) -> None:
+        candidate = _batch_candidate().model_copy(
+            update={"candidate_sha": "candidate-sha", "status": "ready_for_checks"}
+        )
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                {"state": "success"},
+                {"check_runs": [_check_run("completed", "success")]},
+            )
+        )
+
+        observed_candidate = GitHubMergeTrainClient(
+            transport=transport
+        ).observe_batch_candidate_checks(candidate=candidate)
+
+        self.assertEqual(observed_candidate.status, "passed")
+        self.assertEqual(observed_candidate.required_checks_status, "pass")
+        self.assertEqual(
+            [request.path for request in transport.requests],
+            [
+                "/repos/example/merge-train-repo/commits/candidate-sha/status",
+                "/repos/example/merge-train-repo/commits/candidate-sha/check-runs?per_page=100&page=1",
+            ],
+        )
+
+    def test_observe_batch_candidate_checks_leaves_pending_candidate_unlandable(self) -> None:
+        candidate = _batch_candidate().model_copy(
+            update={"candidate_sha": "candidate-sha", "status": "ready_for_checks"}
+        )
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                {"state": "pending"},
+                {"check_runs": [_check_run("queued", None)]},
+            )
+        )
+
+        observed_candidate = GitHubMergeTrainClient(
+            transport=transport
+        ).observe_batch_candidate_checks(candidate=candidate)
+
+        self.assertEqual(observed_candidate.status, "ready_for_checks")
+        self.assertEqual(observed_candidate.required_checks_status, "pending")
+
     def test_repository_must_be_owner_name(self) -> None:
         client = GitHubMergeTrainClient(transport=RecordingMergeTrainGitHubTransport())
 

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -32,6 +32,16 @@ from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFee
 from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.idempotency_record import build_launchplane_idempotency_record_id
+from control_plane.contracts.merge_train_batch import (
+    MergeTrainBatchCandidate,
+    MergeTrainBatchCandidateRecord,
+    MergeTrainBatchEntry,
+    MergeTrainBatchLandingPlanRecord,
+    MergeTrainBatchRecordStatus,
+    build_merge_train_batch_candidate_ref,
+    build_merge_train_batch_id,
+    build_merge_train_batch_landing_plan,
+)
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
 from control_plane.contracts.merge_train_run_record import (
     MergeTrainRunRecord,
@@ -536,6 +546,84 @@ def _merge_train_run_record(*, recorded_at: str = "2026-05-09T02:05:00Z") -> Mer
         policy_sha256=policy.policy_sha256,
         snapshot=snapshot,
         dry_run_result=dry_run_result,
+    )
+
+
+def _merge_train_batch_candidate_record(
+    *,
+    record_id: str = "merge-train-batch-candidate-20260514T010000Z-active",
+    status: MergeTrainBatchRecordStatus = "active",
+    updated_at: str = "2026-05-14T01:00:00Z",
+) -> MergeTrainBatchCandidateRecord:
+    repository = "example/merge-train-repo"
+    base_branch = "main"
+    base_sha = "base-main"
+    entries = (
+        MergeTrainBatchEntry(
+            pull_request_number=10,
+            position=1,
+            head_sha="head-10",
+            title="First queued change",
+            url="https://github.com/example/merge-train-repo/pull/10",
+        ),
+        MergeTrainBatchEntry(
+            pull_request_number=11,
+            position=2,
+            head_sha="head-11",
+            title="Second queued change",
+            url="https://github.com/example/merge-train-repo/pull/11",
+        ),
+    )
+    batch_id = build_merge_train_batch_id(
+        repository=repository,
+        base_branch=base_branch,
+        base_sha=base_sha,
+        entry_head_shas=tuple(entry.head_sha for entry in entries),
+    )
+    return MergeTrainBatchCandidateRecord(
+        record_id=record_id,
+        status=status,
+        source="test",
+        updated_at=updated_at,
+        candidate=MergeTrainBatchCandidate(
+            batch_id=batch_id,
+            repository=repository,
+            base_branch=base_branch,
+            base_sha=base_sha,
+            policy_key=f"{repository}:{base_branch}",
+            policy_sha256="policy-digest",
+            candidate_ref=build_merge_train_batch_candidate_ref(
+                repository=repository,
+                base_branch=base_branch,
+                batch_id=batch_id,
+            ),
+            candidate_sha="candidate-sha",
+            status="passed",
+            entries=entries,
+            required_checks_status="pass",
+            created_at="2026-05-14T00:59:00Z",
+            updated_at=updated_at,
+        ),
+    )
+
+
+def _merge_train_batch_landing_plan_record(
+    *,
+    record_id: str = "merge-train-batch-landing-plan-20260514T010500Z-active",
+    status: MergeTrainBatchRecordStatus = "active",
+    updated_at: str = "2026-05-14T01:05:00Z",
+) -> MergeTrainBatchLandingPlanRecord:
+    landing_plan = build_merge_train_batch_landing_plan(
+        candidate=_merge_train_batch_candidate_record(updated_at=updated_at).candidate,
+        merge_method="squash",
+        created_at=updated_at,
+    )
+    return MergeTrainBatchLandingPlanRecord(
+        record_id=record_id,
+        status=status,
+        source="test",
+        updated_at=updated_at,
+        landing_plan=landing_plan,
     )
 
 
@@ -1661,6 +1749,60 @@ env_var = "GH_TOKEN"
             "merge-blocked",
         )
 
+    def test_merge_train_batch_candidate_records_round_trip(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            older_record = _merge_train_batch_candidate_record(
+                record_id="merge-train-batch-candidate-20260514T005900Z-old",
+                status="superseded",
+                updated_at="2026-05-14T00:59:00Z",
+            )
+            active_record = _merge_train_batch_candidate_record()
+            store.write_merge_train_batch_candidate_record(older_record)
+            store.write_merge_train_batch_candidate_record(active_record)
+            listed_records = store.list_merge_train_batch_candidate_records(
+                repository="example/merge-train-repo",
+                base_branch="main",
+                status="active",
+            )
+            store.close()
+
+        self.assertEqual([record.record_id for record in listed_records], [active_record.record_id])
+        self.assertEqual(listed_records[0].candidate.entries[1].pull_request_number, 11)
+        self.assertEqual(listed_records[0].candidate.required_checks_status, "pass")
+
+    def test_merge_train_batch_landing_plan_records_round_trip(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            older_record = _merge_train_batch_landing_plan_record(
+                record_id="merge-train-batch-landing-plan-20260514T005900Z-old",
+                status="superseded",
+                updated_at="2026-05-14T00:59:00Z",
+            )
+            active_record = _merge_train_batch_landing_plan_record()
+            store.write_merge_train_batch_landing_plan_record(older_record)
+            store.write_merge_train_batch_landing_plan_record(active_record)
+            listed_records = store.list_merge_train_batch_landing_plan_records(
+                repository="example/merge-train-repo",
+                base_branch="main",
+                status="active",
+            )
+            store.close()
+
+        self.assertEqual([record.record_id for record in listed_records], [active_record.record_id])
+        self.assertEqual(listed_records[0].landing_plan.entries[0].merge_method, "squash")
+        self.assertEqual(listed_records[0].landing_plan.entries[1].pull_request_number, 11)
+
     def test_write_and_list_dokploy_target_id_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(
@@ -2057,6 +2199,12 @@ env_var = "GH_TOKEN"
                 )
             )
             filesystem_store.write_merge_train_run_record(_merge_train_run_record())
+            filesystem_store.write_merge_train_batch_candidate_record(
+                _merge_train_batch_candidate_record()
+            )
+            filesystem_store.write_merge_train_batch_landing_plan_record(
+                _merge_train_batch_landing_plan_record()
+            )
 
             counts = store.import_core_records_from_filesystem(filesystem_store)
             self.assertEqual(
@@ -2079,6 +2227,8 @@ env_var = "GH_TOKEN"
                     "preview_pr_feedback": 1,
                     "every_code_preview_gates": 0,
                     "agent_write_intents": 0,
+                    "merge_train_batch_candidates": 1,
+                    "merge_train_batch_landing_plans": 1,
                     "merge_train_policies": 1,
                     "merge_train_runs": 1,
                     "release_tuples": 1,


### PR DESCRIPTION
## Summary
- define Level 1 vs full batch merge train semantics in docs and contracts
- add batch candidate and PR-native landing plan contracts
- persist batch candidate and landing-plan records in filesystem and Postgres stores
- add Alembic migration and storage round-trip/import coverage

Refs #601
Refs #602
Refs #603

## Verification
- `uv run python -m unittest tests.test_merge_train_batch tests.test_filesystem_store tests.test_postgres_store`
- `uv run --extra dev ruff check control_plane/contracts/merge_train_batch.py control_plane/storage/filesystem.py control_plane/storage/postgres.py tests/test_merge_train_batch.py tests/test_filesystem_store.py tests/test_postgres_store.py control_plane/storage/migrations/versions/c178d29af012_add_merge_train_batch_records.py`
- `uv run --extra dev ruff format --check control_plane/contracts/merge_train_batch.py control_plane/storage/filesystem.py control_plane/storage/postgres.py tests/test_merge_train_batch.py tests/test_filesystem_store.py tests/test_postgres_store.py control_plane/storage/migrations/versions/c178d29af012_add_merge_train_batch_records.py`
- `uv run --extra dev mypy control_plane/contracts/merge_train_batch.py control_plane/storage/filesystem.py control_plane/storage/postgres.py tests/test_merge_train_batch.py tests/test_filesystem_store.py tests/test_postgres_store.py`
- `git diff --check`
- PyCharm changed-files inspection clean
