### PR TITLE
Add merge train batch candidate service flow

### DIFF
--- a/control_plane/contracts/merge_train_batch.py
+++ b/control_plane/contracts/merge_train_batch.py
@@ -267,6 +267,34 @@ def build_merge_train_batch_candidate(
     )
 
 
+def build_merge_train_batch_candidate_record(
+    *,
+    candidate: MergeTrainBatchCandidate,
+    source: str,
+    updated_at: str,
+) -> MergeTrainBatchCandidateRecord:
+    record_without_id = MergeTrainBatchCandidateRecord(
+        record_id="pending",
+        source=source,
+        updated_at=updated_at,
+        candidate=candidate,
+    )
+    return record_without_id.model_copy(
+        update={"record_id": build_merge_train_batch_candidate_record_id(record_without_id)}
+    )
+
+
+def build_merge_train_batch_candidate_record_id(
+    record: MergeTrainBatchCandidateRecord,
+) -> str:
+    digest_payload = record.model_dump(mode="json", exclude={"record_id"})
+    digest = hashlib.sha256(
+        json.dumps(digest_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:16]
+    normalized_timestamp = record.updated_at.replace("-", "").replace(":", "")
+    return f"merge-train-batch-candidate-{normalized_timestamp}-{digest}"
+
+
 def build_merge_train_batch_id(
     *, repository: str, base_branch: str, base_sha: str, entry_head_shas: tuple[str, ...]
 ) -> str:

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -76,6 +76,11 @@ from control_plane.contracts.every_code_summary_read_model import (
 )
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.idempotency_record import build_launchplane_idempotency_record_id
+from control_plane.contracts.merge_train_batch import (
+    MergeTrainBatchCandidateRecord,
+    build_merge_train_batch_candidate,
+    build_merge_train_batch_candidate_record,
+)
 from control_plane.contracts.merge_train_run_record import build_merge_train_run_record
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
 from control_plane.merge_train_admission import evaluate_merge_train_admission_from_store
@@ -328,6 +333,7 @@ from control_plane.workflows.verireel_preview_driver import (
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 _EVERY_CODE_GITHUB_WEBHOOK_ROUTE = "/v1/every-code/github-webhook"
 _MERGE_TRAIN_ADMISSION_ROUTE = "/v1/work-graph/merge-train/admission"
+_MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-candidate/run-once"
 _MERGE_TRAIN_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/run-once"
 _EVERY_CODE_GITHUB_WEBHOOK_SECRET_ENV_KEY = "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET"
 
@@ -352,6 +358,33 @@ class MergeTrainRunOnceEnvelope(BaseModel):
             raise ValueError("merge train repository must be owner/name")
         if not self.base_branch:
             raise ValueError("merge train run-once requires base_branch")
+        return self
+
+
+class MergeTrainBatchCandidateRunOnceEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    repository: str
+    base_branch: str = "main"
+    mode: Literal["plan", "build", "observe"] = "plan"
+    candidate_record_id: str = ""
+    github_api_base_url: str = "https://api.github.com"
+
+    @model_validator(mode="after")
+    def _validate_envelope(self) -> "MergeTrainBatchCandidateRunOnceEnvelope":
+        self.repository = self.repository.strip()
+        self.base_branch = self.base_branch.strip()
+        self.candidate_record_id = self.candidate_record_id.strip()
+        self.github_api_base_url = self.github_api_base_url.strip() or "https://api.github.com"
+        if not self.repository:
+            raise ValueError("merge train batch candidate requires repository")
+        if "/" not in self.repository:
+            raise ValueError("merge train repository must be owner/name")
+        if not self.base_branch:
+            raise ValueError("merge train batch candidate requires base_branch")
+        if self.mode in {"build", "observe"} and not self.candidate_record_id:
+            raise ValueError("build and observe require candidate_record_id")
         return self
 
 
@@ -2179,6 +2212,7 @@ def _driver_write_routes_from_descriptors() -> frozenset[str]:
 def _build_write_routes() -> frozenset[str]:
     launchplane_write_routes = {
         _EVERY_CODE_GITHUB_WEBHOOK_ROUTE,
+        _MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE,
         _MERGE_TRAIN_RUN_ONCE_ROUTE,
         "/v1/agent/write-intents/evaluate",
         "/v1/every-code/work-requests/create",
@@ -2367,6 +2401,47 @@ def _agent_write_intent_record_store(record_store: object) -> _AgentWriteIntentR
     if hasattr(record_store, "write_agent_write_intent_record"):
         return cast(_AgentWriteIntentRecordStore, record_store)
     raise TypeError("record store does not support agent write intent records")
+
+
+class _MergeTrainBatchCandidateRecordStore(Protocol):
+    def write_merge_train_batch_candidate_record(
+        self, record: MergeTrainBatchCandidateRecord
+    ) -> object: ...
+
+    def list_merge_train_batch_candidate_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeTrainBatchCandidateRecord, ...]: ...
+
+
+def _merge_train_batch_candidate_record_store(
+    record_store: object,
+) -> _MergeTrainBatchCandidateRecordStore:
+    if hasattr(record_store, "write_merge_train_batch_candidate_record") and hasattr(
+        record_store, "list_merge_train_batch_candidate_records"
+    ):
+        return cast(_MergeTrainBatchCandidateRecordStore, record_store)
+    raise TypeError("record store does not support merge train batch candidate records")
+
+
+def _read_merge_train_batch_candidate_record(
+    *,
+    record_store: _MergeTrainBatchCandidateRecordStore,
+    repository: str,
+    base_branch: str,
+    record_id: str,
+) -> MergeTrainBatchCandidateRecord:
+    records = record_store.list_merge_train_batch_candidate_records(
+        repository=repository, base_branch=base_branch
+    )
+    for record in records:
+        if record.record_id == record_id:
+            return record
+    raise ValueError("merge train batch candidate record not found")
 
 
 def _supports_every_code_work_requests(record_store: object) -> bool:
@@ -3453,6 +3528,7 @@ def _accepted_payload(
                 "feedback_id",
                 "state",
                 "agent_write_intent_record_id",
+                "merge_train_batch_candidate_record_id",
                 "merge_train_run_id",
             }
         },
@@ -6774,6 +6850,127 @@ def create_launchplane_service_app(
                 )
                 record_store.write_merge_train_run_record(run_record)
                 result["merge_train_run_id"] = run_record.run_id
+            elif path == _MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE:
+                batch_request = MergeTrainBatchCandidateRunOnceEnvelope.model_validate(payload)
+                policy_record = resolve_merge_train_policy_record(record_store)
+                policy = policy_record.policy
+                repository_policy = policy.find_repository_policy(
+                    repository=batch_request.repository,
+                    base_branch=batch_request.base_branch,
+                )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action=repository_policy.service_authz.action,
+                    product=repository_policy.service_authz.product,
+                    context=repository_policy.service_authz.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot run the requested merge train policy.",
+                            },
+                        },
+                    )
+                token_env = repository_policy.github_token.env_var
+                if not token_env:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "github_token_not_configured",
+                                "message": "Merge train policy does not define a GitHub token environment variable.",
+                            },
+                        },
+                    )
+                token = os.environ.get(token_env, "").strip()
+                if not token:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "github_token_not_configured",
+                                "message": "Configured merge train GitHub token is not available.",
+                            },
+                        },
+                    )
+                batch_store = _merge_train_batch_candidate_record_store(record_store)
+                transport = UrllibMergeTrainGitHubTransport(
+                    token=token,
+                    api_base_url=batch_request.github_api_base_url,
+                )
+                github_client = GitHubMergeTrainClient(transport=transport)
+                recorded_at = _utc_now_timestamp()
+                if batch_request.mode == "plan":
+                    snapshot = GitHubMergeTrainSnapshotReader(
+                        transport=transport
+                    ).read_merge_train_snapshot(
+                        repository=batch_request.repository,
+                        base_branch=batch_request.base_branch,
+                    )
+                    dry_run_result = build_merge_train_dry_run_result(
+                        policy=policy, snapshot=snapshot
+                    )
+                    base_sha = next(
+                        (
+                            pull_request.base_sha
+                            for pull_request in snapshot.pull_requests
+                            if pull_request.base_sha
+                        ),
+                        "",
+                    )
+                    candidate = build_merge_train_batch_candidate(
+                        dry_run_result=dry_run_result,
+                        base_sha=base_sha,
+                        policy_sha256=policy_record.policy_sha256,
+                        created_at=recorded_at,
+                    )
+                    driver_result = {
+                        "mode": batch_request.mode,
+                        "dry_run_result": dry_run_result.model_dump(mode="json"),
+                        "candidate": candidate.model_dump(mode="json"),
+                    }
+                else:
+                    existing_record = _read_merge_train_batch_candidate_record(
+                        record_store=batch_store,
+                        repository=batch_request.repository,
+                        base_branch=batch_request.base_branch,
+                        record_id=batch_request.candidate_record_id,
+                    )
+                    candidate = existing_record.candidate
+                    if batch_request.mode == "build":
+                        candidate = github_client.build_batch_candidate(candidate=candidate)
+                    else:
+                        candidate = github_client.observe_batch_candidate_checks(
+                            candidate=candidate
+                        )
+                    driver_result = {
+                        "mode": batch_request.mode,
+                        "candidate": candidate.model_dump(mode="json"),
+                    }
+                candidate_record = build_merge_train_batch_candidate_record(
+                    candidate=candidate,
+                    source=f"service:{batch_request.mode}:{request_trace_id}",
+                    updated_at=recorded_at,
+                )
+                batch_store.write_merge_train_batch_candidate_record(candidate_record)
+                result = {
+                    "merge_train_batch_candidate_record_id": candidate_record.record_id,
+                    "repository": candidate.repository,
+                    "base_branch": candidate.base_branch,
+                    "mode": batch_request.mode,
+                    "candidate": candidate.model_dump(mode="json"),
+                }
             elif path == "/v1/agent/write-intents/evaluate":
                 intent_request = AgentWriteIntentRequest.model_validate(payload)
                 intent_authz_action = authz_action_for_agent_write_intent(intent_request.intent)

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -311,8 +311,17 @@ result or applies exactly one worker step. Accepted calls write a
 dry-run decision, selected pull request metadata, and optional worker mutation
 result. Unsupported repository/base pairs, missing token configuration, and
 denied authorization all fail closed. Generic service code must not contain
-product repository conditionals. Future batch train service routes must preserve
-that same policy-backed, DB-backed, fail-closed boundary.
+product repository conditionals.
+
+The batch-candidate service endpoint
+`POST /v1/work-graph/merge-train/batch-candidate/run-once` also uses the same
+policy-backed, DB-backed boundary. It accepts `mode: plan`, `mode: build`, or
+`mode: observe`; writes `launchplane_merge_train_batch_candidates` records; and
+does not land original PRs. Plan mode reads a fresh snapshot and records the
+eligible queued PRs as one candidate. Build mode creates or resets the
+Launchplane train ref and merges queued PR heads into that ref in order. Observe
+mode records required-check state for the exact candidate SHA. Landing the
+original PRs remains a later PR-native phase with separate records.
 
 Scheduler admission is a deterministic decision over the latest stored
 `launchplane_merge_train_runs` record for the repository/base branch. Dry-run

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -230,6 +230,19 @@ performs no GitHub reads and no storage writes. Schedulers use this route to
 pace calls into `run-once`; execution still re-reads GitHub before any dry-run or
 mutation.
 
+`POST /v1/work-graph/merge-train/batch-candidate/run-once` executes one
+policy-backed batch-candidate phase for a requested repository/base branch. The
+route accepts `mode: plan`, `mode: build`, or `mode: observe`. Plan mode reads a
+fresh GitHub snapshot, derives one deterministic batch candidate from the
+currently eligible queued PRs, and writes a
+`launchplane_merge_train_batch_candidates` record. Build mode requires a prior
+candidate record id, creates or resets the Launchplane train ref, merges queued
+PR heads into that ref in order, and records the resulting candidate SHA. Observe
+mode requires a prior candidate record id, reads required checks for that exact
+candidate SHA, and records whether the candidate is still pending, passed, or
+failed. The route never lands original PRs; PR-native landing remains a later
+phase with separate records and pre-merge invariants.
+
 `.github/workflows/merge-train-runner.yml` is the first external scheduler for
 this route. It mints a GitHub Actions OIDC token for the Launchplane service,
 reads admission, and calls `run-once` only when the decision is `admitted`.
@@ -294,6 +307,10 @@ than overloading `run-once`. Its target behavior is to build one combined
 candidate from the base branch plus multiple queued PRs, run required checks on
 that candidate commit, and then land the original PRs in queue order through
 GitHub's normal PR merge path after pre-merge invariants are rechecked.
+The first batch service contract is
+`POST /v1/work-graph/merge-train/batch-candidate/run-once`; it owns only the
+plan/build/observe candidate phases and writes
+`launchplane_merge_train_batch_candidates` records.
 
 `POST /v1/merge-train/policies/import` is the service-owned write path for merge
 train policy records. It requires database storage and

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -30,6 +30,7 @@ from control_plane.contracts.deployment_record import DeploymentRecord, Resolved
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
+from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidate
 from control_plane.contracts.odoo_instance_override_record import OdooConfigParameterOverride
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.odoo_instance_override_record import OdooOverrideValue
@@ -204,6 +205,18 @@ class _FakeMergeTrainGitHubClient:
         merge_method: str,
     ) -> str:
         return f"merge-{pull_request_number}"
+
+    def build_batch_candidate(
+        self, *, candidate: MergeTrainBatchCandidate
+    ) -> MergeTrainBatchCandidate:
+        return candidate.model_copy(
+            update={"candidate_sha": "candidate-built", "status": "ready_for_checks"}
+        )
+
+    def observe_batch_candidate_checks(
+        self, *, candidate: MergeTrainBatchCandidate
+    ) -> MergeTrainBatchCandidate:
+        return candidate.model_copy(update={"required_checks_status": "pass", "status": "passed"})
 
 
 class _NoopMergeTrainGitHubClient:
@@ -1520,6 +1533,160 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(
             payload["result"]["dry_run_result"]["policy_key"], "cbusillo/codex-skills:main"
         )
+
+    def test_merge_train_batch_candidate_service_plans_candidate_record(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                _FakeMergeTrainSnapshotReader,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+            record_id = payload["records"]["merge_train_batch_candidate_record_id"]
+            listed_records = FilesystemRecordStore(
+                state_dir
+            ).list_merge_train_batch_candidate_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "plan")
+        self.assertEqual(payload["result"]["candidate"]["status"], "planned")
+        self.assertEqual(payload["result"]["candidate"]["entries"][0]["pull_request_number"], 1)
+        self.assertEqual(listed_records[0].record_id, record_id)
+        self.assertEqual(listed_records[0].candidate.policy_key, "cbusillo/sellyouroutboard:main")
+
+    def test_merge_train_batch_candidate_service_builds_existing_candidate_record(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                _FakeMergeTrainSnapshotReader,
+            ):
+                _, plan_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "build",
+                        "candidate_record_id": plan_payload["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "build")
+        self.assertEqual(payload["result"]["candidate"]["status"], "ready_for_checks")
+        self.assertEqual(payload["result"]["candidate"]["candidate_sha"], "candidate-built")
+
+    def test_merge_train_batch_candidate_service_observes_existing_candidate_record(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                _FakeMergeTrainSnapshotReader,
+            ):
+                _, plan_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
+                _, build_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "build",
+                        "candidate_record_id": plan_payload["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "observe",
+                        "candidate_record_id": build_payload["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "observe")
+        self.assertEqual(payload["result"]["candidate"]["status"], "passed")
+        self.assertEqual(payload["result"]["candidate"]["required_checks_status"], "pass")
 
     def test_merge_train_admission_service_uses_configured_codex_skills_policy(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add `POST /v1/work-graph/merge-train/batch-candidate/run-once`
- support explicit `plan`, `build`, and `observe` batch-candidate phases
- persist a new batch candidate record for each accepted phase
- document the new service boundary and policy behavior

Refs #601
Refs #604
Refs #605

## Verification
- `uv run python -m unittest tests.test_merge_train_batch tests.test_merge_train_github tests.test_service.LaunchplaneServiceTests.test_merge_train_run_once_service_returns_dry_run_from_policy tests.test_service.LaunchplaneServiceTests.test_merge_train_run_once_service_mutates_one_worker_step tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_candidate_service_plans_candidate_record tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_candidate_service_builds_existing_candidate_record tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_candidate_service_observes_existing_candidate_record`
- `uv run --extra dev ruff check control_plane/service.py control_plane/contracts/merge_train_batch.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/service.py control_plane/contracts/merge_train_batch.py tests/test_service.py`
- `uv run --extra dev mypy control_plane/service.py control_plane/contracts/merge_train_batch.py tests/test_service.py`
- `git diff --check`

## Inspection
PyCharm changed-files inspection returned whole-project existing noise despite the changed-files scope; no new touched-file findings were identified from the targeted verification above.
