### PR TITLE
Add merge train batch candidate dispatch

### DIFF
--- a/.github/workflows/merge-train-runner.yml
+++ b/.github/workflows/merge-train-runner.yml
@@ -22,6 +22,22 @@ name: Merge Train Runner
         type: boolean
         required: false
         default: false
+      batch_candidate_mode:
+        description: >-
+          Optional batch-candidate phase to run instead of the Level 1 worker:
+          none, plan, build, or observe.
+        type: choice
+        required: false
+        default: none
+        options:
+          - none
+          - plan
+          - build
+          - observe
+      batch_candidate_record_id:
+        description: Candidate record id required for build or observe mode
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -57,6 +73,18 @@ jobs:
             github.event_name != 'schedule' && inputs.mutate
           ) && 'true' ||
           'false'
+        }}
+      MERGE_TRAIN_BATCH_CANDIDATE_MODE: >-
+        ${{
+          github.event_name != 'schedule' &&
+          inputs.batch_candidate_mode ||
+          'none'
+        }}
+      MERGE_TRAIN_BATCH_CANDIDATE_RECORD_ID: >-
+        ${{
+          github.event_name != 'schedule' &&
+          inputs.batch_candidate_record_id ||
+          ''
         }}
     steps:
       - name: Request admission decision
@@ -152,6 +180,10 @@ jobs:
           SERVICE_AUDIENCE: ${{ steps.admission.outputs.service_audience }}
         run: |
           set -euo pipefail
+          if [ "${MERGE_TRAIN_BATCH_CANDIDATE_MODE}" != "none" ]; then
+            echo "Batch-candidate mode selected; skipping Level 1 worker pass."
+            exit 0
+          fi
 
           oidc_token="$({
             curl -fsSL \
@@ -203,6 +235,96 @@ jobs:
             })"
             echo "- Run record: ${run_record}"
             echo "- Next action: ${next_action}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run one batch-candidate phase
+        if: >-
+          steps.admission.outputs.admission_status == 'admitted' &&
+          env.MERGE_TRAIN_BATCH_CANDIDATE_MODE != 'none'
+        shell: bash
+        env:
+          SERVICE_ORIGIN: ${{ steps.admission.outputs.service_origin }}
+          SERVICE_AUDIENCE: ${{ steps.admission.outputs.service_audience }}
+        run: |
+          set -euo pipefail
+          case "$MERGE_TRAIN_BATCH_CANDIDATE_MODE" in
+            plan|build|observe) ;;
+            *)
+              echo "Unsupported batch candidate mode:" \
+                "${MERGE_TRAIN_BATCH_CANDIDATE_MODE}" >&2
+              exit 1
+              ;;
+          esac
+          if [ "$MERGE_TRAIN_BATCH_CANDIDATE_MODE" != "plan" ] && \
+             [ -z "${MERGE_TRAIN_BATCH_CANDIDATE_RECORD_ID}" ]; then
+            echo \
+              "batch_candidate_record_id is required for build or observe." \
+              >&2
+            exit 1
+          fi
+
+          oidc_token="$({
+            curl -fsSL \
+              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
+            | jq -r '.value'
+          })"
+          request_payload="$({
+            jq -n \
+              --arg repository "$MERGE_TRAIN_REPOSITORY" \
+              --arg base_branch "$MERGE_TRAIN_BASE_BRANCH" \
+              --arg mode "$MERGE_TRAIN_BATCH_CANDIDATE_MODE" \
+              --arg candidate_record_id \
+                "$MERGE_TRAIN_BATCH_CANDIDATE_RECORD_ID" \
+              '{
+                schema_version: 1,
+                repository: $repository,
+                base_branch: $base_branch,
+                mode: $mode,
+                candidate_record_id: $candidate_record_id
+              }'
+          })"
+          response_file="launchplane-merge-train-batch-candidate.json"
+          batch_candidate_url="${SERVICE_ORIGIN}/v1/work-graph/merge-train"
+          batch_candidate_url="${batch_candidate_url}/batch-candidate/run-once"
+          status_code="$(curl -sS \
+            -o "$response_file" \
+            -w '%{http_code}' \
+            -X POST \
+            -H "Authorization: Bearer ${oidc_token}" \
+            -H 'Content-Type: application/json' \
+            --data "$request_payload" \
+            "$batch_candidate_url")"
+          if [ "$status_code" != "202" ]; then
+            cat "$response_file" >&2
+            echo "Merge-train batch-candidate phase failed" \
+              "with HTTP ${status_code}." >&2
+            exit 1
+          fi
+
+          jq . "$response_file"
+          {
+            echo
+            echo '## Launchplane merge train batch candidate'
+            echo
+            echo "- Mode: $(jq -r '.result.mode' "$response_file")"
+            candidate_status="$(
+              jq -r '.result.candidate.status' "$response_file"
+            )"
+            candidate_sha="$(
+              jq -r '.result.candidate.candidate_sha // ""' "$response_file"
+            )"
+            required_checks="$(
+              jq -r '.result.candidate.required_checks_status' "$response_file"
+            )"
+            candidate_record="$(
+              jq -r '.records.merge_train_batch_candidate_record_id' \
+                "$response_file"
+            )"
+            echo "- Candidate status: ${candidate_status}"
+            echo "- Candidate SHA: ${candidate_sha}"
+            echo "- Required checks: ${required_checks}"
+            echo "- Record: ${candidate_record}"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Record deferred decision


### PR DESCRIPTION
## Summary
- add manual `batch_candidate_mode` dispatch support to Merge Train Runner
- route `plan`, `build`, and `observe` modes to the deployed batch-candidate service endpoint
- keep scheduled runs on the existing Level 1 worker path

Refs #601
Refs #604
Refs #605

## Verification
- YAML parse/yamllint/prettier validation from editor hook
- `uv run --extra dev ruff check --diff .github/workflows/merge-train-runner.yml`
- `git diff --check`

## Notes
The local actionlint hook reports `could not read "never"` in this environment, so I could not use that signal locally. CI Security workflow will run workflow lint on the PR.
