### PR TITLE
Use live base SHA for merge train batches

### DIFF
--- a/control_plane/merge_train.py
+++ b/control_plane/merge_train.py
@@ -84,6 +84,7 @@ class MergeTrainDryRunSnapshot(BaseModel):
 
     repository: str
     base_branch: str
+    base_sha: str = ""
     pull_requests: tuple[MergeTrainPullRequestSnapshot, ...]
 
     @model_validator(mode="after")
@@ -94,6 +95,7 @@ class MergeTrainDryRunSnapshot(BaseModel):
         self.base_branch = _normalize_required_value(
             self.base_branch, "merge train dry-run snapshot requires base_branch"
         )
+        self.base_sha = self.base_sha.strip()
         return self
 
 

--- a/control_plane/merge_train_github.py
+++ b/control_plane/merge_train_github.py
@@ -212,6 +212,9 @@ class GitHubMergeTrainSnapshotReader:
         normalized_base_branch = _required_value(
             base_branch, "GitHub pull request base branch is required."
         )
+        base_sha = self._base_branch_sha(
+            repository_path=repository_path, base_branch=normalized_base_branch
+        )
         pull_requests = tuple(
             self._pull_request_snapshot(
                 repository=repository,
@@ -225,8 +228,20 @@ class GitHubMergeTrainSnapshotReader:
         return MergeTrainDryRunSnapshot(
             repository=repository,
             base_branch=normalized_base_branch,
+            base_sha=base_sha,
             pull_requests=pull_requests,
         )
+
+    def _base_branch_sha(self, *, repository_path: str, base_branch: str) -> str:
+        branch = _json_object(
+            self.transport.request(
+                method="GET",
+                path=f"/repos/{repository_path}/branches/{quote(base_branch, safe='')}",
+            ),
+            "GitHub branch response",
+        )
+        commit = _json_object(branch.get("commit"), "GitHub branch commit")
+        return _required_text(commit.get("sha"), "GitHub branch commit requires sha.")
 
     def _list_open_pull_requests(
         self, *, repository_path: str, base_branch: str

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -6921,17 +6921,9 @@ def create_launchplane_service_app(
                     dry_run_result = build_merge_train_dry_run_result(
                         policy=policy, snapshot=snapshot
                     )
-                    base_sha = next(
-                        (
-                            pull_request.base_sha
-                            for pull_request in snapshot.pull_requests
-                            if pull_request.base_sha
-                        ),
-                        "",
-                    )
                     candidate = build_merge_train_batch_candidate(
                         dry_run_result=dry_run_result,
-                        base_sha=base_sha,
+                        base_sha=snapshot.base_sha,
                         policy_sha256=policy_record.policy_sha256,
                         created_at=recorded_at,
                     )

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -318,10 +318,13 @@ The batch-candidate service endpoint
 policy-backed, DB-backed boundary. It accepts `mode: plan`, `mode: build`, or
 `mode: observe`; writes `launchplane_merge_train_batch_candidates` records; and
 does not land original PRs. Plan mode reads a fresh snapshot and records the
-eligible queued PRs as one candidate. Build mode creates or resets the
-Launchplane train ref and merges queued PR heads into that ref in order. Observe
-mode records required-check state for the exact candidate SHA. Landing the
-original PRs remains a later PR-native phase with separate records.
+eligible queued PRs as one candidate. The candidate base SHA comes from the live
+base branch head, not from any individual pull request's base metadata, so stale
+or ineligible open PRs cannot move the candidate off the target branch. Build
+mode creates or resets the Launchplane train ref and merges queued PR heads into
+that ref in order. Observe mode records required-check state for the exact
+candidate SHA. Landing the original PRs remains a later PR-native phase with
+separate records.
 
 Scheduler admission is a deterministic decision over the latest stored
 `launchplane_merge_train_runs` record for the repository/base branch. Dry-run

--- a/tests/test_merge_train_batch.py
+++ b/tests/test_merge_train_batch.py
@@ -99,6 +99,7 @@ class MergeTrainBatchContractTests(unittest.TestCase):
             snapshot=MergeTrainDryRunSnapshot(
                 repository="example/merge-train-repo",
                 base_branch="main",
+                base_sha="current-main",
                 pull_requests=(
                     _pull_request(2, created_at="2026-05-13T10:02:00Z"),
                     _pull_request(1, created_at="2026-05-13T10:01:00Z"),
@@ -108,13 +109,13 @@ class MergeTrainBatchContractTests(unittest.TestCase):
 
         candidate = build_merge_train_batch_candidate(
             dry_run_result=dry_run_result,
-            base_sha="base-main",
+            base_sha="current-main",
             policy_sha256="policy-sha",
             created_at="2026-05-13T23:00:00Z",
         )
 
         self.assertEqual(candidate.status, "planned")
-        self.assertEqual(candidate.base_sha, "base-main")
+        self.assertEqual(candidate.base_sha, "current-main")
         self.assertEqual(candidate.policy_key, "example/merge-train-repo:main")
         self.assertEqual(
             [entry.pull_request_number for entry in candidate.entries],

--- a/tests/test_merge_train_github.py
+++ b/tests/test_merge_train_github.py
@@ -237,6 +237,7 @@ class GitHubMergeTrainSnapshotReaderTests(unittest.TestCase):
     def test_snapshot_reader_builds_pull_request_snapshots_from_github(self) -> None:
         transport = RecordingMergeTrainGitHubTransport(
             responses=(
+                _github_branch(),
                 [
                     _github_pull_request(42, mergeable=None),
                 ],
@@ -264,9 +265,11 @@ class GitHubMergeTrainSnapshotReaderTests(unittest.TestCase):
         self.assertEqual(pull_request.mergeable, "mergeable")
         self.assertEqual(pull_request.required_checks_status, "pass")
         self.assertFalse(pull_request.branch_update_required)
+        self.assertEqual(snapshot.base_sha, "base-main-current")
         self.assertEqual(
             [request.path for request in transport.requests],
             [
+                "/repos/cbusillo/sellyouroutboard/branches/main",
                 "/repos/cbusillo/sellyouroutboard/pulls?state=open&base=main&sort=created&direction=asc&per_page=100&page=1",
                 "/repos/cbusillo/sellyouroutboard/pulls/42",
                 "/repos/cbusillo/sellyouroutboard/collaborators/cbusillo/permission",
@@ -280,6 +283,7 @@ class GitHubMergeTrainSnapshotReaderTests(unittest.TestCase):
     ) -> None:
         transport = RecordingMergeTrainGitHubTransport(
             responses=(
+                _github_branch(),
                 [_github_pull_request(15, author_association="CONTRIBUTOR")],
                 _github_pull_request(15, author_association="CONTRIBUTOR"),
                 MergeTrainGitHubError("permission not found", status_code=404),
@@ -297,6 +301,7 @@ class GitHubMergeTrainSnapshotReaderTests(unittest.TestCase):
     def test_snapshot_reader_paginates_check_runs_before_computing_status(self) -> None:
         transport = RecordingMergeTrainGitHubTransport(
             responses=(
+                _github_branch(),
                 [_github_pull_request(16)],
                 _github_pull_request(16),
                 {"permission": "admin"},
@@ -325,7 +330,7 @@ class GitHubMergeTrainSnapshotReaderTests(unittest.TestCase):
     def test_snapshot_reader_paginates_pull_requests(self) -> None:
         first_page = [_github_pull_request(number) for number in range(1, 101)]
         second_page = [_github_pull_request(101)]
-        responses: list[object] = [first_page, second_page]
+        responses: list[object] = [_github_branch(), first_page, second_page]
         for number in range(1, 102):
             responses.extend(
                 [
@@ -348,6 +353,7 @@ class GitHubMergeTrainSnapshotReaderTests(unittest.TestCase):
     def test_snapshot_reader_maps_owner_association_without_permission_lookup(self) -> None:
         transport = RecordingMergeTrainGitHubTransport(
             responses=(
+                _github_branch(),
                 [_github_pull_request(12, author_association="OWNER")],
                 _github_pull_request(12, author_association="OWNER"),
                 {"state": "success"},
@@ -365,6 +371,7 @@ class GitHubMergeTrainSnapshotReaderTests(unittest.TestCase):
     def test_snapshot_reader_combines_pending_checks_without_mutation(self) -> None:
         transport = RecordingMergeTrainGitHubTransport(
             responses=(
+                _github_branch(),
                 [_github_pull_request(13)],
                 _github_pull_request(13, mergeable=None, mergeable_state="behind"),
                 {"permission": "admin"},
@@ -386,6 +393,7 @@ class GitHubMergeTrainSnapshotReaderTests(unittest.TestCase):
     def test_snapshot_reader_uses_check_runs_when_legacy_statuses_are_absent(self) -> None:
         transport = RecordingMergeTrainGitHubTransport(
             responses=(
+                _github_branch(),
                 [_github_pull_request(14)],
                 _github_pull_request(14),
                 {"permission": "admin"},
@@ -401,7 +409,9 @@ class GitHubMergeTrainSnapshotReaderTests(unittest.TestCase):
         self.assertEqual(snapshot.pull_requests[0].required_checks_status, "pass")
 
     def test_snapshot_reader_fails_closed_on_missing_required_shape(self) -> None:
-        transport = RecordingMergeTrainGitHubTransport(responses=([{"number": 1}],))
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(_github_branch(), [{"number": 1}])
+        )
 
         with self.assertRaisesRegex(MergeTrainGitHubError, "head"):
             GitHubMergeTrainSnapshotReader(transport=transport).read_merge_train_snapshot(
@@ -431,6 +441,10 @@ def _github_pull_request(
         "mergeable": mergeable,
         "mergeable_state": mergeable_state,
     }
+
+
+def _github_branch() -> dict[str, object]:
+    return {"commit": {"sha": "base-main-current"}}
 
 
 def _check_run(status: str, conclusion: str | None) -> dict[str, object]:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -251,6 +251,7 @@ class _FakeMergeTrainSnapshotReader:
         return MergeTrainDryRunSnapshot(
             repository=repository,
             base_branch=base_branch,
+            base_sha="current-base-main",
             pull_requests=(
                 MergeTrainPullRequestSnapshot(
                     number=1,
@@ -1572,6 +1573,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 202)
         self.assertEqual(payload["result"]["mode"], "plan")
         self.assertEqual(payload["result"]["candidate"]["status"], "planned")
+        self.assertEqual(payload["result"]["candidate"]["base_sha"], "current-base-main")
         self.assertEqual(payload["result"]["candidate"]["entries"][0]["pull_request_number"], 1)
         self.assertEqual(listed_records[0].record_id, record_id)
         self.assertEqual(listed_records[0].candidate.policy_key, "cbusillo/sellyouroutboard:main")


### PR DESCRIPTION
## Summary\n- Store the live base branch SHA on merge-train snapshots read from GitHub\n- Build batch candidates from the live base branch head instead of the first open PR's base metadata\n- Document the base-SHA invariant and cover the service/GitHub paths with targeted tests\n\n## Verification\n- uv run python -m unittest tests.test_merge_train_batch tests.test_merge_train_github tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_candidate_service_plans_candidate_record tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_candidate_service_builds_existing_candidate_record tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_candidate_service_observes_existing_candidate_record\n- uv run --extra dev ruff check --diff control_plane/merge_train.py control_plane/merge_train_github.py control_plane/service.py tests/test_merge_train_batch.py tests/test_merge_train_github.py tests/test_service.py\n- uv run --extra dev ruff check control_plane/merge_train.py control_plane/merge_train_github.py control_plane/service.py tests/test_merge_train_batch.py tests/test_merge_train_github.py tests/test_service.py\n- uv run --extra dev mypy control_plane tests\n\nRefs #604.