### PR TITLE
Add guarded batch merge train landing

### DIFF
--- a/.github/workflows/merge-train-runner.yml
+++ b/.github/workflows/merge-train-runner.yml
@@ -38,6 +38,25 @@ name: Merge Train Runner
         description: Candidate record id required for build or observe mode
         required: false
         default: ""
+      batch_landing_mode:
+        description: >-
+          Optional batch-landing phase to run instead of the Level 1 worker:
+          none, plan, or land.
+        type: choice
+        required: false
+        default: none
+        options:
+          - none
+          - plan
+          - land
+      batch_landing_candidate_record_id:
+        description: Candidate record id required for landing plan mode
+        required: false
+        default: ""
+      batch_landing_plan_record_id:
+        description: Landing-plan record id required for land mode
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -84,6 +103,24 @@ jobs:
         ${{
           github.event_name != 'schedule' &&
           inputs.batch_candidate_record_id ||
+          ''
+        }}
+      MERGE_TRAIN_BATCH_LANDING_MODE: >-
+        ${{
+          github.event_name != 'schedule' &&
+          inputs.batch_landing_mode ||
+          'none'
+        }}
+      MERGE_TRAIN_BATCH_LANDING_CANDIDATE_RECORD_ID: >-
+        ${{
+          github.event_name != 'schedule' &&
+          inputs.batch_landing_candidate_record_id ||
+          ''
+        }}
+      MERGE_TRAIN_BATCH_LANDING_PLAN_RECORD_ID: >-
+        ${{
+          github.event_name != 'schedule' &&
+          inputs.batch_landing_plan_record_id ||
           ''
         }}
     steps:
@@ -180,8 +217,9 @@ jobs:
           SERVICE_AUDIENCE: ${{ steps.admission.outputs.service_audience }}
         run: |
           set -euo pipefail
-          if [ "${MERGE_TRAIN_BATCH_CANDIDATE_MODE}" != "none" ]; then
-            echo "Batch-candidate mode selected; skipping Level 1 worker pass."
+          if [ "${MERGE_TRAIN_BATCH_CANDIDATE_MODE}" != "none" ] || \
+             [ "${MERGE_TRAIN_BATCH_LANDING_MODE}" != "none" ]; then
+            echo "Batch mode selected; skipping Level 1 worker pass."
             exit 0
           fi
 
@@ -325,6 +363,103 @@ jobs:
             echo "- Candidate SHA: ${candidate_sha}"
             echo "- Required checks: ${required_checks}"
             echo "- Record: ${candidate_record}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run one batch-landing phase
+        if: >-
+          steps.admission.outputs.admission_status == 'admitted' &&
+          env.MERGE_TRAIN_BATCH_LANDING_MODE != 'none'
+        shell: bash
+        env:
+          SERVICE_ORIGIN: ${{ steps.admission.outputs.service_origin }}
+          SERVICE_AUDIENCE: ${{ steps.admission.outputs.service_audience }}
+        run: |
+          set -euo pipefail
+          if [ "${MERGE_TRAIN_BATCH_CANDIDATE_MODE}" != "none" ]; then
+            echo "Only one batch mode may run per workflow dispatch." >&2
+            exit 1
+          fi
+          case "$MERGE_TRAIN_BATCH_LANDING_MODE" in
+            plan|land) ;;
+            *)
+              echo "Unsupported batch landing mode:" \
+                "${MERGE_TRAIN_BATCH_LANDING_MODE}" >&2
+              exit 1
+              ;;
+          esac
+          if [ "$MERGE_TRAIN_BATCH_LANDING_MODE" = "plan" ] && \
+             [ -z "${MERGE_TRAIN_BATCH_LANDING_CANDIDATE_RECORD_ID}" ]; then
+            echo \
+              "batch_landing_candidate_record_id is required for plan mode." \
+              >&2
+            exit 1
+          fi
+          if [ "$MERGE_TRAIN_BATCH_LANDING_MODE" = "land" ] && \
+             [ -z "${MERGE_TRAIN_BATCH_LANDING_PLAN_RECORD_ID}" ]; then
+            echo \
+              "batch_landing_plan_record_id is required for land mode." \
+              >&2
+            exit 1
+          fi
+
+          oidc_token="$({
+            curl -fsSL \
+              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
+            | jq -r '.value'
+          })"
+          request_payload="$({
+            jq -n \
+              --arg repository "$MERGE_TRAIN_REPOSITORY" \
+              --arg base_branch "$MERGE_TRAIN_BASE_BRANCH" \
+              --arg mode "$MERGE_TRAIN_BATCH_LANDING_MODE" \
+              --arg candidate_record_id \
+                "$MERGE_TRAIN_BATCH_LANDING_CANDIDATE_RECORD_ID" \
+              --arg landing_plan_record_id \
+                "$MERGE_TRAIN_BATCH_LANDING_PLAN_RECORD_ID" \
+              '{
+                schema_version: 1,
+                repository: $repository,
+                base_branch: $base_branch,
+                mode: $mode,
+                candidate_record_id: $candidate_record_id,
+                landing_plan_record_id: $landing_plan_record_id
+              }'
+          })"
+          response_file="launchplane-merge-train-batch-landing.json"
+          batch_landing_url="${SERVICE_ORIGIN}/v1/work-graph/merge-train"
+          batch_landing_url="${batch_landing_url}/batch-landing/run-once"
+          status_code="$(curl -sS \
+            -o "$response_file" \
+            -w '%{http_code}' \
+            -X POST \
+            -H "Authorization: Bearer ${oidc_token}" \
+            -H 'Content-Type: application/json' \
+            --data "$request_payload" \
+            "$batch_landing_url")"
+          if [ "$status_code" != "202" ]; then
+            cat "$response_file" >&2
+            echo "Merge-train batch-landing phase failed" \
+              "with HTTP ${status_code}." >&2
+            exit 1
+          fi
+
+          jq . "$response_file"
+          {
+            echo
+            echo '## Launchplane merge train batch landing'
+            echo
+            echo "- Mode: $(jq -r '.result.mode' "$response_file")"
+            plan_record="$(
+              jq -r '.records.merge_train_batch_landing_plan_record_id' \
+                "$response_file"
+            )"
+            entry_statuses="$(
+              jq -r '[.result.landing_plan.entries[].status] | join(",")' \
+                "$response_file"
+            )"
+            echo "- Landing-plan record: ${plan_record}"
+            echo "- Entry statuses: ${entry_statuses}"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Record deferred decision

--- a/control_plane/contracts/merge_train_batch.py
+++ b/control_plane/contracts/merge_train_batch.py
@@ -295,6 +295,38 @@ def build_merge_train_batch_candidate_record_id(
     return f"merge-train-batch-candidate-{normalized_timestamp}-{digest}"
 
 
+def build_merge_train_batch_landing_plan_record(
+    *,
+    landing_plan: MergeTrainBatchLandingPlan,
+    source: str,
+    updated_at: str,
+) -> MergeTrainBatchLandingPlanRecord:
+    record_without_id = MergeTrainBatchLandingPlanRecord(
+        record_id="pending",
+        source=source,
+        updated_at=updated_at,
+        landing_plan=landing_plan,
+    )
+    return record_without_id.model_copy(
+        update={
+            "record_id": build_merge_train_batch_landing_plan_record_id(
+                record_without_id
+            )
+        }
+    )
+
+
+def build_merge_train_batch_landing_plan_record_id(
+    record: MergeTrainBatchLandingPlanRecord,
+) -> str:
+    digest_payload = record.model_dump(mode="json", exclude={"record_id"})
+    digest = hashlib.sha256(
+        json.dumps(digest_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:16]
+    normalized_timestamp = record.updated_at.replace("-", "").replace(":", "")
+    return f"merge-train-batch-landing-plan-{normalized_timestamp}-{digest}"
+
+
 def build_merge_train_batch_id(
     *, repository: str, base_branch: str, base_sha: str, entry_head_shas: tuple[str, ...]
 ) -> str:

--- a/control_plane/merge_train_github.py
+++ b/control_plane/merge_train_github.py
@@ -7,6 +7,7 @@ from urllib.request import Request, urlopen
 from pydantic import BaseModel, ConfigDict, model_validator
 
 from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidate
+from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlan
 from control_plane.contracts.merge_train_policy import MergeTrainMergeMethod
 from control_plane.merge_train import MergeTrainCheckStatus
 from control_plane.merge_train import MergeTrainDryRunSnapshot
@@ -129,6 +130,33 @@ class GitHubMergeTrainClient:
             update={"required_checks_status": check_status, "status": candidate_status}
         )
 
+    def land_batch_candidate(self, *, landing_plan: MergeTrainBatchLandingPlan) -> MergeTrainBatchLandingPlan:
+        repository_path = _repository_path(landing_plan.repository)
+        expected_base_sha = landing_plan.entries[0].expected_base_sha
+        current_base_sha = _base_branch_sha(
+            transport=self.transport,
+            repository_path=repository_path,
+            base_branch=landing_plan.base_branch,
+        )
+        if current_base_sha != expected_base_sha:
+            raise MergeTrainGitHubStaleHeadError(
+                "Base branch moved after batch candidate validation.", status_code=409
+            )
+        merged_entries = []
+        for entry in landing_plan.entries:
+            merge_commit_sha = self.merge_pull_request(
+                repository=landing_plan.repository,
+                pull_request_number=entry.pull_request_number,
+                head_sha=entry.expected_head_sha,
+                merge_method=entry.merge_method,
+            )
+            merged_entries.append(
+                entry.model_copy(
+                    update={"status": "merged", "merge_commit_sha": merge_commit_sha}
+                )
+            )
+        return landing_plan.model_copy(update={"entries": tuple(merged_entries)})
+
     def add_pull_request_label(
         self, *, repository: str, pull_request_number: int, label: str
     ) -> None:
@@ -233,15 +261,11 @@ class GitHubMergeTrainSnapshotReader:
         )
 
     def _base_branch_sha(self, *, repository_path: str, base_branch: str) -> str:
-        branch = _json_object(
-            self.transport.request(
-                method="GET",
-                path=f"/repos/{repository_path}/branches/{quote(base_branch, safe='')}",
-            ),
-            "GitHub branch response",
+        return _base_branch_sha(
+            transport=self.transport,
+            repository_path=repository_path,
+            base_branch=base_branch,
         )
-        commit = _json_object(branch.get("commit"), "GitHub branch commit")
-        return _required_text(commit.get("sha"), "GitHub branch commit requires sha.")
 
     def _list_open_pull_requests(
         self, *, repository_path: str, base_branch: str
@@ -468,6 +492,20 @@ def _mergeable_state(source: dict[str, object]) -> MergeTrainMergeableState:
 def _branch_update_required(source: dict[str, object]) -> bool:
     mergeable_state = str(source.get("mergeable_state") or "").strip().lower()
     return mergeable_state == "behind"
+
+
+def _base_branch_sha(
+    *, transport: MergeTrainGitHubTransport, repository_path: str, base_branch: str
+) -> str:
+    branch = _json_object(
+        transport.request(
+            method="GET",
+            path=f"/repos/{repository_path}/branches/{quote(base_branch, safe='')}",
+        ),
+        "GitHub branch response",
+    )
+    commit = _json_object(branch.get("commit"), "GitHub branch commit")
+    return _required_text(commit.get("sha"), "GitHub branch commit requires sha.")
 
 
 def _combined_status_state(payload: dict[str, object]) -> MergeTrainCheckStatus:

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -78,8 +78,11 @@ from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRec
 from control_plane.contracts.idempotency_record import build_launchplane_idempotency_record_id
 from control_plane.contracts.merge_train_batch import (
     MergeTrainBatchCandidateRecord,
+    MergeTrainBatchLandingPlanRecord,
     build_merge_train_batch_candidate,
     build_merge_train_batch_candidate_record,
+    build_merge_train_batch_landing_plan,
+    build_merge_train_batch_landing_plan_record,
 )
 from control_plane.contracts.merge_train_run_record import build_merge_train_run_record
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
@@ -334,6 +337,7 @@ _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 _EVERY_CODE_GITHUB_WEBHOOK_ROUTE = "/v1/every-code/github-webhook"
 _MERGE_TRAIN_ADMISSION_ROUTE = "/v1/work-graph/merge-train/admission"
 _MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-candidate/run-once"
+_MERGE_TRAIN_BATCH_LANDING_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-landing/run-once"
 _MERGE_TRAIN_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/run-once"
 _EVERY_CODE_GITHUB_WEBHOOK_SECRET_ENV_KEY = "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET"
 
@@ -385,6 +389,37 @@ class MergeTrainBatchCandidateRunOnceEnvelope(BaseModel):
             raise ValueError("merge train batch candidate requires base_branch")
         if self.mode in {"build", "observe"} and not self.candidate_record_id:
             raise ValueError("build and observe require candidate_record_id")
+        return self
+
+
+class MergeTrainBatchLandingRunOnceEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    repository: str
+    base_branch: str = "main"
+    mode: Literal["plan", "land"] = "plan"
+    candidate_record_id: str = ""
+    landing_plan_record_id: str = ""
+    github_api_base_url: str = "https://api.github.com"
+
+    @model_validator(mode="after")
+    def _validate_envelope(self) -> "MergeTrainBatchLandingRunOnceEnvelope":
+        self.repository = self.repository.strip()
+        self.base_branch = self.base_branch.strip()
+        self.candidate_record_id = self.candidate_record_id.strip()
+        self.landing_plan_record_id = self.landing_plan_record_id.strip()
+        self.github_api_base_url = self.github_api_base_url.strip() or "https://api.github.com"
+        if not self.repository:
+            raise ValueError("merge train batch landing requires repository")
+        if "/" not in self.repository:
+            raise ValueError("merge train repository must be owner/name")
+        if not self.base_branch:
+            raise ValueError("merge train batch landing requires base_branch")
+        if self.mode == "plan" and not self.candidate_record_id:
+            raise ValueError("landing plan mode requires candidate_record_id")
+        if self.mode == "land" and not self.landing_plan_record_id:
+            raise ValueError("landing land mode requires landing_plan_record_id")
         return self
 
 
@@ -2213,6 +2248,7 @@ def _build_write_routes() -> frozenset[str]:
     launchplane_write_routes = {
         _EVERY_CODE_GITHUB_WEBHOOK_ROUTE,
         _MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE,
+        _MERGE_TRAIN_BATCH_LANDING_RUN_ONCE_ROUTE,
         _MERGE_TRAIN_RUN_ONCE_ROUTE,
         "/v1/agent/write-intents/evaluate",
         "/v1/every-code/work-requests/create",
@@ -2428,6 +2464,31 @@ def _merge_train_batch_candidate_record_store(
     raise TypeError("record store does not support merge train batch candidate records")
 
 
+class _MergeTrainBatchLandingPlanRecordStore(Protocol):
+    def write_merge_train_batch_landing_plan_record(
+        self, record: MergeTrainBatchLandingPlanRecord
+    ) -> object: ...
+
+    def list_merge_train_batch_landing_plan_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeTrainBatchLandingPlanRecord, ...]: ...
+
+
+def _merge_train_batch_landing_plan_record_store(
+    record_store: object,
+) -> _MergeTrainBatchLandingPlanRecordStore:
+    if hasattr(record_store, "write_merge_train_batch_landing_plan_record") and hasattr(
+        record_store, "list_merge_train_batch_landing_plan_records"
+    ):
+        return cast(_MergeTrainBatchLandingPlanRecordStore, record_store)
+    raise TypeError("record store does not support merge train batch landing plan records")
+
+
 def _read_merge_train_batch_candidate_record(
     *,
     record_store: _MergeTrainBatchCandidateRecordStore,
@@ -2442,6 +2503,22 @@ def _read_merge_train_batch_candidate_record(
         if record.record_id == record_id:
             return record
     raise ValueError("merge train batch candidate record not found")
+
+
+def _read_merge_train_batch_landing_plan_record(
+    *,
+    record_store: _MergeTrainBatchLandingPlanRecordStore,
+    repository: str,
+    base_branch: str,
+    record_id: str,
+) -> MergeTrainBatchLandingPlanRecord:
+    records = record_store.list_merge_train_batch_landing_plan_records(
+        repository=repository, base_branch=base_branch
+    )
+    for record in records:
+        if record.record_id == record_id:
+            return record
+    raise ValueError("merge train batch landing plan record not found")
 
 
 def _supports_every_code_work_requests(record_store: object) -> bool:
@@ -3529,6 +3606,7 @@ def _accepted_payload(
                 "state",
                 "agent_write_intent_record_id",
                 "merge_train_batch_candidate_record_id",
+                "merge_train_batch_landing_plan_record_id",
                 "merge_train_run_id",
             }
         },
@@ -6963,6 +7041,103 @@ def create_launchplane_service_app(
                     "mode": batch_request.mode,
                     "candidate": candidate.model_dump(mode="json"),
                 }
+            elif path == _MERGE_TRAIN_BATCH_LANDING_RUN_ONCE_ROUTE:
+                landing_request = MergeTrainBatchLandingRunOnceEnvelope.model_validate(payload)
+                policy_record = resolve_merge_train_policy_record(record_store)
+                policy = policy_record.policy
+                repository_policy = policy.find_repository_policy(
+                    repository=landing_request.repository,
+                    base_branch=landing_request.base_branch,
+                )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action=repository_policy.service_authz.action,
+                    product=repository_policy.service_authz.product,
+                    context=repository_policy.service_authz.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot run the requested merge train policy.",
+                            },
+                        },
+                    )
+                token_env = repository_policy.github_token.env_var
+                if not token_env:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "github_token_not_configured",
+                                "message": "Merge train policy does not define a GitHub token environment variable.",
+                            },
+                        },
+                    )
+                token = os.environ.get(token_env, "").strip()
+                if not token:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "github_token_not_configured",
+                                "message": "Configured merge train GitHub token is not available.",
+                            },
+                        },
+                    )
+                candidate_store = _merge_train_batch_candidate_record_store(record_store)
+                landing_store = _merge_train_batch_landing_plan_record_store(record_store)
+                recorded_at = _utc_now_timestamp()
+                if landing_request.mode == "plan":
+                    candidate_record = _read_merge_train_batch_candidate_record(
+                        record_store=candidate_store,
+                        repository=landing_request.repository,
+                        base_branch=landing_request.base_branch,
+                        record_id=landing_request.candidate_record_id,
+                    )
+                    landing_plan = build_merge_train_batch_landing_plan(
+                        candidate=candidate_record.candidate,
+                        merge_method=repository_policy.merge_method,
+                        created_at=recorded_at,
+                    )
+                else:
+                    landing_record = _read_merge_train_batch_landing_plan_record(
+                        record_store=landing_store,
+                        repository=landing_request.repository,
+                        base_branch=landing_request.base_branch,
+                        record_id=landing_request.landing_plan_record_id,
+                    )
+                    transport = UrllibMergeTrainGitHubTransport(
+                        token=token,
+                        api_base_url=landing_request.github_api_base_url,
+                    )
+                    landing_plan = GitHubMergeTrainClient(
+                        transport=transport
+                    ).land_batch_candidate(landing_plan=landing_record.landing_plan)
+                landing_record = build_merge_train_batch_landing_plan_record(
+                    landing_plan=landing_plan,
+                    source=f"service:{landing_request.mode}:{request_trace_id}",
+                    updated_at=recorded_at,
+                )
+                landing_store.write_merge_train_batch_landing_plan_record(landing_record)
+                result = {
+                    "merge_train_batch_landing_plan_record_id": landing_record.record_id,
+                    "repository": landing_plan.repository,
+                    "base_branch": landing_plan.base_branch,
+                    "mode": landing_request.mode,
+                    "landing_plan": landing_plan.model_dump(mode="json"),
+                }
+                driver_result = {"mode": landing_request.mode, "landing_plan": result["landing_plan"]}
             elif path == "/v1/agent/write-intents/evaluate":
                 intent_request = AgentWriteIntentRequest.model_validate(payload)
                 intent_authz_action = authz_action_for_agent_write_intent(intent_request.intent)

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -326,6 +326,15 @@ that ref in order. Observe mode records required-check state for the exact
 candidate SHA. Landing the original PRs remains a later PR-native phase with
 separate records.
 
+The batch-landing service endpoint
+`POST /v1/work-graph/merge-train/batch-landing/run-once` owns that PR-native
+landing phase. It accepts `mode: plan` with a passed candidate record id and
+writes a `launchplane_merge_train_batch_landing_plans` record, or `mode: land`
+with a landing-plan record id and merges the original pull requests in recorded
+queue order. Landing fails closed if the base branch head has moved from the
+candidate base SHA, and each PR merge uses the recorded head SHA guard so a
+changed PR head cannot be merged under stale validation.
+
 Scheduler admission is a deterministic decision over the latest stored
 `launchplane_merge_train_runs` record for the repository/base branch. Dry-run
 records do not throttle the scheduler. Mutation records with `reread_required`

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -243,6 +243,16 @@ candidate SHA, and records whether the candidate is still pending, passed, or
 failed. The route never lands original PRs; PR-native landing remains a later
 phase with separate records and pre-merge invariants.
 
+`POST /v1/work-graph/merge-train/batch-landing/run-once` executes one
+policy-backed batch-landing phase for a requested repository/base branch. The
+route accepts `mode: plan` with a passed batch-candidate record id or
+`mode: land` with a landing-plan record id. Plan mode writes a
+`launchplane_merge_train_batch_landing_plans` record with the original PR order,
+expected head SHAs, expected base SHA, and policy merge method. Land mode merges
+the original PRs in that order through GitHub's PR merge endpoint, rejects stale
+base-branch movement before merging, and relies on GitHub's SHA guard for each
+PR head.
+
 `.github/workflows/merge-train-runner.yml` is the first external scheduler for
 this route. It mints a GitHub Actions OIDC token for the Launchplane service,
 reads admission, and calls `run-once` only when the decision is `admitted`.
@@ -311,6 +321,10 @@ The first batch service contract is
 `POST /v1/work-graph/merge-train/batch-candidate/run-once`; it owns only the
 plan/build/observe candidate phases and writes
 `launchplane_merge_train_batch_candidates` records.
+The second batch service contract is
+`POST /v1/work-graph/merge-train/batch-landing/run-once`; it owns landing-plan
+creation and guarded PR-native landing, and writes
+`launchplane_merge_train_batch_landing_plans` records.
 
 `POST /v1/merge-train/policies/import` is the service-owned write path for merge
 train policy records. It requires database storage and

--- a/tests/test_merge_train_batch.py
+++ b/tests/test_merge_train_batch.py
@@ -8,6 +8,7 @@ from control_plane.contracts.merge_train_batch import build_merge_train_batch_ca
 from control_plane.contracts.merge_train_batch import build_merge_train_batch_candidate_ref
 from control_plane.contracts.merge_train_batch import build_merge_train_batch_id
 from control_plane.contracts.merge_train_batch import build_merge_train_batch_landing_plan
+from control_plane.contracts.merge_train_batch import build_merge_train_batch_landing_plan_record
 from control_plane.merge_train import MergeTrainDryRunSnapshot
 from control_plane.merge_train import MergeTrainPullRequestSnapshot
 from control_plane.merge_train import build_merge_train_dry_run_result
@@ -92,6 +93,24 @@ class MergeTrainBatchContractTests(unittest.TestCase):
         )
         self.assertEqual({entry.expected_base_sha for entry in plan.entries}, {"base-sha"})
         self.assertEqual({entry.merge_method for entry in plan.entries}, {"merge"})
+
+    def test_landing_plan_record_id_is_deterministic(self) -> None:
+        plan = build_merge_train_batch_landing_plan(
+            candidate=_candidate(status="passed", candidate_sha="candidate-sha"),
+            merge_method="merge",
+            created_at="2026-05-13T23:00:00Z",
+        )
+
+        record = build_merge_train_batch_landing_plan_record(
+            landing_plan=plan,
+            source="test",
+            updated_at="2026-05-14T01:00:00Z",
+        )
+
+        self.assertTrue(
+            record.record_id.startswith("merge-train-batch-landing-plan-20260514T010000Z-")
+        )
+        self.assertEqual(record.landing_plan.plan_id, plan.plan_id)
 
     def test_candidate_builder_uses_all_eligible_queue_entries(self) -> None:
         dry_run_result = build_merge_train_dry_run_result(

--- a/tests/test_merge_train_github.py
+++ b/tests/test_merge_train_github.py
@@ -5,8 +5,10 @@ from urllib.error import HTTPError
 
 from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidate
 from control_plane.contracts.merge_train_batch import MergeTrainBatchEntry
+from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlan
 from control_plane.contracts.merge_train_batch import build_merge_train_batch_candidate_ref
 from control_plane.contracts.merge_train_batch import build_merge_train_batch_id
+from control_plane.contracts.merge_train_batch import build_merge_train_batch_landing_plan
 from control_plane.merge_train_github import GitHubMergeTrainClient
 from control_plane.merge_train_github import GitHubMergeTrainSnapshotReader
 from control_plane.merge_train_github import MergeTrainGitHubError
@@ -205,6 +207,57 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
 
         self.assertEqual(observed_candidate.status, "ready_for_checks")
         self.assertEqual(observed_candidate.required_checks_status, "pending")
+
+    def test_land_batch_candidate_merges_original_prs_in_order(self) -> None:
+        landing_plan = _landing_plan()
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                _github_branch(sha="base-main"),
+                {"sha": "merge-sha-1"},
+                {"sha": "merge-sha-2"},
+            )
+        )
+
+        landed_plan = GitHubMergeTrainClient(transport=transport).land_batch_candidate(
+            landing_plan=landing_plan
+        )
+
+        self.assertEqual(
+            [entry.status for entry in landed_plan.entries], ["merged", "merged"]
+        )
+        self.assertEqual(
+            [entry.merge_commit_sha for entry in landed_plan.entries],
+            ["merge-sha-1", "merge-sha-2"],
+        )
+        self.assertEqual(
+            [(request.method, request.path, request.body) for request in transport.requests],
+            [
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
+                (
+                    "PUT",
+                    "/repos/example/merge-train-repo/pulls/1/merge",
+                    {"sha": "head-1", "merge_method": "merge"},
+                ),
+                (
+                    "PUT",
+                    "/repos/example/merge-train-repo/pulls/2/merge",
+                    {"sha": "head-2", "merge_method": "merge"},
+                ),
+            ],
+        )
+
+    def test_land_batch_candidate_rejects_moved_base_branch(self) -> None:
+        landing_plan = _landing_plan()
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(_github_branch(sha="new-base-main"),)
+        )
+
+        with self.assertRaisesRegex(MergeTrainGitHubStaleHeadError, "Base branch moved"):
+            GitHubMergeTrainClient(transport=transport).land_batch_candidate(
+                landing_plan=landing_plan
+            )
+
+        self.assertEqual(len(transport.requests), 1)
 
     def test_repository_must_be_owner_name(self) -> None:
         client = GitHubMergeTrainClient(transport=RecordingMergeTrainGitHubTransport())
@@ -443,8 +496,8 @@ def _github_pull_request(
     }
 
 
-def _github_branch() -> dict[str, object]:
-    return {"commit": {"sha": "base-main-current"}}
+def _github_branch(*, sha: str = "base-main-current") -> dict[str, object]:
+    return {"commit": {"sha": sha}}
 
 
 def _check_run(status: str, conclusion: str | None) -> dict[str, object]:
@@ -483,6 +536,17 @@ def _batch_candidate() -> MergeTrainBatchCandidate:
         entries=entries,
         created_at="2026-05-13T23:00:00Z",
         updated_at="2026-05-13T23:00:00Z",
+    )
+
+
+def _landing_plan() -> MergeTrainBatchLandingPlan:
+    candidate = _batch_candidate().model_copy(
+        update={"status": "passed", "candidate_sha": "candidate-sha"}
+    )
+    return build_merge_train_batch_landing_plan(
+        candidate=candidate,
+        merge_method="merge",
+        created_at="2026-05-14T01:10:00Z",
     )
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -31,6 +31,7 @@ from control_plane.contracts.dokploy_target_id_record import DokployTargetIdReco
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
 from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidate
+from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlan
 from control_plane.contracts.odoo_instance_override_record import OdooConfigParameterOverride
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.odoo_instance_override_record import OdooOverrideValue
@@ -217,6 +218,23 @@ class _FakeMergeTrainGitHubClient:
         self, *, candidate: MergeTrainBatchCandidate
     ) -> MergeTrainBatchCandidate:
         return candidate.model_copy(update={"required_checks_status": "pass", "status": "passed"})
+
+    def land_batch_candidate(
+        self, *, landing_plan: MergeTrainBatchLandingPlan
+    ) -> MergeTrainBatchLandingPlan:
+        return landing_plan.model_copy(
+            update={
+                "entries": tuple(
+                    entry.model_copy(
+                        update={
+                            "status": "merged",
+                            "merge_commit_sha": f"merge-{entry.pull_request_number}",
+                        }
+                    )
+                    for entry in landing_plan.entries
+                )
+            }
+        )
 
 
 class _NoopMergeTrainGitHubClient:
@@ -1689,6 +1707,181 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["result"]["mode"], "observe")
         self.assertEqual(payload["result"]["candidate"]["status"], "passed")
         self.assertEqual(payload["result"]["candidate"]["required_checks_status"], "pass")
+
+    def test_merge_train_batch_landing_service_plans_from_passed_candidate(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                _FakeMergeTrainSnapshotReader,
+            ):
+                _, plan_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
+                _, build_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "build",
+                        "candidate_record_id": plan_payload["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+                _, observe_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "observe",
+                        "candidate_record_id": build_payload["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-landing/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                        "candidate_record_id": observe_payload["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+            listed_records = FilesystemRecordStore(
+                state_dir
+            ).list_merge_train_batch_landing_plan_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "plan")
+        self.assertEqual(payload["result"]["landing_plan"]["entries"][0]["status"], "planned")
+        self.assertEqual(listed_records[0].record_id, payload["records"]["merge_train_batch_landing_plan_record_id"])
+
+    def test_merge_train_batch_landing_service_lands_existing_plan(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                _FakeMergeTrainSnapshotReader,
+            ):
+                _, candidate_plan_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
+                _, build_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "build",
+                        "candidate_record_id": candidate_plan_payload["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+                _, observe_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "observe",
+                        "candidate_record_id": build_payload["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+                _, landing_plan_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-landing/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                        "candidate_record_id": observe_payload["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-landing/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "land",
+                        "landing_plan_record_id": landing_plan_payload["records"][
+                            "merge_train_batch_landing_plan_record_id"
+                        ],
+                    },
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "land")
+        self.assertEqual(payload["result"]["landing_plan"]["entries"][0]["status"], "merged")
+        self.assertEqual(
+            payload["result"]["landing_plan"]["entries"][0]["merge_commit_sha"], "merge-1"
+        )
 
     def test_merge_train_admission_service_uses_configured_codex_skills_policy(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary\n- Add DB-backed batch landing plan records and a service route for landing plan/land phases\n- Land original PRs in recorded order through GitHub PR merges, with base branch and head SHA guards\n- Extend manual Merge Train Runner dispatch with batch landing controls\n- Document the landing contract and stale-validation guardrails\n\n## Verification\n- uv run python -m unittest tests.test_merge_train_batch tests.test_merge_train_github tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_candidate_service_plans_candidate_record tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_candidate_service_builds_existing_candidate_record tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_candidate_service_observes_existing_candidate_record tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_landing_service_plans_from_passed_candidate tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_landing_service_lands_existing_plan\n- uv run --extra dev ruff check --diff control_plane/contracts/merge_train_batch.py control_plane/merge_train_github.py control_plane/service.py tests/test_merge_train_batch.py tests/test_merge_train_github.py tests/test_service.py\n- uv run --extra dev ruff check control_plane/contracts/merge_train_batch.py control_plane/merge_train_github.py control_plane/service.py tests/test_merge_train_batch.py tests/test_merge_train_github.py tests/test_service.py\n- uv run --extra dev mypy control_plane tests\n- npx prettier --check .github/workflows/merge-train-runner.yml docs/merge-train-policy.md docs/service-boundary.md\n- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/merge-train-runner.yml'); puts 'ok'"\n\nRefs #604.\nRefs #605.