### PR TITLE
Guard batch landing between PR merges

### DIFF
--- a/control_plane/merge_train_github.py
+++ b/control_plane/merge_train_github.py
@@ -133,17 +133,17 @@ class GitHubMergeTrainClient:
     def land_batch_candidate(self, *, landing_plan: MergeTrainBatchLandingPlan) -> MergeTrainBatchLandingPlan:
         repository_path = _repository_path(landing_plan.repository)
         expected_base_sha = landing_plan.entries[0].expected_base_sha
-        current_base_sha = _base_branch_sha(
-            transport=self.transport,
-            repository_path=repository_path,
-            base_branch=landing_plan.base_branch,
-        )
-        if current_base_sha != expected_base_sha:
-            raise MergeTrainGitHubStaleHeadError(
-                "Base branch moved after batch candidate validation.", status_code=409
-            )
         merged_entries = []
         for entry in landing_plan.entries:
+            current_base_sha = _base_branch_sha(
+                transport=self.transport,
+                repository_path=repository_path,
+                base_branch=landing_plan.base_branch,
+            )
+            if current_base_sha != expected_base_sha:
+                raise MergeTrainGitHubStaleHeadError(
+                    "Base branch moved outside the batch landing plan.", status_code=409
+                )
             merge_commit_sha = self.merge_pull_request(
                 repository=landing_plan.repository,
                 pull_request_number=entry.pull_request_number,
@@ -155,6 +155,7 @@ class GitHubMergeTrainClient:
                     update={"status": "merged", "merge_commit_sha": merge_commit_sha}
                 )
             )
+            expected_base_sha = merge_commit_sha
         return landing_plan.model_copy(update={"entries": tuple(merged_entries)})
 
     def add_pull_request_label(

--- a/tests/test_merge_train_github.py
+++ b/tests/test_merge_train_github.py
@@ -214,6 +214,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
             responses=(
                 _github_branch(sha="base-main"),
                 {"sha": "merge-sha-1"},
+                _github_branch(sha="merge-sha-1"),
                 {"sha": "merge-sha-2"},
             )
         )
@@ -238,6 +239,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                     "/repos/example/merge-train-repo/pulls/1/merge",
                     {"sha": "head-1", "merge_method": "merge"},
                 ),
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
                 (
                     "PUT",
                     "/repos/example/merge-train-repo/pulls/2/merge",
@@ -246,13 +248,32 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
             ],
         )
 
+    def test_land_batch_candidate_rejects_base_movement_between_prs(self) -> None:
+        landing_plan = _landing_plan()
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                _github_branch(sha="base-main"),
+                {"sha": "merge-sha-1"},
+                _github_branch(sha="unexpected-base"),
+            )
+        )
+
+        with self.assertRaisesRegex(MergeTrainGitHubStaleHeadError, "outside"):
+            GitHubMergeTrainClient(transport=transport).land_batch_candidate(
+                landing_plan=landing_plan
+            )
+
+        self.assertEqual(
+            [request.method for request in transport.requests], ["GET", "PUT", "GET"]
+        )
+
     def test_land_batch_candidate_rejects_moved_base_branch(self) -> None:
         landing_plan = _landing_plan()
         transport = RecordingMergeTrainGitHubTransport(
             responses=(_github_branch(sha="new-base-main"),)
         )
 
-        with self.assertRaisesRegex(MergeTrainGitHubStaleHeadError, "Base branch moved"):
+        with self.assertRaisesRegex(MergeTrainGitHubStaleHeadError, "outside"):
             GitHubMergeTrainClient(transport=transport).land_batch_candidate(
                 landing_plan=landing_plan
             )


### PR DESCRIPTION
## Summary\n- Re-check the live base branch before each PR-native batch landing merge\n- Advance the expected base SHA to the previous merge commit so the train can land in order\n- Add coverage for unrelated base movement between PR merges\n\n## Verification\n- uv run python -m unittest tests.test_merge_train_github tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_landing_service_lands_existing_plan\n- uv run --extra dev ruff check --diff control_plane/merge_train_github.py tests/test_merge_train_github.py\n- uv run --extra dev ruff check control_plane/merge_train_github.py tests/test_merge_train_github.py\n- uv run --extra dev mypy control_plane tests\n\nRefs #604.