### PR TITLE
Support stacked PR collapse in merge train

### DIFF
--- a/control_plane/contracts/merge_train_stack_collapse.py
+++ b/control_plane/contracts/merge_train_stack_collapse.py
@@ -1,0 +1,539 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from typing import Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.merge_train import MergeTrainStackDiscoveryResult
+
+
+MergeTrainStackCollapseStatus = Literal[
+    "planned", "collapsing", "waiting_for_root_checks", "ready_for_train", "blocked", "stale"
+]
+MergeTrainStackCollapseRunStatus = Literal["planned", "mutated", "blocked", "stale"]
+MergeTrainStackChildDispositionStatus = Literal["planned", "closed", "blocked", "stale"]
+MergeTrainStackCollapseRecordStatus = Literal["active", "superseded"]
+MergeTrainStackCollapseIntentSource = Literal["root_ready_to_merge"]
+
+
+class MergeTrainStackCollapseEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    pull_request_number: int = Field(gt=0)
+    position: int = Field(gt=0)
+    head_sha: str
+    head_ref: str
+    base_sha: str = ""
+    base_ref: str
+
+    @model_validator(mode="after")
+    def _validate_entry(self) -> "MergeTrainStackCollapseEntry":
+        self.head_sha = _normalize_required_value(
+            self.head_sha, "merge train stack collapse entry requires head_sha"
+        )
+        self.head_ref = _normalize_required_value(
+            self.head_ref, "merge train stack collapse entry requires head_ref"
+        )
+        self.base_sha = self.base_sha.strip()
+        self.base_ref = _normalize_required_value(
+            self.base_ref, "merge train stack collapse entry requires base_ref"
+        )
+        return self
+
+
+class MergeTrainStackCollapseMutation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    child_pull_request_number: int = Field(gt=0)
+    parent_pull_request_number: int = Field(gt=0)
+    child_head_sha: str
+    expected_parent_head_sha: str
+    parent_head_ref: str
+    status: MergeTrainStackCollapseRunStatus = "planned"
+    merge_commit_sha: str = ""
+    detail: str = ""
+
+    @model_validator(mode="after")
+    def _validate_mutation(self) -> "MergeTrainStackCollapseMutation":
+        self.child_head_sha = _normalize_required_value(
+            self.child_head_sha, "merge train stack collapse mutation requires child_head_sha"
+        )
+        self.expected_parent_head_sha = _normalize_required_value(
+            self.expected_parent_head_sha,
+            "merge train stack collapse mutation requires expected_parent_head_sha",
+        )
+        self.parent_head_ref = _normalize_required_value(
+            self.parent_head_ref, "merge train stack collapse mutation requires parent_head_ref"
+        )
+        self.merge_commit_sha = self.merge_commit_sha.strip()
+        self.detail = self.detail.strip()
+        return self
+
+
+class MergeTrainStackChildDisposition(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    pull_request_number: int = Field(gt=0)
+    expected_head_sha: str
+    status: MergeTrainStackChildDispositionStatus = "planned"
+    comment_url: str = ""
+    detail: str = ""
+
+    @model_validator(mode="after")
+    def _validate_disposition(self) -> "MergeTrainStackChildDisposition":
+        self.expected_head_sha = _normalize_required_value(
+            self.expected_head_sha,
+            "merge train stack child disposition requires expected_head_sha",
+        )
+        self.comment_url = self.comment_url.strip()
+        self.detail = self.detail.strip()
+        return self
+
+
+class MergeTrainStackCollapsePlan(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    collapse_id: str
+    repository: str
+    base_branch: str
+    root_pull_request_number: int = Field(gt=0)
+    root_initial_head_sha: str
+    root_head_ref: str
+    policy_key: str
+    policy_sha256: str
+    intent_source: MergeTrainStackCollapseIntentSource = "root_ready_to_merge"
+    status: MergeTrainStackCollapseStatus = "planned"
+    entries: tuple[MergeTrainStackCollapseEntry, ...]
+    mutations: tuple[MergeTrainStackCollapseMutation, ...]
+    child_dispositions: tuple[MergeTrainStackChildDisposition, ...] = ()
+    created_at: str
+    updated_at: str
+
+    @model_validator(mode="after")
+    def _validate_plan(self) -> "MergeTrainStackCollapsePlan":
+        self.collapse_id = _normalize_required_value(
+            self.collapse_id, "merge train stack collapse plan requires collapse_id"
+        )
+        self.repository = _normalize_repository(self.repository)
+        self.base_branch = _normalize_required_value(
+            self.base_branch, "merge train stack collapse plan requires base_branch"
+        )
+        self.root_initial_head_sha = _normalize_required_value(
+            self.root_initial_head_sha,
+            "merge train stack collapse plan requires root_initial_head_sha",
+        )
+        self.root_head_ref = _normalize_required_value(
+            self.root_head_ref, "merge train stack collapse plan requires root_head_ref"
+        )
+        self.policy_key = _normalize_required_value(
+            self.policy_key, "merge train stack collapse plan requires policy_key"
+        )
+        self.policy_sha256 = _normalize_required_value(
+            self.policy_sha256, "merge train stack collapse plan requires policy_sha256"
+        )
+        self.created_at = _normalize_required_value(
+            self.created_at, "merge train stack collapse plan requires created_at"
+        )
+        self.updated_at = _normalize_required_value(
+            self.updated_at, "merge train stack collapse plan requires updated_at"
+        )
+        self.entries = _normalize_entries(self.entries)
+        self.mutations = _normalize_mutations(self.entries, self.mutations)
+        self.child_dispositions = _normalize_child_dispositions(
+            self.entries, self.child_dispositions
+        )
+        return self
+
+
+class MergeTrainStackCollapsePlanRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    record_id: str
+    status: MergeTrainStackCollapseRecordStatus = "active"
+    source: str
+    updated_at: str
+    plan: MergeTrainStackCollapsePlan
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "MergeTrainStackCollapsePlanRecord":
+        self.record_id = _normalize_required_value(
+            self.record_id, "merge train stack collapse plan record requires record_id"
+        )
+        self.source = _normalize_required_value(
+            self.source, "merge train stack collapse plan record requires source"
+        )
+        self.updated_at = _normalize_required_value(
+            self.updated_at, "merge train stack collapse plan record requires updated_at"
+        )
+        return self
+
+
+class MergeTrainStackCollapseBranchClient(Protocol):
+    def merge_stack_child_into_parent(
+        self,
+        *,
+        repository: str,
+        child_head_sha: str,
+        expected_parent_head_sha: str,
+        parent_head_ref: str,
+        collapse_id: str,
+        child_pull_request_number: int,
+        parent_pull_request_number: int,
+    ) -> str: ...
+
+
+class MergeTrainStackChildDispositionClient(Protocol):
+    def comment_pull_request(
+        self, *, repository: str, pull_request_number: int, body: str
+    ) -> str: ...
+
+    def add_pull_request_label(
+        self, *, repository: str, pull_request_number: int, label: str
+    ) -> None: ...
+
+    def close_pull_request(
+        self, *, repository: str, pull_request_number: int, expected_head_sha: str
+    ) -> None: ...
+
+
+def execute_merge_train_stack_collapse_plan(
+    *,
+    plan: MergeTrainStackCollapsePlan,
+    branch_client: MergeTrainStackCollapseBranchClient,
+    updated_at: str,
+) -> MergeTrainStackCollapsePlan:
+    if plan.status not in {"planned", "collapsing"}:
+        raise ValueError("merge train stack collapse plan is not executable")
+    updated_mutations: list[MergeTrainStackCollapseMutation] = []
+    current_status: MergeTrainStackCollapseStatus = "waiting_for_root_checks"
+    for mutation in plan.mutations:
+        try:
+            merge_commit_sha = branch_client.merge_stack_child_into_parent(
+                repository=plan.repository,
+                child_head_sha=mutation.child_head_sha,
+                expected_parent_head_sha=mutation.expected_parent_head_sha,
+                parent_head_ref=mutation.parent_head_ref,
+                collapse_id=plan.collapse_id,
+                child_pull_request_number=mutation.child_pull_request_number,
+                parent_pull_request_number=mutation.parent_pull_request_number,
+            )
+        except Exception as error:  # noqa: BLE001
+            updated_mutations.append(
+                mutation.model_copy(
+                    update={
+                        "status": "blocked",
+                        "detail": str(error),
+                    }
+                )
+            )
+            current_status = "blocked"
+            break
+        updated_mutations.append(
+            mutation.model_copy(
+                update={
+                    "status": "mutated",
+                    "merge_commit_sha": merge_commit_sha,
+                    "detail": "child head merged into parent feature branch",
+                }
+            )
+        )
+    if len(updated_mutations) < len(plan.mutations):
+        updated_mutations.extend(plan.mutations[len(updated_mutations) :])
+    return plan.model_copy(
+        update={
+            "status": current_status,
+            "mutations": tuple(updated_mutations),
+            "updated_at": updated_at,
+        }
+    )
+
+
+def reconcile_merge_train_stack_children_after_root_landing(
+    *,
+    plan: MergeTrainStackCollapsePlan,
+    disposition_client: MergeTrainStackChildDispositionClient,
+    root_merge_commit_sha: str,
+    label: str,
+    updated_at: str,
+) -> MergeTrainStackCollapsePlan:
+    if plan.status != "waiting_for_root_checks":
+        raise ValueError("merge train stack collapse plan is not ready for child disposition")
+    normalized_root_merge_commit_sha = _normalize_required_value(
+        root_merge_commit_sha,
+        "merge train stack child disposition requires root_merge_commit_sha",
+    )
+    normalized_label = _normalize_required_value(
+        label, "merge train stack child disposition requires label"
+    )
+    updated_dispositions: list[MergeTrainStackChildDisposition] = []
+    current_status: MergeTrainStackCollapseStatus = "ready_for_train"
+    for disposition in plan.child_dispositions:
+        try:
+            comment_url = disposition_client.comment_pull_request(
+                repository=plan.repository,
+                pull_request_number=disposition.pull_request_number,
+                body=_child_disposition_comment_body(
+                    root_pull_request_number=plan.root_pull_request_number,
+                    root_merge_commit_sha=normalized_root_merge_commit_sha,
+                ),
+            )
+            disposition_client.add_pull_request_label(
+                repository=plan.repository,
+                pull_request_number=disposition.pull_request_number,
+                label=normalized_label,
+            )
+            disposition_client.close_pull_request(
+                repository=plan.repository,
+                pull_request_number=disposition.pull_request_number,
+                expected_head_sha=disposition.expected_head_sha,
+            )
+        except Exception as error:  # noqa: BLE001
+            updated_dispositions.append(
+                disposition.model_copy(update={"status": "blocked", "detail": str(error)})
+            )
+            current_status = "blocked"
+            break
+        updated_dispositions.append(
+            disposition.model_copy(
+                update={
+                    "status": "closed",
+                    "comment_url": comment_url,
+                    "detail": "child PR closed after root landed",
+                }
+            )
+        )
+    if len(updated_dispositions) < len(plan.child_dispositions):
+        updated_dispositions.extend(plan.child_dispositions[len(updated_dispositions) :])
+    return plan.model_copy(
+        update={
+            "status": current_status,
+            "child_dispositions": tuple(updated_dispositions),
+            "updated_at": updated_at,
+        }
+    )
+
+
+def build_merge_train_stack_collapse_plan(
+    *,
+    discovery_result: MergeTrainStackDiscoveryResult,
+    policy_key: str,
+    policy_sha256: str,
+    created_at: str,
+) -> MergeTrainStackCollapsePlan:
+    if discovery_result.status != "ready_for_collapse":
+        raise ValueError("merge train stack collapse plan requires a discovered stack")
+    entries = tuple(
+        MergeTrainStackCollapseEntry(
+            pull_request_number=entry.number,
+            position=position,
+            head_sha=entry.head_sha,
+            head_ref=entry.head_ref,
+            base_sha=entry.base_sha,
+            base_ref=entry.base_ref,
+        )
+        for position, entry in enumerate(discovery_result.entries, start=1)
+    )
+    if not entries:
+        raise ValueError("merge train stack collapse plan requires entries")
+    mutations = tuple(
+        MergeTrainStackCollapseMutation(
+            child_pull_request_number=child.pull_request_number,
+            parent_pull_request_number=parent.pull_request_number,
+            child_head_sha=child.head_sha,
+            expected_parent_head_sha=parent.head_sha,
+            parent_head_ref=parent.head_ref,
+        )
+        for parent, child in zip(entries, entries[1:])
+    )
+    child_dispositions = tuple(
+        MergeTrainStackChildDisposition(
+            pull_request_number=entry.pull_request_number,
+            expected_head_sha=entry.head_sha,
+        )
+        for entry in entries[1:]
+    )
+    collapse_id = build_merge_train_stack_collapse_id(
+        repository=discovery_result.repository,
+        base_branch=discovery_result.base_branch,
+        root_pull_request_number=discovery_result.root_pull_request_number,
+        entry_head_shas=tuple(entry.head_sha for entry in entries),
+    )
+    return MergeTrainStackCollapsePlan(
+        collapse_id=collapse_id,
+        repository=discovery_result.repository,
+        base_branch=discovery_result.base_branch,
+        root_pull_request_number=discovery_result.root_pull_request_number,
+        root_initial_head_sha=entries[0].head_sha,
+        root_head_ref=entries[0].head_ref,
+        policy_key=policy_key,
+        policy_sha256=policy_sha256,
+        entries=entries,
+        mutations=mutations,
+        child_dispositions=child_dispositions,
+        created_at=created_at,
+        updated_at=created_at,
+    )
+
+
+def build_merge_train_stack_collapse_plan_record(
+    *,
+    plan: MergeTrainStackCollapsePlan,
+    source: str,
+    updated_at: str,
+) -> MergeTrainStackCollapsePlanRecord:
+    record_without_id = MergeTrainStackCollapsePlanRecord(
+        record_id="pending",
+        source=source,
+        updated_at=updated_at,
+        plan=plan,
+    )
+    return record_without_id.model_copy(
+        update={"record_id": build_merge_train_stack_collapse_plan_record_id(record_without_id)}
+    )
+
+
+def build_merge_train_stack_collapse_plan_record_id(
+    record: MergeTrainStackCollapsePlanRecord,
+) -> str:
+    canonical_updated_at = _canonical_utc_timestamp(record.updated_at)
+    digest_payload = record.model_dump(mode="json", exclude={"record_id"})
+    digest_payload["updated_at"] = canonical_updated_at
+    digest = hashlib.sha256(
+        json.dumps(digest_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:16]
+    normalized_timestamp = canonical_updated_at.replace("-", "").replace(":", "")
+    return f"merge-train-stack-collapse-plan-{normalized_timestamp}-{digest}"
+
+
+def build_merge_train_stack_collapse_id(
+    *,
+    repository: str,
+    base_branch: str,
+    root_pull_request_number: int,
+    entry_head_shas: tuple[str, ...],
+) -> str:
+    normalized_repository = _normalize_repository(repository).replace("/", "-")
+    normalized_base_branch = _normalize_required_value(
+        base_branch, "merge train stack collapse id requires base_branch"
+    ).replace("/", "-")
+    digest = hashlib.sha256(
+        json.dumps(
+            {
+                "entry_head_shas": [
+                    _normalize_required_value(sha, "merge train stack collapse id requires head sha")
+                    for sha in entry_head_shas
+                ],
+                "root_pull_request_number": root_pull_request_number,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+    return (
+        f"merge-train-stack-collapse-{normalized_repository}-"
+        f"{normalized_base_branch}-{digest}"
+    )
+
+
+def _normalize_entries(
+    entries: tuple[MergeTrainStackCollapseEntry, ...],
+) -> tuple[MergeTrainStackCollapseEntry, ...]:
+    if len(entries) < 2:
+        raise ValueError("merge train stack collapse plan requires at least two entries")
+    positions = [entry.position for entry in entries]
+    if positions != list(range(1, len(positions) + 1)):
+        raise ValueError("merge train stack collapse entry positions must be contiguous")
+    seen_numbers: set[int] = set()
+    for entry in entries:
+        if entry.pull_request_number in seen_numbers:
+            raise ValueError("merge train stack collapse PR numbers must be unique")
+        seen_numbers.add(entry.pull_request_number)
+    return entries
+
+
+def _normalize_mutations(
+    entries: tuple[MergeTrainStackCollapseEntry, ...],
+    mutations: tuple[MergeTrainStackCollapseMutation, ...],
+) -> tuple[MergeTrainStackCollapseMutation, ...]:
+    if len(mutations) != len(entries) - 1:
+        raise ValueError("merge train stack collapse mutations must connect each stack layer")
+    expected_pairs = tuple(
+        (child.pull_request_number, parent.pull_request_number)
+        for parent, child in zip(entries, entries[1:])
+    )
+    actual_pairs = tuple(
+        (mutation.child_pull_request_number, mutation.parent_pull_request_number)
+        for mutation in mutations
+    )
+    if actual_pairs != expected_pairs:
+        raise ValueError("merge train stack collapse mutations must be leaf-to-root ordered")
+    return mutations
+
+
+def _normalize_child_dispositions(
+    entries: tuple[MergeTrainStackCollapseEntry, ...],
+    child_dispositions: tuple[MergeTrainStackChildDisposition, ...],
+) -> tuple[MergeTrainStackChildDisposition, ...]:
+    if not child_dispositions:
+        child_dispositions = tuple(
+            MergeTrainStackChildDisposition(
+                pull_request_number=entry.pull_request_number,
+                expected_head_sha=entry.head_sha,
+            )
+            for entry in entries[1:]
+        )
+    expected_numbers = tuple(entry.pull_request_number for entry in entries[1:])
+    actual_numbers = tuple(
+        disposition.pull_request_number for disposition in child_dispositions
+    )
+    if actual_numbers != expected_numbers:
+        raise ValueError(
+            "merge train stack child dispositions must match stack child order"
+        )
+    return child_dispositions
+
+
+def _child_disposition_comment_body(
+    *, root_pull_request_number: int, root_merge_commit_sha: str
+) -> str:
+    return (
+        "Launchplane landed this stacked PR through root PR "
+        f"#{root_pull_request_number}.\n\n"
+        "The root PR was merged by the merge train at "
+        f"`{root_merge_commit_sha}`. Closing this child PR keeps the stack state "
+        "aligned with the landed root."
+    )
+
+
+def _normalize_repository(repository: str) -> str:
+    normalized = _normalize_required_value(repository, "merge train stack collapse requires repository")
+    if "/" not in normalized:
+        raise ValueError("merge train stack collapse repository must be owner/name")
+    return normalized
+
+
+def _normalize_required_value(value: str, error_message: str) -> str:
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise ValueError(error_message)
+    return normalized_value
+
+
+def _canonical_utc_timestamp(timestamp: str) -> str:
+    normalized_timestamp = _normalize_required_value(
+        timestamp, "merge train stack collapse timestamp is required"
+    )
+    parseable_timestamp = normalized_timestamp
+    if parseable_timestamp.endswith("Z"):
+        parseable_timestamp = f"{parseable_timestamp[:-1]}+00:00"
+    try:
+        parsed_timestamp = datetime.fromisoformat(parseable_timestamp)
+    except ValueError:
+        return normalized_timestamp
+    if parsed_timestamp.tzinfo is None:
+        return normalized_timestamp
+    return parsed_timestamp.astimezone(UTC).strftime("%Y%m%dT%H%M%SZ")

--- a/control_plane/merge_train.py
+++ b/control_plane/merge_train.py
@@ -13,6 +13,9 @@ MergeTrainDryRunAction = Literal[
 ]
 MergeTrainMergeableState = Literal["mergeable", "conflicting", "unknown"]
 MergeTrainPullRequestState = Literal["open", "closed", "merged"]
+MergeTrainStackDiscoveryStatus = Literal[
+    "ready_for_collapse", "not_stacked", "unsupported"
+]
 
 
 class MergeTrainLabelClient(Protocol):
@@ -56,7 +59,11 @@ class MergeTrainPullRequestSnapshot(BaseModel):
     labels: tuple[str, ...] = ()
     actor_role: str = "unknown"
     head_sha: str
+    head_ref: str = ""
+    head_repository: str = ""
     base_sha: str = ""
+    base_ref: str = ""
+    base_repository: str = ""
     mergeable: MergeTrainMergeableState = "unknown"
     required_checks_status: MergeTrainCheckStatus = "unknown"
     branch_update_required: bool = False
@@ -75,7 +82,11 @@ class MergeTrainPullRequestSnapshot(BaseModel):
         self.head_sha = _normalize_required_value(
             self.head_sha, "merge train pull request snapshot requires head_sha"
         )
+        self.head_ref = self.head_ref.strip()
+        self.head_repository = self.head_repository.strip()
         self.base_sha = self.base_sha.strip()
+        self.base_ref = self.base_ref.strip()
+        self.base_repository = self.base_repository.strip()
         return self
 
 
@@ -132,6 +143,28 @@ class MergeTrainDryRunResult(BaseModel):
     selected_pr: MergeTrainQueueEntry | None = None
     intended_next_action: MergeTrainDryRunAction
     next_action_detail: str
+
+
+class MergeTrainStackEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    number: int
+    head_sha: str
+    head_ref: str
+    base_sha: str = ""
+    base_ref: str
+
+
+class MergeTrainStackDiscoveryResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: MergeTrainStackDiscoveryStatus
+    repository: str
+    base_branch: str
+    root_pull_request_number: int
+    stack_order: tuple[int, ...] = ()
+    entries: tuple[MergeTrainStackEntry, ...] = ()
+    unsupported_reasons: tuple[str, ...] = ()
 
 
 class MergeTrainBlockResult(BaseModel):
@@ -202,11 +235,14 @@ def build_merge_train_dry_run_result(
     repository_policy = policy.find_repository_policy(
         repository=snapshot.repository, base_branch=snapshot.base_branch
     )
+    base_pull_requests = tuple(
+        pull_request
+        for pull_request in snapshot.pull_requests
+        if _targets_merge_train_base(pull_request=pull_request, base_branch=snapshot.base_branch)
+    )
     queue = tuple(
         _build_queue_entry(repository_policy, pull_request)
-        for pull_request in sorted(
-            snapshot.pull_requests, key=lambda item: (item.created_at, item.number)
-        )
+        for pull_request in sorted(base_pull_requests, key=lambda item: (item.created_at, item.number))
     )
     selected_pr = next((entry for entry in queue if entry.eligible), None)
     intended_next_action, next_action_detail = _next_action_for_selected_pr(
@@ -225,6 +261,82 @@ def build_merge_train_dry_run_result(
         selected_pr=selected_pr,
         intended_next_action=intended_next_action,
         next_action_detail=next_action_detail,
+    )
+
+
+def discover_merge_train_stack(
+    *, snapshot: MergeTrainDryRunSnapshot, root_pull_request_number: int
+) -> MergeTrainStackDiscoveryResult:
+    pull_requests_by_number = {pull_request.number: pull_request for pull_request in snapshot.pull_requests}
+    root_pull_request = pull_requests_by_number.get(root_pull_request_number)
+    if root_pull_request is None:
+        return MergeTrainStackDiscoveryResult(
+            status="unsupported",
+            repository=snapshot.repository,
+            base_branch=snapshot.base_branch,
+            root_pull_request_number=root_pull_request_number,
+            unsupported_reasons=("root pull request was not present in the snapshot",),
+        )
+    unsupported_reasons = _stack_pull_request_reasons(
+        snapshot=snapshot, pull_request=root_pull_request
+    )
+    if root_pull_request.base_ref != snapshot.base_branch:
+        unsupported_reasons = (*unsupported_reasons, "root pull request does not target base branch")
+    if unsupported_reasons:
+        return _unsupported_stack_result(
+            snapshot=snapshot,
+            root_pull_request_number=root_pull_request_number,
+            unsupported_reasons=unsupported_reasons,
+        )
+
+    children_by_base_ref = _stack_children_by_base_ref(snapshot=snapshot)
+    chain = [root_pull_request]
+    seen_numbers = {root_pull_request.number}
+    current_head_ref = root_pull_request.head_ref
+    while current_head_ref:
+        children = tuple(
+            child
+            for child in children_by_base_ref.get(current_head_ref, ())
+            if child.number not in seen_numbers
+        )
+        if not children:
+            break
+        if len(children) > 1:
+            return _unsupported_stack_result(
+                snapshot=snapshot,
+                root_pull_request_number=root_pull_request_number,
+                unsupported_reasons=(
+                    f"branch {current_head_ref} has multiple stacked child pull requests",
+                ),
+            )
+        child = children[0]
+        child_reasons = _stack_pull_request_reasons(snapshot=snapshot, pull_request=child)
+        if child_reasons:
+            return _unsupported_stack_result(
+                snapshot=snapshot,
+                root_pull_request_number=root_pull_request_number,
+                unsupported_reasons=child_reasons,
+            )
+        chain.append(child)
+        seen_numbers.add(child.number)
+        current_head_ref = child.head_ref
+
+    if len(chain) == 1:
+        return MergeTrainStackDiscoveryResult(
+            status="not_stacked",
+            repository=snapshot.repository,
+            base_branch=snapshot.base_branch,
+            root_pull_request_number=root_pull_request_number,
+            stack_order=(root_pull_request.number,),
+            entries=(_stack_entry(root_pull_request),),
+        )
+    return MergeTrainStackDiscoveryResult(
+        status="ready_for_collapse",
+        repository=snapshot.repository,
+        base_branch=snapshot.base_branch,
+        root_pull_request_number=root_pull_request_number,
+        stack_order=tuple(pull_request.number for pull_request in chain),
+        entries=tuple(_stack_entry(pull_request) for pull_request in chain),
     )
 
 
@@ -428,6 +540,71 @@ def _build_queue_entry(
         branch_update_required=pull_request.branch_update_required,
         eligible=not ineligible_reasons,
         ineligible_reasons=tuple(ineligible_reasons),
+    )
+
+
+def _targets_merge_train_base(
+    *, pull_request: MergeTrainPullRequestSnapshot, base_branch: str
+) -> bool:
+    return not pull_request.base_ref or pull_request.base_ref == base_branch
+
+
+def _stack_children_by_base_ref(
+    *, snapshot: MergeTrainDryRunSnapshot
+) -> dict[str, tuple[MergeTrainPullRequestSnapshot, ...]]:
+    children_by_base_ref: dict[str, list[MergeTrainPullRequestSnapshot]] = {}
+    for pull_request in snapshot.pull_requests:
+        if pull_request.base_ref:
+            children_by_base_ref.setdefault(pull_request.base_ref, []).append(pull_request)
+    return {
+        base_ref: tuple(sorted(children, key=lambda item: (item.created_at, item.number)))
+        for base_ref, children in children_by_base_ref.items()
+    }
+
+
+def _stack_pull_request_reasons(
+    *, snapshot: MergeTrainDryRunSnapshot, pull_request: MergeTrainPullRequestSnapshot
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if pull_request.state != "open":
+        reasons.append(f"pull request #{pull_request.number} is not open")
+    if not pull_request.head_ref:
+        reasons.append(f"pull request #{pull_request.number} is missing head ref")
+    if not pull_request.base_ref:
+        reasons.append(f"pull request #{pull_request.number} is missing base ref")
+    if not pull_request.head_repository or not pull_request.base_repository:
+        reasons.append(f"pull request #{pull_request.number} is missing repository identity")
+    if pull_request.head_repository != snapshot.repository:
+        reasons.append(f"pull request #{pull_request.number} is not from the train repository")
+    if pull_request.base_repository != snapshot.repository:
+        reasons.append(f"pull request #{pull_request.number} does not target the train repository")
+    if pull_request.head_ref == pull_request.base_ref:
+        reasons.append(f"pull request #{pull_request.number} has identical head and base refs")
+    return tuple(reasons)
+
+
+def _unsupported_stack_result(
+    *,
+    snapshot: MergeTrainDryRunSnapshot,
+    root_pull_request_number: int,
+    unsupported_reasons: tuple[str, ...],
+) -> MergeTrainStackDiscoveryResult:
+    return MergeTrainStackDiscoveryResult(
+        status="unsupported",
+        repository=snapshot.repository,
+        base_branch=snapshot.base_branch,
+        root_pull_request_number=root_pull_request_number,
+        unsupported_reasons=unsupported_reasons,
+    )
+
+
+def _stack_entry(pull_request: MergeTrainPullRequestSnapshot) -> MergeTrainStackEntry:
+    return MergeTrainStackEntry(
+        number=pull_request.number,
+        head_sha=pull_request.head_sha,
+        head_ref=pull_request.head_ref,
+        base_sha=pull_request.base_sha,
+        base_ref=pull_request.base_ref,
     )
 
 

--- a/control_plane/merge_train_github.py
+++ b/control_plane/merge_train_github.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict, model_validator
 
 from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidate
 from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlan
+from control_plane.contracts.merge_train_stack_collapse import MergeTrainStackCollapseBranchClient
 from control_plane.contracts.merge_train_policy import MergeTrainMergeMethod
 from control_plane.merge_train import MergeTrainCheckStatus
 from control_plane.merge_train import MergeTrainDryRunSnapshot
@@ -69,7 +70,7 @@ class UrllibMergeTrainGitHubTransport:
             ) from error
 
 
-class GitHubMergeTrainClient:
+class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
     def __init__(self, *, transport: MergeTrainGitHubTransport) -> None:
         self.transport = transport
 
@@ -211,6 +212,94 @@ class GitHubMergeTrainClient:
             )
         return merge_commit_sha
 
+    def comment_pull_request(
+        self, *, repository: str, pull_request_number: int, body: str
+    ) -> str:
+        repository_path = _repository_path(repository)
+        payload = self.transport.request(
+            method="POST",
+            path=f"/repos/{repository_path}/issues/{pull_request_number}/comments",
+            body={"body": _required_value(body, "GitHub pull request comment body is required.")},
+        )
+        if not isinstance(payload, dict):
+            raise MergeTrainGitHubError("GitHub comment response must be a JSON object.")
+        return str(payload.get("html_url") or "").strip()
+
+    def close_pull_request(
+        self, *, repository: str, pull_request_number: int, expected_head_sha: str
+    ) -> None:
+        repository_path = _repository_path(repository)
+        pull_request = _json_object(
+            self.transport.request(
+                method="GET", path=f"/repos/{repository_path}/pulls/{pull_request_number}"
+            ),
+            "GitHub pull request detail response",
+        )
+        head = _json_object(pull_request.get("head"), "GitHub pull request head")
+        current_head_sha = _required_text(
+            head.get("sha"), "GitHub pull request head requires sha."
+        )
+        if current_head_sha != _required_value(
+            expected_head_sha, "Expected pull request head SHA is required."
+        ):
+            raise MergeTrainGitHubStaleHeadError(
+                "Stack child PR moved outside the stored collapse plan.",
+                status_code=409,
+            )
+        self.transport.request(
+            method="PATCH",
+            path=f"/repos/{repository_path}/pulls/{pull_request_number}",
+            body={"state": "closed"},
+        )
+
+    def merge_stack_child_into_parent(
+        self,
+        *,
+        repository: str,
+        child_head_sha: str,
+        expected_parent_head_sha: str,
+        parent_head_ref: str,
+        collapse_id: str,
+        child_pull_request_number: int,
+        parent_pull_request_number: int,
+    ) -> str:
+        repository_path = _repository_path(repository)
+        normalized_parent_ref = _required_value(
+            parent_head_ref, "Stack collapse parent head ref is required."
+        )
+        if normalized_parent_ref in {"main", "master"}:
+            raise MergeTrainGitHubError("Stack collapse cannot mutate a protected base branch.")
+        current_parent_sha = _base_branch_sha(
+            transport=self.transport,
+            repository_path=repository_path,
+            base_branch=normalized_parent_ref,
+        )
+        expected_sha = _required_value(
+            expected_parent_head_sha, "Stack collapse expected parent SHA is required."
+        )
+        if current_parent_sha != expected_sha:
+            raise MergeTrainGitHubStaleHeadError(
+                "Stack collapse parent branch moved outside the stored plan.",
+                status_code=409,
+            )
+        payload = self.transport.request(
+            method="POST",
+            path=f"/repos/{repository_path}/merges",
+            body={
+                "base": normalized_parent_ref,
+                "head": _required_value(
+                    child_head_sha, "Stack collapse child head SHA is required."
+                ),
+                "commit_message": (
+                    f"Launchplane stack collapse {collapse_id}: merge PR "
+                    f"#{child_pull_request_number} into PR #{parent_pull_request_number}"
+                ),
+            },
+        )
+        if not isinstance(payload, dict):
+            raise MergeTrainGitHubError("GitHub stack merge response must be a JSON object.")
+        return _required_text(payload.get("sha"), "GitHub stack merge response requires sha.")
+
     def _create_or_reset_reference(self, *, repository_path: str, reference: str, sha: str) -> None:
         normalized_sha = _required_value(sha, "GitHub reference SHA is required.")
         try:
@@ -244,15 +333,19 @@ class GitHubMergeTrainSnapshotReader:
         base_sha = self._base_branch_sha(
             repository_path=repository_path, base_branch=normalized_base_branch
         )
+        open_pull_requests = self._list_open_pull_requests(repository_path=repository_path)
+        relevant_pull_requests = _base_rooted_pull_requests(
+            pull_requests=open_pull_requests,
+            repository=repository,
+            base_branch=normalized_base_branch,
+        )
         pull_requests = tuple(
             self._pull_request_snapshot(
                 repository=repository,
                 repository_path=repository_path,
                 pull_request=pull_request,
             )
-            for pull_request in self._list_open_pull_requests(
-                repository_path=repository_path, base_branch=normalized_base_branch
-            )
+            for pull_request in relevant_pull_requests
         )
         return MergeTrainDryRunSnapshot(
             repository=repository,
@@ -268,16 +361,13 @@ class GitHubMergeTrainSnapshotReader:
             base_branch=base_branch,
         )
 
-    def _list_open_pull_requests(
-        self, *, repository_path: str, base_branch: str
-    ) -> tuple[dict[str, object], ...]:
+    def _list_open_pull_requests(self, *, repository_path: str) -> tuple[dict[str, object], ...]:
         pull_requests: list[dict[str, object]] = []
         page = 1
         while True:
             query = urlencode(
                 {
                     "state": "open",
-                    "base": base_branch,
                     "sort": "created",
                     "direction": "asc",
                     "per_page": "100",
@@ -315,6 +405,12 @@ class GitHubMergeTrainSnapshotReader:
         head = _json_object(source.get("head"), "GitHub pull request head")
         base = _json_object(source.get("base"), "GitHub pull request base")
         head_sha = _required_text(head.get("sha"), "GitHub pull request head requires sha.")
+        head_repository = _repository_full_name(
+            head.get("repo"), "GitHub pull request head repo"
+        )
+        base_repository = _repository_full_name(
+            base.get("repo"), "GitHub pull request base repo"
+        )
         user = _json_object(source.get("user"), "GitHub pull request user")
         actor_role = self._actor_role_for_pull_request(
             repository_path=repository_path,
@@ -333,7 +429,11 @@ class GitHubMergeTrainSnapshotReader:
             labels=_labels(source.get("labels")),
             actor_role=actor_role,
             head_sha=head_sha,
+            head_ref=_required_text(head.get("ref"), "GitHub pull request head requires ref."),
+            head_repository=head_repository,
             base_sha=str(base.get("sha") or "").strip(),
+            base_ref=_required_text(base.get("ref"), "GitHub pull request base requires ref."),
+            base_repository=base_repository,
             mergeable=_mergeable_state(source),
             required_checks_status=self._required_checks_status(
                 repository_path=repository_path, head_sha=head_sha
@@ -439,6 +539,62 @@ def _json_object(value: object, label: str) -> dict[str, object]:
     if not isinstance(value, dict):
         raise MergeTrainGitHubError(f"{label} must be a JSON object.")
     return value
+
+
+def _repository_full_name(value: object, label: str) -> str:
+    repository = _json_object(value, label)
+    return _required_text(repository.get("full_name"), f"{label} requires full_name.")
+
+
+def _base_rooted_pull_requests(
+    *,
+    pull_requests: tuple[dict[str, object], ...],
+    repository: str,
+    base_branch: str,
+) -> tuple[dict[str, object], ...]:
+    by_base_ref: dict[str, list[dict[str, object]]] = {}
+    relevant_numbers: set[int] = set()
+    for pull_request in pull_requests:
+        base = _json_object(pull_request.get("base"), "GitHub pull request base")
+        base_repository = _repository_full_name(
+            base.get("repo"), "GitHub pull request base repo"
+        )
+        if base_repository != repository:
+            continue
+        base_ref = _required_text(base.get("ref"), "GitHub pull request base requires ref.")
+        by_base_ref.setdefault(base_ref, []).append(pull_request)
+
+    branch_refs = [base_branch]
+    seen_branch_refs: set[str] = set()
+    while branch_refs:
+        branch_ref = branch_refs.pop(0)
+        if branch_ref in seen_branch_refs:
+            continue
+        seen_branch_refs.add(branch_ref)
+        for pull_request in by_base_ref.get(branch_ref, ()):
+            pull_request_number = _required_int(
+                pull_request.get("number"), "GitHub pull request entry requires number."
+            )
+            if pull_request_number in relevant_numbers:
+                continue
+            relevant_numbers.add(pull_request_number)
+            head = _json_object(pull_request.get("head"), "GitHub pull request head")
+            head_repository = _repository_full_name(
+                head.get("repo"), "GitHub pull request head repo"
+            )
+            if head_repository != repository:
+                continue
+            branch_refs.append(
+                _required_text(head.get("ref"), "GitHub pull request head requires ref.")
+            )
+    return tuple(
+        pull_request
+        for pull_request in pull_requests
+        if _required_int(
+            pull_request.get("number"), "GitHub pull request entry requires number."
+        )
+        in relevant_numbers
+    )
 
 
 def _required_int(value: object, message: str) -> int:

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -77,12 +77,21 @@ from control_plane.contracts.every_code_summary_read_model import (
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.idempotency_record import build_launchplane_idempotency_record_id
 from control_plane.contracts.merge_train_batch import (
+    MergeTrainBatchCandidate,
     MergeTrainBatchCandidateRecord,
     MergeTrainBatchLandingPlanRecord,
     build_merge_train_batch_candidate,
     build_merge_train_batch_candidate_record,
     build_merge_train_batch_landing_plan,
     build_merge_train_batch_landing_plan_record,
+)
+from control_plane.contracts.merge_train_stack_collapse import (
+    MergeTrainStackCollapsePlan,
+    MergeTrainStackCollapsePlanRecord,
+    build_merge_train_stack_collapse_plan,
+    build_merge_train_stack_collapse_plan_record,
+    execute_merge_train_stack_collapse_plan,
+    reconcile_merge_train_stack_children_after_root_landing,
 )
 from control_plane.contracts.merge_train_run_record import build_merge_train_run_record
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
@@ -198,7 +207,10 @@ from control_plane.work_graph_http import (
     rank_work_graph_snapshot,
     work_graph_rank_denied_response,
 )
+from control_plane.merge_train import MergeTrainDryRunResult
+from control_plane.merge_train import MergeTrainDryRunSnapshot
 from control_plane.merge_train import build_merge_train_dry_run_result
+from control_plane.merge_train import discover_merge_train_stack
 from control_plane.merge_train_github import (
     GitHubMergeTrainClient,
     GitHubMergeTrainSnapshotReader,
@@ -338,6 +350,7 @@ _EVERY_CODE_GITHUB_WEBHOOK_ROUTE = "/v1/every-code/github-webhook"
 _MERGE_TRAIN_ADMISSION_ROUTE = "/v1/work-graph/merge-train/admission"
 _MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-candidate/run-once"
 _MERGE_TRAIN_BATCH_LANDING_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-landing/run-once"
+_MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/stack-collapse/run-once"
 _MERGE_TRAIN_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/run-once"
 _EVERY_CODE_GITHUB_WEBHOOK_SECRET_ENV_KEY = "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET"
 
@@ -401,6 +414,7 @@ class MergeTrainBatchLandingRunOnceEnvelope(BaseModel):
     mode: Literal["plan", "land"] = "plan"
     candidate_record_id: str = ""
     landing_plan_record_id: str = ""
+    stack_collapse_plan_record_id: str = ""
     github_api_base_url: str = "https://api.github.com"
 
     @model_validator(mode="after")
@@ -409,6 +423,7 @@ class MergeTrainBatchLandingRunOnceEnvelope(BaseModel):
         self.base_branch = self.base_branch.strip()
         self.candidate_record_id = self.candidate_record_id.strip()
         self.landing_plan_record_id = self.landing_plan_record_id.strip()
+        self.stack_collapse_plan_record_id = self.stack_collapse_plan_record_id.strip()
         self.github_api_base_url = self.github_api_base_url.strip() or "https://api.github.com"
         if not self.repository:
             raise ValueError("merge train batch landing requires repository")
@@ -420,6 +435,33 @@ class MergeTrainBatchLandingRunOnceEnvelope(BaseModel):
             raise ValueError("landing plan mode requires candidate_record_id")
         if self.mode == "land" and not self.landing_plan_record_id:
             raise ValueError("landing land mode requires landing_plan_record_id")
+        return self
+
+
+class MergeTrainStackCollapseRunOnceEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    repository: str
+    base_branch: str = "main"
+    mode: Literal["execute", "admit"] = "execute"
+    stack_collapse_plan_record_id: str
+    github_api_base_url: str = "https://api.github.com"
+
+    @model_validator(mode="after")
+    def _validate_envelope(self) -> "MergeTrainStackCollapseRunOnceEnvelope":
+        self.repository = self.repository.strip()
+        self.base_branch = self.base_branch.strip()
+        self.stack_collapse_plan_record_id = self.stack_collapse_plan_record_id.strip()
+        self.github_api_base_url = self.github_api_base_url.strip() or "https://api.github.com"
+        if not self.repository:
+            raise ValueError("merge train stack collapse requires repository")
+        if "/" not in self.repository:
+            raise ValueError("merge train repository must be owner/name")
+        if not self.base_branch:
+            raise ValueError("merge train stack collapse requires base_branch")
+        if not self.stack_collapse_plan_record_id:
+            raise ValueError("merge train stack collapse requires stack_collapse_plan_record_id")
         return self
 
 
@@ -2249,6 +2291,7 @@ def _build_write_routes() -> frozenset[str]:
         _EVERY_CODE_GITHUB_WEBHOOK_ROUTE,
         _MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE,
         _MERGE_TRAIN_BATCH_LANDING_RUN_ONCE_ROUTE,
+        _MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE,
         _MERGE_TRAIN_RUN_ONCE_ROUTE,
         "/v1/agent/write-intents/evaluate",
         "/v1/every-code/work-requests/create",
@@ -2489,6 +2532,51 @@ def _merge_train_batch_landing_plan_record_store(
     raise TypeError("record store does not support merge train batch landing plan records")
 
 
+class _MergeTrainStackCollapsePlanRecordStore(Protocol):
+    def write_merge_train_stack_collapse_plan_record(
+        self, record: MergeTrainStackCollapsePlanRecord
+    ) -> object: ...
+
+    def list_merge_train_stack_collapse_plan_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeTrainStackCollapsePlanRecord, ...]: ...
+
+
+def _merge_train_stack_collapse_plan_record_store(
+    record_store: object,
+) -> _MergeTrainStackCollapsePlanRecordStore:
+    if hasattr(record_store, "write_merge_train_stack_collapse_plan_record") and hasattr(
+        record_store, "list_merge_train_stack_collapse_plan_records"
+    ):
+        return cast(_MergeTrainStackCollapsePlanRecordStore, record_store)
+    raise TypeError("record store does not support merge train stack collapse plans")
+
+
+def _merge_train_snapshot_has_stack_topology(
+    *, snapshot: MergeTrainDryRunSnapshot, dry_run_result: MergeTrainDryRunResult
+) -> bool:
+    selected_pr = dry_run_result.selected_pr
+    if selected_pr is None:
+        return False
+    for pull_request in snapshot.pull_requests:
+        if pull_request.number != selected_pr.number:
+            continue
+        return all(
+            (
+                pull_request.head_ref,
+                pull_request.head_repository,
+                pull_request.base_ref,
+                pull_request.base_repository,
+            )
+        )
+    return False
+
+
 def _read_merge_train_batch_candidate_record(
     *,
     record_store: _MergeTrainBatchCandidateRecordStore,
@@ -2519,6 +2607,22 @@ def _read_merge_train_batch_landing_plan_record(
         if record.record_id == record_id:
             return record
     raise ValueError("merge train batch landing plan record not found")
+
+
+def _read_merge_train_stack_collapse_plan_record(
+    *,
+    record_store: _MergeTrainStackCollapsePlanRecordStore,
+    repository: str,
+    base_branch: str,
+    record_id: str,
+) -> MergeTrainStackCollapsePlanRecord:
+    records = record_store.list_merge_train_stack_collapse_plan_records(
+        repository=repository, base_branch=base_branch
+    )
+    for record in records:
+        if record.record_id == record_id:
+            return record
+    raise ValueError("merge train stack collapse plan record not found")
 
 
 def _supports_every_code_work_requests(record_store: object) -> bool:
@@ -3607,6 +3711,7 @@ def _accepted_payload(
                 "agent_write_intent_record_id",
                 "merge_train_batch_candidate_record_id",
                 "merge_train_batch_landing_plan_record_id",
+                "merge_train_stack_collapse_plan_record_id",
                 "merge_train_run_id",
             }
         },
@@ -6981,14 +7086,18 @@ def create_launchplane_service_app(
                                 "message": "Configured merge train GitHub token is not available.",
                             },
                         },
-                    )
+                )
                 batch_store = _merge_train_batch_candidate_record_store(record_store)
+                stack_collapse_store = _merge_train_stack_collapse_plan_record_store(
+                    record_store
+                )
                 transport = UrllibMergeTrainGitHubTransport(
                     token=token,
                     api_base_url=batch_request.github_api_base_url,
                 )
                 github_client = GitHubMergeTrainClient(transport=transport)
                 recorded_at = _utc_now_timestamp()
+                candidate: MergeTrainBatchCandidate | None = None
                 if batch_request.mode == "plan":
                     snapshot = GitHubMergeTrainSnapshotReader(
                         transport=transport
@@ -6999,17 +7108,68 @@ def create_launchplane_service_app(
                     dry_run_result = build_merge_train_dry_run_result(
                         policy=policy, snapshot=snapshot
                     )
-                    candidate = build_merge_train_batch_candidate(
-                        dry_run_result=dry_run_result,
-                        base_sha=snapshot.base_sha,
-                        policy_sha256=policy_record.policy_sha256,
-                        created_at=recorded_at,
-                    )
-                    driver_result = {
-                        "mode": batch_request.mode,
-                        "dry_run_result": dry_run_result.model_dump(mode="json"),
-                        "candidate": candidate.model_dump(mode="json"),
-                    }
+                    selected_pr = dry_run_result.selected_pr
+                    if selected_pr is not None and _merge_train_snapshot_has_stack_topology(
+                        snapshot=snapshot, dry_run_result=dry_run_result
+                    ):
+                        stack_discovery = discover_merge_train_stack(
+                            snapshot=snapshot,
+                            root_pull_request_number=selected_pr.number,
+                        )
+                    else:
+                        stack_discovery = None
+                    if stack_discovery is not None and stack_discovery.status == "ready_for_collapse":
+                        stack_collapse_plan = build_merge_train_stack_collapse_plan(
+                            discovery_result=stack_discovery,
+                            policy_key=dry_run_result.policy_key,
+                            policy_sha256=policy_record.policy_sha256,
+                            created_at=recorded_at,
+                        )
+                        stack_collapse_record = build_merge_train_stack_collapse_plan_record(
+                            plan=stack_collapse_plan,
+                            source=f"service:{batch_request.mode}:{request_trace_id}",
+                            updated_at=recorded_at,
+                        )
+                        stack_collapse_store.write_merge_train_stack_collapse_plan_record(
+                            stack_collapse_record
+                        )
+                        result = {
+                            "merge_train_stack_collapse_plan_record_id": stack_collapse_record.record_id,
+                            "repository": stack_collapse_plan.repository,
+                            "base_branch": stack_collapse_plan.base_branch,
+                            "mode": batch_request.mode,
+                            "stack_collapse_plan": stack_collapse_plan.model_dump(mode="json"),
+                        }
+                        driver_result = {
+                            "mode": batch_request.mode,
+                            "dry_run_result": dry_run_result.model_dump(mode="json"),
+                            "stack_discovery": stack_discovery.model_dump(mode="json"),
+                            "stack_collapse_plan": stack_collapse_plan.model_dump(mode="json"),
+                        }
+                    elif stack_discovery is not None and stack_discovery.status == "unsupported":
+                        result = {
+                            "repository": batch_request.repository,
+                            "base_branch": batch_request.base_branch,
+                            "mode": batch_request.mode,
+                        }
+                        driver_result = {
+                            "mode": batch_request.mode,
+                            "dry_run_result": dry_run_result.model_dump(mode="json"),
+                            "stack_discovery": stack_discovery.model_dump(mode="json"),
+                            "next_action": "stack_unsupported",
+                        }
+                    else:
+                        candidate = build_merge_train_batch_candidate(
+                            dry_run_result=dry_run_result,
+                            base_sha=snapshot.base_sha,
+                            policy_sha256=policy_record.policy_sha256,
+                            created_at=recorded_at,
+                        )
+                        driver_result = {
+                            "mode": batch_request.mode,
+                            "dry_run_result": dry_run_result.model_dump(mode="json"),
+                            "candidate": candidate.model_dump(mode="json"),
+                        }
                 else:
                     existing_record = _read_merge_train_batch_candidate_record(
                         record_store=batch_store,
@@ -7028,19 +7188,20 @@ def create_launchplane_service_app(
                         "mode": batch_request.mode,
                         "candidate": candidate.model_dump(mode="json"),
                     }
-                candidate_record = build_merge_train_batch_candidate_record(
-                    candidate=candidate,
-                    source=f"service:{batch_request.mode}:{request_trace_id}",
-                    updated_at=recorded_at,
-                )
-                batch_store.write_merge_train_batch_candidate_record(candidate_record)
-                result = {
-                    "merge_train_batch_candidate_record_id": candidate_record.record_id,
-                    "repository": candidate.repository,
-                    "base_branch": candidate.base_branch,
-                    "mode": batch_request.mode,
-                    "candidate": candidate.model_dump(mode="json"),
-                }
+                if candidate is not None:
+                    candidate_record = build_merge_train_batch_candidate_record(
+                        candidate=candidate,
+                        source=f"service:{batch_request.mode}:{request_trace_id}",
+                        updated_at=recorded_at,
+                    )
+                    batch_store.write_merge_train_batch_candidate_record(candidate_record)
+                    result = {
+                        "merge_train_batch_candidate_record_id": candidate_record.record_id,
+                        "repository": candidate.repository,
+                        "base_branch": candidate.base_branch,
+                        "mode": batch_request.mode,
+                        "candidate": candidate.model_dump(mode="json"),
+                    }
             elif path == _MERGE_TRAIN_BATCH_LANDING_RUN_ONCE_ROUTE:
                 landing_request = MergeTrainBatchLandingRunOnceEnvelope.model_validate(payload)
                 policy_record = resolve_merge_train_policy_record(record_store)
@@ -7097,7 +7258,10 @@ def create_launchplane_service_app(
                     )
                 candidate_store = _merge_train_batch_candidate_record_store(record_store)
                 landing_store = _merge_train_batch_landing_plan_record_store(record_store)
+                collapse_store = _merge_train_stack_collapse_plan_record_store(record_store)
                 recorded_at = _utc_now_timestamp()
+                collapse_record: MergeTrainStackCollapsePlanRecord | None = None
+                reconciled_collapse_plan: MergeTrainStackCollapsePlan | None = None
                 if landing_request.mode == "plan":
                     candidate_record = _read_merge_train_batch_candidate_record(
                         record_store=candidate_store,
@@ -7121,9 +7285,47 @@ def create_launchplane_service_app(
                         token=token,
                         api_base_url=landing_request.github_api_base_url,
                     )
-                    landing_plan = GitHubMergeTrainClient(
-                        transport=transport
-                    ).land_batch_candidate(landing_plan=landing_record.landing_plan)
+                    github_client = GitHubMergeTrainClient(transport=transport)
+                    landing_plan = github_client.land_batch_candidate(
+                        landing_plan=landing_record.landing_plan
+                    )
+                    if landing_request.stack_collapse_plan_record_id:
+                        collapse_existing_record = _read_merge_train_stack_collapse_plan_record(
+                            record_store=collapse_store,
+                            repository=landing_request.repository,
+                            base_branch=landing_request.base_branch,
+                            record_id=landing_request.stack_collapse_plan_record_id,
+                        )
+                        root_entry = next(
+                            (
+                                entry
+                                for entry in landing_plan.entries
+                                if entry.pull_request_number
+                                == collapse_existing_record.plan.root_pull_request_number
+                            ),
+                            None,
+                        )
+                        if root_entry is None or root_entry.status != "merged":
+                            raise ValueError(
+                                "merge train stack child disposition requires merged root PR"
+                            )
+                        reconciled_collapse_plan = (
+                            reconcile_merge_train_stack_children_after_root_landing(
+                                plan=collapse_existing_record.plan,
+                                disposition_client=github_client,
+                                root_merge_commit_sha=root_entry.merge_commit_sha,
+                                label="stack-landed",
+                                updated_at=recorded_at,
+                            )
+                        )
+                        collapse_record = build_merge_train_stack_collapse_plan_record(
+                            plan=reconciled_collapse_plan,
+                            source=f"service:child-disposition:{request_trace_id}",
+                            updated_at=recorded_at,
+                        )
+                        collapse_store.write_merge_train_stack_collapse_plan_record(
+                            collapse_record
+                        )
                 landing_record = build_merge_train_batch_landing_plan_record(
                     landing_plan=landing_plan,
                     source=f"service:{landing_request.mode}:{request_trace_id}",
@@ -7137,7 +7339,170 @@ def create_launchplane_service_app(
                     "mode": landing_request.mode,
                     "landing_plan": landing_plan.model_dump(mode="json"),
                 }
+                if landing_request.mode == "land" and landing_request.stack_collapse_plan_record_id:
+                    if collapse_record is None or reconciled_collapse_plan is None:
+                        raise ValueError("merge train stack child disposition record missing")
+                    result["merge_train_stack_collapse_plan_record_id"] = collapse_record.record_id
+                    result["stack_collapse_plan"] = reconciled_collapse_plan.model_dump(
+                        mode="json"
+                    )
                 driver_result = {"mode": landing_request.mode, "landing_plan": result["landing_plan"]}
+                if "stack_collapse_plan" in result:
+                    driver_result["stack_collapse_plan"] = result["stack_collapse_plan"]
+            elif path == _MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE:
+                collapse_request = MergeTrainStackCollapseRunOnceEnvelope.model_validate(payload)
+                policy_record = resolve_merge_train_policy_record(record_store)
+                policy = policy_record.policy
+                repository_policy = policy.find_repository_policy(
+                    repository=collapse_request.repository,
+                    base_branch=collapse_request.base_branch,
+                )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action=repository_policy.service_authz.action,
+                    product=repository_policy.service_authz.product,
+                    context=repository_policy.service_authz.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot run the requested merge train policy.",
+                            },
+                        },
+                    )
+                token_env = repository_policy.github_token.env_var
+                if not token_env:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "github_token_not_configured",
+                                "message": "Merge train policy does not define a GitHub token environment variable.",
+                            },
+                        },
+                    )
+                token = os.environ.get(token_env, "").strip()
+                if not token:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "github_token_not_configured",
+                                "message": "Configured merge train GitHub token is not available.",
+                            },
+                        },
+                    )
+                collapse_store = _merge_train_stack_collapse_plan_record_store(record_store)
+                collapse_existing_record = _read_merge_train_stack_collapse_plan_record(
+                    record_store=collapse_store,
+                    repository=collapse_request.repository,
+                    base_branch=collapse_request.base_branch,
+                    record_id=collapse_request.stack_collapse_plan_record_id,
+                )
+                recorded_at = _utc_now_timestamp()
+                transport = UrllibMergeTrainGitHubTransport(
+                    token=token,
+                    api_base_url=collapse_request.github_api_base_url,
+                )
+                if collapse_request.mode == "execute":
+                    executed_plan = execute_merge_train_stack_collapse_plan(
+                        plan=collapse_existing_record.plan,
+                        branch_client=GitHubMergeTrainClient(transport=transport),
+                        updated_at=recorded_at,
+                    )
+                    collapse_record = build_merge_train_stack_collapse_plan_record(
+                        plan=executed_plan,
+                        source=f"service:execute:{request_trace_id}",
+                        updated_at=recorded_at,
+                    )
+                    collapse_store.write_merge_train_stack_collapse_plan_record(collapse_record)
+                    result = {
+                        "merge_train_stack_collapse_plan_record_id": collapse_record.record_id,
+                        "repository": executed_plan.repository,
+                        "base_branch": executed_plan.base_branch,
+                        "mode": collapse_request.mode,
+                        "stack_collapse_plan": executed_plan.model_dump(mode="json"),
+                    }
+                    driver_result = {
+                        "mode": collapse_request.mode,
+                        "stack_collapse_plan": result["stack_collapse_plan"],
+                    }
+                else:
+                    stack_collapse_plan = collapse_existing_record.plan
+                    if stack_collapse_plan.status != "waiting_for_root_checks":
+                        raise ValueError(
+                            "merge train stack collapse plan is not ready for train admission"
+                        )
+                    if stack_collapse_plan.policy_sha256 != policy_record.policy_sha256:
+                        raise ValueError(
+                            "merge train stack collapse policy digest no longer matches"
+                        )
+                    snapshot = GitHubMergeTrainSnapshotReader(
+                        transport=transport
+                    ).read_merge_train_snapshot(
+                        repository=collapse_request.repository,
+                        base_branch=collapse_request.base_branch,
+                    )
+                    root_pull_request = next(
+                        (
+                            pull_request
+                            for pull_request in snapshot.pull_requests
+                            if pull_request.number
+                            == stack_collapse_plan.root_pull_request_number
+                        ),
+                        None,
+                    )
+                    if root_pull_request is None:
+                        raise ValueError("merge train stack collapse root PR is missing")
+                    if root_pull_request.head_sha != stack_collapse_plan.root_initial_head_sha:
+                        raise ValueError(
+                            "merge train stack collapse root PR head no longer matches"
+                        )
+                    snapshot = snapshot.model_copy(
+                        update={
+                            "pull_requests": (root_pull_request,)
+                        }
+                    )
+                    dry_run_result = build_merge_train_dry_run_result(
+                        policy=policy, snapshot=snapshot
+                    )
+                    candidate = build_merge_train_batch_candidate(
+                        dry_run_result=dry_run_result,
+                        base_sha=snapshot.base_sha,
+                        policy_sha256=policy_record.policy_sha256,
+                        created_at=recorded_at,
+                    )
+                    candidate_record = build_merge_train_batch_candidate_record(
+                        candidate=candidate,
+                        source=f"service:stack-collapse-admit:{request_trace_id}",
+                        updated_at=recorded_at,
+                    )
+                    _merge_train_batch_candidate_record_store(
+                        record_store
+                    ).write_merge_train_batch_candidate_record(candidate_record)
+                    result = {
+                        "merge_train_batch_candidate_record_id": candidate_record.record_id,
+                        "repository": candidate.repository,
+                        "base_branch": candidate.base_branch,
+                        "mode": collapse_request.mode,
+                        "candidate": candidate.model_dump(mode="json"),
+                    }
+                    driver_result = {
+                        "mode": collapse_request.mode,
+                        "dry_run_result": dry_run_result.model_dump(mode="json"),
+                        "candidate": result["candidate"],
+                    }
             elif path == "/v1/agent/write-intents/evaluate":
                 intent_request = AgentWriteIntentRequest.model_validate(payload)
                 intent_authz_action = authz_action_for_agent_write_intent(intent_request.intent)

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -19,6 +19,9 @@ from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFee
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidateRecord
 from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlanRecord
+from control_plane.contracts.merge_train_stack_collapse import (
+    MergeTrainStackCollapsePlanRecord,
+)
 from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
@@ -220,6 +223,36 @@ class FilesystemRecordStore:
             )
             if (not repository or record.landing_plan.repository == repository)
             and (not base_branch or record.landing_plan.base_branch == base_branch)
+            and (not status or record.status == status)
+        ]
+        records.sort(key=lambda record: (record.updated_at, record.record_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def write_merge_train_stack_collapse_plan_record(
+        self, record: MergeTrainStackCollapsePlanRecord
+    ) -> Path:
+        return self._write_model(
+            "launchplane_merge_train_stack_collapse_plans", record.record_id, record
+        )
+
+    def list_merge_train_stack_collapse_plan_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeTrainStackCollapsePlanRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                MergeTrainStackCollapsePlanRecord,
+                "launchplane_merge_train_stack_collapse_plans",
+            )
+            if (not repository or record.plan.repository == repository)
+            and (not base_branch or record.plan.base_branch == base_branch)
             and (not status or record.status == status)
         ]
         records.sort(key=lambda record: (record.updated_at, record.record_id), reverse=True)

--- a/control_plane/storage/migrations/versions/d289e3ab4012_add_merge_train_stack_collapse_plans.py
+++ b/control_plane/storage/migrations/versions/d289e3ab4012_add_merge_train_stack_collapse_plans.py
@@ -1,0 +1,62 @@
+"""add merge train stack collapse plans
+
+Revision ID: d289e3ab4012
+Revises: c178d29af012
+Create Date: 2026-05-14 13:35:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "d289e3ab4012"
+down_revision: str | None = "c178d29af012"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "launchplane_merge_train_stack_collapse_plans",
+        sa.Column("record_id", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("source", sa.String(), nullable=False),
+        sa.Column("updated_at", sa.String(), nullable=False),
+        sa.Column("repository", sa.String(), nullable=False),
+        sa.Column("base_branch", sa.String(), nullable=False),
+        sa.Column("collapse_id", sa.String(), nullable=False),
+        sa.Column("root_pull_request_number", sa.Integer(), nullable=False),
+        sa.Column("plan_status", sa.String(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("record_id"),
+    )
+    op.create_index(
+        "launchplane_merge_train_stack_collapse_plans_repository_base_idx",
+        "launchplane_merge_train_stack_collapse_plans",
+        ["repository", "base_branch", sa.text("updated_at DESC")],
+    )
+    op.create_index(
+        "launchplane_merge_train_stack_collapse_plans_status_idx",
+        "launchplane_merge_train_stack_collapse_plans",
+        ["status", sa.text("updated_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "launchplane_merge_train_stack_collapse_plans_status_idx",
+        table_name="launchplane_merge_train_stack_collapse_plans",
+    )
+    op.drop_index(
+        "launchplane_merge_train_stack_collapse_plans_repository_base_idx",
+        table_name="launchplane_merge_train_stack_collapse_plans",
+    )
+    op.drop_table("launchplane_merge_train_stack_collapse_plans")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -41,6 +41,9 @@ from control_plane.contracts.merge_train_batch import (
     MergeTrainBatchCandidateRecord,
     MergeTrainBatchLandingPlanRecord,
 )
+from control_plane.contracts.merge_train_stack_collapse import (
+    MergeTrainStackCollapsePlanRecord,
+)
 from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
@@ -662,6 +665,34 @@ class LaunchplaneMergeTrainBatchLandingPlanRow(Base):
     base_branch: Mapped[str] = mapped_column(String, nullable=False)
     batch_id: Mapped[str] = mapped_column(String, nullable=False)
     plan_id: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneMergeTrainStackCollapsePlanRow(Base):
+    __tablename__ = "launchplane_merge_train_stack_collapse_plans"
+    __table_args__ = (
+        Index(
+            "launchplane_merge_train_stack_collapse_plans_repository_base_idx",
+            "repository",
+            "base_branch",
+            desc("updated_at"),
+        ),
+        Index(
+            "launchplane_merge_train_stack_collapse_plans_status_idx",
+            "status",
+            desc("updated_at"),
+        ),
+    )
+
+    record_id: Mapped[str] = mapped_column(String, primary_key=True)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    source: Mapped[str] = mapped_column(String, nullable=False)
+    updated_at: Mapped[str] = mapped_column(String, nullable=False)
+    repository: Mapped[str] = mapped_column(String, nullable=False)
+    base_branch: Mapped[str] = mapped_column(String, nullable=False)
+    collapse_id: Mapped[str] = mapped_column(String, nullable=False)
+    root_pull_request_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    plan_status: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -1656,6 +1687,50 @@ class PostgresRecordStore(HumanSessionStore):
             limit=limit,
         )
 
+    def write_merge_train_stack_collapse_plan_record(
+        self, record: MergeTrainStackCollapsePlanRecord
+    ) -> None:
+        self._write_row(
+            LaunchplaneMergeTrainStackCollapsePlanRow(
+                record_id=record.record_id,
+                status=record.status,
+                source=record.source,
+                updated_at=record.updated_at,
+                repository=record.plan.repository,
+                base_branch=record.plan.base_branch,
+                collapse_id=record.plan.collapse_id,
+                root_pull_request_number=record.plan.root_pull_request_number,
+                plan_status=record.plan.status,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def list_merge_train_stack_collapse_plan_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeTrainStackCollapsePlanRecord, ...]:
+        filters: list[object] = []
+        if repository:
+            filters.append(LaunchplaneMergeTrainStackCollapsePlanRow.repository == repository)
+        if base_branch:
+            filters.append(LaunchplaneMergeTrainStackCollapsePlanRow.base_branch == base_branch)
+        if status:
+            filters.append(LaunchplaneMergeTrainStackCollapsePlanRow.status == status)
+        return self._list_models(
+            model_type=MergeTrainStackCollapsePlanRecord,
+            orm_model=LaunchplaneMergeTrainStackCollapsePlanRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneMergeTrainStackCollapsePlanRow.updated_at.desc(),
+                LaunchplaneMergeTrainStackCollapsePlanRow.record_id.desc(),
+            ),
+            limit=limit,
+        )
+
     def list_merge_train_policy_records(
         self,
         *,
@@ -2623,6 +2698,7 @@ class PostgresRecordStore(HumanSessionStore):
             "agent_write_intents": 0,
             "merge_train_batch_candidates": 0,
             "merge_train_batch_landing_plans": 0,
+            "merge_train_stack_collapse_plans": 0,
             "merge_train_policies": 0,
             "merge_train_runs": 0,
             "release_tuples": 0,
@@ -2701,6 +2777,10 @@ class PostgresRecordStore(HumanSessionStore):
             for plan_record in filesystem_store.list_merge_train_batch_landing_plan_records():
                 self.write_merge_train_batch_landing_plan_record(plan_record)
                 counts["merge_train_batch_landing_plans"] += 1
+        if hasattr(filesystem_store, "list_merge_train_stack_collapse_plan_records"):
+            for collapse_record in filesystem_store.list_merge_train_stack_collapse_plan_records():
+                self.write_merge_train_stack_collapse_plan_record(collapse_record)
+                counts["merge_train_stack_collapse_plans"] += 1
         if hasattr(filesystem_store, "list_merge_train_policy_records"):
             for merge_train_policy_record in filesystem_store.list_merge_train_policy_records():
                 self.write_merge_train_policy_record(merge_train_policy_record)

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -111,6 +111,26 @@ preferred first implementation because it hides the normal PR-by-PR merge UX and
 can make repository history and GitHub review state harder to inspect. It should
 remain a separate, explicit future decision if ever needed.
 
+### Stacked Pull Requests
+
+The batch train remains flat: queued entries must target the repository policy's
+`base_branch`. Launchplane may read broader pull request topology so it can see
+stacked PRs, but PRs whose base is another feature branch are not admitted as
+independent train entries.
+
+Stacked PR support is a pre-train normalization workflow. For same-repository
+linear stacks, Launchplane should detect the stack rooted at a PR targeting the
+protected base branch, collapse child changes into that root with explicit
+stored evidence and fresh SHA guards, wait for the root PR to pass required
+checks against the base branch, then admit only the root PR to the flat batch
+train. The root PR's `enqueue_label` is the operator/agent intent: it means
+"land this work through Launchplane," including any required same-repository
+linear stack collapse before train admission. Launchplane records a stack
+collapse plan before mutating branches so the root PR, child order, expected
+SHAs, mutation sequence, policy digest, and idempotency evidence remain
+auditable. Ambiguous, forked, cyclic, or unsupported branch-protection cases
+must fail closed with operator-visible reasons.
+
 ### Blocker Isolation
 
 When the combined candidate fails checks, Launchplane must not assume all queued

--- a/docs/records.md
+++ b/docs/records.md
@@ -104,6 +104,13 @@ an ORM column/table or remains only in the evidence payload.
   previous/new policy ids and shas, trace id, mode, and requested grant details;
   service responses redact that requested-grant detail to counts and scope
   summaries.
+- Merge train stack collapse plan: modeled fields are `record_id`, `status`,
+  `source`, `updated_at`, `repository`, `base_branch`, `collapse_id`,
+  `root_pull_request_number`, and `plan_status`. The payload carries the typed
+  stack entries, expected SHAs, planned child-to-parent mutations, policy digest,
+  and intent source. The initial intent source is the root PR's merge-train
+  enqueue label; no file-backed or hardcoded repository config participates in
+  live collapse authority.
 - Dokploy target id: modeled fields are `context`, `instance`, `target_id`, and
   `updated_at`. Provider lookup/import evidence stays payload-only.
 - Dokploy target: modeled fields are `context`, `instance`, and `updated_at`.

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -26,6 +26,14 @@ from control_plane.contracts.merge_train_batch import (
     build_merge_train_batch_id,
     build_merge_train_batch_landing_plan,
 )
+from control_plane.contracts.merge_train_stack_collapse import (
+    MergeTrainStackCollapseEntry,
+    MergeTrainStackCollapseMutation,
+    MergeTrainStackCollapsePlan,
+    MergeTrainStackCollapsePlanRecord,
+    MergeTrainStackCollapseRecordStatus,
+    build_merge_train_stack_collapse_id,
+)
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
 from control_plane.contracts.odoo_instance_override_record import OdooAddonSettingOverride
 from control_plane.contracts.odoo_instance_override_record import OdooConfigParameterOverride
@@ -157,6 +165,68 @@ def _merge_train_batch_landing_plan_record(
         source="test",
         updated_at=updated_at,
         landing_plan=landing_plan,
+    )
+
+
+def _merge_train_stack_collapse_plan_record(
+    *,
+    record_id: str = "merge-train-stack-collapse-plan-20260514T013000Z-active",
+    status: MergeTrainStackCollapseRecordStatus = "active",
+    updated_at: str = "2026-05-14T01:30:00Z",
+) -> MergeTrainStackCollapsePlanRecord:
+    repository = "example/merge-train-repo"
+    base_branch = "main"
+    entries = (
+        MergeTrainStackCollapseEntry(
+            pull_request_number=10,
+            position=1,
+            head_sha="head-10",
+            head_ref="feature/root",
+            base_sha="base-10",
+            base_ref="main",
+        ),
+        MergeTrainStackCollapseEntry(
+            pull_request_number=11,
+            position=2,
+            head_sha="head-11",
+            head_ref="feature/child",
+            base_sha="base-11",
+            base_ref="feature/root",
+        ),
+    )
+    collapse_id = build_merge_train_stack_collapse_id(
+        repository=repository,
+        base_branch=base_branch,
+        root_pull_request_number=10,
+        entry_head_shas=tuple(entry.head_sha for entry in entries),
+    )
+    return MergeTrainStackCollapsePlanRecord(
+        record_id=record_id,
+        status=status,
+        source="test",
+        updated_at=updated_at,
+        plan=MergeTrainStackCollapsePlan(
+            collapse_id=collapse_id,
+            repository=repository,
+            base_branch=base_branch,
+            root_pull_request_number=10,
+            root_initial_head_sha="head-10",
+            root_head_ref="feature/root",
+            policy_key=f"{repository}:{base_branch}",
+            policy_sha256="policy-digest",
+            entries=entries,
+            mutations=(
+                MergeTrainStackCollapseMutation(
+                    child_pull_request_number=11,
+                    parent_pull_request_number=10,
+                    child_head_sha="head-11",
+                    expected_parent_head_sha="head-10",
+                    parent_head_ref="feature/root",
+                ),
+            ),
+            created_at="2026-05-14T01:29:00Z",
+            updated_at=updated_at,
+        ),
     )
 
 
@@ -417,6 +487,33 @@ class FilesystemRecordStoreTests(unittest.TestCase):
         )
         self.assertEqual([record.record_id for record in listed_records], [active_record.record_id])
         self.assertEqual(listed_records[0].landing_plan.entries[0].merge_method, "squash")
+
+    def test_write_and_list_merge_train_stack_collapse_plan_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            older_record = _merge_train_stack_collapse_plan_record(
+                record_id="merge-train-stack-collapse-plan-20260514T012900Z-old",
+                status="superseded",
+                updated_at="2026-05-14T01:29:00Z",
+            )
+            active_record = _merge_train_stack_collapse_plan_record()
+
+            store.write_merge_train_stack_collapse_plan_record(older_record)
+            written_path = store.write_merge_train_stack_collapse_plan_record(active_record)
+            listed_records = store.list_merge_train_stack_collapse_plan_records(
+                repository="example/merge-train-repo",
+                base_branch="main",
+                status="active",
+            )
+
+        self.assertEqual(
+            written_path.relative_to(state_dir).as_posix(),
+            "launchplane_merge_train_stack_collapse_plans/"
+            "merge-train-stack-collapse-plan-20260514T013000Z-active.json",
+        )
+        self.assertEqual([record.record_id for record in listed_records], [active_record.record_id])
+        self.assertEqual(listed_records[0].plan.intent_source, "root_ready_to_merge")
 
     def test_write_and_read_artifact_manifest(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_merge_train.py
+++ b/tests/test_merge_train.py
@@ -16,6 +16,7 @@ from control_plane.merge_train import (
     apply_merge_train_merge_intent,
     build_merge_train_dry_run_result,
     build_merge_train_wait_result,
+    discover_merge_train_stack,
     reread_merge_train_after_branch_update,
 )
 from control_plane.merge_train_github import MergeTrainGitHubError
@@ -154,6 +155,37 @@ class MergeTrainDryRunTests(unittest.TestCase):
         self.assertEqual(result.intended_next_action, "idle")
         self.assertIn("missing ready-to-merge label", result.queue[0].ineligible_reasons)
         self.assertIn("actor role is not allowed", result.queue[1].ineligible_reasons[0])
+
+    def test_dry_run_ignores_stack_children_that_do_not_target_base_branch(self) -> None:
+        result = build_merge_train_dry_run_result(
+            policy=build_test_merge_train_policy(),
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(
+                    _pull_request(8, head_ref="feature/root", base_ref="main"),
+                    _pull_request(9, head_ref="feature/child", base_ref="feature/root"),
+                ),
+            ),
+        )
+
+        self.assertEqual(result.queue_order, (8,))
+        self.assertEqual([entry.number for entry in result.queue], [8])
+
+    def test_dry_run_preserves_legacy_snapshot_files_without_base_refs(self) -> None:
+        result = build_merge_train_dry_run_result(
+            policy=build_test_merge_train_policy(),
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pull_requests=(
+                    _pull_request(13, head_ref="", base_ref=""),
+                    _pull_request(14, head_ref="", base_ref=""),
+                ),
+            ),
+        )
+
+        self.assertEqual(result.queue_order, (13, 14))
 
     def test_dry_run_reports_block_and_update_actions(self) -> None:
         blocked_result = build_merge_train_dry_run_result(
@@ -385,6 +417,117 @@ class MergeTrainDryRunTests(unittest.TestCase):
         self.assertIn("GitHub merge train request failed", result.output)
         self.assertIn("rate limited", result.output)
         self.assertIn("HTTP 403", result.output)
+
+
+class MergeTrainStackDiscoveryTests(unittest.TestCase):
+    def test_discovers_same_repo_linear_stack_from_root_to_leaf(self) -> None:
+        snapshot = MergeTrainDryRunSnapshot(
+            repository="example/merge-train-repo",
+            base_branch="main",
+            pull_requests=(
+                _pull_request(
+                    10,
+                    head_ref="feature/root",
+                    base_ref="main",
+                    repository="example/merge-train-repo",
+                ),
+                _pull_request(
+                    11,
+                    head_ref="feature/middle",
+                    base_ref="feature/root",
+                    repository="example/merge-train-repo",
+                ),
+                _pull_request(
+                    12,
+                    head_ref="feature/leaf",
+                    base_ref="feature/middle",
+                    repository="example/merge-train-repo",
+                ),
+            ),
+        )
+
+        result = discover_merge_train_stack(snapshot=snapshot, root_pull_request_number=10)
+
+        self.assertEqual(result.status, "ready_for_collapse")
+        self.assertEqual(result.stack_order, (10, 11, 12))
+        self.assertEqual([entry.head_ref for entry in result.entries], ["feature/root", "feature/middle", "feature/leaf"])
+
+    def test_reports_not_stacked_for_single_root_pr(self) -> None:
+        snapshot = MergeTrainDryRunSnapshot(
+            repository="example/merge-train-repo",
+            base_branch="main",
+            pull_requests=(
+                _pull_request(
+                    20,
+                    head_ref="feature/root",
+                    base_ref="main",
+                    repository="example/merge-train-repo",
+                ),
+            ),
+        )
+
+        result = discover_merge_train_stack(snapshot=snapshot, root_pull_request_number=20)
+
+        self.assertEqual(result.status, "not_stacked")
+        self.assertEqual(result.stack_order, (20,))
+        self.assertEqual(result.unsupported_reasons, ())
+
+    def test_rejects_ambiguous_sibling_stack_children(self) -> None:
+        snapshot = MergeTrainDryRunSnapshot(
+            repository="example/merge-train-repo",
+            base_branch="main",
+            pull_requests=(
+                _pull_request(
+                    30,
+                    head_ref="feature/root",
+                    base_ref="main",
+                    repository="example/merge-train-repo",
+                ),
+                _pull_request(
+                    31,
+                    head_ref="feature/child-a",
+                    base_ref="feature/root",
+                    repository="example/merge-train-repo",
+                ),
+                _pull_request(
+                    32,
+                    head_ref="feature/child-b",
+                    base_ref="feature/root",
+                    repository="example/merge-train-repo",
+                ),
+            ),
+        )
+
+        result = discover_merge_train_stack(snapshot=snapshot, root_pull_request_number=30)
+
+        self.assertEqual(result.status, "unsupported")
+        self.assertIn("multiple stacked child", result.unsupported_reasons[0])
+
+    def test_rejects_forked_stack_members(self) -> None:
+        snapshot = MergeTrainDryRunSnapshot(
+            repository="example/merge-train-repo",
+            base_branch="main",
+            pull_requests=(
+                _pull_request(
+                    40,
+                    head_ref="feature/root",
+                    base_ref="main",
+                    repository="example/merge-train-repo",
+                ),
+                _pull_request(
+                    41,
+                    head_ref="feature/child",
+                    base_ref="feature/root",
+                    repository="example/merge-train-repo",
+                    head_repository="fork/merge-train-repo",
+                ),
+            ),
+        )
+
+        result = discover_merge_train_stack(snapshot=snapshot, root_pull_request_number=40)
+
+        self.assertEqual(result.status, "unsupported")
+        self.assertIn("not from the train repository", result.unsupported_reasons[0])
 
 
 class MergeTrainBlockIntentTests(unittest.TestCase):
@@ -718,7 +861,14 @@ def _pull_request(
     mergeable: str = "mergeable",
     required_checks_status: str = "pass",
     branch_update_required: bool = False,
+    head_ref: str = "",
+    base_ref: str = "main",
+    repository: str = "",
+    head_repository: str = "",
+    base_repository: str = "",
 ) -> MergeTrainPullRequestSnapshot:
+    normalized_head_repository = head_repository or repository
+    normalized_base_repository = base_repository or repository
     return MergeTrainPullRequestSnapshot.model_validate(
         {
             "number": number,
@@ -729,7 +879,11 @@ def _pull_request(
             "actor_role": actor_role,
             "is_draft": is_draft,
             "head_sha": f"head-{number}",
+            "head_ref": head_ref,
+            "head_repository": normalized_head_repository,
             "base_sha": "base-main",
+            "base_ref": base_ref,
+            "base_repository": normalized_base_repository,
             "mergeable": mergeable,
             "required_checks_status": required_checks_status,
             "branch_update_required": branch_update_required,

--- a/tests/test_merge_train_admission.py
+++ b/tests/test_merge_train_admission.py
@@ -223,6 +223,7 @@ def _pull_request(
         labels=("ready-to-merge",),
         actor_role="repo_owner",
         head_sha=f"head-{number}",
+        base_ref="main",
         base_sha="base-main",
         mergeable="mergeable",
         required_checks_status=required_checks_status,

--- a/tests/test_merge_train_batch.py
+++ b/tests/test_merge_train_batch.py
@@ -240,6 +240,7 @@ def _pull_request(
             "labels": ("ready-to-merge",),
             "actor_role": "repo_admin",
             "head_sha": f"head-{number}",
+            "base_ref": "main",
             "base_sha": "base-main",
             "mergeable": "mergeable",
             "required_checks_status": required_checks_status,

--- a/tests/test_merge_train_github.py
+++ b/tests/test_merge_train_github.py
@@ -80,6 +80,138 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 merge_method="merge",
             )
 
+    def test_comment_pull_request_posts_issue_comment(self) -> None:
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=({"html_url": "https://github.com/example/repo/pull/11#issuecomment-1"},)
+        )
+
+        comment_url = GitHubMergeTrainClient(transport=transport).comment_pull_request(
+            repository="example/merge-train-repo",
+            pull_request_number=11,
+            body="landed through root",
+        )
+
+        self.assertEqual(comment_url, "https://github.com/example/repo/pull/11#issuecomment-1")
+        self.assertEqual(transport.requests[0].method, "POST")
+        self.assertEqual(
+            transport.requests[0].path,
+            "/repos/example/merge-train-repo/issues/11/comments",
+        )
+        self.assertEqual(transport.requests[0].body, {"body": "landed through root"})
+
+    def test_close_pull_request_checks_head_sha_before_closing(self) -> None:
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=({"head": {"sha": "child-head"}}, {})
+        )
+
+        GitHubMergeTrainClient(transport=transport).close_pull_request(
+            repository="example/merge-train-repo",
+            pull_request_number=11,
+            expected_head_sha="child-head",
+        )
+
+        self.assertEqual(
+            [(request.method, request.path, request.body) for request in transport.requests],
+            [
+                ("GET", "/repos/example/merge-train-repo/pulls/11", None),
+                ("PATCH", "/repos/example/merge-train-repo/pulls/11", {"state": "closed"}),
+            ],
+        )
+
+    def test_close_pull_request_rejects_moved_child_head(self) -> None:
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=({"head": {"sha": "moved-child-head"}},)
+        )
+
+        with self.assertRaises(MergeTrainGitHubStaleHeadError):
+            GitHubMergeTrainClient(transport=transport).close_pull_request(
+                repository="example/merge-train-repo",
+                pull_request_number=11,
+                expected_head_sha="child-head",
+            )
+
+        self.assertEqual(len(transport.requests), 1)
+
+    def test_merge_stack_child_into_parent_checks_parent_sha_then_merges_child_head(self) -> None:
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                _github_branch(sha="parent-head"),
+                {"sha": "parent-after-child"},
+            )
+        )
+
+        merge_commit_sha = GitHubMergeTrainClient(
+            transport=transport
+        ).merge_stack_child_into_parent(
+            repository="example/merge-train-repo",
+            child_head_sha="child-head",
+            expected_parent_head_sha="parent-head",
+            parent_head_ref="feature/root",
+            collapse_id="collapse-123",
+            child_pull_request_number=11,
+            parent_pull_request_number=10,
+        )
+
+        self.assertEqual(merge_commit_sha, "parent-after-child")
+        self.assertEqual(
+            [(request.method, request.path, request.body) for request in transport.requests],
+            [
+                (
+                    "GET",
+                    "/repos/example/merge-train-repo/branches/feature%2Froot",
+                    None,
+                ),
+                (
+                    "POST",
+                    "/repos/example/merge-train-repo/merges",
+                    {
+                        "base": "feature/root",
+                        "head": "child-head",
+                        "commit_message": (
+                            "Launchplane stack collapse collapse-123: merge PR "
+                            "#11 into PR #10"
+                        ),
+                    },
+                ),
+            ],
+        )
+
+    def test_merge_stack_child_into_parent_rejects_stale_parent_branch(self) -> None:
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(_github_branch(sha="moved-parent-head"),)
+        )
+
+        with self.assertRaises(MergeTrainGitHubStaleHeadError):
+            GitHubMergeTrainClient(transport=transport).merge_stack_child_into_parent(
+                repository="example/merge-train-repo",
+                child_head_sha="child-head",
+                expected_parent_head_sha="parent-head",
+                parent_head_ref="feature/root",
+                collapse_id="collapse-123",
+                child_pull_request_number=11,
+                parent_pull_request_number=10,
+            )
+
+        self.assertEqual(len(transport.requests), 1)
+        self.assertEqual(
+            transport.requests[0].path,
+            "/repos/example/merge-train-repo/branches/feature%2Froot",
+        )
+
+    def test_merge_stack_child_into_parent_rejects_main_branch_mutation(self) -> None:
+        with self.assertRaisesRegex(MergeTrainGitHubError, "protected base branch"):
+            GitHubMergeTrainClient(
+                transport=RecordingMergeTrainGitHubTransport()
+            ).merge_stack_child_into_parent(
+                repository="example/merge-train-repo",
+                child_head_sha="child-head",
+                expected_parent_head_sha="parent-head",
+                parent_head_ref="main",
+                collapse_id="collapse-123",
+                child_pull_request_number=11,
+                parent_pull_request_number=10,
+            )
+
     def test_build_batch_candidate_creates_ref_and_merges_heads_in_order(self) -> None:
         candidate = _batch_candidate()
         transport = RecordingMergeTrainGitHubTransport(
@@ -308,14 +440,20 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
 
 
 class GitHubMergeTrainSnapshotReaderTests(unittest.TestCase):
-    def test_snapshot_reader_builds_pull_request_snapshots_from_github(self) -> None:
+    def test_snapshot_reader_builds_pull_request_snapshots_from_base_rooted_graph(self) -> None:
         transport = RecordingMergeTrainGitHubTransport(
             responses=(
                 _github_branch(),
                 [
-                    _github_pull_request(42, mergeable=None),
+                    _github_pull_request(42, mergeable=None, head_ref="feature-root"),
+                    _github_pull_request(43, base_ref="feature-root", head_ref="feature-child"),
+                    _github_pull_request(44, base_ref="other-base", head_ref="unrelated"),
                 ],
                 _github_pull_request(42, mergeable=True),
+                {"permission": "admin"},
+                {"state": "success"},
+                {"check_runs": [_check_run("completed", "success")]},
+                _github_pull_request(43, base_ref="feature-root", head_ref="feature-child"),
                 {"permission": "admin"},
                 {"state": "success"},
                 {"check_runs": [_check_run("completed", "success")]},
@@ -329,28 +467,39 @@ class GitHubMergeTrainSnapshotReaderTests(unittest.TestCase):
 
         self.assertEqual(snapshot.repository, "cbusillo/sellyouroutboard")
         self.assertEqual(snapshot.base_branch, "main")
-        self.assertEqual(len(snapshot.pull_requests), 1)
+        self.assertEqual(len(snapshot.pull_requests), 2)
         pull_request = snapshot.pull_requests[0]
         self.assertEqual(pull_request.number, 42)
         self.assertEqual(pull_request.labels, ("ready-to-merge",))
         self.assertEqual(pull_request.actor_role, "repo_admin")
         self.assertEqual(pull_request.head_sha, "head-42")
+        self.assertEqual(pull_request.head_ref, "feature-42")
+        self.assertEqual(pull_request.head_repository, "cbusillo/sellyouroutboard")
         self.assertEqual(pull_request.base_sha, "base-42")
+        self.assertEqual(pull_request.base_ref, "main")
+        self.assertEqual(pull_request.base_repository, "cbusillo/sellyouroutboard")
         self.assertEqual(pull_request.mergeable, "mergeable")
         self.assertEqual(pull_request.required_checks_status, "pass")
         self.assertFalse(pull_request.branch_update_required)
+        self.assertEqual(snapshot.pull_requests[1].number, 43)
+        self.assertEqual(snapshot.pull_requests[1].base_ref, "feature-root")
         self.assertEqual(snapshot.base_sha, "base-main-current")
         self.assertEqual(
             [request.path for request in transport.requests],
             [
                 "/repos/cbusillo/sellyouroutboard/branches/main",
-                "/repos/cbusillo/sellyouroutboard/pulls?state=open&base=main&sort=created&direction=asc&per_page=100&page=1",
+                "/repos/cbusillo/sellyouroutboard/pulls?state=open&sort=created&direction=asc&per_page=100&page=1",
                 "/repos/cbusillo/sellyouroutboard/pulls/42",
                 "/repos/cbusillo/sellyouroutboard/collaborators/cbusillo/permission",
                 "/repos/cbusillo/sellyouroutboard/commits/head-42/status",
                 "/repos/cbusillo/sellyouroutboard/commits/head-42/check-runs?per_page=100&page=1",
+                "/repos/cbusillo/sellyouroutboard/pulls/43",
+                "/repos/cbusillo/sellyouroutboard/collaborators/cbusillo/permission",
+                "/repos/cbusillo/sellyouroutboard/commits/head-43/status",
+                "/repos/cbusillo/sellyouroutboard/commits/head-43/check-runs?per_page=100&page=1",
             ],
         )
+        self.assertNotIn("/pulls/44", "\n".join(request.path for request in transport.requests))
 
     def test_snapshot_reader_downgrades_missing_collaborator_permission_to_unknown(
         self,
@@ -487,7 +636,7 @@ class GitHubMergeTrainSnapshotReaderTests(unittest.TestCase):
             responses=(_github_branch(), [{"number": 1}])
         )
 
-        with self.assertRaisesRegex(MergeTrainGitHubError, "head"):
+        with self.assertRaisesRegex(MergeTrainGitHubError, "base"):
             GitHubMergeTrainSnapshotReader(transport=transport).read_merge_train_snapshot(
                 repository="cbusillo/sellyouroutboard", base_branch="main"
             )
@@ -499,7 +648,14 @@ def _github_pull_request(
     mergeable: bool | None = True,
     mergeable_state: str = "clean",
     author_association: str = "COLLABORATOR",
+    head_ref: str | None = None,
+    base_ref: str = "main",
+    repository: str = "cbusillo/sellyouroutboard",
+    head_repository: str = "",
+    base_repository: str = "",
 ) -> dict[str, object]:
+    normalized_head_repository = head_repository or repository
+    normalized_base_repository = base_repository or repository
     return {
         "number": number,
         "html_url": f"https://github.com/cbusillo/sellyouroutboard/pull/{number}",
@@ -510,8 +666,16 @@ def _github_pull_request(
         "labels": [{"name": "ready-to-merge"}],
         "user": {"login": "cbusillo"},
         "author_association": author_association,
-        "head": {"sha": f"head-{number}"},
-        "base": {"sha": f"base-{number}"},
+        "head": {
+            "sha": f"head-{number}",
+            "ref": head_ref or f"feature-{number}",
+            "repo": {"full_name": normalized_head_repository},
+        },
+        "base": {
+            "sha": f"base-{number}",
+            "ref": base_ref,
+            "repo": {"full_name": normalized_base_repository},
+        },
         "mergeable": mergeable,
         "mergeable_state": mergeable_state,
     }

--- a/tests/test_merge_train_stack_collapse.py
+++ b/tests/test_merge_train_stack_collapse.py
@@ -1,0 +1,402 @@
+import unittest
+
+from control_plane.contracts.merge_train_stack_collapse import (
+    MergeTrainStackCollapsePlan,
+    build_merge_train_stack_collapse_id,
+    build_merge_train_stack_collapse_plan,
+    build_merge_train_stack_collapse_plan_record,
+    execute_merge_train_stack_collapse_plan,
+    reconcile_merge_train_stack_children_after_root_landing,
+)
+from control_plane.merge_train import (
+    MergeTrainDryRunSnapshot,
+    MergeTrainPullRequestSnapshot,
+    discover_merge_train_stack,
+)
+
+
+class MergeTrainStackCollapseContractTests(unittest.TestCase):
+    def test_collapse_id_is_deterministic(self) -> None:
+        first = build_merge_train_stack_collapse_id(
+            repository="example/merge-train-repo",
+            base_branch="main",
+            root_pull_request_number=10,
+            entry_head_shas=("head-10", "head-11"),
+        )
+        second = build_merge_train_stack_collapse_id(
+            repository="example/merge-train-repo",
+            base_branch="main",
+            root_pull_request_number=10,
+            entry_head_shas=("head-10", "head-11"),
+        )
+
+        self.assertEqual(first, second)
+        self.assertTrue(first.startswith("merge-train-stack-collapse-example-merge-train-repo-main-"))
+
+    def test_plan_uses_root_ready_to_merge_intent_and_leaf_to_root_mutations(self) -> None:
+        discovery_result = discover_merge_train_stack(
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="example/merge-train-repo",
+                base_branch="main",
+                pull_requests=(
+                    _pull_request(10, head_ref="feature/root", base_ref="main"),
+                    _pull_request(11, head_ref="feature/middle", base_ref="feature/root"),
+                    _pull_request(12, head_ref="feature/leaf", base_ref="feature/middle"),
+                ),
+            ),
+            root_pull_request_number=10,
+        )
+
+        plan = build_merge_train_stack_collapse_plan(
+            discovery_result=discovery_result,
+            policy_key="example/merge-train-repo:main",
+            policy_sha256="policy-sha",
+            created_at="2026-05-14T13:30:00Z",
+        )
+
+        self.assertEqual(plan.intent_source, "root_ready_to_merge")
+        self.assertEqual(plan.status, "planned")
+        self.assertEqual(plan.root_pull_request_number, 10)
+        self.assertEqual(plan.root_initial_head_sha, "head-10")
+        self.assertEqual([entry.pull_request_number for entry in plan.entries], [10, 11, 12])
+        self.assertEqual(
+            [
+                (mutation.child_pull_request_number, mutation.parent_pull_request_number)
+                for mutation in plan.mutations
+            ],
+            [(11, 10), (12, 11)],
+        )
+        self.assertEqual(plan.mutations[0].expected_parent_head_sha, "head-10")
+        self.assertEqual(plan.mutations[1].expected_parent_head_sha, "head-11")
+
+    def test_plan_requires_a_ready_stack_discovery_result(self) -> None:
+        discovery_result = discover_merge_train_stack(
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="example/merge-train-repo",
+                base_branch="main",
+                pull_requests=(
+                    _pull_request(20, head_ref="feature/root", base_ref="main"),
+                ),
+            ),
+            root_pull_request_number=20,
+        )
+
+        with self.assertRaisesRegex(ValueError, "requires a discovered stack"):
+            build_merge_train_stack_collapse_plan(
+                discovery_result=discovery_result,
+                policy_key="example/merge-train-repo:main",
+                policy_sha256="policy-sha",
+                created_at="2026-05-14T13:30:00Z",
+            )
+
+    def test_plan_record_id_is_deterministic(self) -> None:
+        plan = build_merge_train_stack_collapse_plan(
+            discovery_result=discover_merge_train_stack(
+                snapshot=MergeTrainDryRunSnapshot(
+                    repository="example/merge-train-repo",
+                    base_branch="main",
+                    pull_requests=(
+                        _pull_request(30, head_ref="feature/root", base_ref="main"),
+                        _pull_request(31, head_ref="feature/child", base_ref="feature/root"),
+                    ),
+                ),
+                root_pull_request_number=30,
+            ),
+            policy_key="example/merge-train-repo:main",
+            policy_sha256="policy-sha",
+            created_at="2026-05-14T13:30:00Z",
+        )
+
+        first = build_merge_train_stack_collapse_plan_record(
+            plan=plan,
+            source="test",
+            updated_at="2026-05-14T13:31:00Z",
+        )
+        second = build_merge_train_stack_collapse_plan_record(
+            plan=plan,
+            source="test",
+            updated_at="2026-05-14T13:31:00Z",
+        )
+
+        self.assertEqual(first.record_id, second.record_id)
+        self.assertEqual(first.plan.collapse_id, plan.collapse_id)
+        self.assertTrue(first.record_id.startswith("merge-train-stack-collapse-plan-"))
+
+    def test_plan_record_id_canonicalizes_equivalent_utc_timestamps(self) -> None:
+        plan = build_merge_train_stack_collapse_plan(
+            discovery_result=discover_merge_train_stack(
+                snapshot=MergeTrainDryRunSnapshot(
+                    repository="example/merge-train-repo",
+                    base_branch="main",
+                    pull_requests=(
+                        _pull_request(40, head_ref="feature/root", base_ref="main"),
+                        _pull_request(41, head_ref="feature/child", base_ref="feature/root"),
+                    ),
+                ),
+                root_pull_request_number=40,
+            ),
+            policy_key="example/merge-train-repo:main",
+            policy_sha256="policy-sha",
+            created_at="2026-05-14T13:30:00Z",
+        )
+
+        zulu_record = build_merge_train_stack_collapse_plan_record(
+            plan=plan,
+            source="test",
+            updated_at="2026-05-14T13:31:00Z",
+        )
+        offset_record = build_merge_train_stack_collapse_plan_record(
+            plan=plan,
+            source="test",
+            updated_at="2026-05-14T09:31:00-04:00",
+        )
+
+        self.assertEqual(zulu_record.record_id, offset_record.record_id)
+        self.assertTrue(
+            zulu_record.record_id.startswith(
+                "merge-train-stack-collapse-plan-20260514T133100Z-"
+            )
+        )
+
+    def test_execute_plan_mutates_each_child_into_its_parent_branch(self) -> None:
+        plan = _collapse_plan()
+        branch_client = _RecordingStackCollapseBranchClient(
+            merge_commit_shas=("merge-31-30", "merge-32-31")
+        )
+
+        executed_plan = execute_merge_train_stack_collapse_plan(
+            plan=plan,
+            branch_client=branch_client,
+            updated_at="2026-05-14T13:45:00Z",
+        )
+
+        self.assertEqual(executed_plan.status, "waiting_for_root_checks")
+        self.assertEqual(
+            [mutation.status for mutation in executed_plan.mutations],
+            ["mutated", "mutated"],
+        )
+        self.assertEqual(
+            [mutation.merge_commit_sha for mutation in executed_plan.mutations],
+            ["merge-31-30", "merge-32-31"],
+        )
+        self.assertEqual(
+            branch_client.requests,
+            [
+                {
+                    "repository": "example/merge-train-repo",
+                    "child_head_sha": "head-31",
+                    "expected_parent_head_sha": "head-30",
+                    "parent_head_ref": "feature/root",
+                    "collapse_id": plan.collapse_id,
+                    "child_pull_request_number": 31,
+                    "parent_pull_request_number": 30,
+                },
+                {
+                    "repository": "example/merge-train-repo",
+                    "child_head_sha": "head-32",
+                    "expected_parent_head_sha": "head-31",
+                    "parent_head_ref": "feature/child",
+                    "collapse_id": plan.collapse_id,
+                    "child_pull_request_number": 32,
+                    "parent_pull_request_number": 31,
+                },
+            ],
+        )
+
+    def test_execute_plan_blocks_at_first_failed_mutation(self) -> None:
+        plan = _collapse_plan()
+        branch_client = _RecordingStackCollapseBranchClient(
+            merge_commit_shas=("merge-31-30",),
+            failure=RuntimeError("parent branch moved"),
+        )
+
+        executed_plan = execute_merge_train_stack_collapse_plan(
+            plan=plan,
+            branch_client=branch_client,
+            updated_at="2026-05-14T13:45:00Z",
+        )
+
+        self.assertEqual(executed_plan.status, "blocked")
+        self.assertEqual(
+            [mutation.status for mutation in executed_plan.mutations],
+            ["mutated", "blocked"],
+        )
+        self.assertEqual(executed_plan.mutations[1].detail, "parent branch moved")
+
+    def test_reconcile_children_after_root_landing_comments_labels_and_closes(self) -> None:
+        plan = execute_merge_train_stack_collapse_plan(
+            plan=_collapse_plan(),
+            branch_client=_RecordingStackCollapseBranchClient(
+                merge_commit_shas=("merge-31-30", "merge-32-31")
+            ),
+            updated_at="2026-05-14T13:45:00Z",
+        )
+        disposition_client = _RecordingStackChildDispositionClient()
+
+        reconciled_plan = reconcile_merge_train_stack_children_after_root_landing(
+            plan=plan,
+            disposition_client=disposition_client,
+            root_merge_commit_sha="root-merge-sha",
+            label="stack-landed",
+            updated_at="2026-05-14T13:50:00Z",
+        )
+
+        self.assertEqual(reconciled_plan.status, "ready_for_train")
+        self.assertEqual(
+            [disposition.status for disposition in reconciled_plan.child_dispositions],
+            ["closed", "closed"],
+        )
+        self.assertEqual(
+            [disposition.comment_url for disposition in reconciled_plan.child_dispositions],
+            [
+                "https://github.com/example/merge-train-repo/pull/31#issuecomment-1",
+                "https://github.com/example/merge-train-repo/pull/32#issuecomment-2",
+            ],
+        )
+        self.assertEqual(
+            disposition_client.closed,
+            [(31, "head-31"), (32, "head-32")],
+        )
+        self.assertEqual(disposition_client.labels, [(31, "stack-landed"), (32, "stack-landed")])
+        self.assertIn("root PR #30", disposition_client.comments[0][1])
+
+    def test_reconcile_children_blocks_at_first_failed_close(self) -> None:
+        plan = execute_merge_train_stack_collapse_plan(
+            plan=_collapse_plan(),
+            branch_client=_RecordingStackCollapseBranchClient(
+                merge_commit_shas=("merge-31-30", "merge-32-31")
+            ),
+            updated_at="2026-05-14T13:45:00Z",
+        )
+        disposition_client = _RecordingStackChildDispositionClient(
+            failure=RuntimeError("child head moved")
+        )
+
+        reconciled_plan = reconcile_merge_train_stack_children_after_root_landing(
+            plan=plan,
+            disposition_client=disposition_client,
+            root_merge_commit_sha="root-merge-sha",
+            label="stack-landed",
+            updated_at="2026-05-14T13:50:00Z",
+        )
+
+        self.assertEqual(reconciled_plan.status, "blocked")
+        self.assertEqual(
+            [disposition.status for disposition in reconciled_plan.child_dispositions],
+            ["blocked", "planned"],
+        )
+        self.assertEqual(reconciled_plan.child_dispositions[0].detail, "child head moved")
+
+
+def _pull_request(
+    number: int,
+    *,
+    head_ref: str,
+    base_ref: str,
+) -> MergeTrainPullRequestSnapshot:
+    return MergeTrainPullRequestSnapshot(
+        number=number,
+        url=f"https://github.com/example/merge-train-repo/pull/{number}",
+        title=f"Pull request {number}",
+        created_at=f"2026-05-14T13:{number % 60:02d}:00Z",
+        labels=("ready-to-merge",),
+        actor_role="repo_admin",
+        head_sha=f"head-{number}",
+        head_ref=head_ref,
+        head_repository="example/merge-train-repo",
+        base_sha=f"base-{number}",
+        base_ref=base_ref,
+        base_repository="example/merge-train-repo",
+        mergeable="mergeable",
+        required_checks_status="pass",
+    )
+
+
+def _collapse_plan() -> MergeTrainStackCollapsePlan:
+    return build_merge_train_stack_collapse_plan(
+        discovery_result=discover_merge_train_stack(
+            snapshot=MergeTrainDryRunSnapshot(
+                repository="example/merge-train-repo",
+                base_branch="main",
+                pull_requests=(
+                    _pull_request(30, head_ref="feature/root", base_ref="main"),
+                    _pull_request(31, head_ref="feature/child", base_ref="feature/root"),
+                    _pull_request(32, head_ref="feature/leaf", base_ref="feature/child"),
+                ),
+            ),
+            root_pull_request_number=30,
+        ),
+        policy_key="example/merge-train-repo:main",
+        policy_sha256="policy-sha",
+        created_at="2026-05-14T13:30:00Z",
+    )
+
+
+class _RecordingStackCollapseBranchClient:
+    def __init__(
+        self, *, merge_commit_shas: tuple[str, ...], failure: Exception | None = None
+    ) -> None:
+        self.merge_commit_shas = list(merge_commit_shas)
+        self.failure = failure
+        self.requests: list[dict[str, object]] = []
+
+    def merge_stack_child_into_parent(
+        self,
+        *,
+        repository: str,
+        child_head_sha: str,
+        expected_parent_head_sha: str,
+        parent_head_ref: str,
+        collapse_id: str,
+        child_pull_request_number: int,
+        parent_pull_request_number: int,
+    ) -> str:
+        self.requests.append(
+            {
+                "repository": repository,
+                "child_head_sha": child_head_sha,
+                "expected_parent_head_sha": expected_parent_head_sha,
+                "parent_head_ref": parent_head_ref,
+                "collapse_id": collapse_id,
+                "child_pull_request_number": child_pull_request_number,
+                "parent_pull_request_number": parent_pull_request_number,
+            }
+        )
+        if self.merge_commit_shas:
+            return self.merge_commit_shas.pop(0)
+        if self.failure is not None:
+            raise self.failure
+        raise RuntimeError("unexpected stack collapse branch mutation")
+
+
+class _RecordingStackChildDispositionClient:
+    def __init__(self, *, failure: Exception | None = None) -> None:
+        self.failure = failure
+        self.comments: list[tuple[int, str]] = []
+        self.labels: list[tuple[int, str]] = []
+        self.closed: list[tuple[int, str]] = []
+
+    def comment_pull_request(
+        self, *, repository: str, pull_request_number: int, body: str
+    ) -> str:
+        self.comments.append((pull_request_number, body))
+        return (
+            f"https://github.com/{repository}/pull/{pull_request_number}"
+            f"#issuecomment-{len(self.comments)}"
+        )
+
+    def add_pull_request_label(
+        self, *, repository: str, pull_request_number: int, label: str
+    ) -> None:
+        self.labels.append((pull_request_number, label))
+
+    def close_pull_request(
+        self, *, repository: str, pull_request_number: int, expected_head_sha: str
+    ) -> None:
+        if self.failure is not None:
+            raise self.failure
+        self.closed.append((pull_request_number, expected_head_sha))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_merge_train_worker.py
+++ b/tests/test_merge_train_worker.py
@@ -244,6 +244,7 @@ def _pull_request(
         labels=labels,
         actor_role="repo_owner",
         head_sha=f"head-{number}",
+        base_ref="main",
         base_sha="base-sha",
         mergeable=mergeable,
         required_checks_status=required_checks_status,

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -42,6 +42,14 @@ from control_plane.contracts.merge_train_batch import (
     build_merge_train_batch_id,
     build_merge_train_batch_landing_plan,
 )
+from control_plane.contracts.merge_train_stack_collapse import (
+    MergeTrainStackCollapseEntry,
+    MergeTrainStackCollapseMutation,
+    MergeTrainStackCollapsePlan,
+    MergeTrainStackCollapsePlanRecord,
+    MergeTrainStackCollapseRecordStatus,
+    build_merge_train_stack_collapse_id,
+)
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
 from control_plane.contracts.merge_train_run_record import (
     MergeTrainRunRecord,
@@ -533,6 +541,7 @@ def _merge_train_run_record(*, recorded_at: str = "2026-05-09T02:05:00Z") -> Mer
                 labels=("ready-to-merge",),
                 actor_role="repo_admin",
                 head_sha="head-42",
+                base_ref="main",
                 base_sha="base-main",
                 mergeable="mergeable",
                 required_checks_status="pass",
@@ -624,6 +633,68 @@ def _merge_train_batch_landing_plan_record(
         source="test",
         updated_at=updated_at,
         landing_plan=landing_plan,
+    )
+
+
+def _merge_train_stack_collapse_plan_record(
+    *,
+    record_id: str = "merge-train-stack-collapse-plan-20260514T013000Z-active",
+    status: MergeTrainStackCollapseRecordStatus = "active",
+    updated_at: str = "2026-05-14T01:30:00Z",
+) -> MergeTrainStackCollapsePlanRecord:
+    repository = "example/merge-train-repo"
+    base_branch = "main"
+    entries = (
+        MergeTrainStackCollapseEntry(
+            pull_request_number=10,
+            position=1,
+            head_sha="head-10",
+            head_ref="feature/root",
+            base_sha="base-10",
+            base_ref="main",
+        ),
+        MergeTrainStackCollapseEntry(
+            pull_request_number=11,
+            position=2,
+            head_sha="head-11",
+            head_ref="feature/child",
+            base_sha="base-11",
+            base_ref="feature/root",
+        ),
+    )
+    collapse_id = build_merge_train_stack_collapse_id(
+        repository=repository,
+        base_branch=base_branch,
+        root_pull_request_number=10,
+        entry_head_shas=tuple(entry.head_sha for entry in entries),
+    )
+    return MergeTrainStackCollapsePlanRecord(
+        record_id=record_id,
+        status=status,
+        source="test",
+        updated_at=updated_at,
+        plan=MergeTrainStackCollapsePlan(
+            collapse_id=collapse_id,
+            repository=repository,
+            base_branch=base_branch,
+            root_pull_request_number=10,
+            root_initial_head_sha="head-10",
+            root_head_ref="feature/root",
+            policy_key=f"{repository}:{base_branch}",
+            policy_sha256="policy-digest",
+            entries=entries,
+            mutations=(
+                MergeTrainStackCollapseMutation(
+                    child_pull_request_number=11,
+                    parent_pull_request_number=10,
+                    child_head_sha="head-11",
+                    expected_parent_head_sha="head-10",
+                    parent_head_ref="feature/root",
+                ),
+            ),
+            created_at="2026-05-14T01:29:00Z",
+            updated_at=updated_at,
+        ),
     )
 
 
@@ -1803,6 +1874,33 @@ env_var = "GH_TOKEN"
         self.assertEqual(listed_records[0].landing_plan.entries[0].merge_method, "squash")
         self.assertEqual(listed_records[0].landing_plan.entries[1].pull_request_number, 11)
 
+    def test_merge_train_stack_collapse_plan_records_round_trip(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            older_record = _merge_train_stack_collapse_plan_record(
+                record_id="merge-train-stack-collapse-plan-20260514T012900Z-old",
+                status="superseded",
+                updated_at="2026-05-14T01:29:00Z",
+            )
+            active_record = _merge_train_stack_collapse_plan_record()
+            store.write_merge_train_stack_collapse_plan_record(older_record)
+            store.write_merge_train_stack_collapse_plan_record(active_record)
+            listed_records = store.list_merge_train_stack_collapse_plan_records(
+                repository="example/merge-train-repo",
+                base_branch="main",
+                status="active",
+            )
+            store.close()
+
+        self.assertEqual([record.record_id for record in listed_records], [active_record.record_id])
+        self.assertEqual(listed_records[0].plan.intent_source, "root_ready_to_merge")
+        self.assertEqual(listed_records[0].plan.mutations[0].parent_pull_request_number, 10)
+
     def test_write_and_list_dokploy_target_id_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(
@@ -2205,6 +2303,9 @@ env_var = "GH_TOKEN"
             filesystem_store.write_merge_train_batch_landing_plan_record(
                 _merge_train_batch_landing_plan_record()
             )
+            filesystem_store.write_merge_train_stack_collapse_plan_record(
+                _merge_train_stack_collapse_plan_record()
+            )
 
             counts = store.import_core_records_from_filesystem(filesystem_store)
             self.assertEqual(
@@ -2229,6 +2330,7 @@ env_var = "GH_TOKEN"
                     "agent_write_intents": 0,
                     "merge_train_batch_candidates": 1,
                     "merge_train_batch_landing_plans": 1,
+                    "merge_train_stack_collapse_plans": 1,
                     "merge_train_policies": 1,
                     "merge_train_runs": 1,
                     "release_tuples": 1,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -236,6 +236,29 @@ class _FakeMergeTrainGitHubClient:
             }
         )
 
+    def merge_stack_child_into_parent(
+        self,
+        *,
+        repository: str,
+        child_head_sha: str,
+        expected_parent_head_sha: str,
+        parent_head_ref: str,
+        collapse_id: str,
+        child_pull_request_number: int,
+        parent_pull_request_number: int,
+    ) -> str:
+        return f"stack-merge-{child_pull_request_number}-into-{parent_pull_request_number}"
+
+    def comment_pull_request(
+        self, *, repository: str, pull_request_number: int, body: str
+    ) -> str:
+        return f"https://github.com/{repository}/pull/{pull_request_number}#issuecomment-1"
+
+    def close_pull_request(
+        self, *, repository: str, pull_request_number: int, expected_head_sha: str
+    ) -> None:
+        return None
+
 
 class _NoopMergeTrainGitHubClient:
     def add_pull_request_label(
@@ -279,11 +302,82 @@ class _FakeMergeTrainSnapshotReader:
                     labels=("ready-to-merge",),
                     actor_role="repo_admin",
                     head_sha="head-1",
+                    head_ref="feature/root",
+                    head_repository=repository,
+                    base_ref=base_branch,
+                    base_repository=repository,
                     base_sha="base-main",
                     mergeable="mergeable",
                     required_checks_status="pass",
                 ),
             ),
+        )
+
+
+class _FakeStackedMergeTrainSnapshotReader:
+    def __init__(self, *, transport: object) -> None:
+        self.transport = transport
+
+    def read_merge_train_snapshot(
+        self, *, repository: str, base_branch: str
+    ) -> MergeTrainDryRunSnapshot:
+        return MergeTrainDryRunSnapshot(
+            repository=repository,
+            base_branch=base_branch,
+            base_sha="current-base-main",
+            pull_requests=(
+                MergeTrainPullRequestSnapshot(
+                    number=1,
+                    url=f"https://github.com/{repository}/pull/1",
+                    title="Root PR",
+                    created_at="2026-05-08T10:00:00Z",
+                    labels=("ready-to-merge",),
+                    actor_role="repo_admin",
+                    head_sha="head-root",
+                    head_ref="feature/root",
+                    head_repository=repository,
+                    base_ref=base_branch,
+                    base_repository=repository,
+                    base_sha="base-main",
+                    mergeable="mergeable",
+                    required_checks_status="pass",
+                ),
+                MergeTrainPullRequestSnapshot(
+                    number=2,
+                    url=f"https://github.com/{repository}/pull/2",
+                    title="Stacked child PR",
+                    created_at="2026-05-08T11:00:00Z",
+                    labels=(),
+                    actor_role="repo_admin",
+                    head_sha="head-child",
+                    head_ref="feature/child",
+                    head_repository=repository,
+                    base_ref="feature/root",
+                    base_repository=repository,
+                    base_sha="head-root",
+                    mergeable="mergeable",
+                    required_checks_status="pending",
+                ),
+            ),
+        )
+
+
+class _FakeMovedRootStackedMergeTrainSnapshotReader(_FakeStackedMergeTrainSnapshotReader):
+    def read_merge_train_snapshot(
+        self, *, repository: str, base_branch: str
+    ) -> MergeTrainDryRunSnapshot:
+        snapshot = super().read_merge_train_snapshot(
+            repository=repository, base_branch=base_branch
+        )
+        return snapshot.model_copy(
+            update={
+                "pull_requests": tuple(
+                    pull_request.model_copy(update={"head_sha": "moved-root-head"})
+                    if pull_request.number == 1
+                    else pull_request
+                    for pull_request in snapshot.pull_requests
+                )
+            }
         )
 
 
@@ -341,6 +435,7 @@ def _merge_train_run_record(
                 labels=("ready-to-merge",),
                 actor_role="repo_admin",
                 head_sha="head-1",
+                base_ref="main",
                 base_sha="base-main",
                 mergeable="mergeable",
                 required_checks_status=required_checks_status,
@@ -1596,6 +1691,340 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(listed_records[0].record_id, record_id)
         self.assertEqual(listed_records[0].candidate.policy_key, "cbusillo/sellyouroutboard:main")
 
+    def test_merge_train_batch_candidate_service_plans_stack_collapse_first(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                _FakeStackedMergeTrainSnapshotReader,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+            record_id = payload["records"]["merge_train_stack_collapse_plan_record_id"]
+            store = FilesystemRecordStore(state_dir)
+            stack_records = store.list_merge_train_stack_collapse_plan_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+            candidate_records = store.list_merge_train_batch_candidate_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "plan")
+        self.assertNotIn("candidate", payload["result"])
+        self.assertEqual(payload["result"]["stack_collapse_plan"]["status"], "planned")
+        self.assertEqual(
+            [
+                entry["pull_request_number"]
+                for entry in payload["result"]["stack_collapse_plan"]["entries"]
+            ],
+            [1, 2],
+        )
+        self.assertEqual(stack_records[0].record_id, record_id)
+        self.assertEqual(stack_records[0].plan.root_pull_request_number, 1)
+        self.assertEqual(stack_records[0].plan.mutations[0].child_pull_request_number, 2)
+        self.assertEqual(stack_records[0].plan.mutations[0].parent_pull_request_number, 1)
+        self.assertEqual(candidate_records, ())
+
+    def test_merge_train_stack_collapse_service_executes_existing_plan_record(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                _FakeStackedMergeTrainSnapshotReader,
+            ):
+                _, plan_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+            plan_record_id = plan_payload["records"]["merge_train_stack_collapse_plan_record_id"]
+            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "stack_collapse_plan_record_id": plan_record_id,
+                    },
+                )
+            executed_record_id = payload["records"]["merge_train_stack_collapse_plan_record_id"]
+            executed_records = FilesystemRecordStore(
+                state_dir
+            ).list_merge_train_stack_collapse_plan_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+            executed_record = next(
+                record for record in executed_records if record.record_id == executed_record_id
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "execute")
+        self.assertEqual(payload["result"]["stack_collapse_plan"]["status"], "waiting_for_root_checks")
+        self.assertEqual(
+            payload["result"]["stack_collapse_plan"]["mutations"][0]["status"], "mutated"
+        )
+        self.assertEqual(
+            payload["result"]["stack_collapse_plan"]["mutations"][0]["merge_commit_sha"],
+            "stack-merge-2-into-1",
+        )
+        self.assertEqual(executed_record.plan.status, "waiting_for_root_checks")
+
+    def test_merge_train_stack_collapse_service_admits_executed_root_only(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                _FakeStackedMergeTrainSnapshotReader,
+            ):
+                _, plan_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+            plan_record_id = plan_payload["records"]["merge_train_stack_collapse_plan_record_id"]
+            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
+                _, execute_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "execute",
+                        "stack_collapse_plan_record_id": plan_record_id,
+                    },
+                )
+            executed_record_id = execute_payload["records"][
+                "merge_train_stack_collapse_plan_record_id"
+            ]
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                _FakeStackedMergeTrainSnapshotReader,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "admit",
+                        "stack_collapse_plan_record_id": executed_record_id,
+                    },
+                )
+            candidate_record_id = payload["records"]["merge_train_batch_candidate_record_id"]
+            candidate_records = FilesystemRecordStore(
+                state_dir
+            ).list_merge_train_batch_candidate_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "admit")
+        self.assertEqual(payload["result"]["candidate"]["entries"][0]["pull_request_number"], 1)
+        self.assertEqual(len(payload["result"]["candidate"]["entries"]), 1)
+        candidate_record = next(
+            record for record in candidate_records if record.record_id == candidate_record_id
+        )
+        self.assertEqual(candidate_record.candidate.entries[0].pull_request_number, 1)
+
+    def test_merge_train_stack_collapse_service_rejects_admit_when_root_head_moves(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                _FakeStackedMergeTrainSnapshotReader,
+            ):
+                _, plan_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+            plan_record_id = plan_payload["records"]["merge_train_stack_collapse_plan_record_id"]
+            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
+                _, execute_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "execute",
+                        "stack_collapse_plan_record_id": plan_record_id,
+                    },
+                )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                _FakeMovedRootStackedMergeTrainSnapshotReader,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "admit",
+                        "stack_collapse_plan_record_id": execute_payload["records"][
+                            "merge_train_stack_collapse_plan_record_id"
+                        ],
+                    },
+                )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+
+    def test_merge_train_stack_collapse_service_rejects_admit_when_policy_digest_changes(
+        self,
+    ) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                _FakeStackedMergeTrainSnapshotReader,
+            ):
+                _, plan_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+            plan_record_id = plan_payload["records"]["merge_train_stack_collapse_plan_record_id"]
+            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
+                _, execute_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "execute",
+                        "stack_collapse_plan_record_id": plan_record_id,
+                    },
+                )
+            _seed_merge_train_policy(
+                state_dir,
+                policy=MergeTrainPolicyRecord(
+                    record_id="merge-train-policy-20260513T220000Z-test",
+                    status="active",
+                    source="test",
+                    updated_at="2026-05-13T22:00:00Z",
+                    policy=build_test_merge_train_policy_with_codex_skills(),
+                ),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                _FakeStackedMergeTrainSnapshotReader,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "admit",
+                        "stack_collapse_plan_record_id": execute_payload["records"][
+                            "merge_train_stack_collapse_plan_record_id"
+                        ],
+                    },
+                )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+
     def test_merge_train_batch_candidate_service_builds_existing_candidate_record(self) -> None:
         with (
             TemporaryDirectory() as temporary_directory_name,
@@ -1881,6 +2310,149 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["result"]["landing_plan"]["entries"][0]["status"], "merged")
         self.assertEqual(
             payload["result"]["landing_plan"]["entries"][0]["merge_commit_sha"], "merge-1"
+        )
+
+    def test_merge_train_batch_landing_service_closes_stack_children_after_root_lands(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                _FakeStackedMergeTrainSnapshotReader,
+            ):
+                _, plan_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+            plan_record_id = plan_payload["records"]["merge_train_stack_collapse_plan_record_id"]
+            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
+                _, execute_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "execute",
+                        "stack_collapse_plan_record_id": plan_record_id,
+                    },
+                )
+            executed_record_id = execute_payload["records"][
+                "merge_train_stack_collapse_plan_record_id"
+            ]
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                _FakeStackedMergeTrainSnapshotReader,
+            ):
+                _, admit_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "admit",
+                        "stack_collapse_plan_record_id": executed_record_id,
+                    },
+                )
+            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
+                _, build_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "build",
+                        "candidate_record_id": admit_payload["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+                _, observe_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "observe",
+                        "candidate_record_id": build_payload["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+                _, landing_plan_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-landing/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                        "candidate_record_id": observe_payload["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-landing/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "land",
+                        "landing_plan_record_id": landing_plan_payload["records"][
+                            "merge_train_batch_landing_plan_record_id"
+                        ],
+                        "stack_collapse_plan_record_id": executed_record_id,
+                    },
+                )
+            disposition_record_id = payload["records"][
+                "merge_train_stack_collapse_plan_record_id"
+            ]
+            stack_records = FilesystemRecordStore(
+                state_dir
+            ).list_merge_train_stack_collapse_plan_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+            disposition_record = next(
+                record for record in stack_records if record.record_id == disposition_record_id
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["stack_collapse_plan"]["status"], "ready_for_train")
+        self.assertEqual(
+            payload["result"]["stack_collapse_plan"]["child_dispositions"][0]["status"],
+            "closed",
+        )
+        self.assertEqual(disposition_record.plan.child_dispositions[0].status, "closed")
+        self.assertEqual(
+            disposition_record.plan.child_dispositions[0].comment_url,
+            "https://github.com/cbusillo/sellyouroutboard/pull/2#issuecomment-1",
         )
 
     def test_merge_train_admission_service_uses_configured_codex_skills_policy(self) -> None:


### PR DESCRIPTION
## Summary

- add DB-backed stack-collapse plan records for merge train stacked PR handling
- detect same-repo linear stacks during batch candidate planning and plan collapse before admitting the root PR
- execute stored collapse plans with SHA guards, admit only the checked root PR, and close child PRs after root landing

## Validation

- `uv run python -m unittest tests.test_merge_train tests.test_merge_train_github tests.test_merge_train_batch tests.test_merge_train_worker tests.test_merge_train_admission tests.test_service tests.test_postgres_store tests.test_filesystem_store tests.test_merge_train_stack_collapse`
- `uv run --extra dev ruff check control_plane/service.py control_plane/merge_train.py control_plane/merge_train_github.py control_plane/contracts/merge_train_stack_collapse.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/d289e3ab4012_add_merge_train_stack_collapse_plans.py tests/test_service.py tests/test_merge_train.py tests/test_merge_train_github.py tests/test_merge_train_batch.py tests/test_merge_train_worker.py tests/test_merge_train_admission.py tests/test_postgres_store.py tests/test_filesystem_store.py tests/test_merge_train_stack_collapse.py`
- `uv run --extra dev mypy control_plane tests`
- PyCharm changed-files inspection: only pre-existing weak warnings in `control_plane/contracts/merge_train_batch.py`

Refs #614
