### PR TITLE
Expose Launchplane image reference at runtime

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     command:
       - /app/scripts/start-launchplane-service.sh
     environment:
+      DOCKER_IMAGE_REFERENCE: ${DOCKER_IMAGE_REFERENCE:-launchplane:local}
       LAUNCHPLANE_SERVICE_AUDIENCE: ${LAUNCHPLANE_SERVICE_AUDIENCE:-localhost}
       LAUNCHPLANE_SERVICE_HOST: 0.0.0.0
       LAUNCHPLANE_SERVICE_PORT: 8080

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -2117,6 +2117,17 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
 
         self.assertEqual(rendered, "KEEP=1\nADD=2")
 
+    def test_launchplane_compose_exports_runtime_image_reference(self) -> None:
+        compose_text = Path("docker-compose.yml").read_text()
+
+        self.assertIn(
+            "image: ${DOCKER_IMAGE_REFERENCE:-launchplane:local}", compose_text
+        )
+        self.assertIn(
+            "DOCKER_IMAGE_REFERENCE: ${DOCKER_IMAGE_REFERENCE:-launchplane:local}",
+            compose_text,
+        )
+
     def test_render_odoo_raw_compose_file_pins_artifact_image_and_services(self) -> None:
         compose_file = control_plane_dokploy.render_odoo_raw_compose_file(
             image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",


### PR DESCRIPTION
## Summary
- export `DOCKER_IMAGE_REFERENCE` into the Launchplane compose service environment
- add a regression test that keeps the compose image interpolation and runtime env export aligned

## Why
The #615 deploy was accepted by Dokploy and reported `done`, but the deploy workflow timed out waiting for `/v1/service/runtime` to report the new image digest. The runtime endpoint reads `DOCKER_IMAGE_REFERENCE` from the process environment, while the compose file previously used that value only for `image:` interpolation. Passing it into the container makes the readiness check verify the digest that compose actually launched.

## Validation
- `docker compose config --quiet`
- `uv run python -m unittest tests.test_dokploy.LaunchplaneServiceDeployTests`
- `uv run --extra dev ruff check tests/test_dokploy.py`
- PyCharm inspection on `tests/test_dokploy.py` only reported existing broad test-file warnings
