### PR TITLE
Guard stack-collapse landing evidence

### DIFF
--- a/control_plane/contracts/merge_train_stack_collapse.py
+++ b/control_plane/contracts/merge_train_stack_collapse.py
@@ -209,13 +209,18 @@ def execute_merge_train_stack_collapse_plan(
     if plan.status not in {"planned", "collapsing"}:
         raise ValueError("merge train stack collapse plan is not executable")
     updated_mutations: list[MergeTrainStackCollapseMutation] = []
+    current_head_shas = {
+        entry.pull_request_number: entry.head_sha for entry in plan.entries
+    }
     current_status: MergeTrainStackCollapseStatus = "waiting_for_root_checks"
     for mutation in plan.mutations:
+        child_head_sha = current_head_shas[mutation.child_pull_request_number]
+        expected_parent_head_sha = current_head_shas[mutation.parent_pull_request_number]
         try:
             merge_commit_sha = branch_client.merge_stack_child_into_parent(
                 repository=plan.repository,
-                child_head_sha=mutation.child_head_sha,
-                expected_parent_head_sha=mutation.expected_parent_head_sha,
+                child_head_sha=child_head_sha,
+                expected_parent_head_sha=expected_parent_head_sha,
                 parent_head_ref=mutation.parent_head_ref,
                 collapse_id=plan.collapse_id,
                 child_pull_request_number=mutation.child_pull_request_number,
@@ -235,12 +240,15 @@ def execute_merge_train_stack_collapse_plan(
         updated_mutations.append(
             mutation.model_copy(
                 update={
+                    "child_head_sha": child_head_sha,
+                    "expected_parent_head_sha": expected_parent_head_sha,
                     "status": "mutated",
                     "merge_commit_sha": merge_commit_sha,
                     "detail": "child head merged into parent feature branch",
                 }
             )
         )
+        current_head_shas[mutation.parent_pull_request_number] = merge_commit_sha
     if len(updated_mutations) < len(plan.mutations):
         updated_mutations.extend(plan.mutations[len(updated_mutations) :])
     return plan.model_copy(
@@ -339,6 +347,7 @@ def build_merge_train_stack_collapse_plan(
     )
     if not entries:
         raise ValueError("merge train stack collapse plan requires entries")
+    parent_child_pairs = tuple(zip(entries, entries[1:]))
     mutations = tuple(
         MergeTrainStackCollapseMutation(
             child_pull_request_number=child.pull_request_number,
@@ -347,7 +356,7 @@ def build_merge_train_stack_collapse_plan(
             expected_parent_head_sha=parent.head_sha,
             parent_head_ref=parent.head_ref,
         )
-        for parent, child in zip(entries, entries[1:])
+        for parent, child in reversed(parent_child_pairs)
     )
     child_dispositions = tuple(
         MergeTrainStackChildDisposition(
@@ -462,8 +471,12 @@ def _normalize_mutations(
     if len(mutations) != len(entries) - 1:
         raise ValueError("merge train stack collapse mutations must connect each stack layer")
     expected_pairs = tuple(
-        (child.pull_request_number, parent.pull_request_number)
-        for parent, child in zip(entries, entries[1:])
+        reversed(
+            tuple(
+                (child.pull_request_number, parent.pull_request_number)
+                for parent, child in zip(entries, entries[1:])
+            )
+        )
     )
     actual_pairs = tuple(
         (mutation.child_pull_request_number, mutation.parent_pull_request_number)

--- a/control_plane/merge_train_github.py
+++ b/control_plane/merge_train_github.py
@@ -229,15 +229,12 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
         self, *, repository: str, pull_request_number: int, expected_head_sha: str
     ) -> None:
         repository_path = _repository_path(repository)
-        pull_request = _json_object(
-            self.transport.request(
-                method="GET", path=f"/repos/{repository_path}/pulls/{pull_request_number}"
-            ),
-            "GitHub pull request detail response",
+        pull_request_path = f"/repos/{repository_path}/pulls/{pull_request_number}"
+        expected_sha = _required_value(
+            expected_head_sha, "Expected pull request head SHA is required."
         )
-        head = _json_object(pull_request.get("head"), "GitHub pull request head")
-        current_head_sha = _required_text(
-            head.get("sha"), "GitHub pull request head requires sha."
+        current_head_sha = self._pull_request_head_sha(
+            pull_request_path=pull_request_path
         )
         if current_head_sha != _required_value(
             expected_head_sha, "Expected pull request head SHA is required."
@@ -248,9 +245,15 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
             )
         self.transport.request(
             method="PATCH",
-            path=f"/repos/{repository_path}/pulls/{pull_request_number}",
+            path=pull_request_path,
             body={"state": "closed"},
         )
+        closed_head_sha = self._pull_request_head_sha(pull_request_path=pull_request_path)
+        if closed_head_sha != expected_sha:
+            raise MergeTrainGitHubStaleHeadError(
+                "Stack child PR moved while Launchplane was closing it.",
+                status_code=409,
+            )
 
     def merge_stack_child_into_parent(
         self,
@@ -317,6 +320,14 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
                 path=f"/repos/{repository_path}/git/refs/{reference_path}",
                 body={"sha": normalized_sha, "force": True},
             )
+
+    def _pull_request_head_sha(self, *, pull_request_path: str) -> str:
+        pull_request = _json_object(
+            self.transport.request(method="GET", path=pull_request_path),
+            "GitHub pull request detail response",
+        )
+        head = _json_object(pull_request.get("head"), "GitHub pull request head")
+        return _required_text(head.get("sha"), "GitHub pull request head requires sha.")
 
 
 class GitHubMergeTrainSnapshotReader:

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -79,6 +79,7 @@ from control_plane.contracts.idempotency_record import build_launchplane_idempot
 from control_plane.contracts.merge_train_batch import (
     MergeTrainBatchCandidate,
     MergeTrainBatchCandidateRecord,
+    MergeTrainBatchLandingPlan,
     MergeTrainBatchLandingPlanRecord,
     build_merge_train_batch_candidate,
     build_merge_train_batch_candidate_record,
@@ -2623,6 +2624,48 @@ def _read_merge_train_stack_collapse_plan_record(
         if record.record_id == record_id:
             return record
     raise ValueError("merge train stack collapse plan record not found")
+
+
+def _validate_stack_collapse_record_for_landing(
+    *,
+    collapse_record: MergeTrainStackCollapsePlanRecord,
+    landing_plan: MergeTrainBatchLandingPlan,
+    policy_sha256: str,
+) -> None:
+    stack_collapse_plan = collapse_record.plan
+    if stack_collapse_plan.repository != landing_plan.repository:
+        raise ValueError("merge train stack collapse repository does not match landing plan")
+    if stack_collapse_plan.base_branch != landing_plan.base_branch:
+        raise ValueError("merge train stack collapse base branch does not match landing plan")
+    if stack_collapse_plan.policy_key != landing_plan.policy_key:
+        raise ValueError("merge train stack collapse policy key does not match landing plan")
+    if stack_collapse_plan.policy_sha256 != policy_sha256:
+        raise ValueError("merge train stack collapse policy digest no longer matches")
+    if stack_collapse_plan.policy_sha256 != landing_plan.policy_sha256:
+        raise ValueError("merge train stack collapse policy digest does not match landing plan")
+    if stack_collapse_plan.status != "waiting_for_root_checks":
+        raise ValueError("merge train stack collapse plan is not ready for landing")
+    root_entry = next(
+        (
+            entry
+            for entry in landing_plan.entries
+            if entry.pull_request_number == stack_collapse_plan.root_pull_request_number
+        ),
+        None,
+    )
+    if root_entry is None:
+        raise ValueError("merge train stack collapse root PR is missing from landing plan")
+    if root_entry.expected_head_sha != _stack_collapse_expected_root_head_sha(
+        stack_collapse_plan
+    ):
+        raise ValueError("merge train stack collapse root PR head no longer matches")
+
+
+def _stack_collapse_expected_root_head_sha(plan: MergeTrainStackCollapsePlan) -> str:
+    for mutation in plan.mutations:
+        if mutation.parent_pull_request_number == plan.root_pull_request_number:
+            return mutation.merge_commit_sha or plan.root_initial_head_sha
+    return plan.root_initial_head_sha
 
 
 def _supports_every_code_work_requests(record_store: object) -> bool:
@@ -7281,6 +7324,19 @@ def create_launchplane_service_app(
                         base_branch=landing_request.base_branch,
                         record_id=landing_request.landing_plan_record_id,
                     )
+                    collapse_existing_record: MergeTrainStackCollapsePlanRecord | None = None
+                    if landing_request.stack_collapse_plan_record_id:
+                        collapse_existing_record = _read_merge_train_stack_collapse_plan_record(
+                            record_store=collapse_store,
+                            repository=landing_request.repository,
+                            base_branch=landing_request.base_branch,
+                            record_id=landing_request.stack_collapse_plan_record_id,
+                        )
+                        _validate_stack_collapse_record_for_landing(
+                            collapse_record=collapse_existing_record,
+                            landing_plan=landing_record.landing_plan,
+                            policy_sha256=policy_record.policy_sha256,
+                        )
                     transport = UrllibMergeTrainGitHubTransport(
                         token=token,
                         api_base_url=landing_request.github_api_base_url,
@@ -7289,13 +7345,7 @@ def create_launchplane_service_app(
                     landing_plan = github_client.land_batch_candidate(
                         landing_plan=landing_record.landing_plan
                     )
-                    if landing_request.stack_collapse_plan_record_id:
-                        collapse_existing_record = _read_merge_train_stack_collapse_plan_record(
-                            record_store=collapse_store,
-                            repository=landing_request.repository,
-                            base_branch=landing_request.base_branch,
-                            record_id=landing_request.stack_collapse_plan_record_id,
-                        )
+                    if collapse_existing_record is not None:
                         root_entry = next(
                             (
                                 entry
@@ -7465,7 +7515,9 @@ def create_launchplane_service_app(
                     )
                     if root_pull_request is None:
                         raise ValueError("merge train stack collapse root PR is missing")
-                    if root_pull_request.head_sha != stack_collapse_plan.root_initial_head_sha:
+                    if root_pull_request.head_sha != _stack_collapse_expected_root_head_sha(
+                        stack_collapse_plan
+                    ):
                         raise ValueError(
                             "merge train stack collapse root PR head no longer matches"
                         )

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -131,6 +131,12 @@ SHAs, mutation sequence, policy digest, and idempotency evidence remain
 auditable. Ambiguous, forked, cyclic, or unsupported branch-protection cases
 must fail closed with operator-visible reasons.
 
+Stack collapse mutates from the leaf PR back toward the root PR. Each child is
+merged into its parent feature branch, and the parent merge commit becomes the
+child head evidence for the next mutation up the stack. Launchplane admits the
+root PR only after the live root head matches the stored final root mutation
+SHA and the root passes required checks from the protected base branch.
+
 ### Blocker Isolation
 
 When the combined candidate fails checks, Launchplane must not assume all queued

--- a/tests/test_merge_train_github.py
+++ b/tests/test_merge_train_github.py
@@ -101,7 +101,11 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
 
     def test_close_pull_request_checks_head_sha_before_closing(self) -> None:
         transport = RecordingMergeTrainGitHubTransport(
-            responses=({"head": {"sha": "child-head"}}, {})
+            responses=(
+                {"head": {"sha": "child-head"}},
+                {},
+                {"head": {"sha": "child-head"}},
+            )
         )
 
         GitHubMergeTrainClient(transport=transport).close_pull_request(
@@ -115,7 +119,28 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
             [
                 ("GET", "/repos/example/merge-train-repo/pulls/11", None),
                 ("PATCH", "/repos/example/merge-train-repo/pulls/11", {"state": "closed"}),
+                ("GET", "/repos/example/merge-train-repo/pulls/11", None),
             ],
+        )
+
+    def test_close_pull_request_rejects_child_head_moved_during_close(self) -> None:
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                {"head": {"sha": "child-head"}},
+                {},
+                {"head": {"sha": "moved-child-head"}},
+            )
+        )
+
+        with self.assertRaises(MergeTrainGitHubStaleHeadError):
+            GitHubMergeTrainClient(transport=transport).close_pull_request(
+                repository="example/merge-train-repo",
+                pull_request_number=11,
+                expected_head_sha="child-head",
+            )
+
+        self.assertEqual(
+            [request.method for request in transport.requests], ["GET", "PATCH", "GET"]
         )
 
     def test_close_pull_request_rejects_moved_child_head(self) -> None:

--- a/tests/test_merge_train_stack_collapse.py
+++ b/tests/test_merge_train_stack_collapse.py
@@ -64,10 +64,10 @@ class MergeTrainStackCollapseContractTests(unittest.TestCase):
                 (mutation.child_pull_request_number, mutation.parent_pull_request_number)
                 for mutation in plan.mutations
             ],
-            [(11, 10), (12, 11)],
+            [(12, 11), (11, 10)],
         )
-        self.assertEqual(plan.mutations[0].expected_parent_head_sha, "head-10")
-        self.assertEqual(plan.mutations[1].expected_parent_head_sha, "head-11")
+        self.assertEqual(plan.mutations[0].expected_parent_head_sha, "head-11")
+        self.assertEqual(plan.mutations[1].expected_parent_head_sha, "head-10")
 
     def test_plan_requires_a_ready_stack_discovery_result(self) -> None:
         discovery_result = discover_merge_train_stack(
@@ -161,7 +161,7 @@ class MergeTrainStackCollapseContractTests(unittest.TestCase):
     def test_execute_plan_mutates_each_child_into_its_parent_branch(self) -> None:
         plan = _collapse_plan()
         branch_client = _RecordingStackCollapseBranchClient(
-            merge_commit_shas=("merge-31-30", "merge-32-31")
+            merge_commit_shas=("merge-32-31", "merge-31-30")
         )
 
         executed_plan = execute_merge_train_stack_collapse_plan(
@@ -177,20 +177,11 @@ class MergeTrainStackCollapseContractTests(unittest.TestCase):
         )
         self.assertEqual(
             [mutation.merge_commit_sha for mutation in executed_plan.mutations],
-            ["merge-31-30", "merge-32-31"],
+            ["merge-32-31", "merge-31-30"],
         )
         self.assertEqual(
             branch_client.requests,
             [
-                {
-                    "repository": "example/merge-train-repo",
-                    "child_head_sha": "head-31",
-                    "expected_parent_head_sha": "head-30",
-                    "parent_head_ref": "feature/root",
-                    "collapse_id": plan.collapse_id,
-                    "child_pull_request_number": 31,
-                    "parent_pull_request_number": 30,
-                },
                 {
                     "repository": "example/merge-train-repo",
                     "child_head_sha": "head-32",
@@ -199,6 +190,15 @@ class MergeTrainStackCollapseContractTests(unittest.TestCase):
                     "collapse_id": plan.collapse_id,
                     "child_pull_request_number": 32,
                     "parent_pull_request_number": 31,
+                },
+                {
+                    "repository": "example/merge-train-repo",
+                    "child_head_sha": "merge-32-31",
+                    "expected_parent_head_sha": "head-30",
+                    "parent_head_ref": "feature/root",
+                    "collapse_id": plan.collapse_id,
+                    "child_pull_request_number": 31,
+                    "parent_pull_request_number": 30,
                 },
             ],
         )
@@ -227,7 +227,7 @@ class MergeTrainStackCollapseContractTests(unittest.TestCase):
         plan = execute_merge_train_stack_collapse_plan(
             plan=_collapse_plan(),
             branch_client=_RecordingStackCollapseBranchClient(
-                merge_commit_shas=("merge-31-30", "merge-32-31")
+                merge_commit_shas=("merge-32-31", "merge-31-30")
             ),
             updated_at="2026-05-14T13:45:00Z",
         )
@@ -264,7 +264,7 @@ class MergeTrainStackCollapseContractTests(unittest.TestCase):
         plan = execute_merge_train_stack_collapse_plan(
             plan=_collapse_plan(),
             branch_client=_RecordingStackCollapseBranchClient(
-                merge_commit_shas=("merge-31-30", "merge-32-31")
+                merge_commit_shas=("merge-32-31", "merge-31-30")
             ),
             updated_at="2026-05-14T13:45:00Z",
         )

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -184,6 +184,8 @@ class _FakeOAuth2Session:
 
 
 class _FakeMergeTrainGitHubClient:
+    land_batch_candidate_calls = 0
+
     def __init__(self, *, transport: object) -> None:
         self.transport = transport
 
@@ -222,6 +224,7 @@ class _FakeMergeTrainGitHubClient:
     def land_batch_candidate(
         self, *, landing_plan: MergeTrainBatchLandingPlan
     ) -> MergeTrainBatchLandingPlan:
+        type(self).land_batch_candidate_calls += 1
         return landing_plan.model_copy(
             update={
                 "entries": tuple(
@@ -333,7 +336,7 @@ class _FakeStackedMergeTrainSnapshotReader:
                     created_at="2026-05-08T10:00:00Z",
                     labels=("ready-to-merge",),
                     actor_role="repo_admin",
-                    head_sha="head-root",
+                    head_sha=self._root_head_sha(),
                     head_ref="feature/root",
                     head_repository=repository,
                     base_ref=base_branch,
@@ -360,6 +363,14 @@ class _FakeStackedMergeTrainSnapshotReader:
                 ),
             ),
         )
+
+    def _root_head_sha(self) -> str:
+        return "head-root"
+
+
+class _FakeCollapsedRootStackedMergeTrainSnapshotReader(_FakeStackedMergeTrainSnapshotReader):
+    def _root_head_sha(self) -> str:
+        return "stack-merge-2-into-1"
 
 
 class _FakeMovedRootStackedMergeTrainSnapshotReader(_FakeStackedMergeTrainSnapshotReader):
@@ -1855,7 +1866,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ]
             with patch(
                 "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeStackedMergeTrainSnapshotReader,
+                _FakeCollapsedRootStackedMergeTrainSnapshotReader,
             ):
                 status_code, payload = _invoke_app(
                     app,
@@ -2359,7 +2370,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ]
             with patch(
                 "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeStackedMergeTrainSnapshotReader,
+                _FakeCollapsedRootStackedMergeTrainSnapshotReader,
             ):
                 _, admit_payload = _invoke_app(
                     app,
@@ -2454,6 +2465,133 @@ class LaunchplaneServiceTests(unittest.TestCase):
             disposition_record.plan.child_dispositions[0].comment_url,
             "https://github.com/cbusillo/sellyouroutboard/pull/2#issuecomment-1",
         )
+
+    def test_merge_train_batch_landing_service_validates_stack_before_root_merge(
+        self,
+    ) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                _FakeStackedMergeTrainSnapshotReader,
+            ):
+                _, plan_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+            plan_record_id = plan_payload["records"]["merge_train_stack_collapse_plan_record_id"]
+            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
+                _, execute_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "execute",
+                        "stack_collapse_plan_record_id": plan_record_id,
+                    },
+                )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                _FakeCollapsedRootStackedMergeTrainSnapshotReader,
+            ):
+                _, admit_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "admit",
+                        "stack_collapse_plan_record_id": execute_payload["records"][
+                            "merge_train_stack_collapse_plan_record_id"
+                        ],
+                    },
+                )
+            stale_stack_record_id = plan_record_id
+            _FakeMergeTrainGitHubClient.land_batch_candidate_calls = 0
+            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
+                _, build_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "build",
+                        "candidate_record_id": admit_payload["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+                _, observe_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "observe",
+                        "candidate_record_id": build_payload["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+                _, landing_plan_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-landing/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                        "candidate_record_id": observe_payload["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-landing/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "land",
+                        "landing_plan_record_id": landing_plan_payload["records"][
+                            "merge_train_batch_landing_plan_record_id"
+                        ],
+                        "stack_collapse_plan_record_id": stale_stack_record_id,
+                    },
+                )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(_FakeMergeTrainGitHubClient.land_batch_candidate_calls, 0)
 
     def test_merge_train_admission_service_uses_configured_codex_skills_policy(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary

- validate stack-collapse evidence before landing the root PR
- execute stack collapse leaf-to-root so the root receives every child change before admission
- re-read child PR heads after close so close races are recorded as stale evidence

## Verification

- `uv run python -m unittest tests.test_merge_train_stack_collapse tests.test_merge_train_github tests.test_service.LaunchplaneServiceTests.test_merge_train_stack_collapse_service_admits_executed_root_only tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_landing_service_closes_stack_children_after_root_lands tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_landing_service_validates_stack_before_root_merge tests.test_service.LaunchplaneServiceTests.test_merge_train_stack_collapse_service_rejects_admit_when_root_head_moves tests.test_service.LaunchplaneServiceTests.test_merge_train_stack_collapse_service_rejects_admit_when_policy_digest_changes`
- `uv run --extra dev ruff check --diff control_plane/contracts/merge_train_stack_collapse.py control_plane/merge_train_github.py control_plane/service.py tests/test_merge_train_stack_collapse.py tests/test_merge_train_github.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/contracts/merge_train_stack_collapse.py control_plane/merge_train_github.py control_plane/service.py tests/test_merge_train_stack_collapse.py tests/test_merge_train_github.py tests/test_service.py`
- `uv run python -m unittest`
- targeted PyCharm inspection on changed files; existing project warnings remain unrelated
