### PR TITLE
Fix merge train stack collapse Postgres index length

### DIFF
--- a/control_plane/storage/migrations/versions/d289e3ab4012_add_merge_train_stack_collapse_plans.py
+++ b/control_plane/storage/migrations/versions/d289e3ab4012_add_merge_train_stack_collapse_plans.py
@@ -39,7 +39,7 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("record_id"),
     )
     op.create_index(
-        "launchplane_merge_train_stack_collapse_plans_repository_base_idx",
+        "launchplane_merge_train_stack_collapse_repository_base_idx",
         "launchplane_merge_train_stack_collapse_plans",
         ["repository", "base_branch", sa.text("updated_at DESC")],
     )
@@ -56,7 +56,7 @@ def downgrade() -> None:
         table_name="launchplane_merge_train_stack_collapse_plans",
     )
     op.drop_index(
-        "launchplane_merge_train_stack_collapse_plans_repository_base_idx",
+        "launchplane_merge_train_stack_collapse_repository_base_idx",
         table_name="launchplane_merge_train_stack_collapse_plans",
     )
     op.drop_table("launchplane_merge_train_stack_collapse_plans")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -672,7 +672,7 @@ class LaunchplaneMergeTrainStackCollapsePlanRow(Base):
     __tablename__ = "launchplane_merge_train_stack_collapse_plans"
     __table_args__ = (
         Index(
-            "launchplane_merge_train_stack_collapse_plans_repository_base_idx",
+            "launchplane_merge_train_stack_collapse_repository_base_idx",
             "repository",
             "base_branch",
             desc("updated_at"),

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -9,6 +9,7 @@ from alembic import command as alembic_command
 from alembic.config import Config as AlembicConfig
 from click.testing import CliRunner
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.sql.schema import Index
 
 from control_plane.cli import main
 from control_plane.contracts.artifact_identity import (
@@ -113,7 +114,7 @@ from control_plane.service_auth import (
 )
 from control_plane.service_human_auth import LaunchplaneHumanSession
 from control_plane.storage.filesystem import FilesystemRecordStore
-from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.storage.postgres import Base, PostgresRecordStore
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy_with_codex_skills
 
@@ -699,6 +700,20 @@ def _merge_train_stack_collapse_plan_record(
 
 
 class PostgresRecordStoreTests(unittest.TestCase):
+    def test_postgres_metadata_index_names_fit_identifier_limit(self) -> None:
+        index_names = tuple(
+            index.name
+            for table in Base.metadata.tables.values()
+            for index in table.indexes
+            if isinstance(index, Index) and index.name is not None
+        )
+
+        too_long_index_names = tuple(
+            index_name for index_name in index_names if len(index_name) > 63
+        )
+
+        self.assertEqual(too_long_index_names, ())
+
     def test_alembic_baseline_creates_schema_used_by_record_store(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             database_url = _sqlite_database_url(


### PR DESCRIPTION
## Summary
- shorten the stack-collapse repository/base Postgres index name so it fits Postgres's 63-byte identifier limit
- keep the Alembic migration and ORM metadata in sync
- add a metadata guard test so future Postgres index names stay within the limit

## Root cause
The first failing deploy introduced a 64-character index name: `launchplane_merge_train_stack_collapse_plans_repository_base_idx`. The live service creates missing schema at startup against Postgres, so the new image could fail before binding HTTP. The rollback image stays healthy, which is why the website remains usable.

## Validation
- `uv run --extra dev ruff check tests/test_postgres_store.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/d289e3ab4012_add_merge_train_stack_collapse_plans.py`
- `uv run python -m unittest tests.test_postgres_store.PostgresRecordStoreTests.test_postgres_metadata_index_names_fit_identifier_limit tests.test_postgres_store.PostgresRecordStoreTests.test_alembic_baseline_creates_schema_used_by_record_store tests.test_postgres_store.PostgresRecordStoreTests.test_merge_train_stack_collapse_plan_records_round_trip`
- `uv run python -m unittest tests.test_postgres_store tests.test_service tests.test_merge_train_stack_collapse`
- `uv run python -m unittest`