### PR TITLE
Refresh stack child head guards after collapse

### DIFF
--- a/control_plane/contracts/merge_train_stack_collapse.py
+++ b/control_plane/contracts/merge_train_stack_collapse.py
@@ -251,10 +251,19 @@ def execute_merge_train_stack_collapse_plan(
         current_head_shas[mutation.parent_pull_request_number] = merge_commit_sha
     if len(updated_mutations) < len(plan.mutations):
         updated_mutations.extend(plan.mutations[len(updated_mutations) :])
+    updated_child_dispositions = tuple(
+        disposition.model_copy(
+            update={
+                "expected_head_sha": current_head_shas[disposition.pull_request_number]
+            }
+        )
+        for disposition in plan.child_dispositions
+    )
     return plan.model_copy(
         update={
             "status": current_status,
             "mutations": tuple(updated_mutations),
+            "child_dispositions": updated_child_dispositions,
             "updated_at": updated_at,
         }
     )

--- a/tests/test_merge_train_stack_collapse.py
+++ b/tests/test_merge_train_stack_collapse.py
@@ -180,6 +180,13 @@ class MergeTrainStackCollapseContractTests(unittest.TestCase):
             ["merge-32-31", "merge-31-30"],
         )
         self.assertEqual(
+            [
+                disposition.expected_head_sha
+                for disposition in executed_plan.child_dispositions
+            ],
+            ["merge-32-31", "head-32"],
+        )
+        self.assertEqual(
             branch_client.requests,
             [
                 {
@@ -255,7 +262,7 @@ class MergeTrainStackCollapseContractTests(unittest.TestCase):
         )
         self.assertEqual(
             disposition_client.closed,
-            [(31, "head-31"), (32, "head-32")],
+            [(31, "merge-32-31"), (32, "head-32")],
         )
         self.assertEqual(disposition_client.labels, [(31, "stack-landed"), (32, "stack-landed")])
         self.assertIn("root PR #30", disposition_client.comments[0][1])


### PR DESCRIPTION
## Summary
- update stack child close guards after each collapse merge advances an intermediate child branch
- keep leaf child guards unchanged when their own head was not mutated
- cover the three-PR stack case where the intermediate child must close against the merge commit SHA

## Validation
- `uv run --extra dev ruff check control_plane/contracts/merge_train_stack_collapse.py tests/test_merge_train_stack_collapse.py`
- `uv run python -m unittest tests.test_merge_train_stack_collapse tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_landing_service_closes_stack_children_after_root_lands`
- `uv run python -m unittest tests.test_merge_train_stack_collapse tests.test_merge_train_github tests.test_service`