### PR TITLE
Deduplicate backed product selector choices

### DIFF
--- a/frontend/src/useProductSelection.ts
+++ b/frontend/src/useProductSelection.ts
@@ -69,6 +69,13 @@ function hasProductBacking(choice: DriverChoice): boolean {
   return Boolean(choice.repository?.trim());
 }
 
+function productChoiceKey(choice: DriverChoice): string {
+  if (hasProductBacking(choice)) {
+    return `product:${choice.driverId}`;
+  }
+  return choiceKey(choice);
+}
+
 function labelForDriverContext(
   driver: DriverDescriptor,
   context: string,
@@ -222,7 +229,7 @@ export function useProductSelection({
       ) {
         return false;
       }
-      const key = choiceKey(choice);
+      const key = productChoiceKey(choice);
       if (seen.has(key)) {
         return false;
       }


### PR DESCRIPTION
## Summary
- dedupe product-backed selector entries by product key when the same product arrives from multiple read surfaces
- continue dropping descriptor/default fallback choices when a backed product with the same label exists
- preserve distinct backed products even if their display labels collide

## Verification
- pnpm --dir frontend validate
- targeted Node simulation for duplicate backed product + fallback behavior
