### PR TITLE
Fix product config dry-run UI response handling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1537,7 +1537,7 @@ function fixtureProductConfigApply(
   payload: ProductConfigApplyRequest,
 ): Promise<ProductConfigApplyPayload> {
   const runtimeKeys = Object.keys(payload.runtime_env?.env ?? {});
-  return Promise.resolve({
+  const response = {
     status: "ok",
     mode: payload.mode,
     product: payload.product,
@@ -1574,7 +1574,8 @@ function fixtureProductConfigApply(
       runtime_changed_key_count: runtimeKeys.length,
       secret_change_count: (payload.secrets ?? []).length,
     },
-  });
+  } satisfies ProductConfigApplyPayload;
+  return Promise.resolve(response);
 }
 
 function ActionReviewDialog({

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -12,6 +12,7 @@ import type {
   LogoutPayload,
   ProductConfigApplyPayload,
   ProductConfigApplyRequest,
+  ProductConfigApplyResponsePayload,
   ProductEnvironmentConfigStatusPayload,
   ProductListPayload,
   ProductProfileListPayload,
@@ -162,11 +163,11 @@ export function rankWorkGraphSnapshot(
 export function applyProductConfig(
   payload: ProductConfigApplyRequest,
 ): Promise<ProductConfigApplyPayload> {
-  return requestJson<ProductConfigApplyPayload>(
+  return requestJson<ProductConfigApplyResponsePayload>(
     "/v1/product-config/apply",
     "POST",
     payload,
-  );
+  ).then((response) => response.result);
 }
 
 export function dryRunGenericWebProdPromotion(

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -391,6 +391,13 @@ export interface ProductConfigApplyPayload {
   };
 }
 
+export interface ProductConfigApplyResponsePayload {
+  status: "accepted";
+  trace_id: string;
+  records: Record<string, string>;
+  result: ProductConfigApplyPayload;
+}
+
 export interface ProductProfileRecord {
   schema_version: number;
   product: string;


### PR DESCRIPTION
## Summary
- unwrap the standard Launchplane accepted envelope for product-config UI calls
- keep the product config panel rendering the inner product-config result shape
- tighten the fixture return type so fixture mode cannot hide envelope/result mismatches

## Why
The live product-config route returns `{ status, trace_id, records, result }`, but the UI rendered the full response as if it were the inner `result`. That can throw after Dry run and produce a black screen.

## Tests
- `pnpm typecheck`
- `pnpm build`
- browser fixture flow: filled runtime key and managed secret, clicked Dry run, verified result rendered with no black screen
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_product_config_api_human_admin_apply_writes_meta_config tests.test_service.LaunchplaneServiceTests.test_product_config_api_dry_run_returns_redacted_plan_without_writes`
