### PR TITLE
Scope merge train landed-batch retirement

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2717,6 +2717,8 @@ def _latest_completed_merge_train_batch_landing_plan_record(
     record_store: _MergeTrainBatchLandingPlanRecordStore,
     repository: str,
     base_branch: str,
+    batch_id: str,
+    candidate_sha: str,
 ) -> MergeTrainBatchLandingPlanRecord | None:
     records = record_store.list_merge_train_batch_landing_plan_records(
         repository=repository,
@@ -2724,7 +2726,13 @@ def _latest_completed_merge_train_batch_landing_plan_record(
         status="active",
         limit=25,
     )
-    latest_record = _latest_merge_train_batch_landing_progress_record(records)
+    matching_records = tuple(
+        record
+        for record in records
+        if record.landing_plan.batch_id == batch_id
+        and record.landing_plan.candidate_sha == candidate_sha
+    )
+    latest_record = _latest_merge_train_batch_landing_progress_record(matching_records)
     if latest_record is None:
         return None
     if not latest_record.landing_plan.entries:
@@ -7865,33 +7873,7 @@ def create_launchplane_service_app(
                     repository=controller_request.repository,
                     base_branch=controller_request.base_branch,
                 )
-                completed_landing_record = None
-                if active_landing_record is None:
-                    completed_landing_record = (
-                        _latest_completed_merge_train_batch_landing_plan_record(
-                            record_store=landing_store,
-                            repository=controller_request.repository,
-                            base_branch=controller_request.base_branch,
-                        )
-                    )
-                if completed_landing_record is not None:
-                    _validate_merge_train_landing_record_for_controller(
-                        landing_record=completed_landing_record,
-                        policy_key=repository_policy.policy_key,
-                        policy_sha256=policy_record.policy_sha256,
-                    )
-                    result = {
-                        "repository": controller_request.repository,
-                        "base_branch": controller_request.base_branch,
-                        "mode": "dry-run",
-                        "controller_action": "batch_landed",
-                        "merge_train_batch_landing_plan_record_id": completed_landing_record.record_id,
-                        "landing_plan": completed_landing_record.landing_plan.model_dump(
-                            mode="json"
-                        ),
-                    }
-                    driver_result = result
-                elif active_landing_record is not None:
+                if active_landing_record is not None:
                     _validate_merge_train_landing_record_for_controller(
                         landing_record=active_landing_record,
                         policy_key=repository_policy.policy_key,
@@ -8062,7 +8044,34 @@ def create_launchplane_service_app(
                             policy_key=repository_policy.policy_key,
                             policy_sha256=policy_record.policy_sha256,
                         )
-                        if not controller_request.mutate:
+                        completed_landing_record = (
+                            _latest_completed_merge_train_batch_landing_plan_record(
+                                record_store=landing_store,
+                                repository=controller_request.repository,
+                                base_branch=controller_request.base_branch,
+                                batch_id=passed_candidate_record.candidate.batch_id,
+                                candidate_sha=passed_candidate_record.candidate.candidate_sha,
+                            )
+                        )
+                        if completed_landing_record is not None:
+                            _validate_merge_train_landing_record_for_controller(
+                                landing_record=completed_landing_record,
+                                policy_key=repository_policy.policy_key,
+                                policy_sha256=policy_record.policy_sha256,
+                            )
+                            result = {
+                                "repository": controller_request.repository,
+                                "base_branch": controller_request.base_branch,
+                                "mode": "dry-run",
+                                "controller_action": "batch_landed",
+                                "merge_train_batch_candidate_record_id": passed_candidate_record.record_id,
+                                "merge_train_batch_landing_plan_record_id": completed_landing_record.record_id,
+                                "landing_plan": completed_landing_record.landing_plan.model_dump(
+                                    mode="json"
+                                ),
+                            }
+                            driver_result = result
+                        elif not controller_request.mutate:
                             result = {
                                 "repository": controller_request.repository,
                                 "base_branch": controller_request.base_branch,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -33,6 +33,7 @@ from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
 from control_plane.contracts.merge_train_policy import parse_merge_train_policy_toml
 from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidate
 from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlan
+from control_plane.contracts.merge_train_batch import build_merge_train_batch_candidate_record
 from control_plane.contracts.odoo_instance_override_record import OdooConfigParameterOverride
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.odoo_instance_override_record import OdooOverrideValue
@@ -1868,6 +1869,42 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 ).list_merge_train_batch_landing_plan_records(
                     repository="cbusillo/sellyouroutboard", base_branch="main"
                 )
+                superseding_candidate = MergeTrainBatchCandidate.model_validate(
+                    {
+                        **observe_payload["result"]["candidate"],
+                        "batch_id": "merge-train-batch-cbusillo-sellyouroutboard-main-next",
+                        "base_sha": "current-base-after-landing",
+                        "candidate_ref": "refs/heads/launchplane/train/cbusillo/sellyouroutboard/main/next",
+                        "candidate_sha": "candidate-next-built",
+                        "status": "passed",
+                        "updated_at": "9999-01-01T00:00:00Z",
+                        "entries": [
+                            {
+                                **observe_payload["result"]["candidate"]["entries"][0],
+                                "head_sha": "head-next",
+                            }
+                        ],
+                    }
+                )
+                superseding_candidate_record = build_merge_train_batch_candidate_record(
+                    candidate=superseding_candidate,
+                    source="test:superseding-candidate",
+                    updated_at="9999-01-01T00:00:00Z",
+                )
+                FilesystemRecordStore(state_dir).write_merge_train_batch_candidate_record(
+                    superseding_candidate_record
+                )
+                next_observe_status, next_observe_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
 
         self.assertEqual(plan_status, 202)
         self.assertEqual(plan_payload["result"]["controller_action"], "plan_candidate")
@@ -1892,6 +1929,12 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(
             tuple(record.record_id for record in landing_records_after_retire),
             tuple(record.record_id for record in landing_records_before_retire),
+        )
+        self.assertEqual(next_observe_status, 202)
+        self.assertEqual(next_observe_payload["result"]["controller_action"], "plan_landing")
+        self.assertEqual(
+            next_observe_payload["result"]["landing_plan"]["batch_id"],
+            superseding_candidate.batch_id,
         )
 
     def test_merge_train_controller_stops_after_candidate_failure(self) -> None:


### PR DESCRIPTION
## Summary
- only return batch_landed when the current passed candidate already has a matching completed landing plan
- stop completed landing plans from short-circuiting later passed candidates
- add regression coverage for a later candidate after an already-landed batch

## Tests
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_advances_unstacked_batch_flow
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_stops_after_candidate_failure
- uv run python -m unittest