### PR TITLE
Clarify product config apply feedback

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -181,6 +181,7 @@ from control_plane.service_human_auth import (
     HumanSessionManager,
     HumanSessionStore,
     InMemoryHumanSessionStore,
+    LaunchplaneHumanSession,
     OAuthLoginStateStore,
     build_pkce_verifier,
     load_github_oauth_config_from_env,
@@ -4897,12 +4898,21 @@ def _matching_every_code_rerun_intent_record(
     return None
 
 
-def _session_identity(
+def _session(
     *, environ: dict[str, object], session_manager: HumanSessionManager | None
-) -> GitHubHumanIdentity | None:
+) -> LaunchplaneHumanSession | None:
     if session_manager is None:
         return None
     session = session_manager.read_cookie(str(environ.get("HTTP_COOKIE", "")))
+    if session is None:
+        return None
+    return session_manager.renew_if_needed(session)
+
+
+def _session_identity(
+    *, environ: dict[str, object], session_manager: HumanSessionManager | None
+) -> GitHubHumanIdentity | None:
+    session = _session(environ=environ, session_manager=session_manager)
     return session.identity if session is not None else None
 
 
@@ -6162,8 +6172,8 @@ def create_launchplane_service_app(
                 headers=[("Set-Cookie", clear_cookie)],
             )
         if method == "GET" and path == "/v1/auth/session":
-            session_identity = _session_identity(environ=environ, session_manager=session_manager)
-            if session_identity is None:
+            auth_session = _session(environ=environ, session_manager=session_manager)
+            if auth_session is None:
                 return _json_response(
                     start_response=start_response,
                     status_code=401,
@@ -6177,14 +6187,20 @@ def create_launchplane_service_app(
                         },
                     },
                 )
+            session_cookie = (
+                session_manager.session_cookie_header(auth_session)
+                if session_manager is not None
+                else ""
+            )
             return _json_response(
                 start_response=start_response,
                 status_code=200,
                 payload={
                     "status": "ok",
                     "trace_id": request_trace_id,
-                    "identity": _human_identity_payload(session_identity),
+                    "identity": _human_identity_payload(auth_session.identity),
                 },
+                headers=[("Set-Cookie", session_cookie)] if session_cookie else None,
             )
         if method == "GET" and (path == "/" or path == "/ui" or path.startswith("/ui/")):
             return _serve_ui_route(

--- a/control_plane/service_human_auth.py
+++ b/control_plane/service_human_auth.py
@@ -30,7 +30,8 @@ GITHUB_ORGS_URL = "https://api.github.com/user/orgs"
 GITHUB_TEAMS_URL = "https://api.github.com/user/teams"
 GITHUB_EMAILS_URL = "https://api.github.com/user/emails"
 SESSION_COOKIE_NAME = "launchplane_session"
-SESSION_TTL_SECONDS = 12 * 60 * 60
+SESSION_TTL_SECONDS = 14 * 24 * 60 * 60
+SESSION_RENEW_AFTER_SECONDS = 24 * 60 * 60
 OAUTH_STATE_TTL_SECONDS = 10 * 60
 
 
@@ -312,6 +313,26 @@ class HumanSessionManager:
         if not session_id:
             return None
         return self._session_store.read_session(session_id)
+
+    def renew_if_needed(
+        self, session: LaunchplaneHumanSession
+    ) -> LaunchplaneHumanSession | None:
+        now = self._now()
+        if session.expires_at <= now:
+            self._session_store.delete_session(session.session_id)
+            return None
+        if session.expires_at - now > timedelta(
+            seconds=SESSION_TTL_SECONDS - SESSION_RENEW_AFTER_SECONDS
+        ):
+            return session
+        renewed_session = LaunchplaneHumanSession(
+            session_id=session.session_id,
+            identity=session.identity,
+            created_at=session.created_at,
+            expires_at=now + timedelta(seconds=SESSION_TTL_SECONDS),
+        )
+        self._session_store.write_session(renewed_session)
+        return renewed_session
 
     def delete_cookie_session(self, cookie_header: str) -> None:
         signed_session_id = _cookie_value(cookie_header, SESSION_COOKIE_NAME)

--- a/frontend/src/ProductConfigPanel.tsx
+++ b/frontend/src/ProductConfigPanel.tsx
@@ -1,4 +1,12 @@
-import { AlertTriangle, Loader2, Play, Plus, Save, Trash2 } from "lucide-react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Loader2,
+  Play,
+  Plus,
+  Save,
+  Trash2,
+} from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { LaunchplaneApiError, applyProductConfig } from "./api";
@@ -60,6 +68,7 @@ export function ProductConfigPanel({
   >(null);
   const [panelError, setPanelError] = useState("");
   const [traceId, setTraceId] = useState("");
+  const [successMessage, setSuccessMessage] = useState("");
   const requestSequence = useRef(0);
 
   const environmentOptions = useMemo(
@@ -132,6 +141,7 @@ export function ProductConfigPanel({
     setSubmitting(null);
     setPanelError("");
     setTraceId("");
+    setSuccessMessage("");
   }
 
   function clearRenderedSecretValues() {
@@ -223,6 +233,7 @@ export function ProductConfigPanel({
     setSubmitting("dry-run");
     setPanelError("");
     setTraceId("");
+    setSuccessMessage("");
     clearRenderedSecretValues();
     applyConfig(payload)
       .then((payloadResult) => {
@@ -232,6 +243,9 @@ export function ProductConfigPanel({
         setResult(payloadResult);
         setPendingApplyPayload({ ...payload, mode: "apply" });
         setReviewed(false);
+        setSuccessMessage(
+          "Dry run completed. Review the plan before applying.",
+        );
       })
       .catch((apiError: unknown) => {
         if (requestSequence.current !== requestId) {
@@ -263,6 +277,7 @@ export function ProductConfigPanel({
     setSubmitting("apply");
     setPanelError("");
     setTraceId("");
+    setSuccessMessage("");
     setPendingApplyPayload(null);
     setReviewed(false);
     clearRenderedSecretValues();
@@ -272,6 +287,7 @@ export function ProductConfigPanel({
           return;
         }
         setResult(payloadResult);
+        setSuccessMessage(applySuccessMessage(payloadResult));
       })
       .catch((apiError: unknown) => {
         if (requestSequence.current !== requestId) {
@@ -499,6 +515,15 @@ export function ProductConfigPanel({
           {traceId ? <code>{traceId}</code> : null}
         </div>
       ) : null}
+      {successMessage ? (
+        <div
+          className="config-inline-alert config-inline-alert-success"
+          role="status"
+        >
+          <CheckCircle2 size={15} aria-hidden="true" />
+          <span>{successMessage}</span>
+        </div>
+      ) : null}
       {result ? <ProductConfigResult result={result} /> : null}
       <div className="config-actions">
         <button
@@ -541,6 +566,19 @@ export function ProductConfigPanel({
   );
 }
 
+function applySuccessMessage(result: ProductConfigApplyPayload): string {
+  if (result.status === "records_applied_live_sync_required") {
+    return "Apply completed. Launchplane records are current; live runtime sync is still required.";
+  }
+  if (
+    result.runtime_environment.action === "unchanged" &&
+    result.summary.secret_change_count === 0
+  ) {
+    return "Apply completed. No record changes were needed.";
+  }
+  return "Apply completed. Launchplane records are current.";
+}
+
 function ProductConfigResult({
   result,
 }: {
@@ -568,6 +606,15 @@ function ProductConfigResult({
         />
       </div>
       <div className="config-result-list">
+        {result.next_actions?.length ? (
+          <div className="config-result-row config-result-row-note">
+            <strong>Next action</strong>
+            <span>
+              {result.next_actions[0].instruction ??
+                "Live runtime sync required."}
+            </span>
+          </div>
+        ) : null}
         {runtime.keys.length ? (
           <div className="config-result-row">
             <strong>Runtime keys</strong>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1317,10 +1317,9 @@ p {
 
 .config-status-row {
   display: grid;
-  grid-template-columns: max-content minmax(120px, 0.75fr) minmax(
-      0,
-      1fr
-    ) minmax(90px, auto);
+  grid-template-columns:
+    max-content minmax(120px, 0.75fr) minmax(0, 1fr)
+    minmax(90px, auto);
   gap: 9px;
   align-items: center;
   min-height: 34px;
@@ -1520,6 +1519,11 @@ p {
   padding: 10px 14px;
 }
 
+.config-inline-alert-success {
+  border-top-color: color-mix(in oklab, var(--status-ok) 52%, var(--hair));
+  color: var(--status-ok);
+}
+
 .config-inline-alert code {
   color: var(--fg-faint);
 }
@@ -1566,6 +1570,11 @@ p {
 }
 
 .config-result-row code {
+  color: var(--fg);
+}
+
+.config-result-row-note span {
+  min-width: 0;
   color: var(--fg);
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -376,7 +376,7 @@ export interface ProductConfigSecretResult {
 }
 
 export interface ProductConfigApplyPayload {
-  status: "ok";
+  status: "ok" | "records_applied_live_sync_required";
   mode: ProductConfigMode;
   product: string;
   context: string;
@@ -388,6 +388,17 @@ export interface ProductConfigApplyPayload {
   summary: {
     runtime_changed_key_count: number;
     secret_change_count: number;
+  };
+  next_actions?: ProductConfigNextAction[];
+}
+
+export interface ProductConfigNextAction {
+  kind: string;
+  required: boolean;
+  instruction?: string;
+  target?: {
+    target_type?: string;
+    target_name?: string;
   };
 }
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1231,6 +1231,37 @@ class GitHubHumanAuthTests(unittest.TestCase):
         self.assertEqual(payload["identity"]["login"], "alice")
         self.assertEqual(payload["identity"]["role"], "read_only")
 
+    def test_session_endpoint_renews_database_backed_human_session(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {"github_humans": [{"logins": ["alice"], "roles": ["read_only"]}]}
+        )
+        oauth_client = _StubGitHubOAuthClient(_human_identity())
+        with TemporaryDirectory() as tmpdir:
+            database_url = f"sqlite+pysqlite:///{Path(tmpdir) / 'launchplane.sqlite3'}"
+            app = create_launchplane_service_app(
+                state_dir=Path(tmpdir) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                database_url=database_url,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=oauth_client,  # type: ignore[arg-type]
+            )
+            cookie = _signed_in_cookie(app)
+
+            status_code, headers, body = _invoke_raw_app(
+                app,
+                method="GET",
+                path="/v1/auth/session",
+                authorization="",
+                headers={"Cookie": cookie},
+            )
+
+        self.assertEqual(status_code, 200)
+        payload = json.loads(body)
+        self.assertEqual(payload["identity"]["login"], "alice")
+        self.assertIn("launchplane_session=", headers["Set-Cookie"])
+        self.assertIn("Max-Age=1209600", headers["Set-Cookie"])
+
     def test_database_backed_human_session_survives_app_recreation(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(
             {"github_humans": [{"logins": ["alice"], "roles": ["read_only"]}]}


### PR DESCRIPTION
## Summary
- show explicit dry-run and apply completion feedback in the product-config panel
- distinguish no-op apply from record-changing apply and live-runtime-sync-required apply
- extend human browser sessions to 14 days and refresh the session cookie from /v1/auth/session

## Validation
- uv run python -m unittest tests.test_service.GitHubHumanAuthTests.test_session_endpoint_reads_github_human_session tests.test_service.GitHubHumanAuthTests.test_session_endpoint_renews_database_backed_human_session
- pnpm typecheck
- pnpm build
- fixture browser flow for product-config dry run -> reviewed -> apply success feedback
- uv run python -m unittest