### PR TITLE
Keep product config sessions fresh

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -4899,20 +4899,33 @@ def _matching_every_code_rerun_intent_record(
 
 
 def _session(
-    *, environ: dict[str, object], session_manager: HumanSessionManager | None
+    *,
+    environ: dict[str, object],
+    session_manager: HumanSessionManager | None,
+    on_authenticated_session: Callable[[LaunchplaneHumanSession], None] | None = None,
 ) -> LaunchplaneHumanSession | None:
     if session_manager is None:
         return None
     session = session_manager.read_cookie(str(environ.get("HTTP_COOKIE", "")))
     if session is None:
         return None
-    return session_manager.renew_if_needed(session)
+    renewed_session = session_manager.renew_if_needed(session)
+    if renewed_session is not None and on_authenticated_session is not None:
+        on_authenticated_session(renewed_session)
+    return renewed_session
 
 
 def _session_identity(
-    *, environ: dict[str, object], session_manager: HumanSessionManager | None
+    *,
+    environ: dict[str, object],
+    session_manager: HumanSessionManager | None,
+    on_authenticated_session: Callable[[LaunchplaneHumanSession], None] | None = None,
 ) -> GitHubHumanIdentity | None:
-    session = _session(environ=environ, session_manager=session_manager)
+    session = _session(
+        environ=environ,
+        session_manager=session_manager,
+        on_authenticated_session=on_authenticated_session,
+    )
     return session.identity if session is not None else None
 
 
@@ -4921,8 +4934,13 @@ def _read_identity(
     environ: dict[str, object],
     verifier: TokenVerifier,
     session_manager: HumanSessionManager | None,
+    on_authenticated_session: Callable[[LaunchplaneHumanSession], None] | None = None,
 ) -> LaunchplaneIdentity:
-    human_identity = _session_identity(environ=environ, session_manager=session_manager)
+    human_identity = _session_identity(
+        environ=environ,
+        session_manager=session_manager,
+        on_authenticated_session=on_authenticated_session,
+    )
     if human_identity is not None:
         return human_identity
     local_operator_identity = _local_operator_identity_from_bearer(environ)
@@ -6055,6 +6073,28 @@ def create_launchplane_service_app(
     ) -> list[bytes]:
         nonlocal authz_policy, resolved_authz_policy_sha256, resolved_authz_policy_source
 
+        authenticated_session: LaunchplaneHumanSession | None = None
+
+        def record_authenticated_session(session: LaunchplaneHumanSession) -> None:
+            nonlocal authenticated_session
+            authenticated_session = session
+
+        original_start_response = start_response
+
+        def start_response_with_session_cookie(
+            status: str, headers: list[tuple[str, str]]
+        ) -> None:
+            response_headers = list(headers)
+            if session_manager is not None and authenticated_session is not None:
+                response_headers.append(
+                    (
+                        "Set-Cookie",
+                        session_manager.session_cookie_header(authenticated_session),
+                    )
+                )
+            original_start_response(status, response_headers)
+
+        start_response = start_response_with_session_cookie
         request_trace_id = _trace_id()
         method = str(environ.get("REQUEST_METHOD", "GET")).upper()
         path = str(environ.get("PATH_INFO", ""))
@@ -6339,6 +6379,7 @@ def create_launchplane_service_app(
                     environ=environ,
                     verifier=verifier,
                     session_manager=session_manager,
+                    on_authenticated_session=record_authenticated_session,
                 )
             else:
                 if (
@@ -6349,6 +6390,7 @@ def create_launchplane_service_app(
                         environ=environ,
                         verifier=verifier,
                         session_manager=session_manager,
+                        on_authenticated_session=record_authenticated_session,
                     )
                 else:
                     token = _bearer_token(environ)

--- a/frontend/src/ProductConfigPanel.tsx
+++ b/frontend/src/ProductConfigPanel.tsx
@@ -263,6 +263,7 @@ export function ProductConfigPanel({
         if (requestSequence.current !== requestId) {
           return;
         }
+        setSuccessMessage("");
         if (apiError instanceof LaunchplaneApiError) {
           setPanelError(apiError.message);
           setTraceId(apiError.traceId);

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1262,6 +1262,47 @@ class GitHubHumanAuthTests(unittest.TestCase):
         self.assertIn("launchplane_session=", headers["Set-Cookie"])
         self.assertIn("Max-Age=1209600", headers["Set-Cookie"])
 
+    def test_authenticated_api_response_renews_human_session_cookie(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_humans": [
+                    {
+                        "logins": ["alice"],
+                        "roles": ["read_only"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["driver.read"],
+                    }
+                ]
+            }
+        )
+        oauth_client = _StubGitHubOAuthClient(_human_identity())
+        with TemporaryDirectory() as tmpdir:
+            database_url = f"sqlite+pysqlite:///{Path(tmpdir) / 'launchplane.sqlite3'}"
+            app = create_launchplane_service_app(
+                state_dir=Path(tmpdir) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                database_url=database_url,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=oauth_client,  # type: ignore[arg-type]
+            )
+            cookie = _signed_in_cookie(app)
+
+            status_code, headers, body = _invoke_raw_app(
+                app,
+                method="GET",
+                path="/v1/drivers",
+                authorization="",
+                headers={"Cookie": cookie},
+            )
+
+        self.assertEqual(status_code, 200)
+        payload = json.loads(body)
+        self.assertEqual(payload["status"], "ok")
+        self.assertIn("launchplane_session=", headers["Set-Cookie"])
+        self.assertIn("Max-Age=1209600", headers["Set-Cookie"])
+
     def test_database_backed_human_session_survives_app_recreation(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(
             {"github_humans": [{"logins": ["alice"], "roles": ["read_only"]}]}


### PR DESCRIPTION
## Summary
- refresh the browser session cookie on authenticated API responses, not only /v1/auth/session
- clear stale product-config success text when a dry run fails
- add a regression test for cookie renewal on a normal authenticated API read

## Validation
- pnpm typecheck
- pnpm build
- uv run python -m unittest tests.test_service.GitHubHumanAuthTests.test_session_endpoint_renews_database_backed_human_session tests.test_service.GitHubHumanAuthTests.test_authenticated_api_response_renews_human_session_cookie
