### PR TITLE
Tighten product config session and secret handling

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -4902,7 +4902,7 @@ def _session(
     *,
     environ: dict[str, object],
     session_manager: HumanSessionManager | None,
-    on_authenticated_session: Callable[[LaunchplaneHumanSession], None] | None = None,
+    on_renewed_session: Callable[[LaunchplaneHumanSession], None] | None = None,
 ) -> LaunchplaneHumanSession | None:
     if session_manager is None:
         return None
@@ -4910,8 +4910,12 @@ def _session(
     if session is None:
         return None
     renewed_session = session_manager.renew_if_needed(session)
-    if renewed_session is not None and on_authenticated_session is not None:
-        on_authenticated_session(renewed_session)
+    if (
+        renewed_session is not None
+        and renewed_session.expires_at != session.expires_at
+        and on_renewed_session is not None
+    ):
+        on_renewed_session(renewed_session)
     return renewed_session
 
 
@@ -4919,12 +4923,12 @@ def _session_identity(
     *,
     environ: dict[str, object],
     session_manager: HumanSessionManager | None,
-    on_authenticated_session: Callable[[LaunchplaneHumanSession], None] | None = None,
+    on_renewed_session: Callable[[LaunchplaneHumanSession], None] | None = None,
 ) -> GitHubHumanIdentity | None:
     session = _session(
         environ=environ,
         session_manager=session_manager,
-        on_authenticated_session=on_authenticated_session,
+        on_renewed_session=on_renewed_session,
     )
     return session.identity if session is not None else None
 
@@ -4934,12 +4938,12 @@ def _read_identity(
     environ: dict[str, object],
     verifier: TokenVerifier,
     session_manager: HumanSessionManager | None,
-    on_authenticated_session: Callable[[LaunchplaneHumanSession], None] | None = None,
+    on_renewed_session: Callable[[LaunchplaneHumanSession], None] | None = None,
 ) -> LaunchplaneIdentity:
     human_identity = _session_identity(
         environ=environ,
         session_manager=session_manager,
-        on_authenticated_session=on_authenticated_session,
+        on_renewed_session=on_renewed_session,
     )
     if human_identity is not None:
         return human_identity
@@ -6073,11 +6077,11 @@ def create_launchplane_service_app(
     ) -> list[bytes]:
         nonlocal authz_policy, resolved_authz_policy_sha256, resolved_authz_policy_source
 
-        authenticated_session: LaunchplaneHumanSession | None = None
+        renewed_session: LaunchplaneHumanSession | None = None
 
-        def record_authenticated_session(session: LaunchplaneHumanSession) -> None:
-            nonlocal authenticated_session
-            authenticated_session = session
+        def record_renewed_session(session: LaunchplaneHumanSession) -> None:
+            nonlocal renewed_session
+            renewed_session = session
 
         original_start_response = start_response
 
@@ -6085,11 +6089,11 @@ def create_launchplane_service_app(
             status: str, headers: list[tuple[str, str]]
         ) -> None:
             response_headers = list(headers)
-            if session_manager is not None and authenticated_session is not None:
+            if session_manager is not None and renewed_session is not None:
                 response_headers.append(
                     (
                         "Set-Cookie",
-                        session_manager.session_cookie_header(authenticated_session),
+                        session_manager.session_cookie_header(renewed_session),
                     )
                 )
             original_start_response(status, response_headers)
@@ -6379,7 +6383,7 @@ def create_launchplane_service_app(
                     environ=environ,
                     verifier=verifier,
                     session_manager=session_manager,
-                    on_authenticated_session=record_authenticated_session,
+                    on_renewed_session=record_renewed_session,
                 )
             else:
                 if (
@@ -6390,7 +6394,7 @@ def create_launchplane_service_app(
                         environ=environ,
                         verifier=verifier,
                         session_manager=session_manager,
-                        on_authenticated_session=record_authenticated_session,
+                        on_renewed_session=record_renewed_session,
                     )
                 else:
                     token = _bearer_token(environ)

--- a/frontend/src/ProductConfigPanel.tsx
+++ b/frontend/src/ProductConfigPanel.tsx
@@ -254,6 +254,7 @@ export function ProductConfigPanel({
         }
         setResult(payloadResult);
         setPendingApplyPayload({ ...payload, mode: "apply" });
+        clearRenderedSecretValues();
         setReviewed(false);
         setSuccessMessage(
           "Dry run completed. Review the plan before applying.",

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 import unittest
 from collections.abc import Callable, Iterable, Mapping
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
@@ -81,6 +82,8 @@ from control_plane.service_human_auth import (
     GITHUB_USER_URL,
     GitHubOAuthClient,
     GitHubOAuthConfig,
+    InMemoryHumanSessionStore,
+    LaunchplaneHumanSession,
     load_github_oauth_config_from_env,
 )
 from control_plane.storage.filesystem import FilesystemRecordStore
@@ -536,6 +539,13 @@ def _github_oauth_config() -> GitHubOAuthConfig:
         session_secret="test-session-secret",
         cookie_secure=False,
     )
+
+
+def _signed_human_session_cookie(session_id: str, session_secret: str) -> str:
+    signature = hmac.new(
+        session_secret.encode("utf-8"), session_id.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+    return f"launchplane_session={session_id}.{signature}"
 
 
 def _signed_in_cookie(app: WsgiApp) -> str:
@@ -1262,7 +1272,9 @@ class GitHubHumanAuthTests(unittest.TestCase):
         self.assertIn("launchplane_session=", headers["Set-Cookie"])
         self.assertIn("Max-Age=1209600", headers["Set-Cookie"])
 
-    def test_authenticated_api_response_renews_human_session_cookie(self) -> None:
+    def test_authenticated_api_response_does_not_refresh_fresh_session_cookie(
+        self,
+    ) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(
             {
                 "github_humans": [
@@ -1278,12 +1290,10 @@ class GitHubHumanAuthTests(unittest.TestCase):
         )
         oauth_client = _StubGitHubOAuthClient(_human_identity())
         with TemporaryDirectory() as tmpdir:
-            database_url = f"sqlite+pysqlite:///{Path(tmpdir) / 'launchplane.sqlite3'}"
             app = create_launchplane_service_app(
-                state_dir=Path(tmpdir) / "state",
+                state_dir=Path(tmpdir),
                 verifier=_StubVerifier(_identity()),
                 authz_policy=policy,
-                database_url=database_url,
                 github_oauth_config=_github_oauth_config(),
                 github_oauth_client=oauth_client,  # type: ignore[arg-type]
             )
@@ -1300,8 +1310,61 @@ class GitHubHumanAuthTests(unittest.TestCase):
         self.assertEqual(status_code, 200)
         payload = json.loads(body)
         self.assertEqual(payload["status"], "ok")
+        self.assertNotIn("Set-Cookie", headers)
+
+    def test_authenticated_api_response_renews_expiring_human_session_cookie(
+        self,
+    ) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_humans": [
+                    {
+                        "logins": ["alice"],
+                        "roles": ["read_only"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["driver.read"],
+                    }
+                ]
+            }
+        )
+        session_store = InMemoryHumanSessionStore()
+        session = LaunchplaneHumanSession(
+            session_id="expiring-session",
+            identity=_human_identity(),
+            created_at=datetime.now(timezone.utc) - timedelta(days=13),
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=12),
+        )
+        session_store.write_session(session)
+        with TemporaryDirectory() as tmpdir:
+            app = create_launchplane_service_app(
+                state_dir=Path(tmpdir),
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                github_oauth_config=_github_oauth_config(),
+                human_session_store=session_store,
+            )
+            cookie = _signed_human_session_cookie(
+                "expiring-session", "test-session-secret"
+            )
+
+            status_code, headers, body = _invoke_raw_app(
+                app,
+                method="GET",
+                path="/v1/drivers",
+                authorization="",
+                headers={"Cookie": cookie},
+            )
+
+        self.assertEqual(status_code, 200)
+        payload = json.loads(body)
+        self.assertEqual(payload["status"], "ok")
         self.assertIn("launchplane_session=", headers["Set-Cookie"])
         self.assertIn("Max-Age=1209600", headers["Set-Cookie"])
+        renewed_session = session_store.read_session("expiring-session")
+        self.assertIsNotNone(renewed_session)
+        assert renewed_session is not None
+        self.assertGreater(renewed_session.expires_at, session.expires_at)
 
     def test_database_backed_human_session_survives_app_recreation(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(


### PR DESCRIPTION
## Summary
- only emit renewed browser session cookies when the backing human session was actually renewed
- clear product-config secret inputs immediately after a successful dry run captures the apply payload
- add session-cookie regression coverage for fresh versus expiring sessions

## Validation
- pnpm typecheck
- pnpm build
- uv run python -m unittest tests.test_service.GitHubHumanAuthTests.test_session_endpoint_renews_database_backed_human_session tests.test_service.GitHubHumanAuthTests.test_authenticated_api_response_does_not_refresh_fresh_session_cookie tests.test_service.GitHubHumanAuthTests.test_authenticated_api_response_renews_expiring_human_session_cookie
- uv run python -m unittest
