### PR TITLE
Document Launchplane helper contracts

### DIFF
--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -370,6 +370,92 @@ The controller does not introduce new live configuration or repo-specific
 conditionals; it fails closed on missing policy, missing token, stale policy
 digests, stale root heads, and the existing batch landing guards.
 
+Controller requests use this shape:
+
+```json
+{
+  "schema_version": 1,
+  "repository": "example/repo",
+  "base_branch": "main",
+  "mutate": false
+}
+```
+
+`github_api_base_url` may be supplied only for a controlled GitHub-compatible
+test endpoint. Normal callers omit it. The service resolves the DB-backed
+repository/base policy, authorizes the policy's declared `service_authz` action,
+loads the GitHub token named by that policy, and then returns a public-safe
+envelope:
+
+```json
+{
+  "status": "accepted",
+  "trace_id": "launchplane_req_example",
+  "records": {
+    "merge_train_batch_candidate_record_id": "merge-train-batch-candidate-example"
+  },
+  "result": {
+    "repository": "example/repo",
+    "base_branch": "main",
+    "mode": "dry-run",
+    "controller_action": "build_candidate",
+    "merge_train_batch_candidate_record_id": "merge-train-batch-candidate-example"
+  }
+}
+```
+
+The response `records` object contains durable record ids for records written or
+selected by this call. The response `result` object is the controller decision.
+It always includes `repository`, `base_branch`, `mode`, and
+`controller_action`; it may also include redacted `dry_run_result`, `candidate`,
+`landing_plan`, `stack_discovery`, `stack_collapse_plan`, and matching record id
+fields. Callers may report controller action, record ids, PR numbers, check
+states, binding-safe labels from policy, trace id, and compact details. They
+must not report GitHub tokens, raw request headers, private API base URLs, local
+paths, or unchecked provider responses.
+
+Controller actions have these retry/stop semantics:
+
+- `plan_stack_collapse`: A same-repo linear stack was found and a collapse plan
+  is next. Dry-run may report. Mutate once, then call again.
+- `execute_stack_collapse`: A stored collapse plan should be applied. Mutate
+  once, then call again. Stop if the resulting plan is `blocked` or `stale`.
+- `wait_for_root_checks`: The collapsed root PR needs fresh required checks.
+  Stop and poll later; do not call phase endpoints.
+- `admit_collapsed_root`: The collapsed root PR is ready to enter the batch
+  candidate path. Mutate once, then call again.
+- `stack_unsupported`: A stack exists but is not a supported same-repo linear
+  stack. Stop and surface the redacted stack discovery details.
+- `plan_candidate`: The queue can produce the next batch candidate. Mutate once,
+  then call again.
+- `build_candidate`: A stored candidate needs its train ref built or refreshed.
+  Mutate once, then call again.
+- `observe_candidate`: A built candidate needs check observation. Mutate or
+  dry-run later until checks pass, fail, or remain pending.
+- `candidate_failed`: Candidate checks failed. Stop and surface the candidate
+  record id and failed check evidence.
+- `plan_landing`: A passed candidate is ready for PR-native landing-plan
+  creation. Mutate once, then call again.
+- `land_batch`: A landing plan is ready to merge original PRs in order. Mutate
+  once only after operator intent; call again to verify terminal state.
+- `batch_landed`: The batch already landed. Stop; the train phase is complete
+  for that batch.
+- `block`: The selected PR is blocked by conflicts or failed checks. Stop and
+  surface `dry_run_result.next_action_detail`.
+- `update_branch`: The selected PR needs a branch update before it can be
+  checked. Stop or use the lower-level recovery workflow deliberately.
+- `wait_for_checks`: Required PR checks are pending. Stop and poll later.
+- `idle`: No eligible queued work exists. Stop.
+
+All controller calls are one-action calls. A caller that wants to drive the
+train should repeat `run-once` only after reading the returned action and should
+stop on terminal or attention states: `batch_landed`, `candidate_failed`,
+`stack_unsupported`, `block`, `update_branch`, `wait_for_checks`,
+`wait_for_root_checks`, and `idle`. A failed HTTP response with `status:
+"rejected"` is also terminal for that attempt. Public-safe helper summaries
+should include `error.code`, `trace_id`, and the retry/stop recommendation, not
+the original request body.
+
 The batch-landing service endpoint
 `POST /v1/work-graph/merge-train/batch-landing/run-once` owns that PR-native
 landing phase. It accepts `mode: plan` with a passed candidate record id and

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -240,7 +240,10 @@ collapsed root PR, plan/build/observe a batch candidate, plan landing, or land
 the original PRs. Dry-run calls return the next controller action without
 writing records or mutating GitHub. Mutation calls reuse the same persisted
 candidate, stack-collapse, and landing-plan records as the phase-specific
-routes, and reject stale policy digests before advancing stored records.
+routes, and reject stale policy digests before advancing stored records. The
+response `result.controller_action` is the helper contract for retry/stop
+behavior; see [merge-train-policy.md](merge-train-policy.md) for the action
+matrix and public-safe reporting fields.
 
 `POST /v1/work-graph/merge-train/batch-candidate/run-once` executes one
 policy-backed batch-candidate phase for a requested repository/base branch. The
@@ -653,17 +656,96 @@ dedicated local-operator bearer credential with a non-empty `reason`, but
 terminal-agent read bearer credentials remain read-only and cannot execute the
 mutation. Local-operator apply requests additionally require a previously
 recorded matching local-operator dry-run. The route authorizes the top-level
-product/context/instance target and
-rejects nested runtime or secret targets that try to broaden or change that
-authorized target. It reuses the same planner/writer as
-`launchplane product-config apply`, returns only actions, keys, counts,
-actor/source metadata, and secret IDs, uses generic validation messages for
-rejected requests, and fails closed when a secret bundle is submitted without
-`LAUNCHPLANE_MASTER_ENCRYPTION_KEY` in the trusted Launchplane runtime or without
-an active runtime key-safety policy that allows the requested managed secret
-binding for the target runtime class. Request bodies for this route must not be
-copied into logs, issues, docs, or workflow artifacts because they can contain
-plaintext secret values.
+product/context/instance target and rejects nested runtime or secret targets
+that try to broaden or change that authorized target. It reuses the same
+planner/writer as `launchplane product-config apply`, returns only actions,
+keys, counts, actor/source metadata, and secret IDs, uses generic validation
+messages for rejected requests, and fails closed when a secret bundle is
+submitted without `LAUNCHPLANE_MASTER_ENCRYPTION_KEY` in the trusted Launchplane
+runtime or without an active runtime key-safety policy that allows the requested
+managed secret binding for the target runtime class. Request bodies for this
+route must not be copied into logs, issues, docs, or workflow artifacts because
+they can contain plaintext secret values.
+
+#### Product-config secret source contract
+
+The product-config apply route supports exactly one secret value source today:
+write-only plaintext supplied inside the HTTPS request by an approval-capable
+operator surface. The value is accepted only for the duration of request
+processing, is written into Launchplane managed-secret storage on apply, and is
+never returned. This source is appropriate for the signed-in operator UI and for
+explicit local-owner operator automation that already holds private credentials
+outside the repository.
+
+Helpers and agents must not ask for, echo, persist, or pass plaintext secret
+values through chat messages, CLI arguments, issue/PR bodies, workflow logs, or
+helper output. For helper-driven product-config work, use this sequence instead:
+
+1. Preflight intent and policy with `POST /v1/agent/write-intents/evaluate`,
+   naming `intent: "product_config_apply"`, `mode: "dry_run"`, product/context,
+   source URL, reason, optional `secret_bindings`, and the runtime destination.
+2. Report only the returned status, reason code, record id, binding keys,
+   runtime key-safety finding codes, trace id, and next action.
+3. Hand off any new or changed plaintext secret value entry to the signed-in
+   operator UI or to explicitly configured local-owner operator automation.
+4. Call `POST /v1/product-config/apply` only when the caller has a safe private
+   value source and explicit operator intent; dry-run before apply.
+
+The service does not currently support committed secret references, provider env
+lookups, stdin/stdout secret transport, arbitrary secret IDs supplied by an
+agent, or a request shape that says "reuse the current managed secret value".
+Those shapes are unsupported and must fail closed in clients instead of being
+translated into a product-config request. Existing managed-secret binding keys
+are safe to name only as metadata for intent evaluation, runtime key-safety
+checks, and redacted reporting. They are not a plaintext source for this route.
+
+Public-safe examples may show key names and placeholder binding keys, but never
+real values:
+
+```json
+{
+  "intent": "product_config_apply",
+  "mode": "dry_run",
+  "product": "example-product",
+  "context": "example-testing",
+  "source_url": "https://github.com/example/repo/issues/123",
+  "reason": "Preflight managed secret-backed product config.",
+  "secret_bindings": ["EXAMPLE_API_TOKEN"],
+  "destination": {
+    "kind": "runtime_environment",
+    "context": "example-testing",
+    "instance": "web"
+  }
+}
+```
+
+Product-config responses are public-safe only after redaction. Clients may
+report `status`, `trace_id`, record ids, `result.mode`, runtime key names,
+secret `binding_key` values, action names such as `created` or `unchanged`,
+counts, `runtime_key_safety.status`, finding codes, and `next_actions`. Clients
+must not report request bodies, runtime values, secret plaintext, ciphertext,
+provider environment dumps, token prefixes, master-key env names from service
+internals, or private hostnames.
+
+Common failure classes are stable enough for helper summaries:
+
+- `authentication_required`: no valid OIDC token, browser session, or allowed
+  local-operator bearer credential.
+- `authorization_denied`: caller lacks `product_config.plan`,
+  `product_config.apply`, or the product/context grant.
+- `reason_required`: local-operator calls omitted a concrete reason.
+- `local_operator_dry_run_required`: local-operator apply did not match a prior
+  recorded dry-run request.
+- `secret_configuration_required`: trusted Launchplane runtime cannot write
+  managed secrets.
+- `runtime_key_safety_unavailable` or `runtime_key_safety_failed`: the active
+  runtime key-safety policy is missing or rejects the requested binding.
+- `invalid_request`: malformed payload, secret-shaped runtime key, or nested
+  runtime/secret target override.
+
+After apply, `next_actions` can require `live_target_runtime_apply`; helpers
+should surface that action and stop. Applying product-config records does not by
+itself guarantee the live target process has been synchronized.
 
 Runtime key-safety policy reconciliation uses
 `POST /v1/runtime-key-safety/policies/apply`. The route is restricted to


### PR DESCRIPTION
## Summary
- document the product-config secret source contract for helper-driven flows
- document merge-train controller run-once response fields and retry/stop semantics
- point service-boundary controller docs at the controller action matrix

Refs #637.
Refs #638.

## Validation
- jq empty .github/github.json
- git diff --check
- public-safety rg scan: only existing documented env var names, fake examples, and pre-existing repo/host references found
- uv run --extra dev ruff format --check docs/service-boundary.md docs/merge-train-policy.md (not applicable: Ruff requires preview mode for Markdown formatting)
- uv run python -m unittest