### PR TITLE
Persist Odoo website bootstrap overrides

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     UV_LINK_MODE=copy
 
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends ca-certificates openssh-client \
     && rm -rf /var/lib/apt/lists/*
 

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -52,6 +52,7 @@ from control_plane.contracts.odoo_instance_override_record import OdooConfigPara
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.odoo_instance_override_record import OdooOverrideApplyResult
 from control_plane.contracts.odoo_instance_override_record import OdooOverrideValue
+from control_plane.contracts.odoo_instance_override_record import OdooWebsiteBootstrapPayload
 from control_plane.contracts.preview_enablement_record import PreviewEnablementRecord
 from control_plane.contracts.preview_generation_record import (
     PreviewGenerationRecord,
@@ -8854,6 +8855,7 @@ def _summarize_odoo_instance_override_record(
         ),
         "config_parameter_count": len(record.config_parameters),
         "addon_setting_count": len(record.addon_settings),
+        "website_bootstrap": record.website_bootstrap is not None,
     }
 
 
@@ -9169,8 +9171,10 @@ def _build_odoo_instance_override_record_with_config_parameter(
     return OdooInstanceOverrideRecord(
         context=normalized_context,
         instance=normalized_instance,
+        apply_on=target_record.apply_on if target_record is not None else ("deploy", "promotion"),
         config_parameters=tuple(config_parameters[key] for key in sorted(config_parameters)),
         addon_settings=addon_settings,
+        website_bootstrap=target_record.website_bootstrap if target_record is not None else None,
         updated_at=utc_now_timestamp(),
         source_label=source_label.strip() or "cli",
     )
@@ -9216,6 +9220,38 @@ def _build_odoo_instance_override_record_with_addon_setting(
         instance=normalized_instance,
         config_parameters=config_parameters,
         addon_settings=tuple(addon_settings[key] for key in sorted(addon_settings)),
+        website_bootstrap=target_record.website_bootstrap if target_record is not None else None,
+        updated_at=utc_now_timestamp(),
+        source_label=source_label.strip() or "cli",
+    )
+
+
+def _build_odoo_instance_override_record_with_website_bootstrap(
+    *,
+    existing_records: tuple[OdooInstanceOverrideRecord, ...],
+    context_name: str,
+    instance_name: str,
+    website_bootstrap: OdooWebsiteBootstrapPayload,
+    source_label: str,
+) -> OdooInstanceOverrideRecord:
+    normalized_context = context_name.strip().lower()
+    normalized_instance = instance_name.strip().lower()
+    if not normalized_context or not normalized_instance:
+        raise click.ClickException(
+            "Odoo instance override records require --context and --instance."
+        )
+    target_record = _find_odoo_instance_override_record(
+        existing_records=existing_records,
+        context_name=normalized_context,
+        instance_name=normalized_instance,
+    )
+    return OdooInstanceOverrideRecord(
+        context=normalized_context,
+        instance=normalized_instance,
+        apply_on=target_record.apply_on if target_record is not None else ("deploy", "promotion"),
+        config_parameters=target_record.config_parameters if target_record is not None else (),
+        addon_settings=target_record.addon_settings if target_record is not None else (),
+        website_bootstrap=website_bootstrap,
         updated_at=utc_now_timestamp(),
         source_label=source_label.strip() or "cli",
     )
@@ -9343,6 +9379,7 @@ def _migrate_odoo_override_secret_transport_record(
             apply_on=record.apply_on,
             config_parameters=tuple(config_parameters),
             addon_settings=tuple(addon_settings),
+            website_bootstrap=record.website_bootstrap,
             last_apply=record.last_apply,
             updated_at=utc_now_timestamp(),
             source_label=source_label.strip() or "odoo-secret-transport-migration",
@@ -14661,6 +14698,57 @@ def odoo_overrides_put_addon_setting(
             addon_name=addon_name,
             setting_name=setting_name,
             override_value=override_value,
+            source_label=source_label,
+        )
+        postgres_store.write_odoo_instance_override_record(record)
+    finally:
+        postgres_store.close()
+    click.echo(
+        json.dumps(
+            {"status": "ok", "record": _summarize_odoo_instance_override_record(record)},
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+@odoo_overrides.command("put-website-bootstrap")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane Odoo override records.",
+)
+@click.option("--context", "context_name", required=True)
+@click.option("--instance", "instance_name", required=True)
+@click.option(
+    "--payload-file",
+    type=click.Path(path_type=Path, dir_okay=False, exists=True),
+    required=True,
+    help="JSON file containing a typed devkit website_bootstrap payload.",
+)
+@click.option("--source-label", default="cli", show_default=True)
+def odoo_overrides_put_website_bootstrap(
+    database_url: str,
+    context_name: str,
+    instance_name: str,
+    payload_file: Path,
+    source_label: str,
+) -> None:
+    try:
+        raw_payload = json.loads(payload_file.read_text(encoding="utf-8"))
+    except JSONDecodeError as error:
+        raise click.ClickException("Odoo website bootstrap payload must be valid JSON.") from error
+    website_bootstrap = OdooWebsiteBootstrapPayload.model_validate(raw_payload)
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    postgres_store.ensure_schema()
+    try:
+        existing_records = postgres_store.list_odoo_instance_override_records()
+        record = _build_odoo_instance_override_record_with_website_bootstrap(
+            existing_records=existing_records,
+            context_name=context_name,
+            instance_name=instance_name,
+            website_bootstrap=website_bootstrap,
             source_label=source_label,
         )
         postgres_store.write_odoo_instance_override_record(record)

--- a/control_plane/contracts/odoo_instance_override_record.py
+++ b/control_plane/contracts/odoo_instance_override_record.py
@@ -1,4 +1,5 @@
 from typing import Literal
+import json
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -75,6 +76,81 @@ class OdooAddonSettingOverride(BaseModel):
         return normalized
 
 
+class OdooWebsiteBootstrapRoute(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    url: str
+    module: str = ""
+    published: bool = True
+    homepage: bool = False
+
+    @field_validator("name", "url", "module", mode="after")
+    @classmethod
+    def _strip_text(cls, value: str) -> str:
+        return value.strip()
+
+    @model_validator(mode="after")
+    def _validate_route(self) -> "OdooWebsiteBootstrapRoute":
+        if not self.name:
+            raise ValueError("Odoo website bootstrap routes require name")
+        if not self.url:
+            raise ValueError("Odoo website bootstrap routes require url")
+        return self
+
+
+class OdooWebsiteBootstrapPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    tenant: str = ""
+    name: str
+    default_lang: str = ""
+    homepage_url: str = ""
+    primary_page_xmlid: str = ""
+    logo_path: str = ""
+    logo_alt: str = ""
+    canonical_url: str = ""
+    pages_source: dict[str, object] = Field(default_factory=dict)
+    routes_source: dict[str, object] = Field(default_factory=dict)
+    routes: tuple[OdooWebsiteBootstrapRoute, ...] = ()
+
+    @field_validator(
+        "tenant",
+        "name",
+        "default_lang",
+        "homepage_url",
+        "primary_page_xmlid",
+        "logo_path",
+        "logo_alt",
+        "canonical_url",
+        mode="after",
+    )
+    @classmethod
+    def _strip_text(cls, value: str) -> str:
+        return value.strip()
+
+    @field_validator("pages_source", "routes_source", mode="after")
+    @classmethod
+    def _validate_json_object(cls, value: dict[str, object]) -> dict[str, object]:
+        try:
+            json.dumps(value, sort_keys=True)
+        except TypeError as error:
+            raise ValueError("Odoo website bootstrap source metadata must be JSON-safe") from error
+        return value
+
+    @model_validator(mode="after")
+    def _validate_payload(self) -> "OdooWebsiteBootstrapPayload":
+        if not self.name:
+            raise ValueError("Odoo website bootstrap requires name")
+        route_urls = [route.url for route in self.routes]
+        if len(route_urls) != len(set(route_urls)):
+            raise ValueError("Odoo website bootstrap has duplicate route urls")
+        route_names = [route.name for route in self.routes]
+        if len(route_names) != len(set(route_names)):
+            raise ValueError("Odoo website bootstrap has duplicate route names")
+        return self
+
+
 class OdooOverrideApplyResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -107,6 +183,7 @@ class OdooInstanceOverrideRecord(BaseModel):
     apply_on: tuple[OdooOverrideApplyPhase, ...] = ("deploy", "promotion")
     config_parameters: tuple[OdooConfigParameterOverride, ...] = ()
     addon_settings: tuple[OdooAddonSettingOverride, ...] = ()
+    website_bootstrap: OdooWebsiteBootstrapPayload | None = None
     last_apply: OdooOverrideApplyResult = Field(default_factory=OdooOverrideApplyResult)
     updated_at: str
     source_label: str = ""
@@ -123,7 +200,7 @@ class OdooInstanceOverrideRecord(BaseModel):
             raise ValueError("Odoo instance override record requires instance")
         if not self.updated_at:
             raise ValueError("Odoo instance override record requires updated_at")
-        if not self.config_parameters and not self.addon_settings:
+        if not self.config_parameters and not self.addon_settings and self.website_bootstrap is None:
             raise ValueError("Odoo instance override record requires at least one override")
         if not self.apply_on:
             raise ValueError("Odoo instance override record requires at least one apply phase")

--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -476,6 +476,16 @@ ODOO_DRIVER = DriverDescriptor(
             writes_records=("odoo_instance_override",),
         ),
         _action(
+            "website_bootstrap_override",
+            "Write website bootstrap override",
+            "Write typed Odoo website bootstrap intent before post-deploy applies it.",
+            safety="safe_write",
+            scope="instance",
+            route_path="/v1/drivers/odoo/website-bootstrap-override",
+            authz_action="odoo_website_bootstrap_override.write",
+            writes_records=("odoo_instance_override",),
+        ),
+        _action(
             "stable_bootstrap",
             "Bootstrap stable instance",
             "Run a guarded Odoo stable bootstrap through Launchplane-owned provider scheduling.",

--- a/control_plane/odoo_instance_overrides.py
+++ b/control_plane/odoo_instance_overrides.py
@@ -225,6 +225,8 @@ def render_post_deploy_payload(
         )
     payload["config_parameters"] = config_parameters
     payload["addon_settings"] = addon_settings
+    if record.website_bootstrap is not None:
+        payload["website_bootstrap"] = record.website_bootstrap.model_dump(mode="json")
     return payload
 
 

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -105,6 +105,7 @@ from control_plane.contracts.odoo_instance_override_record import (
     OdooConfigParameterOverride,
     OdooInstanceOverrideRecord,
     OdooOverrideValue,
+    OdooWebsiteBootstrapPayload,
 )
 from control_plane.contracts.preview_mutation_request import (
     PreviewDestroyMutationRequest,
@@ -1123,6 +1124,31 @@ class OdooConfigParameterOverrideRequest(BaseModel):
         return self
 
 
+class OdooWebsiteBootstrapOverrideRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    context: str
+    instance: str
+    website_bootstrap: OdooWebsiteBootstrapPayload
+    source_label: str = "launchplane-service"
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "OdooWebsiteBootstrapOverrideRequest":
+        self.product = self.product.strip()
+        self.context = self.context.strip().lower()
+        self.instance = self.instance.strip().lower()
+        self.source_label = self.source_label.strip() or "launchplane-service"
+        if not self.product:
+            raise ValueError("Odoo website-bootstrap override requires product.")
+        if not self.context:
+            raise ValueError("Odoo website-bootstrap override requires context.")
+        if not self.instance:
+            raise ValueError("Odoo website-bootstrap override requires instance.")
+        return self
+
+
 class OdooConfigParameterOverrideEnvelope(_ProductRouteEnvelope):
     schema_version: int = Field(default=1, ge=1)
     override: OdooConfigParameterOverrideRequest
@@ -1132,6 +1158,18 @@ class OdooConfigParameterOverrideEnvelope(_ProductRouteEnvelope):
         _validate_driver_envelope_product(self.product, label="Odoo config-parameter override")
         if self.product.strip() != self.override.product.strip():
             raise ValueError("Odoo config-parameter override requires matching product values.")
+        return self
+
+
+class OdooWebsiteBootstrapOverrideEnvelope(_ProductRouteEnvelope):
+    schema_version: int = Field(default=1, ge=1)
+    override: OdooWebsiteBootstrapOverrideRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "OdooWebsiteBootstrapOverrideEnvelope":
+        _validate_driver_envelope_product(self.product, label="Odoo website-bootstrap override")
+        if self.product.strip() != self.override.product.strip():
+            raise ValueError("Odoo website-bootstrap override requires matching product values.")
         return self
 
 
@@ -1181,6 +1219,15 @@ _ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE = _DriverRouteExecutionMetadata(
     envelope_model=OdooConfigParameterOverrideEnvelope,
     denial_message=(
         "Workflow cannot write Odoo config-parameter overrides for the requested product/context."
+    ),
+)
+
+
+_ODOO_WEBSITE_BOOTSTRAP_OVERRIDE_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/odoo/website-bootstrap-override",
+    envelope_model=OdooWebsiteBootstrapOverrideEnvelope,
+    denial_message=(
+        "Workflow cannot write Odoo website-bootstrap overrides for the requested product/context."
     ),
 )
 
@@ -2404,6 +2451,41 @@ def _write_odoo_config_parameter_override(
         apply_on=apply_on,
         config_parameters=tuple(config_parameters[key] for key in sorted(config_parameters)),
         addon_settings=addon_settings,
+        website_bootstrap=existing_record.website_bootstrap if existing_record is not None else None,
+        updated_at=_utc_now_timestamp(),
+        source_label=request.source_label,
+    )
+    record_store.write_odoo_instance_override_record(record)
+    return record
+
+
+def _write_odoo_website_bootstrap_override(
+    *,
+    record_store: _OdooInstanceOverrideStore,
+    request: OdooWebsiteBootstrapOverrideRequest,
+) -> OdooInstanceOverrideRecord:
+    try:
+        existing_record = record_store.read_odoo_instance_override_record(
+            context_name=request.context, instance_name=request.instance
+        )
+    except FileNotFoundError:
+        existing_record = None
+    apply_on = tuple(
+        dict.fromkeys(
+            (
+                *(existing_record.apply_on if existing_record is not None else ()),
+                "deploy",
+                "promotion",
+            )
+        )
+    )
+    record = OdooInstanceOverrideRecord(
+        context=request.context,
+        instance=request.instance,
+        apply_on=apply_on,
+        config_parameters=existing_record.config_parameters if existing_record is not None else (),
+        addon_settings=existing_record.addon_settings if existing_record is not None else (),
+        website_bootstrap=request.website_bootstrap,
         updated_at=_utc_now_timestamp(),
         source_label=request.source_label,
     )
@@ -9806,6 +9888,45 @@ def create_launchplane_service_app(
                         override.key for override in override_record.config_parameters
                     ),
                 }
+            elif path == _ODOO_WEBSITE_BOOTSTRAP_OVERRIDE_ROUTE.route_path:
+                odoo_website_override_request = (
+                    _ODOO_WEBSITE_BOOTSTRAP_OVERRIDE_ROUTE.envelope_model.model_validate(payload)
+                )
+                _, authorization_response = _resolve_and_authorize_descriptor_route(
+                    route_metadata=_ODOO_WEBSITE_BOOTSTRAP_OVERRIDE_ROUTE,
+                    record_store=record_store,
+                    authz_policy=authz_policy,
+                    identity=identity,
+                    product=odoo_website_override_request.product,
+                    authorization_context=odoo_website_override_request.override.context,
+                    descriptor_context=odoo_website_override_request.override.context,
+                    descriptor_instance=odoo_website_override_request.override.instance,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if authorization_response is not None:
+                    return authorization_response
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                override_record = _write_odoo_website_bootstrap_override(
+                    record_store=cast(_OdooInstanceOverrideStore, record_store),
+                    request=odoo_website_override_request.override,
+                )
+                result = {
+                    "context": override_record.context,
+                    "instance": override_record.instance,
+                    "website_bootstrap": override_record.website_bootstrap is not None,
+                }
+                driver_result = result
             elif path == _ODOO_STABLE_BOOTSTRAP_ROUTE.route_path:
                 odoo_bootstrap_request = _ODOO_STABLE_BOOTSTRAP_ROUTE.envelope_model.model_validate(
                     payload

--- a/docs/records.md
+++ b/docs/records.md
@@ -449,6 +449,10 @@ state/
   `web.base.url`.
 - `addon_settings` stores addon-shaped intent such as Authentik SSO or Shopify
   settings without coupling Launchplane records to environment variable names.
+- `website_bootstrap` stores the typed devkit website bootstrap payload,
+  including site identity, canonical URL, logo path, source metadata, and route
+  definitions. Product repos remain the source of that intent; Launchplane
+  persists the typed payload and renders it during Odoo post-deploy.
 - `apply_on` records the phases where the override is intended to apply, and
   `last_apply` records the latest driver result without making the addon layer
   the durable audit surface.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -93,6 +93,7 @@ VeriReel product paths:
   - `POST /v1/drivers/odoo/artifact-publish`
   - `POST /v1/drivers/odoo/post-deploy`
   - `POST /v1/drivers/odoo/config-parameter-override`
+  - `POST /v1/drivers/odoo/website-bootstrap-override`
   - `POST /v1/drivers/odoo/target-replacement-plan`
   - `POST /v1/drivers/odoo/target-replacement-apply`
   - `POST /v1/drivers/odoo/prod-backup-gate`
@@ -925,6 +926,7 @@ current handlers include:
 - `POST /v1/drivers/odoo/post-deploy`
 - `POST /v1/drivers/odoo/artifact-publish-inputs`
 - `POST /v1/drivers/odoo/artifact-publish`
+- `POST /v1/drivers/odoo/website-bootstrap-override`
 - `POST /v1/drivers/odoo/prod-backup-gate`
 - `POST /v1/drivers/odoo/prod-promotion`
 - `POST /v1/drivers/odoo/prod-rollback`

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -39,6 +39,8 @@ from control_plane.contracts.odoo_instance_override_record import OdooAddonSetti
 from control_plane.contracts.odoo_instance_override_record import OdooConfigParameterOverride
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.odoo_instance_override_record import OdooOverrideValue
+from control_plane.contracts.odoo_instance_override_record import OdooWebsiteBootstrapPayload
+from control_plane.contracts.odoo_instance_override_record import OdooWebsiteBootstrapRoute
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductImageProfile,
@@ -1060,6 +1062,20 @@ class FilesystemRecordStoreTests(unittest.TestCase):
                         ),
                     ),
                 ),
+                website_bootstrap=OdooWebsiteBootstrapPayload(
+                    tenant="opw",
+                    name="OPW",
+                    canonical_url="https://opw-prod.example.com",
+                    logo_path="addons/opw/static/src/img/logo.png",
+                    routes=(
+                        OdooWebsiteBootstrapRoute(
+                            name="Home",
+                            url="/",
+                            module="website",
+                            homepage=True,
+                        ),
+                    ),
+                ),
                 updated_at="2026-04-21T18:30:00Z",
                 source_label="test",
             )
@@ -1078,6 +1094,10 @@ class FilesystemRecordStoreTests(unittest.TestCase):
                 loaded_record.addon_settings[0].value.secret_binding_id,
                 "secret-binding-shopify-token",
             )
+            self.assertIsNotNone(loaded_record.website_bootstrap)
+            assert loaded_record.website_bootstrap is not None
+            self.assertEqual(loaded_record.website_bootstrap.name, "OPW")
+            self.assertEqual(loaded_record.website_bootstrap.routes[0].url, "/")
             self.assertEqual(
                 [(record.context, record.instance) for record in listed_records], [("opw", "prod")]
             )

--- a/tests/test_odoo_instance_override_rendering.py
+++ b/tests/test_odoo_instance_override_rendering.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import unittest
+from typing import cast
 
 import click
 
@@ -22,6 +23,8 @@ from control_plane.contracts.odoo_instance_override_record import (
     OdooConfigParameterOverride,
     OdooInstanceOverrideRecord,
     OdooOverrideValue,
+    OdooWebsiteBootstrapPayload,
+    OdooWebsiteBootstrapRoute,
 )
 
 
@@ -98,6 +101,56 @@ class OdooInstanceOverrideRenderingTests(unittest.TestCase):
         self.assertEqual(
             set(environment.inline_environment), {ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY}
         )
+
+    def test_render_post_deploy_payload_preserves_website_bootstrap(self) -> None:
+        record = OdooInstanceOverrideRecord(
+            context="example",
+            instance="testing",
+            website_bootstrap=OdooWebsiteBootstrapPayload(
+                tenant="example",
+                name="Example Site",
+                default_lang="en_US",
+                homepage_url="/home",
+                primary_page_xmlid="example_website.page_home",
+                logo_path="addons/example_website/static/src/img/logo.png",
+                logo_alt="Example Site",
+                canonical_url="https://example-testing.example.com",
+                pages_source={
+                    "module": "example_website",
+                    "data_files": ["views/pages.xml"],
+                    "model": "website.page",
+                },
+                routes_source={"kind": "controller", "module": "website"},
+                routes=(
+                    OdooWebsiteBootstrapRoute(
+                        name="Home",
+                        url="/home",
+                        module="website",
+                        homepage=True,
+                    ),
+                ),
+            ),
+            updated_at="2026-05-16T00:00:00Z",
+        )
+
+        payload = render_post_deploy_payload(record)
+        environment = build_post_deploy_environment(record)
+        decoded_payload = json.loads(
+            base64.b64decode(
+                environment.inline_environment[ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY]
+            ).decode("utf-8")
+        )
+
+        self.assertEqual(payload["config_parameters"], [])
+        self.assertEqual(payload["addon_settings"], [])
+        website_bootstrap = cast("dict[str, object]", payload["website_bootstrap"])
+        routes = cast("list[dict[str, object]]", website_bootstrap["routes"])
+        self.assertEqual(website_bootstrap["name"], "Example Site")
+        self.assertEqual(
+            website_bootstrap["canonical_url"], "https://example-testing.example.com"
+        )
+        self.assertEqual(routes[0]["url"], "/home")
+        self.assertEqual(decoded_payload, payload)
 
     def test_build_post_deploy_environment_requires_container_env_for_secret_backed_values(
         self,

--- a/tests/test_odoo_instance_overrides.py
+++ b/tests/test_odoo_instance_overrides.py
@@ -177,6 +177,77 @@ class OdooInstanceOverrideTests(unittest.TestCase):
         self.assertEqual(payload["records"][0]["addon_settings"], ["shopify.api_token"])
         self.assertNotIn("secret-binding-shopify-token", list_result.output)
 
+    def test_cli_put_website_bootstrap_preserves_existing_overrides(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temp_dir = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(temp_dir / "launchplane.sqlite3")
+            payload_file = temp_dir / "website-bootstrap.json"
+            payload_file.write_text(
+                json.dumps(
+                    {
+                        "tenant": "opw",
+                        "name": "OPW",
+                        "canonical_url": "https://opw-testing.example.com",
+                        "homepage_url": "/shop",
+                        "routes": [
+                            {
+                                "name": "Shop",
+                                "url": "/shop",
+                                "module": "website_sale",
+                                "homepage": True,
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            runner = CliRunner()
+            put_config_result = runner.invoke(
+                main,
+                [
+                    "odoo-overrides",
+                    "put-config-param",
+                    "--database-url",
+                    database_url,
+                    "--context",
+                    "opw",
+                    "--instance",
+                    "testing",
+                    "--key",
+                    "web.base.url",
+                    "--value",
+                    "https://opw-testing.example.com",
+                ],
+            )
+            put_bootstrap_result = runner.invoke(
+                main,
+                [
+                    "odoo-overrides",
+                    "put-website-bootstrap",
+                    "--database-url",
+                    database_url,
+                    "--context",
+                    "opw",
+                    "--instance",
+                    "testing",
+                    "--payload-file",
+                    str(payload_file),
+                ],
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            stored_record = store.read_odoo_instance_override_record(
+                context_name="opw", instance_name="testing"
+            )
+            store.close()
+
+        self.assertEqual(put_config_result.exit_code, 0, msg=put_config_result.output)
+        self.assertEqual(put_bootstrap_result.exit_code, 0, msg=put_bootstrap_result.output)
+        self.assertEqual(stored_record.config_parameters[0].key, "web.base.url")
+        self.assertIsNotNone(stored_record.website_bootstrap)
+        assert stored_record.website_bootstrap is not None
+        self.assertEqual(stored_record.website_bootstrap.name, "OPW")
+        self.assertEqual(stored_record.website_bootstrap.routes[0].url, "/shop")
+
     def test_cli_mark_apply_updates_result_metadata(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             database_url = _sqlite_database_url(

--- a/tests/test_odoo_stable_bootstrap.py
+++ b/tests/test_odoo_stable_bootstrap.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import unittest
 from pathlib import Path
 from typing import cast
@@ -13,6 +15,8 @@ from control_plane.contracts.odoo_instance_override_record import (
     OdooConfigParameterOverride,
     OdooInstanceOverrideRecord,
     OdooOverrideValue,
+    OdooWebsiteBootstrapPayload,
+    OdooWebsiteBootstrapRoute,
 )
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
@@ -268,6 +272,22 @@ class OdooStableBootstrapTests(unittest.TestCase):
                             ),
                         ),
                     ),
+                    website_bootstrap=OdooWebsiteBootstrapPayload(
+                        tenant="cm",
+                        name="Cell Mechanic",
+                        canonical_url="https://cm-testing.shinycomputers.com",
+                        homepage_url="/cell-mechanic",
+                        logo_path="addons/cm_website/static/src/img/logo.png",
+                        logo_alt="Cell Mechanic",
+                        routes=(
+                            OdooWebsiteBootstrapRoute(
+                                name="Cell Mechanic",
+                                url="/cell-mechanic",
+                                module="cm_website",
+                                homepage=True,
+                            ),
+                        ),
+                    ),
                     updated_at="2026-05-10T00:00:00Z",
                 )
 
@@ -320,6 +340,16 @@ class OdooStableBootstrapTests(unittest.TestCase):
             "dict[str, str]", captured_bootstrap_runs[0]["workflow_environment_overrides"]
         )
         self.assertIn("ODOO_INSTANCE_OVERRIDES_PAYLOAD_B64", workflow_environment)
+        decoded_payload = json.loads(
+            base64.b64decode(workflow_environment["ODOO_INSTANCE_OVERRIDES_PAYLOAD_B64"]).decode(
+                "utf-8"
+            )
+        )
+        self.assertEqual(decoded_payload["website_bootstrap"]["name"], "Cell Mechanic")
+        self.assertEqual(
+            decoded_payload["website_bootstrap"]["canonical_url"],
+            "https://cm-testing.shinycomputers.com",
+        )
         self.assertEqual(
             store.environment_inventories[0].bootstrap_record_id,
             "deployment-cm-testing-bootstrap",

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -18628,6 +18628,112 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 "https://cm-testing.shinycomputers.com",
             )
 
+    def test_odoo_website_bootstrap_override_driver_writes_typed_payload(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            store.write_odoo_instance_override_record(
+                OdooInstanceOverrideRecord(
+                    context="cm",
+                    instance="testing",
+                    apply_on=("manual",),
+                    config_parameters=(
+                        OdooConfigParameterOverride(
+                            key="web.base.url",
+                            value=OdooOverrideValue(
+                                source="literal",
+                                value="https://cm-testing.shinycomputers.com",
+                            ),
+                        ),
+                    ),
+                    updated_at="2026-05-10T20:00:00Z",
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "schema_version": 1,
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/odoo-website-bootstrap-override.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["odoo_website_bootstrap_override.write"],
+                        }
+                    ],
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-website-bootstrap-override.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/odoo/website-bootstrap-override",
+                payload={
+                    "product": "odoo-tenant-cm",
+                    "override": {
+                        "product": "odoo-tenant-cm",
+                        "context": "cm",
+                        "instance": "testing",
+                        "website_bootstrap": {
+                            "tenant": "cm",
+                            "name": "Cell Mechanic",
+                            "canonical_url": "https://cm-testing.shinycomputers.com",
+                            "homepage_url": "/cell-mechanic",
+                            "logo_path": "addons/cm_website/static/src/img/logo.png",
+                            "logo_alt": "Cell Mechanic",
+                            "routes": [
+                                {
+                                    "name": "Cell Mechanic",
+                                    "url": "/cell-mechanic",
+                                    "module": "cm_website",
+                                    "homepage": True,
+                                }
+                            ],
+                        },
+                    },
+                },
+                headers={"Idempotency-Key": "odoo-cm-testing-website-bootstrap"},
+            )
+
+            self.assertEqual(status_code, 202)
+            self.assertEqual(payload["status"], "accepted")
+            self.assertEqual(payload["result"]["website_bootstrap"], True)
+            stored_record = store.read_odoo_instance_override_record(
+                context_name="cm", instance_name="testing"
+            )
+            self.assertEqual(stored_record.apply_on, ("manual", "deploy", "promotion"))
+            self.assertEqual(stored_record.config_parameters[0].key, "web.base.url")
+            self.assertIsNotNone(stored_record.website_bootstrap)
+            assert stored_record.website_bootstrap is not None
+            self.assertEqual(stored_record.website_bootstrap.name, "Cell Mechanic")
+            self.assertEqual(
+                stored_record.website_bootstrap.canonical_url,
+                "https://cm-testing.shinycomputers.com",
+            )
+
     def test_odoo_config_parameter_override_driver_rejects_unauthorized_workflow(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- add typed website_bootstrap support to DB-backed Odoo instance override records and post-deploy payload rendering
- add authenticated Odoo website-bootstrap override write route and CLI helper
- preserve config parameters, addon settings, apply phases, and website bootstrap payload across shared override updates
- update records and service-boundary docs

Refs #593

## Validation
- uv run python -m unittest
- uv run python -m unittest tests.test_odoo_instance_override_rendering tests.test_odoo_instance_overrides tests.test_odoo_stable_bootstrap tests.test_filesystem_store tests.test_service
- uv run --extra dev ruff check control_plane/contracts/odoo_instance_override_record.py control_plane/odoo_instance_overrides.py control_plane/service.py control_plane/cli.py control_plane/drivers/registry.py tests/test_odoo_instance_override_rendering.py tests/test_odoo_instance_overrides.py tests/test_odoo_stable_bootstrap.py tests/test_filesystem_store.py tests/test_service.py
- uv run --extra dev mypy control_plane/contracts/odoo_instance_override_record.py control_plane/odoo_instance_overrides.py control_plane/service.py control_plane/cli.py control_plane/drivers/registry.py tests/test_odoo_instance_override_rendering.py tests/test_odoo_instance_overrides.py tests/test_odoo_stable_bootstrap.py tests/test_filesystem_store.py tests/test_service.py