### PR TITLE
Resolve Odoo logo verification from page

### DIFF
--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
+import html
 import json
 from pathlib import Path
+import re
 import time
 from typing import Literal, Protocol
+from urllib.parse import urljoin, urlparse
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
@@ -378,12 +381,46 @@ def _verify_canonical_url(*, base_url: str, expected_base_url: str, timeout_seco
 
 
 def _verify_logo_route(*, base_url: str, timeout_seconds: int) -> None:
-    logo_url = f"{base_url.rstrip('/')}/web/image/website/1/logo"
-    status_code, body, content_type = _http_text(logo_url, timeout_seconds=timeout_seconds)
-    if status_code >= 400:
-        raise click.ClickException(f"Logo check {logo_url} returned HTTP {status_code}.")
-    if "text/html" in content_type.lower() and "404" in body[:500].lower():
-        raise click.ClickException(f"Logo check {logo_url} returned an HTML 404 body.")
+    checked_urls: list[str] = []
+    for logo_url in _candidate_logo_urls(base_url=base_url, timeout_seconds=timeout_seconds):
+        if logo_url in checked_urls:
+            continue
+        checked_urls.append(logo_url)
+        status_code, body, content_type = _http_text(logo_url, timeout_seconds=timeout_seconds)
+        if status_code < 400 and not ("text/html" in content_type.lower() and "404" in body[:500].lower()):
+            return
+    checked = ", ".join(checked_urls) if checked_urls else base_url
+    raise click.ClickException(f"Logo check failed for {checked}.")
+
+
+def _candidate_logo_urls(*, base_url: str, timeout_seconds: int) -> tuple[str, ...]:
+    normalized_base_url = base_url.rstrip("/")
+    status_code, body, _content_type = _http_text(normalized_base_url, timeout_seconds=timeout_seconds)
+    if status_code < 400:
+        urls = tuple(_extract_same_origin_logo_urls(base_url=normalized_base_url, body=body))
+        if urls:
+            return urls
+    return (f"{normalized_base_url}/web/image/website/1/logo",)
+
+
+def _extract_same_origin_logo_urls(*, base_url: str, body: str) -> tuple[str, ...]:
+    base_origin = _url_origin(base_url)
+    logo_urls: list[str] = []
+    for match in re.finditer(
+        r"(?:src|href)\s*=\s*([\"'])(?P<url>[^\"']*/web/image/website/[^\"']*/logo[^\"']*)\1",
+        body,
+        re.IGNORECASE,
+    ):
+        raw_url = html.unescape(match.group("url")).strip()
+        absolute_url = urljoin(f"{base_url.rstrip('/')}/", raw_url)
+        if _url_origin(absolute_url) == base_origin and absolute_url not in logo_urls:
+            logo_urls.append(absolute_url)
+    return tuple(logo_urls)
+
+
+def _url_origin(raw_url: str) -> str:
+    parsed = urlparse(raw_url)
+    return f"{parsed.scheme.lower()}://{parsed.netloc.lower()}"
 
 
 def _run_verification_with_retry(

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -31,6 +31,8 @@ from control_plane.workflows.odoo_stable_target_replacement import (
     DokployRequest,
     OdooStableTargetReplacementApplyRequest,
     OdooStableTargetReplacementRequest,
+    _extract_same_origin_logo_urls,
+    _verify_logo_route,
     _run_verification_with_retry,
     build_odoo_stable_target_replacement_plan,
     execute_odoo_stable_target_replacement_apply,
@@ -241,6 +243,76 @@ def _request(path: str, query: object | None = None, **_: object) -> JsonValue:
 
 
 class OdooStableTargetReplacementTests(unittest.TestCase):
+    def test_logo_verification_uses_logo_url_from_canonical_page(self) -> None:
+        calls: list[str] = []
+
+        def fake_http_text(url: str, *, timeout_seconds: int) -> tuple[int, str, str]:
+            self.assertEqual(timeout_seconds, 5)
+            calls.append(url)
+            if url == "https://cm-testing.example.com":
+                return (
+                    200,
+                    '<html><img src="/web/image/website/7/logo?unique=abc"></html>',
+                    "text/html",
+                )
+            if url == "https://cm-testing.example.com/web/image/website/7/logo?unique=abc":
+                return 200, "image-bytes", "image/png"
+            return 404, "missing", "text/plain"
+
+        with patch(
+            "control_plane.workflows.odoo_stable_target_replacement._http_text",
+            side_effect=fake_http_text,
+        ):
+            _verify_logo_route(base_url="https://cm-testing.example.com", timeout_seconds=5)
+
+        self.assertEqual(
+            calls,
+            [
+                "https://cm-testing.example.com",
+                "https://cm-testing.example.com/web/image/website/7/logo?unique=abc",
+            ],
+        )
+
+    def test_logo_verification_falls_back_to_legacy_website_one_route(self) -> None:
+        calls: list[str] = []
+
+        def fake_http_text(url: str, *, timeout_seconds: int) -> tuple[int, str, str]:
+            self.assertEqual(timeout_seconds, 5)
+            calls.append(url)
+            if url == "https://cm-testing.example.com":
+                return 200, "<html>No logo route here</html>", "text/html"
+            if url == "https://cm-testing.example.com/web/image/website/1/logo":
+                return 200, "image-bytes", "image/png"
+            return 404, "missing", "text/plain"
+
+        with patch(
+            "control_plane.workflows.odoo_stable_target_replacement._http_text",
+            side_effect=fake_http_text,
+        ):
+            _verify_logo_route(base_url="https://cm-testing.example.com/", timeout_seconds=5)
+
+        self.assertEqual(
+            calls,
+            [
+                "https://cm-testing.example.com",
+                "https://cm-testing.example.com/web/image/website/1/logo",
+            ],
+        )
+
+    def test_extract_logo_urls_ignores_cross_origin_assets(self) -> None:
+        urls = _extract_same_origin_logo_urls(
+            base_url="https://cm-testing.example.com",
+            body=(
+                '<img src="https://evil.example.com/web/image/website/9/logo">'
+                '<img src="/web/image/website/7/logo?unique=abc&amp;download=1">'
+            ),
+        )
+
+        self.assertEqual(
+            urls,
+            ("https://cm-testing.example.com/web/image/website/7/logo?unique=abc&download=1",),
+        )
+
     def test_build_plan_allows_issue_backed_opw_upstream_restore_policy(self) -> None:
         with (
             patch(


### PR DESCRIPTION
## Summary
- discover same-origin Odoo website logo URLs from the canonical page before falling back to `/web/image/website/1/logo`
- keep the legacy route as fallback for older/simple deployments
- add focused tests for dynamic website ids, fallback behavior, and cross-origin filtering

## Validation
- `uv run python -m unittest tests.test_odoo_stable_target_replacement tests.test_odoo_stable_bootstrap`
- `uv run --extra dev ruff check control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_stable_target_replacement.py`
- `uv run --extra dev mypy control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_stable_target_replacement.py`
- `uv run python -m unittest`
- PyCharm changed-files inspection clean

Refs #593