### PR TITLE
Harden website bootstrap override CLI

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -9245,10 +9245,12 @@ def _build_odoo_instance_override_record_with_website_bootstrap(
         context_name=normalized_context,
         instance_name=normalized_instance,
     )
+    apply_on = target_record.apply_on if target_record is not None else ()
+    apply_phases = tuple(dict.fromkeys((*apply_on, "deploy", "promotion")))
     return OdooInstanceOverrideRecord(
         context=normalized_context,
         instance=normalized_instance,
-        apply_on=target_record.apply_on if target_record is not None else ("deploy", "promotion"),
+        apply_on=apply_phases,
         config_parameters=target_record.config_parameters if target_record is not None else (),
         addon_settings=target_record.addon_settings if target_record is not None else (),
         website_bootstrap=website_bootstrap,
@@ -14737,9 +14739,11 @@ def odoo_overrides_put_website_bootstrap(
 ) -> None:
     try:
         raw_payload = json.loads(payload_file.read_text(encoding="utf-8"))
+        website_bootstrap = OdooWebsiteBootstrapPayload.model_validate(raw_payload)
     except JSONDecodeError as error:
         raise click.ClickException("Odoo website bootstrap payload must be valid JSON.") from error
-    website_bootstrap = OdooWebsiteBootstrapPayload.model_validate(raw_payload)
+    except ValidationError as error:
+        raise click.ClickException(f"Invalid Odoo website bootstrap payload: {error}") from error
     postgres_store = PostgresRecordStore(database_url=database_url)
     postgres_store.ensure_schema()
     try:

--- a/tests/test_odoo_instance_overrides.py
+++ b/tests/test_odoo_instance_overrides.py
@@ -248,6 +248,93 @@ class OdooInstanceOverrideTests(unittest.TestCase):
         self.assertEqual(stored_record.website_bootstrap.name, "OPW")
         self.assertEqual(stored_record.website_bootstrap.routes[0].url, "/shop")
 
+    def test_cli_put_website_bootstrap_adds_deploy_and_promotion_apply_phases(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temp_dir = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(temp_dir / "launchplane.sqlite3")
+            payload_file = temp_dir / "website-bootstrap.json"
+            payload_file.write_text(
+                json.dumps(
+                    {
+                        "tenant": "opw",
+                        "name": "OPW",
+                        "canonical_url": "https://opw-testing.example.com",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_odoo_instance_override_record(
+                OdooInstanceOverrideRecord(
+                    context="opw",
+                    instance="testing",
+                    apply_on=("manual",),
+                    config_parameters=(
+                        OdooConfigParameterOverride(
+                            key="web.base.url",
+                            value=OdooOverrideValue(
+                                source="literal", value="https://opw-testing.example.com"
+                            ),
+                        ),
+                    ),
+                    updated_at="2026-05-17T00:00:00Z",
+                    source_label="test",
+                )
+            )
+            store.close()
+            runner = CliRunner()
+            put_bootstrap_result = runner.invoke(
+                main,
+                [
+                    "odoo-overrides",
+                    "put-website-bootstrap",
+                    "--database-url",
+                    database_url,
+                    "--context",
+                    "opw",
+                    "--instance",
+                    "testing",
+                    "--payload-file",
+                    str(payload_file),
+                ],
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            stored_record = store.read_odoo_instance_override_record(
+                context_name="opw", instance_name="testing"
+            )
+            store.close()
+
+        self.assertEqual(put_bootstrap_result.exit_code, 0, msg=put_bootstrap_result.output)
+        self.assertEqual(stored_record.apply_on, ("manual", "deploy", "promotion"))
+
+    def test_cli_put_website_bootstrap_reports_schema_errors(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temp_dir = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(temp_dir / "launchplane.sqlite3")
+            payload_file = temp_dir / "website-bootstrap.json"
+            payload_file.write_text(json.dumps({"tenant": "opw"}), encoding="utf-8")
+            runner = CliRunner()
+            put_bootstrap_result = runner.invoke(
+                main,
+                [
+                    "odoo-overrides",
+                    "put-website-bootstrap",
+                    "--database-url",
+                    database_url,
+                    "--context",
+                    "opw",
+                    "--instance",
+                    "testing",
+                    "--payload-file",
+                    str(payload_file),
+                ],
+            )
+
+        self.assertNotEqual(put_bootstrap_result.exit_code, 0)
+        self.assertIn("Invalid Odoo website bootstrap payload", put_bootstrap_result.output)
+        self.assertIn("name", put_bootstrap_result.output)
+
     def test_cli_mark_apply_updates_result_metadata(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             database_url = _sqlite_database_url(


### PR DESCRIPTION
## Summary
- ensure website-bootstrap override imports remain eligible for deploy and promotion when updating an existing restricted override
- convert schema-invalid website-bootstrap payloads into operator-friendly Click errors
- add regression coverage for both cases

## Validation
- uv run python -m unittest tests.test_odoo_instance_overrides
- uv run --extra dev ruff check control_plane/cli.py tests/test_odoo_instance_overrides.py
- uv run --extra dev ruff format --check control_plane/cli.py tests/test_odoo_instance_overrides.py
- uv run --extra dev mypy control_plane/cli.py tests/test_odoo_instance_overrides.py
- uv run python -m unittest
- PyCharm changed-files inspection (existing weak warnings / Click test typing false positives only)