### PR TITLE
Accept Odoo web content logo URLs

### DIFF
--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -407,7 +407,10 @@ def _extract_same_origin_logo_urls(*, base_url: str, body: str) -> tuple[str, ..
     base_origin = _url_origin(base_url)
     logo_urls: list[str] = []
     for match in re.finditer(
-        r"(?:src|href)\s*=\s*([\"'])(?P<url>[^\"']*/web/image/website/[^\"']*/logo[^\"']*)\1",
+        (
+            r"(?:src|href|content)\s*=\s*([\"'])"
+            r"(?P<url>[^\"']*/web/(?:image/website/[^\"']*/logo|content[^\"']*logo)[^\"']*)\1"
+        ),
         body,
         re.IGNORECASE,
     ):

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -313,6 +313,50 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
             ("https://cm-testing.example.com/web/image/website/7/logo?unique=abc&download=1",),
         )
 
+    def test_logo_verification_accepts_odoo_web_content_logo_url(self) -> None:
+        calls: list[str] = []
+
+        def fake_http_text(url: str, *, timeout_seconds: int) -> tuple[int, str, str]:
+            self.assertEqual(timeout_seconds, 5)
+            calls.append(url)
+            if url == "https://cm-testing.example.com":
+                return (
+                    200,
+                    '<meta property="og:image" content="/web/content?model=website&amp;id=1&amp;field=logo">',
+                    "text/html",
+                )
+            if url == "https://cm-testing.example.com/web/content?model=website&id=1&field=logo":
+                return 200, "image-bytes", "image/png"
+            return 404, "missing", "text/plain"
+
+        with patch(
+            "control_plane.workflows.odoo_stable_target_replacement._http_text",
+            side_effect=fake_http_text,
+        ):
+            _verify_logo_route(base_url="https://cm-testing.example.com", timeout_seconds=5)
+
+        self.assertEqual(
+            calls,
+            [
+                "https://cm-testing.example.com",
+                "https://cm-testing.example.com/web/content?model=website&id=1&field=logo",
+            ],
+        )
+
+    def test_extract_logo_urls_accepts_same_origin_web_content_logo_assets(self) -> None:
+        urls = _extract_same_origin_logo_urls(
+            base_url="https://cm-testing.example.com",
+            body=(
+                '<meta property="og:image" content="https://evil.example.com/web/content?model=website&amp;id=1&amp;field=logo">'
+                '<meta name="twitter:image" content="/web/content/website/1/logo/Cell%20Mechanic.png">'
+            ),
+        )
+
+        self.assertEqual(
+            urls,
+            ("https://cm-testing.example.com/web/content/website/1/logo/Cell%20Mechanic.png",),
+        )
+
     def test_build_plan_allows_issue_backed_opw_upstream_restore_policy(self) -> None:
         with (
             patch(


### PR DESCRIPTION
## Summary

- Extend Odoo logo discovery to recognize same-origin `/web/content...logo` URLs in `src`, `href`, and metadata `content` attributes.
- Preserve same-origin filtering before probing discovered logo candidates.
- Add targeted tests for `/web/content` discovery and verification.

## Validation

- `uv run python -m unittest tests.test_odoo_stable_target_replacement.OdooStableTargetReplacementTests.test_logo_verification_uses_logo_url_from_canonical_page tests.test_odoo_stable_target_replacement.OdooStableTargetReplacementTests.test_logo_verification_falls_back_to_legacy_website_one_route tests.test_odoo_stable_target_replacement.OdooStableTargetReplacementTests.test_extract_logo_urls_ignores_cross_origin_assets tests.test_odoo_stable_target_replacement.OdooStableTargetReplacementTests.test_logo_verification_accepts_odoo_web_content_logo_url tests.test_odoo_stable_target_replacement.OdooStableTargetReplacementTests.test_extract_logo_urls_accepts_same_origin_web_content_logo_assets`
- `uv run python -m unittest tests.test_odoo_stable_target_replacement`

## Follow-up

- Captured broader driver probe derivation plan in #645.
