### PR TITLE
Broaden Odoo logo URL extraction

### DIFF
--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -408,8 +408,10 @@ def _extract_same_origin_logo_urls(*, base_url: str, body: str) -> tuple[str, ..
     logo_urls: list[str] = []
     for match in re.finditer(
         (
-            r"(?:src|href|content)\s*=\s*([\"'])"
-            r"(?P<url>[^\"']*/web/(?:image/website/[^\"']*/logo|content[^\"']*logo)[^\"']*)\1"
+            r"(?:src|href|content)\s*=\s*"
+            r"(?P<quote>[\"'])?"
+            r"(?P<url>[^\s\"'<>]*/web/(?:image/website/[^\s\"'<>]*/logo|content[^\s\"'<>]*logo)[^\s\"'<>]*)"
+            r"(?P=quote)?"
         ),
         body,
         re.IGNORECASE,

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -357,6 +357,23 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
             ("https://cm-testing.example.com/web/content/website/1/logo/Cell%20Mechanic.png",),
         )
 
+    def test_extract_logo_urls_accepts_unquoted_same_origin_logo_assets(self) -> None:
+        urls = _extract_same_origin_logo_urls(
+            base_url="https://cm-testing.example.com",
+            body=(
+                "<img src=/web/image/website/7/logo?unique=abc&amp;download=1>"
+                "<meta property=og:image content=/web/content?model=website&amp;id=1&amp;field=logo>"
+            ),
+        )
+
+        self.assertEqual(
+            urls,
+            (
+                "https://cm-testing.example.com/web/image/website/7/logo?unique=abc&download=1",
+                "https://cm-testing.example.com/web/content?model=website&id=1&field=logo",
+            ),
+        )
+
     def test_build_plan_allows_issue_backed_opw_upstream_restore_policy(self) -> None:
         with (
             patch(


### PR DESCRIPTION
## Summary
- broaden Odoo logo URL extraction to accept unquoted src/href/content attributes
- keep same-origin filtering and Odoo logo-path matching in place
- add a regression test for unquoted `/web/image` and `/web/content` logo assets

## Validation
- `uv run python -m unittest tests.test_odoo_instance_overrides.OdooInstanceOverrideTests.test_cli_put_website_bootstrap_adds_deploy_and_promotion_apply_phases tests.test_odoo_stable_target_replacement`

## Notes
- The config-param apply-phase review finding is already covered on current main by `test_cli_put_website_bootstrap_adds_deploy_and_promotion_apply_phases` and the CLI path that adds `deploy` and `promotion` to existing records.
