### PR TITLE
Derive Odoo verification probes

### DIFF
--- a/control_plane/workflows/odoo_stable_bootstrap.py
+++ b/control_plane/workflows/odoo_stable_bootstrap.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-import time
-from typing import Callable, Literal, Protocol
+from typing import Literal, Protocol
 
 import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -32,9 +31,10 @@ from control_plane.workflows.odoo_stable_target_replacement import (
     _read_lane,
     _target_base_url,
     _target_health_url,
-    _verify_canonical_url,
-    _verify_health_url,
-    _verify_logo_route,
+)
+from control_plane.workflows.odoo_verification import (
+    OdooVerificationEvidence,
+    verify_odoo_stable_readiness,
 )
 from control_plane.workflows.ship import (
     build_deployment_record,
@@ -112,6 +112,10 @@ class OdooStableBootstrapResult(BaseModel):
     health_status: Literal["pass", "fail", "skipped"] = "skipped"
     canonical_status: Literal["pass", "fail", "skipped"] = "skipped"
     logo_status: Literal["pass", "fail", "skipped"] = "skipped"
+    health_url: str = ""
+    canonical_url: str = ""
+    logo_urls: tuple[str, ...] = ()
+    verification_evidence: OdooVerificationEvidence = Field(default_factory=OdooVerificationEvidence)
     target_id: str = ""
     target_name: str = ""
     artifact_id: str = ""
@@ -230,26 +234,6 @@ def _write_bootstrap_inventory_pointer(
     )
 
 
-def _run_verification_with_retry(
-    verification: Callable[[], None],
-    *,
-    timeout_seconds: int,
-    retry_interval_seconds: int = ODOO_STABLE_BOOTSTRAP_VERIFY_RETRY_INTERVAL_SECONDS,
-) -> None:
-    deadline = time.monotonic() + timeout_seconds
-    last_error: click.ClickException | None = None
-    while True:
-        try:
-            verification()
-            return
-        except click.ClickException as error:
-            last_error = error
-            remaining_seconds = deadline - time.monotonic()
-            if remaining_seconds <= 0:
-                raise last_error
-            time.sleep(min(retry_interval_seconds, remaining_seconds))
-
-
 def _base_result(
     *,
     request: OdooStableBootstrapRequest,
@@ -264,6 +248,10 @@ def _base_result(
     health_status: Literal["pass", "fail", "skipped"] = "skipped",
     canonical_status: Literal["pass", "fail", "skipped"] = "skipped",
     logo_status: Literal["pass", "fail", "skipped"] = "skipped",
+    health_url: str = "",
+    canonical_url: str = "",
+    logo_urls: tuple[str, ...] = (),
+    verification_evidence: OdooVerificationEvidence | None = None,
     error_message: str = "",
 ) -> OdooStableBootstrapResult:
     artifact_id = ""
@@ -281,6 +269,10 @@ def _base_result(
         health_status=health_status,
         canonical_status=canonical_status,
         logo_status=logo_status,
+        health_url=health_url,
+        canonical_url=canonical_url,
+        logo_urls=logo_urls,
+        verification_evidence=verification_evidence or OdooVerificationEvidence(),
         target_id=target_id_record.target_id,
         target_name=target_record.target_name,
         artifact_id=artifact_id,
@@ -595,35 +587,19 @@ def execute_odoo_stable_bootstrap(
         or target_record.healthcheck_timeout_seconds
         or control_plane_dokploy.DEFAULT_DOKPLOY_HEALTH_TIMEOUT_SECONDS
     )
-    health_status: Literal["pass", "fail", "skipped"] = "skipped"
-    canonical_status: Literal["pass", "fail", "skipped"] = "skipped"
-    logo_status: Literal["pass", "fail", "skipped"] = "skipped"
-    try:
-        if request.verify_health:
-            if not health_url:
-                raise click.ClickException("Odoo stable bootstrap has no health URL.")
-            _run_verification_with_retry(
-                lambda: _verify_health_url(
-                    health_url=health_url, timeout_seconds=health_timeout_seconds
-                ),
-                timeout_seconds=health_timeout_seconds,
-            )
-            health_status = "pass"
-        if request.verify_canonical:
-            if not base_url:
-                raise click.ClickException("Odoo stable bootstrap has no base URL.")
-            _verify_canonical_url(
-                base_url=base_url,
-                expected_base_url=base_url,
-                timeout_seconds=health_timeout_seconds,
-            )
-            canonical_status = "pass"
-        if request.verify_logo:
-            if not base_url:
-                raise click.ClickException("Odoo stable bootstrap has no base URL.")
-            _verify_logo_route(base_url=base_url, timeout_seconds=health_timeout_seconds)
-            logo_status = "pass"
-    except click.ClickException as error:
+    verification = verify_odoo_stable_readiness(
+        base_url=base_url,
+        health_url=health_url,
+        verify_health=request.verify_health,
+        verify_canonical=request.verify_canonical,
+        verify_logo=request.verify_logo,
+        timeout_seconds=health_timeout_seconds,
+        retry_interval_seconds=ODOO_STABLE_BOOTSTRAP_VERIFY_RETRY_INTERVAL_SECONDS,
+    )
+    health_status = verification.health_status
+    canonical_status = verification.canonical_status
+    logo_status = verification.logo_status
+    if verification.error_message:
         destination_health = HealthcheckEvidence(
             verified=health_status == "pass",
             urls=(health_url,) if health_url else (),
@@ -640,7 +616,7 @@ def execute_odoo_stable_bootstrap(
                 attempted=True,
                 run_status="pass",
                 readiness_status="verification_failed",
-                detail=str(error),
+                detail=verification.error_message,
             ),
             post_deploy_update=post_deploy_evidence,
             destination_health=destination_health,
@@ -663,7 +639,11 @@ def execute_odoo_stable_bootstrap(
             health_status=health_status if health_status == "pass" else "fail",
             canonical_status=canonical_status if canonical_status == "pass" else "fail",
             logo_status=logo_status if logo_status == "pass" else "fail",
-            error_message=str(error),
+            health_url=verification.evidence.health_url,
+            canonical_url=verification.evidence.canonical_url,
+            logo_urls=verification.evidence.logo_urls,
+            verification_evidence=verification.evidence,
+            error_message=verification.error_message,
         )
 
     finished_at = utc_now_timestamp()
@@ -711,4 +691,8 @@ def execute_odoo_stable_bootstrap(
         health_status=health_status,
         canonical_status=canonical_status,
         logo_status=logo_status,
+        health_url=verification.evidence.health_url,
+        canonical_url=verification.evidence.canonical_url,
+        logo_urls=verification.evidence.logo_urls,
+        verification_evidence=verification.evidence,
     )

--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -1,15 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
-import html
 import json
 from pathlib import Path
-import re
-import time
 from typing import Literal, Protocol
-from urllib.parse import urljoin, urlparse
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
 
 import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -31,6 +25,11 @@ from control_plane.contracts.ship_request import ShipRequest
 from control_plane.dokploy import JsonObject, JsonValue
 from control_plane.workflows.inventory import build_environment_inventory
 from control_plane.workflows.odoo_post_deploy import OdooPostDeployRequest, execute_odoo_post_deploy
+from control_plane.workflows.odoo_verification import (
+    OdooVerificationEvidence,
+    default_odoo_health_url,
+    verify_odoo_stable_readiness,
+)
 from control_plane.workflows.ship import (
     build_deployment_record,
     generate_deployment_record_id,
@@ -177,6 +176,10 @@ class OdooStableTargetReplacementApplyResult(BaseModel):
     health_status: Literal["pass", "fail", "skipped"] = "skipped"
     canonical_status: Literal["pass", "fail", "skipped"] = "skipped"
     logo_status: Literal["pass", "fail", "skipped"] = "skipped"
+    health_url: str = ""
+    canonical_url: str = ""
+    logo_urls: tuple[str, ...] = ()
+    verification_evidence: OdooVerificationEvidence = Field(default_factory=OdooVerificationEvidence)
     runtime_identity_injected: bool = False
     target_id: str = ""
     target_name: str = ""
@@ -205,6 +208,10 @@ class _ApplyResultBase(BaseModel):
         health_status: Literal["pass", "fail", "skipped"] = "skipped",
         canonical_status: Literal["pass", "fail", "skipped"] = "skipped",
         logo_status: Literal["pass", "fail", "skipped"] = "skipped",
+        health_url: str = "",
+        canonical_url: str = "",
+        logo_urls: tuple[str, ...] = (),
+        verification_evidence: OdooVerificationEvidence | None = None,
         runtime_identity_injected: bool = False,
         error_message: str = "",
     ) -> OdooStableTargetReplacementApplyResult:
@@ -219,6 +226,10 @@ class _ApplyResultBase(BaseModel):
             health_status=health_status,
             canonical_status=canonical_status,
             logo_status=logo_status,
+            health_url=health_url,
+            canonical_url=canonical_url,
+            logo_urls=logo_urls,
+            verification_evidence=verification_evidence or OdooVerificationEvidence(),
             runtime_identity_injected=runtime_identity_injected,
             target_id=self.target_id,
             target_name=self.target_name,
@@ -330,122 +341,7 @@ def _target_health_url(
     if lane.health_url.strip():
         return lane.health_url.strip()
     base_url = _target_base_url(lane=lane, domains=domains)
-    if not base_url:
-        return ""
-    health_path = profile.health_path.strip() or "/web/health"
-    if not health_path.startswith("/"):
-        health_path = f"/{health_path}"
-    return f"{base_url}{health_path}"
-
-
-def _http_text(url: str, *, timeout_seconds: int) -> tuple[int, str, str]:
-    request = Request(url, headers={"User-Agent": "Launchplane-Odoo-Recreate/1"})
-    try:
-        with urlopen(request, timeout=timeout_seconds) as response:  # noqa: S310 - operator-configured URLs only.
-            body = response.read(1024 * 512).decode("utf-8", errors="replace")
-            content_type = response.headers.get("Content-Type", "")
-            return response.status, body, content_type
-    except HTTPError as error:
-        body = error.read(4096).decode("utf-8", errors="replace")
-        return error.code, body, error.headers.get("Content-Type", "")
-    except (TimeoutError, URLError) as error:
-        raise click.ClickException(f"Could not reach {url}: {error}") from error
-
-
-def _verify_health_url(*, health_url: str, timeout_seconds: int) -> None:
-    status_code, body, _content_type = _http_text(health_url, timeout_seconds=timeout_seconds)
-    if status_code >= 400:
-        raise click.ClickException(f"Health check {health_url} returned HTTP {status_code}.")
-    try:
-        payload = json.loads(body)
-    except ValueError:
-        return
-    if isinstance(payload, dict):
-        raw_status = str(payload.get("status") or "").strip().lower()
-        if raw_status and raw_status not in {"ok", "pass", "healthy"}:
-            raise click.ClickException(f"Health check {health_url} returned status={raw_status!r}.")
-
-
-def _verify_canonical_url(*, base_url: str, expected_base_url: str, timeout_seconds: int) -> None:
-    status_code, body, _content_type = _http_text(base_url, timeout_seconds=timeout_seconds)
-    if status_code >= 400:
-        raise click.ClickException(f"Canonical check {base_url} returned HTTP {status_code}.")
-    expected = expected_base_url.rstrip("/")
-    stale_preview_marker = ".cm-preview."
-    if stale_preview_marker in body:
-        raise click.ClickException("Canonical page still contains a cm-preview hostname.")
-    canonical_href = f'rel="canonical" href="{expected}'
-    alternate_canonical_href = f"rel='canonical' href='{expected}"
-    if canonical_href not in body and alternate_canonical_href not in body:
-        raise click.ClickException(f"Canonical page does not advertise {expected}.")
-
-
-def _verify_logo_route(*, base_url: str, timeout_seconds: int) -> None:
-    checked_urls: list[str] = []
-    for logo_url in _candidate_logo_urls(base_url=base_url, timeout_seconds=timeout_seconds):
-        if logo_url in checked_urls:
-            continue
-        checked_urls.append(logo_url)
-        status_code, body, content_type = _http_text(logo_url, timeout_seconds=timeout_seconds)
-        if status_code < 400 and not ("text/html" in content_type.lower() and "404" in body[:500].lower()):
-            return
-    checked = ", ".join(checked_urls) if checked_urls else base_url
-    raise click.ClickException(f"Logo check failed for {checked}.")
-
-
-def _candidate_logo_urls(*, base_url: str, timeout_seconds: int) -> tuple[str, ...]:
-    normalized_base_url = base_url.rstrip("/")
-    status_code, body, _content_type = _http_text(normalized_base_url, timeout_seconds=timeout_seconds)
-    if status_code < 400:
-        urls = tuple(_extract_same_origin_logo_urls(base_url=normalized_base_url, body=body))
-        if urls:
-            return urls
-    return (f"{normalized_base_url}/web/image/website/1/logo",)
-
-
-def _extract_same_origin_logo_urls(*, base_url: str, body: str) -> tuple[str, ...]:
-    base_origin = _url_origin(base_url)
-    logo_urls: list[str] = []
-    for match in re.finditer(
-        (
-            r"(?:src|href|content)\s*=\s*"
-            r"(?P<quote>[\"'])?"
-            r"(?P<url>[^\s\"'<>]*/web/(?:image/website/[^\s\"'<>]*/logo|content[^\s\"'<>]*logo)[^\s\"'<>]*)"
-            r"(?P=quote)?"
-        ),
-        body,
-        re.IGNORECASE,
-    ):
-        raw_url = html.unescape(match.group("url")).strip()
-        absolute_url = urljoin(f"{base_url.rstrip('/')}/", raw_url)
-        if _url_origin(absolute_url) == base_origin and absolute_url not in logo_urls:
-            logo_urls.append(absolute_url)
-    return tuple(logo_urls)
-
-
-def _url_origin(raw_url: str) -> str:
-    parsed = urlparse(raw_url)
-    return f"{parsed.scheme.lower()}://{parsed.netloc.lower()}"
-
-
-def _run_verification_with_retry(
-    verification: Callable[[], None],
-    *,
-    timeout_seconds: int,
-    retry_interval_seconds: int = ODOO_STABLE_TARGET_REPLACEMENT_VERIFY_RETRY_INTERVAL_SECONDS,
-) -> None:
-    deadline = time.monotonic() + timeout_seconds
-    last_error: click.ClickException | None = None
-    while True:
-        try:
-            verification()
-            return
-        except click.ClickException as error:
-            last_error = error
-            remaining_seconds = deadline - time.monotonic()
-            if remaining_seconds <= 0:
-                raise last_error
-            time.sleep(min(retry_interval_seconds, remaining_seconds))
+    return default_odoo_health_url(base_url=base_url, health_path=profile.health_path)
 
 
 def _normalize_domain(raw_domain: str) -> str:
@@ -1054,51 +950,19 @@ def execute_odoo_stable_target_replacement_apply(
 
     base_url = _target_base_url(lane=lane, domains=plan.expected_domain_hosts)
     health_url = _target_health_url(profile=profile, lane=lane, domains=plan.expected_domain_hosts)
-    health_status: Literal["pass", "fail", "skipped"] = "skipped"
-    canonical_status: Literal["pass", "fail", "skipped"] = "skipped"
-    logo_status: Literal["pass", "fail", "skipped"] = "skipped"
-    try:
-        if request.verify_health:
-            if not health_url:
-                raise click.ClickException(
-                    "Odoo target replacement health verification has no health URL."
-                )
-            _run_verification_with_retry(
-                lambda: _verify_health_url(
-                    health_url=health_url,
-                    timeout_seconds=health_timeout_seconds,
-                ),
-                timeout_seconds=health_timeout_seconds,
-            )
-            health_status = "pass"
-        if request.verify_canonical:
-            if not base_url:
-                raise click.ClickException(
-                    "Odoo target replacement canonical verification has no base URL."
-                )
-            _run_verification_with_retry(
-                lambda: _verify_canonical_url(
-                    base_url=base_url,
-                    expected_base_url=base_url,
-                    timeout_seconds=health_timeout_seconds,
-                ),
-                timeout_seconds=health_timeout_seconds,
-            )
-            canonical_status = "pass"
-        if request.verify_logo:
-            if not base_url:
-                raise click.ClickException(
-                    "Odoo target replacement logo verification has no base URL."
-                )
-            _run_verification_with_retry(
-                lambda: _verify_logo_route(
-                    base_url=base_url,
-                    timeout_seconds=health_timeout_seconds,
-                ),
-                timeout_seconds=health_timeout_seconds,
-            )
-            logo_status = "pass"
-    except click.ClickException as error:
+    verification = verify_odoo_stable_readiness(
+        base_url=base_url,
+        health_url=health_url,
+        verify_health=request.verify_health,
+        verify_canonical=request.verify_canonical,
+        verify_logo=request.verify_logo,
+        timeout_seconds=health_timeout_seconds,
+        retry_interval_seconds=ODOO_STABLE_TARGET_REPLACEMENT_VERIFY_RETRY_INTERVAL_SECONDS,
+    )
+    health_status = verification.health_status
+    canonical_status = verification.canonical_status
+    logo_status = verification.logo_status
+    if verification.error_message:
         destination_health = HealthcheckEvidence(
             verified=health_status == "pass",
             urls=(health_url,) if health_url else (),
@@ -1121,8 +985,12 @@ def execute_odoo_stable_target_replacement_apply(
             health_status=health_status if health_status == "pass" else "fail",
             canonical_status=canonical_status if canonical_status == "pass" else "fail",
             logo_status=logo_status if logo_status == "pass" else "fail",
+            health_url=verification.evidence.health_url,
+            canonical_url=verification.evidence.canonical_url,
+            logo_urls=verification.evidence.logo_urls,
+            verification_evidence=verification.evidence,
             runtime_identity_injected=True,
-            error_message=str(error),
+            error_message=verification.error_message,
         )
 
     finished_at = utc_now_timestamp()
@@ -1155,5 +1023,9 @@ def execute_odoo_stable_target_replacement_apply(
         health_status=health_status,
         canonical_status=canonical_status,
         logo_status=logo_status,
+        health_url=verification.evidence.health_url,
+        canonical_url=verification.evidence.canonical_url,
+        logo_urls=verification.evidence.logo_urls,
+        verification_evidence=verification.evidence,
         runtime_identity_injected=True,
     )

--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
-import json
 from pathlib import Path
 from typing import Literal, Protocol
 

--- a/control_plane/workflows/odoo_verification.py
+++ b/control_plane/workflows/odoo_verification.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+import html
+import json
+import re
+import time
+from typing import Literal
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin, urlparse
+from urllib.request import Request, urlopen
+
+import click
+from pydantic import BaseModel, ConfigDict, Field
+
+from control_plane.contracts.promotion_record import ReleaseStatus
+
+
+ODOO_VERIFY_RETRY_INTERVAL_SECONDS = 5
+OdooProbeKind = Literal["health", "canonical", "logo"]
+OdooReadinessStatus = Literal["pass", "fail", "skipped"]
+
+
+class OdooVerificationProbeEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    probe: OdooProbeKind
+    url: str
+    status: ReleaseStatus = "pending"
+    status_code: int | None = None
+    content_type: str = ""
+    failure_class: str = ""
+    detail: str = ""
+
+
+class OdooVerificationEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    base_url: str = ""
+    health_url: str = ""
+    canonical_url: str = ""
+    logo_urls: tuple[str, ...] = ()
+    probes: tuple[OdooVerificationProbeEvidence, ...] = ()
+
+
+class OdooVerificationResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    health_status: OdooReadinessStatus = "skipped"
+    canonical_status: OdooReadinessStatus = "skipped"
+    logo_status: OdooReadinessStatus = "skipped"
+    evidence: OdooVerificationEvidence = Field(default_factory=OdooVerificationEvidence)
+    error_message: str = ""
+
+
+class _ProbeFailure(click.ClickException):
+    def __init__(self, message: str, *, evidence: OdooVerificationProbeEvidence) -> None:
+        super().__init__(message)
+        self.evidence = evidence
+
+
+def default_odoo_health_url(*, base_url: str, health_path: str = "/web/health") -> str:
+    normalized_base_url = base_url.strip().rstrip("/")
+    if not normalized_base_url:
+        return ""
+    normalized_health_path = health_path.strip() or "/web/health"
+    if not normalized_health_path.startswith("/"):
+        normalized_health_path = f"/{normalized_health_path}"
+    return f"{normalized_base_url}{normalized_health_path}"
+
+
+def verify_odoo_stable_readiness(
+    *,
+    base_url: str,
+    health_url: str = "",
+    verify_health: bool = True,
+    verify_canonical: bool = True,
+    verify_logo: bool = True,
+    timeout_seconds: int,
+    retry_interval_seconds: int = ODOO_VERIFY_RETRY_INTERVAL_SECONDS,
+) -> OdooVerificationResult:
+    normalized_base_url = base_url.strip().rstrip("/")
+    normalized_health_url = health_url.strip() or default_odoo_health_url(
+        base_url=normalized_base_url
+    )
+    probes: list[OdooVerificationProbeEvidence] = []
+    health_status: OdooReadinessStatus = "skipped"
+    canonical_status: OdooReadinessStatus = "skipped"
+    logo_status: OdooReadinessStatus = "skipped"
+    logo_urls: tuple[str, ...] = ()
+
+    try:
+        if verify_health:
+            if not normalized_health_url:
+                raise click.ClickException("Odoo health verification has no health URL.")
+            evidence = _run_probe_with_retry(
+                lambda: _verify_health_url(
+                    health_url=normalized_health_url,
+                    timeout_seconds=timeout_seconds,
+                ),
+                timeout_seconds=timeout_seconds,
+                retry_interval_seconds=retry_interval_seconds,
+            )
+            probes.append(evidence)
+            health_status = "pass"
+        if verify_canonical:
+            if not normalized_base_url:
+                raise click.ClickException("Odoo canonical verification has no base URL.")
+            evidence = _run_probe_with_retry(
+                lambda: _verify_canonical_url(
+                    base_url=normalized_base_url,
+                    expected_base_url=normalized_base_url,
+                    timeout_seconds=timeout_seconds,
+                ),
+                timeout_seconds=timeout_seconds,
+                retry_interval_seconds=retry_interval_seconds,
+            )
+            probes.append(evidence)
+            canonical_status = "pass"
+        if verify_logo:
+            if not normalized_base_url:
+                raise click.ClickException("Odoo logo verification has no base URL.")
+            evidence, logo_urls = _run_logo_probe_with_retry(
+                lambda: _verify_logo_route(
+                    base_url=normalized_base_url,
+                    timeout_seconds=timeout_seconds,
+                ),
+                timeout_seconds=timeout_seconds,
+                retry_interval_seconds=retry_interval_seconds,
+            )
+            probes.append(evidence)
+            logo_status = "pass"
+    except _ProbeFailure as error:
+        probes.append(error.evidence)
+        if error.evidence.probe == "health":
+            health_status = "fail"
+        elif error.evidence.probe == "canonical":
+            canonical_status = "fail"
+        elif error.evidence.probe == "logo":
+            logo_status = "fail"
+            logo_urls = (error.evidence.url,) if error.evidence.url else ()
+        return OdooVerificationResult(
+            health_status=health_status,
+            canonical_status=canonical_status,
+            logo_status=logo_status,
+            evidence=OdooVerificationEvidence(
+                base_url=normalized_base_url,
+                health_url=normalized_health_url,
+                canonical_url=normalized_base_url,
+                logo_urls=logo_urls,
+                probes=tuple(probes),
+            ),
+            error_message=str(error),
+        )
+    except click.ClickException as error:
+        return OdooVerificationResult(
+            health_status="fail" if verify_health and health_status != "pass" else health_status,
+            canonical_status="fail" if verify_canonical and canonical_status != "pass" else canonical_status,
+            logo_status="fail" if verify_logo and logo_status != "pass" else logo_status,
+            evidence=OdooVerificationEvidence(
+                base_url=normalized_base_url,
+                health_url=normalized_health_url,
+                canonical_url=normalized_base_url,
+                logo_urls=logo_urls,
+                probes=tuple(probes),
+            ),
+            error_message=str(error),
+        )
+
+    return OdooVerificationResult(
+        health_status=health_status,
+        canonical_status=canonical_status,
+        logo_status=logo_status,
+        evidence=OdooVerificationEvidence(
+            base_url=normalized_base_url,
+            health_url=normalized_health_url,
+            canonical_url=normalized_base_url,
+            logo_urls=logo_urls,
+            probes=tuple(probes),
+        ),
+    )
+
+
+def _http_text(url: str, *, timeout_seconds: int) -> tuple[int, str, str]:
+    request = Request(url, headers={"User-Agent": "Launchplane-Odoo-Verify/1"})
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:  # noqa: S310 - operator-configured URLs only.
+            body = response.read(1024 * 512).decode("utf-8", errors="replace")
+            content_type = response.headers.get("Content-Type", "")
+            return response.status, body, content_type
+    except HTTPError as error:
+        body = error.read(4096).decode("utf-8", errors="replace")
+        return error.code, body, error.headers.get("Content-Type", "")
+    except (TimeoutError, URLError) as error:
+        raise click.ClickException(f"Could not reach {url}: {error}") from error
+
+
+def _verify_health_url(*, health_url: str, timeout_seconds: int) -> OdooVerificationProbeEvidence:
+    status_code, body, content_type = _http_text(health_url, timeout_seconds=timeout_seconds)
+    evidence = OdooVerificationProbeEvidence(
+        probe="health", url=health_url, status_code=status_code, content_type=content_type
+    )
+    if status_code >= 400:
+        raise _ProbeFailure(
+            f"Health check {health_url} returned HTTP {status_code}.",
+            evidence=evidence.model_copy(update={"status": "fail", "failure_class": "http"}),
+        )
+    try:
+        payload = json.loads(body)
+    except ValueError:
+        return evidence.model_copy(update={"status": "pass"})
+    if isinstance(payload, dict):
+        raw_status = str(payload.get("status") or "").strip().lower()
+        if raw_status and raw_status not in {"ok", "pass", "healthy"}:
+            raise _ProbeFailure(
+                f"Health check {health_url} returned status={raw_status!r}.",
+                evidence=evidence.model_copy(
+                    update={
+                        "status": "fail",
+                        "failure_class": "payload_status",
+                        "detail": f"status={raw_status}",
+                    }
+                ),
+            )
+    return evidence.model_copy(update={"status": "pass"})
+
+
+def _verify_canonical_url(
+    *, base_url: str, expected_base_url: str, timeout_seconds: int
+) -> OdooVerificationProbeEvidence:
+    status_code, body, content_type = _http_text(base_url, timeout_seconds=timeout_seconds)
+    evidence = OdooVerificationProbeEvidence(
+        probe="canonical", url=base_url, status_code=status_code, content_type=content_type
+    )
+    if status_code >= 400:
+        raise _ProbeFailure(
+            f"Canonical check {base_url} returned HTTP {status_code}.",
+            evidence=evidence.model_copy(update={"status": "fail", "failure_class": "http"}),
+        )
+    expected = expected_base_url.rstrip("/")
+    stale_preview_marker = ".cm-preview."
+    if stale_preview_marker in body:
+        raise _ProbeFailure(
+            "Canonical page still contains a cm-preview hostname.",
+            evidence=evidence.model_copy(
+                update={"status": "fail", "failure_class": "stale_preview_marker"}
+            ),
+        )
+    canonical_href = f'rel="canonical" href="{expected}'
+    alternate_canonical_href = f"rel='canonical' href='{expected}"
+    if canonical_href not in body and alternate_canonical_href not in body:
+        raise _ProbeFailure(
+            f"Canonical page does not advertise {expected}.",
+            evidence=evidence.model_copy(
+                update={"status": "fail", "failure_class": "canonical_missing"}
+            ),
+        )
+    return evidence.model_copy(update={"status": "pass"})
+
+
+def _verify_logo_route(
+    *, base_url: str, timeout_seconds: int
+) -> tuple[OdooVerificationProbeEvidence, tuple[str, ...]]:
+    checked_urls: list[str] = []
+    last_failure: OdooVerificationProbeEvidence | None = None
+    for logo_url in _candidate_logo_urls(base_url=base_url, timeout_seconds=timeout_seconds):
+        if logo_url in checked_urls:
+            continue
+        checked_urls.append(logo_url)
+        status_code, body, content_type = _http_text(logo_url, timeout_seconds=timeout_seconds)
+        evidence = OdooVerificationProbeEvidence(
+            probe="logo", url=logo_url, status_code=status_code, content_type=content_type
+        )
+        if status_code < 400 and not ("text/html" in content_type.lower() and "404" in body[:500].lower()):
+            return evidence.model_copy(update={"status": "pass"}), tuple(checked_urls)
+        failure_class = "http" if status_code >= 400 else "html_404"
+        last_failure = evidence.model_copy(
+            update={
+                "status": "fail",
+                "failure_class": failure_class,
+                "detail": f"checked={', '.join(checked_urls)}",
+            }
+        )
+    checked = ", ".join(checked_urls) if checked_urls else base_url
+    if last_failure is not None and last_failure.status_code is not None:
+        raise _ProbeFailure(
+            f"Logo check {last_failure.url} returned HTTP {last_failure.status_code}.",
+            evidence=last_failure,
+        )
+    raise _ProbeFailure(
+        f"Logo check failed for {checked}.",
+        evidence=last_failure
+        or OdooVerificationProbeEvidence(
+            probe="logo", url=base_url, status="fail", failure_class="logo_unavailable"
+        ),
+    )
+
+
+def _candidate_logo_urls(*, base_url: str, timeout_seconds: int) -> tuple[str, ...]:
+    normalized_base_url = base_url.rstrip("/")
+    status_code, body, _content_type = _http_text(normalized_base_url, timeout_seconds=timeout_seconds)
+    if status_code < 400:
+        urls = tuple(_extract_same_origin_logo_urls(base_url=normalized_base_url, body=body))
+        if urls:
+            return urls
+    return (f"{normalized_base_url}/web/image/website/1/logo",)
+
+
+def _extract_same_origin_logo_urls(*, base_url: str, body: str) -> tuple[str, ...]:
+    base_origin = _url_origin(base_url)
+    logo_urls: list[str] = []
+    for match in re.finditer(
+        (
+            r"(?:src|href|content)\s*=\s*"
+            r"(?P<quote>[\"'])?"
+            r"(?P<url>[^\s\"'<>]*/web/(?:image/website/[^\s\"'<>]*/logo|content[^\s\"'<>]*logo)[^\s\"'<>]*)"
+            r"(?P=quote)?"
+        ),
+        body,
+        re.IGNORECASE,
+    ):
+        raw_url = html.unescape(match.group("url")).strip()
+        absolute_url = urljoin(f"{base_url.rstrip('/')}/", raw_url)
+        if _url_origin(absolute_url) == base_origin and absolute_url not in logo_urls:
+            logo_urls.append(absolute_url)
+    return tuple(logo_urls)
+
+
+def _url_origin(raw_url: str) -> str:
+    parsed = urlparse(raw_url)
+    return f"{parsed.scheme.lower()}://{parsed.netloc.lower()}"
+
+
+def _run_probe_with_retry(
+    verification: Callable[[], OdooVerificationProbeEvidence],
+    *,
+    timeout_seconds: int,
+    retry_interval_seconds: int,
+) -> OdooVerificationProbeEvidence:
+    deadline = time.monotonic() + timeout_seconds
+    last_error: click.ClickException | None = None
+    while True:
+        try:
+            return verification()
+        except click.ClickException as error:
+            last_error = error
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                if last_error is None:
+                    raise click.ClickException("Odoo verification retry ended without an error.")
+                raise last_error
+            time.sleep(min(retry_interval_seconds, remaining_seconds))
+
+
+def _run_logo_probe_with_retry(
+    verification: Callable[[], tuple[OdooVerificationProbeEvidence, tuple[str, ...]]],
+    *,
+    timeout_seconds: int,
+    retry_interval_seconds: int,
+) -> tuple[OdooVerificationProbeEvidence, tuple[str, ...]]:
+    deadline = time.monotonic() + timeout_seconds
+    last_error: click.ClickException | None = None
+    while True:
+        try:
+            return verification()
+        except click.ClickException as error:
+            last_error = error
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                if last_error is None:
+                    raise click.ClickException("Odoo logo verification retry ended without an error.")
+                raise last_error
+            time.sleep(min(retry_interval_seconds, remaining_seconds))

--- a/tests/test_odoo_stable_bootstrap.py
+++ b/tests/test_odoo_stable_bootstrap.py
@@ -30,9 +30,12 @@ from control_plane.workflows.odoo_post_deploy import OdooPostDeployResult
 from control_plane.workflows.odoo_stable_bootstrap import (
     OdooStableBootstrapRequest,
     execute_odoo_stable_bootstrap,
-    _run_verification_with_retry,
 )
 from control_plane.workflows.odoo_stable_target_replacement import DokployRequest
+from control_plane.workflows.odoo_verification import (
+    OdooVerificationEvidence,
+    OdooVerificationResult,
+)
 
 
 _BOOTSTRAP_CONFIRMATION = "bootstrap cm testing"
@@ -50,6 +53,34 @@ def _mismatched_dokploy_request(
     if path == "/api/domain.byComposeId" and query == {"composeId": "compose-cm-testing"}:
         return [{"host": "cm-prod.shinycomputers.com", "domainId": "domain-cm"}]
     return []
+
+
+def _verification_result() -> OdooVerificationResult:
+    return OdooVerificationResult(
+        health_status="pass",
+        canonical_status="pass",
+        logo_status="pass",
+        evidence=OdooVerificationEvidence(
+            base_url="https://cm-testing.shinycomputers.com",
+            health_url="https://cm-testing.shinycomputers.com/web/health",
+            canonical_url="https://cm-testing.shinycomputers.com",
+            logo_urls=("https://cm-testing.shinycomputers.com/web/image/website/1/logo",),
+        ),
+    )
+
+
+def _verification_failure_result() -> OdooVerificationResult:
+    return OdooVerificationResult(
+        health_status="pass",
+        canonical_status="fail",
+        logo_status="skipped",
+        evidence=OdooVerificationEvidence(
+            base_url="https://cm-testing.shinycomputers.com",
+            health_url="https://cm-testing.shinycomputers.com/web/health",
+            canonical_url="https://cm-testing.shinycomputers.com",
+        ),
+        error_message="canonical failed",
+    )
 
 
 class _Store:
@@ -184,17 +215,9 @@ class OdooStableBootstrapTests(unittest.TestCase):
                 ),
             ) as post_deploy_mock,
             patch(
-                "control_plane.workflows.odoo_stable_bootstrap._verify_health_url",
-                side_effect=lambda **_kwargs: None,
-            ) as health_mock,
-            patch(
-                "control_plane.workflows.odoo_stable_bootstrap._verify_canonical_url",
-                side_effect=lambda **_kwargs: None,
-            ) as canonical_mock,
-            patch(
-                "control_plane.workflows.odoo_stable_bootstrap._verify_logo_route",
-                side_effect=lambda **_kwargs: None,
-            ) as logo_mock,
+                "control_plane.workflows.odoo_stable_bootstrap.verify_odoo_stable_readiness",
+                return_value=_verification_result(),
+            ) as verify_readiness,
             patch(
                 "control_plane.workflows.odoo_stable_bootstrap.utc_now_timestamp",
                 side_effect=("2026-05-10T02:00:00Z", "2026-05-10T02:05:00Z"),
@@ -231,17 +254,22 @@ class OdooStableBootstrapTests(unittest.TestCase):
         self.assertEqual(captured_bootstrap_runs[0]["timeout_seconds"], None)
         post_deploy_mock.assert_called_once()
         self.assertEqual(post_deploy_mock.call_args.kwargs["request"].phase, "deploy")
-        health_mock.assert_called_once()
-        self.assertEqual(
-            health_mock.call_args.kwargs["health_url"],
-            "https://cm-testing.shinycomputers.com/web/health",
+        verify_readiness.assert_called_once_with(
+            base_url="https://cm-testing.shinycomputers.com",
+            health_url="https://cm-testing.shinycomputers.com/web/health",
+            verify_health=True,
+            verify_canonical=True,
+            verify_logo=True,
+            timeout_seconds=30,
+            retry_interval_seconds=5,
         )
-        canonical_mock.assert_called_once()
+        self.assertEqual(result.health_url, "https://cm-testing.shinycomputers.com/web/health")
+        self.assertEqual(result.canonical_url, "https://cm-testing.shinycomputers.com")
         self.assertEqual(
-            canonical_mock.call_args.kwargs["base_url"],
-            "https://cm-testing.shinycomputers.com",
+            result.logo_urls,
+            ("https://cm-testing.shinycomputers.com/web/image/website/1/logo",),
         )
-        logo_mock.assert_called_once()
+        self.assertEqual(result.verification_evidence.health_url, result.health_url)
         self.assertEqual(len(store.deployment_records), 2)
         self.assertEqual(store.deployment_records[-1].bootstrap.run_status, "pass")
         self.assertEqual(store.deployment_records[-1].bootstrap.readiness_status, "pass")
@@ -311,9 +339,10 @@ class OdooStableBootstrapTests(unittest.TestCase):
                     post_deploy_status="pass",
                 ),
             ),
-            patch("control_plane.workflows.odoo_stable_bootstrap._verify_health_url"),
-            patch("control_plane.workflows.odoo_stable_bootstrap._verify_canonical_url"),
-            patch("control_plane.workflows.odoo_stable_bootstrap._verify_logo_route"),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.verify_odoo_stable_readiness",
+                return_value=_verification_result(),
+            ),
             patch(
                 "control_plane.workflows.odoo_stable_bootstrap.utc_now_timestamp",
                 side_effect=("2026-05-10T02:00:00Z", "2026-05-10T02:01:00Z"),
@@ -378,16 +407,8 @@ class OdooStableBootstrapTests(unittest.TestCase):
                 ),
             ),
             patch(
-                "control_plane.workflows.odoo_stable_bootstrap._verify_health_url",
-                side_effect=lambda **_kwargs: None,
-            ),
-            patch(
-                "control_plane.workflows.odoo_stable_bootstrap._verify_canonical_url",
-                side_effect=lambda **_kwargs: None,
-            ),
-            patch(
-                "control_plane.workflows.odoo_stable_bootstrap._verify_logo_route",
-                side_effect=lambda **_kwargs: None,
+                "control_plane.workflows.odoo_stable_bootstrap.verify_odoo_stable_readiness",
+                return_value=_verification_result(),
             ),
         ):
             result = execute_odoo_stable_bootstrap(
@@ -731,12 +752,8 @@ class OdooStableBootstrapTests(unittest.TestCase):
                 ),
             ),
             patch(
-                "control_plane.workflows.odoo_stable_bootstrap._verify_health_url",
-                side_effect=lambda **_kwargs: None,
-            ),
-            patch(
-                "control_plane.workflows.odoo_stable_bootstrap._verify_canonical_url",
-                side_effect=click.ClickException("canonical failed"),
+                "control_plane.workflows.odoo_stable_bootstrap.verify_odoo_stable_readiness",
+                return_value=_verification_failure_result(),
             ),
             patch(
                 "control_plane.workflows.odoo_stable_bootstrap.utc_now_timestamp",
@@ -779,29 +796,6 @@ class OdooStableBootstrapTests(unittest.TestCase):
             store.environment_inventories[0].bootstrap_record_id,
             "deployment-cm-testing-bootstrap",
         )
-
-    def test_verification_retry_allows_transient_startup_failure(self) -> None:
-        attempts = 0
-
-        def flaky_verification() -> None:
-            nonlocal attempts
-            attempts += 1
-            if attempts == 1:
-                raise click.ClickException("temporary health 404")
-
-        with patch(
-            "control_plane.workflows.odoo_stable_bootstrap.time.sleep",
-            side_effect=lambda _seconds: None,
-        ) as sleep_mock:
-            _run_verification_with_retry(
-                flaky_verification,
-                timeout_seconds=30,
-                retry_interval_seconds=5,
-            )
-
-        self.assertEqual(attempts, 2)
-        sleep_mock.assert_called_once()
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -31,11 +31,12 @@ from control_plane.workflows.odoo_stable_target_replacement import (
     DokployRequest,
     OdooStableTargetReplacementApplyRequest,
     OdooStableTargetReplacementRequest,
-    _extract_same_origin_logo_urls,
-    _verify_logo_route,
-    _run_verification_with_retry,
     build_odoo_stable_target_replacement_plan,
     execute_odoo_stable_target_replacement_apply,
+)
+from control_plane.workflows.odoo_verification import (
+    OdooVerificationEvidence,
+    OdooVerificationResult,
 )
 
 
@@ -112,6 +113,20 @@ def _profile(driver_id: str = "odoo") -> LaunchplaneProductProfileRecord:
         preview=ProductPreviewProfile(enabled=True, context="cm"),
         updated_at="2026-05-09T00:00:00Z",
         source="test",
+    )
+
+
+def _verification_result() -> OdooVerificationResult:
+    return OdooVerificationResult(
+        health_status="pass",
+        canonical_status="pass",
+        logo_status="pass",
+        evidence=OdooVerificationEvidence(
+            base_url="https://cm-testing.shinycomputers.com",
+            health_url="https://cm-testing.shinycomputers.com/web/health",
+            canonical_url="https://cm-testing.shinycomputers.com",
+            logo_urls=("https://cm-testing.shinycomputers.com/web/image/website/1/logo",),
+        ),
     )
 
 
@@ -243,137 +258,6 @@ def _request(path: str, query: object | None = None, **_: object) -> JsonValue:
 
 
 class OdooStableTargetReplacementTests(unittest.TestCase):
-    def test_logo_verification_uses_logo_url_from_canonical_page(self) -> None:
-        calls: list[str] = []
-
-        def fake_http_text(url: str, *, timeout_seconds: int) -> tuple[int, str, str]:
-            self.assertEqual(timeout_seconds, 5)
-            calls.append(url)
-            if url == "https://cm-testing.example.com":
-                return (
-                    200,
-                    '<html><img src="/web/image/website/7/logo?unique=abc"></html>',
-                    "text/html",
-                )
-            if url == "https://cm-testing.example.com/web/image/website/7/logo?unique=abc":
-                return 200, "image-bytes", "image/png"
-            return 404, "missing", "text/plain"
-
-        with patch(
-            "control_plane.workflows.odoo_stable_target_replacement._http_text",
-            side_effect=fake_http_text,
-        ):
-            _verify_logo_route(base_url="https://cm-testing.example.com", timeout_seconds=5)
-
-        self.assertEqual(
-            calls,
-            [
-                "https://cm-testing.example.com",
-                "https://cm-testing.example.com/web/image/website/7/logo?unique=abc",
-            ],
-        )
-
-    def test_logo_verification_falls_back_to_legacy_website_one_route(self) -> None:
-        calls: list[str] = []
-
-        def fake_http_text(url: str, *, timeout_seconds: int) -> tuple[int, str, str]:
-            self.assertEqual(timeout_seconds, 5)
-            calls.append(url)
-            if url == "https://cm-testing.example.com":
-                return 200, "<html>No logo route here</html>", "text/html"
-            if url == "https://cm-testing.example.com/web/image/website/1/logo":
-                return 200, "image-bytes", "image/png"
-            return 404, "missing", "text/plain"
-
-        with patch(
-            "control_plane.workflows.odoo_stable_target_replacement._http_text",
-            side_effect=fake_http_text,
-        ):
-            _verify_logo_route(base_url="https://cm-testing.example.com/", timeout_seconds=5)
-
-        self.assertEqual(
-            calls,
-            [
-                "https://cm-testing.example.com",
-                "https://cm-testing.example.com/web/image/website/1/logo",
-            ],
-        )
-
-    def test_extract_logo_urls_ignores_cross_origin_assets(self) -> None:
-        urls = _extract_same_origin_logo_urls(
-            base_url="https://cm-testing.example.com",
-            body=(
-                '<img src="https://evil.example.com/web/image/website/9/logo">'
-                '<img src="/web/image/website/7/logo?unique=abc&amp;download=1">'
-            ),
-        )
-
-        self.assertEqual(
-            urls,
-            ("https://cm-testing.example.com/web/image/website/7/logo?unique=abc&download=1",),
-        )
-
-    def test_logo_verification_accepts_odoo_web_content_logo_url(self) -> None:
-        calls: list[str] = []
-
-        def fake_http_text(url: str, *, timeout_seconds: int) -> tuple[int, str, str]:
-            self.assertEqual(timeout_seconds, 5)
-            calls.append(url)
-            if url == "https://cm-testing.example.com":
-                return (
-                    200,
-                    '<meta property="og:image" content="/web/content?model=website&amp;id=1&amp;field=logo">',
-                    "text/html",
-                )
-            if url == "https://cm-testing.example.com/web/content?model=website&id=1&field=logo":
-                return 200, "image-bytes", "image/png"
-            return 404, "missing", "text/plain"
-
-        with patch(
-            "control_plane.workflows.odoo_stable_target_replacement._http_text",
-            side_effect=fake_http_text,
-        ):
-            _verify_logo_route(base_url="https://cm-testing.example.com", timeout_seconds=5)
-
-        self.assertEqual(
-            calls,
-            [
-                "https://cm-testing.example.com",
-                "https://cm-testing.example.com/web/content?model=website&id=1&field=logo",
-            ],
-        )
-
-    def test_extract_logo_urls_accepts_same_origin_web_content_logo_assets(self) -> None:
-        urls = _extract_same_origin_logo_urls(
-            base_url="https://cm-testing.example.com",
-            body=(
-                '<meta property="og:image" content="https://evil.example.com/web/content?model=website&amp;id=1&amp;field=logo">'
-                '<meta name="twitter:image" content="/web/content/website/1/logo/Cell%20Mechanic.png">'
-            ),
-        )
-
-        self.assertEqual(
-            urls,
-            ("https://cm-testing.example.com/web/content/website/1/logo/Cell%20Mechanic.png",),
-        )
-
-    def test_extract_logo_urls_accepts_unquoted_same_origin_logo_assets(self) -> None:
-        urls = _extract_same_origin_logo_urls(
-            base_url="https://cm-testing.example.com",
-            body=(
-                "<img src=/web/image/website/7/logo?unique=abc&amp;download=1>"
-                "<meta property=og:image content=/web/content?model=website&amp;id=1&amp;field=logo>"
-            ),
-        )
-
-        self.assertEqual(
-            urls,
-            (
-                "https://cm-testing.example.com/web/image/website/7/logo?unique=abc&download=1",
-                "https://cm-testing.example.com/web/content?model=website&id=1&field=logo",
-            ),
-        )
-
     def test_build_plan_allows_issue_backed_opw_upstream_restore_policy(self) -> None:
         with (
             patch(
@@ -692,14 +576,9 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                 return_value=post_deploy_result,
             ) as post_deploy,
             patch(
-                "control_plane.workflows.odoo_stable_target_replacement._verify_health_url"
-            ) as verify_health,
-            patch(
-                "control_plane.workflows.odoo_stable_target_replacement._verify_canonical_url"
-            ) as verify_canonical,
-            patch(
-                "control_plane.workflows.odoo_stable_target_replacement._verify_logo_route"
-            ) as verify_logo,
+                "control_plane.workflows.odoo_stable_target_replacement.verify_odoo_stable_readiness",
+                return_value=_verification_result(),
+            ) as verify_readiness,
         ):
             result = execute_odoo_stable_target_replacement_apply(
                 control_plane_root=Path("."),
@@ -739,9 +618,22 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         trigger_deploy.assert_called_once()
         wait_deploy.assert_called_once()
         post_deploy.assert_called_once()
-        verify_health.assert_called_once()
-        verify_canonical.assert_called_once()
-        verify_logo.assert_called_once()
+        verify_readiness.assert_called_once_with(
+            base_url="https://cm-testing.shinycomputers.com",
+            health_url="https://cm-testing.shinycomputers.com/web/health",
+            verify_health=True,
+            verify_canonical=True,
+            verify_logo=True,
+            timeout_seconds=180,
+            retry_interval_seconds=5,
+        )
+        self.assertEqual(result.health_url, "https://cm-testing.shinycomputers.com/web/health")
+        self.assertEqual(result.canonical_url, "https://cm-testing.shinycomputers.com")
+        self.assertEqual(
+            result.logo_urls,
+            ("https://cm-testing.shinycomputers.com/web/image/website/1/logo",),
+        )
+        self.assertEqual(result.verification_evidence.health_url, result.health_url)
         self.assertIn("LAUNCHPLANE_RUNTIME_IDENTITY_JSON=", persisted_env)
         self.assertIn("LAUNCHPLANE_DEPLOYMENT_RECORD_ID=", persisted_env)
         self.assertIn("LAUNCHPLANE_ARTIFACT_ID=artifact-cm-testing", persisted_env)
@@ -838,13 +730,8 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                 ),
             ),
             patch(
-                "control_plane.workflows.odoo_stable_target_replacement._verify_health_url"
-            ),
-            patch(
-                "control_plane.workflows.odoo_stable_target_replacement._verify_canonical_url"
-            ),
-            patch(
-                "control_plane.workflows.odoo_stable_target_replacement._verify_logo_route"
+                "control_plane.workflows.odoo_stable_target_replacement.verify_odoo_stable_readiness",
+                return_value=_verification_result(),
             ),
         ):
             result = execute_odoo_stable_target_replacement_apply(
@@ -913,28 +800,6 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                     ),
                     dokploy_request=cast(DokployRequest, _request),
                 )
-
-    def test_verification_retry_allows_transient_startup_failure(self) -> None:
-        attempts = 0
-
-        def flaky_verification() -> None:
-            nonlocal attempts
-            attempts += 1
-            if attempts == 1:
-                raise click.ClickException("temporary health 404")
-
-        with patch(
-            "control_plane.workflows.odoo_stable_target_replacement.time.sleep",
-            side_effect=lambda _seconds: None,
-        ) as sleep_mock:
-            _run_verification_with_retry(
-                flaky_verification,
-                timeout_seconds=30,
-                retry_interval_seconds=5,
-            )
-
-        self.assertEqual(attempts, 2)
-        sleep_mock.assert_called_once()
 
     def test_apply_refuses_blocked_plan(self) -> None:
         with self.assertRaises(click.ClickException):

--- a/tests/test_odoo_verification.py
+++ b/tests/test_odoo_verification.py
@@ -1,0 +1,244 @@
+import unittest
+from unittest.mock import patch
+
+import click
+
+from control_plane.workflows.odoo_verification import (
+    _extract_same_origin_logo_urls,
+    verify_odoo_stable_readiness,
+)
+
+
+class OdooVerificationTests(unittest.TestCase):
+    def test_verification_uses_logo_url_from_canonical_page(self) -> None:
+        calls: list[str] = []
+
+        def fake_http_text(url: str, *, timeout_seconds: int) -> tuple[int, str, str]:
+            self.assertEqual(timeout_seconds, 5)
+            calls.append(url)
+            if url == "https://cm-testing.example.com":
+                return (
+                    200,
+                    '<html><link rel="canonical" href="https://cm-testing.example.com">'
+                    '<img src="/web/image/website/7/logo?unique=abc"></html>',
+                    "text/html",
+                )
+            if url == "https://cm-testing.example.com/web/health":
+                return 200, '{"status":"ok"}', "application/json"
+            if url == "https://cm-testing.example.com/web/image/website/7/logo?unique=abc":
+                return 200, "image-bytes", "image/png"
+            return 404, "missing", "text/plain"
+
+        with patch(
+            "control_plane.workflows.odoo_verification._http_text",
+            side_effect=fake_http_text,
+        ):
+            result = verify_odoo_stable_readiness(
+                base_url="https://cm-testing.example.com",
+                timeout_seconds=5,
+            )
+
+        self.assertEqual(result.health_status, "pass")
+        self.assertEqual(result.canonical_status, "pass")
+        self.assertEqual(result.logo_status, "pass")
+        self.assertEqual(
+            calls,
+            [
+                "https://cm-testing.example.com/web/health",
+                "https://cm-testing.example.com",
+                "https://cm-testing.example.com",
+                "https://cm-testing.example.com/web/image/website/7/logo?unique=abc",
+            ],
+        )
+        self.assertEqual(
+            result.evidence.logo_urls,
+            ("https://cm-testing.example.com/web/image/website/7/logo?unique=abc",),
+        )
+
+    def test_verification_falls_back_to_legacy_website_one_logo_route(self) -> None:
+        calls: list[str] = []
+
+        def fake_http_text(url: str, *, timeout_seconds: int) -> tuple[int, str, str]:
+            self.assertEqual(timeout_seconds, 5)
+            calls.append(url)
+            if url == "https://cm-testing.example.com":
+                return 200, '<link rel="canonical" href="https://cm-testing.example.com">', "text/html"
+            if url == "https://cm-testing.example.com/web/image/website/1/logo":
+                return 200, "image-bytes", "image/png"
+            return 404, "missing", "text/plain"
+
+        with patch(
+            "control_plane.workflows.odoo_verification._http_text",
+            side_effect=fake_http_text,
+        ):
+            result = verify_odoo_stable_readiness(
+                base_url="https://cm-testing.example.com/",
+                verify_health=False,
+                verify_canonical=False,
+                timeout_seconds=5,
+            )
+
+        self.assertEqual(result.logo_status, "pass")
+        self.assertEqual(
+            calls,
+            [
+                "https://cm-testing.example.com",
+                "https://cm-testing.example.com/web/image/website/1/logo",
+            ],
+        )
+
+    def test_verification_accepts_odoo_web_content_logo_url(self) -> None:
+        calls: list[str] = []
+
+        def fake_http_text(url: str, *, timeout_seconds: int) -> tuple[int, str, str]:
+            self.assertEqual(timeout_seconds, 5)
+            calls.append(url)
+            if url == "https://cm-testing.example.com":
+                return (
+                    200,
+                    '<meta property="og:image" content="/web/content?model=website&amp;id=1&amp;field=logo">',
+                    "text/html",
+                )
+            if url == "https://cm-testing.example.com/web/content?model=website&id=1&field=logo":
+                return 200, "image-bytes", "image/png"
+            return 404, "missing", "text/plain"
+
+        with patch(
+            "control_plane.workflows.odoo_verification._http_text",
+            side_effect=fake_http_text,
+        ):
+            result = verify_odoo_stable_readiness(
+                base_url="https://cm-testing.example.com",
+                verify_health=False,
+                verify_canonical=False,
+                timeout_seconds=5,
+            )
+
+        self.assertEqual(result.logo_status, "pass")
+        self.assertEqual(
+            result.evidence.logo_urls,
+            ("https://cm-testing.example.com/web/content?model=website&id=1&field=logo",),
+        )
+
+    def test_verification_fails_closed_when_logo_is_missing(self) -> None:
+        calls: list[str] = []
+
+        def fake_http_text(url: str, *, timeout_seconds: int) -> tuple[int, str, str]:
+            self.assertEqual(timeout_seconds, 5)
+            calls.append(url)
+            if url == "https://cm-testing.example.com":
+                return 200, '<link rel="canonical" href="https://cm-testing.example.com">', "text/html"
+            if url == "https://cm-testing.example.com/web/image/website/1/logo":
+                return 404, "missing", "text/plain"
+            return 404, "missing", "text/plain"
+
+        with patch(
+            "control_plane.workflows.odoo_verification._http_text",
+            side_effect=fake_http_text,
+        ):
+            result = verify_odoo_stable_readiness(
+                base_url="https://cm-testing.example.com/",
+                verify_health=False,
+                verify_canonical=False,
+                timeout_seconds=5,
+            )
+
+        self.assertEqual(result.logo_status, "fail")
+        self.assertEqual(
+            result.error_message,
+            "Logo check https://cm-testing.example.com/web/image/website/1/logo returned HTTP 404.",
+        )
+        self.assertEqual(
+            result.evidence.logo_urls,
+            ("https://cm-testing.example.com/web/image/website/1/logo",),
+        )
+        self.assertEqual(result.evidence.probes[-1].failure_class, "http")
+        self.assertEqual(
+            calls,
+            [
+                "https://cm-testing.example.com",
+                "https://cm-testing.example.com/web/image/website/1/logo",
+                "https://cm-testing.example.com",
+                "https://cm-testing.example.com/web/image/website/1/logo",
+            ],
+        )
+
+    def test_extract_logo_urls_ignores_cross_origin_assets(self) -> None:
+        urls = _extract_same_origin_logo_urls(
+            base_url="https://cm-testing.example.com",
+            body=(
+                '<img src="https://evil.example.com/web/image/website/9/logo">'
+                '<img src="/web/image/website/7/logo?unique=abc&amp;download=1">'
+            ),
+        )
+
+        self.assertEqual(
+            urls,
+            ("https://cm-testing.example.com/web/image/website/7/logo?unique=abc&download=1",),
+        )
+
+    def test_extract_logo_urls_accepts_same_origin_web_content_logo_assets(self) -> None:
+        urls = _extract_same_origin_logo_urls(
+            base_url="https://cm-testing.example.com",
+            body=(
+                '<meta property="og:image" content="https://evil.example.com/web/content?model=website&amp;id=1&amp;field=logo">'
+                '<meta name="twitter:image" content="/web/content/website/1/logo/Cell%20Mechanic.png">'
+            ),
+        )
+
+        self.assertEqual(
+            urls,
+            ("https://cm-testing.example.com/web/content/website/1/logo/Cell%20Mechanic.png",),
+        )
+
+    def test_extract_logo_urls_accepts_unquoted_same_origin_logo_assets(self) -> None:
+        urls = _extract_same_origin_logo_urls(
+            base_url="https://cm-testing.example.com",
+            body=(
+                "<img src=/web/image/website/7/logo?unique=abc&amp;download=1>"
+                "<meta property=og:image content=/web/content?model=website&amp;id=1&amp;field=logo>"
+            ),
+        )
+
+        self.assertEqual(
+            urls,
+            (
+                "https://cm-testing.example.com/web/image/website/7/logo?unique=abc&download=1",
+                "https://cm-testing.example.com/web/content?model=website&id=1&field=logo",
+            ),
+        )
+
+    def test_verification_retry_allows_transient_startup_failure(self) -> None:
+        attempts = 0
+
+        def fake_http_text(url: str, *, timeout_seconds: int) -> tuple[int, str, str]:
+            nonlocal attempts
+            self.assertEqual(url, "https://cm-testing.example.com/web/health")
+            self.assertEqual(timeout_seconds, 30)
+            attempts += 1
+            if attempts == 1:
+                raise click.ClickException("temporary health 404")
+            return 200, '{"status":"ok"}', "application/json"
+
+        with (
+            patch("control_plane.workflows.odoo_verification._http_text", side_effect=fake_http_text),
+            patch(
+                "control_plane.workflows.odoo_verification.time.sleep",
+                side_effect=lambda _seconds: None,
+            ) as sleep_mock,
+        ):
+            result = verify_odoo_stable_readiness(
+                base_url="https://cm-testing.example.com",
+                verify_canonical=False,
+                verify_logo=False,
+                timeout_seconds=30,
+                retry_interval_seconds=5,
+            )
+
+        self.assertEqual(result.health_status, "pass")
+        self.assertEqual(attempts, 2)
+        sleep_mock.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a shared Odoo verification helper that derives health, canonical, and logo probes from the lane base URL
- route Odoo stable bootstrap and target replacement through the helper and expose public-safe verification evidence
- cover same-origin logo discovery, `/web/image`, `/web/content`, fallback, retry, and missing-logo failure behavior

## Validation
- `uv run python -m unittest tests.test_odoo_verification tests.test_odoo_stable_bootstrap tests.test_odoo_stable_target_replacement`
- `uv run python -m unittest`

Refs #645
