### PR TITLE
Harden Odoo logo verification

### DIFF
--- a/control_plane/workflows/odoo_verification.py
+++ b/control_plane/workflows/odoo_verification.py
@@ -298,12 +298,14 @@ def _verify_logo_route(
 
 def _candidate_logo_urls(*, base_url: str, timeout_seconds: int) -> tuple[str, ...]:
     normalized_base_url = base_url.rstrip("/")
+    fallback_url = f"{normalized_base_url}/web/image/website/1/logo"
+    candidates: list[str] = []
     status_code, body, _content_type = _http_text(normalized_base_url, timeout_seconds=timeout_seconds)
     if status_code < 400:
-        urls = tuple(_extract_same_origin_logo_urls(base_url=normalized_base_url, body=body))
-        if urls:
-            return urls
-    return (f"{normalized_base_url}/web/image/website/1/logo",)
+        candidates.extend(_extract_same_origin_logo_urls(base_url=normalized_base_url, body=body))
+    if fallback_url not in candidates:
+        candidates.append(fallback_url)
+    return tuple(candidates)
 
 
 def _extract_same_origin_logo_urls(*, base_url: str, body: str) -> tuple[str, ...]:
@@ -313,7 +315,7 @@ def _extract_same_origin_logo_urls(*, base_url: str, body: str) -> tuple[str, ..
         (
             r"(?:src|href|content)\s*=\s*"
             r"(?P<quote>[\"'])?"
-            r"(?P<url>[^\s\"'<>]*/web/(?:image/website/[^\s\"'<>]*/logo|content[^\s\"'<>]*logo)[^\s\"'<>]*)"
+            r"(?P<url>[^\s\"'<>]*/web/(?:image|content)[^\s\"'<>]*)"
             r"(?P=quote)?"
         ),
         body,
@@ -321,9 +323,26 @@ def _extract_same_origin_logo_urls(*, base_url: str, body: str) -> tuple[str, ..
     ):
         raw_url = html.unescape(match.group("url")).strip()
         absolute_url = urljoin(f"{base_url.rstrip('/')}/", raw_url)
-        if _url_origin(absolute_url) == base_origin and absolute_url not in logo_urls:
+        if (
+            _url_origin(absolute_url) == base_origin
+            and _is_odoo_website_logo_url(absolute_url)
+            and absolute_url not in logo_urls
+        ):
             logo_urls.append(absolute_url)
     return tuple(logo_urls)
+
+
+def _is_odoo_website_logo_url(raw_url: str) -> bool:
+    parsed = urlparse(raw_url)
+    path = parsed.path.lower()
+    query = parsed.query.lower()
+    if path.startswith("/web/image/website/") and "/logo" in path:
+        return True
+    if path.startswith("/web/content/website/") and "/logo" in path:
+        return True
+    if path == "/web/content" and "model=website" in query and "field=logo" in query:
+        return True
+    return False
 
 
 def _url_origin(raw_url: str) -> str:

--- a/tests/test_odoo_verification.py
+++ b/tests/test_odoo_verification.py
@@ -55,6 +55,49 @@ class OdooVerificationTests(unittest.TestCase):
             ("https://cm-testing.example.com/web/image/website/7/logo?unique=abc",),
         )
 
+    def test_verification_keeps_canonical_logo_fallback_after_bad_logo_asset(self) -> None:
+        calls: list[str] = []
+
+        def fake_http_text(url: str, *, timeout_seconds: int) -> tuple[int, str, str]:
+            self.assertEqual(timeout_seconds, 5)
+            calls.append(url)
+            if url == "https://cm-testing.example.com":
+                return (
+                    200,
+                    '<link rel="canonical" href="https://cm-testing.example.com">'
+                    '<img src="/web/image/product.template/7/logo_badge">',
+                    "text/html",
+                )
+            if url == "https://cm-testing.example.com/web/image/website/1/logo":
+                return 200, "image-bytes", "image/png"
+            if url == "https://cm-testing.example.com/web/image/product.template/7/logo_badge":
+                return 200, "wrong-image", "image/png"
+            return 404, "missing", "text/plain"
+
+        with patch(
+            "control_plane.workflows.odoo_verification._http_text",
+            side_effect=fake_http_text,
+        ):
+            result = verify_odoo_stable_readiness(
+                base_url="https://cm-testing.example.com",
+                verify_health=False,
+                verify_canonical=False,
+                timeout_seconds=5,
+            )
+
+        self.assertEqual(result.logo_status, "pass")
+        self.assertEqual(
+            result.evidence.logo_urls,
+            ("https://cm-testing.example.com/web/image/website/1/logo",),
+        )
+        self.assertEqual(
+            calls,
+            [
+                "https://cm-testing.example.com",
+                "https://cm-testing.example.com/web/image/website/1/logo",
+            ],
+        )
+
     def test_verification_falls_back_to_legacy_website_one_logo_route(self) -> None:
         calls: list[str] = []
 
@@ -168,6 +211,7 @@ class OdooVerificationTests(unittest.TestCase):
             base_url="https://cm-testing.example.com",
             body=(
                 '<img src="https://evil.example.com/web/image/website/9/logo">'
+                '<img src="/web/image/product.template/7/logo_badge">'
                 '<img src="/web/image/website/7/logo?unique=abc&amp;download=1">'
             ),
         )


### PR DESCRIPTION
## Summary
- keep the canonical `/web/image/website/1/logo` fallback in Odoo logo verification even when page discovery finds candidates
- filter discovered same-origin assets to Odoo website logo URL shapes instead of any asset URL containing `logo`
- add regression coverage for unrelated same-origin logo-ish assets

## Validation
- `uv run --extra dev ruff check control_plane/workflows/odoo_verification.py tests/test_odoo_verification.py`
- `uv run python -m unittest tests.test_odoo_verification tests.test_odoo_stable_bootstrap tests.test_odoo_stable_target_replacement`
- `uv run python -m unittest`

Follow-up to #648 / #645.
