### PR TITLE
Model Odoo lane data policy

### DIFF
--- a/control_plane/contracts/product_environment_read_model.py
+++ b/control_plane/contracts/product_environment_read_model.py
@@ -142,6 +142,12 @@ class ProductEnvironmentSummary(BaseModel):
     prelaunch_rebuild_allowed: bool = False
     prelaunch_rebuild_data_source_mode: str = ""
     prelaunch_rebuild_approval_issue_url: str = ""
+    odoo_data_authority: str = "unknown"
+    odoo_allowed_rebuild_sources: tuple[str, ...] = ()
+    odoo_upstream_source: str = ""
+    odoo_requires_backup_before_destroy: bool = True
+    odoo_requires_restore_proof: bool = True
+    odoo_requires_runtime_identity: bool = True
     trust_state: FreshnessStatus
     provenance: DataProvenance
     warnings: tuple[str, ...] = ()
@@ -197,6 +203,12 @@ class ProductEnvironmentDetail(BaseModel):
     prelaunch_rebuild_allowed: bool = False
     prelaunch_rebuild_data_source_mode: str = ""
     prelaunch_rebuild_approval_issue_url: str = ""
+    odoo_data_authority: str = "unknown"
+    odoo_allowed_rebuild_sources: tuple[str, ...] = ()
+    odoo_upstream_source: str = ""
+    odoo_requires_backup_before_destroy: bool = True
+    odoo_requires_restore_proof: bool = True
+    odoo_requires_runtime_identity: bool = True
     target: ProductTargetSummary
     runtime_settings: tuple[ProductRuntimeSettingSummary, ...] = ()
     managed_secrets: tuple[ProductSecretBindingSummary, ...] = ()
@@ -376,6 +388,12 @@ def build_product_environment_detail(
         if lane.odoo_prelaunch_rebuild.enabled
         else "",
         prelaunch_rebuild_approval_issue_url=lane.odoo_prelaunch_rebuild.approval_issue_url,
+        odoo_data_authority=lane.odoo_data_policy.data_authority,
+        odoo_allowed_rebuild_sources=lane.odoo_data_policy.allowed_rebuild_sources,
+        odoo_upstream_source=lane.odoo_data_policy.upstream_source,
+        odoo_requires_backup_before_destroy=lane.odoo_data_policy.requires_backup_before_destroy,
+        odoo_requires_restore_proof=lane.odoo_data_policy.requires_restore_proof,
+        odoo_requires_runtime_identity=lane.odoo_data_policy.requires_runtime_identity,
         target=_target_summary(lane_summary),
         runtime_settings=_runtime_setting_summaries(lane_summary),
         managed_secrets=_secret_binding_summaries(lane_summary),
@@ -1030,6 +1048,12 @@ def _build_environment_summary(
         if lane.odoo_prelaunch_rebuild.enabled
         else "",
         prelaunch_rebuild_approval_issue_url=lane.odoo_prelaunch_rebuild.approval_issue_url,
+        odoo_data_authority=lane.odoo_data_policy.data_authority,
+        odoo_allowed_rebuild_sources=lane.odoo_data_policy.allowed_rebuild_sources,
+        odoo_upstream_source=lane.odoo_data_policy.upstream_source,
+        odoo_requires_backup_before_destroy=lane.odoo_data_policy.requires_backup_before_destroy,
+        odoo_requires_restore_proof=lane.odoo_data_policy.requires_restore_proof,
+        odoo_requires_runtime_identity=lane.odoo_data_policy.requires_runtime_identity,
         trust_state=provenance.freshness_status,
         provenance=provenance,
         available_actions=_action_availability(

--- a/control_plane/contracts/product_onboarding_manifest.py
+++ b/control_plane/contracts/product_onboarding_manifest.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from control_plane.contracts.dokploy_target_record import DokployTargetType
 from control_plane.contracts.product_profile_record import (
     PRODUCT_PREVIEW_DEFAULT_ENABLE_LABEL,
+    ProductOdooLaneDataPolicy,
     ProductOdooPrelaunchRebuildPolicy,
     ProductOdooStableBootstrapPolicy,
     ProductExpectedConfigProfile,
@@ -27,6 +28,9 @@ class ProductOnboardingLaneManifest(BaseModel):
     )
     odoo_prelaunch_rebuild: ProductOdooPrelaunchRebuildPolicy = Field(
         default_factory=ProductOdooPrelaunchRebuildPolicy
+    )
+    odoo_data_policy: ProductOdooLaneDataPolicy = Field(
+        default_factory=ProductOdooLaneDataPolicy
     )
 
     @model_validator(mode="after")

--- a/control_plane/contracts/product_profile_record.py
+++ b/control_plane/contracts/product_profile_record.py
@@ -4,6 +4,8 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 PRODUCT_PREVIEW_DEFAULT_ENABLE_LABEL = "launchplane-preview"
+OdooDataAuthority = Literal["unknown", "resettable", "restorable", "authoritative"]
+OdooRebuildSourceMode = Literal["empty", "upstream_restore"]
 
 
 class ProductImageProfile(BaseModel):
@@ -117,6 +119,44 @@ class ProductOdooPrelaunchRebuildPolicy(BaseModel):
         return self
 
 
+class ProductOdooLaneDataPolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    data_authority: OdooDataAuthority = "unknown"
+    allowed_rebuild_sources: tuple[OdooRebuildSourceMode, ...] = ()
+    upstream_source: str = ""
+    requires_backup_before_destroy: bool = True
+    requires_restore_proof: bool = True
+    requires_runtime_identity: bool = True
+
+    @model_validator(mode="after")
+    def _validate_policy(self) -> "ProductOdooLaneDataPolicy":
+        normalized_sources: list[OdooRebuildSourceMode] = []
+        for source in self.allowed_rebuild_sources:
+            if source not in normalized_sources:
+                normalized_sources.append(source)
+        self.allowed_rebuild_sources = tuple(normalized_sources)
+        self.upstream_source = self.upstream_source.strip()
+        if self.data_authority == "unknown" and self.allowed_rebuild_sources:
+            raise ValueError(
+                "unknown Odoo data authority cannot allow rebuild sources"
+            )
+        if "upstream_restore" in self.allowed_rebuild_sources and not self.upstream_source:
+            raise ValueError(
+                "Odoo data policy allowing upstream_restore requires upstream_source"
+            )
+        if self.data_authority == "authoritative" and not self.requires_backup_before_destroy:
+            raise ValueError(
+                "authoritative Odoo data policy requires backup before destroy"
+            )
+        if self.data_authority == "authoritative" and not self.requires_restore_proof:
+            raise ValueError("authoritative Odoo data policy requires restore proof")
+        return self
+
+    def allows_rebuild_source(self, source: str) -> bool:
+        return source in self.allowed_rebuild_sources
+
+
 class ProductLaneProfile(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -129,6 +169,9 @@ class ProductLaneProfile(BaseModel):
     )
     odoo_prelaunch_rebuild: ProductOdooPrelaunchRebuildPolicy = Field(
         default_factory=ProductOdooPrelaunchRebuildPolicy
+    )
+    odoo_data_policy: ProductOdooLaneDataPolicy = Field(
+        default_factory=ProductOdooLaneDataPolicy
     )
 
     @model_validator(mode="after")

--- a/control_plane/workflows/odoo_stable_bootstrap.py
+++ b/control_plane/workflows/odoo_stable_bootstrap.py
@@ -148,6 +148,11 @@ def _assert_bootstrap_policy_allows_request(
         raise click.ClickException(
             f"Unsupported Odoo stable bootstrap data source mode {policy.data_source_mode!r}."
         )
+    if not lane.odoo_data_policy.allows_rebuild_source(policy.data_source_mode):
+        raise click.ClickException(
+            "Odoo lane data policy does not allow stable bootstrap data source "
+            f"{policy.data_source_mode!r} for {request.product} {request.context}/{request.instance}."
+        )
     if policy.expected_target_name and target_record.target_name != policy.expected_target_name:
         raise click.ClickException(
             "Odoo stable bootstrap target proof failed: expected target "

--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -366,6 +366,11 @@ def _assert_prelaunch_rebuild_policy_allows_request(
             "Odoo prelaunch rebuild data source mode mismatch: "
             f"request={request.data_source_mode!r} policy={policy.data_source_mode!r}."
         )
+    if not lane.odoo_data_policy.allows_rebuild_source(request.data_source_mode):
+        raise click.ClickException(
+            "Odoo lane data policy does not allow prelaunch rebuild data source "
+            f"{request.data_source_mode!r} for {request.product} {lane.context}/{lane.instance}."
+        )
     if request.confirmation != policy.confirmation:
         raise click.ClickException(
             f"Odoo prelaunch rebuild requires confirmation {policy.confirmation!r}."

--- a/control_plane/workflows/product_onboarding.py
+++ b/control_plane/workflows/product_onboarding.py
@@ -63,6 +63,7 @@ def build_product_profile_record(
                 health_url=lane.health_url or _health_url(lane.base_url, manifest.health_path),
                 odoo_stable_bootstrap=lane.odoo_stable_bootstrap,
                 odoo_prelaunch_rebuild=lane.odoo_prelaunch_rebuild,
+                odoo_data_policy=lane.odoo_data_policy,
             )
             for lane in manifest.lanes
         ),

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -165,13 +165,15 @@ not advertise ready before the checks pass.
 
 Odoo also exposes `POST /v1/drivers/odoo/stable-bootstrap` as a destructive
 instance-scoped action. It is enabled per product-profile lane through
-`odoo_stable_bootstrap` policy rather than driver code literals. The policy
-defines the destructive confirmation phrase, allowed data-source mode, expected
-target name/domains, and required verification checks before Launchplane reuses
-the existing devkit `--bootstrap` data workflow through a Launchplane-owned
-Dokploy schedule. It is separate from target replacement: replacement reconciles
-provider/runtime target state, while bootstrap rebuilds Odoo application data for
-lanes that are explicitly safe to recreate.
+`odoo_stable_bootstrap` and `odoo_data_policy` rather than driver code literals.
+The policies define the destructive confirmation phrase, allowed data-source
+mode, lane data authority, expected target name/domains, and required
+verification checks before Launchplane reuses the existing devkit `--bootstrap`
+data workflow through a Launchplane-owned Dokploy schedule. Routine Odoo probes
+are derived by the driver from the lane base URL and Odoo conventions. It is
+separate from target replacement: replacement reconciles provider/runtime target
+state, while bootstrap rebuilds Odoo application data for lanes that are
+explicitly safe to recreate.
 
 Driver action routes are owned by the base driver contract. The service accepts
 any product key on Odoo and VeriReel action envelopes, then authorizes the call

--- a/docs/records.md
+++ b/docs/records.md
@@ -232,22 +232,32 @@ Odoo stable bootstrap eligibility is lane-owned product-profile data. A lane's
 `odoo_stable_bootstrap` policy defaults to disabled and must explicitly carry
 an issue-backed approval URL, the destructive confirmation phrase,
 `data_source_mode`, expected Dokploy target name, expected domains, and required
-verification checks. Launchplane treats the policy plus stored/observed target
-proof as the authority for whether a bootstrap can proceed; request
-product/context/instance alone is not sufficient. The approval issue is the
-implementation signal, not a launch tracker: close it when the policy is encoded
-and keep launch/cutover retirement in a separate issue or explicit expiration
-record.
+verification checks. The lane's `odoo_data_policy` must also allow that rebuild
+source; `unknown` data authority allows no destructive rebuild source. Launchplane
+treats the policy, data authority, and stored/observed target proof as the
+authority for whether a bootstrap can proceed; request product/context/instance
+alone is not sufficient. The approval issue is the implementation signal, not a
+launch tracker: close it when the policy is encoded and keep launch/cutover
+retirement in a separate issue or explicit expiration record.
 
 Odoo prelaunch rebuild eligibility is also lane-owned product-profile data. A
 lane's `odoo_prelaunch_rebuild` policy defaults to disabled and must explicitly
 carry an issue-backed approval URL, confirmation phrase, data source mode,
 expected Dokploy target name, and expected domains. The initial data source
 modes are `empty` and `upstream_restore`. Target replacement plan/apply requests
-that set a prelaunch data source must match this policy before Launchplane will
-treat missing Odoo volume keys as intentional. This keeps provisional lanes such
-as OPW testing/prod auditable without making environment names like `prod`
-destructive authority by themselves.
+that set a prelaunch data source must match this policy and the lane's
+`odoo_data_policy.allowed_rebuild_sources` before Launchplane will treat missing
+Odoo volume keys as intentional. This keeps provisional lanes such as OPW
+testing/prod auditable without making environment names like `prod` destructive
+authority by themselves.
+
+`odoo_data_policy` records the lane's data authority separately from operational
+driver defaults. `resettable` lanes may explicitly allow `empty` rebuilds;
+`restorable` lanes may explicitly allow `upstream_restore` and must name an
+`upstream_source`; `authoritative` lanes require backup-before-destroy and
+restore-proof safeguards. Routine Odoo probe details such as `/web/health` and
+logo URL discovery belong in the Odoo driver, not in tenant-owned product config,
+unless a lane has a real exception that needs an explicit override.
 
 This file layout describes today's local Launchplane implementation, not the
 final cross-product communication boundary. The stable long-term contract should

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -309,6 +309,13 @@ apply_odoo_cm_onboarding() {
                 require_health_verification: true,
                 require_canonical_verification: true,
                 require_logo_verification: true
+              },
+              odoo_data_policy: {
+                data_authority: "resettable",
+                allowed_rebuild_sources: ["empty"],
+                requires_backup_before_destroy: false,
+                requires_restore_proof: false,
+                requires_runtime_identity: true
               }
             },
             {
@@ -324,6 +331,13 @@ apply_odoo_cm_onboarding() {
                 require_health_verification: true,
                 require_canonical_verification: true,
                 require_logo_verification: true
+              },
+              odoo_data_policy: {
+                data_authority: "resettable",
+                allowed_rebuild_sources: ["empty"],
+                requires_backup_before_destroy: false,
+                requires_restore_proof: false,
+                requires_runtime_identity: true
               }
             }
           ],
@@ -427,6 +441,14 @@ apply_odoo_opw_onboarding() {
                 confirmation: "restore opw upstream",
                 expected_target_name: "opw-testing",
                 expected_domains: ["opw-testing.shinycomputers.com"]
+              },
+              odoo_data_policy: {
+                data_authority: "restorable",
+                allowed_rebuild_sources: ["upstream_restore"],
+                upstream_source: "odoo-tenant-opw/opw/testing-upstream",
+                requires_backup_before_destroy: true,
+                requires_restore_proof: true,
+                requires_runtime_identity: true
               }
             },
             {
@@ -439,6 +461,14 @@ apply_odoo_opw_onboarding() {
                 confirmation: "restore opw upstream",
                 expected_target_name: "opw-prod",
                 expected_domains: ["opw-prod.shinycomputers.com"]
+              },
+              odoo_data_policy: {
+                data_authority: "restorable",
+                allowed_rebuild_sources: ["upstream_restore"],
+                upstream_source: "odoo-tenant-opw/opw/prod-upstream",
+                requires_backup_before_destroy: true,
+                requires_restore_proof: true,
+                requires_runtime_identity: true
               }
             }
           ],

--- a/tests/test_odoo_stable_bootstrap.py
+++ b/tests/test_odoo_stable_bootstrap.py
@@ -20,6 +20,7 @@ from control_plane.contracts.odoo_instance_override_record import (
 )
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
+    ProductOdooLaneDataPolicy,
     ProductOdooStableBootstrapPolicy,
     ProductImageProfile,
     ProductLaneProfile,
@@ -105,6 +106,12 @@ class _Store:
                         confirmation=_BOOTSTRAP_CONFIRMATION,
                         expected_target_name="cm-testing",
                         expected_domains=("cm-testing.shinycomputers.com",),
+                    ),
+                    odoo_data_policy=ProductOdooLaneDataPolicy(
+                        data_authority="resettable",
+                        allowed_rebuild_sources=("empty",),
+                        requires_backup_before_destroy=False,
+                        requires_restore_proof=False,
                     ),
                 ),
             ),
@@ -481,6 +488,27 @@ class OdooStableBootstrapTests(unittest.TestCase):
             )
 
         self.assertIn("requires confirmation", str(raised_error.exception))
+
+    def test_execute_refuses_disallowed_data_policy_source(self) -> None:
+        store = _Store()
+        lane = store.profile.lanes[0].model_copy(
+            update={"odoo_data_policy": ProductOdooLaneDataPolicy()}
+        )
+        store.profile = store.profile.model_copy(update={"lanes": (lane,)})
+        with self.assertRaises(click.ClickException) as raised_error:
+            execute_odoo_stable_bootstrap(
+                control_plane_root=Path("/tmp/launchplane"),
+                record_store=store,
+                request=OdooStableBootstrapRequest(
+                    product="odoo-tenant-cm",
+                    context="cm",
+                    instance="testing",
+                    confirmation=_BOOTSTRAP_CONFIRMATION,
+                ),
+            )
+
+        self.assertIn("lane data policy", str(raised_error.exception))
+        self.assertIn("'empty'", str(raised_error.exception))
 
     def test_execute_refuses_mismatched_target_name(self) -> None:
         store = _Store()

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -18,6 +18,7 @@ from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductImageProfile,
     ProductLaneProfile,
+    ProductOdooLaneDataPolicy,
     ProductOdooPrelaunchRebuildPolicy,
     ProductPreviewProfile,
 )
@@ -152,6 +153,11 @@ def _opw_profile_with_prelaunch_policy(*, enabled: bool) -> LaunchplaneProductPr
                     confirmation="restore opw upstream" if enabled else "",
                     expected_target_name="opw-prod" if enabled else "",
                     expected_domains=("opw-prod.shinycomputers.com",) if enabled else (),
+                ),
+                odoo_data_policy=ProductOdooLaneDataPolicy(
+                    data_authority="restorable" if enabled else "unknown",
+                    allowed_rebuild_sources=("upstream_restore",) if enabled else (),
+                    upstream_source="odoo-tenant-opw/opw/prod-upstream" if enabled else "",
                 ),
             ),
         ),
@@ -388,6 +394,53 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
 
         self.assertEqual(plan.plan_status, "blocked")
         self.assertIn("prelaunch rebuild is not enabled", "; ".join(plan.blockers))
+
+    def test_build_plan_blocks_upstream_restore_disallowed_by_lane_data_policy(self) -> None:
+        profile = _opw_profile_with_prelaunch_policy(enabled=True)
+        lane = profile.lanes[0].model_copy(
+            update={"odoo_data_policy": ProductOdooLaneDataPolicy()}
+        )
+        profile = profile.model_copy(update={"lanes": (lane,)})
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.read_dokploy_config",
+                return_value=("host", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "name": "opw-prod",
+                    "sourceType": "raw",
+                    "composePath": "docker-compose.yml",
+                    "composeFile": "services: {}",
+                    "env": "",
+                },
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.latest_deployment_for_target",
+                return_value={"deploymentId": "deploy-opw", "status": "success"},
+            ),
+        ):
+            plan = build_odoo_stable_target_replacement_plan(
+                control_plane_root=Path("."),
+                record_store=_Store(
+                    profile=profile,
+                    target_record=_opw_target_record(),
+                    target_id_record=_opw_target_id_record(),
+                ),
+                request=OdooStableTargetReplacementRequest(
+                    product="odoo-tenant-opw",
+                    instance="prod",
+                    allow_empty_data=True,
+                    data_source_mode="upstream_restore",
+                    confirmation="restore opw upstream",
+                ),
+                dokploy_request=cast(DokployRequest, _request),
+            )
+
+        self.assertEqual(plan.plan_status, "blocked")
+        self.assertIn("lane data policy", "; ".join(plan.blockers))
+        self.assertIn("'upstream_restore'", "; ".join(plan.blockers))
 
     def test_build_plan_reports_ready_when_records_and_volume_contract_exist(self) -> None:
         identity = json.dumps(

--- a/tests/test_product_environment_read_model.py
+++ b/tests/test_product_environment_read_model.py
@@ -57,6 +57,14 @@ def _site_profile_payload(
                     "expected_target_name": f"{product}-prod",
                     "expected_domains": [f"{product}.example"],
                 },
+                "odoo_data_policy": {
+                    "data_authority": "restorable",
+                    "allowed_rebuild_sources": ["upstream_restore"],
+                    "upstream_source": "example-site/prod/upstream",
+                    "requires_backup_before_destroy": True,
+                    "requires_restore_proof": True,
+                    "requires_runtime_identity": True,
+                },
             },
         ),
         "preview": {
@@ -691,6 +699,12 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
         )
         self.assertTrue(detail.prelaunch_rebuild_allowed)
         self.assertEqual(detail.prelaunch_rebuild_data_source_mode, "upstream_restore")
+        self.assertEqual(prod_summary.odoo_data_authority, "restorable")
+        self.assertEqual(prod_summary.odoo_allowed_rebuild_sources, ("upstream_restore",))
+        self.assertEqual(prod_summary.odoo_upstream_source, "example-site/prod/upstream")
+        self.assertTrue(detail.odoo_requires_backup_before_destroy)
+        self.assertTrue(detail.odoo_requires_restore_proof)
+        self.assertTrue(detail.odoo_requires_runtime_identity)
 
     def test_product_environment_config_status_reports_expected_key_states(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -39,6 +39,13 @@ def _manifest_payload() -> dict[str, object]:
                     "expected_target_name": "example-site-testing",
                     "expected_domains": ["testing.example.invalid"],
                 },
+                "odoo_data_policy": {
+                    "data_authority": "resettable",
+                    "allowed_rebuild_sources": ["empty"],
+                    "requires_backup_before_destroy": False,
+                    "requires_restore_proof": False,
+                    "requires_runtime_identity": True,
+                },
             },
             {
                 "instance": "prod",
@@ -52,6 +59,14 @@ def _manifest_payload() -> dict[str, object]:
                     "confirmation": "restore example upstream",
                     "expected_target_name": "example-site-prod",
                     "expected_domains": ["example.invalid"],
+                },
+                "odoo_data_policy": {
+                    "data_authority": "restorable",
+                    "allowed_rebuild_sources": ["upstream_restore"],
+                    "upstream_source": "example-site/prod/upstream",
+                    "requires_backup_before_destroy": True,
+                    "requires_restore_proof": True,
+                    "requires_runtime_identity": True,
                 },
             },
         ],
@@ -458,6 +473,13 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             profile.lanes[1].odoo_prelaunch_rebuild.data_source_mode,
             "upstream_restore",
         )
+        self.assertEqual(profile.lanes[0].odoo_data_policy.data_authority, "resettable")
+        self.assertEqual(
+            profile.lanes[0].odoo_data_policy.allowed_rebuild_sources,
+            ("empty",),
+        )
+        self.assertEqual(profile.lanes[1].odoo_data_policy.data_authority, "restorable")
+        self.assertEqual(profile.lanes[1].odoo_data_policy.upstream_source, "example-site/prod/upstream")
         self.assertEqual(profile.preview.enable_label, "preview-requested")
         self.assertEqual(profile.expected_config.runtime_environment_keys[0].key, "PUBLIC_BASE_URL")
         self.assertEqual(


### PR DESCRIPTION
## Summary
- add explicit Odoo lane data authority and allowed rebuild source policy
- enforce lane data policy for stable bootstrap and prelaunch rebuild source requests
- expose data policy in environment read models and seed CM/OPW lane policies
- document the split between tenant intent/data authority and driver-derived Odoo probe defaults

Refs #564

## Tests
- uv run python -m unittest tests.test_product_onboarding tests.test_product_environment_read_model tests.test_odoo_stable_bootstrap tests.test_odoo_stable_target_replacement
- uv run python -m unittest
- bash -n scripts/deploy/ensure-authz-grants.sh
- uv run python -m py_compile control_plane/contracts/product_profile_record.py control_plane/contracts/product_onboarding_manifest.py control_plane/contracts/product_environment_read_model.py control_plane/workflows/odoo_stable_bootstrap.py control_plane/workflows/odoo_stable_target_replacement.py control_plane/workflows/product_onboarding.py