### PR TITLE
Fix Odoo override phases and verifier retry

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -9168,10 +9168,12 @@ def _build_odoo_instance_override_record_with_config_parameter(
     config_parameters[normalized_key] = OdooConfigParameterOverride(
         key=normalized_key, value=override_value
     )
+    apply_on = target_record.apply_on if target_record is not None else ()
+    apply_phases = tuple(dict.fromkeys((*apply_on, "deploy", "promotion")))
     return OdooInstanceOverrideRecord(
         context=normalized_context,
         instance=normalized_instance,
-        apply_on=target_record.apply_on if target_record is not None else ("deploy", "promotion"),
+        apply_on=apply_phases,
         config_parameters=tuple(config_parameters[key] for key in sorted(config_parameters)),
         addon_settings=addon_settings,
         website_bootstrap=target_record.website_bootstrap if target_record is not None else None,
@@ -9215,9 +9217,12 @@ def _build_odoo_instance_override_record_with_addon_setting(
         setting=normalized_setting,
         value=override_value,
     )
+    apply_on = target_record.apply_on if target_record is not None else ()
+    apply_phases = tuple(dict.fromkeys((*apply_on, "deploy", "promotion")))
     return OdooInstanceOverrideRecord(
         context=normalized_context,
         instance=normalized_instance,
+        apply_on=apply_phases,
         config_parameters=config_parameters,
         addon_settings=tuple(addon_settings[key] for key in sorted(addon_settings)),
         website_bootstrap=target_record.website_bootstrap if target_record is not None else None,

--- a/control_plane/workflows/odoo_verification.py
+++ b/control_plane/workflows/odoo_verification.py
@@ -361,6 +361,8 @@ def _run_probe_with_retry(
     while True:
         try:
             return verification()
+        except _ProbeFailure:
+            raise
         except click.ClickException as error:
             last_error = error
             remaining_seconds = deadline - time.monotonic()
@@ -382,6 +384,8 @@ def _run_logo_probe_with_retry(
     while True:
         try:
             return verification()
+        except _ProbeFailure:
+            raise
         except click.ClickException as error:
             last_error = error
             remaining_seconds = deadline - time.monotonic()

--- a/tests/test_odoo_instance_overrides.py
+++ b/tests/test_odoo_instance_overrides.py
@@ -112,6 +112,59 @@ class OdooInstanceOverrideTests(unittest.TestCase):
             stored_record.config_parameters[0].value.value, "https://opw-prod.example.com"
         )
 
+    def test_cli_put_config_param_adds_deploy_phases_to_existing_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_odoo_instance_override_record(
+                OdooInstanceOverrideRecord(
+                    context="opw",
+                    instance="prod",
+                    apply_on=("manual",),
+                    config_parameters=(
+                        OdooConfigParameterOverride(
+                            key="web.base.url",
+                            value=OdooOverrideValue(
+                                source="literal", value="https://old.example.com"
+                            ),
+                        ),
+                    ),
+                    updated_at="2026-05-17T00:00:00Z",
+                    source_label="test",
+                )
+            )
+            store.close()
+            runner = CliRunner()
+
+            result = runner.invoke(
+                main,
+                [
+                    "odoo-overrides",
+                    "put-config-param",
+                    "--database-url",
+                    database_url,
+                    "--context",
+                    "opw",
+                    "--instance",
+                    "prod",
+                    "--key",
+                    "web.base.url",
+                    "--value",
+                    "https://opw-prod.example.com",
+                ],
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            stored_record = store.read_odoo_instance_override_record(
+                context_name="opw", instance_name="prod"
+            )
+            store.close()
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertEqual(stored_record.apply_on, ("manual", "deploy", "promotion"))
+
     def test_cli_put_addon_setting_requires_secret_binding_for_secret_shaped_setting(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             database_url = _sqlite_database_url(
@@ -176,6 +229,63 @@ class OdooInstanceOverrideTests(unittest.TestCase):
         payload = json.loads(list_result.output)
         self.assertEqual(payload["records"][0]["addon_settings"], ["shopify.api_token"])
         self.assertNotIn("secret-binding-shopify-token", list_result.output)
+
+    def test_cli_put_addon_setting_adds_deploy_phases_to_existing_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_odoo_instance_override_record(
+                OdooInstanceOverrideRecord(
+                    context="opw",
+                    instance="prod",
+                    apply_on=("manual",),
+                    addon_settings=(
+                        OdooAddonSettingOverride(
+                            addon="shopify",
+                            setting="api_token",
+                            value=OdooOverrideValue(
+                                source="secret_binding",
+                                secret_binding_id="secret-binding-old-shopify-token",
+                            ),
+                        ),
+                    ),
+                    updated_at="2026-05-17T00:00:00Z",
+                    source_label="test",
+                )
+            )
+            store.close()
+            runner = CliRunner()
+
+            result = runner.invoke(
+                main,
+                [
+                    "odoo-overrides",
+                    "put-addon-setting",
+                    "--database-url",
+                    database_url,
+                    "--context",
+                    "opw",
+                    "--instance",
+                    "prod",
+                    "--addon",
+                    "shopify",
+                    "--setting",
+                    "api_token",
+                    "--secret-binding-id",
+                    "secret-binding-shopify-token",
+                ],
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            stored_record = store.read_odoo_instance_override_record(
+                context_name="opw", instance_name="prod"
+            )
+            store.close()
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertEqual(stored_record.apply_on, ("manual", "deploy", "promotion"))
 
     def test_cli_put_website_bootstrap_preserves_existing_overrides(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_odoo_verification.py
+++ b/tests/test_odoo_verification.py
@@ -201,10 +201,70 @@ class OdooVerificationTests(unittest.TestCase):
             [
                 "https://cm-testing.example.com",
                 "https://cm-testing.example.com/web/image/website/1/logo",
+            ],
+        )
+
+    def test_verification_does_not_retry_permanent_canonical_failure(self) -> None:
+        calls: list[str] = []
+
+        def fake_http_text(url: str, *, timeout_seconds: int) -> tuple[int, str, str]:
+            calls.append(url)
+            return 200, "<html>not canonical yet</html>", "text/html"
+
+        with (
+            patch("control_plane.workflows.odoo_verification._http_text", side_effect=fake_http_text),
+            patch(
+                "control_plane.workflows.odoo_verification.time.sleep",
+                side_effect=lambda _seconds: None,
+            ) as sleep_mock,
+        ):
+            result = verify_odoo_stable_readiness(
+                base_url="https://cm-testing.example.com",
+                verify_health=False,
+                verify_logo=False,
+                timeout_seconds=30,
+                retry_interval_seconds=5,
+            )
+
+        self.assertEqual(result.canonical_status, "fail")
+        self.assertEqual(result.evidence.probes[-1].failure_class, "canonical_missing")
+        self.assertEqual(calls, ["https://cm-testing.example.com"])
+        sleep_mock.assert_not_called()
+
+    def test_verification_does_not_retry_permanent_logo_failure(self) -> None:
+        calls: list[str] = []
+
+        def fake_http_text(url: str, *, timeout_seconds: int) -> tuple[int, str, str]:
+            calls.append(url)
+            if url == "https://cm-testing.example.com":
+                return 200, '<link rel="canonical" href="https://cm-testing.example.com">', "text/html"
+            return 404, "missing", "text/plain"
+
+        with (
+            patch("control_plane.workflows.odoo_verification._http_text", side_effect=fake_http_text),
+            patch(
+                "control_plane.workflows.odoo_verification.time.sleep",
+                side_effect=lambda _seconds: None,
+            ) as sleep_mock,
+        ):
+            result = verify_odoo_stable_readiness(
+                base_url="https://cm-testing.example.com",
+                verify_health=False,
+                verify_canonical=False,
+                timeout_seconds=30,
+                retry_interval_seconds=5,
+            )
+
+        self.assertEqual(result.logo_status, "fail")
+        self.assertEqual(result.evidence.probes[-1].failure_class, "http")
+        self.assertEqual(
+            calls,
+            [
                 "https://cm-testing.example.com",
                 "https://cm-testing.example.com/web/image/website/1/logo",
             ],
         )
+        sleep_mock.assert_not_called()
 
     def test_extract_logo_urls_ignores_cross_origin_assets(self) -> None:
         urls = _extract_same_origin_logo_urls(


### PR DESCRIPTION
## Summary
- keep CLI config-parameter and addon-setting overrides active on deploy/promotion after updating an existing record
- stop retrying permanent Odoo canonical/logo probe failures for the full timeout
- add regression coverage for override phases and non-retried permanent verifier failures

## Tests
- uv run python -m unittest tests.test_odoo_instance_overrides tests.test_odoo_verification tests.test_service.LaunchplaneServiceTests.test_odoo_config_parameter_override_driver_writes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_config_parameter_override_driver_keeps_existing_phases_and_adds_deploy
- uv run python -m unittest
- git diff --check
- uv run python -m py_compile control_plane/cli.py control_plane/workflows/odoo_verification.py