### PR TITLE
Add runtime identity breadcrumbs

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -199,6 +199,9 @@ from control_plane.workflows.promote import (
     build_promotion_record,
     generate_promotion_record_id,
 )
+from control_plane.workflows.runtime_identity_health import (
+    wait_for_healthcheck_with_retry,
+)
 from control_plane.workflows.ship import (
     build_deployment_record,
     generate_deployment_record_id,
@@ -6362,21 +6365,12 @@ def _load_github_webhook_json_bytes(
 
 
 def _wait_for_ship_healthcheck(*, url: str, timeout_seconds: int) -> None:
-    deadline = time.monotonic() + timeout_seconds
-    last_error: str = ""
-    while time.monotonic() < deadline:
-        try:
-            request = Request(url, method="GET")
-            with urlopen(request, timeout=min(5, timeout_seconds)) as response:
-                if 200 <= response.status < 300:
-                    return
-                last_error = f"http {response.status}"
-        except HTTPError as error:
-            last_error = f"http {error.code}"
-        except URLError as error:
-            last_error = str(error.reason)
-        time.sleep(1)
-    raise click.ClickException(f"Healthcheck failed for {url}: {last_error or 'timeout'}")
+    wait_for_healthcheck_with_retry(
+        url=url,
+        timeout_seconds=timeout_seconds,
+        sleep=time.sleep,
+        monotonic=time.monotonic,
+    )
 
 
 def _verify_ship_healthchecks(*, request: ShipRequest) -> None:

--- a/control_plane/contracts/preview_generation_record.py
+++ b/control_plane/contracts/preview_generation_record.py
@@ -3,6 +3,7 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane.contracts.promotion_record import ReleaseStatus
+from control_plane.contracts.runtime_identity import RuntimeIdentity
 
 PreviewGenerationState = Literal[
     "resolving",
@@ -78,6 +79,7 @@ class PreviewGenerationRecord(BaseModel):
     overall_health_status: ReleaseStatus = "pending"
     failure_stage: str = ""
     failure_summary: str = ""
+    runtime_identity: RuntimeIdentity | None = None
 
     @model_validator(mode="after")
     def _validate_record(self) -> "PreviewGenerationRecord":

--- a/control_plane/contracts/product_environment_read_model.py
+++ b/control_plane/contracts/product_environment_read_model.py
@@ -17,6 +17,7 @@ from control_plane.contracts.product_profile_record import (
     ProductSecretConfigRequirement,
 )
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
+from control_plane.contracts.runtime_identity import RuntimeIdentity, RuntimeIdentityStatus
 from control_plane.contracts.secret_record import SecretBinding
 from control_plane.drivers.registry import (
     build_driver_context_view,
@@ -129,6 +130,10 @@ class ProductTargetSummary(BaseModel):
     target_type: str = ""
     target_name: str = ""
     target_id_recorded: bool = False
+    expected_runtime_identity: RuntimeIdentity | None = None
+    observed_runtime_identity: RuntimeIdentity | None = None
+    runtime_identity_status: RuntimeIdentityStatus = "unchecked"
+    runtime_identity_detail: str = ""
     trust_state: FreshnessStatus = "missing"
 
 
@@ -1469,12 +1474,44 @@ def _config_requirement_applies(
 
 
 def _target_summary(lane_summary: LaunchplaneLaneSummary | None) -> ProductTargetSummary:
-    if lane_summary is None or lane_summary.dokploy_target is None:
+    if lane_summary is None:
         return ProductTargetSummary()
+    expected_identity = None
+    destination_health = None
+    if lane_summary.inventory is not None:
+        expected_identity = lane_summary.inventory.runtime_identity
+        destination_health = lane_summary.inventory.destination_health
+    elif lane_summary.latest_deployment is not None:
+        expected_identity = lane_summary.latest_deployment.runtime_identity
+        destination_health = lane_summary.latest_deployment.destination_health
+    if lane_summary.dokploy_target is None:
+        return ProductTargetSummary(
+            expected_runtime_identity=expected_identity,
+            observed_runtime_identity=destination_health.observed_runtime_identity
+            if destination_health is not None
+            else None,
+            runtime_identity_status=destination_health.runtime_identity_status
+            if destination_health is not None
+            else "unchecked",
+            runtime_identity_detail=destination_health.runtime_identity_detail
+            if destination_health is not None
+            else "",
+            trust_state=lane_summary.provenance.freshness_status,
+        )
     return ProductTargetSummary(
         target_type=lane_summary.dokploy_target.target_type,
         target_name=lane_summary.dokploy_target.target_name,
         target_id_recorded=lane_summary.dokploy_target_id is not None,
+        expected_runtime_identity=expected_identity,
+        observed_runtime_identity=destination_health.observed_runtime_identity
+        if destination_health is not None
+        else None,
+        runtime_identity_status=destination_health.runtime_identity_status
+        if destination_health is not None
+        else "unchecked",
+        runtime_identity_detail=destination_health.runtime_identity_detail
+        if destination_health is not None
+        else "",
         trust_state="recorded",
     )
 

--- a/control_plane/contracts/promotion_record.py
+++ b/control_plane/contracts/promotion_record.py
@@ -2,6 +2,8 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane.contracts.runtime_identity import RuntimeIdentity, RuntimeIdentityStatus
+
 ReleaseStatus = Literal["pending", "pass", "fail", "skipped"]
 
 
@@ -19,6 +21,9 @@ class HealthcheckEvidence(BaseModel):
     urls: tuple[str, ...] = ()
     timeout_seconds: int | None = Field(default=None, ge=1)
     status: ReleaseStatus = "skipped"
+    runtime_identity_status: RuntimeIdentityStatus = "unchecked"
+    runtime_identity_detail: str = ""
+    observed_runtime_identity: RuntimeIdentity | None = None
 
     @model_validator(mode="after")
     def _validate_verified_healthcheck(self) -> "HealthcheckEvidence":

--- a/control_plane/contracts/runtime_identity.py
+++ b/control_plane/contracts/runtime_identity.py
@@ -1,6 +1,19 @@
 import json
+from collections.abc import Mapping
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+RuntimeIdentityStatus = Literal[
+    "unchecked",
+    "match",
+    "mismatch",
+    "missing",
+    "unverifiable",
+]
+
+RUNTIME_IDENTITY_ENV_KEY = "LAUNCHPLANE_RUNTIME_IDENTITY_JSON"
 
 
 class RuntimeIdentity(BaseModel):
@@ -38,7 +51,7 @@ class RuntimeIdentity(BaseModel):
 def runtime_identity_env(identity: RuntimeIdentity) -> dict[str, str]:
     payload = identity.model_dump(mode="json", exclude_none=True)
     return {
-        "LAUNCHPLANE_RUNTIME_IDENTITY_JSON": json.dumps(
+        RUNTIME_IDENTITY_ENV_KEY: json.dumps(
             payload,
             sort_keys=True,
             separators=(",", ":"),
@@ -47,3 +60,82 @@ def runtime_identity_env(identity: RuntimeIdentity) -> dict[str, str]:
         "LAUNCHPLANE_ARTIFACT_ID": identity.artifact_id,
         "LAUNCHPLANE_SOURCE_GIT_REF": identity.source_git_ref,
     }
+
+
+def parse_runtime_identity_payload(value: object) -> RuntimeIdentity | None:
+    if isinstance(value, RuntimeIdentity):
+        return value
+    if isinstance(value, str):
+        stripped_value = value.strip()
+        if not stripped_value:
+            return None
+        try:
+            decoded_value: Any = json.loads(stripped_value)
+        except json.JSONDecodeError:
+            return None
+        return parse_runtime_identity_payload(decoded_value)
+    if isinstance(value, Mapping):
+        try:
+            return RuntimeIdentity.model_validate(dict(value))
+        except ValueError:
+            return None
+    return None
+
+
+def runtime_identity_from_health_payload(payload: object) -> RuntimeIdentity | None:
+    if not isinstance(payload, Mapping):
+        return None
+    for key in (
+        "runtime_identity",
+        "launchplane_runtime_identity",
+        "launchplaneRuntimeIdentity",
+        RUNTIME_IDENTITY_ENV_KEY,
+    ):
+        identity = parse_runtime_identity_payload(payload.get(key))
+        if identity is not None:
+            return identity
+    return None
+
+
+def compare_runtime_identity(
+    *, expected: RuntimeIdentity | None, observed: RuntimeIdentity | None
+) -> tuple[RuntimeIdentityStatus, str]:
+    if expected is None:
+        return "unchecked", "Runtime identity verification was not requested."
+    if observed is None:
+        return "missing", "Runtime identity was not reported by the health endpoint."
+
+    mismatches: list[str] = []
+    for field_name in (
+        "product",
+        "context",
+        "instance",
+        "environment_kind",
+        "deployment_record_id",
+        "artifact_id",
+        "source_git_ref",
+    ):
+        expected_value = str(getattr(expected, field_name) or "")
+        observed_value = str(getattr(observed, field_name) or "")
+        if expected_value and observed_value != expected_value:
+            mismatches.append(field_name)
+    if mismatches:
+        return "mismatch", "Runtime identity mismatched fields: " + ", ".join(mismatches)
+    return "match", "Runtime identity matches the expected deployment record."
+
+
+def health_payload_runtime_identity_status(
+    *, expected: RuntimeIdentity | None, payload: object, json_parse_failed: bool = False
+) -> tuple[RuntimeIdentityStatus, str, RuntimeIdentity | None]:
+    if expected is None:
+        status, detail = compare_runtime_identity(expected=None, observed=None)
+        return status, detail, None
+    if json_parse_failed:
+        return (
+            "unverifiable",
+            "Health endpoint passed but did not return JSON runtime identity evidence.",
+            None,
+        )
+    observed = runtime_identity_from_health_payload(payload)
+    status, detail = compare_runtime_identity(expected=expected, observed=observed)
+    return status, detail, observed

--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -20,6 +20,7 @@ from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductLaneProfile,
 )
+from control_plane.contracts.runtime_identity import RuntimeIdentity, runtime_identity_env
 from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeKeySafetyPolicyRecord,
     RuntimeKeySafetyTarget,
@@ -31,7 +32,7 @@ from control_plane.runtime_key_safety import (
     latest_active_runtime_key_safety_policy,
 )
 from control_plane.workflows.preview_desired_state import discover_github_preview_desired_state
-from control_plane.workflows.ship import utc_now_timestamp
+from control_plane.workflows.ship import generate_deployment_record_id, utc_now_timestamp
 
 
 _SECRET_SHAPED_RUNTIME_ENV_KEY_PARTS = {"PASSWORD", "TOKEN", "SECRET", "KEY"}
@@ -311,6 +312,33 @@ def _anchor_repo(repository: str) -> str:
     if not separator or not owner.strip() or not repo.strip() or "/" in repo.strip():
         raise click.ClickException("GitHub repository must use owner/repo format.")
     return repo.strip()
+
+
+def _build_preview_runtime_identity(
+    *,
+    profile: "LaunchplaneProductProfileRecord",
+    preview_slug: str,
+    image_reference: str,
+    anchor_head_sha: str,
+    deployed_at: str = "",
+) -> RuntimeIdentity | None:
+    if not anchor_head_sha.strip():
+        return None
+    return RuntimeIdentity(
+        product=profile.product,
+        context=profile.preview.context,
+        instance=preview_slug,
+        environment_kind="preview",
+        deployment_record_id=generate_deployment_record_id(
+            context_name=profile.preview.context,
+            instance_name=preview_slug,
+        ),
+        artifact_id=image_reference,
+        source_git_ref=anchor_head_sha,
+        image_reference=image_reference,
+        preview_id=preview_slug,
+        deployed_at=deployed_at,
+    )
 
 
 def _preview_slug_prefix(slug_template: str) -> str:
@@ -904,6 +932,7 @@ def _render_preview_env_text(
     profile: LaunchplaneProductProfileRecord,
     template_application: JsonObject,
     preview_url: str,
+    runtime_identity: RuntimeIdentity | None = None,
 ) -> str:
     template_env = control_plane_dokploy.parse_dokploy_env_text(
         str(template_application.get("env") or "")
@@ -919,6 +948,8 @@ def _render_preview_env_text(
         updates[key] = preview_url
     for key in profile.preview.preview_domain_env_keys:
         updates[key] = preview_host
+    if runtime_identity is not None:
+        updates.update(runtime_identity_env(runtime_identity))
     return control_plane_dokploy.render_dokploy_env_text_with_overrides(
         "",
         updates=updates,
@@ -933,6 +964,7 @@ def _render_odoo_compose_stage_preview_env_text(
     template_payload: JsonObject,
     preview_url: str,
     image_reference: str,
+    runtime_identity: RuntimeIdentity | None = None,
 ) -> str:
     template_env = control_plane_dokploy.parse_dokploy_env_text(
         str(template_payload.get("env") or "")
@@ -952,6 +984,8 @@ def _render_odoo_compose_stage_preview_env_text(
         desired_env[key] = preview_url
     for key in profile.preview.preview_domain_env_keys:
         desired_env[key] = preview_host
+    if runtime_identity is not None:
+        desired_env.update(runtime_identity_env(runtime_identity))
     return control_plane_dokploy.serialize_dokploy_env_text(desired_env)
 
 
@@ -1527,6 +1561,12 @@ def execute_generic_web_preview_refresh(
                 target_definition=target_definition,
                 template_payload=template_application,
                 preview_url=preview_url,
+                runtime_identity=_build_preview_runtime_identity(
+                    profile=resolved_profile,
+                    preview_slug=request.preview_slug,
+                    image_reference=request.image_reference,
+                    anchor_head_sha=request.anchor_head_sha,
+                ),
             )
             finished_at = utc_now_timestamp()
             refresh_status: Literal["pass", "blocked", "fail"] = (
@@ -1553,10 +1593,17 @@ def execute_generic_web_preview_refresh(
             template_application=template_application,
             preview_slug=request.preview_slug,
         )
+        preview_runtime_identity = _build_preview_runtime_identity(
+            profile=resolved_profile,
+            preview_slug=request.preview_slug,
+            image_reference=request.image_reference,
+            anchor_head_sha=request.anchor_head_sha,
+        )
         env_text = _render_preview_env_text(
             profile=resolved_profile,
             template_application=template_application,
             preview_url=preview_url,
+            runtime_identity=preview_runtime_identity,
         )
         application, created_application = _ensure_application(
             host=host,
@@ -1667,6 +1714,7 @@ def _execute_odoo_compose_stage_preview_refresh(
     target_definition: control_plane_dokploy.DokployTargetDefinition,
     template_payload: JsonObject,
     preview_url: str,
+    runtime_identity: RuntimeIdentity | None = None,
 ) -> tuple[str, GenericWebPreviewSmokeResult]:
     _enforce_preview_copied_runtime_key_safety(
         record_store=record_store,
@@ -1699,6 +1747,7 @@ def _execute_odoo_compose_stage_preview_refresh(
         template_payload=template_payload,
         preview_url=preview_url,
         image_reference=request.image_reference,
+        runtime_identity=runtime_identity,
     )
     control_plane_dokploy.update_dokploy_target_env(
         host=host,

--- a/control_plane/workflows/generic_web_promotion.py
+++ b/control_plane/workflows/generic_web_promotion.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 import time
 from pathlib import Path
 from typing import Literal, Protocol
-from urllib.error import HTTPError, URLError
 from urllib.parse import quote
-from urllib.request import Request, urlopen
 
 import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -26,6 +24,7 @@ from control_plane.contracts.promotion_record import (
     PromotionRecord,
     ReleaseStatus,
 )
+from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.workflows.generic_web_deploy import (
     GenericWebDeployStore,
     GenericWebDeployRequest,
@@ -37,6 +36,10 @@ from control_plane.workflows.inventory import build_environment_inventory
 from control_plane.workflows.launchplane import (
     github_api_request,
     resolve_launchplane_github_token,
+)
+from control_plane.workflows.runtime_identity_health import (
+    healthcheck_evidence_with_runtime_identity,
+    wait_for_healthcheck_with_retry,
 )
 from control_plane.workflows.promote import generate_promotion_record_id
 from control_plane.workflows.ship import utc_now_timestamp
@@ -273,7 +276,10 @@ def execute_generic_web_prod_promotion(
     )
     if deploy_result.deploy_status == "pass":
         try:
-            destination_health = _verify_health_evidence(destination_health)
+            destination_health = _verify_health_evidence_with_identity(
+                destination_health,
+                expected_runtime_identity=deployment_record.runtime_identity,
+            )
         except click.ClickException as error:
             destination_health = _mark_health_failed(destination_health)
             _write_deployment_health(
@@ -476,21 +482,12 @@ def _health_evidence_for_lane(
 
 
 def _wait_for_healthcheck(*, url: str, timeout_seconds: int) -> None:
-    deadline = time.monotonic() + timeout_seconds
-    last_error = ""
-    while time.monotonic() < deadline:
-        try:
-            request = Request(url, method="GET")
-            with urlopen(request, timeout=min(5, timeout_seconds)) as response:
-                if 200 <= response.status < 300:
-                    return
-                last_error = f"http {response.status}"
-        except HTTPError as error:
-            last_error = f"http {error.code}"
-        except URLError as error:
-            last_error = str(error.reason)
-        time.sleep(1)
-    raise click.ClickException(f"Healthcheck failed for {url}: {last_error or 'timeout'}")
+    wait_for_healthcheck_with_retry(
+        url=url,
+        timeout_seconds=timeout_seconds,
+        sleep=time.sleep,
+        monotonic=time.monotonic,
+    )
 
 
 def _verify_health_evidence(evidence: HealthcheckEvidence) -> HealthcheckEvidence:
@@ -506,6 +503,45 @@ def _verify_health_evidence(evidence: HealthcheckEvidence) -> HealthcheckEvidenc
                 urls=evidence.urls,
                 timeout_seconds=timeout_seconds,
                 status="pass",
+            )
+        except click.ClickException as error:
+            healthcheck_errors.append(str(error))
+        except (TimeoutError, OSError) as error:
+            healthcheck_errors.append(str(error))
+    raise click.ClickException(
+        "Healthcheck verification failed for all generic web URLs:\n"
+        + "\n".join(healthcheck_errors)
+    )
+
+
+def _verify_health_evidence_with_identity(
+    evidence: HealthcheckEvidence,
+    *,
+    expected_runtime_identity: RuntimeIdentity | None,
+) -> HealthcheckEvidence:
+    if evidence.status == "skipped" or not evidence.urls:
+        return evidence
+    if expected_runtime_identity is None:
+        return _verify_health_evidence(evidence)
+    timeout_seconds = evidence.timeout_seconds or DEFAULT_GENERIC_WEB_HEALTH_TIMEOUT_SECONDS
+    healthcheck_errors: list[str] = []
+    for health_url in evidence.urls:
+        try:
+            healthcheck_pass = wait_for_healthcheck_with_retry(
+                url=health_url,
+                timeout_seconds=timeout_seconds,
+                sleep=time.sleep,
+                monotonic=time.monotonic,
+            )
+            return healthcheck_evidence_with_runtime_identity(
+                HealthcheckEvidence(
+                    verified=True,
+                    urls=evidence.urls,
+                    timeout_seconds=timeout_seconds,
+                    status="pass",
+                ),
+                expected_runtime_identity=expected_runtime_identity,
+                healthcheck_pass=healthcheck_pass,
             )
         except click.ClickException as error:
             healthcheck_errors.append(str(error))

--- a/control_plane/workflows/launchplane.py
+++ b/control_plane/workflows/launchplane.py
@@ -43,6 +43,7 @@ from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
 )
 from control_plane.contracts.promotion_record import ReleaseStatus
+from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.ship import utc_now_timestamp
 
@@ -1474,6 +1475,7 @@ def build_preview_generation_record(
     overall_health_status: ReleaseStatus = "pending",
     failure_stage: str = "",
     failure_summary: str = "",
+    runtime_identity: RuntimeIdentity | None = None,
 ) -> PreviewGenerationRecord:
     resolved_generation_id = generation_id or generate_preview_generation_id(
         preview_id=preview_id,
@@ -1508,6 +1510,7 @@ def build_preview_generation_record(
         overall_health_status=overall_health_status,
         failure_stage=failure_stage,
         failure_summary=failure_summary,
+        runtime_identity=runtime_identity,
     )
 
 

--- a/control_plane/workflows/runtime_identity_health.py
+++ b/control_plane/workflows/runtime_identity_health.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import NamedTuple
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import click
+
+from control_plane.contracts.promotion_record import HealthcheckEvidence
+from control_plane.contracts.runtime_identity import (
+    RuntimeIdentity,
+    health_payload_runtime_identity_status,
+)
+
+
+class HealthcheckPass(NamedTuple):
+    payload: object = None
+    json_parse_failed: bool = False
+
+
+WaitForHealthcheck = Callable[[str, int], HealthcheckPass]
+
+
+def wait_for_json_healthcheck(*, url: str, timeout_seconds: int) -> HealthcheckPass:
+    request = Request(url, method="GET")
+    with urlopen(request, timeout=min(5, timeout_seconds)) as response:  # noqa: S310 - operator-configured URL.
+        body = response.read(1024 * 256)
+        if not 200 <= response.status < 300:
+            raise click.ClickException(f"http {response.status}")
+    if not body.strip():
+        return HealthcheckPass()
+    try:
+        return HealthcheckPass(payload=json.loads(body.decode("utf-8")))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return HealthcheckPass(json_parse_failed=True)
+
+
+def wait_for_healthcheck_with_retry(
+    *,
+    url: str,
+    timeout_seconds: int,
+    sleep: Callable[[float], None],
+    monotonic: Callable[[], float],
+    wait_once: Callable[..., HealthcheckPass] = wait_for_json_healthcheck,
+) -> HealthcheckPass:
+    deadline = monotonic() + timeout_seconds
+    last_error: str = ""
+    while monotonic() < deadline:
+        try:
+            return wait_once(url, timeout_seconds)
+        except click.ClickException as error:
+            last_error = str(error)
+        except HTTPError as error:
+            last_error = f"http {error.code}"
+        except URLError as error:
+            last_error = str(error.reason)
+        sleep(1)
+    raise click.ClickException(f"Healthcheck failed for {url}: {last_error or 'timeout'}")
+
+
+def healthcheck_evidence_with_runtime_identity(
+    evidence: HealthcheckEvidence,
+    *,
+    expected_runtime_identity: RuntimeIdentity | None,
+    healthcheck_pass: HealthcheckPass,
+) -> HealthcheckEvidence:
+    status, detail, observed = health_payload_runtime_identity_status(
+        expected=expected_runtime_identity,
+        payload=healthcheck_pass.payload,
+        json_parse_failed=healthcheck_pass.json_parse_failed,
+    )
+    return evidence.model_copy(
+        update={
+            "runtime_identity_status": status,
+            "runtime_identity_detail": detail,
+            "observed_runtime_identity": observed,
+        }
+    )

--- a/control_plane/workflows/verireel_preview_driver.py
+++ b/control_plane/workflows/verireel_preview_driver.py
@@ -18,13 +18,14 @@ from control_plane import dokploy as control_plane_dokploy
 from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane import secrets as control_plane_secrets
 from control_plane.dokploy import JsonObject
+from control_plane.contracts.runtime_identity import RuntimeIdentity, runtime_identity_env
 from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyTarget
 from control_plane.runtime_key_safety import (
     RuntimeKeySafetyPolicyReadStore,
     evaluate_runtime_key_safety,
     latest_active_runtime_key_safety_policy,
 )
-from control_plane.workflows.ship import utc_now_timestamp
+from control_plane.workflows.ship import generate_deployment_record_id, utc_now_timestamp
 
 
 DEFAULT_PREVIEW_TIMEOUT_SECONDS = 300
@@ -36,6 +37,28 @@ _SECRET_SHAPED_RUNTIME_ENV_KEY_PARTS = {"PASSWORD", "TOKEN", "SECRET", "KEY"}
 
 def _expected_preview_slug(anchor_pr_number: int) -> str:
     return f"pr-{anchor_pr_number}"
+
+
+def _build_preview_runtime_identity(
+    *,
+    request: "VeriReelPreviewRefreshRequest",
+    deployed_at: str = "",
+) -> RuntimeIdentity:
+    return RuntimeIdentity(
+        product="verireel",
+        context=request.context,
+        instance=request.preview_slug,
+        environment_kind="preview",
+        deployment_record_id=generate_deployment_record_id(
+            context_name=request.context,
+            instance_name=request.preview_slug,
+        ),
+        artifact_id=request.image_reference,
+        source_git_ref=request.anchor_head_sha,
+        image_reference=request.image_reference,
+        preview_id=request.preview_slug,
+        deployed_at=deployed_at,
+    )
 
 
 class VeriReelPreviewRefreshRequest(BaseModel):
@@ -1159,6 +1182,9 @@ def execute_verireel_preview_refresh(
                     database_name=database_parts.database,
                     role_name=database_parts.username,
                     password=database_parts.password,
+                ),
+                **runtime_identity_env(
+                    _build_preview_runtime_identity(request=request)
                 ),
             },
         )

--- a/control_plane/workflows/verireel_stable_deploy.py
+++ b/control_plane/workflows/verireel_stable_deploy.py
@@ -11,6 +11,7 @@ from control_plane import runtime_environments as control_plane_runtime_environm
 from control_plane.contracts.deployment_record import ResolvedTargetEvidence
 from control_plane.contracts.dokploy_target_record import DokployTargetType
 from control_plane.contracts.promotion_record import HealthcheckEvidence, ReleaseStatus
+from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.dokploy_deploy import execute_dokploy_artifact_deploy
@@ -91,6 +92,26 @@ def _expected_build_revision(request: VeriReelStableDeployRequest) -> str:
 
 def _expected_build_tag(request: VeriReelStableDeployRequest) -> str:
     return request.expected_build_tag.strip() or _artifact_tag(request.artifact_id)
+
+
+def _build_runtime_identity(
+    *,
+    request: VeriReelStableDeployRequest,
+    ship_request: ShipRequest,
+    deployment_record_id: str,
+    deployed_at: str = "",
+) -> RuntimeIdentity:
+    return RuntimeIdentity(
+        product="verireel",
+        context=request.context,
+        instance=request.instance,
+        environment_kind="stable",
+        deployment_record_id=deployment_record_id,
+        artifact_id=ship_request.artifact_id,
+        source_git_ref=ship_request.source_git_ref,
+        image_reference=ship_request.artifact_id,
+        deployed_at=deployed_at,
+    )
 
 
 def _resolve_deploy_mode(*, configured_ship_mode: str, target_type: DokployTargetType) -> str:
@@ -187,6 +208,7 @@ def _execute_dokploy_deploy(
     ship_request: ShipRequest,
     resolved_target: ResolvedTargetEvidence,
     deploy_timeout_seconds: int,
+    runtime_identity: RuntimeIdentity | None = None,
 ) -> None:
     host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
     execute_dokploy_artifact_deploy(
@@ -195,6 +217,7 @@ def _execute_dokploy_deploy(
         ship_request=ship_request,
         resolved_target=resolved_target,
         deploy_timeout_seconds=deploy_timeout_seconds,
+        runtime_identity=runtime_identity,
     )
 
 
@@ -268,12 +291,18 @@ def execute_verireel_stable_deploy(
         )
     )
 
+    runtime_identity = _build_runtime_identity(
+        request=request,
+        ship_request=ship_request,
+        deployment_record_id=record_id,
+    )
     try:
         _execute_dokploy_deploy(
             control_plane_root=control_plane_root,
             ship_request=ship_request,
             resolved_target=resolved_target,
             deploy_timeout_seconds=deploy_timeout_seconds,
+            runtime_identity=runtime_identity,
         )
     except click.ClickException as exc:
         finished_at = utc_now_timestamp()
@@ -321,6 +350,7 @@ def execute_verireel_stable_deploy(
                 started_at=started_at,
                 finished_at=finished_at,
                 resolved_target=resolved_target,
+                runtime_identity=runtime_identity,
                 destination_health=health_evidence_from_rollout(
                     result=failed_rollout_result,
                     timeout_seconds=request.rollout_timeout_seconds,
@@ -350,6 +380,12 @@ def execute_verireel_stable_deploy(
             started_at=started_at,
             finished_at=finished_at,
             resolved_target=resolved_target,
+            runtime_identity=_build_runtime_identity(
+                request=request,
+                ship_request=ship_request,
+                deployment_record_id=record_id,
+                deployed_at=finished_at,
+            ),
             destination_health=health_evidence_from_rollout(
                 result=rollout_result,
                 timeout_seconds=request.rollout_timeout_seconds,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -752,6 +752,16 @@ against the stored artifact manifest. Do not manually delete canonical stable
 targets as a replacement shortcut; add the missing Launchplane apply coverage
 first, then use the service-backed workflow.
 
+Runtime identity is a driver-owned breadcrumb, not tenant config. Launchplane
+injects `LAUNCHPLANE_RUNTIME_IDENTITY_JSON`, `LAUNCHPLANE_DEPLOYMENT_RECORD_ID`,
+`LAUNCHPLANE_ARTIFACT_ID`, and `LAUNCHPLANE_SOURCE_GIT_REF` into supported
+Dokploy targets. Product health endpoints may echo the JSON payload as
+`runtime_identity`, `launchplane_runtime_identity`, `launchplaneRuntimeIdentity`,
+or `LAUNCHPLANE_RUNTIME_IDENTITY_JSON`; Launchplane records whether the observed
+payload matches, mismatches, is missing, or cannot be parsed. Missing observed
+identity is evidence for adoption work, not a reason to hardcode product-specific
+health or logo probe URLs.
+
 Target replacement only reconciles the provider target and runtime envelope. If
 an intentionally empty CM testing lane needs its Odoo database and filestore
 rebuilt, use the trusted `Odoo Stable Bootstrap` workflow instead of repairing

--- a/docs/records.md
+++ b/docs/records.md
@@ -77,15 +77,19 @@ an ORM column/table or remains only in the evidence payload.
   evidence stay payload-only.
 - Deployment: modeled fields are `record_id`, `context`, `instance`,
   `artifact_id`, `source_git_ref`, deploy timestamps, and an optional structured
-  runtime identity. Resolved provider evidence, health detail, and post-deploy
-  product facts stay payload-only.
+  expected runtime identity. Destination health evidence may also record an
+  observed runtime identity and classify it as `match`, `mismatch`, `missing`,
+  `unverifiable`, or `unchecked`. Resolved provider evidence, health detail, and
+  post-deploy product facts stay payload-only.
 - Promotion: modeled fields are `record_id`, `context`, `from_instance`,
   `to_instance`, `artifact_id`, and deploy timestamps. Rollback annotations,
   backup evidence detail, and provider health envelopes stay payload-only.
 - Inventory: modeled fields are `context`, `instance`, `artifact_id`,
   `source_git_ref`, `updated_at`, linked deployment/promotion ids, and the
-  expected runtime identity copied from the current deployment record. Full
-  deploy evidence and product-specific live facts stay payload-only.
+  expected runtime identity copied from the current deployment record. Inventory
+  carries the destination health runtime-identity evidence from that deployment
+  so read models can show whether the live app reported the expected breadcrumb.
+  Full deploy evidence and product-specific live facts stay payload-only.
 - Preview: modeled fields are `preview_id`, `context`, `anchor_repo`,
   `anchor_pr_number`, `state`, and `updated_at`. Canonical URLs, lifecycle
   notes, and provider route evidence stay payload-only.

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -827,6 +827,7 @@ class GenericWebPreviewTests(unittest.TestCase):
                     preview_slug="preview-42-site",
                     preview_url="https://preview-42.example.test",
                     image_reference="ghcr.io/cbusillo/sellyouroutboard:sha",
+                    anchor_head_sha="abc123",
                 ),
             )
 
@@ -1051,6 +1052,7 @@ class GenericWebPreviewTests(unittest.TestCase):
                     preview_slug="preview-42-site",
                     preview_url="https://preview-42.example.test",
                     image_reference="ghcr.io/cbusillo/sellyouroutboard:sha",
+                    anchor_head_sha="abc123",
                 ),
             )
 
@@ -1082,6 +1084,10 @@ class GenericWebPreviewTests(unittest.TestCase):
         self.assertIn("SMTP_FROM=hello@example.com", env_text)
         self.assertIn("PUBLIC_URL=https://preview-42.example.test", env_text)
         self.assertIn("PUBLIC_DOMAIN=preview-42.example.test", env_text)
+        self.assertIn("LAUNCHPLANE_RUNTIME_IDENTITY_JSON=", env_text)
+        self.assertIn("LAUNCHPLANE_DEPLOYMENT_RECORD_ID=", env_text)
+        self.assertIn("LAUNCHPLANE_ARTIFACT_ID=ghcr.io/cbusillo/sellyouroutboard:sha", env_text)
+        self.assertIn("LAUNCHPLANE_SOURCE_GIT_REF=", env_text)
         self.assertNotIn("SMTP_HOST=", env_text)
         trigger_deployment.assert_called_once()
         wait_health.assert_called_once()
@@ -1305,6 +1311,10 @@ class GenericWebPreviewTests(unittest.TestCase):
         self.assertIn("ODOO_INSTALL_MODULES=cm_custom,cm_website", env_updates[0])
         self.assertIn("WEB_BASE_URL=https://pr-28.cm-preview.shinycomputers.com", env_updates[0])
         self.assertIn("DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/odoo-tenant-cm:sha", env_updates[0])
+        self.assertIn("LAUNCHPLANE_RUNTIME_IDENTITY_JSON=", env_updates[0])
+        self.assertIn("LAUNCHPLANE_DEPLOYMENT_RECORD_ID=", env_updates[0])
+        self.assertIn("LAUNCHPLANE_ARTIFACT_ID=ghcr.io/cbusillo/odoo-tenant-cm:sha", env_updates[0])
+        self.assertIn("LAUNCHPLANE_SOURCE_GIT_REF=abc123", env_updates[0])
         self.assertEqual(
             [request["path"] for request in domain_requests],
             ["/api/domain.byComposeId", "/api/domain.create"],

--- a/tests/test_launchplane_previews.py
+++ b/tests/test_launchplane_previews.py
@@ -31,6 +31,7 @@ from control_plane.contracts.preview_request_metadata import (
     LaunchplanePreviewRequestParseStatus,
 )
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
     BackupGateEvidence,
@@ -625,6 +626,16 @@ ODOO_DB_PASSWORD = "local-secret"
                     )
 
     def test_build_preview_generation_record_links_anchor_and_sequence(self) -> None:
+        runtime_identity = RuntimeIdentity(
+            product="odoo-tenant-opw",
+            context="opw-preview",
+            instance="pr-123",
+            environment_kind="preview",
+            deployment_record_id="deployment-preview-123",
+            artifact_id="artifact-opw-124",
+            source_git_ref="aaaa1111",
+            preview_id="preview-opw-tenant-opw-pr-123",
+        )
         generation_record = build_preview_generation_record(
             preview_id="preview-opw-tenant-opw-pr-123",
             sequence=2,
@@ -642,6 +653,7 @@ ODOO_DB_PASSWORD = "local-secret"
             overall_health_status="fail",
             failure_stage="deploying",
             failure_summary="Replacement generation failed during deploy.",
+            runtime_identity=runtime_identity,
         )
 
         self.assertEqual(
@@ -651,6 +663,7 @@ ODOO_DB_PASSWORD = "local-secret"
         self.assertEqual(generation_record.anchor_summary.repo, "tenant-opw")
         self.assertEqual(generation_record.anchor_summary.pr_number, 123)
         self.assertEqual(generation_record.failure_stage, "deploying")
+        self.assertEqual(generation_record.runtime_identity, runtime_identity)
 
     def test_apply_generation_requested_transition_keeps_existing_serving_generation(self) -> None:
         preview = _preview_record(

--- a/tests/test_product_environment_read_model.py
+++ b/tests/test_product_environment_read_model.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from typing import cast
 import unittest
 
+from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.product_environment_read_model import (
     ACTION_AUTHZ_BY_ROUTE,
@@ -15,7 +16,13 @@ from control_plane.contracts.product_environment_read_model import (
     build_product_site_overview,
 )
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.promotion_record import (
+    ArtifactIdentityReference,
+    DeploymentEvidence,
+    HealthcheckEvidence,
+)
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
+from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.contracts.secret_record import SecretBinding
 from control_plane.storage.postgres import PostgresRecordStore
 
@@ -143,6 +150,23 @@ class _PreviewRecordStore:
     ) -> tuple[PreviewRecord, ...]:
         self.preview_record_calls.append((context_name, anchor_repo))
         return self._previews
+
+
+class _RuntimeIdentityReadModelStore(_PreviewRecordStore):
+    def __init__(
+        self,
+        profile: LaunchplaneProductProfileRecord,
+        inventory: EnvironmentInventory,
+    ) -> None:
+        super().__init__(profile, ())
+        self._inventory = inventory
+
+    def read_environment_inventory(
+        self, *, context_name: str, instance_name: str
+    ) -> EnvironmentInventory:
+        if context_name == self._inventory.context and instance_name == self._inventory.instance:
+            return self._inventory
+        raise FileNotFoundError(f"{context_name}/{instance_name}")
 
 
 class _ActivityRecordStore(_PreviewRecordStore):
@@ -705,6 +729,58 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
         self.assertTrue(detail.odoo_requires_backup_before_destroy)
         self.assertTrue(detail.odoo_requires_restore_proof)
         self.assertTrue(detail.odoo_requires_runtime_identity)
+
+    def test_product_environment_detail_exposes_runtime_identity_evidence(self) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(
+            _site_profile_payload(preview_enabled=False)
+        )
+        expected = RuntimeIdentity(
+            product="example-site",
+            context="example-site-prod",
+            instance="prod",
+            deployment_record_id="deployment-prod-1",
+            artifact_id="ghcr.io/every/example-site@sha256:abc123",
+            source_git_ref="abc123",
+        )
+        inventory = EnvironmentInventory(
+            context="example-site-prod",
+            instance="prod",
+            artifact_identity=ArtifactIdentityReference(artifact_id=expected.artifact_id),
+            source_git_ref="abc123",
+            deploy=DeploymentEvidence(
+                target_name="example-site-prod",
+                target_type="application",
+                deploy_mode="dokploy-application-api",
+                deployment_id="control-plane-dokploy",
+                status="pass",
+                started_at="2026-05-02T10:00:00Z",
+                finished_at="2026-05-02T10:01:00Z",
+            ),
+            runtime_identity=expected,
+            destination_health=HealthcheckEvidence(
+                verified=True,
+                urls=("https://example-site.example/healthz",),
+                timeout_seconds=30,
+                status="pass",
+                runtime_identity_status="match",
+                runtime_identity_detail="Runtime identity matches the expected deployment record.",
+                observed_runtime_identity=expected,
+            ),
+            updated_at="2026-05-02T10:01:00Z",
+            deployment_record_id="deployment-prod-1",
+        )
+        store = _RuntimeIdentityReadModelStore(profile, inventory)
+
+        detail = build_product_environment_detail(
+            record_store=store,
+            product="example-site",
+            environment="prod",
+            action_allowed=lambda *_: False,
+        )
+
+        self.assertEqual(detail.target.expected_runtime_identity, expected)
+        self.assertEqual(detail.target.observed_runtime_identity, expected)
+        self.assertEqual(detail.target.runtime_identity_status, "match")
 
     def test_product_environment_config_status_reports_expected_key_states(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_runtime_identity.py
+++ b/tests/test_runtime_identity.py
@@ -1,7 +1,13 @@
 import json
 import unittest
 
-from control_plane.contracts.runtime_identity import RuntimeIdentity, runtime_identity_env
+from control_plane.contracts.runtime_identity import (
+    RuntimeIdentity,
+    compare_runtime_identity,
+    health_payload_runtime_identity_status,
+    runtime_identity_env,
+    runtime_identity_from_health_payload,
+)
 
 
 class RuntimeIdentityTests(unittest.TestCase):
@@ -29,6 +35,72 @@ class RuntimeIdentityTests(unittest.TestCase):
         self.assertEqual(payload["schema_version"], 1)
         self.assertEqual(payload["product"], "sellyouroutboard")
         self.assertEqual(payload["deployment_record_id"], "deployment-123")
+
+    def test_runtime_identity_from_health_payload_accepts_nested_identity(self) -> None:
+        identity = RuntimeIdentity(
+            product="sellyouroutboard",
+            context="sellyouroutboard-testing",
+            instance="testing",
+            deployment_record_id="deployment-123",
+            artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+            source_git_ref="abc123",
+        )
+        payload = {"runtime_identity": identity.model_dump(mode="json")}
+
+        self.assertEqual(runtime_identity_from_health_payload(payload), identity)
+
+    def test_runtime_identity_from_health_payload_accepts_env_json(self) -> None:
+        identity = RuntimeIdentity(
+            product="sellyouroutboard",
+            context="sellyouroutboard-testing",
+            instance="testing",
+            deployment_record_id="deployment-123",
+            artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+            source_git_ref="abc123",
+        )
+
+        self.assertEqual(
+            runtime_identity_from_health_payload(runtime_identity_env(identity)), identity
+        )
+
+    def test_compare_runtime_identity_reports_mismatch_fields(self) -> None:
+        expected = RuntimeIdentity(
+            product="sellyouroutboard",
+            context="sellyouroutboard-testing",
+            instance="testing",
+            deployment_record_id="deployment-123",
+            artifact_id="artifact-a",
+            source_git_ref="abc123",
+        )
+        observed = expected.model_copy(
+            update={"artifact_id": "artifact-b", "source_git_ref": "def456"}
+        )
+
+        status, detail = compare_runtime_identity(expected=expected, observed=observed)
+
+        self.assertEqual(status, "mismatch")
+        self.assertIn("artifact_id", detail)
+        self.assertIn("source_git_ref", detail)
+
+    def test_health_payload_runtime_identity_status_marks_non_json_unverifiable(self) -> None:
+        expected = RuntimeIdentity(
+            product="sellyouroutboard",
+            context="sellyouroutboard-testing",
+            instance="testing",
+            deployment_record_id="deployment-123",
+            artifact_id="artifact-a",
+            source_git_ref="abc123",
+        )
+
+        status, detail, observed = health_payload_runtime_identity_status(
+            expected=expected,
+            payload=None,
+            json_parse_failed=True,
+        )
+
+        self.assertEqual(status, "unverifiable")
+        self.assertIn("did not return JSON", detail)
+        self.assertIsNone(observed)
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime_identity_health.py
+++ b/tests/test_runtime_identity_health.py
@@ -1,0 +1,64 @@
+import unittest
+
+from control_plane.contracts.promotion_record import HealthcheckEvidence
+from control_plane.contracts.runtime_identity import RuntimeIdentity
+from control_plane.workflows.runtime_identity_health import (
+    HealthcheckPass,
+    healthcheck_evidence_with_runtime_identity,
+)
+
+
+class RuntimeIdentityHealthTests(unittest.TestCase):
+    def test_healthcheck_evidence_records_matching_runtime_identity(self) -> None:
+        identity = RuntimeIdentity(
+            product="sellyouroutboard",
+            context="sellyouroutboard-testing",
+            instance="testing",
+            deployment_record_id="deployment-123",
+            artifact_id="artifact-a",
+            source_git_ref="abc123",
+        )
+
+        evidence = healthcheck_evidence_with_runtime_identity(
+            HealthcheckEvidence(
+                verified=True,
+                urls=("https://testing.example/health",),
+                timeout_seconds=5,
+                status="pass",
+            ),
+            expected_runtime_identity=identity,
+            healthcheck_pass=HealthcheckPass(
+                payload={"runtime_identity": identity.model_dump(mode="json")}
+            ),
+        )
+
+        self.assertEqual(evidence.runtime_identity_status, "match")
+        self.assertEqual(evidence.observed_runtime_identity, identity)
+
+    def test_healthcheck_evidence_marks_missing_runtime_identity(self) -> None:
+        identity = RuntimeIdentity(
+            product="sellyouroutboard",
+            context="sellyouroutboard-testing",
+            instance="testing",
+            deployment_record_id="deployment-123",
+            artifact_id="artifact-a",
+            source_git_ref="abc123",
+        )
+
+        evidence = healthcheck_evidence_with_runtime_identity(
+            HealthcheckEvidence(
+                verified=True,
+                urls=("https://testing.example/health",),
+                timeout_seconds=5,
+                status="pass",
+            ),
+            expected_runtime_identity=identity,
+            healthcheck_pass=HealthcheckPass(payload={"status": "ok"}),
+        )
+
+        self.assertEqual(evidence.runtime_identity_status, "missing")
+        self.assertIsNone(evidence.observed_runtime_identity)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_verireel_testing_deploy.py
+++ b/tests/test_verireel_testing_deploy.py
@@ -94,6 +94,16 @@ class VeriReelTestingDeployWorkflowTests(unittest.TestCase):
             self.assertEqual(deployment.deploy.started_at, "2026-04-20T18:20:00Z")
             self.assertEqual(deployment.deploy.finished_at, "2026-04-20T18:21:15Z")
             self.assertEqual(deployment.destination_health.status, "pass")
+            self.assertIsNotNone(deployment.runtime_identity)
+            assert deployment.runtime_identity is not None
+            self.assertEqual(deployment.runtime_identity.product, "verireel")
+            self.assertEqual(deployment.runtime_identity.context, "verireel")
+            self.assertEqual(deployment.runtime_identity.instance, "testing")
+            self.assertEqual(
+                deployment.runtime_identity.deployment_record_id,
+                "deployment-verireel-testing-run-12345-attempt-1",
+            )
+            self.assertEqual(deployment.runtime_identity.source_git_ref, request.source_git_ref)
             self.assertEqual(result.rollout_status, "pass")
 
     def test_execute_writes_failed_deployment_record(self) -> None:


### PR DESCRIPTION
## Summary
- inject runtime identity into stable, preview, generic web, Odoo compose-stage preview, and VeriReel deploy paths
- record observed runtime identity status in health evidence and expose expected/observed identity in product environment target summaries
- document the runtime identity health payload contract

## Tests
- uv run python -m unittest tests.test_generic_web_preview tests.test_verireel_preview_driver tests.test_verireel_testing_deploy tests.test_runtime_identity tests.test_runtime_identity_health tests.test_product_environment_read_model tests.test_generic_web_promotion tests.test_launchplane_previews
- uv run python -m unittest

Closes #516