### PR TITLE
Restore Odoo health readiness retries

### DIFF
--- a/control_plane/workflows/odoo_verification.py
+++ b/control_plane/workflows/odoo_verification.py
@@ -93,7 +93,7 @@ def verify_odoo_stable_readiness(
         if verify_health:
             if not normalized_health_url:
                 raise click.ClickException("Odoo health verification has no health URL.")
-            evidence = _run_probe_with_retry(
+            evidence = _run_health_probe_with_retry(
                 lambda: _verify_health_url(
                     health_url=normalized_health_url,
                     timeout_seconds=timeout_seconds,
@@ -357,19 +357,32 @@ def _run_probe_with_retry(
     retry_interval_seconds: int,
 ) -> OdooVerificationProbeEvidence:
     deadline = time.monotonic() + timeout_seconds
-    last_error: click.ClickException | None = None
     while True:
         try:
             return verification()
         except _ProbeFailure:
             raise
         except click.ClickException as error:
-            last_error = error
             remaining_seconds = deadline - time.monotonic()
             if remaining_seconds <= 0:
-                if last_error is None:
-                    raise click.ClickException("Odoo verification retry ended without an error.")
-                raise last_error
+                raise error
+            time.sleep(min(retry_interval_seconds, remaining_seconds))
+
+
+def _run_health_probe_with_retry(
+    verification: Callable[[], OdooVerificationProbeEvidence],
+    *,
+    timeout_seconds: int,
+    retry_interval_seconds: int,
+) -> OdooVerificationProbeEvidence:
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        try:
+            return verification()
+        except click.ClickException as error:
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                raise error
             time.sleep(min(retry_interval_seconds, remaining_seconds))
 
 
@@ -380,17 +393,13 @@ def _run_logo_probe_with_retry(
     retry_interval_seconds: int,
 ) -> tuple[OdooVerificationProbeEvidence, tuple[str, ...]]:
     deadline = time.monotonic() + timeout_seconds
-    last_error: click.ClickException | None = None
     while True:
         try:
             return verification()
         except _ProbeFailure:
             raise
         except click.ClickException as error:
-            last_error = error
             remaining_seconds = deadline - time.monotonic()
             if remaining_seconds <= 0:
-                if last_error is None:
-                    raise click.ClickException("Odoo logo verification retry ended without an error.")
-                raise last_error
+                raise error
             time.sleep(min(retry_interval_seconds, remaining_seconds))

--- a/tests/test_odoo_verification.py
+++ b/tests/test_odoo_verification.py
@@ -343,6 +343,68 @@ class OdooVerificationTests(unittest.TestCase):
         self.assertEqual(attempts, 2)
         sleep_mock.assert_called_once()
 
+    def test_verification_retries_transient_health_http_failure(self) -> None:
+        attempts = 0
+
+        def fake_http_text(url: str, *, timeout_seconds: int) -> tuple[int, str, str]:
+            nonlocal attempts
+            self.assertEqual(url, "https://cm-testing.example.com/web/health")
+            self.assertEqual(timeout_seconds, 30)
+            attempts += 1
+            if attempts == 1:
+                return 503, "starting", "text/plain"
+            return 200, '{"status":"ok"}', "application/json"
+
+        with (
+            patch("control_plane.workflows.odoo_verification._http_text", side_effect=fake_http_text),
+            patch(
+                "control_plane.workflows.odoo_verification.time.sleep",
+                side_effect=lambda _seconds: None,
+            ) as sleep_mock,
+        ):
+            result = verify_odoo_stable_readiness(
+                base_url="https://cm-testing.example.com",
+                verify_canonical=False,
+                verify_logo=False,
+                timeout_seconds=30,
+                retry_interval_seconds=5,
+            )
+
+        self.assertEqual(result.health_status, "pass")
+        self.assertEqual(attempts, 2)
+        sleep_mock.assert_called_once()
+
+    def test_verification_retries_transient_health_status_payload(self) -> None:
+        attempts = 0
+
+        def fake_http_text(url: str, *, timeout_seconds: int) -> tuple[int, str, str]:
+            nonlocal attempts
+            self.assertEqual(url, "https://cm-testing.example.com/web/health")
+            self.assertEqual(timeout_seconds, 30)
+            attempts += 1
+            if attempts == 1:
+                return 200, '{"status":"starting"}', "application/json"
+            return 200, '{"status":"healthy"}', "application/json"
+
+        with (
+            patch("control_plane.workflows.odoo_verification._http_text", side_effect=fake_http_text),
+            patch(
+                "control_plane.workflows.odoo_verification.time.sleep",
+                side_effect=lambda _seconds: None,
+            ) as sleep_mock,
+        ):
+            result = verify_odoo_stable_readiness(
+                base_url="https://cm-testing.example.com",
+                verify_canonical=False,
+                verify_logo=False,
+                timeout_seconds=30,
+                retry_interval_seconds=5,
+            )
+
+        self.assertEqual(result.health_status, "pass")
+        self.assertEqual(attempts, 2)
+        sleep_mock.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- keep Odoo health verification retrying transient startup HTTP/status failures
- preserve immediate failure for permanent canonical/logo readiness mismatches
- add regression coverage for health 503 and status=starting recovery

## Verification
- uv run python -m unittest tests.test_odoo_verification tests.test_odoo_stable_bootstrap tests.test_odoo_stable_target_replacement
- uv run python -m unittest
- git diff --check
- JetBrains inspection on touched files