### PR TITLE
Add durable Odoo stable bootstrap operations

### DIFF
--- a/.github/workflows/odoo-stable-bootstrap.yml
+++ b/.github/workflows/odoo-stable-bootstrap.yml
@@ -74,6 +74,8 @@ jobs:
       HEALTH_TIMEOUT_SECONDS: ${{ inputs.health_timeout_seconds }}
       LAUNCHPLANE_SERVICE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
       LAUNCHPLANE_SERVICE_AUDIENCE: launchplane.shinycomputers.com
+      POLL_INTERVAL_SECONDS: "15"
+      POLL_TIMEOUT_SECONDS: "3600"
     steps:
       - name: Validate runtime inputs
         shell: bash
@@ -94,7 +96,7 @@ jobs:
             exit 1
           fi
 
-      - name: Run bootstrap
+      - name: Create and poll bootstrap operation
         shell: bash
         run: |
           set -euo pipefail
@@ -129,11 +131,27 @@ jobs:
               }'
           })"
           if [ -n "${TIMEOUT_SECONDS:-}" ]; then
-            payload="$(jq --argjson timeout_seconds "$TIMEOUT_SECONDS" '.bootstrap.timeout_seconds = $timeout_seconds' <<<"$payload")"
+            payload="$(
+              jq \
+                --argjson timeout_seconds "$TIMEOUT_SECONDS" \
+                '.bootstrap.timeout_seconds = $timeout_seconds' \
+                <<<"$payload"
+            )"
           fi
           if [ -n "${HEALTH_TIMEOUT_SECONDS:-}" ]; then
-            payload="$(jq --argjson health_timeout_seconds "$HEALTH_TIMEOUT_SECONDS" '.bootstrap.health_timeout_seconds = $health_timeout_seconds' <<<"$payload")"
+            payload="$(
+              jq \
+                --argjson health_timeout_seconds "$HEALTH_TIMEOUT_SECONDS" \
+                '.bootstrap.health_timeout_seconds = $health_timeout_seconds' \
+                <<<"$payload"
+            )"
           fi
+          idempotency_key="$({
+            printf '%s' \
+              "odoo-stable-bootstrap:${PRODUCT}:${CONTEXT}:${INSTANCE}:" \
+              "${VERIFY_HEALTH}:${VERIFY_CANONICAL}:${VERIFY_LOGO}:" \
+              "${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
+          })"
           status_code="$({
             curl -sS \
               -o odoo-stable-bootstrap.json \
@@ -141,39 +159,147 @@ jobs:
               -X POST \
               -H "Authorization: Bearer ${oidc_token}" \
               -H 'Content-Type: application/json' \
-              -H "Idempotency-Key: odoo-stable-bootstrap:${PRODUCT}:${CONTEXT}:${INSTANCE}:${VERIFY_HEALTH}:${VERIFY_CANONICAL}:${VERIFY_LOGO}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}" \
+              -H "Idempotency-Key: ${idempotency_key}" \
               --data "$payload" \
               "${LAUNCHPLANE_SERVICE_URL}/v1/drivers/odoo/stable-bootstrap"
           })"
           if [ "$status_code" != "202" ]; then
-            echo "Launchplane Odoo stable bootstrap failed with HTTP ${status_code}." >&2
+            echo 'Launchplane Odoo stable bootstrap operation create failed' \
+              "with HTTP ${status_code}." >&2
             cat odoo-stable-bootstrap.json >&2
             exit 1
           fi
+          poll_url="$(
+            jq -r '.result.poll_url // empty' odoo-stable-bootstrap.json
+          )"
+          operation_id="$({
+            jq -r \
+              '.records.odoo_stable_bootstrap_operation_id //
+               .result.operation_id //
+               empty' \
+              odoo-stable-bootstrap.json
+          })"
+          if [ -z "$poll_url" ] || [ -z "$operation_id" ]; then
+            echo 'Odoo bootstrap response missing poll metadata.' >&2
+            jq . odoo-stable-bootstrap.json >&2
+            exit 1
+          fi
+          deadline=$((SECONDS + POLL_TIMEOUT_SECONDS))
+          while true; do
+            status_code="$({
+              curl -sS \
+                -o odoo-stable-bootstrap.json \
+                -w '%{http_code}' \
+                -H "Authorization: Bearer ${oidc_token}" \
+                "${LAUNCHPLANE_SERVICE_URL}${poll_url}"
+            })"
+            if [ "$status_code" != "200" ]; then
+              echo 'Launchplane Odoo stable bootstrap operation poll failed' \
+                "with HTTP ${status_code}." >&2
+              cat odoo-stable-bootstrap.json >&2
+              exit 1
+            fi
+            operation_status="$(
+              jq -r '.operation.status // empty' odoo-stable-bootstrap.json
+            )"
+            operation_phase="$(
+              jq -r '.operation.phase // empty' odoo-stable-bootstrap.json
+            )"
+            echo 'Odoo stable bootstrap operation:' \
+              "status=${operation_status} phase=${operation_phase}"
+            if [ "$operation_status" = "pass" ] || \
+              [ "$operation_status" = "fail" ]; then
+              break
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo 'Launchplane Odoo stable bootstrap operation' \
+                "${operation_id} timed out while polling." >&2
+              jq . odoo-stable-bootstrap.json >&2
+              exit 1
+            fi
+            sleep "$POLL_INTERVAL_SECONDS"
+          done
           jq . odoo-stable-bootstrap.json
-          bootstrap_status="$(jq -r '.result.bootstrap_status // ""' odoo-stable-bootstrap.json)"
-          post_deploy_status="$(jq -r '.result.post_deploy_status // ""' odoo-stable-bootstrap.json)"
-          health_status="$(jq -r '.result.health_status // ""' odoo-stable-bootstrap.json)"
-          canonical_status="$(jq -r '.result.canonical_status // ""' odoo-stable-bootstrap.json)"
-          logo_status="$(jq -r '.result.logo_status // ""' odoo-stable-bootstrap.json)"
-          if [ "$bootstrap_status" != "pass" ] || [ "$post_deploy_status" != "pass" ]; then
-            echo "Launchplane Odoo stable bootstrap did not pass: bootstrap=${bootstrap_status} post_deploy=${post_deploy_status}." >&2
-            jq -r '.result.error_message // ""' odoo-stable-bootstrap.json >&2
+          operation_status="$(
+            jq -r '.operation.status // ""' odoo-stable-bootstrap.json
+          )"
+          bootstrap_status="$(
+            jq -r \
+              '.operation.result.bootstrap_status //
+               .result.bootstrap_status //
+               ""' \
+              odoo-stable-bootstrap.json
+          )"
+          post_deploy_status="$(
+            jq -r \
+              '.operation.result.post_deploy_status //
+               .result.post_deploy_status //
+               ""' \
+              odoo-stable-bootstrap.json
+          )"
+          health_status="$(
+            jq -r \
+              '.operation.result.health_status //
+               .result.health_status //
+               ""' \
+              odoo-stable-bootstrap.json
+          )"
+          canonical_status="$(
+            jq -r \
+              '.operation.result.canonical_status //
+               .result.canonical_status //
+               ""' \
+              odoo-stable-bootstrap.json
+          )"
+          logo_status="$(
+            jq -r \
+              '.operation.result.logo_status //
+               .result.logo_status //
+               ""' \
+              odoo-stable-bootstrap.json
+          )"
+          if [ "$operation_status" != "pass" ]; then
+            echo 'Launchplane Odoo stable bootstrap operation did not pass:' \
+              "${operation_status}." >&2
+            jq -r \
+              '.operation.error_message // .result.error_message // ""' \
+              odoo-stable-bootstrap.json >&2
             exit 1
           fi
-          if [ "$VERIFY_HEALTH" = "true" ] && [ "$health_status" != "pass" ]; then
-            echo "Launchplane Odoo stable bootstrap health verification did not pass: ${health_status}." >&2
-            jq -r '.result.error_message // ""' odoo-stable-bootstrap.json >&2
+          if [ "$bootstrap_status" != "pass" ] || \
+            [ "$post_deploy_status" != "pass" ]; then
+            echo 'Launchplane Odoo stable bootstrap did not pass:' >&2
+            echo "bootstrap=${bootstrap_status}" \
+              "post_deploy=${post_deploy_status}." >&2
+            jq -r \
+              '.operation.result.error_message // .result.error_message // ""' \
+              odoo-stable-bootstrap.json >&2
             exit 1
           fi
-          if [ "$VERIFY_CANONICAL" = "true" ] && [ "$canonical_status" != "pass" ]; then
-            echo "Launchplane Odoo stable bootstrap canonical verification did not pass: ${canonical_status}." >&2
-            jq -r '.result.error_message // ""' odoo-stable-bootstrap.json >&2
+          if [ "$VERIFY_HEALTH" = "true" ] && \
+            [ "$health_status" != "pass" ]; then
+            echo 'Launchplane Odoo stable bootstrap health verification' \
+              "did not pass: ${health_status}." >&2
+            jq -r \
+              '.operation.result.error_message // .result.error_message // ""' \
+              odoo-stable-bootstrap.json >&2
+            exit 1
+          fi
+          if [ "$VERIFY_CANONICAL" = "true" ] && \
+            [ "$canonical_status" != "pass" ]; then
+            echo 'Launchplane Odoo stable bootstrap canonical verification' \
+              "did not pass: ${canonical_status}." >&2
+            jq -r \
+              '.operation.result.error_message // .result.error_message // ""' \
+              odoo-stable-bootstrap.json >&2
             exit 1
           fi
           if [ "$VERIFY_LOGO" = "true" ] && [ "$logo_status" != "pass" ]; then
-            echo "Launchplane Odoo stable bootstrap logo verification did not pass: ${logo_status}." >&2
-            jq -r '.result.error_message // ""' odoo-stable-bootstrap.json >&2
+            echo 'Launchplane Odoo stable bootstrap logo verification' \
+              "did not pass: ${logo_status}." >&2
+            jq -r \
+              '.operation.result.error_message // .result.error_message // ""' \
+              odoo-stable-bootstrap.json >&2
             exit 1
           fi
 
@@ -181,6 +307,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: odoo-stable-bootstrap-${{ inputs.product }}-${{ inputs.context }}-${{ inputs.instance }}
+          name: odoo-stable-bootstrap-result
           path: odoo-stable-bootstrap.json
           if-no-files-found: ignore

--- a/control_plane/contracts/odoo_stable_bootstrap.py
+++ b/control_plane/contracts/odoo_stable_bootstrap.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.workflows.odoo_verification import (
+    OdooVerificationEvidence,
+)
+
+
+class OdooStableBootstrapRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    context: str = "cm"
+    instance: str
+    confirmation: str
+    verify_health: bool = True
+    verify_canonical: bool = True
+    verify_logo: bool = True
+    timeout_seconds: int | None = Field(default=None, ge=1)
+    health_timeout_seconds: int | None = Field(default=None, ge=1)
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "OdooStableBootstrapRequest":
+        self.product = self.product.strip()
+        self.context = self.context.strip().lower()
+        self.instance = self.instance.strip().lower()
+        self.confirmation = self.confirmation.strip().lower()
+        if not self.product:
+            raise ValueError("Odoo stable bootstrap requires product.")
+        if not self.context:
+            raise ValueError("Odoo stable bootstrap requires context.")
+        if not self.instance:
+            raise ValueError("Odoo stable bootstrap requires instance.")
+        return self
+
+
+class OdooStableBootstrapResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    product: str
+    context: str
+    instance: str
+    deployment_record_id: str = ""
+    bootstrap_status: Literal["pass", "fail"]
+    bootstrap_run_status: Literal["pass", "fail", "skipped"] = "skipped"
+    readiness_status: Literal["pass", "fail", "verification_failed", "skipped"] = "skipped"
+    post_deploy_status: Literal["pass", "fail", "skipped"] = "skipped"
+    health_status: Literal["pass", "fail", "skipped"] = "skipped"
+    canonical_status: Literal["pass", "fail", "skipped"] = "skipped"
+    logo_status: Literal["pass", "fail", "skipped"] = "skipped"
+    health_url: str = ""
+    canonical_url: str = ""
+    logo_urls: tuple[str, ...] = ()
+    verification_evidence: OdooVerificationEvidence = Field(
+        default_factory=OdooVerificationEvidence
+    )
+    target_id: str = ""
+    target_name: str = ""
+    artifact_id: str = ""
+    source_git_ref: str = ""
+    error_message: str = ""

--- a/control_plane/contracts/odoo_stable_bootstrap_operation.py
+++ b/control_plane/contracts/odoo_stable_bootstrap_operation.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.odoo_stable_bootstrap import (
+    OdooStableBootstrapRequest,
+    OdooStableBootstrapResult,
+)
+
+OdooStableBootstrapOperationStatus = Literal["pending", "running", "pass", "fail"]
+OdooStableBootstrapOperationPhase = Literal[
+    "created",
+    "running",
+    "bootstrap",
+    "post_deploy",
+    "verification",
+    "completed",
+    "failed",
+]
+
+_TERMINAL_OPERATION_STATUSES: tuple[OdooStableBootstrapOperationStatus, ...] = (
+    "pass",
+    "fail",
+)
+ODOO_STABLE_BOOTSTRAP_TERMINAL_OPERATION_STATUSES: frozenset[
+    OdooStableBootstrapOperationStatus
+] = frozenset(_TERMINAL_OPERATION_STATUSES)
+
+
+class OdooStableBootstrapOperationRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    operation_id: str
+    product: str
+    context: str
+    instance: str
+    idempotency_key: str
+    request_fingerprint: str
+    request: OdooStableBootstrapRequest
+    status: OdooStableBootstrapOperationStatus = "pending"
+    phase: OdooStableBootstrapOperationPhase = "created"
+    deployment_record_id: str = ""
+    created_at: str
+    updated_at: str
+    started_at: str = ""
+    finished_at: str = ""
+    result: OdooStableBootstrapResult | None = None
+    error_message: str = ""
+    runner_trace_id: str = ""
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "OdooStableBootstrapOperationRecord":
+        self.operation_id = _normalize_required(
+            self.operation_id, "Odoo stable bootstrap operation requires operation_id."
+        )
+        self.product = _normalize_required(
+            self.product, "Odoo stable bootstrap operation requires product."
+        )
+        self.context = _normalize_required(
+            self.context, "Odoo stable bootstrap operation requires context."
+        ).lower()
+        self.instance = _normalize_required(
+            self.instance, "Odoo stable bootstrap operation requires instance."
+        ).lower()
+        self.idempotency_key = _normalize_required(
+            self.idempotency_key,
+            "Odoo stable bootstrap operation requires idempotency_key.",
+        )
+        self.request_fingerprint = _normalize_required(
+            self.request_fingerprint,
+            "Odoo stable bootstrap operation requires request_fingerprint.",
+        )
+        self.created_at = _normalize_required(
+            self.created_at, "Odoo stable bootstrap operation requires created_at."
+        )
+        self.updated_at = _normalize_required(
+            self.updated_at, "Odoo stable bootstrap operation requires updated_at."
+        )
+        self.started_at = self.started_at.strip()
+        self.finished_at = self.finished_at.strip()
+        self.deployment_record_id = self.deployment_record_id.strip()
+        self.error_message = self.error_message.strip()
+        self.runner_trace_id = self.runner_trace_id.strip()
+        if self.product != self.request.product:
+            raise ValueError("Odoo stable bootstrap operation product must match request.")
+        if self.context != self.request.context:
+            raise ValueError("Odoo stable bootstrap operation context must match request.")
+        if self.instance != self.request.instance:
+            raise ValueError("Odoo stable bootstrap operation instance must match request.")
+        if self.status in ODOO_STABLE_BOOTSTRAP_TERMINAL_OPERATION_STATUSES:
+            if not self.finished_at:
+                raise ValueError("Terminal Odoo stable bootstrap operations require finished_at.")
+            if self.status == "pass" and self.error_message:
+                raise ValueError("Passing Odoo stable bootstrap operations must not include error_message.")
+            if self.status == "fail" and not self.error_message:
+                raise ValueError("Failed Odoo stable bootstrap operations require error_message.")
+        return self
+
+
+def build_odoo_stable_bootstrap_operation_id(
+    *, product: str, context: str, instance: str, created_at: str, idempotency_key: str
+) -> str:
+    normalized_product = product.strip().lower().replace("/", "-")
+    normalized_context = context.strip().lower()
+    normalized_instance = instance.strip().lower()
+    normalized_created_at = created_at.strip().replace(":", "").replace("+", "z")
+    digest = hashlib.sha256(
+        "|".join(
+            (
+                normalized_product,
+                normalized_context,
+                normalized_instance,
+                normalized_created_at,
+                idempotency_key.strip(),
+            )
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+    return (
+        "odoo-stable-bootstrap-"
+        f"{normalized_context}-{normalized_instance}-{normalized_created_at}-{digest}"
+    )
+
+
+def odoo_stable_bootstrap_operation_is_terminal(
+    record: OdooStableBootstrapOperationRecord,
+) -> bool:
+    return record.status in ODOO_STABLE_BOOTSTRAP_TERMINAL_OPERATION_STATUSES
+
+
+def _normalize_required(value: str, message: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(message)
+    return normalized

--- a/control_plane/contracts/odoo_stable_bootstrap_operation.py
+++ b/control_plane/contracts/odoo_stable_bootstrap_operation.py
@@ -102,7 +102,7 @@ class OdooStableBootstrapOperationRecord(BaseModel):
 
 
 def build_odoo_stable_bootstrap_operation_id(
-    *, product: str, context: str, instance: str, created_at: str, idempotency_key: str
+    *, product: str, context: str, instance: str, created_at: str
 ) -> str:
     normalized_product = product.strip().lower().replace("/", "-")
     normalized_context = context.strip().lower()
@@ -115,7 +115,6 @@ def build_odoo_stable_bootstrap_operation_id(
                 normalized_context,
                 normalized_instance,
                 normalized_created_at,
-                idempotency_key.strip(),
             )
         ).encode("utf-8")
     ).hexdigest()[:16]

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -10,6 +10,7 @@ import mimetypes
 import os
 import re
 import secrets
+import threading
 from socketserver import ThreadingMixIn
 import uuid
 from pathlib import Path
@@ -106,6 +107,11 @@ from control_plane.contracts.odoo_instance_override_record import (
     OdooInstanceOverrideRecord,
     OdooOverrideValue,
     OdooWebsiteBootstrapPayload,
+)
+from control_plane.contracts.odoo_stable_bootstrap_operation import (
+    OdooStableBootstrapOperationRecord,
+    build_odoo_stable_bootstrap_operation_id,
+    odoo_stable_bootstrap_operation_is_terminal,
 )
 from control_plane.contracts.preview_mutation_request import (
     PreviewDestroyMutationRequest,
@@ -284,8 +290,11 @@ from control_plane.workflows.odoo_post_deploy import (
     OdooPostDeployRequest,
     execute_odoo_post_deploy,
 )
-from control_plane.workflows.odoo_stable_bootstrap import (
+from control_plane.contracts.odoo_stable_bootstrap import (
     OdooStableBootstrapRequest,
+    OdooStableBootstrapResult,
+)
+from control_plane.workflows.odoo_stable_bootstrap import (
     OdooStableBootstrapStore,
     execute_odoo_stable_bootstrap,
 )
@@ -551,6 +560,27 @@ class _IdempotencyCapableStore(Protocol):
     ) -> LaunchplaneIdempotencyRecord: ...
 
     def write_idempotency_record(self, record: LaunchplaneIdempotencyRecord) -> object: ...
+
+
+class _OdooStableBootstrapOperationStore(Protocol):
+    def write_odoo_stable_bootstrap_operation_record(
+        self, record: OdooStableBootstrapOperationRecord
+    ) -> object: ...
+
+    def read_odoo_stable_bootstrap_operation_record(
+        self, operation_id: str
+    ) -> OdooStableBootstrapOperationRecord: ...
+
+    def list_odoo_stable_bootstrap_operation_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        idempotency_key: str = "",
+        statuses: tuple[str, ...] = (),
+        limit: int | None = None,
+    ) -> tuple[OdooStableBootstrapOperationRecord, ...]: ...
 
 
 _StartResponse = Callable[[str, list[tuple[str, str]]], None]
@@ -1699,6 +1729,7 @@ _HUMAN_IDENTITY_MUTATION_ROUTES = frozenset(
 _HUMAN_IDENTITY_READ_MODEL_POST_ROUTES = frozenset({"/v1/work-graph/rank"})
 _NON_IDEMPOTENT_DRIVER_RESULT_ROUTES = frozenset(
     {
+        _ODOO_STABLE_BOOTSTRAP_ROUTE.route_path,
         _VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path,
         _VERIREEL_RUNTIME_VERIFICATION_ROUTE.route_path,
         _VERIREEL_PREVIEW_INVENTORY_ROUTE.route_path,
@@ -2238,6 +2269,12 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "driver.read", {}
     if len(segments) == 3 and segments[:2] == ["v1", "drivers"]:
         return "driver.read", {"driver_id": segments[2]}
+    if (
+        len(segments) == 6
+        and segments[:4] == ["v1", "drivers", "odoo", "stable-bootstrap"]
+        and segments[4] == "operations"
+    ):
+        return "odoo_stable_bootstrap.execute", {"operation_id": segments[5]}
     if len(segments) == 4 and segments[:2] == ["v1", "contexts"] and segments[3] == "driver-view":
         return "driver.read", {"context": segments[2]}
     if (
@@ -4082,6 +4119,7 @@ def _accepted_payload(
                 "merge_train_batch_landing_plan_record_id",
                 "merge_train_stack_collapse_plan_record_id",
                 "merge_train_run_id",
+                "odoo_stable_bootstrap_operation_id",
             }
         },
         **({"result": serialized_driver_result} if serialized_driver_result else {}),
@@ -4090,6 +4128,184 @@ def _accepted_payload(
         payload["replayed"] = True
         payload["original_trace_id"] = original_trace_id
     return payload
+
+
+def _operation_payload(
+    operation: OdooStableBootstrapOperationRecord,
+) -> dict[str, object]:
+    payload = operation.model_dump(mode="json")
+    payload["poll_url"] = _odoo_stable_bootstrap_operation_poll_url(operation.operation_id)
+    return payload
+
+
+def _odoo_stable_bootstrap_operation_poll_url(operation_id: str) -> str:
+    return f"/v1/drivers/odoo/stable-bootstrap/operations/{operation_id.strip()}"
+
+
+def _odoo_stable_bootstrap_operation_store(
+    record_store: object,
+) -> _OdooStableBootstrapOperationStore:
+    required_methods = (
+        "write_odoo_stable_bootstrap_operation_record",
+        "read_odoo_stable_bootstrap_operation_record",
+        "list_odoo_stable_bootstrap_operation_records",
+    )
+    if all(hasattr(record_store, method_name) for method_name in required_methods):
+        return cast(_OdooStableBootstrapOperationStore, record_store)
+    raise click.ClickException(
+        "Odoo stable bootstrap operations require Launchplane operation-record storage."
+    )
+
+
+def _find_odoo_stable_bootstrap_operation_by_idempotency_key(
+    *,
+    operation_store: _OdooStableBootstrapOperationStore,
+    idempotency_key: str,
+) -> OdooStableBootstrapOperationRecord | None:
+    records = operation_store.list_odoo_stable_bootstrap_operation_records(
+        idempotency_key=idempotency_key,
+        limit=1,
+    )
+    return records[0] if records else None
+
+
+def _find_active_odoo_stable_bootstrap_operation(
+    *,
+    operation_store: _OdooStableBootstrapOperationStore,
+    product: str,
+    context: str,
+    instance: str,
+) -> OdooStableBootstrapOperationRecord | None:
+    records = operation_store.list_odoo_stable_bootstrap_operation_records(
+        product=product,
+        context_name=context,
+        instance_name=instance,
+        statuses=("pending", "running"),
+        limit=1,
+    )
+    return records[0] if records else None
+
+
+def _build_odoo_stable_bootstrap_operation_record(
+    *,
+    bootstrap_request: OdooStableBootstrapRequest,
+    idempotency_key: str,
+    request_fingerprint: str,
+    created_at: str,
+) -> OdooStableBootstrapOperationRecord:
+    return OdooStableBootstrapOperationRecord(
+        operation_id=build_odoo_stable_bootstrap_operation_id(
+            product=bootstrap_request.product,
+            context=bootstrap_request.context,
+            instance=bootstrap_request.instance,
+            created_at=created_at,
+            idempotency_key=idempotency_key,
+        ),
+        product=bootstrap_request.product,
+        context=bootstrap_request.context,
+        instance=bootstrap_request.instance,
+        idempotency_key=idempotency_key,
+        request_fingerprint=request_fingerprint,
+        request=bootstrap_request,
+        status="pending",
+        phase="created",
+        created_at=created_at,
+        updated_at=created_at,
+    )
+
+
+def _start_odoo_stable_bootstrap_operation_worker(
+    *,
+    operation_id: str,
+    control_plane_root_path: Path,
+    record_store: object,
+    trace_id: str,
+) -> None:
+    worker = threading.Thread(
+        target=_run_odoo_stable_bootstrap_operation_worker,
+        kwargs={
+            "operation_id": operation_id,
+            "control_plane_root_path": control_plane_root_path,
+            "record_store": record_store,
+            "trace_id": trace_id,
+        },
+        name=f"odoo-stable-bootstrap-{operation_id}",
+        daemon=True,
+    )
+    worker.start()
+
+
+def _run_odoo_stable_bootstrap_operation_worker(
+    *,
+    operation_id: str,
+    control_plane_root_path: Path,
+    record_store: object,
+    trace_id: str,
+) -> None:
+    operation_store = _odoo_stable_bootstrap_operation_store(record_store)
+    operation = operation_store.read_odoo_stable_bootstrap_operation_record(operation_id)
+    if odoo_stable_bootstrap_operation_is_terminal(operation):
+        return
+    started_at = _utc_now_timestamp()
+    running_operation = operation.model_copy(
+        update={
+            "status": "running",
+            "phase": "running",
+            "started_at": operation.started_at or started_at,
+            "updated_at": started_at,
+            "runner_trace_id": trace_id,
+        }
+    )
+    operation_store.write_odoo_stable_bootstrap_operation_record(running_operation)
+    try:
+        result = execute_odoo_stable_bootstrap(
+            control_plane_root=control_plane_root_path,
+            record_store=cast(OdooStableBootstrapStore, record_store),
+            request=running_operation.request,
+        )
+    except Exception as error:
+        logging.exception(
+            "Odoo stable bootstrap operation %s failed before producing a result.",
+            operation_id,
+        )
+        finished_at = _utc_now_timestamp()
+        failed_operation = running_operation.model_copy(
+            update={
+                "status": "fail",
+                "phase": "failed",
+                "updated_at": finished_at,
+                "finished_at": finished_at,
+                "error_message": str(error),
+            }
+        )
+        operation_store.write_odoo_stable_bootstrap_operation_record(failed_operation)
+        return
+    finished_at = _utc_now_timestamp()
+    passed = _odoo_stable_bootstrap_operation_result_passed(result)
+    terminal_operation = running_operation.model_copy(
+        update={
+            "status": "pass" if passed else "fail",
+            "phase": "completed" if passed else "failed",
+            "deployment_record_id": result.deployment_record_id,
+            "updated_at": finished_at,
+            "finished_at": finished_at,
+            "result": result,
+            "error_message": "" if passed else (result.error_message or "Odoo stable bootstrap failed."),
+        }
+    )
+    operation_store.write_odoo_stable_bootstrap_operation_record(terminal_operation)
+
+
+def _odoo_stable_bootstrap_operation_result_passed(
+    result: OdooStableBootstrapResult,
+) -> bool:
+    return (
+        result.bootstrap_status == "pass"
+        and result.post_deploy_status == "pass"
+        and result.health_status != "fail"
+        and result.canonical_status != "fail"
+        and result.logo_status != "fail"
+    )
 
 
 def _replay_idempotent_response(
@@ -6504,6 +6720,51 @@ def create_launchplane_service_app(
             if method == "GET":
                 assert read_route is not None
                 action, params = read_route
+                if action == "odoo_stable_bootstrap.execute":
+                    operation_id = params["operation_id"]
+                    operation_store = _odoo_stable_bootstrap_operation_store(record_store)
+                    try:
+                        operation = operation_store.read_odoo_stable_bootstrap_operation_record(
+                            operation_id
+                        )
+                    except FileNotFoundError:
+                        return _not_found_response(
+                            start_response=start_response,
+                            trace_id=request_trace_id,
+                            path=path,
+                        )
+                    if not authz_policy.allows(
+                        identity=identity,
+                        action=action,
+                        product=operation.product,
+                        context=operation.context,
+                    ):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=403,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "authorization_denied",
+                                    "message": "Workflow cannot read Odoo stable bootstrap operation status for the requested product/context.",
+                                },
+                            },
+                        )
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=200,
+                        payload={
+                            "status": "ok",
+                            "trace_id": request_trace_id,
+                            "operation": _operation_payload(operation),
+                            **(
+                                {"result": operation.result.model_dump(mode="json")}
+                                if operation.result is not None
+                                else {}
+                            ),
+                        },
+                    )
                 if action == "driver.read":
                     context_name = params.get("context", _LAUNCHPLANE_SERVICE_CONTEXT)
                     if not authz_policy.allows(
@@ -9945,23 +10206,83 @@ def create_launchplane_service_app(
                 )
                 if authorization_response is not None:
                     return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
+                if not request_idempotency_key:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=400,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "idempotency_key_required",
+                                "message": "Odoo stable bootstrap operations require an Idempotency-Key header.",
+                            },
+                        },
+                    )
+                operation_store = _odoo_stable_bootstrap_operation_store(record_store)
+                existing_operation = _find_odoo_stable_bootstrap_operation_by_idempotency_key(
+                    operation_store=operation_store,
                     idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
                 )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = execute_odoo_stable_bootstrap(
-                    control_plane_root=resolved_root,
-                    record_store=cast(OdooStableBootstrapStore, record_store),
-                    request=odoo_bootstrap_request.bootstrap,
-                )
-                result = {"deployment_record_id": driver_result.deployment_record_id}
+                if existing_operation is not None:
+                    if existing_operation.request_fingerprint != request_fingerprint:
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=409,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "idempotency_key_reused",
+                                    "message": "Idempotency-Key was already used for a different Odoo stable bootstrap request.",
+                                },
+                            },
+                        )
+                    driver_result = _operation_payload(existing_operation)
+                    result = {
+                        "odoo_stable_bootstrap_operation_id": existing_operation.operation_id,
+                        **(
+                            {"deployment_record_id": existing_operation.deployment_record_id}
+                            if existing_operation.deployment_record_id
+                            else {}
+                        ),
+                    }
+                else:
+                    active_operation = _find_active_odoo_stable_bootstrap_operation(
+                        operation_store=operation_store,
+                        product=odoo_bootstrap_request.product,
+                        context=odoo_bootstrap_request.bootstrap.context,
+                        instance=odoo_bootstrap_request.bootstrap.instance,
+                    )
+                    if active_operation is not None:
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=409,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "odoo_stable_bootstrap_operation_active",
+                                    "message": "An Odoo stable bootstrap operation is already active for this product/context/instance.",
+                                },
+                                "operation": _operation_payload(active_operation),
+                            },
+                        )
+                    operation = _build_odoo_stable_bootstrap_operation_record(
+                        bootstrap_request=odoo_bootstrap_request.bootstrap,
+                        idempotency_key=request_idempotency_key,
+                        request_fingerprint=request_fingerprint,
+                        created_at=_utc_now_timestamp(),
+                    )
+                    operation_store.write_odoo_stable_bootstrap_operation_record(operation)
+                    _start_odoo_stable_bootstrap_operation_worker(
+                        operation_id=operation.operation_id,
+                        control_plane_root_path=resolved_root,
+                        record_store=record_store,
+                        trace_id=request_trace_id,
+                    )
+                    driver_result = _operation_payload(operation)
+                    result = {"odoo_stable_bootstrap_operation_id": operation.operation_id}
             elif path == _ODOO_ARTIFACT_PUBLISH_ROUTE.route_path:
                 odoo_publish_request = _ODOO_ARTIFACT_PUBLISH_ROUTE.envelope_model.model_validate(
                     payload

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -4199,7 +4199,6 @@ def _build_odoo_stable_bootstrap_operation_record(
             context=bootstrap_request.context,
             instance=bootstrap_request.instance,
             created_at=created_at,
-            idempotency_key=idempotency_key,
         ),
         product=bootstrap_request.product,
         context=bootstrap_request.context,

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -25,6 +25,9 @@ from control_plane.contracts.merge_train_stack_collapse import (
 from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
+from control_plane.contracts.odoo_stable_bootstrap_operation import (
+    OdooStableBootstrapOperationRecord,
+)
 from control_plane.contracts.preview_enablement_record import PreviewEnablementRecord
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
@@ -546,6 +549,51 @@ class FilesystemRecordStore:
             ):
                 return record
         return None
+
+    def write_odoo_stable_bootstrap_operation_record(
+        self, record: OdooStableBootstrapOperationRecord
+    ) -> Path:
+        return self._write_model(
+            "odoo_stable_bootstrap_operations", record.operation_id, record
+        )
+
+    def read_odoo_stable_bootstrap_operation_record(
+        self, operation_id: str
+    ) -> OdooStableBootstrapOperationRecord:
+        return OdooStableBootstrapOperationRecord.model_validate(
+            self._read_model(
+                OdooStableBootstrapOperationRecord,
+                "odoo_stable_bootstrap_operations",
+                operation_id,
+            ).model_dump(mode="json")
+        )
+
+    def list_odoo_stable_bootstrap_operation_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        idempotency_key: str = "",
+        statuses: tuple[str, ...] = (),
+        limit: int | None = None,
+    ) -> tuple[OdooStableBootstrapOperationRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                OdooStableBootstrapOperationRecord,
+                "odoo_stable_bootstrap_operations",
+            )
+            if (not product or record.product == product)
+            and (not context_name or record.context == context_name)
+            and (not instance_name or record.instance == instance_name)
+            and (not idempotency_key or record.idempotency_key == idempotency_key)
+            and (not statuses or record.status in statuses)
+        ]
+        records.sort(key=lambda record: (record.updated_at, record.operation_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
 
     def write_backup_gate_record(self, record: BackupGateRecord) -> Path:
         return self._write_model("backup_gates", record.record_id, record)

--- a/control_plane/storage/migrations/versions/e39f4a5b6c7d_add_odoo_stable_bootstrap_operations.py
+++ b/control_plane/storage/migrations/versions/e39f4a5b6c7d_add_odoo_stable_bootstrap_operations.py
@@ -1,0 +1,62 @@
+"""add Odoo stable bootstrap operations
+
+Revision ID: e39f4a5b6c7d
+Revises: d289e3ab4012
+Create Date: 2026-05-17 15:40:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "e39f4a5b6c7d"
+down_revision: str | None = "d289e3ab4012"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "launchplane_odoo_stable_bootstrap_operations",
+        sa.Column("operation_id", sa.String(), nullable=False),
+        sa.Column("product", sa.String(), nullable=False),
+        sa.Column("context", sa.String(), nullable=False),
+        sa.Column("instance", sa.String(), nullable=False),
+        sa.Column("idempotency_key", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("phase", sa.String(), nullable=False),
+        sa.Column("created_at", sa.String(), nullable=False),
+        sa.Column("updated_at", sa.String(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("operation_id"),
+    )
+    op.create_index(
+        "launchplane_odoo_bootstrap_operation_lane_status_idx",
+        "launchplane_odoo_stable_bootstrap_operations",
+        ["product", "context", "instance", "status", sa.text("updated_at DESC")],
+    )
+    op.create_index(
+        "launchplane_odoo_bootstrap_operation_idempotency_idx",
+        "launchplane_odoo_stable_bootstrap_operations",
+        ["idempotency_key", sa.text("updated_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "launchplane_odoo_bootstrap_operation_idempotency_idx",
+        table_name="launchplane_odoo_stable_bootstrap_operations",
+    )
+    op.drop_index(
+        "launchplane_odoo_bootstrap_operation_lane_status_idx",
+        table_name="launchplane_odoo_stable_bootstrap_operations",
+    )
+    op.drop_table("launchplane_odoo_stable_bootstrap_operations")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -47,6 +47,9 @@ from control_plane.contracts.merge_train_stack_collapse import (
 from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
+from control_plane.contracts.odoo_stable_bootstrap_operation import (
+    OdooStableBootstrapOperationRecord,
+)
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
 from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
@@ -719,6 +722,36 @@ class LaunchplaneIdempotencyRow(Base):
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
+class LaunchplaneOdooStableBootstrapOperationRow(Base):
+    __tablename__ = "launchplane_odoo_stable_bootstrap_operations"
+    __table_args__ = (
+        Index(
+            "launchplane_odoo_bootstrap_operation_lane_status_idx",
+            "product",
+            "context",
+            "instance",
+            "status",
+            desc("updated_at"),
+        ),
+        Index(
+            "launchplane_odoo_bootstrap_operation_idempotency_idx",
+            "idempotency_key",
+            desc("updated_at"),
+        ),
+    )
+
+    operation_id: Mapped[str] = mapped_column(String, primary_key=True)
+    product: Mapped[str] = mapped_column(String, nullable=False)
+    context: Mapped[str] = mapped_column(String, nullable=False)
+    instance: Mapped[str] = mapped_column(String, nullable=False)
+    idempotency_key: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    phase: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[str] = mapped_column(String, nullable=False)
+    updated_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
 class LaunchplaneHumanSessionRow(Base):
     __tablename__ = "launchplane_human_sessions"
     __table_args__ = (
@@ -1074,6 +1107,67 @@ class PostgresRecordStore(HumanSessionStore):
             if row is None:
                 return None
             return self._read_payload(model_type=LaunchplaneIdempotencyRecord, payload=row.payload)
+
+    def write_odoo_stable_bootstrap_operation_record(
+        self, record: OdooStableBootstrapOperationRecord
+    ) -> None:
+        self._write_row(
+            LaunchplaneOdooStableBootstrapOperationRow(
+                operation_id=record.operation_id,
+                product=record.product,
+                context=record.context,
+                instance=record.instance,
+                idempotency_key=record.idempotency_key,
+                status=record.status,
+                phase=record.phase,
+                created_at=record.created_at,
+                updated_at=record.updated_at,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def read_odoo_stable_bootstrap_operation_record(
+        self, operation_id: str
+    ) -> OdooStableBootstrapOperationRecord:
+        return self._read_model(
+            model_type=OdooStableBootstrapOperationRecord,
+            orm_model=LaunchplaneOdooStableBootstrapOperationRow,
+            filters=(LaunchplaneOdooStableBootstrapOperationRow.operation_id == operation_id,),
+        )
+
+    def list_odoo_stable_bootstrap_operation_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        idempotency_key: str = "",
+        statuses: tuple[str, ...] = (),
+        limit: int | None = None,
+    ) -> tuple[OdooStableBootstrapOperationRecord, ...]:
+        filters: list[object] = []
+        if product:
+            filters.append(LaunchplaneOdooStableBootstrapOperationRow.product == product)
+        if context_name:
+            filters.append(LaunchplaneOdooStableBootstrapOperationRow.context == context_name)
+        if instance_name:
+            filters.append(LaunchplaneOdooStableBootstrapOperationRow.instance == instance_name)
+        if idempotency_key:
+            filters.append(
+                LaunchplaneOdooStableBootstrapOperationRow.idempotency_key == idempotency_key
+            )
+        if statuses:
+            filters.append(LaunchplaneOdooStableBootstrapOperationRow.status.in_(statuses))
+        return self._list_models(
+            model_type=OdooStableBootstrapOperationRecord,
+            orm_model=LaunchplaneOdooStableBootstrapOperationRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneOdooStableBootstrapOperationRow.updated_at.desc(),
+                LaunchplaneOdooStableBootstrapOperationRow.operation_id.desc(),
+            ),
+            limit=limit,
+        )
 
     def write_session(self, session: LaunchplaneHumanSession) -> None:
         self._write_row(
@@ -2701,6 +2795,7 @@ class PostgresRecordStore(HumanSessionStore):
             "merge_train_stack_collapse_plans": 0,
             "merge_train_policies": 0,
             "merge_train_runs": 0,
+            "odoo_stable_bootstrap_operations": 0,
             "release_tuples": 0,
             "runtime_key_safety_policies": 0,
         }
@@ -2785,6 +2880,10 @@ class PostgresRecordStore(HumanSessionStore):
             for merge_train_policy_record in filesystem_store.list_merge_train_policy_records():
                 self.write_merge_train_policy_record(merge_train_policy_record)
                 counts["merge_train_policies"] += 1
+        if hasattr(filesystem_store, "list_odoo_stable_bootstrap_operation_records"):
+            for operation_record in filesystem_store.list_odoo_stable_bootstrap_operation_records():
+                self.write_odoo_stable_bootstrap_operation_record(operation_record)
+                counts["odoo_stable_bootstrap_operations"] += 1
         for release_tuple_record in filesystem_store.list_release_tuple_records():
             self.write_release_tuple_record(release_tuple_record)
             counts["release_tuples"] += 1

--- a/control_plane/workflows/odoo_stable_bootstrap.py
+++ b/control_plane/workflows/odoo_stable_bootstrap.py
@@ -46,6 +46,14 @@ from control_plane.workflows.ship import (
 
 ODOO_STABLE_BOOTSTRAP_VERIFY_RETRY_INTERVAL_SECONDS = 5
 
+__all__ = [
+    "ODOO_STABLE_BOOTSTRAP_VERIFY_RETRY_INTERVAL_SECONDS",
+    "OdooStableBootstrapRequest",
+    "OdooStableBootstrapResult",
+    "OdooStableBootstrapStore",
+    "execute_odoo_stable_bootstrap",
+]
+
 
 class OdooStableBootstrapStore(Protocol):
     def read_odoo_instance_override_record(

--- a/control_plane/workflows/odoo_stable_bootstrap.py
+++ b/control_plane/workflows/odoo_stable_bootstrap.py
@@ -4,8 +4,6 @@ from pathlib import Path
 from typing import Literal, Protocol
 
 import click
-from pydantic import BaseModel, ConfigDict, Field, model_validator
-
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import odoo_instance_overrides as control_plane_odoo_instance_overrides
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
@@ -13,6 +11,10 @@ from control_plane.contracts.dokploy_target_id_record import DokployTargetIdReco
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
+from control_plane.contracts.odoo_stable_bootstrap import (
+    OdooStableBootstrapRequest,
+    OdooStableBootstrapResult,
+)
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductLaneProfile,
@@ -67,60 +69,6 @@ class OdooStableBootstrapStore(Protocol):
     def write_deployment_record(self, record: DeploymentRecord) -> object: ...
 
     def write_environment_inventory(self, record: EnvironmentInventory) -> object: ...
-
-
-class OdooStableBootstrapRequest(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    product: str
-    context: str = "cm"
-    instance: str
-    confirmation: str
-    verify_health: bool = True
-    verify_canonical: bool = True
-    verify_logo: bool = True
-    timeout_seconds: int | None = Field(default=None, ge=1)
-    health_timeout_seconds: int | None = Field(default=None, ge=1)
-
-    @model_validator(mode="after")
-    def _validate_request(self) -> "OdooStableBootstrapRequest":
-        self.product = self.product.strip()
-        self.context = self.context.strip().lower()
-        self.instance = self.instance.strip().lower()
-        self.confirmation = self.confirmation.strip().lower()
-        if not self.product:
-            raise ValueError("Odoo stable bootstrap requires product.")
-        if not self.context:
-            raise ValueError("Odoo stable bootstrap requires context.")
-        if not self.instance:
-            raise ValueError("Odoo stable bootstrap requires instance.")
-        return self
-
-
-class OdooStableBootstrapResult(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    product: str
-    context: str
-    instance: str
-    deployment_record_id: str = ""
-    bootstrap_status: Literal["pass", "fail"]
-    bootstrap_run_status: Literal["pass", "fail", "skipped"] = "skipped"
-    readiness_status: Literal["pass", "fail", "verification_failed", "skipped"] = "skipped"
-    post_deploy_status: Literal["pass", "fail", "skipped"] = "skipped"
-    health_status: Literal["pass", "fail", "skipped"] = "skipped"
-    canonical_status: Literal["pass", "fail", "skipped"] = "skipped"
-    logo_status: Literal["pass", "fail", "skipped"] = "skipped"
-    health_url: str = ""
-    canonical_url: str = ""
-    logo_urls: tuple[str, ...] = ()
-    verification_evidence: OdooVerificationEvidence = Field(default_factory=OdooVerificationEvidence)
-    target_id: str = ""
-    target_name: str = ""
-    artifact_id: str = ""
-    source_git_ref: str = ""
-    error_message: str = ""
 
 
 def _normalize_domain(raw_domain: str) -> str:

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -174,6 +174,10 @@ are derived by the driver from the lane base URL and Odoo conventions. It is
 separate from target replacement: replacement reconciles provider/runtime target
 state, while bootstrap rebuilds Odoo application data for lanes that are
 explicitly safe to recreate.
+The POST route returns a durable operation record instead of holding the request
+open for the whole bootstrap. Callers poll
+`/v1/drivers/odoo/stable-bootstrap/operations/{operation_id}` and treat terminal
+`pass`/`fail` as the source of truth for workflow exit status and artifacts.
 
 Driver action routes are owned by the base driver contract. The service accepts
 any product key on Odoo and VeriReel action envelopes, then authorizes the call

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -785,6 +785,18 @@ current deployment pointer and records the failed attempt in `bootstrap_record_i
 Do not use this path for prod until Launchplane has explicit backup/restore
 policy evidence for that lane.
 
+The service route creates a durable Odoo stable-bootstrap operation and returns
+an operation id immediately. The GitHub workflow polls
+`GET /v1/drivers/odoo/stable-bootstrap/operations/{operation_id}` until the
+operation status is `pass` or `fail`, then uploads the final operation payload as
+the workflow artifact. `Idempotency-Key` is required: a repeated request with the
+same key returns the existing operation, while a different key for the same
+product/context/instance is rejected while a `pending` or `running` operation is
+active. The operation record stores the request, status, phase,
+deployment-record linkage when known, final bootstrap result, and any terminal
+error message so operators can inspect progress after the original HTTP request
+has ended.
+
 For OPW prelaunch lanes that should be rebuilt from the current upstream
 non-Docker source, encode `odoo_prelaunch_rebuild` on the product profile lane
 with `data_source_mode="upstream_restore"`, the approval issue URL, expected

--- a/docs/records.md
+++ b/docs/records.md
@@ -387,6 +387,13 @@ state/
   same record as `deployment_record_id`; failed or partially verified bootstrap
   attempts leave the current deployment inventory unchanged and update only
   `bootstrap_record_id` so operators can see the latest bootstrap attempt.
+- Odoo stable bootstrap also writes durable operation records under
+  `odoo_stable_bootstrap_operations`. These operation records are the
+  create/read/poll boundary for the service-backed workflow: they store the
+  original request, idempotency key, request fingerprint, active status/phase,
+  deployment-record id when available, final driver result, and terminal error.
+  A `pending` or `running` record is the single-flight guard for that
+  product/context/instance.
 - Odoo prod rollback writes a normal deployment record for the rollback deploy,
   refreshes prod inventory, mints the prod release tuple from the selected
   artifact manifest, and annotates the current prod promotion record's

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -446,6 +446,7 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             control_plane_service._NON_IDEMPOTENT_DRIVER_RESULT_ROUTES,
             frozenset(
                 {
+                    control_plane_service._ODOO_STABLE_BOOTSTRAP_ROUTE.route_path,
                     control_plane_service._VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path,
                     control_plane_service._VERIREEL_RUNTIME_VERIFICATION_ROUTE.route_path,
                     control_plane_service._VERIREEL_PREVIEW_INVENTORY_ROUTE.route_path,

--- a/tests/test_odoo_stable_bootstrap_operation.py
+++ b/tests/test_odoo_stable_bootstrap_operation.py
@@ -47,14 +47,12 @@ class OdooStableBootstrapOperationRecordTests(unittest.TestCase):
             context="cm",
             instance="testing",
             created_at="2026-05-17T00:00:00Z",
-            idempotency_key="bootstrap-cm-testing",
         )
         second = build_odoo_stable_bootstrap_operation_id(
             product="odoo-tenant-cm",
             context="cm",
             instance="testing",
             created_at="2026-05-17T00:00:00Z",
-            idempotency_key="bootstrap-cm-testing",
         )
 
         self.assertEqual(first, second)

--- a/tests/test_odoo_stable_bootstrap_operation.py
+++ b/tests/test_odoo_stable_bootstrap_operation.py
@@ -1,0 +1,112 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from control_plane.contracts.odoo_stable_bootstrap_operation import (
+    OdooStableBootstrapOperationRecord,
+    build_odoo_stable_bootstrap_operation_id,
+)
+from control_plane.contracts.odoo_stable_bootstrap import OdooStableBootstrapRequest
+from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.storage.postgres import PostgresRecordStore
+
+
+def _operation_payload(operation_id: str = "operation-cm-testing") -> dict[str, object]:
+    return {
+        "operation_id": operation_id,
+        "product": "odoo-tenant-cm",
+        "context": "cm",
+        "instance": "testing",
+        "idempotency_key": "bootstrap-cm-testing",
+        "request_fingerprint": "fingerprint-123",
+        "request": {
+            "schema_version": 1,
+            "product": "odoo-tenant-cm",
+            "context": "cm",
+            "instance": "testing",
+            "confirmation": "bootstrap cm testing",
+        },
+        "status": "pending",
+        "phase": "created",
+        "created_at": "2026-05-17T00:00:00Z",
+        "updated_at": "2026-05-17T00:00:00Z",
+    }
+
+
+class OdooStableBootstrapOperationRecordTests(unittest.TestCase):
+    def test_operation_record_round_trips(self) -> None:
+        record = OdooStableBootstrapOperationRecord.model_validate(_operation_payload())
+
+        self.assertEqual(record.product, "odoo-tenant-cm")
+        self.assertIsInstance(record.request, OdooStableBootstrapRequest)
+        self.assertEqual(record.request.confirmation, "bootstrap cm testing")
+
+    def test_operation_id_is_stable_for_same_inputs(self) -> None:
+        first = build_odoo_stable_bootstrap_operation_id(
+            product="odoo-tenant-cm",
+            context="cm",
+            instance="testing",
+            created_at="2026-05-17T00:00:00Z",
+            idempotency_key="bootstrap-cm-testing",
+        )
+        second = build_odoo_stable_bootstrap_operation_id(
+            product="odoo-tenant-cm",
+            context="cm",
+            instance="testing",
+            created_at="2026-05-17T00:00:00Z",
+            idempotency_key="bootstrap-cm-testing",
+        )
+
+        self.assertEqual(first, second)
+        self.assertTrue(first.startswith("odoo-stable-bootstrap-cm-testing-"))
+
+    def test_filesystem_store_filters_operations(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name))
+            active = OdooStableBootstrapOperationRecord.model_validate(_operation_payload())
+            finished = OdooStableBootstrapOperationRecord.model_validate(
+                {
+                    **_operation_payload("operation-cm-testing-done"),
+                    "idempotency_key": "bootstrap-cm-testing-done",
+                    "status": "pass",
+                    "phase": "completed",
+                    "finished_at": "2026-05-17T00:05:00Z",
+                    "updated_at": "2026-05-17T00:05:00Z",
+                }
+            )
+
+            store.write_odoo_stable_bootstrap_operation_record(active)
+            store.write_odoo_stable_bootstrap_operation_record(finished)
+
+            loaded = store.read_odoo_stable_bootstrap_operation_record(active.operation_id)
+            active_records = store.list_odoo_stable_bootstrap_operation_records(
+                product="odoo-tenant-cm",
+                context_name="cm",
+                instance_name="testing",
+                statuses=("pending", "running"),
+            )
+
+            self.assertEqual(loaded.operation_id, active.operation_id)
+            self.assertEqual(tuple(record.operation_id for record in active_records), (active.operation_id,))
+
+    def test_postgres_store_round_trips_operation(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            store = PostgresRecordStore(database_url=f"sqlite:///{database_path}")
+            store.ensure_schema()
+            record = OdooStableBootstrapOperationRecord.model_validate(_operation_payload())
+
+            store.write_odoo_stable_bootstrap_operation_record(record)
+
+            loaded = store.read_odoo_stable_bootstrap_operation_record(record.operation_id)
+            active_records = store.list_odoo_stable_bootstrap_operation_records(
+                idempotency_key="bootstrap-cm-testing",
+                statuses=("pending",),
+            )
+
+            self.assertEqual(loaded.operation_id, record.operation_id)
+            self.assertEqual(tuple(item.operation_id for item in active_records), (record.operation_id,))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -64,6 +64,9 @@ from control_plane.merge_train import (
 from control_plane.contracts.odoo_instance_override_record import OdooConfigParameterOverride
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.odoo_instance_override_record import OdooOverrideValue
+from control_plane.contracts.odoo_stable_bootstrap_operation import (
+    OdooStableBootstrapOperationRecord,
+)
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
 from control_plane.contracts.preview_generation_record import (
     PreviewGenerationRecord,
@@ -2321,6 +2324,29 @@ env_var = "GH_TOKEN"
             filesystem_store.write_merge_train_stack_collapse_plan_record(
                 _merge_train_stack_collapse_plan_record()
             )
+            filesystem_store.write_odoo_stable_bootstrap_operation_record(
+                OdooStableBootstrapOperationRecord.model_validate(
+                    {
+                        "operation_id": "odoo-stable-bootstrap-cm-testing-test",
+                        "product": "odoo-tenant-cm",
+                        "context": "cm",
+                        "instance": "testing",
+                        "idempotency_key": "bootstrap-cm-testing",
+                        "request_fingerprint": "fingerprint-123",
+                        "request": {
+                            "schema_version": 1,
+                            "product": "odoo-tenant-cm",
+                            "context": "cm",
+                            "instance": "testing",
+                            "confirmation": "bootstrap cm testing",
+                        },
+                        "status": "pending",
+                        "phase": "created",
+                        "created_at": "2026-05-17T00:00:00Z",
+                        "updated_at": "2026-05-17T00:00:00Z",
+                    }
+                )
+            )
 
             counts = store.import_core_records_from_filesystem(filesystem_store)
             self.assertEqual(
@@ -2348,6 +2374,7 @@ env_var = "GH_TOKEN"
                     "merge_train_stack_collapse_plans": 1,
                     "merge_train_policies": 1,
                     "merge_train_runs": 1,
+                    "odoo_stable_bootstrap_operations": 1,
                     "release_tuples": 1,
                     "runtime_key_safety_policies": 1,
                 },
@@ -2377,6 +2404,15 @@ env_var = "GH_TOKEN"
                     limit=1,
                 )[0].desired_state_id,
                 "preview-desired-state-verireel-testing-20260420T100550Z",
+            )
+            self.assertEqual(
+                store.list_odoo_stable_bootstrap_operation_records(
+                    context_name="cm",
+                    instance_name="testing",
+                    statuses=("pending",),
+                    limit=1,
+                )[0].operation_id,
+                "odoo-stable-bootstrap-cm-testing-test",
             )
             self.assertEqual(
                 store.list_preview_lifecycle_plan_records(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -19,6 +19,7 @@ from click.testing import CliRunner
 
 from control_plane.cli import main
 from control_plane import secrets as control_plane_secrets
+from control_plane import service as control_plane_service
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.authz_policy_record import (
     LaunchplaneAuthzPolicyRecord,
@@ -38,6 +39,9 @@ from control_plane.contracts.merge_train_batch import build_merge_train_batch_ca
 from control_plane.contracts.odoo_instance_override_record import OdooConfigParameterOverride
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.odoo_instance_override_record import OdooOverrideValue
+from control_plane.contracts.odoo_stable_bootstrap_operation import (
+    OdooStableBootstrapOperationRecord,
+)
 from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
 from control_plane.contracts.merge_train_run_record import build_merge_train_run_record
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
@@ -104,8 +108,8 @@ from control_plane.workflows.verireel_stable_deploy import VeriReelStableDeployR
 from control_plane.workflows.verireel_environment import VeriReelStableEnvironmentResult
 from control_plane.workflows.verireel_rollout import VeriReelRolloutVerificationResult
 from control_plane.workflows.odoo_artifact_publish import OdooArtifactPublishResult
+from control_plane.contracts.odoo_stable_bootstrap import OdooStableBootstrapResult
 from control_plane.workflows.odoo_post_deploy import OdooPostDeployResult
-from control_plane.workflows.odoo_stable_bootstrap import OdooStableBootstrapResult
 from control_plane.workflows.odoo_prod_backup_gate import OdooProdBackupGateResult
 from control_plane.workflows.odoo_prod_promotion import OdooProdPromotionResult
 from control_plane.workflows.odoo_prod_rollback import OdooProdRollbackResult
@@ -18852,7 +18856,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(status_code, 400)
             self.assertEqual(payload["error"]["code"], "invalid_request")
 
-    def test_odoo_stable_bootstrap_driver_runs_for_authorized_workflow(self) -> None:
+    def test_odoo_stable_bootstrap_driver_creates_operation_for_authorized_workflow(
+        self,
+    ) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             state_dir = root / "state"
@@ -18891,20 +18897,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 control_plane_root_path=root,
             )
 
-            with patch(
-                "control_plane.service.execute_odoo_stable_bootstrap",
-                return_value=OdooStableBootstrapResult(
-                    product="odoo-tenant-cm",
-                    context="cm",
-                    instance="testing",
-                    deployment_record_id="deployment-cm-testing-bootstrap",
-                    bootstrap_status="pass",
-                    post_deploy_status="pass",
-                    health_status="pass",
-                    canonical_status="pass",
-                    logo_status="pass",
-                ),
-            ) as bootstrap_mock:
+            with patch("control_plane.service._start_odoo_stable_bootstrap_operation_worker") as worker_mock:
                 status_code, payload = _invoke_app(
                     app,
                     method="POST",
@@ -18926,14 +18919,373 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
             self.assertEqual(status_code, 202)
             self.assertEqual(payload["status"], "accepted")
+            operation_id = payload["records"]["odoo_stable_bootstrap_operation_id"]
+            self.assertTrue(str(operation_id).startswith("odoo-stable-bootstrap-cm-testing-"))
+            self.assertEqual(payload["result"]["status"], "pending")
+            self.assertEqual(payload["result"]["phase"], "created")
+            self.assertEqual(payload["result"]["request"]["confirmation"], "bootstrap cm testing")
             self.assertEqual(
-                payload["records"],
-                {"deployment_record_id": "deployment-cm-testing-bootstrap"},
+                payload["result"]["poll_url"],
+                f"/v1/drivers/odoo/stable-bootstrap/operations/{operation_id}",
             )
-            self.assertEqual(payload["result"]["bootstrap_status"], "pass")
-            bootstrap_mock.assert_called_once()
-            request = bootstrap_mock.call_args.kwargs["request"]
-            self.assertEqual(request.confirmation, "bootstrap cm testing")
+            worker_mock.assert_called_once()
+            self.assertEqual(worker_mock.call_args.kwargs["operation_id"], operation_id)
+            stored_operation = store.read_odoo_stable_bootstrap_operation_record(
+                str(operation_id)
+            )
+            self.assertEqual(stored_operation.status, "pending")
+            self.assertEqual(stored_operation.idempotency_key, "bootstrap-cm-testing")
+
+    def test_odoo_stable_bootstrap_driver_replays_existing_operation(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/odoo-stable-bootstrap.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["odoo_stable_bootstrap.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-stable-bootstrap.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            request_payload = {
+                "product": "odoo-tenant-cm",
+                "bootstrap": {
+                    "product": "odoo-tenant-cm",
+                    "context": "cm",
+                    "instance": "testing",
+                    "confirmation": "bootstrap cm testing",
+                    "verify_health": True,
+                    "verify_canonical": True,
+                    "verify_logo": True,
+                },
+            }
+
+            with patch("control_plane.service._start_odoo_stable_bootstrap_operation_worker") as worker_mock:
+                first_status, first_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/stable-bootstrap",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "bootstrap-cm-testing"},
+                )
+                second_status, second_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/stable-bootstrap",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "bootstrap-cm-testing"},
+                )
+
+            self.assertEqual(first_status, 202)
+            self.assertEqual(second_status, 202)
+            self.assertEqual(
+                first_payload["records"]["odoo_stable_bootstrap_operation_id"],
+                second_payload["records"]["odoo_stable_bootstrap_operation_id"],
+            )
+            worker_mock.assert_called_once()
+
+    def test_odoo_stable_bootstrap_driver_blocks_second_active_lane_operation(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/odoo-stable-bootstrap.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["odoo_stable_bootstrap.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-stable-bootstrap.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            request_payload = {
+                "product": "odoo-tenant-cm",
+                "bootstrap": {
+                    "product": "odoo-tenant-cm",
+                    "context": "cm",
+                    "instance": "testing",
+                    "confirmation": "bootstrap cm testing",
+                },
+            }
+
+            with patch("control_plane.service._start_odoo_stable_bootstrap_operation_worker"):
+                first_status, _ = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/stable-bootstrap",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "bootstrap-cm-testing-1"},
+                )
+                second_status, second_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/stable-bootstrap",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "bootstrap-cm-testing-2"},
+                )
+
+            self.assertEqual(first_status, 202)
+            self.assertEqual(second_status, 409)
+            self.assertEqual(
+                second_payload["error"]["code"], "odoo_stable_bootstrap_operation_active"
+            )
+
+    def test_odoo_stable_bootstrap_operation_status_reads_for_authorized_workflow(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            request = {
+                "schema_version": 1,
+                "product": "odoo-tenant-cm",
+                "context": "cm",
+                "instance": "testing",
+                "confirmation": "bootstrap cm testing",
+            }
+            store.write_odoo_stable_bootstrap_operation_record(
+                OdooStableBootstrapOperationRecord.model_validate(
+                    {
+                        "operation_id": "operation-cm-testing",
+                        "product": "odoo-tenant-cm",
+                        "context": "cm",
+                        "instance": "testing",
+                        "idempotency_key": "bootstrap-cm-testing",
+                        "request_fingerprint": "abc123",
+                        "request": request,
+                        "status": "running",
+                        "phase": "running",
+                        "created_at": "2026-05-17T00:00:00Z",
+                        "updated_at": "2026-05-17T00:01:00Z",
+                        "started_at": "2026-05-17T00:01:00Z",
+                    }
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/odoo-stable-bootstrap.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["odoo_stable_bootstrap.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-stable-bootstrap.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/drivers/odoo/stable-bootstrap/operations/operation-cm-testing",
+            )
+
+            self.assertEqual(status_code, 200)
+            self.assertEqual(payload["status"], "ok")
+            self.assertEqual(payload["operation"]["status"], "running")
+            self.assertEqual(
+                payload["operation"]["poll_url"],
+                "/v1/drivers/odoo/stable-bootstrap/operations/operation-cm-testing",
+            )
+
+    def test_odoo_stable_bootstrap_operation_worker_records_terminal_result(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_odoo_stable_bootstrap_operation_record(
+                OdooStableBootstrapOperationRecord.model_validate(
+                    {
+                        "operation_id": "operation-cm-testing",
+                        "product": "odoo-tenant-cm",
+                        "context": "cm",
+                        "instance": "testing",
+                        "idempotency_key": "bootstrap-cm-testing",
+                        "request_fingerprint": "abc123",
+                        "request": {
+                            "schema_version": 1,
+                            "product": "odoo-tenant-cm",
+                            "context": "cm",
+                            "instance": "testing",
+                            "confirmation": "bootstrap cm testing",
+                        },
+                        "status": "pending",
+                        "phase": "created",
+                        "created_at": "2026-05-17T00:00:00Z",
+                        "updated_at": "2026-05-17T00:00:00Z",
+                    }
+                )
+            )
+            result = OdooStableBootstrapResult(
+                product="odoo-tenant-cm",
+                context="cm",
+                instance="testing",
+                deployment_record_id="deployment-cm-testing",
+                bootstrap_status="pass",
+                bootstrap_run_status="pass",
+                readiness_status="pass",
+                post_deploy_status="pass",
+                health_status="pass",
+                canonical_status="pass",
+                logo_status="pass",
+            )
+
+            with patch(
+                "control_plane.service.execute_odoo_stable_bootstrap",
+                return_value=result,
+            ):
+                control_plane_service._run_odoo_stable_bootstrap_operation_worker(
+                    operation_id="operation-cm-testing",
+                    control_plane_root_path=root,
+                    record_store=store,
+                    trace_id="launchplane_req_worker",
+                )
+
+            operation = store.read_odoo_stable_bootstrap_operation_record(
+                "operation-cm-testing"
+            )
+            self.assertEqual(operation.status, "pass")
+            self.assertEqual(operation.phase, "completed")
+            self.assertEqual(operation.deployment_record_id, "deployment-cm-testing")
+            self.assertEqual(operation.runner_trace_id, "launchplane_req_worker")
+            self.assertIsNotNone(operation.result)
+
+    def test_odoo_stable_bootstrap_operation_worker_fails_partial_result(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_odoo_stable_bootstrap_operation_record(
+                OdooStableBootstrapOperationRecord.model_validate(
+                    {
+                        "operation_id": "operation-cm-testing",
+                        "product": "odoo-tenant-cm",
+                        "context": "cm",
+                        "instance": "testing",
+                        "idempotency_key": "bootstrap-cm-testing",
+                        "request_fingerprint": "abc123",
+                        "request": {
+                            "schema_version": 1,
+                            "product": "odoo-tenant-cm",
+                            "context": "cm",
+                            "instance": "testing",
+                            "confirmation": "bootstrap cm testing",
+                        },
+                        "status": "pending",
+                        "phase": "created",
+                        "created_at": "2026-05-17T00:00:00Z",
+                        "updated_at": "2026-05-17T00:00:00Z",
+                    }
+                )
+            )
+            result = OdooStableBootstrapResult(
+                product="odoo-tenant-cm",
+                context="cm",
+                instance="testing",
+                deployment_record_id="deployment-cm-testing",
+                bootstrap_status="pass",
+                bootstrap_run_status="pass",
+                readiness_status="verification_failed",
+                post_deploy_status="pass",
+                health_status="pass",
+                canonical_status="fail",
+                logo_status="skipped",
+                error_message="Canonical verification failed.",
+            )
+
+            with patch(
+                "control_plane.service.execute_odoo_stable_bootstrap",
+                return_value=result,
+            ):
+                control_plane_service._run_odoo_stable_bootstrap_operation_worker(
+                    operation_id="operation-cm-testing",
+                    control_plane_root_path=root,
+                    record_store=store,
+                    trace_id="launchplane_req_worker",
+                )
+
+            operation = store.read_odoo_stable_bootstrap_operation_record(
+                "operation-cm-testing"
+            )
+            self.assertEqual(operation.status, "fail")
+            self.assertEqual(operation.phase, "failed")
+            self.assertEqual(operation.error_message, "Canonical verification failed.")
 
     def test_odoo_stable_bootstrap_driver_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary

- add durable Odoo stable bootstrap operation records with filesystem/Postgres storage and migration
- convert the service endpoint into create/read/poll operation flow with idempotency-key replay and single-flight lane safeguards
- update the GitHub workflow to create the operation, poll to terminal state, and preserve the final operation/result artifact
- document the operation contract and record type

## Validation

- `uv run python -m unittest tests.test_driver_descriptors tests.test_odoo_stable_bootstrap_operation tests.test_service.LaunchplaneServiceTests.test_odoo_stable_bootstrap_driver_creates_operation_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_stable_bootstrap_driver_replays_existing_operation tests.test_service.LaunchplaneServiceTests.test_odoo_stable_bootstrap_driver_blocks_second_active_lane_operation tests.test_service.LaunchplaneServiceTests.test_odoo_stable_bootstrap_operation_status_reads_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_stable_bootstrap_operation_worker_records_terminal_result tests.test_service.LaunchplaneServiceTests.test_odoo_stable_bootstrap_operation_worker_fails_partial_result tests.test_service.LaunchplaneServiceTests.test_odoo_stable_bootstrap_driver_rejects_unauthorized_workflow`
- `uv run python -m py_compile control_plane/service.py control_plane/contracts/odoo_stable_bootstrap.py control_plane/contracts/odoo_stable_bootstrap_operation.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/workflows/odoo_stable_bootstrap.py`
- `git diff --check`
- JetBrains changed-file inspection for touched service/operation files; remaining warnings are pre-existing service.py type-noise tracked by #653
- `uv run python -m unittest`

Closes #556.
