### PR TITLE
Harden runtime identity health evidence

### DIFF
--- a/control_plane/contracts/runtime_identity.py
+++ b/control_plane/contracts/runtime_identity.py
@@ -10,6 +10,7 @@ RuntimeIdentityStatus = Literal[
     "match",
     "mismatch",
     "missing",
+    "malformed",
     "unverifiable",
 ]
 
@@ -97,6 +98,20 @@ def runtime_identity_from_health_payload(payload: object) -> RuntimeIdentity | N
     return None
 
 
+def health_payload_has_runtime_identity_key(payload: object) -> bool:
+    if not isinstance(payload, Mapping):
+        return False
+    return any(
+        key in payload
+        for key in (
+            "runtime_identity",
+            "launchplane_runtime_identity",
+            "launchplaneRuntimeIdentity",
+            RUNTIME_IDENTITY_ENV_KEY,
+        )
+    )
+
+
 def compare_runtime_identity(
     *, expected: RuntimeIdentity | None, observed: RuntimeIdentity | None
 ) -> tuple[RuntimeIdentityStatus, str]:
@@ -137,5 +152,11 @@ def health_payload_runtime_identity_status(
             None,
         )
     observed = runtime_identity_from_health_payload(payload)
+    if observed is None and health_payload_has_runtime_identity_key(payload):
+        return (
+            "malformed",
+            "Health endpoint returned runtime identity evidence that could not be parsed.",
+            None,
+        )
     status, detail = compare_runtime_identity(expected=expected, observed=observed)
     return status, detail, observed

--- a/control_plane/workflows/generic_web_promotion.py
+++ b/control_plane/workflows/generic_web_promotion.py
@@ -38,8 +38,10 @@ from control_plane.workflows.launchplane import (
     resolve_launchplane_github_token,
 )
 from control_plane.workflows.runtime_identity_health import (
+    RuntimeIdentityHealthcheckError,
     healthcheck_evidence_with_runtime_identity,
     wait_for_healthcheck_with_retry,
+    wait_for_runtime_identity_healthcheck_with_retry,
 )
 from control_plane.workflows.promote import generate_promotion_record_id
 from control_plane.workflows.ship import utc_now_timestamp
@@ -352,7 +354,8 @@ def execute_generic_web_prod_promotion(
         inventory_record_id=inventory_record_id,
         target_id=deploy_result.target_id,
         dry_run=False,
-        error_message=deploy_result.error_message,
+        error_message=deploy_result.error_message
+        or _health_failure_detail(final_record.destination_health),
     )
     if final_result.promotion_status != "pass" or not request.release_tag:
         return final_result
@@ -527,9 +530,10 @@ def _verify_health_evidence_with_identity(
     healthcheck_errors: list[str] = []
     for health_url in evidence.urls:
         try:
-            healthcheck_pass = wait_for_healthcheck_with_retry(
+            healthcheck_pass = wait_for_runtime_identity_healthcheck_with_retry(
                 url=health_url,
                 timeout_seconds=timeout_seconds,
+                expected_runtime_identity=expected_runtime_identity,
                 sleep=time.sleep,
                 monotonic=time.monotonic,
             )
@@ -544,8 +548,21 @@ def _verify_health_evidence_with_identity(
                 healthcheck_pass=healthcheck_pass,
             )
             if verified_evidence.runtime_identity_status != "match":
-                raise click.ClickException(verified_evidence.runtime_identity_detail)
+                return verified_evidence.model_copy(update={"status": "fail"})
             return verified_evidence
+        except RuntimeIdentityHealthcheckError as error:
+            healthcheck_errors.append(str(error))
+            if error.healthcheck_pass is not None:
+                return healthcheck_evidence_with_runtime_identity(
+                    HealthcheckEvidence(
+                        verified=True,
+                        urls=evidence.urls,
+                        timeout_seconds=timeout_seconds,
+                        status="fail",
+                    ),
+                    expected_runtime_identity=expected_runtime_identity,
+                    healthcheck_pass=error.healthcheck_pass,
+                )
         except click.ClickException as error:
             healthcheck_errors.append(str(error))
     raise click.ClickException(
@@ -557,12 +574,18 @@ def _verify_health_evidence_with_identity(
 def _mark_health_failed(evidence: HealthcheckEvidence) -> HealthcheckEvidence:
     if evidence.status == "skipped":
         return evidence
-    return HealthcheckEvidence(
-        verified=bool(evidence.urls),
-        urls=evidence.urls,
-        timeout_seconds=evidence.timeout_seconds,
-        status="fail",
+    return evidence.model_copy(
+        update={
+            "verified": bool(evidence.urls),
+            "status": "fail",
+        }
     )
+
+
+def _health_failure_detail(evidence: HealthcheckEvidence) -> str:
+    if evidence.status != "fail":
+        return ""
+    return evidence.runtime_identity_detail
 
 
 def _mark_health_skipped(evidence: HealthcheckEvidence) -> HealthcheckEvidence:

--- a/control_plane/workflows/runtime_identity_health.py
+++ b/control_plane/workflows/runtime_identity_health.py
@@ -20,6 +20,12 @@ class HealthcheckPass(NamedTuple):
     json_parse_failed: bool = False
 
 
+class RuntimeIdentityHealthcheckError(click.ClickException):
+    def __init__(self, message: str, *, healthcheck_pass: HealthcheckPass | None = None) -> None:
+        super().__init__(message)
+        self.healthcheck_pass = healthcheck_pass
+
+
 WaitForHealthcheck = Callable[[str, int], HealthcheckPass]
 
 
@@ -49,7 +55,10 @@ def wait_for_healthcheck_with_retry(
     last_error: str = ""
     while monotonic() < deadline:
         try:
-            return wait_once(url=url, timeout_seconds=timeout_seconds)
+            healthcheck_pass = wait_once(url=url, timeout_seconds=timeout_seconds)
+            if not healthcheck_pass.json_parse_failed:
+                return healthcheck_pass
+            last_error = "health endpoint did not return parseable JSON"
         except click.ClickException as error:
             last_error = str(error)
         except HTTPError as error:
@@ -58,6 +67,44 @@ def wait_for_healthcheck_with_retry(
             last_error = str(error.reason)
         sleep(1)
     raise click.ClickException(f"Healthcheck failed for {url}: {last_error or 'timeout'}")
+
+
+def wait_for_runtime_identity_healthcheck_with_retry(
+    *,
+    url: str,
+    timeout_seconds: int,
+    expected_runtime_identity: RuntimeIdentity,
+    sleep: Callable[[float], None],
+    monotonic: Callable[[], float],
+    wait_once: Callable[..., HealthcheckPass] = wait_for_json_healthcheck,
+) -> HealthcheckPass:
+    deadline = monotonic() + timeout_seconds
+    last_detail = "timeout"
+    last_healthcheck_pass: HealthcheckPass | None = None
+    while monotonic() < deadline:
+        try:
+            healthcheck_pass = wait_once(url=url, timeout_seconds=timeout_seconds)
+        except click.ClickException as error:
+            last_detail = str(error)
+        except HTTPError as error:
+            last_detail = f"http {error.code}"
+        except URLError as error:
+            last_detail = str(error.reason)
+        else:
+            last_healthcheck_pass = healthcheck_pass
+            status, detail, _observed = health_payload_runtime_identity_status(
+                expected=expected_runtime_identity,
+                payload=healthcheck_pass.payload,
+                json_parse_failed=healthcheck_pass.json_parse_failed,
+            )
+            if status in {"match", "mismatch"}:
+                return healthcheck_pass
+            last_detail = detail
+        sleep(1)
+    raise RuntimeIdentityHealthcheckError(
+        f"Healthcheck failed for {url}: {last_detail}",
+        healthcheck_pass=last_healthcheck_pass,
+    )
 
 
 def healthcheck_evidence_with_runtime_identity(

--- a/tests/test_generic_web_promotion.py
+++ b/tests/test_generic_web_promotion.py
@@ -236,7 +236,7 @@ class GenericWebProdPromotionTests(unittest.TestCase):
                 return_value=None,
             ) as healthcheck,
             patch(
-                "control_plane.workflows.generic_web_promotion.wait_for_healthcheck_with_retry",
+                "control_plane.workflows.generic_web_promotion.wait_for_runtime_identity_healthcheck_with_retry",
                 return_value=HealthcheckPass(
                     payload={"runtime_identity": _runtime_identity_payload()}
                 ),
@@ -301,7 +301,7 @@ class GenericWebProdPromotionTests(unittest.TestCase):
                 return_value=None,
             ),
             patch(
-                "control_plane.workflows.generic_web_promotion.wait_for_healthcheck_with_retry",
+                "control_plane.workflows.generic_web_promotion.wait_for_runtime_identity_healthcheck_with_retry",
                 return_value=HealthcheckPass(
                     payload={
                         "runtime_identity": _runtime_identity_payload(
@@ -358,7 +358,7 @@ class GenericWebProdPromotionTests(unittest.TestCase):
                 return_value=None,
             ),
             patch(
-                "control_plane.workflows.generic_web_promotion.wait_for_healthcheck_with_retry",
+                "control_plane.workflows.generic_web_promotion.wait_for_runtime_identity_healthcheck_with_retry",
                 return_value=HealthcheckPass(
                     payload={"runtime_identity": _runtime_identity_payload()}
                 ),
@@ -436,7 +436,7 @@ class GenericWebProdPromotionTests(unittest.TestCase):
                 return_value=None,
             ),
             patch(
-                "control_plane.workflows.generic_web_promotion.wait_for_healthcheck_with_retry",
+                "control_plane.workflows.generic_web_promotion.wait_for_runtime_identity_healthcheck_with_retry",
                 return_value=HealthcheckPass(
                     payload={"runtime_identity": _runtime_identity_payload()}
                 ),
@@ -524,7 +524,7 @@ class GenericWebProdPromotionTests(unittest.TestCase):
                 return_value=None,
             ) as healthcheck,
             patch(
-                "control_plane.workflows.generic_web_promotion.wait_for_healthcheck_with_retry",
+                "control_plane.workflows.generic_web_promotion.wait_for_runtime_identity_healthcheck_with_retry",
                 return_value=HealthcheckPass(
                     payload={"runtime_identity": _runtime_identity_payload()}
                 ),
@@ -621,7 +621,11 @@ class GenericWebProdPromotionTests(unittest.TestCase):
                 side_effect=fake_deploy,
             ),
             patch(
-                "control_plane.workflows.generic_web_promotion.wait_for_healthcheck_with_retry",
+                "control_plane.workflows.generic_web_promotion._wait_for_healthcheck",
+                return_value=None,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_promotion.wait_for_runtime_identity_healthcheck_with_retry",
                 return_value=HealthcheckPass(payload={"status": "ok"}),
             ),
         ):
@@ -637,7 +641,8 @@ class GenericWebProdPromotionTests(unittest.TestCase):
         self.assertNotIn(("sellyouroutboard-testing", "prod"), store.inventories)
         promotion = next(iter(store.promotions.values()))
         self.assertEqual(promotion.destination_health.status, "fail")
-        self.assertEqual(promotion.deploy.status, "fail")
+        self.assertEqual(promotion.destination_health.runtime_identity_status, "missing")
+        self.assertEqual(promotion.deploy.status, "pass")
 
     def test_runtime_identity_mismatch_fails_promotion_without_inventory_refresh(self) -> None:
         store = _GenericWebPromotionStore(_profile())
@@ -661,7 +666,11 @@ class GenericWebProdPromotionTests(unittest.TestCase):
                 side_effect=fake_deploy,
             ),
             patch(
-                "control_plane.workflows.generic_web_promotion.wait_for_healthcheck_with_retry",
+                "control_plane.workflows.generic_web_promotion._wait_for_healthcheck",
+                return_value=None,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_promotion.wait_for_runtime_identity_healthcheck_with_retry",
                 return_value=HealthcheckPass(
                     payload={"runtime_identity": observed_identity.model_dump(mode="json")}
                 ),
@@ -677,6 +686,10 @@ class GenericWebProdPromotionTests(unittest.TestCase):
         self.assertEqual(result.destination_health_status, "fail")
         self.assertIn("Runtime identity mismatched fields", result.error_message)
         self.assertNotIn(("sellyouroutboard-testing", "prod"), store.inventories)
+        promotion = next(iter(store.promotions.values()))
+        self.assertEqual(promotion.destination_health.status, "fail")
+        self.assertEqual(promotion.destination_health.runtime_identity_status, "mismatch")
+        self.assertEqual(promotion.destination_health.observed_runtime_identity, observed_identity)
 
     def test_execute_rejects_stale_source_inventory(self) -> None:
         store = _GenericWebPromotionStore(_profile())

--- a/tests/test_runtime_identity.py
+++ b/tests/test_runtime_identity.py
@@ -102,6 +102,25 @@ class RuntimeIdentityTests(unittest.TestCase):
         self.assertIn("did not return JSON", detail)
         self.assertIsNone(observed)
 
+    def test_health_payload_runtime_identity_status_marks_invalid_identity_malformed(self) -> None:
+        expected = RuntimeIdentity(
+            product="sellyouroutboard",
+            context="sellyouroutboard-testing",
+            instance="testing",
+            deployment_record_id="deployment-123",
+            artifact_id="artifact-a",
+            source_git_ref="abc123",
+        )
+
+        status, detail, observed = health_payload_runtime_identity_status(
+            expected=expected,
+            payload={"runtime_identity": {"deployment_record_id": "deployment-123"}},
+        )
+
+        self.assertEqual(status, "malformed")
+        self.assertIn("could not be parsed", detail)
+        self.assertIsNone(observed)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_runtime_identity_health.py
+++ b/tests/test_runtime_identity_health.py
@@ -78,6 +78,62 @@ class RuntimeIdentityHealthTests(unittest.TestCase):
         self.assertEqual(result.payload, {"status": "ok"})
         self.assertEqual(seen_calls, [("https://example.com/health", 30)])
 
+    def test_wait_for_healthcheck_retries_unparseable_json(self) -> None:
+        attempts = iter(
+            (
+                HealthcheckPass(json_parse_failed=True),
+                HealthcheckPass(payload={"status": "ok"}),
+            )
+        )
+        sleeps: list[float] = []
+
+        result = wait_for_healthcheck_with_retry(
+            url="https://example.com/health",
+            timeout_seconds=30,
+            sleep=sleeps.append,
+            monotonic=lambda: 0,
+            wait_once=lambda **_kwargs: next(attempts),
+        )
+
+        self.assertEqual(result.payload, {"status": "ok"})
+        self.assertEqual(sleeps, [1])
+
+    def test_wait_for_runtime_identity_healthcheck_retries_until_identity_parseable(
+        self,
+    ) -> None:
+        identity = RuntimeIdentity(
+            product="sellyouroutboard",
+            context="sellyouroutboard-testing",
+            instance="testing",
+            deployment_record_id="deployment-123",
+            artifact_id="artifact-a",
+            source_git_ref="abc123",
+        )
+        attempts = iter(
+            (
+                HealthcheckPass(payload={"status": "ok"}),
+                HealthcheckPass(payload={"runtime_identity": {"deployment_record_id": "deployment-123"}}),
+                HealthcheckPass(payload={"runtime_identity": identity.model_dump(mode="json")}),
+            )
+        )
+        sleeps: list[float] = []
+
+        from control_plane.workflows.runtime_identity_health import (
+            wait_for_runtime_identity_healthcheck_with_retry,
+        )
+
+        result = wait_for_runtime_identity_healthcheck_with_retry(
+            url="https://example.com/health",
+            timeout_seconds=30,
+            expected_runtime_identity=identity,
+            sleep=sleeps.append,
+            monotonic=lambda: 0,
+            wait_once=lambda **_kwargs: next(attempts),
+        )
+
+        self.assertEqual(result.payload, {"runtime_identity": identity.model_dump(mode="json")})
+        self.assertEqual(sleeps, [1, 1])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- classify malformed runtime identity payloads separately from missing identity
- retry runtime identity health polling until identity evidence is parseable or terminally mismatched
- preserve runtime identity evidence/details when promotion health fails after deploy

## Validation

- `uv run python -m unittest tests.test_runtime_identity tests.test_runtime_identity_health tests.test_generic_web_promotion`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m py_compile control_plane/contracts/runtime_identity.py control_plane/workflows/runtime_identity_health.py control_plane/workflows/generic_web_promotion.py`
- `git diff --check`
- `uv run python -m unittest` (`1293` tests)
- JetBrains changed-file inspection was retried twice and reported `0` problems, but the plugin marked both captures incomplete.
