### PR TITLE
Add durable Odoo target replacement operations

### DIFF
--- a/.github/workflows/odoo-target-replacement-apply.yml
+++ b/.github/workflows/odoo-target-replacement-apply.yml
@@ -120,6 +120,8 @@ jobs:
       HEALTH_TIMEOUT_SECONDS: ${{ inputs.health_timeout_seconds }}
       LAUNCHPLANE_SERVICE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
       LAUNCHPLANE_SERVICE_AUDIENCE: launchplane.shinycomputers.com
+      POLL_INTERVAL_SECONDS: "15"
+      POLL_TIMEOUT_SECONDS: "3600"
     steps:
       - name: Validate runtime inputs
         shell: bash
@@ -151,7 +153,7 @@ jobs:
             exit 1
           fi
 
-      - name: Apply replacement
+      - name: Create and poll replacement operation
         shell: bash
         run: |
           set -euo pipefail
@@ -237,18 +239,103 @@ jobs:
           })"
           jq . odoo-target-replacement-apply.json
           if [ "$status_code" != "202" ]; then
-            echo \
-              "Odoo target replacement apply failed: ${status_code}." \
-              >&2
+            echo 'Odoo target replacement operation create failed:' \
+              "${status_code}." >&2
+            cat odoo-target-replacement-apply.json >&2
             exit 1
           fi
-          deploy_status="$(jq -r '.result.deploy_status // ""' odoo-target-replacement-apply.json)"
-          post_deploy_status="$(jq -r '.result.post_deploy_status // ""' odoo-target-replacement-apply.json)"
-          if [ "$deploy_status" != "pass" ] || [ "$post_deploy_status" != "pass" ]; then
-            echo \
-              "Odoo target replacement apply did not pass: deploy=${deploy_status} post_deploy=${post_deploy_status}." \
-              >&2
-            jq -r '.result.error_message // ""' odoo-target-replacement-apply.json >&2
+          poll_url="$(
+            jq -r \
+              '.result.poll_url // empty' \
+              odoo-target-replacement-apply.json
+          )"
+          operation_id="$({
+            jq -r \
+              '.records.odoo_stable_target_replacement_operation_id //
+               .result.operation_id //
+               empty' \
+              odoo-target-replacement-apply.json
+          })"
+          if [ -z "$poll_url" ] || [ -z "$operation_id" ]; then
+            echo 'Odoo target replacement response missing poll metadata.' >&2
+            jq . odoo-target-replacement-apply.json >&2
+            exit 1
+          fi
+          deadline=$((SECONDS + POLL_TIMEOUT_SECONDS))
+          while true; do
+            status_code="$({
+              curl -sS \
+                -o odoo-target-replacement-apply.json \
+                -w '%{http_code}' \
+                -H "Authorization: Bearer ${oidc_token}" \
+                "${LAUNCHPLANE_SERVICE_URL}${poll_url}"
+            })"
+            if [ "$status_code" != "200" ]; then
+              echo 'Odoo target replacement operation poll failed:' \
+                "${status_code}." >&2
+              cat odoo-target-replacement-apply.json >&2
+              exit 1
+            fi
+            operation_status="$(
+              jq -r \
+                '.operation.status // empty' \
+                odoo-target-replacement-apply.json
+            )"
+            operation_phase="$(
+              jq -r \
+                '.operation.phase // empty' \
+                odoo-target-replacement-apply.json
+            )"
+            echo 'Odoo target replacement operation:' \
+              "status=${operation_status} phase=${operation_phase}"
+            if [ "$operation_status" = "pass" ] || \
+              [ "$operation_status" = "fail" ]; then
+              break
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo 'Launchplane Odoo target replacement operation' \
+                "${operation_id} timed out while polling." >&2
+              jq . odoo-target-replacement-apply.json >&2
+              exit 1
+            fi
+            sleep "$POLL_INTERVAL_SECONDS"
+          done
+          jq . odoo-target-replacement-apply.json
+          operation_status="$(
+            jq -r '.operation.status // ""' odoo-target-replacement-apply.json
+          )"
+          deploy_status="$(
+            jq -r \
+              '.operation.result.deploy_status //
+               .result.deploy_status //
+               ""' \
+              odoo-target-replacement-apply.json
+          )"
+          post_deploy_status="$(
+            jq -r \
+              '.operation.result.post_deploy_status //
+               .result.post_deploy_status //
+               ""' \
+              odoo-target-replacement-apply.json
+          )"
+          if [ "$operation_status" != "pass" ]; then
+            echo 'Odoo target replacement operation did not pass:' \
+              "status=${operation_status}." >&2
+            jq -r \
+              '.operation.error_message // .result.error_message // ""' \
+              odoo-target-replacement-apply.json >&2
+            exit 1
+          fi
+          if [ "$deploy_status" != "pass" ] || \
+            [ "$post_deploy_status" != "pass" ]; then
+            echo 'Odoo target replacement apply did not pass:' \
+              "deploy=${deploy_status}" \
+              "post_deploy=${post_deploy_status}." >&2
+            jq -r \
+              '.operation.result.error_message //
+               .result.error_message //
+               ""' \
+              odoo-target-replacement-apply.json >&2
             exit 1
           fi
 

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -190,8 +190,10 @@ from control_plane.workflows.odoo_prod_rollback import (
     OdooProdRollbackRequest,
     execute_odoo_prod_rollback,
 )
-from control_plane.workflows.odoo_stable_target_replacement import (
+from control_plane.contracts.odoo_stable_target_replacement import (
     OdooStableTargetReplacementRequest,
+)
+from control_plane.workflows.odoo_stable_target_replacement import (
     build_odoo_stable_target_replacement_plan,
 )
 from control_plane.workflows.promote import (

--- a/control_plane/contracts/odoo_stable_target_replacement.py
+++ b/control_plane/contracts/odoo_stable_target_replacement.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.workflows.odoo_verification import OdooVerificationEvidence
+
+
+class OdooStableTargetReplacementRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    instance: str
+    strategy: Literal["recreate-in-place", "replace-and-cutover"] = "recreate-in-place"
+    allow_empty_data: bool = False
+    data_source_mode: Literal["existing", "empty", "upstream_restore"] = "existing"
+    confirmation: str = ""
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "OdooStableTargetReplacementRequest":
+        self.product = self.product.strip()
+        self.instance = self.instance.strip().lower()
+        self.confirmation = self.confirmation.strip().lower()
+        if not self.product:
+            raise ValueError("Odoo stable target replacement requires product.")
+        if not self.instance:
+            raise ValueError("Odoo stable target replacement requires instance.")
+        return self
+
+
+class OdooStableTargetReplacementApplyRequest(OdooStableTargetReplacementRequest):
+    artifact_id: str = ""
+    source_git_ref: str = ""
+    verify_health: bool = True
+    verify_canonical: bool = True
+    verify_logo: bool = True
+    no_cache: bool = False
+    timeout_seconds: int | None = Field(default=None, ge=1)
+    health_timeout_seconds: int | None = Field(default=None, ge=1)
+
+    @model_validator(mode="after")
+    def _validate_apply_request(self) -> "OdooStableTargetReplacementApplyRequest":
+        self.artifact_id = self.artifact_id.strip()
+        self.source_git_ref = self.source_git_ref.strip()
+        if self.strategy != "recreate-in-place":
+            raise ValueError(
+                "Odoo target replacement apply currently supports recreate-in-place only."
+            )
+        if bool(self.artifact_id) != bool(self.source_git_ref):
+            raise ValueError(
+                "Odoo target replacement apply requires artifact_id and source_git_ref together."
+            )
+        return self
+
+
+class OdooStableTargetReplacementApplyResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    product: str
+    context: str
+    instance: str
+    strategy: Literal["recreate-in-place"]
+    deployment_record_id: str = ""
+    deploy_status: Literal["pass", "fail"]
+    post_deploy_status: Literal["pass", "fail", "skipped"] = "skipped"
+    health_status: Literal["pass", "fail", "skipped"] = "skipped"
+    canonical_status: Literal["pass", "fail", "skipped"] = "skipped"
+    logo_status: Literal["pass", "fail", "skipped"] = "skipped"
+    health_url: str = ""
+    canonical_url: str = ""
+    logo_urls: tuple[str, ...] = ()
+    verification_evidence: OdooVerificationEvidence = Field(
+        default_factory=OdooVerificationEvidence
+    )
+    runtime_identity_injected: bool = False
+    target_id: str = ""
+    target_name: str = ""
+    artifact_id: str = ""
+    image_reference: str = ""
+    error_message: str = ""

--- a/control_plane/contracts/odoo_stable_target_replacement_operation.py
+++ b/control_plane/contracts/odoo_stable_target_replacement_operation.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.odoo_stable_target_replacement import (
+    OdooStableTargetReplacementApplyRequest,
+    OdooStableTargetReplacementApplyResult,
+)
+
+OdooStableTargetReplacementOperationStatus = Literal["pending", "running", "pass", "fail"]
+OdooStableTargetReplacementOperationPhase = Literal[
+    "created",
+    "running",
+    "plan",
+    "apply",
+    "post_deploy",
+    "verification",
+    "completed",
+    "failed",
+]
+
+_TERMINAL_OPERATION_STATUSES: tuple[OdooStableTargetReplacementOperationStatus, ...] = (
+    "pass",
+    "fail",
+)
+ODOO_STABLE_TARGET_REPLACEMENT_TERMINAL_OPERATION_STATUSES: frozenset[
+    OdooStableTargetReplacementOperationStatus
+] = frozenset(_TERMINAL_OPERATION_STATUSES)
+
+
+class OdooStableTargetReplacementOperationRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    operation_id: str
+    product: str
+    context: str
+    instance: str
+    idempotency_key: str
+    request_fingerprint: str
+    request: OdooStableTargetReplacementApplyRequest
+    status: OdooStableTargetReplacementOperationStatus = "pending"
+    phase: OdooStableTargetReplacementOperationPhase = "created"
+    deployment_record_id: str = ""
+    created_at: str
+    updated_at: str
+    started_at: str = ""
+    finished_at: str = ""
+    result: OdooStableTargetReplacementApplyResult | None = None
+    error_message: str = ""
+    runner_trace_id: str = ""
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "OdooStableTargetReplacementOperationRecord":
+        self.operation_id = _normalize_required(
+            self.operation_id, "Odoo stable target replacement operation requires operation_id."
+        )
+        self.product = _normalize_required(
+            self.product, "Odoo stable target replacement operation requires product."
+        )
+        self.context = _normalize_required(
+            self.context, "Odoo stable target replacement operation requires context."
+        ).lower()
+        self.instance = _normalize_required(
+            self.instance, "Odoo stable target replacement operation requires instance."
+        ).lower()
+        self.idempotency_key = _normalize_required(
+            self.idempotency_key,
+            "Odoo stable target replacement operation requires idempotency_key.",
+        )
+        self.request_fingerprint = _normalize_required(
+            self.request_fingerprint,
+            "Odoo stable target replacement operation requires request_fingerprint.",
+        )
+        self.created_at = _normalize_required(
+            self.created_at, "Odoo stable target replacement operation requires created_at."
+        )
+        self.updated_at = _normalize_required(
+            self.updated_at, "Odoo stable target replacement operation requires updated_at."
+        )
+        self.started_at = self.started_at.strip()
+        self.finished_at = self.finished_at.strip()
+        self.deployment_record_id = self.deployment_record_id.strip()
+        self.error_message = self.error_message.strip()
+        self.runner_trace_id = self.runner_trace_id.strip()
+        if self.product != self.request.product:
+            raise ValueError("Odoo stable target replacement operation product must match request.")
+        if self.instance != self.request.instance:
+            raise ValueError(
+                "Odoo stable target replacement operation instance must match request."
+            )
+        if self.status in ODOO_STABLE_TARGET_REPLACEMENT_TERMINAL_OPERATION_STATUSES:
+            if not self.finished_at:
+                raise ValueError(
+                    "Terminal Odoo stable target replacement operations require finished_at."
+                )
+            if self.status == "pass" and self.error_message:
+                raise ValueError(
+                    "Passing Odoo stable target replacement operations must not include error_message."
+                )
+            if self.status == "fail" and not self.error_message:
+                raise ValueError(
+                    "Failed Odoo stable target replacement operations require error_message."
+                )
+        return self
+
+
+def build_odoo_stable_target_replacement_operation_id(
+    *, product: str, context: str, instance: str, created_at: str
+) -> str:
+    normalized_product = product.strip().lower().replace("/", "-")
+    normalized_context = context.strip().lower()
+    normalized_instance = instance.strip().lower()
+    normalized_created_at = created_at.strip().replace(":", "").replace("+", "z")
+    digest = hashlib.sha256(
+        "|".join(
+            (
+                normalized_product,
+                normalized_context,
+                normalized_instance,
+                normalized_created_at,
+            )
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+    return (
+        "odoo-target-replacement-"
+        f"{normalized_context}-{normalized_instance}-{normalized_created_at}-{digest}"
+    )
+
+
+def odoo_stable_target_replacement_operation_is_terminal(
+    record: OdooStableTargetReplacementOperationRecord,
+) -> bool:
+    return record.status in ODOO_STABLE_TARGET_REPLACEMENT_TERMINAL_OPERATION_STATUSES
+
+
+def _normalize_required(value: str, message: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(message)
+    return normalized

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -113,6 +113,16 @@ from control_plane.contracts.odoo_stable_bootstrap_operation import (
     build_odoo_stable_bootstrap_operation_id,
     odoo_stable_bootstrap_operation_is_terminal,
 )
+from control_plane.contracts.odoo_stable_target_replacement import (
+    OdooStableTargetReplacementApplyRequest,
+    OdooStableTargetReplacementApplyResult,
+    OdooStableTargetReplacementRequest,
+)
+from control_plane.contracts.odoo_stable_target_replacement_operation import (
+    OdooStableTargetReplacementOperationRecord,
+    build_odoo_stable_target_replacement_operation_id,
+    odoo_stable_target_replacement_operation_is_terminal,
+)
 from control_plane.contracts.preview_mutation_request import (
     PreviewDestroyMutationRequest,
     PreviewGenerationMutationRequest,
@@ -311,9 +321,7 @@ from control_plane.workflows.odoo_prod_rollback import (
     execute_odoo_prod_rollback,
 )
 from control_plane.workflows.odoo_stable_target_replacement import (
-    OdooStableTargetReplacementApplyRequest,
     OdooStableTargetReplacementStore,
-    OdooStableTargetReplacementRequest,
     build_odoo_stable_target_replacement_plan,
     execute_odoo_stable_target_replacement_apply,
 )
@@ -581,6 +589,27 @@ class _OdooStableBootstrapOperationStore(Protocol):
         statuses: tuple[str, ...] = (),
         limit: int | None = None,
     ) -> tuple[OdooStableBootstrapOperationRecord, ...]: ...
+
+
+class _OdooStableTargetReplacementOperationStore(Protocol):
+    def write_odoo_stable_target_replacement_operation_record(
+        self, record: OdooStableTargetReplacementOperationRecord
+    ) -> object: ...
+
+    def read_odoo_stable_target_replacement_operation_record(
+        self, operation_id: str
+    ) -> OdooStableTargetReplacementOperationRecord: ...
+
+    def list_odoo_stable_target_replacement_operation_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        idempotency_key: str = "",
+        statuses: tuple[str, ...] = (),
+        limit: int | None = None,
+    ) -> tuple[OdooStableTargetReplacementOperationRecord, ...]: ...
 
 
 _StartResponse = Callable[[str, list[tuple[str, str]]], None]
@@ -1730,6 +1759,7 @@ _HUMAN_IDENTITY_READ_MODEL_POST_ROUTES = frozenset({"/v1/work-graph/rank"})
 _NON_IDEMPOTENT_DRIVER_RESULT_ROUTES = frozenset(
     {
         _ODOO_STABLE_BOOTSTRAP_ROUTE.route_path,
+        _ODOO_TARGET_REPLACEMENT_APPLY_ROUTE.route_path,
         _VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path,
         _VERIREEL_RUNTIME_VERIFICATION_ROUTE.route_path,
         _VERIREEL_PREVIEW_INVENTORY_ROUTE.route_path,
@@ -2275,6 +2305,12 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         and segments[4] == "operations"
     ):
         return "odoo_stable_bootstrap.execute", {"operation_id": segments[5]}
+    if (
+        len(segments) == 6
+        and segments[:4] == ["v1", "drivers", "odoo", "target-replacement"]
+        and segments[4] == "operations"
+    ):
+        return "odoo_target_replacement_apply.execute", {"operation_id": segments[5]}
     if len(segments) == 4 and segments[:2] == ["v1", "contexts"] and segments[3] == "driver-view":
         return "driver.read", {"context": segments[2]}
     if (
@@ -2488,7 +2524,9 @@ def _write_odoo_config_parameter_override(
         apply_on=apply_on,
         config_parameters=tuple(config_parameters[key] for key in sorted(config_parameters)),
         addon_settings=addon_settings,
-        website_bootstrap=existing_record.website_bootstrap if existing_record is not None else None,
+        website_bootstrap=existing_record.website_bootstrap
+        if existing_record is not None
+        else None,
         updated_at=_utc_now_timestamp(),
         source_label=request.source_label,
     )
@@ -4120,6 +4158,7 @@ def _accepted_payload(
                 "merge_train_stack_collapse_plan_record_id",
                 "merge_train_run_id",
                 "odoo_stable_bootstrap_operation_id",
+                "odoo_stable_target_replacement_operation_id",
             }
         },
         **({"result": serialized_driver_result} if serialized_driver_result else {}),
@@ -4142,6 +4181,18 @@ def _odoo_stable_bootstrap_operation_poll_url(operation_id: str) -> str:
     return f"/v1/drivers/odoo/stable-bootstrap/operations/{operation_id.strip()}"
 
 
+def _target_replacement_operation_payload(
+    operation: OdooStableTargetReplacementOperationRecord,
+) -> dict[str, object]:
+    payload = operation.model_dump(mode="json")
+    payload["poll_url"] = _odoo_stable_target_replacement_operation_poll_url(operation.operation_id)
+    return payload
+
+
+def _odoo_stable_target_replacement_operation_poll_url(operation_id: str) -> str:
+    return f"/v1/drivers/odoo/target-replacement/operations/{operation_id.strip()}"
+
+
 def _odoo_stable_bootstrap_operation_store(
     record_store: object,
 ) -> _OdooStableBootstrapOperationStore:
@@ -4154,6 +4205,21 @@ def _odoo_stable_bootstrap_operation_store(
         return cast(_OdooStableBootstrapOperationStore, record_store)
     raise click.ClickException(
         "Odoo stable bootstrap operations require Launchplane operation-record storage."
+    )
+
+
+def _odoo_stable_target_replacement_operation_store(
+    record_store: object,
+) -> _OdooStableTargetReplacementOperationStore:
+    required_methods = (
+        "write_odoo_stable_target_replacement_operation_record",
+        "read_odoo_stable_target_replacement_operation_record",
+        "list_odoo_stable_target_replacement_operation_records",
+    )
+    if all(hasattr(record_store, method_name) for method_name in required_methods):
+        return cast(_OdooStableTargetReplacementOperationStore, record_store)
+    raise click.ClickException(
+        "Odoo stable target replacement operations require Launchplane operation-record storage."
     )
 
 
@@ -4177,6 +4243,35 @@ def _find_active_odoo_stable_bootstrap_operation(
     instance: str,
 ) -> OdooStableBootstrapOperationRecord | None:
     records = operation_store.list_odoo_stable_bootstrap_operation_records(
+        product=product,
+        context_name=context,
+        instance_name=instance,
+        statuses=("pending", "running"),
+        limit=1,
+    )
+    return records[0] if records else None
+
+
+def _find_odoo_stable_target_replacement_operation_by_idempotency_key(
+    *,
+    operation_store: _OdooStableTargetReplacementOperationStore,
+    idempotency_key: str,
+) -> OdooStableTargetReplacementOperationRecord | None:
+    records = operation_store.list_odoo_stable_target_replacement_operation_records(
+        idempotency_key=idempotency_key,
+        limit=1,
+    )
+    return records[0] if records else None
+
+
+def _find_active_odoo_stable_target_replacement_operation(
+    *,
+    operation_store: _OdooStableTargetReplacementOperationStore,
+    product: str,
+    context: str,
+    instance: str,
+) -> OdooStableTargetReplacementOperationRecord | None:
+    records = operation_store.list_odoo_stable_target_replacement_operation_records(
         product=product,
         context_name=context,
         instance_name=instance,
@@ -4213,6 +4308,34 @@ def _build_odoo_stable_bootstrap_operation_record(
     )
 
 
+def _build_odoo_stable_target_replacement_operation_record(
+    *,
+    replacement_request: OdooStableTargetReplacementApplyRequest,
+    context: str,
+    idempotency_key: str,
+    request_fingerprint: str,
+    created_at: str,
+) -> OdooStableTargetReplacementOperationRecord:
+    return OdooStableTargetReplacementOperationRecord(
+        operation_id=build_odoo_stable_target_replacement_operation_id(
+            product=replacement_request.product,
+            context=context,
+            instance=replacement_request.instance,
+            created_at=created_at,
+        ),
+        product=replacement_request.product,
+        context=context,
+        instance=replacement_request.instance,
+        idempotency_key=idempotency_key,
+        request_fingerprint=request_fingerprint,
+        request=replacement_request,
+        status="pending",
+        phase="created",
+        created_at=created_at,
+        updated_at=created_at,
+    )
+
+
 def _start_odoo_stable_bootstrap_operation_worker(
     *,
     operation_id: str,
@@ -4229,6 +4352,27 @@ def _start_odoo_stable_bootstrap_operation_worker(
             "trace_id": trace_id,
         },
         name=f"odoo-stable-bootstrap-{operation_id}",
+        daemon=True,
+    )
+    worker.start()
+
+
+def _start_odoo_stable_target_replacement_operation_worker(
+    *,
+    operation_id: str,
+    control_plane_root_path: Path,
+    record_store: object,
+    trace_id: str,
+) -> None:
+    worker = threading.Thread(
+        target=_run_odoo_stable_target_replacement_operation_worker,
+        kwargs={
+            "operation_id": operation_id,
+            "control_plane_root_path": control_plane_root_path,
+            "record_store": record_store,
+            "trace_id": trace_id,
+        },
+        name=f"odoo-target-replacement-{operation_id}",
         daemon=True,
     )
     worker.start()
@@ -4289,10 +4433,75 @@ def _run_odoo_stable_bootstrap_operation_worker(
             "updated_at": finished_at,
             "finished_at": finished_at,
             "result": result,
-            "error_message": "" if passed else (result.error_message or "Odoo stable bootstrap failed."),
+            "error_message": ""
+            if passed
+            else (result.error_message or "Odoo stable bootstrap failed."),
         }
     )
     operation_store.write_odoo_stable_bootstrap_operation_record(terminal_operation)
+
+
+def _run_odoo_stable_target_replacement_operation_worker(
+    *,
+    operation_id: str,
+    control_plane_root_path: Path,
+    record_store: object,
+    trace_id: str,
+) -> None:
+    operation_store = _odoo_stable_target_replacement_operation_store(record_store)
+    operation = operation_store.read_odoo_stable_target_replacement_operation_record(operation_id)
+    if odoo_stable_target_replacement_operation_is_terminal(operation):
+        return
+    started_at = _utc_now_timestamp()
+    running_operation = operation.model_copy(
+        update={
+            "status": "running",
+            "phase": "running",
+            "started_at": operation.started_at or started_at,
+            "updated_at": started_at,
+            "runner_trace_id": trace_id,
+        }
+    )
+    operation_store.write_odoo_stable_target_replacement_operation_record(running_operation)
+    try:
+        result = execute_odoo_stable_target_replacement_apply(
+            control_plane_root=control_plane_root_path,
+            record_store=cast(OdooStableTargetReplacementStore, record_store),
+            request=running_operation.request,
+        )
+    except Exception as error:
+        logging.exception(
+            "Odoo stable target replacement operation %s failed before producing a result.",
+            operation_id,
+        )
+        finished_at = _utc_now_timestamp()
+        failed_operation = running_operation.model_copy(
+            update={
+                "status": "fail",
+                "phase": "failed",
+                "updated_at": finished_at,
+                "finished_at": finished_at,
+                "error_message": str(error),
+            }
+        )
+        operation_store.write_odoo_stable_target_replacement_operation_record(failed_operation)
+        return
+    finished_at = _utc_now_timestamp()
+    passed = _odoo_stable_target_replacement_operation_result_passed(result)
+    terminal_operation = running_operation.model_copy(
+        update={
+            "status": "pass" if passed else "fail",
+            "phase": "completed" if passed else "failed",
+            "deployment_record_id": result.deployment_record_id,
+            "updated_at": finished_at,
+            "finished_at": finished_at,
+            "result": result,
+            "error_message": ""
+            if passed
+            else (result.error_message or "Odoo stable target replacement failed."),
+        }
+    )
+    operation_store.write_odoo_stable_target_replacement_operation_record(terminal_operation)
 
 
 def _odoo_stable_bootstrap_operation_result_passed(
@@ -4300,6 +4509,18 @@ def _odoo_stable_bootstrap_operation_result_passed(
 ) -> bool:
     return (
         result.bootstrap_status == "pass"
+        and result.post_deploy_status == "pass"
+        and result.health_status != "fail"
+        and result.canonical_status != "fail"
+        and result.logo_status != "fail"
+    )
+
+
+def _odoo_stable_target_replacement_operation_result_passed(
+    result: OdooStableTargetReplacementApplyResult,
+) -> bool:
+    return (
+        result.deploy_status == "pass"
         and result.post_deploy_status == "pass"
         and result.health_status != "fail"
         and result.canonical_status != "fail"
@@ -6382,9 +6603,7 @@ def create_launchplane_service_app(
 
         original_start_response = start_response
 
-        def start_response_with_session_cookie(
-            status: str, headers: list[tuple[str, str]]
-        ) -> None:
+        def start_response_with_session_cookie(status: str, headers: list[tuple[str, str]]) -> None:
             response_headers = list(headers)
             if session_manager is not None and renewed_session is not None:
                 response_headers.append(
@@ -6760,6 +6979,55 @@ def create_launchplane_service_app(
                             **(
                                 {"result": operation.result.model_dump(mode="json")}
                                 if operation.result is not None
+                                else {}
+                            ),
+                        },
+                    )
+                if action == "odoo_target_replacement_apply.execute":
+                    replacement_operation_id = params["operation_id"]
+                    replacement_operation_store = _odoo_stable_target_replacement_operation_store(
+                        record_store
+                    )
+                    try:
+                        replacement_operation = replacement_operation_store.read_odoo_stable_target_replacement_operation_record(
+                            replacement_operation_id
+                        )
+                    except FileNotFoundError:
+                        return _not_found_response(
+                            start_response=start_response,
+                            trace_id=request_trace_id,
+                            path=path,
+                        )
+                    if not authz_policy.allows(
+                        identity=identity,
+                        action=action,
+                        product=replacement_operation.product,
+                        context=replacement_operation.context,
+                    ):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=403,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "authorization_denied",
+                                    "message": "Workflow cannot read Odoo target replacement operation status for the requested product/context.",
+                                },
+                            },
+                        )
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=200,
+                        payload={
+                            "status": "ok",
+                            "trace_id": request_trace_id,
+                            "operation": _target_replacement_operation_payload(
+                                replacement_operation
+                            ),
+                            **(
+                                {"result": replacement_operation.result.model_dump(mode="json")}
+                                if replacement_operation.result is not None
                                 else {}
                             ),
                         },
@@ -10540,23 +10808,100 @@ def create_launchplane_service_app(
                 )
                 if authorization_response is not None:
                     return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
+                if not request_idempotency_key:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=400,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "idempotency_key_required",
+                                "message": "Odoo target replacement operations require an Idempotency-Key header.",
+                            },
+                        },
+                    )
+                replacement_operation_store = _odoo_stable_target_replacement_operation_store(
+                    record_store
                 )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = execute_odoo_stable_target_replacement_apply(
-                    control_plane_root=resolved_root,
-                    record_store=cast(OdooStableTargetReplacementStore, record_store),
-                    request=odoo_replacement_apply_request.replacement,
+                existing_replacement_operation = (
+                    _find_odoo_stable_target_replacement_operation_by_idempotency_key(
+                        operation_store=replacement_operation_store,
+                        idempotency_key=request_idempotency_key,
+                    )
                 )
-                result = {"deployment_record_id": driver_result.deployment_record_id}
+                if existing_replacement_operation is not None:
+                    if existing_replacement_operation.request_fingerprint != request_fingerprint:
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=409,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "idempotency_key_reused",
+                                    "message": "Idempotency-Key was already used for a different Odoo target replacement request.",
+                                },
+                            },
+                        )
+                    driver_result = _target_replacement_operation_payload(
+                        existing_replacement_operation
+                    )
+                    result = {
+                        "odoo_stable_target_replacement_operation_id": existing_replacement_operation.operation_id,
+                        **(
+                            {
+                                "deployment_record_id": existing_replacement_operation.deployment_record_id
+                            }
+                            if existing_replacement_operation.deployment_record_id
+                            else {}
+                        ),
+                    }
+                else:
+                    active_replacement_operation = (
+                        _find_active_odoo_stable_target_replacement_operation(
+                            operation_store=replacement_operation_store,
+                            product=odoo_replacement_apply_request.product,
+                            context=replacement_apply_lane.context,
+                            instance=odoo_replacement_apply_request.replacement.instance,
+                        )
+                    )
+                    if active_replacement_operation is not None:
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=409,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "odoo_stable_target_replacement_operation_active",
+                                    "message": "An Odoo target replacement operation is already active for this product/context/instance.",
+                                },
+                                "operation": _target_replacement_operation_payload(
+                                    active_replacement_operation
+                                ),
+                            },
+                        )
+                    replacement_operation = _build_odoo_stable_target_replacement_operation_record(
+                        replacement_request=odoo_replacement_apply_request.replacement,
+                        context=replacement_apply_lane.context,
+                        idempotency_key=request_idempotency_key,
+                        request_fingerprint=request_fingerprint,
+                        created_at=_utc_now_timestamp(),
+                    )
+                    replacement_operation_store.write_odoo_stable_target_replacement_operation_record(
+                        replacement_operation
+                    )
+                    _start_odoo_stable_target_replacement_operation_worker(
+                        operation_id=replacement_operation.operation_id,
+                        control_plane_root_path=resolved_root,
+                        record_store=record_store,
+                        trace_id=request_trace_id,
+                    )
+                    driver_result = _target_replacement_operation_payload(replacement_operation)
+                    result = {
+                        "odoo_stable_target_replacement_operation_id": replacement_operation.operation_id
+                    }
             elif path == _VERIREEL_TESTING_DEPLOY_ROUTE.route_path:
                 verireel_testing_deploy_request = (
                     _VERIREEL_TESTING_DEPLOY_ROUTE.envelope_model.model_validate(payload)

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -28,6 +28,9 @@ from control_plane.contracts.odoo_instance_override_record import OdooInstanceOv
 from control_plane.contracts.odoo_stable_bootstrap_operation import (
     OdooStableBootstrapOperationRecord,
 )
+from control_plane.contracts.odoo_stable_target_replacement_operation import (
+    OdooStableTargetReplacementOperationRecord,
+)
 from control_plane.contracts.preview_enablement_record import PreviewEnablementRecord
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
@@ -553,9 +556,7 @@ class FilesystemRecordStore:
     def write_odoo_stable_bootstrap_operation_record(
         self, record: OdooStableBootstrapOperationRecord
     ) -> Path:
-        return self._write_model(
-            "odoo_stable_bootstrap_operations", record.operation_id, record
-        )
+        return self._write_model("odoo_stable_bootstrap_operations", record.operation_id, record)
 
     def read_odoo_stable_bootstrap_operation_record(
         self, operation_id: str
@@ -583,6 +584,51 @@ class FilesystemRecordStore:
             for record in self._list_models(
                 OdooStableBootstrapOperationRecord,
                 "odoo_stable_bootstrap_operations",
+            )
+            if (not product or record.product == product)
+            and (not context_name or record.context == context_name)
+            and (not instance_name or record.instance == instance_name)
+            and (not idempotency_key or record.idempotency_key == idempotency_key)
+            and (not statuses or record.status in statuses)
+        ]
+        records.sort(key=lambda record: (record.updated_at, record.operation_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def write_odoo_stable_target_replacement_operation_record(
+        self, record: OdooStableTargetReplacementOperationRecord
+    ) -> Path:
+        return self._write_model(
+            "odoo_stable_target_replacement_operations", record.operation_id, record
+        )
+
+    def read_odoo_stable_target_replacement_operation_record(
+        self, operation_id: str
+    ) -> OdooStableTargetReplacementOperationRecord:
+        return OdooStableTargetReplacementOperationRecord.model_validate(
+            self._read_model(
+                OdooStableTargetReplacementOperationRecord,
+                "odoo_stable_target_replacement_operations",
+                operation_id,
+            ).model_dump(mode="json")
+        )
+
+    def list_odoo_stable_target_replacement_operation_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        idempotency_key: str = "",
+        statuses: tuple[str, ...] = (),
+        limit: int | None = None,
+    ) -> tuple[OdooStableTargetReplacementOperationRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                OdooStableTargetReplacementOperationRecord,
+                "odoo_stable_target_replacement_operations",
             )
             if (not product or record.product == product)
             and (not context_name or record.context == context_name)

--- a/control_plane/storage/migrations/versions/f4a5b6c7d8e9_add_odoo_target_replacement_operations.py
+++ b/control_plane/storage/migrations/versions/f4a5b6c7d8e9_add_odoo_target_replacement_operations.py
@@ -1,0 +1,62 @@
+"""add Odoo target replacement operations
+
+Revision ID: f4a5b6c7d8e9
+Revises: e39f4a5b6c7d
+Create Date: 2026-05-17 17:05:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "f4a5b6c7d8e9"
+down_revision: str | None = "e39f4a5b6c7d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "launchplane_odoo_stable_target_replacement_operations",
+        sa.Column("operation_id", sa.String(), nullable=False),
+        sa.Column("product", sa.String(), nullable=False),
+        sa.Column("context", sa.String(), nullable=False),
+        sa.Column("instance", sa.String(), nullable=False),
+        sa.Column("idempotency_key", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("phase", sa.String(), nullable=False),
+        sa.Column("created_at", sa.String(), nullable=False),
+        sa.Column("updated_at", sa.String(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("operation_id"),
+    )
+    op.create_index(
+        "launchplane_odoo_replacement_operation_lane_status_idx",
+        "launchplane_odoo_stable_target_replacement_operations",
+        ["product", "context", "instance", "status", sa.text("updated_at DESC")],
+    )
+    op.create_index(
+        "launchplane_odoo_replacement_operation_idempotency_idx",
+        "launchplane_odoo_stable_target_replacement_operations",
+        ["idempotency_key", sa.text("updated_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "launchplane_odoo_replacement_operation_idempotency_idx",
+        table_name="launchplane_odoo_stable_target_replacement_operations",
+    )
+    op.drop_index(
+        "launchplane_odoo_replacement_operation_lane_status_idx",
+        table_name="launchplane_odoo_stable_target_replacement_operations",
+    )
+    op.drop_table("launchplane_odoo_stable_target_replacement_operations")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -50,6 +50,9 @@ from control_plane.contracts.odoo_instance_override_record import OdooInstanceOv
 from control_plane.contracts.odoo_stable_bootstrap_operation import (
     OdooStableBootstrapOperationRecord,
 )
+from control_plane.contracts.odoo_stable_target_replacement_operation import (
+    OdooStableTargetReplacementOperationRecord,
+)
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
 from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
@@ -752,6 +755,36 @@ class LaunchplaneOdooStableBootstrapOperationRow(Base):
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
+class LaunchplaneOdooStableTargetReplacementOperationRow(Base):
+    __tablename__ = "launchplane_odoo_stable_target_replacement_operations"
+    __table_args__ = (
+        Index(
+            "launchplane_odoo_replacement_operation_lane_status_idx",
+            "product",
+            "context",
+            "instance",
+            "status",
+            desc("updated_at"),
+        ),
+        Index(
+            "launchplane_odoo_replacement_operation_idempotency_idx",
+            "idempotency_key",
+            desc("updated_at"),
+        ),
+    )
+
+    operation_id: Mapped[str] = mapped_column(String, primary_key=True)
+    product: Mapped[str] = mapped_column(String, nullable=False)
+    context: Mapped[str] = mapped_column(String, nullable=False)
+    instance: Mapped[str] = mapped_column(String, nullable=False)
+    idempotency_key: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    phase: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[str] = mapped_column(String, nullable=False)
+    updated_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
 class LaunchplaneHumanSessionRow(Base):
     __tablename__ = "launchplane_human_sessions"
     __table_args__ = (
@@ -1165,6 +1198,74 @@ class PostgresRecordStore(HumanSessionStore):
             order_by=(
                 LaunchplaneOdooStableBootstrapOperationRow.updated_at.desc(),
                 LaunchplaneOdooStableBootstrapOperationRow.operation_id.desc(),
+            ),
+            limit=limit,
+        )
+
+    def write_odoo_stable_target_replacement_operation_record(
+        self, record: OdooStableTargetReplacementOperationRecord
+    ) -> None:
+        self._write_row(
+            LaunchplaneOdooStableTargetReplacementOperationRow(
+                operation_id=record.operation_id,
+                product=record.product,
+                context=record.context,
+                instance=record.instance,
+                idempotency_key=record.idempotency_key,
+                status=record.status,
+                phase=record.phase,
+                created_at=record.created_at,
+                updated_at=record.updated_at,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def read_odoo_stable_target_replacement_operation_record(
+        self, operation_id: str
+    ) -> OdooStableTargetReplacementOperationRecord:
+        return self._read_model(
+            model_type=OdooStableTargetReplacementOperationRecord,
+            orm_model=LaunchplaneOdooStableTargetReplacementOperationRow,
+            filters=(
+                LaunchplaneOdooStableTargetReplacementOperationRow.operation_id == operation_id,
+            ),
+        )
+
+    def list_odoo_stable_target_replacement_operation_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        idempotency_key: str = "",
+        statuses: tuple[str, ...] = (),
+        limit: int | None = None,
+    ) -> tuple[OdooStableTargetReplacementOperationRecord, ...]:
+        filters: list[object] = []
+        if product:
+            filters.append(LaunchplaneOdooStableTargetReplacementOperationRow.product == product)
+        if context_name:
+            filters.append(
+                LaunchplaneOdooStableTargetReplacementOperationRow.context == context_name
+            )
+        if instance_name:
+            filters.append(
+                LaunchplaneOdooStableTargetReplacementOperationRow.instance == instance_name
+            )
+        if idempotency_key:
+            filters.append(
+                LaunchplaneOdooStableTargetReplacementOperationRow.idempotency_key
+                == idempotency_key
+            )
+        if statuses:
+            filters.append(LaunchplaneOdooStableTargetReplacementOperationRow.status.in_(statuses))
+        return self._list_models(
+            model_type=OdooStableTargetReplacementOperationRecord,
+            orm_model=LaunchplaneOdooStableTargetReplacementOperationRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneOdooStableTargetReplacementOperationRow.updated_at.desc(),
+                LaunchplaneOdooStableTargetReplacementOperationRow.operation_id.desc(),
             ),
             limit=limit,
         )
@@ -2796,6 +2897,7 @@ class PostgresRecordStore(HumanSessionStore):
             "merge_train_policies": 0,
             "merge_train_runs": 0,
             "odoo_stable_bootstrap_operations": 0,
+            "odoo_stable_target_replacement_operations": 0,
             "release_tuples": 0,
             "runtime_key_safety_policies": 0,
         }
@@ -2881,9 +2983,19 @@ class PostgresRecordStore(HumanSessionStore):
                 self.write_merge_train_policy_record(merge_train_policy_record)
                 counts["merge_train_policies"] += 1
         if hasattr(filesystem_store, "list_odoo_stable_bootstrap_operation_records"):
-            for operation_record in filesystem_store.list_odoo_stable_bootstrap_operation_records():
-                self.write_odoo_stable_bootstrap_operation_record(operation_record)
+            for (
+                bootstrap_operation_record
+            ) in filesystem_store.list_odoo_stable_bootstrap_operation_records():
+                self.write_odoo_stable_bootstrap_operation_record(bootstrap_operation_record)
                 counts["odoo_stable_bootstrap_operations"] += 1
+        if hasattr(filesystem_store, "list_odoo_stable_target_replacement_operation_records"):
+            for (
+                replacement_operation_record
+            ) in filesystem_store.list_odoo_stable_target_replacement_operation_records():
+                self.write_odoo_stable_target_replacement_operation_record(
+                    replacement_operation_record
+                )
+                counts["odoo_stable_target_replacement_operations"] += 1
         for release_tuple_record in filesystem_store.list_release_tuple_records():
             self.write_release_tuple_record(release_tuple_record)
             counts["release_tuples"] += 1

--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Literal, Protocol
 
 import click
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import runtime_environments as control_plane_runtime_environments
@@ -21,6 +21,11 @@ from control_plane.contracts.product_profile_record import (
 from control_plane.contracts.promotion_record import HealthcheckEvidence, PostDeployUpdateEvidence
 from control_plane.contracts.runtime_identity import RuntimeIdentity, runtime_identity_env
 from control_plane.contracts.ship_request import ShipRequest
+from control_plane.contracts.odoo_stable_target_replacement import (
+    OdooStableTargetReplacementApplyRequest,
+    OdooStableTargetReplacementApplyResult,
+    OdooStableTargetReplacementRequest,
+)
 from control_plane.dokploy import JsonObject, JsonValue
 from control_plane.workflows.inventory import build_environment_inventory
 from control_plane.workflows.odoo_post_deploy import OdooPostDeployRequest, execute_odoo_post_deploy
@@ -60,29 +65,6 @@ class OdooStableTargetReplacementStore(Protocol):
 
 DokployRequest = Callable[..., JsonValue]
 ODOO_STABLE_TARGET_REPLACEMENT_VERIFY_RETRY_INTERVAL_SECONDS = 5
-
-
-class OdooStableTargetReplacementRequest(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    product: str
-    instance: str
-    strategy: Literal["recreate-in-place", "replace-and-cutover"] = "recreate-in-place"
-    allow_empty_data: bool = False
-    data_source_mode: Literal["existing", "empty", "upstream_restore"] = "existing"
-    confirmation: str = ""
-
-    @model_validator(mode="after")
-    def _validate_request(self) -> "OdooStableTargetReplacementRequest":
-        self.product = self.product.strip()
-        self.instance = self.instance.strip().lower()
-        self.confirmation = self.confirmation.strip().lower()
-        if not self.product:
-            raise ValueError("Odoo stable target replacement requires product.")
-        if not self.instance:
-            raise ValueError("Odoo stable target replacement requires instance.")
-        return self
 
 
 class OdooStableTargetRuntimeSnapshot(BaseModel):
@@ -135,56 +117,6 @@ class OdooStableTargetReplacementPlan(BaseModel):
     blockers: tuple[str, ...] = ()
     warnings: tuple[str, ...] = ()
     steps: tuple[OdooStableTargetReplacementStep, ...] = ()
-
-
-class OdooStableTargetReplacementApplyRequest(OdooStableTargetReplacementRequest):
-    artifact_id: str = ""
-    source_git_ref: str = ""
-    verify_health: bool = True
-    verify_canonical: bool = True
-    verify_logo: bool = True
-    no_cache: bool = False
-    timeout_seconds: int | None = Field(default=None, ge=1)
-    health_timeout_seconds: int | None = Field(default=None, ge=1)
-
-    @model_validator(mode="after")
-    def _validate_apply_request(self) -> "OdooStableTargetReplacementApplyRequest":
-        self.artifact_id = self.artifact_id.strip()
-        self.source_git_ref = self.source_git_ref.strip()
-        if self.strategy != "recreate-in-place":
-            raise ValueError(
-                "Odoo target replacement apply currently supports recreate-in-place only."
-            )
-        if bool(self.artifact_id) != bool(self.source_git_ref):
-            raise ValueError(
-                "Odoo target replacement apply requires artifact_id and source_git_ref together."
-            )
-        return self
-
-
-class OdooStableTargetReplacementApplyResult(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    product: str
-    context: str
-    instance: str
-    strategy: Literal["recreate-in-place"]
-    deployment_record_id: str = ""
-    deploy_status: Literal["pass", "fail"]
-    post_deploy_status: Literal["pass", "fail", "skipped"] = "skipped"
-    health_status: Literal["pass", "fail", "skipped"] = "skipped"
-    canonical_status: Literal["pass", "fail", "skipped"] = "skipped"
-    logo_status: Literal["pass", "fail", "skipped"] = "skipped"
-    health_url: str = ""
-    canonical_url: str = ""
-    logo_urls: tuple[str, ...] = ()
-    verification_evidence: OdooVerificationEvidence = Field(default_factory=OdooVerificationEvidence)
-    runtime_identity_injected: bool = False
-    target_id: str = ""
-    target_name: str = ""
-    artifact_id: str = ""
-    image_reference: str = ""
-    error_message: str = ""
 
 
 class _ApplyResultBase(BaseModel):
@@ -611,9 +543,7 @@ def build_odoo_stable_target_replacement_plan(
         blockers.append("Odoo stable replacement currently requires a compose target.")
     approval_issue_url = ""
     if request.data_source_mode != "existing" and not request.allow_empty_data:
-        blockers.append(
-            "Odoo prelaunch rebuild requests must explicitly set allow_empty_data."
-        )
+        blockers.append("Odoo prelaunch rebuild requests must explicitly set allow_empty_data.")
     if isinstance(target_record, DokployTargetRecord) and isinstance(
         target_id_record, DokployTargetIdRecord
     ):

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -178,6 +178,10 @@ The POST route returns a durable operation record instead of holding the request
 open for the whole bootstrap. Callers poll
 `/v1/drivers/odoo/stable-bootstrap/operations/{operation_id}` and treat terminal
 `pass`/`fail` as the source of truth for workflow exit status and artifacts.
+Odoo target replacement apply uses the same durable operation shape for the
+guarded `recreate-in-place` path: `POST /v1/drivers/odoo/target-replacement-apply`
+creates or replays an operation, and callers poll
+`/v1/drivers/odoo/target-replacement/operations/{operation_id}` until terminal.
 
 Driver action routes are owned by the base driver contract. The service accepts
 any product key on Odoo and VeriReel action envelopes, then authorizes the call

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -738,9 +738,16 @@ or change routes.
 
 When a plan is `ready`, the trusted `Odoo Target Replacement Apply` workflow can
 call `POST /v1/drivers/odoo/target-replacement-apply` for the guarded
-`recreate-in-place` path. The first apply surface is testing-only and keeps the
-existing compose target, explicit Odoo volume env keys, and expected hostnames;
-it re-syncs the Launchplane-rendered compose source, reconciles each expected
+`recreate-in-place` path. The service creates a durable operation record and
+returns immediately; the workflow polls
+`GET /v1/drivers/odoo/target-replacement/operations/{operation_id}` until the
+operation status is `pass` or `fail`, then uploads the final operation payload as
+the workflow artifact. `Idempotency-Key` is required: a repeated request with the
+same key returns the existing operation, while a different key for the same
+product/context/instance is rejected while a `pending` or `running` operation is
+active. The first apply surface is testing-only and keeps the existing compose
+target, explicit Odoo volume env keys, and expected hostnames; the operation
+worker re-syncs the Launchplane-rendered compose source, reconciles each expected
 Dokploy compose domain route to the `web` service on the product runtime port,
 renders the matching Traefik router labels into the raw compose, injects the
 runtime identity breadcrumb, triggers Dokploy deploy, runs Odoo post-deploy,

--- a/docs/records.md
+++ b/docs/records.md
@@ -394,6 +394,15 @@ state/
   deployment-record id when available, final driver result, and terminal error.
   A `pending` or `running` record is the single-flight guard for that
   product/context/instance.
+- Odoo stable target replacement apply writes durable operation records under
+  `odoo_stable_target_replacement_operations`. These records mirror the stable
+  bootstrap operation boundary for the guarded `recreate-in-place` replacement
+  path: the service stores the apply request, `Idempotency-Key`, request
+  fingerprint, status/phase, deployment-record id when available, final apply
+  result, and terminal error. Reusing the same key with the same request replays
+  the existing operation; reusing it for a different request is rejected; an
+  active `pending` or `running` operation blocks another apply for the same
+  product/context/instance.
 - Odoo prod rollback writes a normal deployment record for the rollback deploy,
   refreshes prod inventory, mints the prod release tuple from the selected
   artifact manifest, and annotates the current prod promotion record's

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -447,6 +447,7 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             frozenset(
                 {
                     control_plane_service._ODOO_STABLE_BOOTSTRAP_ROUTE.route_path,
+                    control_plane_service._ODOO_TARGET_REPLACEMENT_APPLY_ROUTE.route_path,
                     control_plane_service._VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path,
                     control_plane_service._VERIREEL_RUNTIME_VERIFICATION_ROUTE.route_path,
                     control_plane_service._VERIREEL_PREVIEW_INVENTORY_ROUTE.route_path,

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -26,12 +26,14 @@ from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
     DeploymentEvidence,
 )
+from control_plane.contracts.odoo_stable_target_replacement import (
+    OdooStableTargetReplacementApplyRequest,
+    OdooStableTargetReplacementRequest,
+)
 from control_plane.dokploy import JsonValue
 from control_plane.workflows.odoo_post_deploy import OdooPostDeployResult
 from control_plane.workflows.odoo_stable_target_replacement import (
     DokployRequest,
-    OdooStableTargetReplacementApplyRequest,
-    OdooStableTargetReplacementRequest,
     build_odoo_stable_target_replacement_plan,
     execute_odoo_stable_target_replacement_apply,
 )
@@ -397,9 +399,7 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
 
     def test_build_plan_blocks_upstream_restore_disallowed_by_lane_data_policy(self) -> None:
         profile = _opw_profile_with_prelaunch_policy(enabled=True)
-        lane = profile.lanes[0].model_copy(
-            update={"odoo_data_policy": ProductOdooLaneDataPolicy()}
-        )
+        lane = profile.lanes[0].model_copy(update={"odoo_data_policy": ProductOdooLaneDataPolicy()})
         profile = profile.model_copy(update={"lanes": (lane,)})
         with (
             patch(

--- a/tests/test_odoo_stable_target_replacement_operation.py
+++ b/tests/test_odoo_stable_target_replacement_operation.py
@@ -1,0 +1,121 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from control_plane.contracts.odoo_stable_target_replacement_operation import (
+    OdooStableTargetReplacementOperationRecord,
+    build_odoo_stable_target_replacement_operation_id,
+)
+from control_plane.contracts.odoo_stable_target_replacement import (
+    OdooStableTargetReplacementApplyRequest,
+)
+from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.storage.postgres import PostgresRecordStore
+
+
+def _operation_payload(operation_id: str = "operation-cm-testing") -> dict[str, object]:
+    return {
+        "operation_id": operation_id,
+        "product": "odoo-tenant-cm",
+        "context": "cm",
+        "instance": "testing",
+        "idempotency_key": "replacement-cm-testing",
+        "request_fingerprint": "fingerprint-123",
+        "request": {
+            "schema_version": 1,
+            "product": "odoo-tenant-cm",
+            "instance": "testing",
+            "strategy": "recreate-in-place",
+            "confirmation": "recreate cm testing",
+            "data_source_mode": "empty",
+            "allow_empty_data": True,
+        },
+        "status": "pending",
+        "phase": "created",
+        "created_at": "2026-05-17T00:00:00Z",
+        "updated_at": "2026-05-17T00:00:00Z",
+    }
+
+
+class OdooStableTargetReplacementOperationRecordTests(unittest.TestCase):
+    def test_operation_record_round_trips(self) -> None:
+        record = OdooStableTargetReplacementOperationRecord.model_validate(_operation_payload())
+
+        self.assertEqual(record.product, "odoo-tenant-cm")
+        self.assertEqual(record.context, "cm")
+        self.assertIsInstance(record.request, OdooStableTargetReplacementApplyRequest)
+        self.assertEqual(record.request.confirmation, "recreate cm testing")
+
+    def test_operation_id_is_stable_for_same_inputs(self) -> None:
+        first = build_odoo_stable_target_replacement_operation_id(
+            product="odoo-tenant-cm",
+            context="cm",
+            instance="testing",
+            created_at="2026-05-17T00:00:00Z",
+        )
+        second = build_odoo_stable_target_replacement_operation_id(
+            product="odoo-tenant-cm",
+            context="cm",
+            instance="testing",
+            created_at="2026-05-17T00:00:00Z",
+        )
+
+        self.assertEqual(first, second)
+        self.assertTrue(first.startswith("odoo-target-replacement-cm-testing-"))
+
+    def test_filesystem_store_filters_operations(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name))
+            active = OdooStableTargetReplacementOperationRecord.model_validate(_operation_payload())
+            finished = OdooStableTargetReplacementOperationRecord.model_validate(
+                {
+                    **_operation_payload("operation-cm-testing-done"),
+                    "idempotency_key": "replacement-cm-testing-done",
+                    "status": "pass",
+                    "phase": "completed",
+                    "finished_at": "2026-05-17T00:05:00Z",
+                    "updated_at": "2026-05-17T00:05:00Z",
+                }
+            )
+
+            store.write_odoo_stable_target_replacement_operation_record(active)
+            store.write_odoo_stable_target_replacement_operation_record(finished)
+
+            loaded = store.read_odoo_stable_target_replacement_operation_record(active.operation_id)
+            active_records = store.list_odoo_stable_target_replacement_operation_records(
+                product="odoo-tenant-cm",
+                context_name="cm",
+                instance_name="testing",
+                statuses=("pending", "running"),
+            )
+
+            self.assertEqual(loaded.operation_id, active.operation_id)
+            self.assertEqual(
+                tuple(record.operation_id for record in active_records),
+                (active.operation_id,),
+            )
+
+    def test_postgres_store_round_trips_operation(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            store = PostgresRecordStore(database_url=f"sqlite:///{database_path}")
+            store.ensure_schema()
+            record = OdooStableTargetReplacementOperationRecord.model_validate(_operation_payload())
+
+            store.write_odoo_stable_target_replacement_operation_record(record)
+
+            loaded = store.read_odoo_stable_target_replacement_operation_record(record.operation_id)
+            active_records = store.list_odoo_stable_target_replacement_operation_records(
+                idempotency_key="replacement-cm-testing",
+                statuses=("pending",),
+            )
+
+            self.assertEqual(loaded.operation_id, record.operation_id)
+            self.assertEqual(
+                tuple(item.operation_id for item in active_records),
+                (record.operation_id,),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -67,6 +67,9 @@ from control_plane.contracts.odoo_instance_override_record import OdooOverrideVa
 from control_plane.contracts.odoo_stable_bootstrap_operation import (
     OdooStableBootstrapOperationRecord,
 )
+from control_plane.contracts.odoo_stable_target_replacement_operation import (
+    OdooStableTargetReplacementOperationRecord,
+)
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
 from control_plane.contracts.preview_generation_record import (
     PreviewGenerationRecord,
@@ -2347,6 +2350,29 @@ env_var = "GH_TOKEN"
                     }
                 )
             )
+            filesystem_store.write_odoo_stable_target_replacement_operation_record(
+                OdooStableTargetReplacementOperationRecord.model_validate(
+                    {
+                        "operation_id": "odoo-target-replacement-cm-testing-test",
+                        "product": "odoo-tenant-cm",
+                        "context": "cm",
+                        "instance": "testing",
+                        "idempotency_key": "replacement-cm-testing",
+                        "request_fingerprint": "fingerprint-123",
+                        "request": {
+                            "schema_version": 1,
+                            "product": "odoo-tenant-cm",
+                            "instance": "testing",
+                            "strategy": "recreate-in-place",
+                            "allow_empty_data": False,
+                        },
+                        "status": "pending",
+                        "phase": "created",
+                        "created_at": "2026-05-17T00:00:00Z",
+                        "updated_at": "2026-05-17T00:00:00Z",
+                    }
+                )
+            )
 
             counts = store.import_core_records_from_filesystem(filesystem_store)
             self.assertEqual(
@@ -2375,6 +2401,7 @@ env_var = "GH_TOKEN"
                     "merge_train_policies": 1,
                     "merge_train_runs": 1,
                     "odoo_stable_bootstrap_operations": 1,
+                    "odoo_stable_target_replacement_operations": 1,
                     "release_tuples": 1,
                     "runtime_key_safety_policies": 1,
                 },
@@ -2413,6 +2440,15 @@ env_var = "GH_TOKEN"
                     limit=1,
                 )[0].operation_id,
                 "odoo-stable-bootstrap-cm-testing-test",
+            )
+            self.assertEqual(
+                store.list_odoo_stable_target_replacement_operation_records(
+                    context_name="cm",
+                    instance_name="testing",
+                    statuses=("pending",),
+                    limit=1,
+                )[0].operation_id,
+                "odoo-target-replacement-cm-testing-test",
             )
             self.assertEqual(
                 store.list_preview_lifecycle_plan_records(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -42,6 +42,12 @@ from control_plane.contracts.odoo_instance_override_record import OdooOverrideVa
 from control_plane.contracts.odoo_stable_bootstrap_operation import (
     OdooStableBootstrapOperationRecord,
 )
+from control_plane.contracts.odoo_stable_target_replacement import (
+    OdooStableTargetReplacementApplyResult,
+)
+from control_plane.contracts.odoo_stable_target_replacement_operation import (
+    OdooStableTargetReplacementOperationRecord,
+)
 from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
 from control_plane.contracts.merge_train_run_record import build_merge_train_run_record
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
@@ -114,7 +120,6 @@ from control_plane.workflows.odoo_prod_backup_gate import OdooProdBackupGateResu
 from control_plane.workflows.odoo_prod_promotion import OdooProdPromotionResult
 from control_plane.workflows.odoo_prod_rollback import OdooProdRollbackResult
 from control_plane.workflows.odoo_stable_target_replacement import (
-    OdooStableTargetReplacementApplyResult,
     OdooStableTargetReplacementPlan,
 )
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy
@@ -1297,9 +1302,7 @@ class GitHubHumanAuthTests(unittest.TestCase):
                 github_oauth_config=_github_oauth_config(),
                 human_session_store=session_store,
             )
-            cookie = _signed_human_session_cookie(
-                "expiring-session", "test-session-secret"
-            )
+            cookie = _signed_human_session_cookie("expiring-session", "test-session-secret")
 
             status_code, headers, body = _invoke_raw_app(
                 app,
@@ -1391,9 +1394,7 @@ class GitHubHumanAuthTests(unittest.TestCase):
                 github_oauth_config=_github_oauth_config(),
                 human_session_store=session_store,
             )
-            cookie = _signed_human_session_cookie(
-                "expiring-session", "test-session-secret"
-            )
+            cookie = _signed_human_session_cookie("expiring-session", "test-session-secret")
 
             status_code, headers, body = _invoke_raw_app(
                 app,
@@ -18897,7 +18898,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 control_plane_root_path=root,
             )
 
-            with patch("control_plane.service._start_odoo_stable_bootstrap_operation_worker") as worker_mock:
+            with patch(
+                "control_plane.service._start_odoo_stable_bootstrap_operation_worker"
+            ) as worker_mock:
                 status_code, payload = _invoke_app(
                     app,
                     method="POST",
@@ -18930,9 +18933,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             worker_mock.assert_called_once()
             self.assertEqual(worker_mock.call_args.kwargs["operation_id"], operation_id)
-            stored_operation = store.read_odoo_stable_bootstrap_operation_record(
-                str(operation_id)
-            )
+            stored_operation = store.read_odoo_stable_bootstrap_operation_record(str(operation_id))
             self.assertEqual(stored_operation.status, "pending")
             self.assertEqual(stored_operation.idempotency_key, "bootstrap-cm-testing")
 
@@ -18987,7 +18988,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             }
 
-            with patch("control_plane.service._start_odoo_stable_bootstrap_operation_worker") as worker_mock:
+            with patch(
+                "control_plane.service._start_odoo_stable_bootstrap_operation_worker"
+            ) as worker_mock:
                 first_status, first_payload = _invoke_app(
                     app,
                     method="POST",
@@ -19215,9 +19218,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     trace_id="launchplane_req_worker",
                 )
 
-            operation = store.read_odoo_stable_bootstrap_operation_record(
-                "operation-cm-testing"
-            )
+            operation = store.read_odoo_stable_bootstrap_operation_record("operation-cm-testing")
             self.assertEqual(operation.status, "pass")
             self.assertEqual(operation.phase, "completed")
             self.assertEqual(operation.deployment_record_id, "deployment-cm-testing")
@@ -19280,9 +19281,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     trace_id="launchplane_req_worker",
                 )
 
-            operation = store.read_odoo_stable_bootstrap_operation_record(
-                "operation-cm-testing"
-            )
+            operation = store.read_odoo_stable_bootstrap_operation_record("operation-cm-testing")
             self.assertEqual(operation.status, "fail")
             self.assertEqual(operation.phase, "failed")
             self.assertEqual(operation.error_message, "Canonical verification failed.")
@@ -19476,7 +19475,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(status_code, 403)
             self.assertEqual(payload["error"]["code"], "authorization_denied")
 
-    def test_odoo_target_replacement_apply_driver_runs_for_authorized_workflow(self) -> None:
+    def test_odoo_target_replacement_apply_driver_creates_operation_for_authorized_workflow(
+        self,
+    ) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             state_dir = root / "state"
@@ -19516,21 +19517,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
 
             with patch(
-                "control_plane.service.execute_odoo_stable_target_replacement_apply",
-                return_value=OdooStableTargetReplacementApplyResult(
-                    product="odoo-tenant-cm",
-                    context="cm",
-                    instance="testing",
-                    strategy="recreate-in-place",
-                    deployment_record_id="deployment-cm-testing",
-                    deploy_status="pass",
-                    post_deploy_status="pass",
-                    health_status="pass",
-                    canonical_status="pass",
-                    logo_status="pass",
-                    runtime_identity_injected=True,
-                ),
-            ) as apply_mock:
+                "control_plane.service._start_odoo_stable_target_replacement_operation_worker"
+            ) as worker_mock:
                 status_code, payload = _invoke_app(
                     app,
                     method="POST",
@@ -19552,11 +19540,311 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
             self.assertEqual(status_code, 202)
             self.assertEqual(payload["status"], "accepted")
-            self.assertEqual(payload["result"]["deployment_record_id"], "deployment-cm-testing")
-            apply_mock.assert_called_once()
-            request = apply_mock.call_args.kwargs["request"]
-            self.assertTrue(request.verify_health)
-            self.assertFalse(request.allow_empty_data)
+            operation_id = payload["records"]["odoo_stable_target_replacement_operation_id"]
+            self.assertTrue(str(operation_id).startswith("odoo-target-replacement-cm-testing-"))
+            self.assertEqual(payload["result"]["status"], "pending")
+            self.assertEqual(payload["result"]["phase"], "created")
+            self.assertEqual(
+                payload["result"]["poll_url"],
+                f"/v1/drivers/odoo/target-replacement/operations/{operation_id}",
+            )
+            worker_mock.assert_called_once()
+            self.assertEqual(worker_mock.call_args.kwargs["operation_id"], operation_id)
+            stored_operation = store.read_odoo_stable_target_replacement_operation_record(
+                str(operation_id)
+            )
+            self.assertEqual(stored_operation.status, "pending")
+            self.assertTrue(stored_operation.request.verify_health)
+            self.assertFalse(stored_operation.request.allow_empty_data)
+
+    def test_odoo_target_replacement_apply_driver_replays_existing_operation(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/odoo-target-replacement-apply.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["odoo_target_replacement_apply.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-target-replacement-apply.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            request_payload = {
+                "product": "odoo-tenant-cm",
+                "replacement": {
+                    "product": "odoo-tenant-cm",
+                    "instance": "testing",
+                    "strategy": "recreate-in-place",
+                    "allow_empty_data": False,
+                },
+            }
+
+            with patch(
+                "control_plane.service._start_odoo_stable_target_replacement_operation_worker"
+            ) as worker_mock:
+                first_status, first_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/target-replacement-apply",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "apply-cm-testing"},
+                )
+                second_status, second_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/target-replacement-apply",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "apply-cm-testing"},
+                )
+
+            self.assertEqual(first_status, 202)
+            self.assertEqual(second_status, 202)
+            self.assertEqual(
+                first_payload["records"]["odoo_stable_target_replacement_operation_id"],
+                second_payload["records"]["odoo_stable_target_replacement_operation_id"],
+            )
+            worker_mock.assert_called_once()
+
+    def test_odoo_target_replacement_apply_driver_blocks_second_active_lane_operation(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/odoo-target-replacement-apply.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["odoo_target_replacement_apply.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-target-replacement-apply.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            request_payload = {
+                "product": "odoo-tenant-cm",
+                "replacement": {
+                    "product": "odoo-tenant-cm",
+                    "instance": "testing",
+                    "strategy": "recreate-in-place",
+                    "allow_empty_data": False,
+                },
+            }
+
+            with patch(
+                "control_plane.service._start_odoo_stable_target_replacement_operation_worker"
+            ):
+                first_status, _ = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/target-replacement-apply",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "apply-cm-testing-1"},
+                )
+                second_status, second_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/target-replacement-apply",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "apply-cm-testing-2"},
+                )
+
+            self.assertEqual(first_status, 202)
+            self.assertEqual(second_status, 409)
+            self.assertEqual(
+                second_payload["error"]["code"],
+                "odoo_stable_target_replacement_operation_active",
+            )
+
+    def test_odoo_target_replacement_operation_status_reads_for_authorized_workflow(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_odoo_stable_target_replacement_operation_record(
+                OdooStableTargetReplacementOperationRecord.model_validate(
+                    {
+                        "operation_id": "operation-cm-testing",
+                        "product": "odoo-tenant-cm",
+                        "context": "cm",
+                        "instance": "testing",
+                        "idempotency_key": "apply-cm-testing",
+                        "request_fingerprint": "abc123",
+                        "request": {
+                            "schema_version": 1,
+                            "product": "odoo-tenant-cm",
+                            "instance": "testing",
+                            "strategy": "recreate-in-place",
+                            "allow_empty_data": False,
+                        },
+                        "status": "running",
+                        "phase": "running",
+                        "created_at": "2026-05-17T00:00:00Z",
+                        "updated_at": "2026-05-17T00:01:00Z",
+                        "started_at": "2026-05-17T00:01:00Z",
+                    }
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/odoo-target-replacement-apply.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["odoo_target_replacement_apply.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-target-replacement-apply.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/drivers/odoo/target-replacement/operations/operation-cm-testing",
+            )
+
+            self.assertEqual(status_code, 200)
+            self.assertEqual(payload["status"], "ok")
+            self.assertEqual(payload["operation"]["status"], "running")
+            self.assertEqual(
+                payload["operation"]["poll_url"],
+                "/v1/drivers/odoo/target-replacement/operations/operation-cm-testing",
+            )
+
+    def test_odoo_target_replacement_operation_worker_records_terminal_result(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_odoo_stable_target_replacement_operation_record(
+                OdooStableTargetReplacementOperationRecord.model_validate(
+                    {
+                        "operation_id": "operation-cm-testing",
+                        "product": "odoo-tenant-cm",
+                        "context": "cm",
+                        "instance": "testing",
+                        "idempotency_key": "apply-cm-testing",
+                        "request_fingerprint": "abc123",
+                        "request": {
+                            "schema_version": 1,
+                            "product": "odoo-tenant-cm",
+                            "instance": "testing",
+                            "strategy": "recreate-in-place",
+                            "allow_empty_data": False,
+                        },
+                        "status": "pending",
+                        "phase": "created",
+                        "created_at": "2026-05-17T00:00:00Z",
+                        "updated_at": "2026-05-17T00:00:00Z",
+                    }
+                )
+            )
+            result = OdooStableTargetReplacementApplyResult(
+                product="odoo-tenant-cm",
+                context="cm",
+                instance="testing",
+                strategy="recreate-in-place",
+                deployment_record_id="deployment-cm-testing",
+                deploy_status="pass",
+                post_deploy_status="pass",
+                health_status="pass",
+                canonical_status="pass",
+                logo_status="pass",
+                runtime_identity_injected=True,
+            )
+
+            with patch(
+                "control_plane.service.execute_odoo_stable_target_replacement_apply",
+                return_value=result,
+            ):
+                control_plane_service._run_odoo_stable_target_replacement_operation_worker(
+                    operation_id="operation-cm-testing",
+                    control_plane_root_path=root,
+                    record_store=store,
+                    trace_id="launchplane_req_worker",
+                )
+
+            operation = store.read_odoo_stable_target_replacement_operation_record(
+                "operation-cm-testing"
+            )
+            self.assertEqual(operation.status, "pass")
+            self.assertEqual(operation.phase, "completed")
+            self.assertEqual(operation.deployment_record_id, "deployment-cm-testing")
+            self.assertEqual(operation.runner_trace_id, "launchplane_req_worker")
+            self.assertIsNotNone(operation.result)
 
     def test_odoo_target_replacement_apply_driver_rejects_unauthorized_workflow(
         self,


### PR DESCRIPTION
## Summary
- add durable Odoo stable target-replacement operation contracts, filesystem/Postgres storage, and Alembic migration
- convert target-replacement apply service route to create/read/poll operation flow with idempotency replay and lane single-flight protection
- update the GitHub apply workflow to create and poll operations, preserve final artifacts, and document the durable operation contract

## Validation
- `uv run python -m unittest tests.test_odoo_stable_target_replacement_operation tests.test_odoo_stable_target_replacement tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_apply_driver_creates_operation_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_apply_driver_replays_existing_operation tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_apply_driver_blocks_second_active_lane_operation tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_operation_status_reads_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_operation_worker_records_terminal_result tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_apply_driver_rejects_unauthorized_workflow`
- `uv run python -m unittest tests.test_service tests.test_odoo_stable_target_replacement_operation tests.test_odoo_stable_target_replacement tests.test_driver_descriptors`
- `uv run python -m unittest tests.test_postgres_store.PostgresRecordStoreTests.test_import_core_records_from_filesystem tests.test_odoo_stable_target_replacement_operation tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_apply_driver_creates_operation_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_operation_status_reads_for_authorized_workflow`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m py_compile control_plane/contracts/odoo_stable_target_replacement.py control_plane/contracts/odoo_stable_target_replacement_operation.py control_plane/service.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/f4a5b6c7d8e9_add_odoo_target_replacement_operations.py tests/test_odoo_stable_target_replacement_operation.py`
- `uv run --extra dev ruff check ...changed Python files...`
- `uv run --extra dev ruff format --check ...changed Python files...`
- `git diff --check`
- `uv run python -m unittest` (1301 tests)
- JetBrains inspection on changed Python files: completed; remaining warnings are pre-existing/static-analysis noise also covered by clean mypy/full tests

No live Odoo target-replacement workflow was dispatched.

Closes #520.
