### PR TITLE
Add Odoo preview verification ingestion

### DIFF
--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -544,6 +544,17 @@ ODOO_DRIVER = DriverDescriptor(
             writes_records=("preview",),
         ),
         _action(
+            "preview_verification",
+            "Record preview verification",
+            "Record Odoo product smoke verification for the latest preview generation.",
+            safety="safe_write",
+            scope="preview",
+            route_path="/v1/drivers/odoo/preview-verification",
+            authz_action="preview_generation.write",
+            operator_visible=False,
+            writes_records=("preview", "preview_generation"),
+        ),
+        _action(
             "prod_backup_gate",
             "Capture prod backup gate",
             "Capture concrete backup evidence before a prod-changing action.",

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1418,6 +1418,52 @@ _ODOO_TARGET_REPLACEMENT_APPLY_ROUTE = _DriverRouteExecutionMetadata(
 )
 
 
+class OdooPreviewVerificationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    context: str
+    anchor_repo: str
+    anchor_pr_number: int = Field(ge=1)
+    verification_status: ReleaseStatus
+    verified_at: str
+    failure_summary: str = ""
+
+    @field_validator("verification_status", mode="before")
+    @classmethod
+    def _normalize_status(cls, value: object) -> ReleaseStatus:
+        return _normalize_release_status(value, label="Odoo preview verification status")
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "OdooPreviewVerificationRequest":
+        if not self.context.strip():
+            raise ValueError("Odoo preview verification requires context.")
+        if not self.anchor_repo.strip():
+            raise ValueError("Odoo preview verification requires anchor_repo.")
+        if self.verification_status not in {"pass", "fail"}:
+            raise ValueError("Odoo preview verification status must be pass or fail.")
+        if not self.verified_at.strip():
+            raise ValueError("Odoo preview verification requires verified_at.")
+        return self
+
+
+class OdooPreviewVerificationEnvelope(_ProductRouteEnvelope):
+    schema_version: int = Field(default=1, ge=1)
+    verification: OdooPreviewVerificationRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "OdooPreviewVerificationEnvelope":
+        _validate_driver_envelope_product(self.product, label="Odoo preview verification")
+        return self
+
+
+_ODOO_PREVIEW_VERIFICATION_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/odoo/preview-verification",
+    envelope_model=OdooPreviewVerificationEnvelope,
+    denial_message="Workflow cannot write Odoo preview verification for the requested product/context.",
+)
+
+
 class VeriReelTestingDeployEnvelope(_ProductRouteEnvelope):
     schema_version: int = Field(default=1, ge=1)
     deploy: VeriReelStableDeployRequest
@@ -6383,6 +6429,75 @@ def _apply_verireel_preview_verification_records(
     verified_at = request.verified_at.strip()
     verification_passed = request.verification_status.strip() == "pass"
     failure_summary = request.failure_summary.strip() or "Preview E2E verification failed."
+    return apply_launchplane_generation_evidence(
+        control_plane_root_path=control_plane_root_path,
+        record_store=typed_record_store,
+        preview_request=PreviewMutationRequest(
+            context=preview.context,
+            anchor_repo=preview.anchor_repo,
+            anchor_pr_number=preview.anchor_pr_number,
+            anchor_pr_url=preview.anchor_pr_url,
+            canonical_url=preview.canonical_url,
+            state="active" if verification_passed else "failed",
+            created_at=preview.created_at,
+            updated_at=verified_at,
+            eligible_at=preview.eligible_at,
+        ),
+        generation_request=PreviewGenerationMutationRequest(
+            context=preview.context,
+            anchor_repo=preview.anchor_repo,
+            anchor_pr_number=preview.anchor_pr_number,
+            anchor_pr_url=preview.anchor_pr_url,
+            anchor_head_sha=generation.anchor_summary.head_sha,
+            sequence=generation.sequence,
+            generation_id=generation.generation_id,
+            state="ready" if verification_passed else "failed",
+            requested_reason=generation.requested_reason,
+            requested_at=generation.requested_at,
+            started_at=generation.started_at,
+            ready_at=verified_at if verification_passed else "",
+            finished_at=verified_at,
+            failed_at="" if verification_passed else verified_at,
+            resolved_manifest_fingerprint=generation.resolved_manifest_fingerprint,
+            artifact_id=generation.artifact_id,
+            baseline_release_tuple_id=generation.baseline_release_tuple_id,
+            source_map=generation.source_map,
+            companion_summaries=generation.companion_summaries,
+            deploy_status=generation.deploy_status,
+            verify_status="pass" if verification_passed else "fail",
+            overall_health_status="pass" if verification_passed else "fail",
+            failure_stage="" if verification_passed else "verify",
+            failure_summary="" if verification_passed else failure_summary,
+        ),
+    )
+
+
+def _apply_odoo_preview_verification_records(
+    *,
+    control_plane_root_path: Path,
+    record_store: object,
+    request: OdooPreviewVerificationRequest,
+) -> dict[str, object]:
+    typed_record_store = cast(FilesystemRecordStore, record_store)
+    preview = find_preview_record(
+        record_store=typed_record_store,
+        context_name=request.context,
+        anchor_repo=request.anchor_repo,
+        anchor_pr_number=request.anchor_pr_number,
+    )
+    if preview is None:
+        raise click.ClickException(
+            f"No Launchplane preview found for {request.context}/{request.anchor_repo}/pr-{request.anchor_pr_number}."
+        )
+    generation_id = preview.latest_generation_id or preview.active_generation_id
+    if not generation_id:
+        raise click.ClickException(
+            f"No Launchplane preview generation found for {preview.preview_id}."
+        )
+    generation = typed_record_store.read_preview_generation_record(generation_id)
+    verified_at = request.verified_at.strip()
+    verification_passed = request.verification_status == "pass"
+    failure_summary = request.failure_summary.strip() or "Odoo preview verification failed."
     return apply_launchplane_generation_evidence(
         control_plane_root_path=control_plane_root_path,
         record_store=typed_record_store,
@@ -11403,6 +11518,43 @@ def create_launchplane_service_app(
                     control_plane_root_path=resolved_root,
                     record_store=record_store,
                     request=verireel_preview_verification_request.verification,
+                )
+            elif path == _ODOO_PREVIEW_VERIFICATION_ROUTE.route_path:
+                odoo_preview_verification_request = (
+                    _ODOO_PREVIEW_VERIFICATION_ROUTE.envelope_model.model_validate(payload)
+                )
+                _resolve_descriptor_product_driver_context(
+                    record_store=record_store,
+                    route_path=path,
+                    product=odoo_preview_verification_request.product,
+                )
+                authorization_response = _driver_route_authorization_response(
+                    authz_policy=authz_policy,
+                    identity=identity,
+                    route_path=path,
+                    product=odoo_preview_verification_request.product,
+                    context=odoo_preview_verification_request.verification.context,
+                    denial_message=_ODOO_PREVIEW_VERIFICATION_ROUTE.denial_message,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if authorization_response is not None:
+                    return authorization_response
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                result = _apply_odoo_preview_verification_records(
+                    control_plane_root_path=resolved_root,
+                    record_store=record_store,
+                    request=odoo_preview_verification_request.verification,
                 )
             elif path == "/v1/product-profiles/context-cutover/apply":
                 context_cutover_request = control_plane_product_context_cutover.ProductContextCutoverRequest.model_validate(

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -140,8 +140,9 @@ Odoo declares `base_driver_id="generic-web"` and exposes Odoo-shaped preview
 routes for the same lifecycle: `POST /v1/drivers/odoo/preview-desired-state`,
 `POST /v1/drivers/odoo/preview-refresh`,
 `POST /v1/drivers/odoo/preview-inventory`,
-`POST /v1/drivers/odoo/preview-readiness`, and
-`POST /v1/drivers/odoo/preview-destroy`. These routes use the generic-web
+`POST /v1/drivers/odoo/preview-readiness`,
+`POST /v1/drivers/odoo/preview-destroy`, and
+`POST /v1/drivers/odoo/preview-verification`. These routes use the generic-web
 preview request schema, live URL derivation, and record writer so Odoo PR
 previews land in the same Launchplane preview and preview-generation records as
 generic-web previews.
@@ -162,6 +163,10 @@ source revision evidence, module install/update evidence from rendered Odoo env,
 the preview generation as `ready` with deploy, verify, and overall health status
 `pass`; failed smoke records a concise verification failure so PR feedback does
 not advertise ready before the checks pass.
+The verification route is a Launchplane-owned evidence ingress for follow-up
+browser or product smoke checks: it marks the latest preview generation ready or
+failed through the same preview-generation records without mutating provider
+state.
 
 Odoo also exposes `POST /v1/drivers/odoo/stable-bootstrap` as a destructive
 instance-scoped action. It is enabled per product-profile lane through

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -105,6 +105,11 @@ artifact/revision evidence, and module install/update evidence. Product
 workflows should treat the Odoo refresh route's `refresh_status="pass"` as the
 ready-to-comment signal instead of independently deciding readiness from raw
 health checks.
+If a later browser or product-specific smoke workflow needs to publish evidence,
+it should call `POST /v1/drivers/odoo/preview-verification` with the PR identity,
+`verification_status`, `verified_at`, and optional failure summary. Launchplane
+updates the latest preview generation and preserves the result in the same
+preview records used by refresh.
 
 Preview destroy routes receive the PR number, source/run metadata, and an
 explicit destroy reason such as `pull_request_closed`, `preview_label_removed`,

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1143,6 +1143,14 @@ CLI adapters and expose them over HTTP.
 
 ### Preview generation evidence
 
+Driver-owned preview verification routes can update those records without
+requiring product workflows to render Launchplane record payloads directly. For
+Odoo preview smoke follow-ups, `POST /v1/drivers/odoo/preview-verification`
+accepts the product, context, anchor repo/PR, `verification_status`,
+`verified_at`, and an optional failure summary, then marks the latest preview
+generation ready or failed. The route is safe-write evidence ingestion only; it
+does not mutate provider state.
+
 `POST /v1/evidence/previews/generations`
 
 ```json

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -12773,6 +12773,284 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(status_code, 400)
             self.assertEqual(payload["error"]["code"], "invalid_request")
 
+    def test_odoo_preview_verification_driver_marks_latest_generation_ready(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            store.write_preview_record(
+                PreviewRecord(
+                    preview_id="preview-cm-odoo-tenant-cm-pr-42",
+                    context="cm",
+                    anchor_repo="odoo-tenant-cm",
+                    anchor_pr_number=42,
+                    anchor_pr_url="https://github.com/cbusillo/odoo-tenant-cm/pull/42",
+                    preview_label="preview",
+                    canonical_url="https://pr-42.cm-preview.example.test",
+                    state="pending",
+                    created_at="2026-05-09T15:00:00Z",
+                    updated_at="2026-05-09T15:05:00Z",
+                    eligible_at="2026-05-09T15:00:00Z",
+                    active_generation_id="preview-cm-odoo-tenant-cm-pr-42-generation-0001",
+                    latest_generation_id="preview-cm-odoo-tenant-cm-pr-42-generation-0001",
+                    latest_manifest_fingerprint="odoo-preview-manifest-pr-42-abc123",
+                )
+            )
+            store.write_preview_generation_record(
+                PreviewGenerationRecord(
+                    generation_id="preview-cm-odoo-tenant-cm-pr-42-generation-0001",
+                    preview_id="preview-cm-odoo-tenant-cm-pr-42",
+                    sequence=1,
+                    state="verifying",
+                    requested_reason="external_preview_refresh",
+                    requested_at="2026-05-09T15:00:00Z",
+                    started_at="2026-05-09T15:00:00Z",
+                    resolved_manifest_fingerprint="odoo-preview-manifest-pr-42-abc123",
+                    artifact_id="ghcr.io/cbusillo/odoo-tenant-cm:sha",
+                    anchor_summary=PreviewPullRequestSummary(
+                        repo="odoo-tenant-cm",
+                        pr_number=42,
+                        head_sha="abc123",
+                        pr_url="https://github.com/cbusillo/odoo-tenant-cm/pull/42",
+                    ),
+                    deploy_status="pass",
+                    verify_status="pending",
+                    overall_health_status="pending",
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/odoo-tenant-cm",
+                            "workflow_refs": [
+                                "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["preview_generation.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/odoo-tenant-cm",
+                        workflow_ref=(
+                            "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/odoo/preview-verification",
+                payload={
+                    "schema_version": 1,
+                    "product": "odoo-tenant-cm",
+                    "verification": {
+                        "schema_version": 1,
+                        "context": "cm",
+                        "anchor_repo": "odoo-tenant-cm",
+                        "anchor_pr_number": 42,
+                        "verification_status": "pass",
+                        "verified_at": "2026-05-09T15:08:00Z",
+                    },
+                },
+                headers={"Idempotency-Key": "odoo-preview-verification:cm:42:run-1"},
+            )
+
+            self.assertEqual(status_code, 202)
+            self.assertEqual(payload["records"]["transition"], "ready")
+            preview = store.read_preview_record("preview-cm-odoo-tenant-cm-pr-42")
+            generation = store.read_preview_generation_record(
+                "preview-cm-odoo-tenant-cm-pr-42-generation-0001"
+            )
+            self.assertEqual(preview.state, "active")
+            self.assertEqual(preview.serving_generation_id, generation.generation_id)
+            self.assertEqual(generation.state, "ready")
+            self.assertEqual(generation.verify_status, "pass")
+            self.assertEqual(generation.overall_health_status, "pass")
+            self.assertEqual(generation.ready_at, "2026-05-09T15:08:00Z")
+
+    def test_odoo_preview_verification_driver_marks_latest_generation_failed(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            store.write_preview_record(
+                PreviewRecord(
+                    preview_id="preview-cm-odoo-tenant-cm-pr-42",
+                    context="cm",
+                    anchor_repo="odoo-tenant-cm",
+                    anchor_pr_number=42,
+                    anchor_pr_url="https://github.com/cbusillo/odoo-tenant-cm/pull/42",
+                    preview_label="preview",
+                    canonical_url="https://pr-42.cm-preview.example.test",
+                    state="active",
+                    created_at="2026-05-09T15:00:00Z",
+                    updated_at="2026-05-09T15:05:00Z",
+                    eligible_at="2026-05-09T15:00:00Z",
+                    active_generation_id="preview-cm-odoo-tenant-cm-pr-42-generation-0001",
+                    serving_generation_id="preview-cm-odoo-tenant-cm-pr-42-generation-0001",
+                    latest_generation_id="preview-cm-odoo-tenant-cm-pr-42-generation-0001",
+                    latest_manifest_fingerprint="odoo-preview-manifest-pr-42-abc123",
+                )
+            )
+            store.write_preview_generation_record(
+                PreviewGenerationRecord(
+                    generation_id="preview-cm-odoo-tenant-cm-pr-42-generation-0001",
+                    preview_id="preview-cm-odoo-tenant-cm-pr-42",
+                    sequence=1,
+                    state="verifying",
+                    requested_reason="external_preview_refresh",
+                    requested_at="2026-05-09T15:00:00Z",
+                    started_at="2026-05-09T15:00:00Z",
+                    resolved_manifest_fingerprint="odoo-preview-manifest-pr-42-abc123",
+                    artifact_id="ghcr.io/cbusillo/odoo-tenant-cm:sha",
+                    anchor_summary=PreviewPullRequestSummary(
+                        repo="odoo-tenant-cm",
+                        pr_number=42,
+                        head_sha="abc123",
+                        pr_url="https://github.com/cbusillo/odoo-tenant-cm/pull/42",
+                    ),
+                    deploy_status="pass",
+                    verify_status="pending",
+                    overall_health_status="pending",
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/odoo-tenant-cm",
+                            "workflow_refs": [
+                                "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["preview_generation.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/odoo-tenant-cm",
+                        workflow_ref=(
+                            "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, _payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/odoo/preview-verification",
+                payload={
+                    "schema_version": 1,
+                    "product": "odoo-tenant-cm",
+                    "verification": {
+                        "schema_version": 1,
+                        "context": "cm",
+                        "anchor_repo": "odoo-tenant-cm",
+                        "anchor_pr_number": 42,
+                        "verification_status": "fail",
+                        "verified_at": "2026-05-09T15:08:00Z",
+                        "failure_summary": "Odoo preview page did not include Cell Mechanic.",
+                    },
+                },
+                headers={"Idempotency-Key": "odoo-preview-verification:cm:42:run-1"},
+            )
+
+            self.assertEqual(status_code, 202)
+            preview = store.read_preview_record("preview-cm-odoo-tenant-cm-pr-42")
+            generation = store.read_preview_generation_record(
+                "preview-cm-odoo-tenant-cm-pr-42-generation-0001"
+            )
+            self.assertEqual(preview.state, "failed")
+            self.assertEqual(generation.state, "failed")
+            self.assertEqual(generation.verify_status, "fail")
+            self.assertEqual(generation.overall_health_status, "fail")
+            self.assertEqual(generation.failure_stage, "verify")
+            self.assertIn("Cell Mechanic", generation.failure_summary)
+
+    def test_odoo_preview_verification_driver_rejects_unauthorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/odoo-tenant-cm",
+                        workflow_ref=(
+                            "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate(
+                    {
+                        "github_actions": [
+                            {
+                                "repository": "cbusillo/odoo-tenant-cm",
+                                "workflow_refs": [
+                                    "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
+                                ],
+                                "event_names": ["pull_request"],
+                                "products": ["odoo-tenant-cm"],
+                                "contexts": ["cm"],
+                                "actions": ["preview_refresh.execute"],
+                            }
+                        ]
+                    }
+                ),
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/odoo/preview-verification",
+                payload={
+                    "schema_version": 1,
+                    "product": "odoo-tenant-cm",
+                    "verification": {
+                        "schema_version": 1,
+                        "context": "cm",
+                        "anchor_repo": "odoo-tenant-cm",
+                        "anchor_pr_number": 42,
+                        "verification_status": "pass",
+                        "verified_at": "2026-05-09T15:08:00Z",
+                    },
+                },
+                headers={"Idempotency-Key": "odoo-preview-verification:cm:42:run-1"},
+            )
+
+            self.assertEqual(status_code, 403)
+            self.assertEqual(payload["error"]["code"], "authorization_denied")
+
     def test_generic_web_preview_refresh_route_keeps_blocked_result_non_mutating(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- add a safe-write Odoo preview verification route that marks the latest preview generation ready or failed
- expose the route in the Odoo driver descriptor
- document the verification ingestion handoff and add service coverage for pass/fail/authz

## Validation
- uv run python -m unittest tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_odoo_preview_verification_driver_marks_latest_generation_ready tests.test_service.LaunchplaneServiceTests.test_odoo_preview_verification_driver_marks_latest_generation_failed tests.test_service.LaunchplaneServiceTests.test_odoo_preview_verification_driver_rejects_unauthorized_workflow
- uv run --extra dev mypy control_plane tests
- uv run python -m py_compile control_plane/service.py control_plane/drivers/registry.py tests/test_service.py tests/test_driver_descriptors.py
- git diff --check
- uv run --extra dev ruff check --diff control_plane/service.py control_plane/drivers/registry.py tests/test_service.py tests/test_driver_descriptors.py
- uv run --extra dev ruff check control_plane/service.py control_plane/drivers/registry.py tests/test_service.py tests/test_driver_descriptors.py
- uv run --extra dev ruff format --check control_plane/service.py control_plane/drivers/registry.py tests/test_service.py tests/test_driver_descriptors.py
- uv run python -m unittest
- JetBrains changed-file inspection run; remaining warnings are existing baseline noise in large service/test files, not introduced line ranges

Note: whole-repo ruff format check still reports the existing 44-file formatting baseline; changed files pass format check.

Refs #512