### PR TITLE
Add Odoo stable verification ingestion

### DIFF
--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -555,6 +555,17 @@ ODOO_DRIVER = DriverDescriptor(
             writes_records=("preview", "preview_generation"),
         ),
         _action(
+            "stable_verification",
+            "Record stable verification",
+            "Record Odoo product smoke verification for an existing stable deployment or promotion.",
+            safety="safe_write",
+            scope="instance",
+            route_path="/v1/drivers/odoo/stable-verification",
+            authz_action="deployment.write",
+            operator_visible=False,
+            writes_records=("deployment", "promotion", "inventory"),
+        ),
+        _action(
             "prod_backup_gate",
             "Capture prod backup gate",
             "Capture concrete backup evidence before a prod-changing action.",

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -241,6 +241,7 @@ from control_plane.workflows.merge_train_worker import (
     run_merge_train_worker_step,
 )
 from control_plane.workflows.evidence_ingestion import (
+    EvidenceIngestionStore,
     apply_deployment_evidence,
     apply_promotion_evidence,
 )
@@ -1461,6 +1462,57 @@ _ODOO_PREVIEW_VERIFICATION_ROUTE = _DriverRouteExecutionMetadata(
     route_path="/v1/drivers/odoo/preview-verification",
     envelope_model=OdooPreviewVerificationEnvelope,
     denial_message="Workflow cannot write Odoo preview verification for the requested product/context.",
+)
+
+
+class OdooStableVerificationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    context: str
+    instance: Literal["testing", "prod"]
+    deployment_record_id: str
+    promotion_record_id: str = ""
+    verification_status: ReleaseStatus
+    verified_at: str
+    checked_urls: tuple[str, ...] = ()
+    timeout_seconds: int | None = Field(default=None, ge=1)
+    failure_summary: str = ""
+
+    @field_validator("verification_status", mode="before")
+    @classmethod
+    def _normalize_status(cls, value: object) -> ReleaseStatus:
+        return _normalize_release_status(value, label="Odoo stable verification status")
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "OdooStableVerificationRequest":
+        if not self.context.strip():
+            raise ValueError("Odoo stable verification requires context.")
+        if not self.deployment_record_id.strip():
+            raise ValueError("Odoo stable verification requires deployment_record_id.")
+        if self.verification_status not in {"pass", "fail"}:
+            raise ValueError("Odoo stable verification status must be pass or fail.")
+        if not self.verified_at.strip():
+            raise ValueError("Odoo stable verification requires verified_at.")
+        if self.checked_urls and self.timeout_seconds is None:
+            raise ValueError("Odoo stable verification checked_urls require timeout_seconds.")
+        return self
+
+
+class OdooStableVerificationEnvelope(_ProductRouteEnvelope):
+    schema_version: int = Field(default=1, ge=1)
+    verification: OdooStableVerificationRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "OdooStableVerificationEnvelope":
+        _validate_driver_envelope_product(self.product, label="Odoo stable verification")
+        return self
+
+
+_ODOO_STABLE_VERIFICATION_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/odoo/stable-verification",
+    envelope_model=OdooStableVerificationEnvelope,
+    denial_message="Workflow cannot write Odoo stable verification for the requested product/context.",
 )
 
 
@@ -6541,6 +6593,88 @@ def _apply_odoo_preview_verification_records(
     )
 
 
+def _stable_verification_health_evidence(
+    *, request: OdooStableVerificationRequest
+) -> HealthcheckEvidence:
+    return HealthcheckEvidence(
+        verified=bool(request.checked_urls),
+        urls=request.checked_urls,
+        timeout_seconds=request.timeout_seconds if request.checked_urls else None,
+        status=request.verification_status,
+    )
+
+
+def _apply_odoo_stable_verification_records(
+    *,
+    record_store: object,
+    request: OdooStableVerificationRequest,
+) -> dict[str, object]:
+    typed_record_store = cast(FilesystemRecordStore, record_store)
+    evidence_store = cast(EvidenceIngestionStore, typed_record_store)
+    try:
+        deployment_record = typed_record_store.read_deployment_record(request.deployment_record_id)
+    except FileNotFoundError as exc:
+        raise click.ClickException(
+            f"No Launchplane deployment record found for {request.deployment_record_id}."
+        ) from exc
+    if deployment_record.context != request.context:
+        raise click.ClickException(
+            "Odoo stable verification context does not match deployment record context."
+        )
+    if deployment_record.instance != request.instance:
+        raise click.ClickException(
+            "Odoo stable verification instance does not match deployment record instance."
+        )
+
+    health_evidence = _stable_verification_health_evidence(request=request)
+    updated_deployment = deployment_record.model_copy(
+        update={"destination_health": health_evidence}
+    )
+    result: dict[str, object] = dict(
+        apply_deployment_evidence(
+            record_store=evidence_store,
+            deployment_record=updated_deployment,
+        )
+    )
+    result["deployment_health_status"] = request.verification_status
+
+    promotion_record_id = request.promotion_record_id.strip()
+    if promotion_record_id:
+        try:
+            promotion_record = typed_record_store.read_promotion_record(promotion_record_id)
+        except FileNotFoundError as exc:
+            raise click.ClickException(
+                f"No Launchplane promotion record found for {promotion_record_id}."
+            ) from exc
+        if promotion_record.context != request.context:
+            raise click.ClickException(
+                "Odoo stable verification context does not match promotion record context."
+            )
+        if promotion_record.to_instance != request.instance:
+            raise click.ClickException(
+                "Odoo stable verification instance does not match promotion destination instance."
+            )
+        if promotion_record.deployment_record_id.strip() not in {
+            "",
+            request.deployment_record_id,
+        }:
+            raise click.ClickException(
+                "Odoo stable verification deployment_record_id does not match linked promotion record."
+            )
+        updated_promotion = promotion_record.model_copy(
+            update={"destination_health": health_evidence}
+        )
+        result.update(
+            apply_promotion_evidence(
+                record_store=evidence_store,
+                promotion_record=updated_promotion,
+            )
+        )
+        result["promotion_health_status"] = request.verification_status
+
+    return result
+
+
 def _testing_post_deploy_detail(status: ReleaseStatus) -> str:
     if status == "pass":
         return "Prisma migrations completed on testing."
@@ -6584,6 +6718,7 @@ def _apply_verireel_testing_verification_records(
     request: VeriReelTestingVerificationRequest,
 ) -> dict[str, str]:
     typed_record_store = cast(FilesystemRecordStore, record_store)
+    evidence_store = cast(EvidenceIngestionStore, typed_record_store)
     try:
         deployment_record = typed_record_store.read_deployment_record(request.deployment_record_id)
     except FileNotFoundError as exc:
@@ -6617,7 +6752,7 @@ def _apply_verireel_testing_verification_records(
         }
     )
     result = apply_deployment_evidence(
-        record_store=typed_record_store,
+        record_store=evidence_store,
         deployment_record=updated_record,
     )
     result["deployment_health_status"] = destination_health_status
@@ -11555,6 +11690,44 @@ def create_launchplane_service_app(
                     control_plane_root_path=resolved_root,
                     record_store=record_store,
                     request=odoo_preview_verification_request.verification,
+                )
+            elif path == _ODOO_STABLE_VERIFICATION_ROUTE.route_path:
+                odoo_stable_verification_request = (
+                    _ODOO_STABLE_VERIFICATION_ROUTE.envelope_model.model_validate(payload)
+                )
+                _resolve_descriptor_product_driver_context(
+                    record_store=record_store,
+                    route_path=path,
+                    product=odoo_stable_verification_request.product,
+                    context=odoo_stable_verification_request.verification.context,
+                    instance=odoo_stable_verification_request.verification.instance,
+                )
+                authorization_response = _driver_route_authorization_response(
+                    authz_policy=authz_policy,
+                    identity=identity,
+                    route_path=path,
+                    product=odoo_stable_verification_request.product,
+                    context=odoo_stable_verification_request.verification.context,
+                    denial_message=_ODOO_STABLE_VERIFICATION_ROUTE.denial_message,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if authorization_response is not None:
+                    return authorization_response
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                result = _apply_odoo_stable_verification_records(
+                    record_store=record_store,
+                    request=odoo_stable_verification_request.verification,
                 )
             elif path == "/v1/product-profiles/context-cutover/apply":
                 context_cutover_request = control_plane_product_context_cutover.ProductContextCutoverRequest.model_validate(

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -167,6 +167,11 @@ The verification route is a Launchplane-owned evidence ingress for follow-up
 browser or product smoke checks: it marks the latest preview generation ready or
 failed through the same preview-generation records without mutating provider
 state.
+Stable smoke follow-ups use the same shape at
+`POST /v1/drivers/odoo/stable-verification`: product workflows submit the
+deployment record, optional promotion record, checked URLs, and pass/fail status;
+Launchplane updates deployment, promotion, and inventory evidence without
+mutating provider state.
 
 Odoo also exposes `POST /v1/drivers/odoo/stable-bootstrap` as a destructive
 instance-scoped action. It is enabled per product-profile lane through

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -96,6 +96,7 @@ VeriReel product paths:
   - `POST /v1/drivers/odoo/website-bootstrap-override`
   - `POST /v1/drivers/odoo/target-replacement-plan`
   - `POST /v1/drivers/odoo/target-replacement-apply`
+  - `POST /v1/drivers/odoo/stable-verification`
   - `POST /v1/drivers/odoo/prod-backup-gate`
   - `POST /v1/drivers/odoo/prod-promotion`
   - `POST /v1/drivers/odoo/prod-rollback`
@@ -1150,6 +1151,13 @@ accepts the product, context, anchor repo/PR, `verification_status`,
 `verified_at`, and an optional failure summary, then marks the latest preview
 generation ready or failed. The route is safe-write evidence ingestion only; it
 does not mutate provider state.
+
+For stable Odoo smoke follow-ups, `POST /v1/drivers/odoo/stable-verification`
+accepts the product, context, instance, deployment record, optional promotion
+record, checked URLs, `verification_status`, `verified_at`, and optional failure
+summary. Launchplane updates deployment health evidence and, when a promotion
+record is supplied, promotion/inventory evidence. The route is safe-write
+evidence ingestion only; it does not mutate provider state.
 
 `POST /v1/evidence/previews/generations`
 

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -179,6 +179,16 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         self.assertFalse(
             route_actions["/v1/drivers/verireel/preview-verification"].operator_visible
         )
+        self.assertEqual(
+            route_actions["/v1/drivers/odoo/preview-verification"].authz_action,
+            "preview_generation.write",
+        )
+        self.assertFalse(route_actions["/v1/drivers/odoo/preview-verification"].operator_visible)
+        self.assertEqual(
+            route_actions["/v1/drivers/odoo/stable-verification"].authz_action,
+            "deployment.write",
+        )
+        self.assertFalse(route_actions["/v1/drivers/odoo/stable-verification"].operator_visible)
 
     def test_service_accepts_descriptor_post_driver_routes(self) -> None:
         descriptor_post_route_metadata = {

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -626,6 +626,23 @@ def _odoo_preview_profile_payload(product: str = "odoo-tenant-cm") -> dict[str, 
     }
 
 
+def _odoo_profile_payload_with_prod_lane(
+    product: str = "odoo-tenant-cm",
+) -> dict[str, object]:
+    payload = _odoo_preview_profile_payload(product)
+    lanes = list(cast(tuple[dict[str, object], ...], payload["lanes"]))
+    lanes.append(
+        {
+            "instance": "prod",
+            "context": "cm",
+            "base_url": "https://cm.example.com",
+            "health_url": "https://cm.example.com/web/health",
+        }
+    )
+    payload["lanes"] = tuple(lanes)
+    return payload
+
+
 def _product_profile_payload_with_prod(product: str = "sellyouroutboard") -> dict[str, object]:
     payload = _product_profile_payload(product)
     lanes = list(cast(tuple[dict[str, object], ...], payload["lanes"]))
@@ -12444,8 +12461,19 @@ class LaunchplaneServiceTests(unittest.TestCase):
             root = Path(temporary_directory_name)
             state_dir = root / "state"
             store = FilesystemRecordStore(state_dir=state_dir)
+            profile_payload = _odoo_preview_profile_payload()
+            lanes = list(cast(tuple[dict[str, object], ...], profile_payload["lanes"]))
+            lanes.append(
+                {
+                    "instance": "prod",
+                    "context": "cm",
+                    "base_url": "https://cm.example.com",
+                    "health_url": "https://cm.example.com/web/health",
+                }
+            )
+            profile_payload["lanes"] = tuple(lanes)
             store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
             )
             policy = LaunchplaneAuthzPolicy.model_validate(
                 {
@@ -12526,8 +12554,19 @@ class LaunchplaneServiceTests(unittest.TestCase):
             root = Path(temporary_directory_name)
             state_dir = root / "state"
             store = FilesystemRecordStore(state_dir=state_dir)
+            profile_payload = _odoo_preview_profile_payload()
+            lanes = list(cast(tuple[dict[str, object], ...], profile_payload["lanes"]))
+            lanes.append(
+                {
+                    "instance": "prod",
+                    "context": "cm",
+                    "base_url": "https://cm.example.com",
+                    "health_url": "https://cm.example.com/web/health",
+                }
+            )
+            profile_payload["lanes"] = tuple(lanes)
             store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
             )
             policy = LaunchplaneAuthzPolicy.model_validate(
                 {
@@ -12620,8 +12659,19 @@ class LaunchplaneServiceTests(unittest.TestCase):
             root = Path(temporary_directory_name)
             state_dir = root / "state"
             store = FilesystemRecordStore(state_dir=state_dir)
+            profile_payload = _odoo_preview_profile_payload()
+            lanes = list(cast(tuple[dict[str, object], ...], profile_payload["lanes"]))
+            lanes.append(
+                {
+                    "instance": "prod",
+                    "context": "cm",
+                    "base_url": "https://cm.example.com",
+                    "health_url": "https://cm.example.com/web/health",
+                }
+            )
+            profile_payload["lanes"] = tuple(lanes)
             store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
             )
             policy = LaunchplaneAuthzPolicy.model_validate(
                 {
@@ -12889,7 +12939,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
             state_dir = root / "state"
             store = FilesystemRecordStore(state_dir=state_dir)
             store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+                LaunchplaneProductProfileRecord.model_validate(
+                    _odoo_profile_payload_with_prod_lane()
+                )
             )
             store.write_preview_record(
                 PreviewRecord(
@@ -15800,6 +15852,333 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(resolved_target.target_id, "compose-123")
             self.assertEqual(inventory.deployment_record_id, deployment.record_id)
             self.assertEqual(inventory.promotion_record_id, "")
+
+    def test_odoo_stable_verification_driver_updates_testing_deployment_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            store.write_deployment_record(
+                DeploymentRecord(
+                    record_id="deployment-20260420T153000Z-cm-testing",
+                    artifact_identity=ArtifactIdentityReference(
+                        artifact_id="artifact-20260420-a1b2c3d4"
+                    ),
+                    context="cm",
+                    instance="testing",
+                    source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
+                    deploy=DeploymentEvidence(
+                        target_name="cm-testing",
+                        target_type="compose",
+                        deploy_mode="dokploy-compose-api",
+                        deployment_id="delegated-compose-ship",
+                        status="pass",
+                    ),
+                    destination_health=HealthcheckEvidence(status="pending"),
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/tenant-cm",
+                            "workflow_refs": [
+                                "every/tenant-cm/.github/workflows/stable-smoke.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["deployment.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="every/tenant-cm",
+                        workflow_ref=(
+                            "every/tenant-cm/.github/workflows/stable-smoke.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/odoo/stable-verification",
+                payload={
+                    "schema_version": 1,
+                    "product": "odoo-tenant-cm",
+                    "verification": {
+                        "schema_version": 1,
+                        "context": "cm",
+                        "instance": "testing",
+                        "deployment_record_id": "deployment-20260420T153000Z-cm-testing",
+                        "verification_status": "success",
+                        "verified_at": "2026-04-20T15:35:00Z",
+                        "checked_urls": ["https://cm-testing.example.com/web/health"],
+                        "timeout_seconds": 45,
+                    },
+                },
+                headers={"Idempotency-Key": "odoo-stable-verification:cm:testing:1"},
+            )
+
+            self.assertEqual(status_code, 202, msg=json.dumps(payload, indent=2))
+            self.assertEqual(payload["status"], "accepted")
+            self.assertEqual(
+                payload["records"],
+                {
+                    "deployment_record_id": "deployment-20260420T153000Z-cm-testing",
+                    "inventory_record_id": "cm-testing",
+                },
+            )
+            deployment = store.read_deployment_record("deployment-20260420T153000Z-cm-testing")
+            inventory = store.read_environment_inventory(context_name="cm", instance_name="testing")
+            self.assertEqual(deployment.destination_health.status, "pass")
+            self.assertEqual(
+                deployment.destination_health.urls,
+                ("https://cm-testing.example.com/web/health",),
+            )
+            self.assertEqual(inventory.deployment_record_id, deployment.record_id)
+
+            replay_status, replay_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/odoo/stable-verification",
+                payload={
+                    "schema_version": 1,
+                    "product": "odoo-tenant-cm",
+                    "verification": {
+                        "schema_version": 1,
+                        "context": "cm",
+                        "instance": "testing",
+                        "deployment_record_id": "deployment-20260420T153000Z-cm-testing",
+                        "verification_status": "success",
+                        "verified_at": "2026-04-20T15:35:00Z",
+                        "checked_urls": ["https://cm-testing.example.com/web/health"],
+                        "timeout_seconds": 45,
+                    },
+                },
+                headers={"Idempotency-Key": "odoo-stable-verification:cm:testing:1"},
+            )
+
+            self.assertEqual(replay_status, 202, msg=json.dumps(replay_payload, indent=2))
+            self.assertTrue(replay_payload["replayed"])
+            self.assertEqual(replay_payload["records"], payload["records"])
+
+    def test_odoo_stable_verification_driver_updates_prod_promotion_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            profile_payload = _odoo_preview_profile_payload("odoo-tenant-cm")
+            lanes = list(cast(tuple[dict[str, object], ...], profile_payload["lanes"]))
+            lanes.append(
+                {
+                    "instance": "prod",
+                    "context": "cm",
+                    "base_url": "https://cm.example.com",
+                    "health_url": "https://cm.example.com/web/health",
+                }
+            )
+            profile_payload["lanes"] = tuple(lanes)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
+            )
+            store.write_deployment_record(
+                DeploymentRecord(
+                    record_id="deployment-20260420T160500Z-cm-prod",
+                    artifact_identity=ArtifactIdentityReference(
+                        artifact_id="artifact-20260420-a1b2c3d4"
+                    ),
+                    context="cm",
+                    instance="prod",
+                    source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
+                    deploy=DeploymentEvidence(
+                        target_name="cm-prod",
+                        target_type="compose",
+                        deploy_mode="dokploy-compose-api",
+                        deployment_id="delegated-compose-ship",
+                        status="pass",
+                    ),
+                    destination_health=HealthcheckEvidence(status="pending"),
+                )
+            )
+            store.write_promotion_record(
+                PromotionRecord(
+                    record_id="promotion-20260420T160500Z-cm-testing-to-prod",
+                    artifact_identity=ArtifactIdentityReference(
+                        artifact_id="artifact-20260420-a1b2c3d4"
+                    ),
+                    deployment_record_id="deployment-20260420T160500Z-cm-prod",
+                    backup_record_id="backup-cm-prod-20260420T155000Z",
+                    context="cm",
+                    from_instance="testing",
+                    to_instance="prod",
+                    deploy=DeploymentEvidence(
+                        target_name="cm-prod",
+                        target_type="compose",
+                        deploy_mode="dokploy-compose-api",
+                        deployment_id="delegated-compose-ship",
+                        status="pass",
+                    ),
+                    destination_health=HealthcheckEvidence(status="pending"),
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/tenant-cm",
+                            "workflow_refs": [
+                                "every/tenant-cm/.github/workflows/prod-smoke.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["deployment.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="every/tenant-cm",
+                        workflow_ref=(
+                            "every/tenant-cm/.github/workflows/prod-smoke.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/odoo/stable-verification",
+                payload={
+                    "schema_version": 1,
+                    "product": "odoo-tenant-cm",
+                    "verification": {
+                        "schema_version": 1,
+                        "context": "cm",
+                        "instance": "prod",
+                        "deployment_record_id": "deployment-20260420T160500Z-cm-prod",
+                        "promotion_record_id": "promotion-20260420T160500Z-cm-testing-to-prod",
+                        "verification_status": "failure",
+                        "verified_at": "2026-04-20T16:12:00Z",
+                        "checked_urls": ["https://cm.example.com/web/health"],
+                        "timeout_seconds": 45,
+                        "failure_summary": "Prod smoke failed.",
+                    },
+                },
+            )
+
+            self.assertEqual(status_code, 202, msg=json.dumps(payload, indent=2))
+            self.assertEqual(
+                payload["records"]["deployment_record_id"],
+                "deployment-20260420T160500Z-cm-prod",
+            )
+            self.assertEqual(
+                payload["records"]["promotion_record_id"],
+                "promotion-20260420T160500Z-cm-testing-to-prod",
+            )
+            deployment = store.read_deployment_record("deployment-20260420T160500Z-cm-prod")
+            promotion = store.read_promotion_record("promotion-20260420T160500Z-cm-testing-to-prod")
+            inventory = store.read_environment_inventory(context_name="cm", instance_name="prod")
+            self.assertEqual(deployment.destination_health.status, "fail")
+            self.assertEqual(promotion.destination_health.status, "fail")
+            self.assertEqual(inventory.promotion_record_id, promotion.record_id)
+            self.assertEqual(inventory.promoted_from_instance, "testing")
+
+    def test_odoo_stable_verification_driver_rejects_mismatched_deployment(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(
+                    _odoo_profile_payload_with_prod_lane()
+                )
+            )
+            store.write_deployment_record(
+                DeploymentRecord(
+                    record_id="deployment-20260420T153000Z-cm-testing",
+                    context="cm",
+                    instance="testing",
+                    source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
+                    deploy=DeploymentEvidence(
+                        target_name="cm-testing",
+                        target_type="compose",
+                        deploy_mode="dokploy-compose-api",
+                        status="pass",
+                    ),
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/tenant-cm",
+                            "workflow_refs": [
+                                "every/tenant-cm/.github/workflows/stable-smoke.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["deployment.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="every/tenant-cm",
+                        workflow_ref=(
+                            "every/tenant-cm/.github/workflows/stable-smoke.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/odoo/stable-verification",
+                payload={
+                    "schema_version": 1,
+                    "product": "odoo-tenant-cm",
+                    "verification": {
+                        "schema_version": 1,
+                        "context": "cm",
+                        "instance": "prod",
+                        "deployment_record_id": "deployment-20260420T153000Z-cm-testing",
+                        "verification_status": "success",
+                        "verified_at": "2026-04-20T16:12:00Z",
+                    },
+                },
+            )
+
+            self.assertEqual(status_code, 400)
+            self.assertEqual(payload["error"]["code"], "invalid_request")
 
     def test_deployment_endpoint_replays_idempotent_write(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary

- Add hidden safe-write Odoo stable verification descriptor action and service route.
- Let stable smoke workflows submit deployment/promotion health evidence without provider mutation.
- Update deployment, optional promotion, and inventory records with pass/fail health evidence and idempotent replay support.
- Document the stable verification ingress alongside preview verification.

Refs #512.

## Validation

- `uv run python -m unittest tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_odoo_stable_verification_driver_updates_testing_deployment_record tests.test_service.LaunchplaneServiceTests.test_odoo_stable_verification_driver_updates_prod_promotion_record tests.test_service.LaunchplaneServiceTests.test_odoo_stable_verification_driver_rejects_mismatched_deployment tests.test_service.LaunchplaneServiceTests.test_verireel_testing_verification_driver_updates_deployment_record`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m py_compile control_plane/service.py control_plane/drivers/registry.py tests/test_service.py tests/test_driver_descriptors.py`
- `git diff --check`
- `uv run --extra dev ruff check control_plane/drivers/registry.py control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/drivers/registry.py control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py`
- `uv run python -m unittest`
- JetBrains changed-files inspection run 7: existing broad service/test baseline remains; no new stable-ingestion defect after protocol cast cleanup.
