### PR TITLE
Fix Odoo target replacement operation races

### DIFF
--- a/control_plane/contracts/odoo_stable_target_replacement_operation.py
+++ b/control_plane/contracts/odoo_stable_target_replacement_operation.py
@@ -40,6 +40,7 @@ class OdooStableTargetReplacementOperationRecord(BaseModel):
     context: str
     instance: str
     idempotency_key: str
+    idempotency_scope: str = ""
     request_fingerprint: str
     request: OdooStableTargetReplacementApplyRequest
     status: OdooStableTargetReplacementOperationStatus = "pending"
@@ -71,6 +72,7 @@ class OdooStableTargetReplacementOperationRecord(BaseModel):
             self.idempotency_key,
             "Odoo stable target replacement operation requires idempotency_key.",
         )
+        self.idempotency_scope = self.idempotency_scope.strip()
         self.request_fingerprint = _normalize_required(
             self.request_fingerprint,
             "Odoo stable target replacement operation requires request_fingerprint.",

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -597,6 +597,10 @@ class _OdooStableTargetReplacementOperationStore(Protocol):
         self, record: OdooStableTargetReplacementOperationRecord
     ) -> object: ...
 
+    def create_odoo_stable_target_replacement_operation_record_if_no_active_lane(
+        self, record: OdooStableTargetReplacementOperationRecord
+    ) -> tuple[OdooStableTargetReplacementOperationRecord, bool]: ...
+
     def read_odoo_stable_target_replacement_operation_record(
         self, operation_id: str
     ) -> OdooStableTargetReplacementOperationRecord: ...
@@ -608,6 +612,7 @@ class _OdooStableTargetReplacementOperationStore(Protocol):
         context_name: str = "",
         instance_name: str = "",
         idempotency_key: str = "",
+        idempotency_scope: str = "",
         statuses: tuple[str, ...] = (),
         limit: int | None = None,
     ) -> tuple[OdooStableTargetReplacementOperationRecord, ...]: ...
@@ -4311,6 +4316,7 @@ def _odoo_stable_target_replacement_operation_store(
 ) -> _OdooStableTargetReplacementOperationStore:
     required_methods = (
         "write_odoo_stable_target_replacement_operation_record",
+        "create_odoo_stable_target_replacement_operation_record_if_no_active_lane",
         "read_odoo_stable_target_replacement_operation_record",
         "list_odoo_stable_target_replacement_operation_records",
     )
@@ -4354,26 +4360,11 @@ def _find_odoo_stable_target_replacement_operation_by_idempotency_key(
     *,
     operation_store: _OdooStableTargetReplacementOperationStore,
     idempotency_key: str,
+    idempotency_scope: str,
 ) -> OdooStableTargetReplacementOperationRecord | None:
     records = operation_store.list_odoo_stable_target_replacement_operation_records(
         idempotency_key=idempotency_key,
-        limit=1,
-    )
-    return records[0] if records else None
-
-
-def _find_active_odoo_stable_target_replacement_operation(
-    *,
-    operation_store: _OdooStableTargetReplacementOperationStore,
-    product: str,
-    context: str,
-    instance: str,
-) -> OdooStableTargetReplacementOperationRecord | None:
-    records = operation_store.list_odoo_stable_target_replacement_operation_records(
-        product=product,
-        context_name=context,
-        instance_name=instance,
-        statuses=("pending", "running"),
+        idempotency_scope=idempotency_scope,
         limit=1,
     )
     return records[0] if records else None
@@ -4411,6 +4402,7 @@ def _build_odoo_stable_target_replacement_operation_record(
     replacement_request: OdooStableTargetReplacementApplyRequest,
     context: str,
     idempotency_key: str,
+    idempotency_scope: str,
     request_fingerprint: str,
     created_at: str,
 ) -> OdooStableTargetReplacementOperationRecord:
@@ -4425,6 +4417,7 @@ def _build_odoo_stable_target_replacement_operation_record(
         context=context,
         instance=replacement_request.instance,
         idempotency_key=idempotency_key,
+        idempotency_scope=idempotency_scope,
         request_fingerprint=request_fingerprint,
         request=replacement_request,
         status="pending",
@@ -11131,6 +11124,7 @@ def create_launchplane_service_app(
                     _find_odoo_stable_target_replacement_operation_by_idempotency_key(
                         operation_store=replacement_operation_store,
                         idempotency_key=request_idempotency_key,
+                        idempotency_scope=request_scope,
                     )
                 )
                 if existing_replacement_operation is not None:
@@ -11161,15 +11155,20 @@ def create_launchplane_service_app(
                         ),
                     }
                 else:
-                    active_replacement_operation = (
-                        _find_active_odoo_stable_target_replacement_operation(
-                            operation_store=replacement_operation_store,
-                            product=odoo_replacement_apply_request.product,
-                            context=replacement_apply_lane.context,
-                            instance=odoo_replacement_apply_request.replacement.instance,
+                    replacement_operation = _build_odoo_stable_target_replacement_operation_record(
+                        replacement_request=odoo_replacement_apply_request.replacement,
+                        context=replacement_apply_lane.context,
+                        idempotency_key=request_idempotency_key,
+                        idempotency_scope=request_scope,
+                        request_fingerprint=request_fingerprint,
+                        created_at=_utc_now_timestamp(),
+                    )
+                    replacement_operation, created_replacement_operation = (
+                        replacement_operation_store.create_odoo_stable_target_replacement_operation_record_if_no_active_lane(
+                            replacement_operation
                         )
                     )
-                    if active_replacement_operation is not None:
+                    if not created_replacement_operation:
                         return _json_response(
                             start_response=start_response,
                             status_code=409,
@@ -11181,20 +11180,10 @@ def create_launchplane_service_app(
                                     "message": "An Odoo target replacement operation is already active for this product/context/instance.",
                                 },
                                 "operation": _target_replacement_operation_payload(
-                                    active_replacement_operation
+                                    replacement_operation
                                 ),
                             },
                         )
-                    replacement_operation = _build_odoo_stable_target_replacement_operation_record(
-                        replacement_request=odoo_replacement_apply_request.replacement,
-                        context=replacement_apply_lane.context,
-                        idempotency_key=request_idempotency_key,
-                        request_fingerprint=request_fingerprint,
-                        created_at=_utc_now_timestamp(),
-                    )
-                    replacement_operation_store.write_odoo_stable_target_replacement_operation_record(
-                        replacement_operation
-                    )
                     _start_odoo_stable_target_replacement_operation_worker(
                         operation_id=replacement_operation.operation_id,
                         control_plane_root_path=resolved_root,

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -1,4 +1,6 @@
+import hashlib
 import json
+import time
 from pathlib import Path
 from typing import TypeVar
 
@@ -621,6 +623,7 @@ class FilesystemRecordStore:
         context_name: str = "",
         instance_name: str = "",
         idempotency_key: str = "",
+        idempotency_scope: str = "",
         statuses: tuple[str, ...] = (),
         limit: int | None = None,
     ) -> tuple[OdooStableTargetReplacementOperationRecord, ...]:
@@ -634,12 +637,58 @@ class FilesystemRecordStore:
             and (not context_name or record.context == context_name)
             and (not instance_name or record.instance == instance_name)
             and (not idempotency_key or record.idempotency_key == idempotency_key)
+            and (not idempotency_scope or record.idempotency_scope == idempotency_scope)
             and (not statuses or record.status in statuses)
         ]
         records.sort(key=lambda record: (record.updated_at, record.operation_id), reverse=True)
         if limit is not None:
             records = records[:limit]
         return tuple(records)
+
+    def create_odoo_stable_target_replacement_operation_record_if_no_active_lane(
+        self, record: OdooStableTargetReplacementOperationRecord
+    ) -> tuple[OdooStableTargetReplacementOperationRecord, bool]:
+        reservation_id = _odoo_target_replacement_lane_reservation_id(record)
+        reservation_path = self._record_path(
+            "odoo_stable_target_replacement_lane_reservations", reservation_id
+        )
+        reservation_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with reservation_path.open("x", encoding="utf-8") as reservation_file:
+                reservation_file.write(record.operation_id)
+        except FileExistsError:
+            reserved_operation_id = reservation_path.read_text(encoding="utf-8").strip()
+            if reserved_operation_id:
+                reserved_operation = (
+                    self._wait_for_odoo_stable_target_replacement_reserved_operation(
+                        reserved_operation_id
+                    )
+                )
+                if reserved_operation is None:
+                    reservation_path.unlink(missing_ok=True)
+                    return self.create_odoo_stable_target_replacement_operation_record_if_no_active_lane(
+                        record
+                    )
+                if reserved_operation.status in {"pending", "running"}:
+                    return reserved_operation, False
+            reservation_path.unlink(missing_ok=True)
+            return self.create_odoo_stable_target_replacement_operation_record_if_no_active_lane(
+                record
+            )
+        self.write_odoo_stable_target_replacement_operation_record(record)
+        return record, True
+
+    def _wait_for_odoo_stable_target_replacement_reserved_operation(
+        self, operation_id: str
+    ) -> OdooStableTargetReplacementOperationRecord | None:
+        deadline = time.monotonic() + 1.0
+        while True:
+            try:
+                return self.read_odoo_stable_target_replacement_operation_record(operation_id)
+            except FileNotFoundError:
+                if time.monotonic() >= deadline:
+                    return None
+                time.sleep(0.01)
 
     def write_backup_gate_record(self, record: BackupGateRecord) -> Path:
         return self._write_model("backup_gates", record.record_id, record)
@@ -969,3 +1018,11 @@ class FilesystemRecordStore:
         if limit is not None:
             records = records[:limit]
         return tuple(records)
+
+
+def _odoo_target_replacement_lane_reservation_id(
+    record: OdooStableTargetReplacementOperationRecord,
+) -> str:
+    lane_key = "|".join((record.product, record.context, record.instance))
+    digest = hashlib.sha256(lane_key.encode()).hexdigest()[:16]
+    return f"{record.product}-{record.context}-{record.instance}".replace("/", "-") + f"-{digest}"

--- a/control_plane/storage/migrations/versions/f5b6c7d8e9a0_scope_odoo_target_replacement_operations.py
+++ b/control_plane/storage/migrations/versions/f5b6c7d8e9a0_scope_odoo_target_replacement_operations.py
@@ -1,0 +1,59 @@
+"""scope Odoo target replacement operation reservations
+
+Revision ID: f5b6c7d8e9a0
+Revises: f4a5b6c7d8e9
+Create Date: 2026-05-17 19:35:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "f5b6c7d8e9a0"
+down_revision: str | None = "f4a5b6c7d8e9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "launchplane_odoo_stable_target_replacement_operations"
+_ACTIVE_LANE_INDEX = "launchplane_odoo_replacement_active_lane_uidx"
+_IDEMPOTENCY_INDEX = "launchplane_odoo_replacement_operation_idempotency_idx"
+
+
+def upgrade() -> None:
+    op.add_column(
+        _TABLE,
+        sa.Column(
+            "idempotency_scope",
+            sa.String(),
+            nullable=False,
+            server_default="",
+        ),
+    )
+    op.drop_index(_IDEMPOTENCY_INDEX, table_name=_TABLE)
+    op.create_index(
+        _IDEMPOTENCY_INDEX,
+        _TABLE,
+        ["idempotency_scope", "idempotency_key", sa.text("updated_at DESC")],
+    )
+    op.create_index(
+        _ACTIVE_LANE_INDEX,
+        _TABLE,
+        ["product", "context", "instance"],
+        unique=True,
+        postgresql_where=sa.text("status IN ('pending', 'running')"),
+        sqlite_where=sa.text("status IN ('pending', 'running')"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(_ACTIVE_LANE_INDEX, table_name=_TABLE)
+    op.drop_index(_IDEMPOTENCY_INDEX, table_name=_TABLE)
+    op.create_index(
+        _IDEMPOTENCY_INDEX,
+        _TABLE,
+        ["idempotency_key", sa.text("updated_at DESC")],
+    )
+    op.drop_column(_TABLE, "idempotency_scope")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     create_engine,
     delete,
     desc,
+    text,
     select,
 )
 from sqlalchemy.dialects.postgresql import JSONB
@@ -768,8 +769,18 @@ class LaunchplaneOdooStableTargetReplacementOperationRow(Base):
         ),
         Index(
             "launchplane_odoo_replacement_operation_idempotency_idx",
+            "idempotency_scope",
             "idempotency_key",
             desc("updated_at"),
+        ),
+        Index(
+            "launchplane_odoo_replacement_active_lane_uidx",
+            "product",
+            "context",
+            "instance",
+            unique=True,
+            postgresql_where=text("status IN ('pending', 'running')"),
+            sqlite_where=text("status IN ('pending', 'running')"),
         ),
     )
 
@@ -778,6 +789,7 @@ class LaunchplaneOdooStableTargetReplacementOperationRow(Base):
     context: Mapped[str] = mapped_column(String, nullable=False)
     instance: Mapped[str] = mapped_column(String, nullable=False)
     idempotency_key: Mapped[str] = mapped_column(String, nullable=False)
+    idempotency_scope: Mapped[str] = mapped_column(String, nullable=False, default="")
     status: Mapped[str] = mapped_column(String, nullable=False)
     phase: Mapped[str] = mapped_column(String, nullable=False)
     created_at: Mapped[str] = mapped_column(String, nullable=False)
@@ -1212,6 +1224,7 @@ class PostgresRecordStore(HumanSessionStore):
                 context=record.context,
                 instance=record.instance,
                 idempotency_key=record.idempotency_key,
+                idempotency_scope=record.idempotency_scope,
                 status=record.status,
                 phase=record.phase,
                 created_at=record.created_at,
@@ -1219,6 +1232,45 @@ class PostgresRecordStore(HumanSessionStore):
                 payload=self._payload_dict(record),
             )
         )
+
+    def create_odoo_stable_target_replacement_operation_record_if_no_active_lane(
+        self, record: OdooStableTargetReplacementOperationRecord
+    ) -> tuple[OdooStableTargetReplacementOperationRecord, bool]:
+        with self._session_factory() as session:
+            session.add(
+                LaunchplaneOdooStableTargetReplacementOperationRow(
+                    operation_id=record.operation_id,
+                    product=record.product,
+                    context=record.context,
+                    instance=record.instance,
+                    idempotency_key=record.idempotency_key,
+                    idempotency_scope=record.idempotency_scope,
+                    status=record.status,
+                    phase=record.phase,
+                    created_at=record.created_at,
+                    updated_at=record.updated_at,
+                    payload=self._payload_dict(record),
+                )
+            )
+            try:
+                session.commit()
+            except IntegrityError:
+                session.rollback()
+                active_records = self.list_odoo_stable_target_replacement_operation_records(
+                    product=record.product,
+                    context_name=record.context,
+                    instance_name=record.instance,
+                    statuses=("pending", "running"),
+                    limit=1,
+                )
+                if active_records:
+                    return active_records[0], False
+                return (
+                    self.create_odoo_stable_target_replacement_operation_record_if_no_active_lane(
+                        record
+                    )
+                )
+        return record, True
 
     def read_odoo_stable_target_replacement_operation_record(
         self, operation_id: str
@@ -1238,6 +1290,7 @@ class PostgresRecordStore(HumanSessionStore):
         context_name: str = "",
         instance_name: str = "",
         idempotency_key: str = "",
+        idempotency_scope: str = "",
         statuses: tuple[str, ...] = (),
         limit: int | None = None,
     ) -> tuple[OdooStableTargetReplacementOperationRecord, ...]:
@@ -1256,6 +1309,11 @@ class PostgresRecordStore(HumanSessionStore):
             filters.append(
                 LaunchplaneOdooStableTargetReplacementOperationRow.idempotency_key
                 == idempotency_key
+            )
+        if idempotency_scope:
+            filters.append(
+                LaunchplaneOdooStableTargetReplacementOperationRow.idempotency_scope
+                == idempotency_scope
             )
         if statuses:
             filters.append(LaunchplaneOdooStableTargetReplacementOperationRow.status.in_(statuses))

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -192,6 +192,9 @@ Odoo target replacement apply uses the same durable operation shape for the
 guarded `recreate-in-place` path: `POST /v1/drivers/odoo/target-replacement-apply`
 creates or replays an operation, and callers poll
 `/v1/drivers/odoo/target-replacement/operations/{operation_id}` until terminal.
+Replay is scoped to the authenticated caller identity, and storage reserves the
+product/context/instance lane before the worker starts so concurrent apply
+requests cannot launch duplicate replacements.
 
 Driver action routes are owned by the base driver contract. The service accepts
 any product key on Odoo and VeriReel action envelopes, then authorizes the call

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -743,9 +743,11 @@ returns immediately; the workflow polls
 `GET /v1/drivers/odoo/target-replacement/operations/{operation_id}` until the
 operation status is `pass` or `fail`, then uploads the final operation payload as
 the workflow artifact. `Idempotency-Key` is required: a repeated request with the
-same key returns the existing operation, while a different key for the same
-product/context/instance is rejected while a `pending` or `running` operation is
-active. The first apply surface is testing-only and keeps the existing compose
+same key from the same caller identity returns the existing operation, while a
+different key for the same product/context/instance is rejected while a
+`pending` or `running` operation is active. Storage owns that active-lane
+reservation so the worker starts only after the lane is claimed. The first apply
+surface is testing-only and keeps the existing compose
 target, explicit Odoo volume env keys, and expected hostnames; the operation
 worker re-syncs the Launchplane-rendered compose source, reconciles each expected
 Dokploy compose domain route to the `web` service on the product runtime port,

--- a/docs/records.md
+++ b/docs/records.md
@@ -398,11 +398,12 @@ state/
   `odoo_stable_target_replacement_operations`. These records mirror the stable
   bootstrap operation boundary for the guarded `recreate-in-place` replacement
   path: the service stores the apply request, `Idempotency-Key`, request
-  fingerprint, status/phase, deployment-record id when available, final apply
-  result, and terminal error. Reusing the same key with the same request replays
-  the existing operation; reusing it for a different request is rejected; an
-  active `pending` or `running` operation blocks another apply for the same
-  product/context/instance.
+  fingerprint, caller idempotency scope, status/phase, deployment-record id
+  when available, final apply result, and terminal error. Reusing the same key
+  with the same request and caller identity replays the existing operation;
+  reusing it for a different request is rejected; an active `pending` or
+  `running` operation blocks another apply for the same product/context/instance
+  through a storage-owned lane reservation.
 - Odoo prod rollback writes a normal deployment record for the rollback deploy,
   refreshes prod inventory, mints the prod release tuple from the selected
   artifact manifest, and annotates the current prod promotion record's

--- a/tests/test_odoo_stable_target_replacement_operation.py
+++ b/tests/test_odoo_stable_target_replacement_operation.py
@@ -1,4 +1,5 @@
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -20,6 +21,7 @@ def _operation_payload(operation_id: str = "operation-cm-testing") -> dict[str, 
         "context": "cm",
         "instance": "testing",
         "idempotency_key": "replacement-cm-testing",
+        "idempotency_scope": "github-actions|cbusillo/launchplane|apply.yml|subject-a",
         "request_fingerprint": "fingerprint-123",
         "request": {
             "schema_version": 1,
@@ -95,6 +97,79 @@ class OdooStableTargetReplacementOperationRecordTests(unittest.TestCase):
                 (active.operation_id,),
             )
 
+    def test_filesystem_store_filters_idempotency_by_scope(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name))
+            first = OdooStableTargetReplacementOperationRecord.model_validate(
+                {
+                    **_operation_payload("operation-scope-a"),
+                    "idempotency_scope": "caller-a",
+                    "status": "pass",
+                    "phase": "completed",
+                    "finished_at": "2026-05-17T00:05:00Z",
+                    "updated_at": "2026-05-17T00:05:00Z",
+                }
+            )
+            second = OdooStableTargetReplacementOperationRecord.model_validate(
+                {
+                    **_operation_payload("operation-scope-b"),
+                    "idempotency_scope": "caller-b",
+                    "status": "pass",
+                    "phase": "completed",
+                    "finished_at": "2026-05-17T00:06:00Z",
+                    "updated_at": "2026-05-17T00:06:00Z",
+                }
+            )
+
+            store.write_odoo_stable_target_replacement_operation_record(first)
+            store.write_odoo_stable_target_replacement_operation_record(second)
+
+            scoped_records = store.list_odoo_stable_target_replacement_operation_records(
+                idempotency_key="replacement-cm-testing",
+                idempotency_scope="caller-a",
+            )
+
+            self.assertEqual(
+                tuple(record.operation_id for record in scoped_records),
+                ("operation-scope-a",),
+            )
+
+    def test_filesystem_store_reserves_active_lane_atomically(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name))
+            records = [
+                OdooStableTargetReplacementOperationRecord.model_validate(
+                    {
+                        **_operation_payload(f"operation-cm-testing-{index}"),
+                        "idempotency_key": f"replacement-cm-testing-{index}",
+                        "idempotency_scope": f"caller-{index}",
+                    }
+                )
+                for index in range(2)
+            ]
+
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                results = tuple(
+                    executor.map(
+                        store.create_odoo_stable_target_replacement_operation_record_if_no_active_lane,
+                        records,
+                    )
+                )
+
+            created_results = tuple(created for _, created in results)
+            returned_ids = {record.operation_id for record, _ in results}
+            active_records = store.list_odoo_stable_target_replacement_operation_records(
+                product="odoo-tenant-cm",
+                context_name="cm",
+                instance_name="testing",
+                statuses=("pending", "running"),
+            )
+
+            self.assertEqual(created_results.count(True), 1)
+            self.assertEqual(created_results.count(False), 1)
+            self.assertEqual(len(returned_ids), 1)
+            self.assertEqual(len(active_records), 1)
+
     def test_postgres_store_round_trips_operation(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
@@ -107,6 +182,7 @@ class OdooStableTargetReplacementOperationRecordTests(unittest.TestCase):
             loaded = store.read_odoo_stable_target_replacement_operation_record(record.operation_id)
             active_records = store.list_odoo_stable_target_replacement_operation_records(
                 idempotency_key="replacement-cm-testing",
+                idempotency_scope="github-actions|cbusillo/launchplane|apply.yml|subject-a",
                 statuses=("pending",),
             )
 
@@ -115,6 +191,37 @@ class OdooStableTargetReplacementOperationRecordTests(unittest.TestCase):
                 tuple(item.operation_id for item in active_records),
                 (record.operation_id,),
             )
+
+    def test_postgres_store_reserves_active_lane(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            store = PostgresRecordStore(database_url=f"sqlite:///{database_path}")
+            store.ensure_schema()
+            first = OdooStableTargetReplacementOperationRecord.model_validate(
+                _operation_payload("operation-cm-testing-a")
+            )
+            second = OdooStableTargetReplacementOperationRecord.model_validate(
+                {
+                    **_operation_payload("operation-cm-testing-b"),
+                    "idempotency_key": "replacement-cm-testing-b",
+                    "idempotency_scope": "caller-b",
+                }
+            )
+
+            created_first = (
+                store.create_odoo_stable_target_replacement_operation_record_if_no_active_lane(
+                    first
+                )
+            )
+            created_second = (
+                store.create_odoo_stable_target_replacement_operation_record_if_no_active_lane(
+                    second
+                )
+            )
+
+            self.assertTrue(created_first[1])
+            self.assertFalse(created_second[1])
+            self.assertEqual(created_first[0].operation_id, created_second[0].operation_id)
 
 
 if __name__ == "__main__":

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -20342,6 +20342,122 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             worker_mock.assert_called_once()
 
+    def test_odoo_target_replacement_apply_driver_scopes_replay_to_caller(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            profile_payload = _odoo_profile_payload_with_prod_lane()
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/odoo-target-replacement-apply.yml@refs/heads/main",
+                                "cbusillo/launchplane/.github/workflows/odoo-target-replacement-apply-other.yml@refs/heads/main",
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["odoo_target_replacement_apply.execute"],
+                        }
+                    ]
+                }
+            )
+            first_app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-target-replacement-apply.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            second_app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-target-replacement-apply-other.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service._start_odoo_stable_target_replacement_operation_worker"
+            ) as worker_mock:
+                first_status, first_payload = _invoke_app(
+                    first_app,
+                    method="POST",
+                    path="/v1/drivers/odoo/target-replacement-apply",
+                    payload={
+                        "product": "odoo-tenant-cm",
+                        "replacement": {
+                            "product": "odoo-tenant-cm",
+                            "instance": "testing",
+                            "strategy": "recreate-in-place",
+                            "allow_empty_data": False,
+                        },
+                    },
+                    headers={"Idempotency-Key": "shared-target-replacement-key"},
+                )
+                first_operation_id = first_payload["records"][
+                    "odoo_stable_target_replacement_operation_id"
+                ]
+                first_operation = store.read_odoo_stable_target_replacement_operation_record(
+                    first_operation_id
+                )
+                store.write_odoo_stable_target_replacement_operation_record(
+                    first_operation.model_copy(
+                        update={
+                            "status": "pass",
+                            "phase": "completed",
+                            "finished_at": "2026-05-17T00:05:00Z",
+                            "updated_at": "2026-05-17T00:05:00Z",
+                        }
+                    )
+                )
+                second_status, second_payload = _invoke_app(
+                    second_app,
+                    method="POST",
+                    path="/v1/drivers/odoo/target-replacement-apply",
+                    payload={
+                        "product": "odoo-tenant-cm",
+                        "replacement": {
+                            "product": "odoo-tenant-cm",
+                            "instance": "prod",
+                            "strategy": "recreate-in-place",
+                            "allow_empty_data": False,
+                        },
+                    },
+                    headers={"Idempotency-Key": "shared-target-replacement-key"},
+                )
+
+            self.assertEqual(first_status, 202)
+            self.assertEqual(second_status, 202)
+            self.assertNotEqual(
+                first_payload["records"]["odoo_stable_target_replacement_operation_id"],
+                second_payload["records"]["odoo_stable_target_replacement_operation_id"],
+            )
+            worker_mock.assert_called()
+            self.assertEqual(worker_mock.call_count, 2)
+
     def test_odoo_target_replacement_apply_driver_blocks_second_active_lane_operation(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- Scope durable Odoo target-replacement idempotency replay to the authenticated caller identity.
- Add storage-owned active-lane reservation before worker start for filesystem and Postgres/SQLite stores.
- Add migration, docs, and focused service/storage concurrency coverage.

## Validation
- `uv run python -m unittest tests.test_odoo_stable_target_replacement_operation tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_apply_driver_creates_operation_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_apply_driver_replays_existing_operation tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_apply_driver_scopes_replay_to_caller tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_apply_driver_blocks_second_active_lane_operation`
- `uv run python -m py_compile control_plane/service.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/contracts/odoo_stable_target_replacement_operation.py control_plane/storage/migrations/versions/f5b6c7d8e9a0_scope_odoo_target_replacement_operations.py tests/test_odoo_stable_target_replacement_operation.py tests/test_service.py`
- `uv run mypy control_plane tests`
- `uv run ruff format --check control_plane/contracts/odoo_stable_target_replacement_operation.py control_plane/service.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/f5b6c7d8e9a0_scope_odoo_target_replacement_operations.py tests/test_odoo_stable_target_replacement_operation.py tests/test_service.py`
- `uv run ruff check --diff control_plane/contracts/odoo_stable_target_replacement_operation.py control_plane/service.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/f5b6c7d8e9a0_scope_odoo_target_replacement_operations.py tests/test_odoo_stable_target_replacement_operation.py tests/test_service.py`
- `git diff --check`
- `uv run python -m unittest` (1313 tests)
- JetBrains changed-files inspection: completed; remaining findings are existing broad baseline noise, not in the new reservation/idempotency path.

Refs #520.
