### PR TITLE
Harden Odoo preview verification ingestion

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1433,12 +1433,33 @@ class OdooPreviewVerificationRequest(BaseModel):
     anchor_pr_number: int = Field(ge=1)
     verification_status: ReleaseStatus
     verified_at: str
+    checked_urls: tuple[str, ...] = ()
+    timeout_seconds: int | None = Field(default=None, ge=1)
     failure_summary: str = ""
 
     @field_validator("verification_status", mode="before")
     @classmethod
     def _normalize_status(cls, value: object) -> ReleaseStatus:
         return _normalize_release_status(value, label="Odoo preview verification status")
+
+    @field_validator("checked_urls", mode="before")
+    @classmethod
+    def _normalize_checked_urls(cls, value: object) -> tuple[str, ...]:
+        if value in (None, ""):
+            return ()
+        if isinstance(value, str):
+            raw_values: tuple[object, ...] = (value,)
+        else:
+            try:
+                raw_values = tuple(cast(Iterable[object], value))
+            except TypeError as exc:
+                raise ValueError("Odoo preview verification checked_urls must be a list.") from exc
+        if any(not isinstance(item, str) for item in raw_values):
+            raise ValueError("Odoo preview verification checked_urls must be strings.")
+        checked_urls = tuple(item.strip() for item in cast(tuple[str, ...], raw_values))
+        if any(not item for item in checked_urls):
+            raise ValueError("Odoo preview verification checked_urls cannot contain blanks.")
+        return checked_urls
 
     @model_validator(mode="after")
     def _validate_request(self) -> "OdooPreviewVerificationRequest":
@@ -1450,7 +1471,23 @@ class OdooPreviewVerificationRequest(BaseModel):
             raise ValueError("Odoo preview verification status must be pass or fail.")
         if not self.verified_at.strip():
             raise ValueError("Odoo preview verification requires verified_at.")
+        if self.checked_urls and self.timeout_seconds is None:
+            raise ValueError("Odoo preview verification checked_urls require timeout_seconds.")
         return self
+
+
+class OdooPreviewVerificationResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    preview_id: str
+    preview_generation_id: str
+    preview_state: str
+    generation_state: str
+    verification_status: ReleaseStatus
+    verified_at: str
+    checked_urls: tuple[str, ...] = ()
+    timeout_seconds: int | None = None
+    failure_summary: str = ""
 
 
 class OdooPreviewVerificationEnvelope(_ProductRouteEnvelope):
@@ -4219,51 +4256,60 @@ def _accepted_payload(
         serialized_driver_result = driver_result.model_dump(mode="json")
     elif isinstance(driver_result, dict):
         serialized_driver_result = dict(driver_result)
+    record_keys = {
+        "deployment_record_id",
+        "backup_gate_record_id",
+        "backup_record_id",
+        "release_tuple_id",
+        "inventory_record_id",
+        "preview_id",
+        "preview_desired_state_id",
+        "preview_inventory_scan_id",
+        "preview_pr_feedback_id",
+        "preview_lifecycle_cleanup_id",
+        "preview_lifecycle_plan_id",
+        "authz_policy_record_id",
+        "runtime_key_safety_policy_record_id",
+        "product_profile",
+        "dokploy_target_count",
+        "dokploy_target_id_count",
+        "runtime_environment_record_count",
+        "secret_binding_count",
+        "generation_id",
+        "promotion_record_id",
+        "target_id",
+        "target_type",
+        "image_reference",
+        "artifact_id",
+        "transition",
+        "preview_state",
+        "preview_generation_id",
+        "verification_status",
+        "verified_at",
+        "odoo_preview_verification",
+        "request_id",
+        "feedback_id",
+        "state",
+        "agent_write_intent_record_id",
+        "merge_train_batch_candidate_record_id",
+        "merge_train_batch_landing_plan_record_id",
+        "merge_train_stack_collapse_plan_record_id",
+        "merge_train_run_id",
+        "odoo_stable_bootstrap_operation_id",
+        "odoo_stable_target_replacement_operation_id",
+    }
+    records: dict[str, object] = {}
+    for key, value in result.items():
+        if key not in record_keys:
+            continue
+        if key == "odoo_preview_verification" and isinstance(value, dict):
+            records[key] = value
+            continue
+        records[key] = str(value)
     payload: dict[str, object] = {
         "status": "accepted",
         "trace_id": trace_id,
-        "records": {
-            key: str(value)
-            for key, value in result.items()
-            if key
-            in {
-                "deployment_record_id",
-                "backup_gate_record_id",
-                "backup_record_id",
-                "release_tuple_id",
-                "inventory_record_id",
-                "preview_id",
-                "preview_desired_state_id",
-                "preview_inventory_scan_id",
-                "preview_pr_feedback_id",
-                "preview_lifecycle_cleanup_id",
-                "preview_lifecycle_plan_id",
-                "authz_policy_record_id",
-                "runtime_key_safety_policy_record_id",
-                "product_profile",
-                "dokploy_target_count",
-                "dokploy_target_id_count",
-                "runtime_environment_record_count",
-                "secret_binding_count",
-                "generation_id",
-                "promotion_record_id",
-                "target_id",
-                "target_type",
-                "image_reference",
-                "artifact_id",
-                "transition",
-                "request_id",
-                "feedback_id",
-                "state",
-                "agent_write_intent_record_id",
-                "merge_train_batch_candidate_record_id",
-                "merge_train_batch_landing_plan_record_id",
-                "merge_train_stack_collapse_plan_record_id",
-                "merge_train_run_id",
-                "odoo_stable_bootstrap_operation_id",
-                "odoo_stable_target_replacement_operation_id",
-            }
-        },
+        "records": records,
         **({"result": serialized_driver_result} if serialized_driver_result else {}),
     }
     if replayed:
@@ -6527,7 +6573,7 @@ def _apply_verireel_preview_verification_records(
     verified_at = request.verified_at.strip()
     verification_passed = request.verification_status.strip() == "pass"
     failure_summary = request.failure_summary.strip() or "Preview E2E verification failed."
-    return apply_launchplane_generation_evidence(
+    result = apply_launchplane_generation_evidence(
         control_plane_root_path=control_plane_root_path,
         record_store=typed_record_store,
         preview_request=PreviewMutationRequest(
@@ -6568,6 +6614,7 @@ def _apply_verireel_preview_verification_records(
             failure_summary="" if verification_passed else failure_summary,
         ),
     )
+    return result
 
 
 def _apply_odoo_preview_verification_records(
@@ -6596,7 +6643,7 @@ def _apply_odoo_preview_verification_records(
     verified_at = request.verified_at.strip()
     verification_passed = request.verification_status == "pass"
     failure_summary = request.failure_summary.strip() or "Odoo preview verification failed."
-    return apply_launchplane_generation_evidence(
+    result = apply_launchplane_generation_evidence(
         control_plane_root_path=control_plane_root_path,
         record_store=typed_record_store,
         preview_request=PreviewMutationRequest(
@@ -6637,6 +6684,25 @@ def _apply_odoo_preview_verification_records(
             failure_summary="" if verification_passed else failure_summary,
         ),
     )
+    preview_state = "active" if verification_passed else "failed"
+    generation_state = "ready" if verification_passed else "failed"
+    verification_result = OdooPreviewVerificationResult(
+        preview_id=preview.preview_id,
+        preview_generation_id=generation.generation_id,
+        preview_state=preview_state,
+        generation_state=generation_state,
+        verification_status=request.verification_status,
+        verified_at=verified_at,
+        checked_urls=request.checked_urls,
+        timeout_seconds=request.timeout_seconds if request.checked_urls else None,
+        failure_summary="" if verification_passed else failure_summary,
+    )
+    result["preview_state"] = preview_state
+    result["preview_generation_id"] = generation.generation_id
+    result["verification_status"] = request.verification_status
+    result["verified_at"] = verified_at
+    result["odoo_preview_verification"] = verification_result.model_dump(mode="json")
+    return result
 
 
 def _stable_verification_health_evidence(

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import os
 import time
 from pathlib import Path
 from typing import TypeVar
@@ -656,6 +657,8 @@ class FilesystemRecordStore:
         try:
             with reservation_path.open("x", encoding="utf-8") as reservation_file:
                 reservation_file.write(record.operation_id)
+                reservation_file.flush()
+                os.fsync(reservation_file.fileno())
         except FileExistsError:
             reserved_operation_id = reservation_path.read_text(encoding="utf-8").strip()
             if reserved_operation_id:

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -146,6 +146,9 @@ routes for the same lifecycle: `POST /v1/drivers/odoo/preview-desired-state`,
 preview request schema, live URL derivation, and record writer so Odoo PR
 previews land in the same Launchplane preview and preview-generation records as
 generic-web previews.
+The preview-verification route accepts optional checked URL evidence and returns
+a typed `odoo_preview_verification` result while only mutating Launchplane
+preview-generation records.
 Odoo is the only current generic-web-based driver allowed to use the staged
 compose preview MVP: if its product profile uses `preview.data_transport_mode =
 "bootstrap"` and its template lane is a Dokploy `compose` target, preview refresh

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -107,9 +107,10 @@ ready-to-comment signal instead of independently deciding readiness from raw
 health checks.
 If a later browser or product-specific smoke workflow needs to publish evidence,
 it should call `POST /v1/drivers/odoo/preview-verification` with the PR identity,
-`verification_status`, `verified_at`, and optional failure summary. Launchplane
-updates the latest preview generation and preserves the result in the same
-preview records used by refresh.
+`verification_status`, `verified_at`, optional checked URLs plus timeout, and
+optional failure summary. Launchplane updates the latest preview generation and
+returns a typed `odoo_preview_verification` result while preserving the durable
+status/failure evidence in the same preview records used by refresh.
 
 Preview destroy routes receive the PR number, source/run metadata, and an
 explicit destroy reason such as `pull_request_closed`, `preview_label_removed`,

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1148,9 +1148,12 @@ Driver-owned preview verification routes can update those records without
 requiring product workflows to render Launchplane record payloads directly. For
 Odoo preview smoke follow-ups, `POST /v1/drivers/odoo/preview-verification`
 accepts the product, context, anchor repo/PR, `verification_status`,
-`verified_at`, and an optional failure summary, then marks the latest preview
-generation ready or failed. The route is safe-write evidence ingestion only; it
-does not mutate provider state.
+`verified_at`, optional checked URLs plus `timeout_seconds`, and an optional
+failure summary, then marks the latest preview generation ready or failed. The
+accepted response includes an `odoo_preview_verification` result with the
+generation identity, final states, status, checked URLs, timeout, and failure
+summary. The route is safe-write evidence ingestion only; it does not mutate
+provider state.
 
 For stable Odoo smoke follow-ups, `POST /v1/drivers/odoo/stable-verification`
 accepts the product, context, instance, deployment record, optional promotion

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -12969,6 +12969,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "anchor_pr_number": 42,
                         "verification_status": "pass",
                         "verified_at": "2026-05-09T15:08:00Z",
+                        "checked_urls": [
+                            "https://pr-42.cm-preview.example.test/web/health",
+                            "https://pr-42.cm-preview.example.test/cell-mechanic",
+                        ],
+                        "timeout_seconds": 30,
                     },
                 },
                 headers={"Idempotency-Key": "odoo-preview-verification:cm:42:run-1"},
@@ -12976,6 +12981,21 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
             self.assertEqual(status_code, 202)
             self.assertEqual(payload["records"]["transition"], "ready")
+            self.assertEqual(payload["records"]["preview_state"], "active")
+            self.assertEqual(
+                payload["records"]["preview_generation_id"],
+                "preview-cm-odoo-tenant-cm-pr-42-generation-0001",
+            )
+            self.assertEqual(payload["records"]["verification_status"], "pass")
+            self.assertEqual(payload["records"]["verified_at"], "2026-05-09T15:08:00Z")
+            self.assertEqual(
+                payload["records"]["odoo_preview_verification"]["checked_urls"],
+                [
+                    "https://pr-42.cm-preview.example.test/web/health",
+                    "https://pr-42.cm-preview.example.test/cell-mechanic",
+                ],
+            )
+            self.assertEqual(payload["records"]["odoo_preview_verification"]["timeout_seconds"], 30)
             preview = store.read_preview_record("preview-cm-odoo-tenant-cm-pr-42")
             generation = store.read_preview_generation_record(
                 "preview-cm-odoo-tenant-cm-pr-42-generation-0001"
@@ -13068,7 +13088,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 control_plane_root_path=root,
             )
 
-            status_code, _payload = _invoke_app(
+            status_code, payload = _invoke_app(
                 app,
                 method="POST",
                 path="/v1/drivers/odoo/preview-verification",
@@ -13082,6 +13102,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "anchor_pr_number": 42,
                         "verification_status": "fail",
                         "verified_at": "2026-05-09T15:08:00Z",
+                        "checked_urls": ["https://pr-42.cm-preview.example.test/cell-mechanic"],
+                        "timeout_seconds": 20,
                         "failure_summary": "Odoo preview page did not include Cell Mechanic.",
                     },
                 },
@@ -13089,6 +13111,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
 
             self.assertEqual(status_code, 202)
+            self.assertEqual(payload["records"]["transition"], "failed")
+            self.assertEqual(payload["records"]["preview_state"], "failed")
+            self.assertEqual(payload["records"]["verification_status"], "fail")
+            self.assertEqual(
+                payload["records"]["odoo_preview_verification"]["failure_summary"],
+                "Odoo preview page did not include Cell Mechanic.",
+            )
             preview = store.read_preview_record("preview-cm-odoo-tenant-cm-pr-42")
             generation = store.read_preview_generation_record(
                 "preview-cm-odoo-tenant-cm-pr-42-generation-0001"
@@ -13099,6 +13128,67 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(generation.overall_health_status, "fail")
             self.assertEqual(generation.failure_stage, "verify")
             self.assertIn("Cell Mechanic", generation.failure_summary)
+
+    def test_odoo_preview_verification_driver_rejects_checked_urls_without_timeout(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/odoo-tenant-cm",
+                            "workflow_refs": [
+                                "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["preview_generation.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/odoo-tenant-cm",
+                        workflow_ref=(
+                            "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/odoo/preview-verification",
+                payload={
+                    "schema_version": 1,
+                    "product": "odoo-tenant-cm",
+                    "verification": {
+                        "schema_version": 1,
+                        "context": "cm",
+                        "anchor_repo": "odoo-tenant-cm",
+                        "anchor_pr_number": 42,
+                        "verification_status": "pass",
+                        "verified_at": "2026-05-09T15:08:00Z",
+                        "checked_urls": ["https://pr-42.cm-preview.example.test/web/health"],
+                    },
+                },
+                headers={"Idempotency-Key": "odoo-preview-verification:cm:42:missing-timeout"},
+            )
+
+            self.assertEqual(status_code, 400)
+            self.assertEqual(payload["error"]["code"], "invalid_request")
 
     def test_odoo_preview_verification_driver_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- extend Odoo preview verification ingestion with optional checked URL/timeout evidence
- return a typed `odoo_preview_verification` result while continuing to update the latest preview generation record
- document the safe-write contract and add pass/fail/validation coverage

## Validation
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_odoo_preview_verification_driver_marks_latest_generation_ready tests.test_service.LaunchplaneServiceTests.test_odoo_preview_verification_driver_marks_latest_generation_failed tests.test_service.LaunchplaneServiceTests.test_odoo_preview_verification_driver_rejects_checked_urls_without_timeout tests.test_service.LaunchplaneServiceTests.test_odoo_preview_verification_driver_rejects_unauthorized_workflow`
- `uv run --extra dev ruff check control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/service.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m compileall control_plane tests`
- `git diff --check`
- `uv run python -m unittest` (`1314` tests)
- JetBrains changed-files inspection run; remaining warnings are existing broad baseline warnings in touched files

No live/provider mutations performed.

Refs #512
