### PR TITLE
Reject Odoo preview checked URL mappings

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1449,11 +1449,10 @@ class OdooPreviewVerificationRequest(BaseModel):
             return ()
         if isinstance(value, str):
             raw_values: tuple[object, ...] = (value,)
+        elif isinstance(value, (list, tuple)):
+            raw_values = tuple(value)
         else:
-            try:
-                raw_values = tuple(cast(Iterable[object], value))
-            except TypeError as exc:
-                raise ValueError("Odoo preview verification checked_urls must be a list.") from exc
+            raise ValueError("Odoo preview verification checked_urls must be a list.")
         if any(not isinstance(item, str) for item in raw_values):
             raise ValueError("Odoo preview verification checked_urls must be strings.")
         checked_urls = tuple(item.strip() for item in cast(tuple[str, ...], raw_values))

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -13190,6 +13190,70 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(status_code, 400)
             self.assertEqual(payload["error"]["code"], "invalid_request")
 
+    def test_odoo_preview_verification_driver_rejects_checked_url_mapping(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/odoo-tenant-cm",
+                            "workflow_refs": [
+                                "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["preview_generation.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/odoo-tenant-cm",
+                        workflow_ref=(
+                            "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/odoo/preview-verification",
+                payload={
+                    "schema_version": 1,
+                    "product": "odoo-tenant-cm",
+                    "verification": {
+                        "schema_version": 1,
+                        "context": "cm",
+                        "anchor_repo": "odoo-tenant-cm",
+                        "anchor_pr_number": 42,
+                        "verification_status": "pass",
+                        "verified_at": "2026-05-09T15:08:00Z",
+                        "checked_urls": {
+                            "health": "https://pr-42.cm-preview.example.test/web/health"
+                        },
+                        "timeout_seconds": 30,
+                    },
+                },
+                headers={"Idempotency-Key": "odoo-preview-verification:cm:42:mapping"},
+            )
+
+            self.assertEqual(status_code, 400)
+            self.assertEqual(payload["error"]["code"], "invalid_request")
+
     def test_odoo_preview_verification_driver_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"


### PR DESCRIPTION
## Summary
- reject mapping/object inputs for Odoo preview verification checked_urls instead of iterating mapping keys
- keep string and list/tuple checked_urls normalization behavior unchanged
- add a regression route test for malformed checked_urls mappings

Refs #512

## Validation
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_odoo_preview_verification_driver_marks_latest_generation_ready tests.test_service.LaunchplaneServiceTests.test_odoo_preview_verification_driver_rejects_checked_urls_without_timeout tests.test_service.LaunchplaneServiceTests.test_odoo_preview_verification_driver_rejects_checked_url_mapping
- uv run --extra dev ruff check control_plane/service.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_service.py
- uv run --extra dev mypy control_plane tests
- git diff --check
- uv run python -m compileall control_plane tests
- uv run python -m unittest
- JetBrains changed-file inspection (baseline service/test warnings remain)