### PR TITLE
Extract policy record summary base

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -8,7 +8,7 @@ import subprocess
 import time
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Literal, cast, overload
+from typing import Literal, Protocol, cast, overload
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit
 from urllib.request import Request, urlopen
@@ -367,13 +367,35 @@ def _normalize_dokploy_target_type(target_type: str) -> Literal["compose", "appl
     raise click.ClickException("Dokploy target type must be compose or application.")
 
 
-def _summarize_authz_policy_record(record: LaunchplaneAuthzPolicyRecord) -> dict[str, object]:
+class _PolicyRecordSummaryFields(Protocol):
+    @property
+    def record_id(self) -> str: ...
+
+    @property
+    def status(self) -> str: ...
+
+    @property
+    def source(self) -> str: ...
+
+    @property
+    def updated_at(self) -> str: ...
+
+    @property
+    def policy_sha256(self) -> str: ...
+
+
+def _policy_record_summary_base(record: _PolicyRecordSummaryFields) -> dict[str, object]:
     return {
         "record_id": record.record_id,
         "status": record.status,
         "source": record.source,
         "updated_at": record.updated_at,
         "policy_sha256": record.policy_sha256,
+    }
+
+
+def _summarize_authz_policy_record(record: LaunchplaneAuthzPolicyRecord) -> dict[str, object]:
+    return _policy_record_summary_base(record) | {
         "github_actions_rule_count": len(record.policy.github_actions),
         "github_humans_rule_count": len(record.policy.github_humans),
     }
@@ -382,24 +404,14 @@ def _summarize_authz_policy_record(record: LaunchplaneAuthzPolicyRecord) -> dict
 def _summarize_runtime_key_safety_policy_record(
     record: RuntimeKeySafetyPolicyRecord,
 ) -> dict[str, object]:
-    return {
-        "record_id": record.record_id,
-        "status": record.status,
-        "source": record.source,
-        "updated_at": record.updated_at,
-        "policy_sha256": record.policy_sha256,
+    return _policy_record_summary_base(record) | {
         "rule_count": len(record.rules),
         "binding_keys": [rule.binding_key for rule in record.rules],
     }
 
 
 def _summarize_merge_train_policy_record(record: MergeTrainPolicyRecord) -> dict[str, object]:
-    return {
-        "record_id": record.record_id,
-        "status": record.status,
-        "source": record.source,
-        "updated_at": record.updated_at,
-        "policy_sha256": record.policy_sha256,
+    return _policy_record_summary_base(record) | {
         "repository_count": len(record.policy.policies),
         "policy_keys": [
             repository_policy.policy_key for repository_policy in record.policy.policies

--- a/tests/test_merge_train_policy.py
+++ b/tests/test_merge_train_policy.py
@@ -7,6 +7,7 @@ import unittest
 from click.testing import CliRunner
 from pydantic import ValidationError
 
+from control_plane import cli as control_plane_cli
 from control_plane.cli import main
 from control_plane.contracts.merge_train_policy import (
     MergeTrainPolicyRecord,
@@ -56,6 +57,31 @@ class MergeTrainPolicyTests(unittest.TestCase):
         self.assertEqual(
             record.record_id,
             f"merge-train-policy-20260513T210000Z-{policy.policy_sha256[:12]}",
+        )
+
+    def test_cli_merge_train_policy_summary_uses_shared_policy_base(self) -> None:
+        policy = build_test_merge_train_policy_with_codex_skills()
+        record = MergeTrainPolicyRecord(
+            record_id=build_merge_train_policy_record_id(
+                updated_at="2026-05-13T21:00:00Z",
+                policy_sha256=policy.policy_sha256,
+            ),
+            source="test",
+            updated_at="2026-05-13T21:00:00Z",
+            policy=policy,
+        )
+
+        summary = control_plane_cli._summarize_merge_train_policy_record(record)
+
+        self.assertEqual(summary["record_id"], record.record_id)
+        self.assertEqual(summary["status"], "active")
+        self.assertEqual(summary["source"], "test")
+        self.assertEqual(summary["updated_at"], "2026-05-13T21:00:00Z")
+        self.assertEqual(summary["policy_sha256"], policy.policy_sha256)
+        self.assertEqual(summary["repository_count"], 2)
+        self.assertEqual(
+            summary["policy_keys"],
+            ["cbusillo/sellyouroutboard:main", "cbusillo/codex-skills:main"],
         )
 
     def test_policy_record_digest_ignores_missing_optional_stack_child_label(


### PR DESCRIPTION
## Summary
- extract shared policy-record summary fields for authz, runtime-key-safety, and merge-train policy CLI read models
- keep policy-specific summary fields unchanged
- add a focused merge-train policy summary regression test

Refs #653

## Validation
- uv run python -m unittest tests.test_merge_train_policy.MergeTrainPolicyTests.test_cli_merge_train_policy_summary_uses_shared_policy_base tests.test_merge_train_policy.MergeTrainPolicyTests.test_policy_record_validates_digest
- uv run --extra dev ruff check control_plane/cli.py tests/test_merge_train_policy.py
- uv run --extra dev ruff format --check control_plane/cli.py tests/test_merge_train_policy.py
- uv run --extra dev mypy control_plane tests
- git diff --check
- uv run python -m compileall control_plane tests
- uv run python -m unittest
- JetBrains changed-file inspection (existing CliRunner command typing warning remains in tests/test_merge_train_policy.py)