### PR TITLE
Refactor CLI choice normalizers

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -8,7 +8,7 @@ import subprocess
 import time
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Literal, Protocol, cast, overload
+from typing import Literal, Protocol, TypeVar, cast, overload
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit
 from urllib.request import Request, urlopen
@@ -324,47 +324,80 @@ def _build_authz_policy_record(
     )
 
 
+_ChoiceValue = TypeVar("_ChoiceValue", bound=str)
+OdooOverrideApplyStatus = Literal["skipped", "pending", "pass", "fail"]
+OdooProdRollbackSourceChannel = Literal["testing"]
+DokployTargetType = Literal["compose", "application"]
+
+
+def _normalize_cli_choice(
+    value: str,
+    *,
+    choices: Mapping[str, _ChoiceValue],
+    error_message: str,
+) -> _ChoiceValue:
+    normalized_value = value.strip().lower()
+    try:
+        return choices[normalized_value]
+    except KeyError as exc:
+        raise click.ClickException(error_message) from exc
+
+
 def _normalize_secret_scope(scope: str) -> SecretScope:
-    normalized_scope = scope.strip().lower()
-    if normalized_scope == "global":
-        return "global"
-    if normalized_scope == "context":
-        return "context"
-    if normalized_scope == "context_instance":
-        return "context_instance"
-    raise click.ClickException("Secret scope must be one of global, context, or context_instance.")
+    return cast(
+        SecretScope,
+        _normalize_cli_choice(
+            scope,
+            choices={
+                "global": "global",
+                "context": "context",
+                "context_instance": "context_instance",
+            },
+            error_message="Secret scope must be one of global, context, or context_instance.",
+        ),
+    )
 
 
 def _normalize_odoo_apply_status(
     status: str,
-) -> Literal["skipped", "pending", "pass", "fail"]:
-    normalized_status = status.strip().lower()
-    if normalized_status == "skipped":
-        return "skipped"
-    if normalized_status == "pending":
-        return "pending"
-    if normalized_status == "pass":
-        return "pass"
-    if normalized_status == "fail":
-        return "fail"
-    raise click.ClickException(
-        "Odoo override apply status must be skipped, pending, pass, or fail."
+) -> OdooOverrideApplyStatus:
+    return cast(
+        OdooOverrideApplyStatus,
+        _normalize_cli_choice(
+            status,
+            choices={
+                "skipped": "skipped",
+                "pending": "pending",
+                "pass": "pass",
+                "fail": "fail",
+            },
+            error_message="Odoo override apply status must be skipped, pending, pass, or fail.",
+        ),
     )
 
 
-def _normalize_odoo_prod_rollback_source_channel(source_channel: str) -> Literal["testing"]:
-    if source_channel.strip().lower() == "testing":
-        return "testing"
-    raise click.ClickException("Odoo prod rollback source channel must be testing.")
+def _normalize_odoo_prod_rollback_source_channel(
+    source_channel: str,
+) -> OdooProdRollbackSourceChannel:
+    return cast(
+        OdooProdRollbackSourceChannel,
+        _normalize_cli_choice(
+            source_channel,
+            choices={"testing": "testing"},
+            error_message="Odoo prod rollback source channel must be testing.",
+        ),
+    )
 
 
-def _normalize_dokploy_target_type(target_type: str) -> Literal["compose", "application"]:
-    normalized_target_type = target_type.strip().lower()
-    if normalized_target_type == "compose":
-        return "compose"
-    if normalized_target_type == "application":
-        return "application"
-    raise click.ClickException("Dokploy target type must be compose or application.")
+def _normalize_dokploy_target_type(target_type: str) -> DokployTargetType:
+    return cast(
+        DokployTargetType,
+        _normalize_cli_choice(
+            target_type,
+            choices={"compose": "compose", "application": "application"},
+            error_message="Dokploy target type must be compose or application.",
+        ),
+    )
 
 
 class _PolicyRecordSummaryFields(Protocol):

--- a/tests/test_merge_train_policy.py
+++ b/tests/test_merge_train_policy.py
@@ -4,6 +4,7 @@ from tempfile import TemporaryDirectory
 import textwrap
 import unittest
 
+import click
 from click.testing import CliRunner
 from pydantic import ValidationError
 
@@ -83,6 +84,47 @@ class MergeTrainPolicyTests(unittest.TestCase):
             summary["policy_keys"],
             ["cbusillo/sellyouroutboard:main", "cbusillo/codex-skills:main"],
         )
+
+    def test_cli_choice_normalizers_share_trimmed_case_insensitive_choices(self) -> None:
+        self.assertEqual(control_plane_cli._normalize_secret_scope(" Context "), "context")
+        self.assertEqual(control_plane_cli._normalize_odoo_apply_status(" PASS "), "pass")
+        self.assertEqual(
+            control_plane_cli._normalize_odoo_prod_rollback_source_channel(" testing "),
+            "testing",
+        )
+        self.assertEqual(
+            control_plane_cli._normalize_dokploy_target_type(" APPLICATION "),
+            "application",
+        )
+
+    def test_cli_choice_normalizer_preserves_domain_error_messages(self) -> None:
+        invalid_cases = [
+            (
+                control_plane_cli._normalize_secret_scope,
+                "environment",
+                "Secret scope must be one of global, context, or context_instance.",
+            ),
+            (
+                control_plane_cli._normalize_odoo_apply_status,
+                "success",
+                "Odoo override apply status must be skipped, pending, pass, or fail.",
+            ),
+            (
+                control_plane_cli._normalize_odoo_prod_rollback_source_channel,
+                "prod",
+                "Odoo prod rollback source channel must be testing.",
+            ),
+            (
+                control_plane_cli._normalize_dokploy_target_type,
+                "service",
+                "Dokploy target type must be compose or application.",
+            ),
+        ]
+
+        for normalizer, value, expected_message in invalid_cases:
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(click.ClickException, expected_message):
+                    normalizer(value)
 
     def test_policy_record_digest_ignores_missing_optional_stack_child_label(
         self,


### PR DESCRIPTION
## Summary
- extract shared CLI choice normalization for repeated trimmed/case-insensitive enum inputs
- preserve the existing domain-specific ClickException messages for invalid values
- cover the shared behavior and error contracts with focused tests

## Validation
- `uv run python -m unittest tests.test_merge_train_policy.MergeTrainPolicyTests.test_cli_choice_normalizers_share_trimmed_case_insensitive_choices tests.test_merge_train_policy.MergeTrainPolicyTests.test_cli_choice_normalizer_preserves_domain_error_messages tests.test_merge_train_policy.MergeTrainPolicyTests.test_cli_merge_train_policy_summary_uses_shared_policy_base`
- `uv run --extra dev ruff check control_plane/cli.py tests/test_merge_train_policy.py`
- `uv run --extra dev ruff format --check control_plane/cli.py tests/test_merge_train_policy.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m compileall control_plane tests`
- `git diff --check`
- `uv run python -m unittest` (`1320` tests)
- JetBrains changed-file inspection run 21; remaining warnings are existing `CliRunner` command typing and `object.drivers` baseline findings, no new literal-return findings after casts
