### PR TITLE
Type driver payload helper

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -37,6 +37,7 @@ from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.deployment_record import ResolvedTargetEvidence
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane.contracts.driver_descriptor import DriverContextView
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.every_code_work_request import build_every_code_work_request_id
 from control_plane.contracts.github_pull_request_event import GitHubPullRequestEvent
@@ -11090,9 +11091,9 @@ def service_inspect_config_boundary(control_plane_root: Path | None) -> None:
     click.echo(json.dumps(payload, indent=2, sort_keys=True))
 
 
-def _first_driver_payload(view_payload: object, *, driver_id: str) -> dict[str, object] | None:
-    if not hasattr(view_payload, "drivers"):
-        return None
+def _first_driver_payload(
+    view_payload: DriverContextView, *, driver_id: str
+) -> dict[str, object] | None:
     for driver_view in view_payload.drivers:
         if getattr(driver_view, "driver_id", "") == driver_id:
             return _json_object(driver_view.model_dump(mode="json"))

--- a/tests/test_merge_train_policy.py
+++ b/tests/test_merge_train_policy.py
@@ -10,6 +10,8 @@ from pydantic import ValidationError
 
 from control_plane import cli as control_plane_cli
 from control_plane.cli import main
+from control_plane.contracts.driver_descriptor import DriverContextView, DriverDescriptor
+from control_plane.contracts.driver_descriptor import DriverView
 from control_plane.contracts.merge_train_policy import (
     MergeTrainPolicyRecord,
     build_merge_train_policy_record_id,
@@ -125,6 +127,53 @@ class MergeTrainPolicyTests(unittest.TestCase):
             with self.subTest(value=value):
                 with self.assertRaisesRegex(click.ClickException, expected_message):
                     normalizer(value)
+
+    def test_cli_first_driver_payload_uses_typed_driver_context_view(self) -> None:
+        view = DriverContextView(
+            context="demo",
+            drivers=(
+                DriverView(
+                    driver_id="generic-web",
+                    descriptor=DriverDescriptor(
+                        driver_id="generic-web",
+                        label="Generic Web",
+                        product="generic-web",
+                        description="Generic web driver",
+                        provider_boundary="launchplane",
+                    ),
+                ),
+                DriverView(
+                    driver_id="verireel",
+                    descriptor=DriverDescriptor(
+                        driver_id="verireel",
+                        label="Verireel",
+                        product="verireel",
+                        description="Verireel driver",
+                        provider_boundary="launchplane",
+                    ),
+                ),
+            ),
+        )
+
+        payload = control_plane_cli._first_driver_payload(view, driver_id="verireel")
+
+        self.assertIsNotNone(payload)
+        assert payload is not None
+        self.assertEqual(payload["driver_id"], "verireel")
+        descriptor = payload["descriptor"]
+        self.assertIsInstance(descriptor, dict)
+        assert isinstance(descriptor, dict)
+        self.assertEqual(descriptor["driver_id"], "verireel")
+        self.assertEqual(descriptor["label"], "Verireel")
+        self.assertEqual(descriptor["product"], "verireel")
+        self.assertEqual(descriptor["provider_boundary"], "launchplane")
+
+    def test_cli_first_driver_payload_returns_none_for_missing_driver(self) -> None:
+        view = DriverContextView(context="demo")
+
+        payload = control_plane_cli._first_driver_payload(view, driver_id="verireel")
+
+        self.assertIsNone(payload)
 
     def test_policy_record_digest_ignores_missing_optional_stack_child_label(
         self,


### PR DESCRIPTION
## Summary
- type `_first_driver_payload` against the `DriverContextView` contract instead of accepting `object`
- remove the stale `hasattr(..., "drivers")` fallback that caused the JetBrains `object.drivers` warning
- add focused tests for matching and missing driver payload lookup

## Validation
- `uv run python -m unittest tests.test_merge_train_policy.MergeTrainPolicyTests.test_cli_first_driver_payload_uses_typed_driver_context_view tests.test_merge_train_policy.MergeTrainPolicyTests.test_cli_first_driver_payload_returns_none_for_missing_driver`
- `uv run --extra dev ruff check control_plane/cli.py tests/test_merge_train_policy.py`
- `uv run --extra dev ruff format --check control_plane/cli.py tests/test_merge_train_policy.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m compileall control_plane tests`
- `git diff --check`
- `uv run python -m unittest` (`1322` tests)
- JetBrains changed-file inspection run 22; the prior `object.drivers` warning is gone, remaining warning is existing `CliRunner` command typing baseline in `tests/test_merge_train_policy.py`
