### PR TITLE
Type merge train policy CLI test command

### DIFF
--- a/tests/test_merge_train_policy.py
+++ b/tests/test_merge_train_policy.py
@@ -3,8 +3,10 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 import textwrap
 import unittest
+from typing import cast
 
 import click
+from click import Command
 from click.testing import CliRunner
 from pydantic import ValidationError
 
@@ -21,6 +23,9 @@ from control_plane.merge_train_policy_source import MergeTrainPolicyStoreMissing
 from control_plane.merge_train_policy_source import resolve_merge_train_policy_record
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy_with_codex_skills
+
+
+CLI_MAIN = cast(Command, main)
 
 
 class MergeTrainPolicyTests(unittest.TestCase):
@@ -340,7 +345,7 @@ class MergeTrainPolicyTests(unittest.TestCase):
     def test_work_graph_merge_train_policy_cli_renders_dry_run_contract(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             result = CliRunner().invoke(
-                main,
+                CLI_MAIN,
                 [
                     "work-graph",
                     "merge-train-policy",


### PR DESCRIPTION
## Summary
- cast the Click-decorated CLI `main` object to `click.Command` for merge-train policy CLI tests
- use the typed alias for `CliRunner.invoke` to remove the local command typing warning
- keep runtime CLI behavior unchanged

## Validation
- `uv run python -m unittest tests.test_merge_train_policy.MergeTrainPolicyTests.test_work_graph_merge_train_policy_cli_renders_dry_run_contract`
- `uv run --extra dev ruff check tests/test_merge_train_policy.py`
- `uv run --extra dev ruff format --check tests/test_merge_train_policy.py`
- `uv run --extra dev mypy tests/test_merge_train_policy.py`
- `uv run python -m compileall control_plane tests`
- `git diff --check`
- `uv run python -m unittest` (`1322` tests)
- JetBrains file inspection runs 23 and 24 reported `total_problems: 0` for `tests/test_merge_train_policy.py`, but both returned `capture_incomplete`; no concrete file problems were returned after the cast
