### PR TITLE
Reject scalar Odoo preview checked URLs

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1445,11 +1445,9 @@ class OdooPreviewVerificationRequest(BaseModel):
     @field_validator("checked_urls", mode="before")
     @classmethod
     def _normalize_checked_urls(cls, value: object) -> tuple[str, ...]:
-        if value in (None, ""):
+        if value is None:
             return ()
-        if isinstance(value, str):
-            raw_values: tuple[object, ...] = (value,)
-        elif isinstance(value, (list, tuple)):
+        if isinstance(value, (list, tuple)):
             raw_values = tuple(value)
         else:
             raise ValueError("Odoo preview verification checked_urls must be a list.")

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1148,12 +1148,13 @@ Driver-owned preview verification routes can update those records without
 requiring product workflows to render Launchplane record payloads directly. For
 Odoo preview smoke follow-ups, `POST /v1/drivers/odoo/preview-verification`
 accepts the product, context, anchor repo/PR, `verification_status`,
-`verified_at`, optional checked URLs plus `timeout_seconds`, and an optional
-failure summary, then marks the latest preview generation ready or failed. The
-accepted response includes an `odoo_preview_verification` result with the
-generation identity, final states, status, checked URLs, timeout, and failure
-summary. The route is safe-write evidence ingestion only; it does not mutate
-provider state.
+`verified_at`, optional checked URLs as an explicit list plus
+`timeout_seconds`, and an optional failure summary, then marks the latest preview
+generation ready or failed. Scalar or object-shaped `checked_urls` payloads are
+rejected. The accepted response includes an `odoo_preview_verification` result
+with the generation identity, final states, status, checked URLs, timeout, and
+failure summary. The route is safe-write evidence ingestion only; it does not
+mutate provider state.
 
 For stable Odoo smoke follow-ups, `POST /v1/drivers/odoo/stable-verification`
 accepts the product, context, instance, deployment record, optional promotion

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -78,7 +78,7 @@ from control_plane.contracts.work_graph_read_model import WorkGraphPlanningIssue
 from control_plane.merge_train import MergeTrainDryRunSnapshot, MergeTrainPullRequestSnapshot
 from control_plane.merge_train import MergeTrainCheckStatus
 from control_plane.merge_train import build_merge_train_dry_run_result
-from control_plane.service import create_launchplane_service_app
+from control_plane.service import OdooPreviewVerificationRequest, create_launchplane_service_app
 from control_plane.service_auth import (
     GitHubActionsIdentity,
     GitHubHumanIdentity,
@@ -13253,6 +13253,103 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
             self.assertEqual(status_code, 400)
             self.assertEqual(payload["error"]["code"], "invalid_request")
+
+    def test_odoo_preview_verification_driver_rejects_scalar_checked_url(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/odoo-tenant-cm",
+                            "workflow_refs": [
+                                "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["preview_generation.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/odoo-tenant-cm",
+                        workflow_ref=(
+                            "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/odoo/preview-verification",
+                payload={
+                    "schema_version": 1,
+                    "product": "odoo-tenant-cm",
+                    "verification": {
+                        "schema_version": 1,
+                        "context": "cm",
+                        "anchor_repo": "odoo-tenant-cm",
+                        "anchor_pr_number": 42,
+                        "verification_status": "pass",
+                        "verified_at": "2026-05-09T15:08:00Z",
+                        "checked_urls": "https://pr-42.cm-preview.example.test/web/health",
+                        "timeout_seconds": 30,
+                    },
+                },
+                headers={"Idempotency-Key": "odoo-preview-verification:cm:42:scalar"},
+            )
+
+            self.assertEqual(status_code, 400)
+            self.assertEqual(payload["error"]["code"], "invalid_request")
+
+    def test_odoo_preview_verification_request_accepts_explicit_url_collections(
+        self,
+    ) -> None:
+        base_payload = {
+            "schema_version": 1,
+            "context": "cm",
+            "anchor_repo": "odoo-tenant-cm",
+            "anchor_pr_number": 42,
+            "verification_status": "pass",
+            "verified_at": "2026-05-09T15:08:00Z",
+            "timeout_seconds": 30,
+        }
+
+        list_request = OdooPreviewVerificationRequest.model_validate(
+            {
+                **base_payload,
+                "checked_urls": [" https://pr-42.cm-preview.example.test/web/health "],
+            }
+        )
+        tuple_request = OdooPreviewVerificationRequest.model_validate(
+            {
+                **base_payload,
+                "checked_urls": ("https://pr-42.cm-preview.example.test/cell-mechanic",),
+            }
+        )
+
+        self.assertEqual(
+            list_request.checked_urls,
+            ("https://pr-42.cm-preview.example.test/web/health",),
+        )
+        self.assertEqual(
+            tuple_request.checked_urls,
+            ("https://pr-42.cm-preview.example.test/cell-mechanic",),
+        )
 
     def test_odoo_preview_verification_driver_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- reject scalar string and object-shaped `checked_urls` payloads for Odoo preview verification
- keep only explicit URL collections, preserving list/tuple normalization and timeout coupling
- document the stricter preview verification payload shape

## Validation
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_odoo_preview_verification_driver_rejects_checked_urls_without_timeout tests.test_service.LaunchplaneServiceTests.test_odoo_preview_verification_driver_rejects_checked_url_mapping tests.test_service.LaunchplaneServiceTests.test_odoo_preview_verification_driver_rejects_scalar_checked_url tests.test_service.LaunchplaneServiceTests.test_odoo_preview_verification_request_accepts_explicit_url_collections tests.test_service.LaunchplaneServiceTests.test_odoo_preview_verification_driver_marks_latest_generation_ready`
- `uv run --extra dev ruff check control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/service.py tests/test_service.py`
- `uv run --extra dev mypy control_plane/service.py tests/test_service.py`
- `uv run python -m compileall control_plane tests`
- `git diff --check`
- `uv run python -m unittest` (`1325` tests)
- JetBrains changed-file inspection: `docs/service-boundary.md` clean; `control_plane/service.py` and `tests/test_service.py` still report existing broad baseline warnings unrelated to these lines.

No live/provider actions.
