### PR TITLE
Type service CLI runner command

### DIFF
--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -15,6 +15,7 @@ from typing import Any, Literal, cast
 from urllib.parse import parse_qs, urlparse
 from unittest.mock import patch
 
+from click import Command
 from click.testing import CliRunner
 
 from control_plane.cli import main
@@ -139,6 +140,7 @@ from control_plane.workflows.generic_web_preview import (
 
 StartResponse = Callable[[str, list[tuple[str, str]]], None]
 WsgiApp = Callable[[dict[str, object], StartResponse], Iterable[bytes]]
+CLI_MAIN = cast(Command, main)
 
 
 class _StubVerifier:
@@ -14450,7 +14452,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
 
             result = runner.invoke(
-                main,
+                CLI_MAIN,
                 [
                     "service",
                     "inspect-data-freshness",
@@ -14491,7 +14493,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
 
             result = runner.invoke(
-                main,
+                CLI_MAIN,
                 [
                     "service",
                     "inspect-data-freshness",


### PR DESCRIPTION
## Summary
- add a typed `CLI_MAIN` alias for the Click root command in service tests
- use it for the two data-freshness `CliRunner.invoke` calls that JetBrains flagged

## Validation
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_data_freshness_report_covers_visible_surfaces tests.test_service.LaunchplaneServiceTests.test_data_freshness_report_uses_empty_preview_inventory_scan`
- `uv run --extra dev ruff check tests/test_service.py`
- `uv run --extra dev ruff format --check tests/test_service.py`
- `uv run --extra dev mypy tests/test_service.py`
- `uv run python -m compileall tests/test_service.py`
- `git diff --check`
- `uv run python -m unittest` (`1325` tests)
- JetBrains changed-file inspection: the two `Expected type 'Command'` warnings for the data-freshness `runner.invoke` calls are gone; remaining `tests/test_service.py` findings are existing baseline warnings.

No live/provider actions.
