### PR TITLE
Clean up service test string fixtures

### DIFF
--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1131,9 +1131,7 @@ class GitHubHumanAuthTests(unittest.TestCase):
                 "LAUNCHPLANE_PUBLIC_URL": "https://launchplane.example/",
                 "LAUNCHPLANE_SESSION_SECRET": "session-secret",
                 "LAUNCHPLANE_COOKIE_SECURE": "false",
-                "LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS": (
-                    " Info@ShinyComputers.com, ops@example.com "
-                ),
+                "LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS": " Info@ShinyComputers.com, ops@example.com ",
             },
             clear=True,
         ):
@@ -3661,7 +3659,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     app,
                     method="GET",
                     path="/v1/work-graph/merge-train/admission",
-                    query_string=("repository=cbusillo/sellyouroutboard&base_branch=main"),
+                    query_string="repository=cbusillo/sellyouroutboard&base_branch=main",
                 )
 
         self.assertEqual(status_code, 200)
@@ -9286,7 +9284,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 app,
                 method="GET",
                 path="/v1/product-profiles/sellyouroutboard/context-cutover-audit",
-                query_string=("source_context=sellyouroutboard&target_context=sellyouroutboard"),
+                query_string="source_context=sellyouroutboard&target_context=sellyouroutboard",
             )
 
         self.assertEqual(status_code, 400)
@@ -14622,8 +14620,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                             "oauth_env": {
                                 "LAUNCHPLANE_GITHUB_CLIENT_ID": "client-id",
                                 "LAUNCHPLANE_PUBLIC_URL": "https://launchplane.example",
-                                "LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS": ("info@shinycomputers.com"),
-                                "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": ("webhook-secret"),
+                                "LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS": "info@shinycomputers.com",
+                                "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": "webhook-secret",
                                 "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "worker-token",
                                 "LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN": "terminal-read-token",
                                 "LAUNCHPLANE_TERMINAL_AGENT_SUBJECT": "local-owner-agent",


### PR DESCRIPTION
## Summary
- Remove redundant grouping parentheses from string/query-string fixtures in `tests/test_service.py`.
- Keeps this #653 inspection cleanup slice behavior-preserving and test-only.

## Validation
- `uv run python -m unittest tests.test_service.GitHubHumanAuthTests.test_github_oauth_config_loads_bootstrap_admin_emails tests.test_service.LaunchplaneServiceTests.test_self_deploy_endpoint_updates_target_env_and_triggers_dokploy tests.test_service.LaunchplaneServiceTests.test_merge_train_admission_service_admits_without_prior_run tests.test_service.LaunchplaneServiceTests.test_product_profile_context_cutover_audit_invalid_request_is_generic`
- `uv run --extra dev ruff check tests/test_service.py`
- `uv run --extra dev ruff format --check tests/test_service.py`
- `uv run --extra dev mypy tests/test_service.py`
- `uv run python -m compileall tests/test_service.py`
- `git diff --check`
- `uv run python -m unittest` (`1325` tests)
- JetBrains changed-file inspection run `30` for `tests/test_service.py`: redundant-parentheses warnings cleared; remaining findings are existing baseline weak warnings.

No live/provider/destructive actions.
