### PR TITLE
Keep target replacement reservations authoritative

### DIFF
--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -670,11 +670,6 @@ class FilesystemRecordStore:
                         reserved_operation_id
                     )
                 )
-                if reserved_operation is None:
-                    reservation_path.unlink(missing_ok=True)
-                    return self.create_odoo_stable_target_replacement_operation_record_if_no_active_lane(
-                        record
-                    )
                 if reserved_operation.status in {"pending", "running"}:
                     return reserved_operation, False
             reservation_path.unlink(missing_ok=True)
@@ -688,26 +683,22 @@ class FilesystemRecordStore:
     def _wait_for_odoo_stable_target_replacement_reservation_owner(
         reservation_path: Path,
     ) -> str:
-        deadline = time.monotonic() + 1.0
         while True:
             try:
                 reserved_operation_id = reservation_path.read_text(encoding="utf-8").strip()
             except FileNotFoundError:
                 return ""
-            if reserved_operation_id or time.monotonic() >= deadline:
+            if reserved_operation_id:
                 return reserved_operation_id
             time.sleep(0.01)
 
     def _wait_for_odoo_stable_target_replacement_reserved_operation(
         self, operation_id: str
-    ) -> OdooStableTargetReplacementOperationRecord | None:
-        deadline = time.monotonic() + 1.0
+    ) -> OdooStableTargetReplacementOperationRecord:
         while True:
             try:
                 return self.read_odoo_stable_target_replacement_operation_record(operation_id)
             except (FileNotFoundError, JSONDecodeError):
-                if time.monotonic() >= deadline:
-                    return None
                 time.sleep(0.01)
 
     def write_backup_gate_record(self, record: BackupGateRecord) -> Path:

--- a/tests/test_odoo_stable_target_replacement_operation.py
+++ b/tests/test_odoo_stable_target_replacement_operation.py
@@ -225,6 +225,76 @@ class OdooStableTargetReplacementOperationRecordTests(unittest.TestCase):
             self.assertEqual(second_record.operation_id, first.operation_id)
             self.assertFalse(second_created)
 
+    def test_filesystem_store_waits_past_slow_reserved_operation_write(self) -> None:
+        class SlowWriteFilesystemRecordStore(FilesystemRecordStore):
+            def __init__(self, state_dir: Path) -> None:
+                super().__init__(state_dir)
+                self.first_write_started = Event()
+                self.release_first_write = Event()
+                self._write_lock = Lock()
+                self._write_count = 0
+
+            def write_odoo_stable_target_replacement_operation_record(
+                self, record: OdooStableTargetReplacementOperationRecord
+            ) -> Path:
+                with self._write_lock:
+                    is_first_write = self._write_count == 0
+                    self._write_count += 1
+                if is_first_write:
+                    self.first_write_started.set()
+                    self.release_first_write.wait(timeout=2.0)
+                return super().write_odoo_stable_target_replacement_operation_record(record)
+
+            def _wait_for_odoo_stable_target_replacement_reserved_operation(
+                self, operation_id: str
+            ) -> OdooStableTargetReplacementOperationRecord:
+                if operation_id == "operation-cm-testing-first":
+                    self.first_write_started.wait(timeout=2.0)
+                    self.release_first_write.set()
+                return super()._wait_for_odoo_stable_target_replacement_reserved_operation(
+                    operation_id
+                )
+
+        with TemporaryDirectory() as temporary_directory_name:
+            store = SlowWriteFilesystemRecordStore(state_dir=Path(temporary_directory_name))
+            first = OdooStableTargetReplacementOperationRecord.model_validate(
+                _operation_payload("operation-cm-testing-first")
+            )
+            second = OdooStableTargetReplacementOperationRecord.model_validate(
+                {
+                    **_operation_payload("operation-cm-testing-second"),
+                    "idempotency_key": "replacement-cm-testing-second",
+                    "idempotency_scope": "caller-second",
+                }
+            )
+
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                first_future = executor.submit(
+                    store.create_odoo_stable_target_replacement_operation_record_if_no_active_lane,
+                    first,
+                )
+                self.assertTrue(store.first_write_started.wait(timeout=2.0))
+                second_future = executor.submit(
+                    store.create_odoo_stable_target_replacement_operation_record_if_no_active_lane,
+                    second,
+                )
+
+                first_record, first_created = first_future.result(timeout=2.0)
+                second_record, second_created = second_future.result(timeout=2.0)
+
+            active_records = store.list_odoo_stable_target_replacement_operation_records(
+                product="odoo-tenant-cm",
+                context_name="cm",
+                instance_name="testing",
+                statuses=("pending", "running"),
+            )
+
+            self.assertEqual(first_record.operation_id, first.operation_id)
+            self.assertTrue(first_created)
+            self.assertEqual(second_record.operation_id, first.operation_id)
+            self.assertFalse(second_created)
+            self.assertEqual(len(active_records), 1)
+
     def test_filesystem_store_waits_for_reserved_operation_json_to_settle(self) -> None:
         class SettlingReadFilesystemRecordStore(FilesystemRecordStore):
             def __init__(self, state_dir: Path) -> None:


### PR DESCRIPTION
## Summary
- Keep Odoo target-replacement filesystem lane reservations authoritative once a reservation owner exists.
- Remove the fixed one-second stale window that could delete a slow owner reservation and allow duplicate same-lane operation creation.
- Add a deterministic regression covering a slow first operation write while a second same-lane request waits and reuses the owner operation.

## Validation
- `uv run python -m unittest tests.test_odoo_stable_target_replacement_operation` (`10` tests)
- `uv run --extra dev ruff check control_plane/storage/filesystem.py tests/test_odoo_stable_target_replacement_operation.py`
- `uv run --extra dev ruff format --check control_plane/storage/filesystem.py tests/test_odoo_stable_target_replacement_operation.py`
- `uv run --extra dev mypy control_plane/storage/filesystem.py tests/test_odoo_stable_target_replacement_operation.py`
- `uv run python -m compileall control_plane/storage/filesystem.py tests/test_odoo_stable_target_replacement_operation.py`
- `git diff --check`
- `uv run python -m unittest` (`1327` tests)
- JetBrains changed-file inspection runs `32` and `33` were attempted; both reported zero problems but `capture_incomplete`, so not recorded as clean.

No live/provider/destructive actions.
