### PR TITLE
Clean up service test response header callbacks

### DIFF
--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1053,7 +1053,7 @@ def _invoke_app(
         environ[f"HTTP_{header_name.upper().replace('-', '_')}"] = header_value
     captured_status = ""
 
-    def start_response(status: str, headers: list[tuple[str, str]]) -> None:
+    def start_response(status: str, _response_headers: list[tuple[str, str]]) -> None:
         nonlocal captured_status
         captured_status = status
 
@@ -1108,10 +1108,10 @@ def _invoke_raw_app(
     captured_status = ""
     captured_headers: list[tuple[str, str]] = []
 
-    def start_response(status: str, headers: list[tuple[str, str]]) -> None:
+    def start_response(status: str, response_headers: list[tuple[str, str]]) -> None:
         nonlocal captured_status, captured_headers
         captured_status = status
-        captured_headers = headers
+        captured_headers = response_headers
 
     response_body = b"".join(app(environ, start_response))
     return (


### PR DESCRIPTION
## Summary
- Rename nested WSGI `start_response` header callback parameters in `tests/test_service.py` so they no longer shadow helper request headers.
- Mark the unused callback headers in `_invoke_app` explicitly unused while keeping `_invoke_raw_app` response header capture behavior unchanged.
- Keep this as a behavior-preserving #653 test cleanup slice.

## Validation
- `uv run python -m unittest tests.test_service.GitHubHumanAuthTests.test_github_oauth_callback_issues_session_cookie tests.test_service.GitHubHumanAuthTests.test_session_endpoint_reads_github_human_session`
- `uv run --extra dev ruff check tests/test_service.py`
- `uv run --extra dev ruff format --check tests/test_service.py`
- `uv run --extra dev mypy tests/test_service.py`
- `uv run python -m compileall tests/test_service.py`
- `git diff --check`
- `uv run python -m unittest` (`1327` tests)
- JetBrains changed-file inspection run `35` completed with `capture_incomplete=false`; existing baseline findings remain in `tests/test_service.py`, and the touched callback warning dropped the file total from `105` to `104`.

No live/provider/destructive actions.
