### PR TITLE
Recover stale target replacement lane reservations

### DIFF
--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -52,6 +52,9 @@ RecordModel = TypeVar("RecordModel", bound=BaseModel)
 
 
 class FilesystemRecordStore:
+    odoo_target_replacement_reservation_settle_timeout_seconds = 30.0
+    odoo_target_replacement_reservation_poll_seconds = 0.01
+
     def __init__(self, state_dir: Path) -> None:
         self.state_dir = state_dir
 
@@ -661,16 +664,22 @@ class FilesystemRecordStore:
                 reservation_file.flush()
                 os.fsync(reservation_file.fileno())
         except FileExistsError:
+            stale_reservation_deadline = (
+                time.monotonic() + self.odoo_target_replacement_reservation_settle_timeout_seconds
+            )
             reserved_operation_id = self._wait_for_odoo_stable_target_replacement_reservation_owner(
-                reservation_path
+                reservation_path, stale_reservation_deadline
             )
             if reserved_operation_id:
                 reserved_operation = (
                     self._wait_for_odoo_stable_target_replacement_reserved_operation(
-                        reserved_operation_id
+                        reserved_operation_id, stale_reservation_deadline
                     )
                 )
-                if reserved_operation.status in {"pending", "running"}:
+                if reserved_operation is not None and reserved_operation.status in {
+                    "pending",
+                    "running",
+                }:
                     return reserved_operation, False
             reservation_path.unlink(missing_ok=True)
             return self.create_odoo_stable_target_replacement_operation_record_if_no_active_lane(
@@ -679,9 +688,10 @@ class FilesystemRecordStore:
         self.write_odoo_stable_target_replacement_operation_record(record)
         return record, True
 
-    @staticmethod
     def _wait_for_odoo_stable_target_replacement_reservation_owner(
+        self,
         reservation_path: Path,
+        deadline: float,
     ) -> str:
         while True:
             try:
@@ -690,16 +700,20 @@ class FilesystemRecordStore:
                 return ""
             if reserved_operation_id:
                 return reserved_operation_id
-            time.sleep(0.01)
+            if time.monotonic() >= deadline:
+                return ""
+            time.sleep(self.odoo_target_replacement_reservation_poll_seconds)
 
     def _wait_for_odoo_stable_target_replacement_reserved_operation(
-        self, operation_id: str
-    ) -> OdooStableTargetReplacementOperationRecord:
+        self, operation_id: str, deadline: float
+    ) -> OdooStableTargetReplacementOperationRecord | None:
         while True:
             try:
                 return self.read_odoo_stable_target_replacement_operation_record(operation_id)
             except (FileNotFoundError, JSONDecodeError):
-                time.sleep(0.01)
+                if time.monotonic() >= deadline:
+                    return None
+                time.sleep(self.odoo_target_replacement_reservation_poll_seconds)
 
     def write_backup_gate_record(self, record: BackupGateRecord) -> Path:
         return self._write_model("backup_gates", record.record_id, record)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -746,8 +746,10 @@ the workflow artifact. `Idempotency-Key` is required: a repeated request with th
 same key from the same caller identity returns the existing operation, while a
 different key for the same product/context/instance is rejected while a
 `pending` or `running` operation is active. Storage owns that active-lane
-reservation so the worker starts only after the lane is claimed. The first apply
-surface is testing-only and keeps the existing compose
+reservation so the worker starts only after the lane is claimed; abandoned
+filesystem reservations recover after a bounded settle window if the owner or
+owner record never appears. The first apply surface is testing-only and keeps
+the existing compose
 target, explicit Odoo volume env keys, and expected hostnames; the operation
 worker re-syncs the Launchplane-rendered compose source, reconciles each expected
 Dokploy compose domain route to the `web` service on the product runtime port,

--- a/docs/records.md
+++ b/docs/records.md
@@ -403,7 +403,10 @@ state/
   with the same request and caller identity replays the existing operation;
   reusing it for a different request is rejected; an active `pending` or
   `running` operation blocks another apply for the same product/context/instance
-  through a storage-owned lane reservation.
+  through a storage-owned lane reservation. Filesystem reservations wait briefly
+  for a concurrent owner and operation record to settle, then clear abandoned
+  empty or orphaned reservations so an interrupted writer cannot block the lane
+  forever.
 - Odoo prod rollback writes a normal deployment record for the rollback deploy,
   refreshes prod inventory, mints the prod release tuple from the selected
   artifact manifest, and annotates the current prod promotion record's

--- a/tests/test_odoo_stable_target_replacement_operation.py
+++ b/tests/test_odoo_stable_target_replacement_operation.py
@@ -1,3 +1,4 @@
+import hashlib
 import unittest
 from concurrent.futures import ThreadPoolExecutor
 from json import JSONDecodeError
@@ -39,6 +40,18 @@ def _operation_payload(operation_id: str = "operation-cm-testing") -> dict[str, 
         "created_at": "2026-05-17T00:00:00Z",
         "updated_at": "2026-05-17T00:00:00Z",
     }
+
+
+def _lane_reservation_path(
+    store: FilesystemRecordStore,
+    record: OdooStableTargetReplacementOperationRecord,
+) -> Path:
+    lane_key = "|".join((record.product, record.context, record.instance))
+    digest = hashlib.sha256(lane_key.encode()).hexdigest()[:16]
+    reservation_id = (
+        f"{record.product}-{record.context}-{record.instance}".replace("/", "-") + f"-{digest}"
+    )
+    return store._record_path("odoo_stable_target_replacement_lane_reservations", reservation_id)
 
 
 class OdooStableTargetReplacementOperationRecordTests(unittest.TestCase):
@@ -227,6 +240,8 @@ class OdooStableTargetReplacementOperationRecordTests(unittest.TestCase):
 
     def test_filesystem_store_waits_past_slow_reserved_operation_write(self) -> None:
         class SlowWriteFilesystemRecordStore(FilesystemRecordStore):
+            odoo_target_replacement_reservation_settle_timeout_seconds = 2.0
+
             def __init__(self, state_dir: Path) -> None:
                 super().__init__(state_dir)
                 self.first_write_started = Event()
@@ -246,13 +261,13 @@ class OdooStableTargetReplacementOperationRecordTests(unittest.TestCase):
                 return super().write_odoo_stable_target_replacement_operation_record(record)
 
             def _wait_for_odoo_stable_target_replacement_reserved_operation(
-                self, operation_id: str
-            ) -> OdooStableTargetReplacementOperationRecord:
+                self, operation_id: str, deadline: float
+            ) -> OdooStableTargetReplacementOperationRecord | None:
                 if operation_id == "operation-cm-testing-first":
                     self.first_write_started.wait(timeout=2.0)
                     self.release_first_write.set()
                 return super()._wait_for_odoo_stable_target_replacement_reserved_operation(
-                    operation_id
+                    operation_id, deadline
                 )
 
         with TemporaryDirectory() as temporary_directory_name:
@@ -295,8 +310,84 @@ class OdooStableTargetReplacementOperationRecordTests(unittest.TestCase):
             self.assertFalse(second_created)
             self.assertEqual(len(active_records), 1)
 
+    def test_filesystem_store_recovers_empty_crashed_lane_reservation(self) -> None:
+        class FastRecoveryFilesystemRecordStore(FilesystemRecordStore):
+            odoo_target_replacement_reservation_settle_timeout_seconds = 0.01
+            odoo_target_replacement_reservation_poll_seconds = 0.001
+
+        with TemporaryDirectory() as temporary_directory_name:
+            store: FilesystemRecordStore = FastRecoveryFilesystemRecordStore(
+                state_dir=Path(temporary_directory_name)
+            )
+            record = OdooStableTargetReplacementOperationRecord.model_validate(
+                _operation_payload("operation-cm-testing-recovered")
+            )
+            reservation_path = _lane_reservation_path(store, record)
+            reservation_path.parent.mkdir(parents=True, exist_ok=True)
+            reservation_path.write_text("", encoding="utf-8")
+
+            created_record, created = (
+                store.create_odoo_stable_target_replacement_operation_record_if_no_active_lane(
+                    record
+                )
+            )
+
+            active_records = store.list_odoo_stable_target_replacement_operation_records(
+                product="odoo-tenant-cm",
+                context_name="cm",
+                instance_name="testing",
+                statuses=("pending", "running"),
+            )
+
+            self.assertEqual(created_record.operation_id, record.operation_id)
+            self.assertTrue(created)
+            self.assertEqual(reservation_path.read_text(encoding="utf-8"), record.operation_id)
+            self.assertEqual(
+                tuple(active_record.operation_id for active_record in active_records),
+                (record.operation_id,),
+            )
+
+    def test_filesystem_store_recovers_missing_reserved_owner_record(self) -> None:
+        class FastRecoveryFilesystemRecordStore(FilesystemRecordStore):
+            odoo_target_replacement_reservation_settle_timeout_seconds = 0.01
+            odoo_target_replacement_reservation_poll_seconds = 0.001
+
+        with TemporaryDirectory() as temporary_directory_name:
+            store: FilesystemRecordStore = FastRecoveryFilesystemRecordStore(
+                state_dir=Path(temporary_directory_name)
+            )
+            record = OdooStableTargetReplacementOperationRecord.model_validate(
+                _operation_payload("operation-cm-testing-recovered")
+            )
+            reservation_path = _lane_reservation_path(store, record)
+            reservation_path.parent.mkdir(parents=True, exist_ok=True)
+            reservation_path.write_text("operation-cm-testing-missing", encoding="utf-8")
+
+            created_record, created = (
+                store.create_odoo_stable_target_replacement_operation_record_if_no_active_lane(
+                    record
+                )
+            )
+
+            active_records = store.list_odoo_stable_target_replacement_operation_records(
+                product="odoo-tenant-cm",
+                context_name="cm",
+                instance_name="testing",
+                statuses=("pending", "running"),
+            )
+
+            self.assertEqual(created_record.operation_id, record.operation_id)
+            self.assertTrue(created)
+            self.assertEqual(reservation_path.read_text(encoding="utf-8"), record.operation_id)
+            self.assertEqual(
+                tuple(active_record.operation_id for active_record in active_records),
+                (record.operation_id,),
+            )
+
     def test_filesystem_store_waits_for_reserved_operation_json_to_settle(self) -> None:
         class SettlingReadFilesystemRecordStore(FilesystemRecordStore):
+            odoo_target_replacement_reservation_settle_timeout_seconds = 2.0
+
             def __init__(self, state_dir: Path) -> None:
                 super().__init__(state_dir)
                 self._operation_reads: dict[str, int] = {}


### PR DESCRIPTION
## Summary
- Restore bounded recovery for filesystem target-replacement lane reservations when a writer crashes before publishing an owner or owner operation record.
- Keep duplicate-lane protection by waiting for healthy concurrent owners to settle before clearing stale reservation state.
- Document the bounded filesystem recovery behavior in records and operations docs.

## Validation
- `uv run python -m unittest tests.test_odoo_stable_target_replacement_operation` (`12` tests)
- `uv run --extra dev ruff check control_plane/storage/filesystem.py tests/test_odoo_stable_target_replacement_operation.py`
- `uv run --extra dev ruff format --check control_plane/storage/filesystem.py tests/test_odoo_stable_target_replacement_operation.py`
- `uv run --extra dev mypy control_plane/storage/filesystem.py tests/test_odoo_stable_target_replacement_operation.py`
- `uv run python -m compileall control_plane/storage/filesystem.py tests/test_odoo_stable_target_replacement_operation.py`
- `git diff --check`
- `uv run python -m unittest` (`1329` tests)
- JetBrains changed-file inspection run `36` reported zero problems but `capture_incomplete`; retry run `37` on `control_plane/storage/filesystem.py` completed clean with `capture_incomplete=false`.

No live/provider/destructive actions.

Refs #653
