### PR TITLE
Reuse promotion status tone helper

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -4573,19 +4573,23 @@ def _render_launchplane_promotion_status_page_html(
     testing_live = _json_object(payload.get("testing_live"))
     prod_live = _json_object(payload.get("prod_live"))
 
-    evidence_html = (
-        "".join(
+    evidence_cards: list[str] = []
+    for check in evidence_checks:
+        check_status = str(check.get("status", "pending"))
+        check_tone = _status_tone(check_status)
+        evidence_cards.append(
             f"""
-        <article class=\"promotion-detail-check promotion-detail-check-{("good" if str(check.get("status", "")).strip().lower() == "pass" else "bad" if str(check.get("status", "")).strip().lower() == "fail" else "warn")}\">
+        <article class=\"promotion-detail-check promotion-detail-check-{check_tone}\">
           <div class=\"promotion-detail-check-head\">
             <h4>{escape(str(check.get("label", "Evidence")))}</h4>
-            <span class=\"signal-chip signal-{("good" if str(check.get("status", "")).strip().lower() == "pass" else "bad" if str(check.get("status", "")).strip().lower() == "fail" else "warn")}\">{escape(_status_label(str(check.get("status", "pending"))))}</span>
+            <span class=\"signal-chip signal-{check_tone}\">{escape(_status_label(check_status))}</span>
           </div>
           <p>{escape(str(check.get("detail", "No evidence detail recorded.")))}</p>
         </article>
         """
-            for check in evidence_checks
         )
+    evidence_html = (
+        "".join(evidence_cards)
         or '<p class="table-empty">No promotion evidence checks recorded yet.</p>'
     )
 

--- a/tests/test_launchplane_previews.py
+++ b/tests/test_launchplane_previews.py
@@ -2637,9 +2637,40 @@ ODOO_DB_PASSWORD = "local-secret"
             self.assertIn('href="../../policy.html"', promotion_detail_html)
             self.assertIn("Recent promotions into prod", promotion_detail_html)
             self.assertIn("Recent prod backup authorization", promotion_detail_html)
+            self.assertIn("promotion-detail-check-good", promotion_detail_html)
+            self.assertIn("signal-chip signal-good", promotion_detail_html)
             self.assertIn(
                 "promotion-2026-04-14T11:10:00Z-opw-testing-to-prod", promotion_detail_html
             )
+
+    def test_launchplane_promotion_status_html_uses_shared_status_tone_for_evidence(
+        self,
+    ) -> None:
+        html = control_plane_cli._render_launchplane_promotion_status_page_html(
+            {
+                "context": "opw",
+                "path_label": "opw/testing-to-prod",
+                "evidence_checks": [
+                    {
+                        "label": "Deployment health",
+                        "status": "healthy",
+                        "detail": "Destination is serving.",
+                    },
+                    {
+                        "label": "Backup gate",
+                        "status": "failed",
+                        "detail": "Backup gate failed.",
+                    },
+                ],
+            }
+        )
+
+        self.assertIn("promotion-detail-check-good", html)
+        self.assertIn("signal-chip signal-good", html)
+        self.assertIn("promotion-detail-check-bad", html)
+        self.assertIn("signal-chip signal-bad", html)
+        self.assertNotIn("promotion-detail-check promotion-detail-check-warn", html)
+        self.assertNotIn("signal-chip signal-warn", html)
 
     def test_launchplane_previews_render_status_page_calls_out_failed_latest_replacement(
         self,


### PR DESCRIPTION
## Summary
- Reuse `_status_tone()` when rendering Launchplane promotion detail evidence check CSS classes.
- Compute each evidence check status/tone once and feed both the card and signal chip from the shared helper.
- Add a focused renderer regression for helper-only states such as `healthy` and `failed`.

## Validation
- `uv run python -m unittest tests.test_launchplane_previews.LaunchplanePreviewReadModelTests.test_launchplane_previews_render_site_writes_promotion_detail_page_and_link_from_overview tests.test_launchplane_previews.LaunchplanePreviewReadModelTests.test_launchplane_promotion_status_html_uses_shared_status_tone_for_evidence` (`2` tests)
- `uv run --extra dev ruff check control_plane/cli.py tests/test_launchplane_previews.py`
- `uv run --extra dev ruff format --check control_plane/cli.py tests/test_launchplane_previews.py`
- `uv run --extra dev mypy control_plane/cli.py tests/test_launchplane_previews.py`
- `uv run python -m compileall control_plane/cli.py tests/test_launchplane_previews.py`
- `git diff --check`
- `uv run python -m unittest` (`1330` tests)
- JetBrains changed-file inspection run `38` completed with `capture_incomplete=false`; it reported the existing `tests/test_launchplane_previews.py` `CliRunner.invoke(main, ...)` typing baseline and no new finding near the touched renderer/test lines.

No live/provider/destructive actions.

Refs #653
