### PR TITLE
Reset target replacement owner settle window

### DIFF
--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -671,9 +671,13 @@ class FilesystemRecordStore:
                 reservation_path, stale_reservation_deadline
             )
             if reserved_operation_id:
+                owner_record_deadline = (
+                    time.monotonic()
+                    + self.odoo_target_replacement_reservation_settle_timeout_seconds
+                )
                 reserved_operation = (
                     self._wait_for_odoo_stable_target_replacement_reserved_operation(
-                        reserved_operation_id, stale_reservation_deadline
+                        reserved_operation_id, owner_record_deadline
                     )
                 )
                 if reserved_operation is not None and reserved_operation.status in {

--- a/docs/records.md
+++ b/docs/records.md
@@ -404,9 +404,9 @@ state/
   reusing it for a different request is rejected; an active `pending` or
   `running` operation blocks another apply for the same product/context/instance
   through a storage-owned lane reservation. Filesystem reservations wait briefly
-  for a concurrent owner and operation record to settle, then clear abandoned
-  empty or orphaned reservations so an interrupted writer cannot block the lane
-  forever.
+  for a concurrent owner id to settle, then give that owner record its own
+  bounded settle window before clearing abandoned empty or orphaned reservations
+  so an interrupted writer cannot block the lane forever.
 - Odoo prod rollback writes a normal deployment record for the rollback deploy,
   refreshes prod inventory, mints the prod release tuple from the selected
   artifact manifest, and annotates the current prod promotion record's

--- a/tests/test_odoo_stable_target_replacement_operation.py
+++ b/tests/test_odoo_stable_target_replacement_operation.py
@@ -5,6 +5,7 @@ from json import JSONDecodeError
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from threading import Event, Lock
+from unittest.mock import patch
 
 from control_plane.contracts.odoo_stable_target_replacement_operation import (
     OdooStableTargetReplacementOperationRecord,
@@ -308,6 +309,65 @@ class OdooStableTargetReplacementOperationRecordTests(unittest.TestCase):
             self.assertTrue(first_created)
             self.assertEqual(second_record.operation_id, first.operation_id)
             self.assertFalse(second_created)
+            self.assertEqual(len(active_records), 1)
+
+    def test_filesystem_store_restarts_settle_window_after_owner_id_appears(self) -> None:
+        class LateOwnerFilesystemRecordStore(FilesystemRecordStore):
+            odoo_target_replacement_reservation_settle_timeout_seconds = 0.08
+            odoo_target_replacement_reservation_poll_seconds = 0.001
+
+        with TemporaryDirectory() as temporary_directory_name:
+            store = LateOwnerFilesystemRecordStore(state_dir=Path(temporary_directory_name))
+            owner = OdooStableTargetReplacementOperationRecord.model_validate(
+                _operation_payload("operation-cm-testing-first")
+            )
+            requester = OdooStableTargetReplacementOperationRecord.model_validate(
+                {
+                    **_operation_payload("operation-cm-testing-second"),
+                    "idempotency_key": "replacement-cm-testing-second",
+                    "idempotency_scope": "caller-second",
+                }
+            )
+            reservation_path = _lane_reservation_path(store, owner)
+            reservation_path.parent.mkdir(parents=True, exist_ok=True)
+            reservation_path.write_text("", encoding="utf-8")
+
+            monotonic_time = 0.0
+            owner_id_published = False
+            owner_record_published = False
+
+            def monotonic() -> float:
+                return monotonic_time
+
+            def sleep(seconds: float) -> None:
+                nonlocal monotonic_time, owner_id_published, owner_record_published
+                monotonic_time += seconds
+                if not owner_id_published and monotonic_time >= 0.06:
+                    reservation_path.write_text(owner.operation_id, encoding="utf-8")
+                    owner_id_published = True
+                if not owner_record_published and monotonic_time >= 0.10:
+                    store.write_odoo_stable_target_replacement_operation_record(owner)
+                    owner_record_published = True
+
+            with (
+                patch("control_plane.storage.filesystem.time.monotonic", monotonic),
+                patch("control_plane.storage.filesystem.time.sleep", sleep),
+            ):
+                requester_record, requester_created = (
+                    store.create_odoo_stable_target_replacement_operation_record_if_no_active_lane(
+                        requester
+                    )
+                )
+
+            active_records = store.list_odoo_stable_target_replacement_operation_records(
+                product="odoo-tenant-cm",
+                context_name="cm",
+                instance_name="testing",
+                statuses=("pending", "running"),
+            )
+
+            self.assertEqual(requester_record.operation_id, owner.operation_id)
+            self.assertFalse(requester_created)
             self.assertEqual(len(active_records), 1)
 
     def test_filesystem_store_recovers_empty_crashed_lane_reservation(self) -> None:


### PR DESCRIPTION
## Summary
- reset the filesystem target-replacement owner-record settle deadline after a reservation owner id appears
- add a deterministic late-owner-id plus slow-owner-record regression using a patched clock
- document the two bounded settle windows for filesystem lane reservations

## Auto-review triage
- inspected /Users/cbusillo/.code/working/launchplane/branches/auto-review-cc9918ce
- the finding is genuine on current main, but the branch is an older snapshot, so this PR applies the minimal fix-forward directly on fresh main

## Validation
- uv run python -m unittest tests.test_odoo_stable_target_replacement_operation (13 tests)
- uv run --extra dev ruff check control_plane/storage/filesystem.py tests/test_odoo_stable_target_replacement_operation.py
- uv run --extra dev ruff format --check control_plane/storage/filesystem.py tests/test_odoo_stable_target_replacement_operation.py
- uv run --extra dev mypy control_plane/storage/filesystem.py tests/test_odoo_stable_target_replacement_operation.py
- uv run python -m compileall control_plane/storage/filesystem.py tests/test_odoo_stable_target_replacement_operation.py
- git diff --check
- uv run python -m unittest (1331 tests)
- JetBrains changed-file inspection run 39 reported 0 problems but capture_incomplete; retry run 40 on control_plane/storage/filesystem.py completed clean with capture_incomplete=false

Refs #653

No live/provider/destructive actions performed.