### PR TITLE
Refactor work graph Project env parsing

### DIFF
--- a/control_plane/work_graph_github_projects.py
+++ b/control_plane/work_graph_github_projects.py
@@ -4,7 +4,7 @@ import json
 import subprocess
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Literal, cast
+from typing import Any, Literal
 from urllib.parse import urlparse
 
 import click
@@ -17,6 +17,14 @@ from control_plane.contracts.work_graph_read_model import (
 
 _API_VERSION_ARGS = ("-H", "X-GitHub-Api-Version: 2022-11-28")
 GitHubCheckState = Literal["success", "pending", "failure", "unknown"]
+_WORK_ITEM_FOCUS_BY_VALUE: dict[str, WorkItemFocus] = {
+    "Now": "Now",
+    "Next": "Next",
+    "Waiting": "Waiting",
+    "Later": "Later",
+    "Done": "Done",
+    "Unknown": "Unknown",
+}
 
 
 @dataclass(frozen=True)
@@ -83,26 +91,20 @@ def load_github_project_planning_facts_config_from_env(
             "Set both LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER and "
             "LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER to enable work graph Project facts."
         )
-    try:
-        project_number = int(project_number_value)
-    except ValueError as error:
-        raise click.ClickException(
-            "LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER must be a positive integer."
-        ) from error
-    limit_value = environ.get("LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT", "").strip()
-    try:
-        limit = int(limit_value) if limit_value else 200
-    except ValueError as error:
-        raise click.ClickException(
-            "LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT must be a positive integer."
-        ) from error
-    signal_limit_value = environ.get("LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT", "").strip()
-    try:
-        signal_limit = int(signal_limit_value) if signal_limit_value else 50
-    except ValueError as error:
-        raise click.ClickException(
-            "LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT must be a positive integer."
-        ) from error
+    project_number = _int_env_value(
+        environ,
+        name="LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER",
+    )
+    limit = _int_env_value(
+        environ,
+        name="LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT",
+        default=200,
+    )
+    signal_limit = _int_env_value(
+        environ,
+        name="LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT",
+        default=50,
+    )
     return GitHubProjectPlanningFactsConfig(
         owner=owner,
         project_number=project_number,
@@ -110,6 +112,16 @@ def load_github_project_planning_facts_config_from_env(
         signal_limit=signal_limit,
         gh_binary=environ.get("LAUNCHPLANE_WORK_GRAPH_GH_BINARY", "gh").strip() or "gh",
     )
+
+
+def _int_env_value(environ: dict[str, str], *, name: str, default: int | None = None) -> int:
+    value = environ.get(name, "").strip()
+    if not value and default is not None:
+        return default
+    try:
+        return int(value)
+    except ValueError as error:
+        raise click.ClickException(f"{name} must be a positive integer.") from error
 
 
 def _run_gh_json(command: Sequence[str]) -> dict[str, Any]:
@@ -165,9 +177,7 @@ def _enrich_planning_facts_with_github_signals(
         enriched.append(
             fact
             if not updates
-            else WorkGraphPlanningIssueFacts.model_validate(
-                fact.model_dump(mode="python") | updates
-            )
+            else WorkGraphPlanningIssueFacts.model_validate(fact.model_dump() | updates)
         )
     return tuple(enriched)
 
@@ -344,8 +354,9 @@ def _repository_from_url(value: str) -> str:
 
 def _focus_from_project_item(*, item: dict[str, Any], status: str) -> WorkItemFocus | None:
     focus = _string(item.get("focus") or item.get("Focus"))
-    if focus in {"Now", "Next", "Waiting", "Later", "Done", "Unknown"}:
-        return cast(WorkItemFocus, focus)
+    recognized_focus = _WORK_ITEM_FOCUS_BY_VALUE.get(focus)
+    if recognized_focus is not None:
+        return recognized_focus
     if status == "Done":
         return "Done"
     if status == "Waiting":

--- a/tests/test_work_graph_github_projects.py
+++ b/tests/test_work_graph_github_projects.py
@@ -315,6 +315,19 @@ class GitHubProjectPlanningFactsTests(unittest.TestCase):
         assert config is not None
         self.assertEqual(config.signal_limit, 12)
 
+    def test_env_config_rejects_invalid_limit(self) -> None:
+        with self.assertRaisesRegex(
+            click.ClickException,
+            "LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT must be a positive integer.",
+        ):
+            load_github_project_planning_facts_config_from_env(
+                {
+                    "LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER": "cbusillo",
+                    "LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER": "4",
+                    "LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT": "many",
+                }
+            )
+
     def test_failed_gh_call_is_operator_visible(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             directory = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- centralize work-graph GitHub Project integer env parsing in a private helper
- add a focused regression for invalid project item limit parsing
- clean up provider inspection nits with a typed focus lookup and default-free model dump

## Validation
- uv run python -m unittest tests.test_work_graph_github_projects (9 tests)
- uv run --extra dev ruff check control_plane/work_graph_github_projects.py tests/test_work_graph_github_projects.py
- uv run --extra dev ruff format --check control_plane/work_graph_github_projects.py tests/test_work_graph_github_projects.py
- uv run --extra dev mypy control_plane/work_graph_github_projects.py tests/test_work_graph_github_projects.py
- uv run python -m compileall control_plane/work_graph_github_projects.py tests/test_work_graph_github_projects.py
- git diff --check
- uv run python -m unittest (1332 tests)
- JetBrains changed-file inspection run 41 reported zero problems but capture_incomplete; run 42 exposed two weak warnings in control_plane/work_graph_github_projects.py, which this PR clears; retry run 44 on control_plane/work_graph_github_projects.py completed clean with capture_incomplete=false

Refs #653

No live/provider/destructive actions performed.