### PR TITLE
Type product onboarding CLI test command

### DIFF
--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -6,12 +6,16 @@ from tempfile import TemporaryDirectory
 from typing import cast
 import unittest
 
+from click import Command
 from click.testing import CliRunner
 
 from control_plane.cli import main
 from control_plane.contracts.product_onboarding_manifest import ProductOnboardingManifest
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.product_onboarding import apply_product_onboarding_manifest
+
+
+CLI_MAIN = cast(Command, main)
 
 
 def _sqlite_database_url(database_path: Path) -> str:
@@ -559,7 +563,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             manifest_path.write_text(json.dumps(_manifest_payload()))
 
             result = CliRunner().invoke(
-                main,
+                CLI_MAIN,
                 [
                     "product-onboarding",
                     "apply",


### PR DESCRIPTION
## Summary
- wrap the product onboarding CLI entrypoint in a typed Click `Command` for `CliRunner.invoke`
- keep the cleanup scoped to the single direct `main` invocation in the product onboarding tests

## Validation
- `uv run python -m unittest tests.test_product_onboarding`
- `uv run --extra dev ruff check tests/test_product_onboarding.py`
- `uv run --extra dev ruff format --check tests/test_product_onboarding.py` (reports pre-existing quote-normalization drift in shell-script fixture strings; not applied to keep this diff surgical)
- `uv run --extra dev mypy tests/test_product_onboarding.py`
- `uv run python -m compileall tests/test_product_onboarding.py`
- `git diff --check`
- JetBrains inspection run 55 on `tests/test_product_onboarding.py` found three existing weak warnings for explicit `check=False` subprocess defaults
- `uv run python -m unittest`

Refs #653