### PR TITLE
Type Odoo prod rollback CLI test command

### DIFF
--- a/tests/test_odoo_prod_rollback.py
+++ b/tests/test_odoo_prod_rollback.py
@@ -1,8 +1,10 @@
 import unittest
 from pathlib import Path
+from typing import cast
 from unittest.mock import Mock, patch
 
 import click
+from click import Command
 from click.testing import CliRunner
 from pydantic import ValidationError
 
@@ -34,6 +36,9 @@ from control_plane.workflows.odoo_prod_rollback import (
     OdooProdRollbackRequest,
     execute_odoo_prod_rollback,
 )
+
+
+CLI_MAIN = cast(Command, main)
 
 
 def _artifact_manifest() -> ArtifactIdentityManifest:
@@ -481,7 +486,7 @@ class OdooProdRollbackWorkflowTests(unittest.TestCase):
             patch("control_plane.cli._store", return_value=Mock()),
         ):
             result = CliRunner().invoke(
-                main,
+                CLI_MAIN,
                 [
                     "odoo-rollbacks",
                     "execute",


### PR DESCRIPTION
## Summary
- wrap the Odoo prod rollback CLI entrypoint in a typed Click `Command` for `CliRunner.invoke`
- keep the cleanup scoped to the single direct `main` invocation in the rollback tests

## Validation
- `uv run python -m unittest tests.test_odoo_prod_rollback`
- `uv run --extra dev ruff check tests/test_odoo_prod_rollback.py`
- `uv run --extra dev ruff format --check tests/test_odoo_prod_rollback.py`
- `uv run --extra dev mypy tests/test_odoo_prod_rollback.py`
- `uv run python -m compileall tests/test_odoo_prod_rollback.py`
- `git diff --check`
- JetBrains inspection runs 56 and 57 on `tests/test_odoo_prod_rollback.py` captured zero problems but both ended `capture_incomplete`, so inspection is recorded as inconclusive rather than clean
- `uv run python -m unittest`

Refs #653