### PR TITLE
Restrict base-driver compatibility to preview routes

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -948,6 +948,13 @@ _PREVIEW_READINESS_ROUTE_PATHS = frozenset(
 _PREVIEW_DESTROY_ROUTE_PATHS = frozenset(
     {_GENERIC_WEB_PREVIEW_DESTROY_ROUTE.route_path, _ODOO_PREVIEW_DESTROY_ROUTE.route_path}
 )
+_GENERIC_WEB_BASE_DRIVER_PREVIEW_ROUTE_PATHS = frozenset(
+    _PREVIEW_DESIRED_STATE_ROUTE_PATHS
+    | _PREVIEW_INVENTORY_ROUTE_PATHS
+    | _PREVIEW_REFRESH_ROUTE_PATHS
+    | _PREVIEW_READINESS_ROUTE_PATHS
+    | _PREVIEW_DESTROY_ROUTE_PATHS
+)
 
 
 class BackupGateEvidenceEnvelope(BaseModel):
@@ -5722,10 +5729,25 @@ def _product_driver_compatible(
     *, profile: LaunchplaneProductProfileRecord, expected_driver_id: str
 ) -> bool:
     expected = expected_driver_id.strip()
-    if profile.driver_id == expected:
+    profile_driver_id = profile.driver_id.strip()
+    if profile_driver_id == expected:
         return True
-    descriptor = read_driver_descriptor(profile.driver_id)
+    descriptor = read_driver_descriptor(profile_driver_id)
     return descriptor.base_driver_id == expected
+
+
+def _product_driver_route_compatible(
+    *, profile: LaunchplaneProductProfileRecord, expected_driver_id: str, route_path: str
+) -> bool:
+    if profile.driver_id.strip() == expected_driver_id.strip():
+        return True
+    return (
+        route_path in _GENERIC_WEB_BASE_DRIVER_PREVIEW_ROUTE_PATHS
+        and _product_driver_compatible(
+            profile=profile,
+            expected_driver_id=expected_driver_id,
+        )
+    )
 
 
 def _find_product_profile_lane(
@@ -5748,6 +5770,7 @@ def _resolve_product_driver_context(
     record_store: object,
     product: str,
     driver_id: str,
+    route_path: str = "",
     context: str = "",
     instance: str = "",
     require_profile: bool = False,
@@ -5760,7 +5783,11 @@ def _resolve_product_driver_context(
     if not callable(read_profile):
         raise ValueError("Product driver validation requires product profile storage.")
     profile = cast(LaunchplaneProductProfileRecord, read_profile(normalized_product))
-    if not _product_driver_compatible(profile=profile, expected_driver_id=normalized_driver_id):
+    if not _product_driver_route_compatible(
+        profile=profile,
+        expected_driver_id=normalized_driver_id,
+        route_path=route_path,
+    ):
         raise ProductDriverMismatchError(
             "Product profile is not compatible with the requested driver route."
         )
@@ -5787,6 +5814,7 @@ def _resolve_descriptor_product_driver_context(
         record_store=record_store,
         product=product,
         driver_id=_driver_route_metadata_from_descriptors()[route_path].driver_id,
+        route_path=route_path,
         context=context,
         instance=instance,
         require_profile=require_profile,
@@ -10418,6 +10446,12 @@ def create_launchplane_service_app(
             elif path == _GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path:
                 generic_web_promotion_request = (
                     _GENERIC_WEB_PROD_PROMOTION_ROUTE.envelope_model.model_validate(payload)
+                )
+                _resolve_descriptor_product_driver_context(
+                    record_store=record_store,
+                    route_path=path,
+                    product=generic_web_promotion_request.product,
+                    require_profile=True,
                 )
                 _profile, _source_lane, destination_lane = resolve_generic_web_promotion_lanes(
                     record_store=record_store,

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -251,8 +251,12 @@ route metadata, so new drivers do not need a second hardcoded router allowlist
 or authz-action entry.
 The same route metadata also drives product-driver compatibility checks. A
 product whose descriptor names a `base_driver_id` can use the base driver's
-shared routes when its profile owns the requested lane, which keeps reusable
-site plumbing in Launchplane instead of copied into every site repo.
+shared preview routes when its profile owns the requested preview context, which
+keeps reusable preview plumbing in Launchplane instead of copied into every site
+repo. Base-driver compatibility is route-scoped: stable deploy and promotion
+routes require the profile's concrete `driver_id` to match the requested driver,
+so Odoo or other generic-web-based products do not inherit generic-web stable
+mutation authority.
 
 Preview read models are capability-driven. A driver that exposes
 `previewable`, `preview_inventory_managed`, legacy `preview_lifecycle`, or the

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -11025,12 +11025,12 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(kwargs["profile"].product, "sellyouroutboard")
         self.assertEqual(kwargs["lane"].context, "sellyouroutboard-testing")
 
-    def test_generic_web_deploy_route_accepts_base_driver_product(self) -> None:
+    def test_generic_web_deploy_route_rejects_base_driver_product(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             store = FilesystemRecordStore(state_dir=root / "state")
             profile_payload = _product_profile_payload()
-            profile_payload["driver_id"] = "verireel"
+            profile_payload["driver_id"] = "odoo"
             store.write_product_profile_record(
                 LaunchplaneProductProfileRecord.model_validate(profile_payload)
             )
@@ -11038,9 +11038,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 {
                     "github_actions": [
                         {
-                            "repository": "every/verireel",
+                            "repository": "cbusillo/odoo-tenant-cm",
                             "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                                "cbusillo/odoo-tenant-cm/.github/workflows/preview-control-plane.yml@refs/heads/main"
                             ],
                             "event_names": ["pull_request"],
                             "products": ["sellyouroutboard"],
@@ -11052,16 +11052,20 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             app = create_launchplane_service_app(
                 state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/odoo-tenant-cm",
+                        workflow_ref=(
+                            "cbusillo/odoo-tenant-cm/.github/workflows/preview-control-plane.yml"
+                            "@refs/heads/main"
+                        ),
+                    )
+                ),
                 authz_policy=policy,
                 control_plane_root_path=root,
             )
-            driver_result = SimpleNamespace(deployment_record_id="deployment-syo-testing")
 
-            with patch(
-                "control_plane.service.execute_generic_web_deploy",
-                return_value=driver_result,
-            ) as deploy:
+            with patch("control_plane.service.execute_generic_web_deploy") as deploy:
                 status_code, payload = _invoke_app(
                     app,
                     method="POST",
@@ -11080,12 +11084,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     headers={"Idempotency-Key": "generic-web-deploy-derived-driver"},
                 )
 
-        self.assertEqual(status_code, 202)
-        self.assertEqual(payload["records"]["deployment_record_id"], "deployment-syo-testing")
-        deploy.assert_called_once()
-        _, kwargs = deploy.call_args
-        self.assertEqual(kwargs["profile"].driver_id, "verireel")
-        self.assertEqual(kwargs["lane"].instance, "testing")
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "product_driver_mismatch")
+        deploy.assert_not_called()
 
     def test_generic_web_deploy_route_accepts_padded_lane_context(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -11409,6 +11410,69 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_generic_web_prod_promotion_route_rejects_base_driver_product(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            profile_payload = _product_profile_payload_with_prod()
+            profile_payload["driver_id"] = "odoo"
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/odoo-tenant-cm",
+                            "workflow_refs": [
+                                "cbusillo/odoo-tenant-cm/.github/workflows/promote-prod.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["generic_web_prod_promotion.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/odoo-tenant-cm",
+                        workflow_ref=(
+                            "cbusillo/odoo-tenant-cm/.github/workflows/promote-prod.yml"
+                            "@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch("control_plane.service.execute_generic_web_prod_promotion") as execute_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/prod-promotion",
+                    payload={
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "promotion": {
+                            "schema_version": 1,
+                            "product": "sellyouroutboard",
+                            "artifact_id": "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+                            "source_git_ref": "abc123",
+                        },
+                    },
+                )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "product_driver_mismatch")
+        execute_mock.assert_not_called()
 
     def test_generic_web_prod_promotion_route_accepts_padded_lane_context(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -11816,6 +11880,69 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_generic_web_promotion_workflow_rejects_base_driver_product(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            profile_payload = _product_profile_payload_with_prod()
+            profile_payload["driver_id"] = "odoo"
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/odoo-tenant-cm",
+                            "workflow_refs": [
+                                "cbusillo/odoo-tenant-cm/.github/workflows/promote-prod.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["generic_web_prod_promotion.dispatch"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/odoo-tenant-cm",
+                        workflow_ref=(
+                            "cbusillo/odoo-tenant-cm/.github/workflows/promote-prod.yml"
+                            "@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch("control_plane.service.dispatch_generic_web_promotion_workflow") as dispatch_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/prod-promotion-workflow",
+                    payload={
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "workflow": {
+                            "schema_version": 1,
+                            "product": "sellyouroutboard",
+                            "context": "sellyouroutboard-testing",
+                            "dry_run": False,
+                        },
+                    },
+                )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "product_driver_mismatch")
+        dispatch_mock.assert_not_called()
 
     def test_generic_web_promotion_workflow_rejects_unowned_context_before_authz(
         self,


### PR DESCRIPTION
## Summary
- Scope base-driver route compatibility to generic-web preview routes only.
- Reject Odoo/generic-web-based profiles on stable generic-web deploy, prod-promotion, and prod-promotion workflow routes before dispatch.
- Clarify the route-scoped compatibility contract in driver descriptor docs.

Refs #491
Refs #653

## Validation
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_generic_web_deploy_route_rejects_base_driver_product tests.test_service.LaunchplaneServiceTests.test_generic_web_prod_promotion_route_rejects_base_driver_product tests.test_service.LaunchplaneServiceTests.test_generic_web_promotion_workflow_rejects_base_driver_product tests.test_service.LaunchplaneServiceTests.test_odoo_preview_refresh_route_reuses_generic_preview_records
- uv run ruff check --diff control_plane/service.py tests/test_service.py
- uv run ruff check control_plane/service.py tests/test_service.py
- uv run --extra dev ruff check .
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest
- pnpm --dir frontend validate
- JetBrains inspection on changed files completed; findings are existing backlog/weak warnings, no new blocking issue from this slice.

Note: repo-wide Would reformat: control_plane/agent_context_service.py
Would reformat: control_plane/authz_grant_service.py
Would reformat: control_plane/contracts/agent_write_intent.py
Would reformat: control_plane/contracts/every_code_preview_gate_record.py
Would reformat: control_plane/contracts/merge_train_admission.py
Would reformat: control_plane/contracts/merge_train_batch.py
Would reformat: control_plane/contracts/merge_train_run_record.py
Would reformat: control_plane/contracts/odoo_instance_override_record.py
Would reformat: control_plane/contracts/odoo_stable_bootstrap_operation.py
Would reformat: control_plane/contracts/product_onboarding_manifest.py
Would reformat: control_plane/contracts/product_profile_record.py
Would reformat: control_plane/contracts/runner_lane_inventory.py
Would reformat: control_plane/contracts/work_graph_read_model.py
Would reformat: control_plane/every_code_worker.py
Would reformat: control_plane/merge_train.py
Would reformat: control_plane/merge_train_github.py
Would reformat: control_plane/runner_lane_github.py
Would reformat: control_plane/service_human_auth.py
Would reformat: control_plane/work_graph_http.py
Would reformat: control_plane/workflows/generic_web_promotion.py
Would reformat: control_plane/workflows/launchplane.py
Would reformat: control_plane/workflows/odoo_stable_bootstrap.py
Would reformat: control_plane/workflows/odoo_verification.py
Would reformat: control_plane/workflows/preview_pr_feedback.py
Would reformat: control_plane/workflows/verireel_preview_driver.py
Would reformat: tests/test_authz_grant_service.py
Would reformat: tests/test_dokploy.py
Would reformat: tests/test_every_code_summary_read_model.py
Would reformat: tests/test_every_code_worker.py
Would reformat: tests/test_generic_web_promotion.py
Would reformat: tests/test_merge_train_github.py
Would reformat: tests/test_odoo_instance_override_rendering.py
Would reformat: tests/test_odoo_stable_bootstrap.py
Would reformat: tests/test_odoo_stable_bootstrap_operation.py
Would reformat: tests/test_odoo_verification.py
Would reformat: tests/test_preview_pr_feedback.py
Would reformat: tests/test_product_environment_read_model.py
Would reformat: tests/test_product_onboarding.py
Would reformat: tests/test_runtime_identity_health.py
Would reformat: tests/test_service.py
Would reformat: tests/test_work_graph_service.py
41 files would be reformatted, 197 files already formatted still reports pre-existing formatting drift across 41 files, including untouched modules; this PR keeps formatting surgical.