### PR TITLE
Harden runner lane inventory parsing

### DIFF
--- a/control_plane/runner_lane_github.py
+++ b/control_plane/runner_lane_github.py
@@ -48,7 +48,7 @@ class GitHubRunnerLaneInventoryReader:
                 )
             page_lanes = tuple(
                 _runner_lane_record(
-                    repository=repository,
+                    repository=repository_path,
                     observed_at=observed_at,
                     payload=_json_object(runner, "GitHub runner entry"),
                 )
@@ -57,7 +57,7 @@ class GitHubRunnerLaneInventoryReader:
             lanes.extend(page_lanes)
             if len(page_lanes) < 100:
                 return build_runner_lane_inventory(
-                    repository=repository,
+                    repository=repository_path,
                     observed_at=observed_at,
                     lanes=tuple(lanes),
                 )
@@ -72,7 +72,7 @@ def _runner_lane_record(
         name=_required_text(payload.get("name"), "GitHub runner entry requires name."),
         repository=repository,
         status=_required_text(payload.get("status"), "GitHub runner entry requires status."),
-        busy=bool(payload.get("busy")),
+        busy=_required_bool(payload.get("busy"), "GitHub runner entry requires busy."),
         labels=_runner_labels(payload.get("labels")),
         host_hint=_host_hint_from_name(
             _required_text(payload.get("name"), "GitHub runner entry requires name.")
@@ -107,7 +107,7 @@ def _host_hint_from_name(name: str) -> str:
 
 
 def _repository_path(repository: str) -> str:
-    normalized_repository = repository.strip()
+    normalized_repository = "/".join(part.strip() for part in repository.strip().split("/"))
     if normalized_repository.count("/") != 1:
         raise ValueError("GitHub repository must be formatted as owner/name.")
     owner, repo = normalized_repository.split("/", 1)
@@ -131,5 +131,11 @@ def _required_text(value: object, message: str) -> str:
 
 def _required_int(value: object, message: str) -> int:
     if not isinstance(value, int) or isinstance(value, bool):
+        raise MergeTrainGitHubError(message)
+    return value
+
+
+def _required_bool(value: object, message: str) -> bool:
+    if not isinstance(value, bool):
         raise MergeTrainGitHubError(message)
     return value

--- a/tests/test_runner_lane_inventory.py
+++ b/tests/test_runner_lane_inventory.py
@@ -89,6 +89,22 @@ class GitHubRunnerLaneInventoryReaderTests(unittest.TestCase):
             ],
         )
 
+    def test_reader_normalizes_pasted_repository_components(self) -> None:
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=({"total_count": 1, "runners": [_runner(301, "lane-1")]},)
+        )
+
+        inventory = GitHubRunnerLaneInventoryReader(
+            transport=transport, clock=_FixedClock()
+        ).read_runner_lane_inventory(repository=" cbusillo / launchplane ")
+
+        self.assertEqual(inventory.repository, "cbusillo/launchplane")
+        self.assertEqual(inventory.lanes[0].repository, "cbusillo/launchplane")
+        self.assertEqual(
+            [request.path for request in transport.requests],
+            ["/repos/cbusillo/launchplane/actions/runners?per_page=100&page=1"],
+        )
+
     def test_reader_rejects_malformed_runner_response(self) -> None:
         reader = GitHubRunnerLaneInventoryReader(
             transport=RecordingMergeTrainGitHubTransport(responses=({"runners": {}},)),
@@ -96,6 +112,32 @@ class GitHubRunnerLaneInventoryReaderTests(unittest.TestCase):
         )
 
         with self.assertRaisesRegex(MergeTrainGitHubError, "must include runners"):
+            reader.read_runner_lane_inventory(repository="cbusillo/repo")
+
+    def test_reader_rejects_missing_busy_flag(self) -> None:
+        runner = _runner(401, "lane-1")
+        runner.pop("busy")
+        reader = GitHubRunnerLaneInventoryReader(
+            transport=RecordingMergeTrainGitHubTransport(
+                responses=({"total_count": 1, "runners": [runner]},)
+            ),
+            clock=_FixedClock(),
+        )
+
+        with self.assertRaisesRegex(MergeTrainGitHubError, "requires busy"):
+            reader.read_runner_lane_inventory(repository="cbusillo/repo")
+
+    def test_reader_rejects_non_boolean_busy_flag(self) -> None:
+        runner = _runner(402, "lane-1")
+        runner["busy"] = "false"
+        reader = GitHubRunnerLaneInventoryReader(
+            transport=RecordingMergeTrainGitHubTransport(
+                responses=({"total_count": 1, "runners": [runner]},)
+            ),
+            clock=_FixedClock(),
+        )
+
+        with self.assertRaisesRegex(MergeTrainGitHubError, "requires busy"):
             reader.read_runner_lane_inventory(repository="cbusillo/repo")
 
 


### PR DESCRIPTION
## Summary
- Normalize pasted repository strings like `owner / repo` before runner inventory API calls and persisted inventory records.
- Treat missing or non-boolean GitHub runner `busy` fields as malformed provider data instead of silently marking lanes idle.
- Add deterministic unit coverage for repository normalization, missing `busy`, and non-boolean `busy` values.

Refs #413
Refs #653

## Validation
- `uv run python -m unittest tests.test_runner_lane_inventory`
- `uv run ruff check --diff control_plane/runner_lane_github.py tests/test_runner_lane_inventory.py`
- `uv run ruff check control_plane/runner_lane_github.py tests/test_runner_lane_inventory.py`
- `uv run --extra dev mypy control_plane/runner_lane_github.py tests/test_runner_lane_inventory.py`
- `uv run python -m compileall control_plane/runner_lane_github.py tests/test_runner_lane_inventory.py`
- `git diff --check`
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `pnpm --dir frontend validate`
- `uv run python -m unittest`

Inspection note: JetBrains inspection runs 62 and 63 reported zero problems but ended with `capture_incomplete`, including a one-file retry on `control_plane/runner_lane_github.py`; recorded as inconclusive, not clean.

No live runner inventory smoke was performed because this slice avoids live/provider actions.
