### PR TITLE
Extract merge train controller decisions

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -240,6 +240,12 @@ from control_plane.workflows.merge_train_worker import (
     MergeTrainWorkerClients,
     run_merge_train_worker_step,
 )
+from control_plane.workflows.merge_train_controller import (
+    latest_merge_train_batch_candidate_progress_record as controller_latest_merge_train_batch_candidate_progress_record,
+    latest_merge_train_batch_landing_progress_record as controller_latest_merge_train_batch_landing_progress_record,
+    latest_merge_train_stack_collapse_progress_record as controller_latest_merge_train_stack_collapse_progress_record,
+    merge_train_batch_landing_entry_rank as controller_merge_train_batch_landing_entry_rank,
+)
 from control_plane.workflows.evidence_ingestion import (
     EvidenceIngestionStore,
     apply_deployment_evidence,
@@ -3023,73 +3029,23 @@ def _validate_merge_train_stack_collapse_record_for_controller(
 def _latest_merge_train_batch_candidate_progress_record(
     records: tuple[MergeTrainBatchCandidateRecord, ...],
 ) -> MergeTrainBatchCandidateRecord | None:
-    if not records:
-        return None
-    status_rank = {
-        "planned": 0,
-        "building": 1,
-        "ready_for_checks": 2,
-        "passed": 3,
-        "failed": 4,
-        "stale": 4,
-        "blocked": 4,
-    }
-    return max(
-        records,
-        key=lambda record: (
-            record.updated_at,
-            status_rank[record.candidate.status],
-            record.record_id,
-        ),
-    )
+    return controller_latest_merge_train_batch_candidate_progress_record(records)
 
 
 def _latest_merge_train_batch_landing_progress_record(
     records: tuple[MergeTrainBatchLandingPlanRecord, ...],
 ) -> MergeTrainBatchLandingPlanRecord | None:
-    if not records:
-        return None
-    return max(
-        records,
-        key=lambda record: (
-            record.updated_at,
-            max(
-                _merge_train_batch_landing_entry_rank(entry.status)
-                for entry in record.landing_plan.entries
-            ),
-            record.record_id,
-        ),
-    )
+    return controller_latest_merge_train_batch_landing_progress_record(records)
 
 
 def _latest_merge_train_stack_collapse_progress_record(
     records: tuple[MergeTrainStackCollapsePlanRecord, ...],
 ) -> MergeTrainStackCollapsePlanRecord | None:
-    if not records:
-        return None
-    status_rank = {
-        "planned": 0,
-        "collapsing": 1,
-        "waiting_for_root_checks": 2,
-        "ready_for_train": 3,
-        "blocked": 4,
-        "stale": 4,
-    }
-    return max(
-        records,
-        key=lambda record: (record.updated_at, status_rank[record.plan.status], record.record_id),
-    )
+    return controller_latest_merge_train_stack_collapse_progress_record(records)
 
 
 def _merge_train_batch_landing_entry_rank(status: str) -> int:
-    return {
-        "planned": 0,
-        "merging": 1,
-        "merged": 2,
-        "blocked": 3,
-        "stale": 3,
-        "skipped": 3,
-    }[status]
+    return controller_merge_train_batch_landing_entry_rank(status)
 
 
 def _validate_stack_collapse_record_for_landing(

--- a/control_plane/workflows/merge_train_controller.py
+++ b/control_plane/workflows/merge_train_controller.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from control_plane.contracts.merge_train_batch import (
+    MergeTrainBatchCandidateRecord,
+    MergeTrainBatchLandingPlanRecord,
+)
+from control_plane.contracts.merge_train_stack_collapse import (
+    MergeTrainStackCollapsePlanRecord,
+)
+
+
+MergeTrainControllerAction = Literal[
+    "idle",
+    "build_candidate",
+    "observe_candidate",
+    "candidate_failed",
+    "candidate_stopped",
+    "plan_landing",
+    "land_batch",
+    "batch_landed",
+    "admit_collapsed_root",
+    "execute_stack_collapse",
+]
+
+
+class MergeTrainControllerDecision(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    action: MergeTrainControllerAction
+    reason: str
+    candidate_record_id: str = ""
+    landing_plan_record_id: str = ""
+    stack_collapse_plan_record_id: str = ""
+
+
+def decide_merge_train_controller_record_action(
+    *,
+    candidate_records: tuple[MergeTrainBatchCandidateRecord, ...],
+    landing_plan_records: tuple[MergeTrainBatchLandingPlanRecord, ...],
+    stack_collapse_plan_records: tuple[MergeTrainStackCollapsePlanRecord, ...],
+) -> MergeTrainControllerDecision:
+    active_landing_record = latest_merge_train_batch_landing_plan_record(
+        landing_plan_records
+    )
+    if active_landing_record is not None:
+        waiting_collapse_record = latest_merge_train_stack_collapse_plan_record(
+            stack_collapse_plan_records,
+            plan_status="waiting_for_root_checks",
+        )
+        return MergeTrainControllerDecision(
+            action="land_batch",
+            reason="active landing plan has planned entries",
+            landing_plan_record_id=active_landing_record.record_id,
+            stack_collapse_plan_record_id=""
+            if waiting_collapse_record is None
+            else waiting_collapse_record.record_id,
+        )
+
+    active_candidate_record = latest_merge_train_batch_candidate_record(candidate_records)
+    if active_candidate_record is not None:
+        if active_candidate_record.candidate.status == "failed":
+            return MergeTrainControllerDecision(
+                action="candidate_failed",
+                reason="latest active candidate failed",
+                candidate_record_id=active_candidate_record.record_id,
+            )
+        if active_candidate_record.candidate.status in {"stale", "blocked"}:
+            return MergeTrainControllerDecision(
+                action="candidate_stopped",
+                reason=f"latest active candidate is {active_candidate_record.candidate.status}",
+                candidate_record_id=active_candidate_record.record_id,
+            )
+        if active_candidate_record.candidate.status in {"planned", "building"}:
+            return MergeTrainControllerDecision(
+                action="build_candidate",
+                reason="candidate branch needs build/update",
+                candidate_record_id=active_candidate_record.record_id,
+            )
+        return MergeTrainControllerDecision(
+            action="observe_candidate",
+            reason="candidate branch is ready for check observation",
+            candidate_record_id=active_candidate_record.record_id,
+        )
+
+    passed_candidate_record = latest_passed_merge_train_batch_candidate_record(
+        candidate_records
+    )
+    if passed_candidate_record is not None:
+        completed_landing_record = latest_completed_merge_train_batch_landing_plan_record(
+            landing_plan_records=landing_plan_records,
+            batch_id=passed_candidate_record.candidate.batch_id,
+            candidate_sha=passed_candidate_record.candidate.candidate_sha,
+        )
+        if completed_landing_record is not None:
+            return MergeTrainControllerDecision(
+                action="batch_landed",
+                reason="passed candidate already has a completed landing plan",
+                candidate_record_id=passed_candidate_record.record_id,
+                landing_plan_record_id=completed_landing_record.record_id,
+            )
+        return MergeTrainControllerDecision(
+            action="plan_landing",
+            reason="latest passed candidate needs a landing plan",
+            candidate_record_id=passed_candidate_record.record_id,
+        )
+
+    waiting_collapse_record = latest_merge_train_stack_collapse_plan_record(
+        stack_collapse_plan_records,
+        plan_status="waiting_for_root_checks",
+    )
+    if waiting_collapse_record is not None:
+        return MergeTrainControllerDecision(
+            action="admit_collapsed_root",
+            reason="collapsed stack root is waiting for root checks",
+            stack_collapse_plan_record_id=waiting_collapse_record.record_id,
+        )
+
+    planned_collapse_record = latest_merge_train_stack_collapse_plan_record(
+        stack_collapse_plan_records,
+        plan_status="planned",
+    )
+    if planned_collapse_record is not None:
+        return MergeTrainControllerDecision(
+            action="execute_stack_collapse",
+            reason="stack collapse plan is ready to execute",
+            stack_collapse_plan_record_id=planned_collapse_record.record_id,
+        )
+
+    return MergeTrainControllerDecision(
+        action="idle",
+        reason="no active merge train records require controller action",
+    )
+
+
+def latest_merge_train_batch_candidate_record(
+    records: tuple[MergeTrainBatchCandidateRecord, ...],
+) -> MergeTrainBatchCandidateRecord | None:
+    latest_record = latest_merge_train_batch_candidate_progress_record(records)
+    if latest_record is None:
+        return None
+    if latest_record.candidate.status == "passed":
+        return None
+    return latest_record
+
+
+def latest_passed_merge_train_batch_candidate_record(
+    records: tuple[MergeTrainBatchCandidateRecord, ...],
+) -> MergeTrainBatchCandidateRecord | None:
+    latest_record = latest_merge_train_batch_candidate_progress_record(records)
+    if latest_record is None:
+        return None
+    if latest_record.candidate.status != "passed":
+        return None
+    return latest_record
+
+
+def latest_merge_train_batch_landing_plan_record(
+    records: tuple[MergeTrainBatchLandingPlanRecord, ...],
+) -> MergeTrainBatchLandingPlanRecord | None:
+    latest_record = latest_merge_train_batch_landing_progress_record(records)
+    if latest_record is None:
+        return None
+    if not any(entry.status == "planned" for entry in latest_record.landing_plan.entries):
+        return None
+    return latest_record
+
+
+def latest_completed_merge_train_batch_landing_plan_record(
+    *,
+    landing_plan_records: tuple[MergeTrainBatchLandingPlanRecord, ...],
+    batch_id: str,
+    candidate_sha: str,
+) -> MergeTrainBatchLandingPlanRecord | None:
+    matching_records = tuple(
+        record
+        for record in landing_plan_records
+        if record.landing_plan.batch_id == batch_id
+        and record.landing_plan.candidate_sha == candidate_sha
+    )
+    latest_record = latest_merge_train_batch_landing_progress_record(matching_records)
+    if latest_record is None:
+        return None
+    if not latest_record.landing_plan.entries:
+        return None
+    if any(entry.status != "merged" for entry in latest_record.landing_plan.entries):
+        return None
+    return latest_record
+
+
+def latest_merge_train_stack_collapse_plan_record(
+    records: tuple[MergeTrainStackCollapsePlanRecord, ...],
+    *,
+    plan_status: str,
+) -> MergeTrainStackCollapsePlanRecord | None:
+    latest_record = latest_merge_train_stack_collapse_progress_record(records)
+    if latest_record is None:
+        return None
+    if latest_record.plan.status != plan_status:
+        return None
+    return latest_record
+
+
+def latest_merge_train_batch_candidate_progress_record(
+    records: tuple[MergeTrainBatchCandidateRecord, ...],
+) -> MergeTrainBatchCandidateRecord | None:
+    if not records:
+        return None
+    status_rank = {
+        "planned": 0,
+        "building": 1,
+        "ready_for_checks": 2,
+        "passed": 3,
+        "failed": 4,
+        "stale": 4,
+        "blocked": 4,
+    }
+    return max(
+        records,
+        key=lambda record: (
+            record.updated_at,
+            status_rank[record.candidate.status],
+            record.record_id,
+        ),
+    )
+
+
+def latest_merge_train_batch_landing_progress_record(
+    records: tuple[MergeTrainBatchLandingPlanRecord, ...],
+) -> MergeTrainBatchLandingPlanRecord | None:
+    if not records:
+        return None
+    return max(
+        records,
+        key=lambda record: (
+            record.updated_at,
+            max(
+                merge_train_batch_landing_entry_rank(entry.status)
+                for entry in record.landing_plan.entries
+            ),
+            record.record_id,
+        ),
+    )
+
+
+def latest_merge_train_stack_collapse_progress_record(
+    records: tuple[MergeTrainStackCollapsePlanRecord, ...],
+) -> MergeTrainStackCollapsePlanRecord | None:
+    if not records:
+        return None
+    status_rank = {
+        "planned": 0,
+        "collapsing": 1,
+        "waiting_for_root_checks": 2,
+        "ready_for_train": 3,
+        "blocked": 4,
+        "stale": 4,
+    }
+    return max(
+        records,
+        key=lambda record: (record.updated_at, status_rank[record.plan.status], record.record_id),
+    )
+
+
+def merge_train_batch_landing_entry_rank(status: str) -> int:
+    return {
+        "planned": 0,
+        "merging": 1,
+        "merged": 2,
+        "blocked": 3,
+        "stale": 3,
+        "skipped": 3,
+    }[status]

--- a/tests/test_merge_train_controller.py
+++ b/tests/test_merge_train_controller.py
@@ -1,0 +1,274 @@
+import unittest
+
+from control_plane.contracts.merge_train_batch import (
+    MergeTrainBatchCandidate,
+    MergeTrainBatchCandidateRecord,
+    MergeTrainBatchEntry,
+    MergeTrainBatchLandingPlanRecord,
+    build_merge_train_batch_candidate_ref,
+    build_merge_train_batch_id,
+    build_merge_train_batch_landing_plan,
+)
+from control_plane.contracts.merge_train_stack_collapse import (
+    MergeTrainStackCollapseEntry,
+    MergeTrainStackCollapseMutation,
+    MergeTrainStackCollapsePlan,
+    MergeTrainStackCollapsePlanRecord,
+    build_merge_train_stack_collapse_id,
+)
+from control_plane.workflows.merge_train_controller import (
+    decide_merge_train_controller_record_action,
+)
+
+
+class MergeTrainControllerDecisionTests(unittest.TestCase):
+    def test_decision_is_idle_without_existing_records(self) -> None:
+        decision = decide_merge_train_controller_record_action(
+            candidate_records=(), landing_plan_records=(), stack_collapse_plan_records=()
+        )
+
+        self.assertEqual(decision.action, "idle")
+
+    def test_decision_waits_on_pending_candidate(self) -> None:
+        planned_record = _candidate_record(status="planned")
+        building_record = _candidate_record(
+            status="building",
+            record_id="candidate-building",
+            updated_at="2026-05-18T01:01:00Z",
+        )
+
+        decision = decide_merge_train_controller_record_action(
+            candidate_records=(planned_record, building_record),
+            landing_plan_records=(),
+            stack_collapse_plan_records=(),
+        )
+
+        self.assertEqual(decision.action, "build_candidate")
+        self.assertEqual(decision.candidate_record_id, "candidate-building")
+
+    def test_decision_observes_candidate_waiting_for_checks(self) -> None:
+        decision = decide_merge_train_controller_record_action(
+            candidate_records=(_candidate_record(status="ready_for_checks"),),
+            landing_plan_records=(),
+            stack_collapse_plan_records=(),
+        )
+
+        self.assertEqual(decision.action, "observe_candidate")
+
+    def test_decision_stops_on_failed_or_stale_candidate(self) -> None:
+        failed_decision = decide_merge_train_controller_record_action(
+            candidate_records=(_candidate_record(status="failed"),),
+            landing_plan_records=(),
+            stack_collapse_plan_records=(),
+        )
+        stale_decision = decide_merge_train_controller_record_action(
+            candidate_records=(_candidate_record(status="stale"),),
+            landing_plan_records=(),
+            stack_collapse_plan_records=(),
+        )
+
+        self.assertEqual(failed_decision.action, "candidate_failed")
+        self.assertEqual(stale_decision.action, "candidate_stopped")
+
+    def test_decision_plans_landing_for_passed_candidate(self) -> None:
+        passed_record = _candidate_record(status="passed", candidate_sha="candidate-sha")
+
+        decision = decide_merge_train_controller_record_action(
+            candidate_records=(passed_record,),
+            landing_plan_records=(),
+            stack_collapse_plan_records=(),
+        )
+
+        self.assertEqual(decision.action, "plan_landing")
+        self.assertEqual(decision.candidate_record_id, passed_record.record_id)
+
+    def test_decision_lands_active_landing_plan_before_candidate(self) -> None:
+        passed_record = _candidate_record(status="passed", candidate_sha="candidate-sha")
+        landing_record = _landing_plan_record(candidate=passed_record.candidate)
+
+        decision = decide_merge_train_controller_record_action(
+            candidate_records=(passed_record,),
+            landing_plan_records=(landing_record,),
+            stack_collapse_plan_records=(),
+        )
+
+        self.assertEqual(decision.action, "land_batch")
+        self.assertEqual(decision.landing_plan_record_id, landing_record.record_id)
+
+    def test_decision_reports_terminal_landed_batch(self) -> None:
+        passed_record = _candidate_record(status="passed", candidate_sha="candidate-sha")
+        merged_landing_record = _landing_plan_record(
+            candidate=passed_record.candidate,
+            record_id="landing-merged",
+            entry_status="merged",
+            updated_at="2026-05-18T01:02:00Z",
+        )
+
+        decision = decide_merge_train_controller_record_action(
+            candidate_records=(passed_record,),
+            landing_plan_records=(merged_landing_record,),
+            stack_collapse_plan_records=(),
+        )
+
+        self.assertEqual(decision.action, "batch_landed")
+        self.assertEqual(decision.landing_plan_record_id, "landing-merged")
+
+    def test_decision_supports_stack_collapse_records(self) -> None:
+        planned_record = _stack_collapse_record(status="planned")
+        waiting_record = _stack_collapse_record(
+            status="waiting_for_root_checks",
+            record_id="stack-waiting",
+            updated_at="2026-05-18T01:01:00Z",
+        )
+
+        planned_decision = decide_merge_train_controller_record_action(
+            candidate_records=(),
+            landing_plan_records=(),
+            stack_collapse_plan_records=(planned_record,),
+        )
+        waiting_decision = decide_merge_train_controller_record_action(
+            candidate_records=(),
+            landing_plan_records=(),
+            stack_collapse_plan_records=(planned_record, waiting_record),
+        )
+
+        self.assertEqual(planned_decision.action, "execute_stack_collapse")
+        self.assertEqual(planned_decision.stack_collapse_plan_record_id, planned_record.record_id)
+        self.assertEqual(waiting_decision.action, "admit_collapsed_root")
+        self.assertEqual(waiting_decision.stack_collapse_plan_record_id, "stack-waiting")
+
+
+def _candidate_record(
+    *,
+    status: str,
+    record_id: str = "candidate-record",
+    updated_at: str = "2026-05-18T01:00:00Z",
+    candidate_sha: str = "",
+) -> MergeTrainBatchCandidateRecord:
+    entries = (_batch_entry(),)
+    batch_id = build_merge_train_batch_id(
+        repository="example/merge-train-repo",
+        base_branch="main",
+        base_sha="base-sha",
+        entry_head_shas=tuple(entry.head_sha for entry in entries),
+    )
+    return MergeTrainBatchCandidateRecord(
+        record_id=record_id,
+        source="test",
+        updated_at=updated_at,
+        candidate=MergeTrainBatchCandidate(
+            batch_id=batch_id,
+            repository="example/merge-train-repo",
+            base_branch="main",
+            base_sha="base-sha",
+            policy_key="example/merge-train-repo:main",
+            policy_sha256="policy-sha",
+            candidate_ref=build_merge_train_batch_candidate_ref(
+                repository="example/merge-train-repo",
+                base_branch="main",
+                batch_id=batch_id,
+            ),
+            candidate_sha=candidate_sha,
+            status=status,  # type: ignore[arg-type]
+            entries=entries,
+            required_checks_status="pass" if status == "passed" else "unknown",
+            created_at="2026-05-18T00:59:00Z",
+            updated_at=updated_at,
+        ),
+    )
+
+
+def _landing_plan_record(
+    *,
+    candidate: MergeTrainBatchCandidate,
+    record_id: str = "landing-record",
+    entry_status: str = "planned",
+    updated_at: str = "2026-05-18T01:01:00Z",
+) -> MergeTrainBatchLandingPlanRecord:
+    landing_plan = build_merge_train_batch_landing_plan(
+        candidate=candidate,
+        merge_method="squash",
+        created_at=updated_at,
+    )
+    landing_plan = landing_plan.model_copy(
+        update={
+            "entries": tuple(
+                entry.model_copy(update={"status": entry_status})
+                for entry in landing_plan.entries
+            )
+        }
+    )
+    return MergeTrainBatchLandingPlanRecord(
+        record_id=record_id,
+        source="test",
+        updated_at=updated_at,
+        landing_plan=landing_plan,
+    )
+
+
+def _stack_collapse_record(
+    *,
+    status: str,
+    record_id: str = "stack-record",
+    updated_at: str = "2026-05-18T01:00:00Z",
+) -> MergeTrainStackCollapsePlanRecord:
+    entries = (
+        MergeTrainStackCollapseEntry(
+            pull_request_number=1,
+            position=1,
+            head_sha="head-1",
+            head_ref="feature/root",
+            base_ref="main",
+        ),
+        MergeTrainStackCollapseEntry(
+            pull_request_number=2,
+            position=2,
+            head_sha="head-2",
+            head_ref="feature/child",
+            base_ref="feature/root",
+        ),
+    )
+    collapse_id = build_merge_train_stack_collapse_id(
+        repository="example/merge-train-repo",
+        base_branch="main",
+        root_pull_request_number=1,
+        entry_head_shas=tuple(entry.head_sha for entry in entries),
+    )
+    return MergeTrainStackCollapsePlanRecord(
+        record_id=record_id,
+        source="test",
+        updated_at=updated_at,
+        plan=MergeTrainStackCollapsePlan(
+            collapse_id=collapse_id,
+            repository="example/merge-train-repo",
+            base_branch="main",
+            root_pull_request_number=1,
+            root_initial_head_sha="head-1",
+            root_head_ref="feature/root",
+            policy_key="example/merge-train-repo:main",
+            policy_sha256="policy-sha",
+            status=status,  # type: ignore[arg-type]
+            entries=entries,
+            mutations=(
+                MergeTrainStackCollapseMutation(
+                    child_pull_request_number=2,
+                    parent_pull_request_number=1,
+                    child_head_sha="head-2",
+                    expected_parent_head_sha="head-1",
+                    parent_head_ref="feature/root",
+                ),
+            ),
+            created_at="2026-05-18T00:59:00Z",
+            updated_at=updated_at,
+        ),
+    )
+
+
+def _batch_entry() -> MergeTrainBatchEntry:
+    return MergeTrainBatchEntry(
+        pull_request_number=1,
+        position=1,
+        head_sha="head-1",
+        title="PR 1",
+        url="https://github.com/example/merge-train-repo/pull/1",
+    )


### PR DESCRIPTION
## Summary
- add a pure typed merge-train controller decision module for existing candidate, landing-plan, and stack-collapse records
- delegate the service controller ranking helpers to the new workflow module without changing provider mutation paths
- cover idle, pending/build, observe/wait, failed/stale stop, plan landing, land-ready, terminal, and stack record decisions

## Validation
- `uv run python -m unittest tests.test_merge_train_controller tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_advances_unstacked_batch_flow tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_stops_after_candidate_failure tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_advances_stacked_batch_flow`
- `uv run python -m unittest`
- `uv run --extra dev ruff check control_plane/workflows/merge_train_controller.py control_plane/service.py tests/test_merge_train_controller.py --diff`
- `uv run --extra dev ruff check control_plane/workflows/merge_train_controller.py control_plane/service.py tests/test_merge_train_controller.py`
- `uv run --extra dev mypy control_plane tests`
- JetBrains inspection: new controller module and focused test file clean; service.py still has pre-existing broad warnings unrelated to this adapter
