### PR TITLE
Represent merge train root-check waits

### DIFF
--- a/control_plane/workflows/merge_train_controller.py
+++ b/control_plane/workflows/merge_train_controller.py
@@ -22,7 +22,7 @@ MergeTrainControllerAction = Literal[
     "plan_landing",
     "land_batch",
     "batch_landed",
-    "admit_collapsed_root",
+    "wait_for_root_checks",
     "execute_stack_collapse",
 ]
 
@@ -114,8 +114,8 @@ def decide_merge_train_controller_record_action(
     )
     if waiting_collapse_record is not None:
         return MergeTrainControllerDecision(
-            action="admit_collapsed_root",
-            reason="collapsed stack root is waiting for root checks",
+            action="wait_for_root_checks",
+            reason="collapsed stack root still needs mergeability checks",
             stack_collapse_plan_record_id=waiting_collapse_record.record_id,
         )
 

--- a/tests/test_merge_train_controller.py
+++ b/tests/test_merge_train_controller.py
@@ -55,7 +55,7 @@ class MergeTrainControllerDecisionTests(unittest.TestCase):
 
         self.assertEqual(decision.action, "observe_candidate")
 
-    def test_decision_stops_on_failed_or_stale_candidate(self) -> None:
+    def test_decision_handles_failed_and_terminal_candidates(self) -> None:
         failed_decision = decide_merge_train_controller_record_action(
             candidate_records=(_candidate_record(status="failed"),),
             landing_plan_records=(),
@@ -69,6 +69,43 @@ class MergeTrainControllerDecisionTests(unittest.TestCase):
 
         self.assertEqual(failed_decision.action, "candidate_failed")
         self.assertEqual(stale_decision.action, "candidate_stopped")
+
+    def test_decision_stops_for_newest_terminal_candidate_over_older_passed_candidate(
+        self,
+    ) -> None:
+        passed_record = _candidate_record(
+            status="passed",
+            record_id="candidate-passed",
+            candidate_sha="candidate-sha",
+        )
+        stale_record = _candidate_record(
+            status="stale",
+            record_id="candidate-stale",
+            updated_at="2026-05-18T01:01:00Z",
+            candidate_sha="candidate-sha-stale",
+        )
+        blocked_record = _candidate_record(
+            status="blocked",
+            record_id="candidate-blocked",
+            updated_at="2026-05-18T01:02:00Z",
+            candidate_sha="candidate-sha-blocked",
+        )
+
+        stale_decision = decide_merge_train_controller_record_action(
+            candidate_records=(passed_record, stale_record),
+            landing_plan_records=(),
+            stack_collapse_plan_records=(),
+        )
+        blocked_decision = decide_merge_train_controller_record_action(
+            candidate_records=(passed_record, blocked_record),
+            landing_plan_records=(),
+            stack_collapse_plan_records=(),
+        )
+
+        self.assertEqual(stale_decision.action, "candidate_stopped")
+        self.assertEqual(stale_decision.candidate_record_id, stale_record.record_id)
+        self.assertEqual(blocked_decision.action, "candidate_stopped")
+        self.assertEqual(blocked_decision.candidate_record_id, blocked_record.record_id)
 
     def test_decision_plans_landing_for_passed_candidate(self) -> None:
         passed_record = _candidate_record(status="passed", candidate_sha="candidate-sha")
@@ -134,7 +171,7 @@ class MergeTrainControllerDecisionTests(unittest.TestCase):
 
         self.assertEqual(planned_decision.action, "execute_stack_collapse")
         self.assertEqual(planned_decision.stack_collapse_plan_record_id, planned_record.record_id)
-        self.assertEqual(waiting_decision.action, "admit_collapsed_root")
+        self.assertEqual(waiting_decision.action, "wait_for_root_checks")
         self.assertEqual(waiting_decision.stack_collapse_plan_record_id, "stack-waiting")
 
 


### PR DESCRIPTION
## Summary
- represent persisted stack-collapse `waiting_for_root_checks` records as `wait_for_root_checks` in the pure controller decision layer
- keep `admit_collapsed_root` semantics out of the record-only decision path because admission requires provider-backed root readiness evidence
- add regression coverage for the stack wait outcome and newest terminal candidate precedence

## Validation
- `uv run python -m unittest tests.test_merge_train_controller tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_advances_stacked_batch_flow tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_advances_unstacked_batch_flow`
- `uv run python -m unittest` passed, 1346 tests
- `uv run --extra dev ruff check control_plane/workflows/merge_train_controller.py tests/test_merge_train_controller.py --diff`
- `uv run --extra dev ruff check control_plane/workflows/merge_train_controller.py tests/test_merge_train_controller.py`
- `uv run --extra dev mypy control_plane tests`
- JetBrains inspection clean for `control_plane/workflows/merge_train_controller.py` and `tests/test_merge_train_controller.py`

Refs #605, #653.
