### PR TITLE
Harden Odoo replacement planner errors

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -14805,6 +14805,12 @@ def odoo_targets_replacement_plan(
                 ),
                 confirmation=confirmation,
             ),
+            dokploy_config_reader=lambda *, control_plane_root: (
+                control_plane_dokploy.read_dokploy_config(
+                    control_plane_root=control_plane_root,
+                    database_url=database_url,
+                )
+            ),
         )
     finally:
         postgres_store.close()

--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -496,9 +496,13 @@ def resolve_ship_healthcheck_urls(
     return tuple(f"{base_url}{healthcheck_path}" for base_url in base_urls)
 
 
-def read_control_plane_environment_values(*, control_plane_root: Path) -> dict[str, str]:
+def read_control_plane_environment_values(
+    *, control_plane_root: Path, database_url: str | None = None
+) -> dict[str, str]:
     del control_plane_root
-    return control_plane_secrets.overlay_dokploy_environment_values(environment_values={})
+    return control_plane_secrets.overlay_dokploy_environment_values(
+        environment_values={}, database_url=database_url
+    )
 
 
 def read_control_plane_dokploy_source_of_truth(
@@ -674,9 +678,11 @@ def _load_optional_dokploy_source_of_truth_from_database(
             pass
 
 
-def read_dokploy_config(*, control_plane_root: Path) -> tuple[str, str]:
+def read_dokploy_config(
+    *, control_plane_root: Path, database_url: str | None = None
+) -> tuple[str, str]:
     environment_values = read_control_plane_environment_values(
-        control_plane_root=control_plane_root
+        control_plane_root=control_plane_root, database_url=database_url
     )
 
     host = environment_values.get("DOKPLOY_HOST", "").strip()

--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -64,6 +64,7 @@ class OdooStableTargetReplacementStore(Protocol):
 
 
 DokployRequest = Callable[..., JsonValue]
+DokployConfigReader = Callable[..., tuple[str, str]]
 ODOO_STABLE_TARGET_REPLACEMENT_VERIFY_RETRY_INTERVAL_SECONDS = 5
 
 
@@ -507,9 +508,19 @@ def build_odoo_stable_target_replacement_plan(
     control_plane_root: Path,
     record_store: OdooStableTargetReplacementStore,
     request: OdooStableTargetReplacementRequest,
-    dokploy_request: DokployRequest = control_plane_dokploy.dokploy_request,
+    dokploy_request: DokployRequest | None = None,
+    dokploy_config_reader: DokployConfigReader | None = None,
 ) -> OdooStableTargetReplacementPlan:
-    profile = record_store.read_product_profile_record(request.product)
+    resolved_dokploy_request = dokploy_request or control_plane_dokploy.dokploy_request
+    resolved_dokploy_config_reader = (
+        dokploy_config_reader or control_plane_dokploy.read_dokploy_config
+    )
+    try:
+        profile = record_store.read_product_profile_record(request.product)
+    except FileNotFoundError as error:
+        raise click.ClickException(
+            f"Launchplane has no product profile record for {request.product!r}."
+        ) from error
     if profile.driver_id != "odoo":
         raise click.ClickException(
             f"Product {profile.product!r} is configured for driver {profile.driver_id!r}, not odoo."
@@ -547,15 +558,13 @@ def build_odoo_stable_target_replacement_plan(
     if isinstance(target_record, DokployTargetRecord) and isinstance(
         target_id_record, DokployTargetIdRecord
     ):
-        host, token = control_plane_dokploy.read_dokploy_config(
-            control_plane_root=control_plane_root
-        )
+        host, token = resolved_dokploy_config_reader(control_plane_root=control_plane_root)
         current_target = _snapshot_current_target(
             host=host,
             token=token,
             target_record=target_record,
             target_id_record=target_id_record,
-            request=dokploy_request,
+            request=resolved_dokploy_request,
         )
         try:
             approval_issue_url = _assert_prelaunch_rebuild_policy_allows_request(

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -14,6 +14,7 @@ from click.testing import CliRunner
 from pydantic import ValidationError
 
 from control_plane import dokploy as control_plane_dokploy
+from control_plane.dokploy import JsonValue
 from control_plane.odoo_instance_overrides import ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY
 from control_plane import secrets as control_plane_secrets
 from control_plane.cli import main
@@ -21,6 +22,12 @@ from control_plane.contracts.dokploy_target_id_record import DokployTargetIdReco
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductImageProfile,
+    ProductLaneProfile,
+    ProductPreviewProfile,
+)
 from control_plane.storage.postgres import PostgresRecordStore
 
 
@@ -75,6 +82,24 @@ def _seed_dokploy_target_records(
                 source_label="test",
             )
         )
+
+
+def _write_odoo_product_profile_record(*, store: PostgresRecordStore) -> None:
+    store.write_product_profile_record(
+        LaunchplaneProductProfileRecord(
+            product="odoo-tenant-cm",
+            display_name="Odoo CM",
+            repository="cbusillo/odoo-tenant-cm",
+            driver_id="odoo",
+            image=ProductImageProfile(repository="ghcr.io/cbusillo/odoo-tenant-cm"),
+            runtime_port=8069,
+            health_path="/web/health",
+            lanes=(ProductLaneProfile(instance="testing", context="cm"),),
+            preview=ProductPreviewProfile(enabled=True, context="cm"),
+            updated_at="2026-05-09T00:00:00Z",
+            source="test",
+        )
+    )
 
 
 class _FakeDokployTargetStore:
@@ -1632,6 +1657,154 @@ protected_store_keys = ["yps-your-part-supplier"]
         self.assertEqual(host, "https://dokploy.db.example")
         self.assertEqual(token, "db-token")
 
+    def test_read_dokploy_config_uses_explicit_database_url(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            explicit_database_url = _sqlite_database_url(
+                control_plane_root / "explicit-launchplane.sqlite3"
+            )
+            ignored_database_url = _sqlite_database_url(
+                control_plane_root / "ignored-launchplane.sqlite3"
+            )
+            explicit_store = PostgresRecordStore(database_url=explicit_database_url)
+            ignored_store = PostgresRecordStore(database_url=ignored_database_url)
+            explicit_store.ensure_schema()
+            ignored_store.ensure_schema()
+
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_DATABASE_URL": ignored_database_url,
+                    control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                },
+                clear=True,
+            ):
+                _write_dokploy_managed_secrets(
+                    store=explicit_store,
+                    host="https://dokploy.explicit.example",
+                    token="explicit-token",
+                )
+                _write_dokploy_managed_secrets(
+                    store=ignored_store,
+                    host="https://dokploy.ignored.example",
+                    token="ignored-token",
+                )
+                host, token = control_plane_dokploy.read_dokploy_config(
+                    control_plane_root=control_plane_root,
+                    database_url=explicit_database_url,
+                )
+
+            explicit_store.close()
+            ignored_store.close()
+
+        self.assertEqual(host, "https://dokploy.explicit.example")
+        self.assertEqual(token, "explicit-token")
+
+    def test_odoo_target_replacement_plan_cli_uses_database_bound_dokploy_secrets(
+        self,
+    ) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            explicit_database_url = _sqlite_database_url(
+                control_plane_root / "explicit-launchplane.sqlite3"
+            )
+            ignored_database_url = _sqlite_database_url(
+                control_plane_root / "ignored-launchplane.sqlite3"
+            )
+            explicit_store = PostgresRecordStore(database_url=explicit_database_url)
+            ignored_store = PostgresRecordStore(database_url=ignored_database_url)
+            explicit_store.ensure_schema()
+            ignored_store.ensure_schema()
+            _write_odoo_product_profile_record(store=explicit_store)
+            _seed_dokploy_target_records(
+                store=explicit_store,
+                payload="""
+schema_version = 2
+
+[[targets]]
+context = "cm"
+instance = "testing"
+target_id = "compose-cm-testing"
+target_type = "compose"
+target_name = "cm-testing"
+domains = ["cm-testing.shinycomputers.com"]
+""",
+            )
+
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_DATABASE_URL": ignored_database_url,
+                    control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                },
+                clear=True,
+            ):
+                _write_dokploy_managed_secrets(
+                    store=explicit_store,
+                    host="https://dokploy.explicit.example",
+                    token="explicit-token",
+                )
+                _write_dokploy_managed_secrets(
+                    store=ignored_store,
+                    host="https://dokploy.ignored.example",
+                    token="ignored-token",
+                )
+                captured_requests: list[dict[str, object]] = []
+
+                def fake_dokploy_request(**kwargs: object) -> JsonValue:
+                    captured_requests.append(dict(kwargs))
+                    if kwargs.get("path") == "/api/domain.byComposeId":
+                        return [
+                            {
+                                "host": "cm-testing.shinycomputers.com",
+                                "domainId": "domain-cm",
+                            }
+                        ]
+                    return []
+
+                with (
+                    patch(
+                        "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.dokploy_request",
+                        side_effect=fake_dokploy_request,
+                    ),
+                    patch(
+                        "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.fetch_dokploy_target_payload",
+                        return_value={
+                            "name": "cm-testing",
+                            "sourceType": "raw",
+                            "composePath": "docker-compose.yml",
+                            "composeFile": "services: {}",
+                            "env": "",
+                        },
+                    ),
+                ):
+                    result = runner.invoke(
+                        main,
+                        [
+                            "odoo-targets",
+                            "replacement-plan",
+                            "--database-url",
+                            explicit_database_url,
+                            "--product",
+                            "odoo-tenant-cm",
+                            "--instance",
+                            "testing",
+                            "--control-plane-root",
+                            str(control_plane_root),
+                        ],
+                        catch_exceptions=False,
+                    )
+
+            explicit_store.close()
+            ignored_store.close()
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertTrue(captured_requests)
+        self.assertEqual(captured_requests[0]["host"], "https://dokploy.explicit.example")
+        self.assertEqual(captured_requests[0]["token"], "explicit-token")
+        self.assertNotIn("ignored-token", result.output)
+
     def test_read_dokploy_config_ignores_repo_env_file(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -2120,9 +2293,7 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
     def test_launchplane_compose_exports_runtime_image_reference(self) -> None:
         compose_text = Path("docker-compose.yml").read_text()
 
-        self.assertIn(
-            "image: ${DOCKER_IMAGE_REFERENCE:-launchplane:local}", compose_text
-        )
+        self.assertIn("image: ${DOCKER_IMAGE_REFERENCE:-launchplane:local}", compose_text)
         self.assertIn(
             "DOCKER_IMAGE_REFERENCE: ${DOCKER_IMAGE_REFERENCE:-launchplane:local}",
             compose_text,
@@ -2143,7 +2314,7 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
         self.assertIn("\n  script-runner:", compose_file)
         self.assertIn("name: ${ODOO_PROJECT_NAME:-odoo}", compose_file)
         self.assertIn("dokploy-network:", compose_file)
-        self.assertIn('traefik.enable=true', compose_file)
+        self.assertIn("traefik.enable=true", compose_file)
         self.assertIn(
             "traefik.http.routers.launchplane-odoo-web-cm-testing-shinycomputers-com-",
             compose_file,

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -508,6 +508,21 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         self.assertIn("Launchplane has no Dokploy target record for this lane.", plan.blockers)
         self.assertIn("Launchplane has no Dokploy target-id record for this lane.", plan.blockers)
 
+    def test_build_plan_reports_missing_product_profile_as_operator_error(self) -> None:
+        with self.assertRaises(click.ClickException) as raised_error:
+            build_odoo_stable_target_replacement_plan(
+                control_plane_root=Path("."),
+                record_store=_Store(),
+                request=OdooStableTargetReplacementRequest(
+                    product="missing-tenant", instance="testing"
+                ),
+            )
+
+        self.assertIn(
+            "Launchplane has no product profile record for 'missing-tenant'.",
+            str(raised_error.exception),
+        )
+
     def test_build_plan_blocks_missing_volume_contract(self) -> None:
         with (
             patch(


### PR DESCRIPTION
## Summary

- bind `launchplane odoo-targets replacement-plan --database-url` Dokploy secret resolution to the same database URL used for planner records
- surface missing product profile records as concise Click errors instead of raw `FileNotFoundError`
- keep planner request/config readers late-bound/injectable so tests and callers avoid accidental live provider calls

## Safety

- no live/provider mutation paths changed
- no VeriReel runtime/deploy/preview/prod actions were run
- planner remains read-only apart from existing local record reads and mocked test requests

## Validation

- `uv run python -m unittest tests.test_dokploy tests.test_odoo_stable_target_replacement`
- `uv run python -m unittest`
- `uv run --extra dev ruff format --check control_plane/dokploy.py control_plane/workflows/odoo_stable_target_replacement.py control_plane/cli.py tests/test_dokploy.py tests/test_odoo_stable_target_replacement.py`
- `uv run --extra dev ruff check control_plane/dokploy.py control_plane/workflows/odoo_stable_target_replacement.py control_plane/cli.py tests/test_dokploy.py tests/test_odoo_stable_target_replacement.py`
- `uv run --extra dev mypy control_plane/dokploy.py control_plane/workflows/odoo_stable_target_replacement.py control_plane/cli.py tests/test_dokploy.py tests/test_odoo_stable_target_replacement.py`
- JetBrains changed-files inspection run: findings were pre-existing weak duplicate-code / older Click command typing warnings, none on the new implementation lines

Refs #545
