### PR TITLE
Add collapsed-root admit controller action

### DIFF
--- a/control_plane/workflows/merge_train_controller.py
+++ b/control_plane/workflows/merge_train_controller.py
@@ -24,6 +24,7 @@ MergeTrainControllerAction = Literal[
     "batch_landed",
     "wait_for_root_checks",
     "execute_stack_collapse",
+    "admit_collapsed_root",
 ]
 
 
@@ -43,9 +44,7 @@ def decide_merge_train_controller_record_action(
     landing_plan_records: tuple[MergeTrainBatchLandingPlanRecord, ...],
     stack_collapse_plan_records: tuple[MergeTrainStackCollapsePlanRecord, ...],
 ) -> MergeTrainControllerDecision:
-    active_landing_record = latest_merge_train_batch_landing_plan_record(
-        landing_plan_records
-    )
+    active_landing_record = latest_merge_train_batch_landing_plan_record(landing_plan_records)
     if active_landing_record is not None:
         waiting_collapse_record = latest_merge_train_stack_collapse_plan_record(
             stack_collapse_plan_records,
@@ -86,9 +85,7 @@ def decide_merge_train_controller_record_action(
             candidate_record_id=active_candidate_record.record_id,
         )
 
-    passed_candidate_record = latest_passed_merge_train_batch_candidate_record(
-        candidate_records
-    )
+    passed_candidate_record = latest_passed_merge_train_batch_candidate_record(candidate_records)
     if passed_candidate_record is not None:
         completed_landing_record = latest_completed_merge_train_batch_landing_plan_record(
             landing_plan_records=landing_plan_records,

--- a/tests/test_merge_train_controller.py
+++ b/tests/test_merge_train_controller.py
@@ -17,11 +17,22 @@ from control_plane.contracts.merge_train_stack_collapse import (
     build_merge_train_stack_collapse_id,
 )
 from control_plane.workflows.merge_train_controller import (
+    MergeTrainControllerDecision,
     decide_merge_train_controller_record_action,
 )
 
 
 class MergeTrainControllerDecisionTests(unittest.TestCase):
+    def test_decision_accepts_service_admit_collapsed_root_action(self) -> None:
+        decision = MergeTrainControllerDecision(
+            action="admit_collapsed_root",
+            reason="collapsed root is ready for batch admission",
+            stack_collapse_plan_record_id="stack-ready",
+        )
+
+        self.assertEqual(decision.action, "admit_collapsed_root")
+        self.assertEqual(decision.model_dump(mode="json")["action"], "admit_collapsed_root")
+
     def test_decision_is_idle_without_existing_records(self) -> None:
         decision = decide_merge_train_controller_record_action(
             candidate_records=(), landing_plan_records=(), stack_collapse_plan_records=()
@@ -230,8 +241,7 @@ def _landing_plan_record(
     landing_plan = landing_plan.model_copy(
         update={
             "entries": tuple(
-                entry.model_copy(update={"status": entry_status})
-                for entry in landing_plan.entries
+                entry.model_copy(update={"status": entry_status}) for entry in landing_plan.entries
             )
         }
     )


### PR DESCRIPTION
## Summary

- add the service-emitted/documented `admit_collapsed_root` action to the typed merge-train controller action vocabulary
- add a focused serialization regression so the extracted controller decision model accepts that controller outcome

## Safety

- no service/provider behavior changes
- no live/provider actions were run
- no VeriReel prod/runtime/deploy/preview action was touched

## Validation

- `uv run python -m unittest tests.test_merge_train_controller tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_advances_stacked_batch_flow`
- `uv run --extra dev ruff check control_plane/workflows/merge_train_controller.py tests/test_merge_train_controller.py`
- `uv run --extra dev mypy control_plane/workflows/merge_train_controller.py tests/test_merge_train_controller.py`
- JetBrains changed-files inspection: clean

Refs #605
