### PR TITLE
Add runner lane baseline readiness contract

### DIFF
--- a/control_plane/contracts/runner_lane_baseline.py
+++ b/control_plane/contracts/runner_lane_baseline.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+RunnerLaneBaselineViolationCode = Literal[
+    "docker_config_isolation_missing",
+    "home_directory_outside_allowed_roots",
+    "required_label_missing",
+    "service_user_not_allowed",
+]
+
+
+class RunnerLaneBaselinePolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    required_labels: tuple[str, ...] = ("self-hosted", "launchplane")
+    require_docker_config_isolation: bool = True
+    allowed_service_users: tuple[str, ...] = ()
+    allowed_home_roots: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def _normalize_policy(self) -> "RunnerLaneBaselinePolicy":
+        self.required_labels = _normalized_tokens(self.required_labels)
+        self.allowed_service_users = _normalized_tokens(self.allowed_service_users)
+        self.allowed_home_roots = _normalized_paths(self.allowed_home_roots)
+        return self
+
+
+class RunnerLaneBaselineObservation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    runner_name: str
+    labels: tuple[str, ...] = ()
+    docker_config_isolated: bool | None = None
+    service_user: str = ""
+    home_directory: str = ""
+    observed_at: str
+
+    @model_validator(mode="after")
+    def _normalize_observation(self) -> "RunnerLaneBaselineObservation":
+        self.runner_name = _required_text(
+            self.runner_name, "runner lane baseline observation requires runner_name"
+        )
+        self.labels = _normalized_tokens(self.labels)
+        self.service_user = self.service_user.strip()
+        self.home_directory = _normalized_path(self.home_directory)
+        self.observed_at = _required_text(
+            self.observed_at, "runner lane baseline observation requires observed_at"
+        )
+        return self
+
+
+class RunnerLaneBaselineViolation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    runner_name: str
+    code: RunnerLaneBaselineViolationCode
+    message: str
+
+    @model_validator(mode="after")
+    def _normalize_violation(self) -> "RunnerLaneBaselineViolation":
+        self.runner_name = _required_text(
+            self.runner_name, "runner lane baseline violation requires runner_name"
+        )
+        self.message = _required_text(
+            self.message, "runner lane baseline violation requires message"
+        )
+        return self
+
+
+class RunnerLaneBaselineReadiness(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    ready: bool
+    observed_lanes: int = Field(ge=0)
+    compliant_lanes: int = Field(ge=0)
+    violations: tuple[RunnerLaneBaselineViolation, ...] = ()
+    summary: str
+
+    @model_validator(mode="after")
+    def _normalize_readiness(self) -> "RunnerLaneBaselineReadiness":
+        self.violations = tuple(
+            sorted(self.violations, key=lambda violation: (violation.runner_name, violation.code))
+        )
+        self.summary = _required_text(
+            self.summary, "runner lane baseline readiness requires summary"
+        )
+        return self
+
+
+def evaluate_runner_lane_baseline(
+    *,
+    policy: RunnerLaneBaselinePolicy,
+    observations: tuple[RunnerLaneBaselineObservation, ...],
+) -> RunnerLaneBaselineReadiness:
+    violations: list[RunnerLaneBaselineViolation] = []
+    for observation in sorted(observations, key=lambda lane: lane.runner_name):
+        violations.extend(_evaluate_observation(policy=policy, observation=observation))
+
+    lanes_with_violations = {violation.runner_name for violation in violations}
+    compliant_lanes = len(
+        {observation.runner_name for observation in observations} - lanes_with_violations
+    )
+    ready = bool(observations) and not violations
+    summary = "runner lane baseline satisfied"
+    if not observations:
+        summary = "no runner lane baseline observations supplied"
+    elif violations:
+        summary = "runner lane baseline violations found"
+    return RunnerLaneBaselineReadiness(
+        ready=ready,
+        observed_lanes=len(observations),
+        compliant_lanes=compliant_lanes,
+        violations=tuple(violations),
+        summary=summary,
+    )
+
+
+def _evaluate_observation(
+    *, policy: RunnerLaneBaselinePolicy, observation: RunnerLaneBaselineObservation
+) -> tuple[RunnerLaneBaselineViolation, ...]:
+    violations: list[RunnerLaneBaselineViolation] = []
+    missing_labels = tuple(
+        label for label in policy.required_labels if label not in observation.labels
+    )
+    if missing_labels:
+        violations.append(
+            RunnerLaneBaselineViolation(
+                runner_name=observation.runner_name,
+                code="required_label_missing",
+                message=f"runner lane is missing required labels: {', '.join(missing_labels)}",
+            )
+        )
+    if policy.require_docker_config_isolation and observation.docker_config_isolated is not True:
+        violations.append(
+            RunnerLaneBaselineViolation(
+                runner_name=observation.runner_name,
+                code="docker_config_isolation_missing",
+                message="runner lane lacks verified per-job Docker credential isolation",
+            )
+        )
+    if (
+        policy.allowed_service_users
+        and observation.service_user not in policy.allowed_service_users
+    ):
+        violations.append(
+            RunnerLaneBaselineViolation(
+                runner_name=observation.runner_name,
+                code="service_user_not_allowed",
+                message=f"runner lane service user is not allowed: {observation.service_user}",
+            )
+        )
+    if policy.allowed_home_roots and not _path_is_under_roots(
+        observation.home_directory, policy.allowed_home_roots
+    ):
+        violations.append(
+            RunnerLaneBaselineViolation(
+                runner_name=observation.runner_name,
+                code="home_directory_outside_allowed_roots",
+                message=(
+                    "runner lane home directory is outside allowed roots: "
+                    f"{observation.home_directory}"
+                ),
+            )
+        )
+    return tuple(violations)
+
+
+def _path_is_under_roots(path: str, roots: tuple[str, ...]) -> bool:
+    if not path:
+        return False
+    for root in roots:
+        if path == root or path.startswith(f"{root}/"):
+            return True
+    return False
+
+
+def _normalized_paths(values: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(sorted({_normalized_path(value) for value in values if value.strip()}))
+
+
+def _normalized_path(value: str) -> str:
+    return value.strip().rstrip("/")
+
+
+def _normalized_tokens(values: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(sorted({value.strip().lower() for value in values if value.strip()}))
+
+
+def _required_text(value: str, message: str) -> str:
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise ValueError(message)
+    return normalized_value

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,8 @@ Use these docs as the source of truth for `launchplane`.
   graph snapshot and recommendation queue contract.
 - [merge-train-policy.md](merge-train-policy.md) — repository/base-branch merge
   train policy contract, enqueue authority, and smoke-target policy.
+- [runner-lane-baseline.md](runner-lane-baseline.md) — self-hosted runner lane
+  baseline, Docker credential isolation, and readiness contract.
 - [agent-context-boundary.md](agent-context-boundary.md) — public-safe agent
   context, caller profiles, scoped intent, redaction, and provenance boundary.
 - [operations.md](operations.md) — operator workflows and runtime boundary rules.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -227,6 +227,11 @@ Dokploy-hosted.
   read GitHub's current repository runner list. The command is read-only and
   reports lane count, online/busy/idle/offline counts, labels, host hints, and a
   capacity-constrained heuristic from the observation timestamp.
+- Treat [runner-lane-baseline.md](runner-lane-baseline.md) as the readiness
+  contract before routing shared product automation onto a lane. The baseline
+  fails closed without positive per-job Docker credential isolation evidence, so
+  product repositories should not carry local `DOCKER_CONFIG` workaround retries
+  as the long-term safety mechanism.
 - Deploy verification should probe Launchplane's live health endpoint, currently
   `GET /v1/health`, after the Dokploy update.
 - When rollout health fails, deploy automation should restore the previous

--- a/docs/records.md
+++ b/docs/records.md
@@ -763,6 +763,12 @@ preflights.
   DB-backed authority boundary: runtime train state belongs in Launchplane
   storage, not checked-in config, service-host env, logs, or product-repo
   conditionals.
+- Runner lane baseline readiness is represented by typed policy, observation,
+  violation, and readiness contracts in
+  `control_plane.contracts.runner_lane_baseline`. These contracts are evidence
+  about whether a self-hosted runner lane satisfies Launchplane's host baseline;
+  they are not product deploy authority and they do not replace route-specific
+  authorization, promotion, backup-gate, or provider safety checks.
 - Scoped agent write-intent evaluation is exposed at
   `POST /v1/agent/write-intents/evaluate`. It validates intent shape, maps the
   intent to an exact existing policy action, evaluates authorization, and returns

--- a/docs/runner-lane-baseline.md
+++ b/docs/runner-lane-baseline.md
@@ -1,0 +1,60 @@
+---
+title: Runner Lane Baseline
+---
+
+Launchplane owns the safety contract for self-hosted GitHub Actions runner lanes
+used by product publish, preview, and promotion workflows. Product repositories
+may request work, but runner host readiness and Docker credential hygiene belong
+to Launchplane rather than repo-by-repo workflow workarounds.
+
+## Baseline Policy
+
+Every Launchplane-controlled runner lane must satisfy the baseline before it is
+treated as ready for shared product automation:
+
+- The lane is discoverable through GitHub's self-hosted runner inventory.
+- The lane carries the required identity labels, including `self-hosted` and
+  `launchplane` unless a narrower policy overrides them.
+- Docker registry credentials are isolated per job. The readiness contract fails
+  closed unless there is positive evidence that jobs do not share a mutable
+  host-level Docker config.
+- Optional host checks may constrain the service user and home-directory roots
+  used by managed runner lanes.
+
+The baseline does not grant permission to mutate product or provider state. It
+only says whether a runner lane is safe enough to receive work that other
+Launchplane policies already authorized.
+
+## Readiness Contract
+
+The typed contract in `control_plane.contracts.runner_lane_baseline` separates
+policy from observation:
+
+- `RunnerLaneBaselinePolicy` records required labels, whether Docker credential
+  isolation is mandatory, and optional service-user or home-root constraints.
+- `RunnerLaneBaselineObservation` records observed lane facts from a host or
+  runner bootstrap check.
+- `evaluate_runner_lane_baseline(...)` returns `RunnerLaneBaselineReadiness`
+  with a fail-closed summary and structured violations.
+
+No observation means not ready. Unknown Docker credential isolation means not
+ready. Missing labels or configured host guardrails also make the lane not ready.
+
+## Operations
+
+Use the existing read-only inventory command before adding or controlling runner
+lanes:
+
+```bash
+uv run launchplane work-graph runner-inventory --repository owner/name
+```
+
+That command reads GitHub runner metadata only. Host-level observation and future
+reconciliation must run through a Launchplane-owned runner lane flow, not through
+product workflow edits and not through ad hoc retries after a shared Docker
+credential race.
+
+For live products, use a non-production runner or a read-only observation path
+until the operator explicitly approves host changes. VeriReel production must
+not be used as a runner-baseline test surface without explicit operator
+permission.

--- a/tests/test_runner_lane_baseline.py
+++ b/tests/test_runner_lane_baseline.py
@@ -1,0 +1,104 @@
+import unittest
+
+from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselineObservation
+from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselinePolicy
+from control_plane.contracts.runner_lane_baseline import evaluate_runner_lane_baseline
+
+
+class RunnerLaneBaselineTests(unittest.TestCase):
+    def test_readiness_passes_for_isolated_launchplane_runner(self) -> None:
+        readiness = evaluate_runner_lane_baseline(
+            policy=RunnerLaneBaselinePolicy(),
+            observations=(
+                RunnerLaneBaselineObservation(
+                    runner_name="launchplane-runner-1",
+                    labels=("self-hosted", "Launchplane", "Linux"),
+                    docker_config_isolated=True,
+                    observed_at="2026-05-18T12:00:00Z",
+                ),
+            ),
+        )
+
+        self.assertTrue(readiness.ready)
+        self.assertEqual(readiness.observed_lanes, 1)
+        self.assertEqual(readiness.compliant_lanes, 1)
+        self.assertEqual(readiness.violations, ())
+        self.assertEqual(readiness.summary, "runner lane baseline satisfied")
+
+    def test_readiness_fails_closed_without_observations(self) -> None:
+        readiness = evaluate_runner_lane_baseline(
+            policy=RunnerLaneBaselinePolicy(), observations=()
+        )
+
+        self.assertFalse(readiness.ready)
+        self.assertEqual(readiness.observed_lanes, 0)
+        self.assertEqual(readiness.compliant_lanes, 0)
+        self.assertEqual(readiness.summary, "no runner lane baseline observations supplied")
+
+    def test_readiness_requires_docker_credential_isolation_evidence(self) -> None:
+        readiness = evaluate_runner_lane_baseline(
+            policy=RunnerLaneBaselinePolicy(),
+            observations=(
+                RunnerLaneBaselineObservation(
+                    runner_name="launchplane-runner-1",
+                    labels=("self-hosted", "launchplane"),
+                    docker_config_isolated=None,
+                    observed_at="2026-05-18T12:00:00Z",
+                ),
+            ),
+        )
+
+        self.assertFalse(readiness.ready)
+        self.assertEqual(readiness.compliant_lanes, 0)
+        self.assertEqual(
+            [violation.code for violation in readiness.violations],
+            ["docker_config_isolation_missing"],
+        )
+
+    def test_readiness_reports_missing_required_labels(self) -> None:
+        readiness = evaluate_runner_lane_baseline(
+            policy=RunnerLaneBaselinePolicy(required_labels=("self-hosted", "deploy")),
+            observations=(
+                RunnerLaneBaselineObservation(
+                    runner_name="launchplane-runner-1",
+                    labels=("self-hosted",),
+                    docker_config_isolated=True,
+                    observed_at="2026-05-18T12:00:00Z",
+                ),
+            ),
+        )
+
+        self.assertFalse(readiness.ready)
+        self.assertEqual(
+            [violation.code for violation in readiness.violations],
+            ["required_label_missing"],
+        )
+        self.assertIn("deploy", readiness.violations[0].message)
+
+    def test_readiness_can_enforce_service_user_and_home_root(self) -> None:
+        readiness = evaluate_runner_lane_baseline(
+            policy=RunnerLaneBaselinePolicy(
+                allowed_service_users=("actions",),
+                allowed_home_roots=("/var/lib/actions-runners",),
+            ),
+            observations=(
+                RunnerLaneBaselineObservation(
+                    runner_name="launchplane-runner-1",
+                    labels=("self-hosted", "launchplane"),
+                    docker_config_isolated=True,
+                    service_user="root",
+                    home_directory="/home/actions",
+                    observed_at="2026-05-18T12:00:00Z",
+                ),
+            ),
+        )
+
+        self.assertFalse(readiness.ready)
+        self.assertEqual(
+            [violation.code for violation in readiness.violations],
+            ["home_directory_outside_allowed_roots", "service_user_not_allowed"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a typed runner lane baseline readiness contract with fail-closed Docker credential isolation checks
- document the runner baseline in the docs index, operations guide, and records boundary
- add focused unit coverage for ready, no-observation, missing-label, missing-Docker-isolation, and host guardrail cases

## Verification
- `uv run python -m unittest tests.test_runner_lane_baseline tests.test_runner_lane_inventory`
- `uv run --extra dev ruff check --diff control_plane/contracts/runner_lane_baseline.py tests/test_runner_lane_baseline.py`
- `uv run --extra dev ruff check control_plane/contracts/runner_lane_baseline.py tests/test_runner_lane_baseline.py`
- `uv run --extra dev ruff format --check control_plane/contracts/runner_lane_baseline.py tests/test_runner_lane_baseline.py`
- `uv run --extra dev mypy control_plane/contracts/runner_lane_baseline.py tests/test_runner_lane_baseline.py`
- `git diff --check`
- `uv run python -m unittest`

JetBrains changed-file inspection was attempted with `jb-inspect.py run --scope changed_files`, but the local helper returned `STATUS: error` without problem details.

No live runner, provider, or product environment action was run. VeriReel production was not touched.

Refs #636
