### PR TITLE
Handle missing preview base URL in refresh result

### DIFF
--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -1493,17 +1493,31 @@ def execute_generic_web_preview_refresh(
             record_store=record_store,
             product=request.product,
         )
-    preview_url = resolve_generic_web_preview_url(
-        control_plane_root=control_plane_root,
-        profile=resolved_profile,
-        request=request,
-    )
     started_at = utc_now_timestamp()
     app_name_prefix = effective_preview_app_name_prefix(profile=resolved_profile)
     application_name = preview_application_name(
         app_name_prefix=app_name_prefix,
         preview_slug=request.preview_slug,
     )
+    try:
+        preview_url = resolve_generic_web_preview_url(
+            control_plane_root=control_plane_root,
+            profile=resolved_profile,
+            request=request,
+        )
+    except click.ClickException as exc:
+        finished_at = utc_now_timestamp()
+        return GenericWebPreviewRefreshResult(
+            refresh_status="blocked",
+            refresh_started_at=started_at,
+            refresh_finished_at=finished_at,
+            product=resolved_profile.product,
+            context=resolved_profile.preview.context,
+            preview_slug=request.preview_slug,
+            application_name=application_name,
+            preview_url="",
+            error_message=str(exc),
+        )
     readiness = evaluate_generic_web_preview_readiness(
         control_plane_root=control_plane_root,
         record_store=record_store,

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -895,6 +895,53 @@ class GenericWebPreviewTests(unittest.TestCase):
                     ),
                 )
 
+    def test_execute_generic_web_preview_refresh_blocks_when_base_url_missing(self) -> None:
+        profile = _profile().model_copy(
+            update={
+                "preview": _profile().preview.model_copy(update={"slug_template": "pr-{number}"})
+            }
+        )
+        store = _GenericWebPreviewStore(profile)
+        with (
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.load_runtime_environment_definition",
+                return_value=control_plane_runtime_environments.build_runtime_environment_definition_from_records(
+                    (
+                        RuntimeEnvironmentRecord(
+                            scope="context",
+                            context="sellyouroutboard-testing",
+                            env={"OTHER_KEY": "value"},
+                            updated_at="2026-05-10T05:30:00Z",
+                            source_label="test",
+                        ),
+                    )
+                ),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.dokploy_request"
+            ) as dokploy_request,
+            patch(
+                "control_plane.workflows.generic_web_preview.utc_now_timestamp",
+                side_effect=["2026-05-10T05:30:00Z", "2026-05-10T05:30:01Z"],
+            ),
+        ):
+            result = execute_generic_web_preview_refresh(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebPreviewRefreshRequest(
+                    product="sellyouroutboard",
+                    preview_slug="pr-42",
+                    preview_url="",
+                    image_reference="ghcr.io/cbusillo/sellyouroutboard:sha",
+                    anchor_head_sha="abc123",
+                ),
+            )
+
+        self.assertEqual(result.refresh_status, "blocked")
+        self.assertEqual(result.preview_url, "")
+        self.assertIn("Missing LAUNCHPLANE_PREVIEW_BASE_URL", result.error_message)
+        dokploy_request.assert_not_called()
+
     def test_resolve_preview_url_rejects_non_root_base_url(self) -> None:
         profile = _profile().model_copy(
             update={


### PR DESCRIPTION
## Summary
- Return a structured `blocked` preview refresh result when Launchplane cannot derive a preview URL from runtime-context config.
- Preserve the specific `Missing LAUNCHPLANE_PREVIEW_BASE_URL...` message for product workflow feedback instead of surfacing opaque HTTP 400 `invalid_request`.
- Add a regression test proving provider mutation is not attempted when the preview base URL record is missing.

## Verification
- `uv run python -m unittest tests.test_generic_web_preview.GenericWebPreviewTests.test_execute_generic_web_preview_refresh_blocks_when_base_url_missing`
- `uv run python -m unittest tests.test_generic_web_preview`
- `uv run python -m unittest`
- `uv run --extra dev ruff check --diff control_plane/workflows/generic_web_preview.py tests/test_generic_web_preview.py`
- `uv run --extra dev ruff check control_plane/workflows/generic_web_preview.py tests/test_generic_web_preview.py`

## Notes
- JetBrains changed-file inspection ran and reported weak warnings in `tests/test_generic_web_preview.py` around existing duplicate/default-argument/static-method inspections. I left those alone to keep this patch scoped.
- This hardens the failure mode for #553 but does not create the CM preview by itself. The non-prod runtime context still needs `LAUNCHPLANE_PREVIEW_BASE_URL=https://cm-preview.shinycomputers.com` applied through Launchplane's sanctioned operator path.
