### PR TITLE
Canonicalize runner baseline home paths

### DIFF
--- a/control_plane/contracts/runner_lane_baseline.py
+++ b/control_plane/contracts/runner_lane_baseline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import posixpath
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -172,10 +173,16 @@ def _evaluate_observation(
 
 
 def _path_is_under_roots(path: str, roots: tuple[str, ...]) -> bool:
-    if not path:
+    normalized_path = _normalized_path(path)
+    if not normalized_path or not posixpath.isabs(normalized_path):
         return False
     for root in roots:
-        if path == root or path.startswith(f"{root}/"):
+        normalized_root = _normalized_path(root)
+        if not normalized_root or not posixpath.isabs(normalized_root):
+            continue
+        if normalized_path == normalized_root or normalized_path.startswith(
+            f"{normalized_root}/"
+        ):
             return True
     return False
 
@@ -185,7 +192,10 @@ def _normalized_paths(values: tuple[str, ...]) -> tuple[str, ...]:
 
 
 def _normalized_path(value: str) -> str:
-    return value.strip().rstrip("/")
+    normalized_value = value.strip()
+    if not normalized_value:
+        return ""
+    return posixpath.normpath(normalized_value)
 
 
 def _normalized_tokens(values: tuple[str, ...]) -> tuple[str, ...]:

--- a/docs/runner-lane-baseline.md
+++ b/docs/runner-lane-baseline.md
@@ -39,6 +39,9 @@ policy from observation:
 
 No observation means not ready. Unknown Docker credential isolation means not
 ready. Missing labels or configured host guardrails also make the lane not ready.
+Home-directory checks canonicalize observed and allowed paths before comparing
+roots, so traversal segments such as `..` cannot satisfy a configured root by
+string prefix alone.
 
 ## Operations
 

--- a/tests/test_runner_lane_baseline.py
+++ b/tests/test_runner_lane_baseline.py
@@ -99,6 +99,30 @@ class RunnerLaneBaselineTests(unittest.TestCase):
             ["home_directory_outside_allowed_roots", "service_user_not_allowed"],
         )
 
+    def test_readiness_rejects_home_directory_traversal_outside_allowed_roots(
+        self,
+    ) -> None:
+        readiness = evaluate_runner_lane_baseline(
+            policy=RunnerLaneBaselinePolicy(
+                allowed_home_roots=("/var/lib/actions-runners",),
+            ),
+            observations=(
+                RunnerLaneBaselineObservation(
+                    runner_name="launchplane-runner-1",
+                    labels=("self-hosted", "launchplane"),
+                    docker_config_isolated=True,
+                    home_directory="/var/lib/actions-runners/../tmp",
+                    observed_at="2026-05-18T12:00:00Z",
+                ),
+            ),
+        )
+
+        self.assertFalse(readiness.ready)
+        self.assertEqual(
+            [violation.code for violation in readiness.violations],
+            ["home_directory_outside_allowed_roots"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Canonicalize runner home-directory observations and allowed roots with POSIX path normalization before checking root membership.
- Reject relative or empty home/root paths in configured root comparisons.
- Add a regression test for traversal outside an allowed runner home root and document the canonicalization contract.

## Verification
- `uv run python -m unittest tests.test_runner_lane_baseline`
- `uv run --extra dev ruff check --diff control_plane/contracts/runner_lane_baseline.py tests/test_runner_lane_baseline.py`
- `uv run --extra dev ruff check control_plane/contracts/runner_lane_baseline.py tests/test_runner_lane_baseline.py`
- `uv run python -m unittest` passed before the docs-only note was added, 1357 tests.

## Inspection
- JetBrains changed-file inspection was attempted; the helper returned `capture_incomplete` with zero problems shown.
