### PR TITLE
Fix runner baseline and preview URL regressions

### DIFF
--- a/control_plane/contracts/runner_lane_baseline.py
+++ b/control_plane/contracts/runner_lane_baseline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import posixpath
+from pathlib import Path
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -173,16 +174,14 @@ def _evaluate_observation(
 
 
 def _path_is_under_roots(path: str, roots: tuple[str, ...]) -> bool:
-    normalized_path = _normalized_path(path)
+    normalized_path = _resolved_path(path)
     if not normalized_path or not posixpath.isabs(normalized_path):
         return False
     for root in roots:
-        normalized_root = _normalized_path(root)
+        normalized_root = _resolved_path(root)
         if not normalized_root or not posixpath.isabs(normalized_root):
             continue
-        if normalized_path == normalized_root or normalized_path.startswith(
-            f"{normalized_root}/"
-        ):
+        if normalized_path == normalized_root or normalized_path.startswith(f"{normalized_root}/"):
             return True
     return False
 
@@ -196,6 +195,13 @@ def _normalized_path(value: str) -> str:
     if not normalized_value:
         return ""
     return posixpath.normpath(normalized_value)
+
+
+def _resolved_path(value: str) -> str:
+    normalized_value = _normalized_path(value)
+    if not normalized_value:
+        return ""
+    return Path(normalized_value).resolve(strict=False).as_posix()
 
 
 def _normalized_tokens(values: tuple[str, ...]) -> tuple[str, ...]:

--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -234,6 +234,10 @@ class GenericWebPreviewRefreshResult(BaseModel):
     error_message: str = ""
 
 
+class MissingPreviewBaseUrlError(click.ClickException):
+    pass
+
+
 class GenericWebPreviewReadinessRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -918,7 +922,7 @@ def resolve_generic_web_preview_url(
     )
     preview_base_url = str(context_values.get(_PREVIEW_BASE_URL_ENV_KEY) or "").strip()
     if not preview_base_url:
-        raise click.ClickException(
+        raise MissingPreviewBaseUrlError(
             f"Missing {_PREVIEW_BASE_URL_ENV_KEY} in Launchplane runtime-environment records for {profile.preview.context}."
         )
     return _preview_url_from_base_url(
@@ -1505,7 +1509,7 @@ def execute_generic_web_preview_refresh(
             profile=resolved_profile,
             request=request,
         )
-    except click.ClickException as exc:
+    except MissingPreviewBaseUrlError as exc:
         finished_at = utc_now_timestamp()
         return GenericWebPreviewRefreshResult(
             refresh_status="blocked",

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -942,6 +942,47 @@ class GenericWebPreviewTests(unittest.TestCase):
         self.assertIn("Missing LAUNCHPLANE_PREVIEW_BASE_URL", result.error_message)
         dokploy_request.assert_not_called()
 
+    def test_execute_generic_web_preview_refresh_rejects_malformed_base_url(self) -> None:
+        profile = _profile().model_copy(
+            update={
+                "preview": _profile().preview.model_copy(update={"slug_template": "pr-{number}"})
+            }
+        )
+        store = _GenericWebPreviewStore(profile)
+        with (
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.load_runtime_environment_definition",
+                return_value=control_plane_runtime_environments.build_runtime_environment_definition_from_records(
+                    (
+                        RuntimeEnvironmentRecord(
+                            scope="context",
+                            context="sellyouroutboard-testing",
+                            env={"LAUNCHPLANE_PREVIEW_BASE_URL": "https://preview.example/path"},
+                            updated_at="2026-05-10T05:30:00Z",
+                            source_label="test",
+                        ),
+                    )
+                ),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.dokploy_request"
+            ) as dokploy_request,
+        ):
+            with self.assertRaisesRegex(click.ClickException, "root URL"):
+                execute_generic_web_preview_refresh(
+                    control_plane_root=Path("."),
+                    record_store=store,
+                    request=GenericWebPreviewRefreshRequest(
+                        product="sellyouroutboard",
+                        preview_slug="pr-42",
+                        preview_url="",
+                        image_reference="ghcr.io/cbusillo/sellyouroutboard:sha",
+                        anchor_head_sha="abc123",
+                    ),
+                )
+
+        dokploy_request.assert_not_called()
+
     def test_resolve_preview_url_rejects_non_root_base_url(self) -> None:
         profile = _profile().model_copy(
             update={

--- a/tests/test_runner_lane_baseline.py
+++ b/tests/test_runner_lane_baseline.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
 import unittest
 
 from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselineObservation
@@ -116,6 +118,39 @@ class RunnerLaneBaselineTests(unittest.TestCase):
                 ),
             ),
         )
+
+        self.assertFalse(readiness.ready)
+        self.assertEqual(
+            [violation.code for violation in readiness.violations],
+            ["home_directory_outside_allowed_roots"],
+        )
+
+    def test_readiness_rejects_symlinked_home_directory_outside_allowed_roots(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            allowed_root = root / "actions-runners"
+            outside_root = root / "outside-home"
+            linked_home = allowed_root / "runner-home"
+            allowed_root.mkdir()
+            outside_root.mkdir()
+            linked_home.symlink_to(outside_root, target_is_directory=True)
+
+            readiness = evaluate_runner_lane_baseline(
+                policy=RunnerLaneBaselinePolicy(
+                    allowed_home_roots=(allowed_root.as_posix(),),
+                ),
+                observations=(
+                    RunnerLaneBaselineObservation(
+                        runner_name="launchplane-runner-1",
+                        labels=("self-hosted", "launchplane"),
+                        docker_config_isolated=True,
+                        home_directory=linked_home.as_posix(),
+                        observed_at="2026-05-18T12:00:00Z",
+                    ),
+                ),
+            )
 
         self.assertFalse(readiness.ready)
         self.assertEqual(


### PR DESCRIPTION
## Summary

- resolve runner-baseline home paths before allowed-root comparison so symlinked homes cannot bypass the guard
- keep missing `LAUNCHPLANE_PREVIEW_BASE_URL` as a structured blocked refresh, but let malformed configured base URLs fail loudly
- add regression tests for symlinked runner homes and malformed preview base URLs

## Verification

- `uv run --extra dev ruff check control_plane/contracts/runner_lane_baseline.py control_plane/workflows/generic_web_preview.py tests/test_runner_lane_baseline.py tests/test_generic_web_preview.py`
- `uv run --extra dev ruff format --check control_plane/contracts/runner_lane_baseline.py control_plane/workflows/generic_web_preview.py tests/test_runner_lane_baseline.py tests/test_generic_web_preview.py`
- `uv run python -m unittest tests.test_runner_lane_baseline tests.test_generic_web_preview.GenericWebPreviewTests.test_execute_generic_web_preview_refresh_blocks_when_base_url_missing tests.test_generic_web_preview.GenericWebPreviewTests.test_execute_generic_web_preview_refresh_rejects_malformed_base_url tests.test_generic_web_preview.GenericWebPreviewTests.test_resolve_preview_url_rejects_non_root_base_url`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files`

## Notes

This addresses the auto-review findings from the cleanup branch. No live/provider action was run; VeriReel prod was not touched.
