### PR TITLE
Fix runner baseline normalization edge cases

### DIFF
--- a/control_plane/contracts/runner_lane_baseline.py
+++ b/control_plane/contracts/runner_lane_baseline.py
@@ -48,7 +48,7 @@ class RunnerLaneBaselineObservation(BaseModel):
             self.runner_name, "runner lane baseline observation requires runner_name"
         )
         self.labels = _normalized_tokens(self.labels)
-        self.service_user = self.service_user.strip()
+        self.service_user = _normalized_token(self.service_user)
         self.home_directory = _normalized_path(self.home_directory)
         self.observed_at = _required_text(
             self.observed_at, "runner lane baseline observation requires observed_at"
@@ -181,6 +181,8 @@ def _path_is_under_roots(path: str, roots: tuple[str, ...]) -> bool:
         normalized_root = _resolved_path(root)
         if not normalized_root or not posixpath.isabs(normalized_root):
             continue
+        if normalized_root == "/":
+            return True
         if normalized_path == normalized_root or normalized_path.startswith(f"{normalized_root}/"):
             return True
     return False
@@ -205,7 +207,11 @@ def _resolved_path(value: str) -> str:
 
 
 def _normalized_tokens(values: tuple[str, ...]) -> tuple[str, ...]:
-    return tuple(sorted({value.strip().lower() for value in values if value.strip()}))
+    return tuple(sorted({normalized for value in values if (normalized := _normalized_token(value))}))
+
+
+def _normalized_token(value: str) -> str:
+    return value.strip().lower()
 
 
 def _required_text(value: str, message: str) -> str:

--- a/tests/test_runner_lane_baseline.py
+++ b/tests/test_runner_lane_baseline.py
@@ -134,6 +134,27 @@ class RunnerLaneBaselineTests(unittest.TestCase):
             ["home_directory_outside_allowed_roots"],
         )
 
+    def test_readiness_allows_absolute_home_directory_under_root(self) -> None:
+        readiness = evaluate_runner_lane_baseline(
+            policy=RunnerLaneBaselinePolicy(
+                allowed_service_users=("gha",),
+                allowed_home_roots=("/",),
+            ),
+            observations=(
+                RunnerLaneBaselineObservation(
+                    runner_name="launchplane-runner-1",
+                    labels=("self-hosted", "launchplane"),
+                    docker_config_isolated=True,
+                    service_user="GHA ",
+                    home_directory="/home/gha",
+                    observed_at="2026-05-18T12:00:00Z",
+                ),
+            ),
+        )
+
+        self.assertTrue(readiness.ready)
+        self.assertEqual(readiness.violations, ())
+
     def test_readiness_rejects_symlinked_home_directory_outside_allowed_roots(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- normalize observed runner service users the same way policy service users are normalized
- treat `/` as a valid allowed home root for absolute observed home directories
- add regression coverage for both runner-baseline edge cases

## Verification

- `uv run --extra dev ruff check control_plane/contracts/runner_lane_baseline.py tests/test_runner_lane_baseline.py`
- `uv run python -m unittest tests.test_runner_lane_baseline`
- `uv run --extra dev mypy control_plane/contracts/runner_lane_baseline.py tests/test_runner_lane_baseline.py`
- `uv run python -m unittest`
- JetBrains changed-files inspection: zero findings, but capture incomplete, so recorded as inconclusive

## Notes

Follow-up to PR #708 auto-review findings. No live/provider/product mutation was run; VeriReel production was not touched.