### PR TITLE
Add runner queue wait evidence

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -97,6 +97,7 @@ from control_plane.contracts.runtime_environment_record import (
 from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselineObservation
 from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselinePolicy
 from control_plane.contracts.runner_lane_baseline import evaluate_runner_lane_baseline
+from control_plane.contracts.runner_lane_inventory import RunnerLaneInventory
 from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeEnvironmentClass,
     RuntimeKeySafetyPolicyRecord,
@@ -143,6 +144,7 @@ from control_plane.merge_train_github import (
     UrllibMergeTrainGitHubTransport,
 )
 from control_plane.runner_lane_github import GitHubRunnerLaneInventoryReader
+from control_plane.runner_queue_wait_github import GitHubRunnerQueueWaitReader
 from control_plane.service import serve_launchplane_service
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.factory import build_record_store, resolve_database_url
@@ -9882,6 +9884,84 @@ def work_graph_runner_inventory(
     except (OSError, ValidationError, ValueError) as error:
         raise click.ClickException(str(error)) from error
     click.echo(json.dumps(runner_inventory.model_dump(mode="json"), indent=2, sort_keys=True))
+
+
+@work_graph.command("runner-queue-wait")
+@click.option(
+    "--repository",
+    required=True,
+    help="owner/name repository whose recent GitHub Actions jobs should be inspected.",
+)
+@click.option(
+    "--github-token-env",
+    default="GITHUB_TOKEN",
+    show_default=True,
+    help="Environment variable containing the GitHub token used for read-only Actions metadata.",
+)
+@click.option(
+    "--github-api-base-url",
+    default="https://api.github.com",
+    show_default=True,
+    help="GitHub API base URL.",
+)
+@click.option(
+    "--workflow-run-limit",
+    default=20,
+    show_default=True,
+    type=click.IntRange(min=1, max=100),
+    help="Recent workflow runs to inspect for job timing evidence.",
+)
+@click.option(
+    "--constrained-threshold-seconds",
+    default=300,
+    show_default=True,
+    type=click.IntRange(min=0),
+    help="Queue-wait threshold that marks the sample as capacity constrained.",
+)
+@click.option(
+    "--include-runner-inventory/--skip-runner-inventory",
+    default=True,
+    show_default=True,
+    help="Also read current runner inventory so queue wait can be correlated with lane capacity.",
+)
+def work_graph_runner_queue_wait(
+    repository: str,
+    github_token_env: str,
+    github_api_base_url: str,
+    workflow_run_limit: int,
+    constrained_threshold_seconds: int,
+    include_runner_inventory: bool,
+) -> None:
+    try:
+        token_env = github_token_env.strip()
+        if not token_env:
+            raise click.ClickException("runner queue wait requires --github-token-env.")
+        token = os.environ.get(token_env, "").strip()
+        if not token:
+            raise click.ClickException(f"Missing GitHub token in environment variable {token_env}.")
+        transport = UrllibMergeTrainGitHubTransport(token=token, api_base_url=github_api_base_url)
+        inventory: RunnerLaneInventory | None = None
+        if include_runner_inventory:
+            inventory = GitHubRunnerLaneInventoryReader(
+                transport=transport
+            ).read_runner_lane_inventory(repository=repository)
+        queue_wait = GitHubRunnerQueueWaitReader(transport=transport).read_runner_queue_wait(
+            repository=repository,
+            workflow_run_limit=workflow_run_limit,
+            constrained_threshold_seconds=constrained_threshold_seconds,
+            inventory_capacity_constrained=(
+                inventory.capacity_constrained if inventory is not None else None
+            ),
+            inventory_capacity_reason=(inventory.capacity_reason if inventory is not None else ""),
+        )
+    except MergeTrainGitHubError as error:
+        detail = str(error)
+        if error.status_code is not None:
+            detail = f"{detail} (HTTP {error.status_code})"
+        raise click.ClickException(f"GitHub runner queue wait request failed: {detail}") from error
+    except (OSError, ValidationError, ValueError) as error:
+        raise click.ClickException(str(error)) from error
+    click.echo(json.dumps(queue_wait.model_dump(mode="json"), indent=2, sort_keys=True))
 
 
 @work_graph.command("runner-baseline-observe")

--- a/control_plane/contracts/runner_queue_wait.py
+++ b/control_plane/contracts/runner_queue_wait.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+RunnerQueueWaitStatus = Literal["unknown", "not_capacity_constrained", "capacity_constrained"]
+
+
+class RunnerQueueWaitJob(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    github_id: int = Field(ge=1)
+    run_id: int = Field(ge=1)
+    repository: str
+    workflow_name: str = ""
+    job_name: str
+    status: str
+    conclusion: str = ""
+    labels: tuple[str, ...] = ()
+    runner_name: str = ""
+    runner_group_name: str = ""
+    html_url: str = ""
+    created_at: str = ""
+    started_at: str = ""
+    completed_at: str = ""
+    queue_wait_seconds: int | None = Field(default=None, ge=0)
+    queue_wait_reason: str
+
+    @model_validator(mode="after")
+    def _normalize_job(self) -> "RunnerQueueWaitJob":
+        self.repository = _required_text(
+            self.repository, "runner queue wait job requires repository"
+        )
+        self.workflow_name = self.workflow_name.strip()
+        self.job_name = _required_text(self.job_name, "runner queue wait job requires job_name")
+        self.status = _required_text(self.status, "runner queue wait job requires status").lower()
+        self.conclusion = self.conclusion.strip().lower()
+        self.labels = tuple(sorted({label.strip() for label in self.labels if label.strip()}))
+        self.runner_name = self.runner_name.strip()
+        self.runner_group_name = self.runner_group_name.strip()
+        self.html_url = self.html_url.strip()
+        self.created_at = self.created_at.strip()
+        self.started_at = self.started_at.strip()
+        self.completed_at = self.completed_at.strip()
+        self.queue_wait_reason = _required_text(
+            self.queue_wait_reason, "runner queue wait job requires queue_wait_reason"
+        )
+        return self
+
+
+class RunnerQueueWaitSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    repository: str
+    observed_at: str
+    workflow_runs_scanned: int = Field(ge=0)
+    jobs_scanned: int = Field(ge=0)
+    known_wait_jobs: int = Field(ge=0)
+    unknown_wait_jobs: int = Field(ge=0)
+    constrained_threshold_seconds: int = Field(ge=0)
+    max_queue_wait_seconds: int | None = Field(default=None, ge=0)
+    average_queue_wait_seconds: float | None = Field(default=None, ge=0)
+    queue_wait_status: RunnerQueueWaitStatus
+    capacity_constrained: bool | None
+    capacity_reason: str
+    inventory_capacity_constrained: bool | None = None
+    inventory_capacity_reason: str = ""
+    jobs: tuple[RunnerQueueWaitJob, ...]
+
+    @model_validator(mode="after")
+    def _normalize_summary(self) -> "RunnerQueueWaitSummary":
+        self.repository = _required_text(
+            self.repository, "runner queue wait summary requires repository"
+        )
+        self.observed_at = _required_text(
+            self.observed_at, "runner queue wait summary requires observed_at"
+        )
+        self.capacity_reason = _required_text(
+            self.capacity_reason, "runner queue wait summary requires capacity_reason"
+        )
+        self.inventory_capacity_reason = self.inventory_capacity_reason.strip()
+        self.jobs = tuple(
+            sorted(self.jobs, key=lambda job: (job.run_id, job.job_name, job.github_id))
+        )
+        return self
+
+
+def build_runner_queue_wait_job(
+    *,
+    github_id: int,
+    run_id: int,
+    repository: str,
+    workflow_name: str = "",
+    job_name: str,
+    status: str,
+    conclusion: str = "",
+    labels: tuple[str, ...] = (),
+    runner_name: str = "",
+    runner_group_name: str = "",
+    html_url: str = "",
+    created_at: str = "",
+    started_at: str = "",
+    completed_at: str = "",
+) -> RunnerQueueWaitJob:
+    queue_wait_seconds, queue_wait_reason = _queue_wait_seconds(
+        created_at=created_at, started_at=started_at
+    )
+    return RunnerQueueWaitJob(
+        github_id=github_id,
+        run_id=run_id,
+        repository=repository,
+        workflow_name=workflow_name,
+        job_name=job_name,
+        status=status,
+        conclusion=conclusion,
+        labels=labels,
+        runner_name=runner_name,
+        runner_group_name=runner_group_name,
+        html_url=html_url,
+        created_at=created_at,
+        started_at=started_at,
+        completed_at=completed_at,
+        queue_wait_seconds=queue_wait_seconds,
+        queue_wait_reason=queue_wait_reason,
+    )
+
+
+def build_runner_queue_wait_summary(
+    *,
+    repository: str,
+    observed_at: str,
+    workflow_runs_scanned: int,
+    jobs: tuple[RunnerQueueWaitJob, ...],
+    constrained_threshold_seconds: int = 300,
+    inventory_capacity_constrained: bool | None = None,
+    inventory_capacity_reason: str = "",
+) -> RunnerQueueWaitSummary:
+    known_waits = tuple(
+        job.queue_wait_seconds for job in jobs if job.queue_wait_seconds is not None
+    )
+    max_queue_wait_seconds = max(known_waits) if known_waits else None
+    average_queue_wait_seconds = (
+        round(sum(known_waits) / len(known_waits), 3) if known_waits else None
+    )
+    queue_wait_status: RunnerQueueWaitStatus = "unknown"
+    capacity_constrained: bool | None = None
+    capacity_reason = "GitHub Actions job timestamps are not available for recent jobs"
+    if not jobs:
+        capacity_reason = "no recent GitHub Actions jobs discovered"
+    elif known_waits:
+        if (
+            max_queue_wait_seconds is not None
+            and max_queue_wait_seconds >= constrained_threshold_seconds
+        ):
+            queue_wait_status = "capacity_constrained"
+            capacity_constrained = True
+            capacity_reason = (
+                f"max queue wait {max_queue_wait_seconds}s meets or exceeds "
+                f"{constrained_threshold_seconds}s threshold"
+            )
+        else:
+            queue_wait_status = "not_capacity_constrained"
+            capacity_constrained = False
+            capacity_reason = (
+                f"observed queue waits are below {constrained_threshold_seconds}s threshold"
+            )
+    return RunnerQueueWaitSummary(
+        repository=repository,
+        observed_at=observed_at,
+        workflow_runs_scanned=workflow_runs_scanned,
+        jobs_scanned=len(jobs),
+        known_wait_jobs=len(known_waits),
+        unknown_wait_jobs=len(jobs) - len(known_waits),
+        constrained_threshold_seconds=constrained_threshold_seconds,
+        max_queue_wait_seconds=max_queue_wait_seconds,
+        average_queue_wait_seconds=average_queue_wait_seconds,
+        queue_wait_status=queue_wait_status,
+        capacity_constrained=capacity_constrained,
+        capacity_reason=capacity_reason,
+        inventory_capacity_constrained=inventory_capacity_constrained,
+        inventory_capacity_reason=inventory_capacity_reason,
+        jobs=jobs,
+    )
+
+
+def _queue_wait_seconds(*, created_at: str, started_at: str) -> tuple[int | None, str]:
+    normalized_created_at = created_at.strip()
+    normalized_started_at = started_at.strip()
+    if not normalized_created_at and not normalized_started_at:
+        return None, "missing created_at and started_at"
+    if not normalized_created_at:
+        return None, "missing created_at"
+    if not normalized_started_at:
+        return None, "missing started_at"
+    created = _parse_github_timestamp(normalized_created_at)
+    if created is None:
+        return None, "invalid created_at"
+    started = _parse_github_timestamp(normalized_started_at)
+    if started is None:
+        return None, "invalid started_at"
+    wait_seconds = int((started - created).total_seconds())
+    if wait_seconds < 0:
+        return None, "started_at precedes created_at"
+    return wait_seconds, "created_at and started_at available"
+
+
+def _parse_github_timestamp(value: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _required_text(value: str, message: str) -> str:
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise ValueError(message)
+    return normalized_value

--- a/control_plane/runner_queue_wait_github.py
+++ b/control_plane/runner_queue_wait_github.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Protocol
+from urllib.parse import urlencode
+
+from control_plane.contracts.runner_queue_wait import RunnerQueueWaitJob
+from control_plane.contracts.runner_queue_wait import RunnerQueueWaitSummary
+from control_plane.contracts.runner_queue_wait import build_runner_queue_wait_job
+from control_plane.contracts.runner_queue_wait import build_runner_queue_wait_summary
+from control_plane.merge_train_github import MergeTrainGitHubError
+from control_plane.merge_train_github import MergeTrainGitHubTransport
+
+
+class RunnerQueueWaitClock(Protocol):
+    def now(self) -> datetime: ...
+
+
+class SystemRunnerQueueWaitClock:
+    def now(self) -> datetime:
+        return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+class GitHubRunnerQueueWaitReader:
+    def __init__(
+        self,
+        *,
+        transport: MergeTrainGitHubTransport,
+        clock: RunnerQueueWaitClock | None = None,
+    ) -> None:
+        self.transport = transport
+        self.clock = clock or SystemRunnerQueueWaitClock()
+
+    def read_runner_queue_wait(
+        self,
+        *,
+        repository: str,
+        workflow_run_limit: int = 20,
+        constrained_threshold_seconds: int = 300,
+        inventory_capacity_constrained: bool | None = None,
+        inventory_capacity_reason: str = "",
+    ) -> RunnerQueueWaitSummary:
+        repository_path = _repository_path(repository)
+        observed_at = self.clock.now().isoformat().replace("+00:00", "Z")
+        workflow_runs = self._read_workflow_runs(
+            repository=repository_path, workflow_run_limit=workflow_run_limit
+        )
+        jobs: list[RunnerQueueWaitJob] = []
+        for workflow_run in workflow_runs:
+            workflow_run_object = _json_object(workflow_run, "GitHub workflow run entry")
+            run_id = _required_int(
+                workflow_run_object.get("id"), "GitHub workflow run requires id."
+            )
+            workflow_name = _optional_text(workflow_run_object.get("name"))
+            jobs.extend(
+                self._read_workflow_run_jobs(
+                    repository=repository_path,
+                    run_id=run_id,
+                    workflow_name=workflow_name,
+                )
+            )
+        return build_runner_queue_wait_summary(
+            repository=repository_path,
+            observed_at=observed_at,
+            workflow_runs_scanned=len(workflow_runs),
+            jobs=tuple(jobs),
+            constrained_threshold_seconds=constrained_threshold_seconds,
+            inventory_capacity_constrained=inventory_capacity_constrained,
+            inventory_capacity_reason=inventory_capacity_reason,
+        )
+
+    def _read_workflow_runs(
+        self, *, repository: str, workflow_run_limit: int
+    ) -> tuple[object, ...]:
+        if workflow_run_limit < 1:
+            raise ValueError("workflow run limit must be at least 1.")
+        query = urlencode({"per_page": str(min(workflow_run_limit, 100))})
+        payload = self.transport.request(
+            method="GET", path=f"/repos/{repository}/actions/runs?{query}"
+        )
+        payload_object = _json_object(payload, "GitHub workflow run list response")
+        workflow_runs = payload_object.get("workflow_runs")
+        if not isinstance(workflow_runs, list):
+            raise MergeTrainGitHubError(
+                "GitHub workflow run list response must include workflow_runs."
+            )
+        return tuple(workflow_runs[:workflow_run_limit])
+
+    def _read_workflow_run_jobs(
+        self, *, repository: str, run_id: int, workflow_name: str
+    ) -> tuple[RunnerQueueWaitJob, ...]:
+        jobs: list[RunnerQueueWaitJob] = []
+        page = 1
+        while True:
+            query = urlencode({"per_page": "100", "page": str(page)})
+            payload = self.transport.request(
+                method="GET", path=f"/repos/{repository}/actions/runs/{run_id}/jobs?{query}"
+            )
+            payload_object = _json_object(payload, "GitHub workflow run jobs response")
+            jobs_payload = payload_object.get("jobs")
+            if not isinstance(jobs_payload, list):
+                raise MergeTrainGitHubError("GitHub workflow run jobs response must include jobs.")
+            page_jobs = tuple(
+                _runner_queue_wait_job(
+                    repository=repository,
+                    run_id=run_id,
+                    workflow_name=workflow_name,
+                    payload=_json_object(job, "GitHub workflow run job entry"),
+                )
+                for job in jobs_payload
+            )
+            jobs.extend(page_jobs)
+            if len(page_jobs) < 100:
+                return tuple(jobs)
+            page += 1
+
+
+def _runner_queue_wait_job(
+    *, repository: str, run_id: int, workflow_name: str, payload: dict[str, object]
+) -> RunnerQueueWaitJob:
+    return build_runner_queue_wait_job(
+        github_id=_required_int(payload.get("id"), "GitHub workflow run job requires id."),
+        run_id=run_id,
+        repository=repository,
+        workflow_name=workflow_name,
+        job_name=_required_text(payload.get("name"), "GitHub workflow run job requires name."),
+        status=_required_text(payload.get("status"), "GitHub workflow run job requires status."),
+        conclusion=_optional_text(payload.get("conclusion")),
+        labels=_job_labels(payload.get("labels")),
+        runner_name=_optional_text(payload.get("runner_name")),
+        runner_group_name=_optional_text(payload.get("runner_group_name")),
+        html_url=_optional_text(payload.get("html_url")),
+        created_at=_optional_text(payload.get("created_at")),
+        started_at=_optional_text(payload.get("started_at")),
+        completed_at=_optional_text(payload.get("completed_at")),
+    )
+
+
+def _job_labels(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise MergeTrainGitHubError("GitHub workflow run job labels must be a JSON array.")
+    return tuple(
+        _required_text(label, "GitHub workflow run job label requires value.") for label in value
+    )
+
+
+def _repository_path(repository: str) -> str:
+    normalized_repository = "/".join(part.strip() for part in repository.strip().split("/"))
+    if normalized_repository.count("/") != 1:
+        raise ValueError("GitHub repository must be formatted as owner/name.")
+    owner, repo = normalized_repository.split("/", 1)
+    if not owner or not repo:
+        raise ValueError("GitHub repository must be formatted as owner/name.")
+    return normalized_repository
+
+
+def _json_object(value: object, label: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise MergeTrainGitHubError(f"{label} must be a JSON object.")
+    return value
+
+
+def _required_text(value: object, message: str) -> str:
+    normalized_value = str(value or "").strip()
+    if not normalized_value:
+        raise MergeTrainGitHubError(message)
+    return normalized_value
+
+
+def _optional_text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _required_int(value: object, message: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise MergeTrainGitHubError(message)
+    return value

--- a/docs/runner-lane-baseline.md
+++ b/docs/runner-lane-baseline.md
@@ -57,6 +57,20 @@ reconciliation must run through a Launchplane-owned runner lane flow, not throug
 product workflow edits and not through ad hoc retries after a shared Docker
 credential race.
 
+To inspect whether recent workflow jobs look runner-capacity constrained from
+GitHub Actions timing evidence, run:
+
+```bash
+uv run launchplane work-graph runner-queue-wait --repository owner/name
+```
+
+The queue-wait command is also read-only. It reads recent workflow runs and their
+job metadata, computes `started_at - created_at` only when GitHub exposes both
+timestamps, and reports missing or malformed timestamps as `unknown` rather than
+as a zero-second wait. By default it also reads current runner inventory so the
+JSON summary can show queue-wait evidence next to current lane-capacity status.
+Use `--skip-runner-inventory` for fixture-only or permission-limited reads.
+
 To emit baseline observation evidence from a self-hosted runner job, run:
 
 ```bash

--- a/tests/test_runner_queue_wait.py
+++ b/tests/test_runner_queue_wait.py
@@ -1,0 +1,252 @@
+from datetime import datetime, timezone
+import json
+import unittest
+from typing import cast
+from unittest.mock import patch
+
+from click import Command
+from click.testing import CliRunner
+
+from control_plane.cli import main
+from control_plane.contracts.runner_queue_wait import build_runner_queue_wait_job
+from control_plane.contracts.runner_queue_wait import build_runner_queue_wait_summary
+from control_plane.merge_train_github import MergeTrainGitHubError
+from control_plane.merge_train_github import RecordingMergeTrainGitHubTransport
+from control_plane.runner_queue_wait_github import GitHubRunnerQueueWaitReader
+
+
+CLI_MAIN = cast(Command, main)
+
+
+class _FixedClock:
+    def now(self) -> datetime:
+        return datetime(2026, 5, 18, 14, 30, tzinfo=timezone.utc)
+
+
+class RunnerQueueWaitContractTests(unittest.TestCase):
+    def test_summary_reports_normal_queue_waits_below_threshold(self) -> None:
+        summary = build_runner_queue_wait_summary(
+            repository="cbusillo/launchplane",
+            observed_at="2026-05-18T14:30:00Z",
+            workflow_runs_scanned=1,
+            jobs=(
+                build_runner_queue_wait_job(
+                    github_id=101,
+                    run_id=1001,
+                    repository="cbusillo/launchplane",
+                    job_name="test",
+                    status="completed",
+                    created_at="2026-05-18T14:00:00Z",
+                    started_at="2026-05-18T14:00:42Z",
+                ),
+            ),
+            constrained_threshold_seconds=300,
+        )
+
+        self.assertEqual(summary.queue_wait_status, "not_capacity_constrained")
+        self.assertFalse(summary.capacity_constrained)
+        self.assertEqual(summary.known_wait_jobs, 1)
+        self.assertEqual(summary.unknown_wait_jobs, 0)
+        self.assertEqual(summary.max_queue_wait_seconds, 42)
+
+    def test_missing_timestamps_are_unknown_not_zero(self) -> None:
+        summary = build_runner_queue_wait_summary(
+            repository="cbusillo/launchplane",
+            observed_at="2026-05-18T14:30:00Z",
+            workflow_runs_scanned=1,
+            jobs=(
+                build_runner_queue_wait_job(
+                    github_id=102,
+                    run_id=1001,
+                    repository="cbusillo/launchplane",
+                    job_name="static_checks",
+                    status="queued",
+                    created_at="2026-05-18T14:00:00Z",
+                ),
+            ),
+        )
+
+        self.assertEqual(summary.queue_wait_status, "unknown")
+        self.assertIsNone(summary.capacity_constrained)
+        self.assertEqual(summary.known_wait_jobs, 0)
+        self.assertEqual(summary.unknown_wait_jobs, 1)
+        self.assertIsNone(summary.max_queue_wait_seconds)
+        self.assertEqual(summary.jobs[0].queue_wait_reason, "missing started_at")
+
+    def test_summary_marks_capacity_constrained_sample(self) -> None:
+        summary = build_runner_queue_wait_summary(
+            repository="cbusillo/launchplane",
+            observed_at="2026-05-18T14:30:00Z",
+            workflow_runs_scanned=1,
+            jobs=(
+                build_runner_queue_wait_job(
+                    github_id=103,
+                    run_id=1002,
+                    repository="cbusillo/launchplane",
+                    job_name="container_scan",
+                    status="completed",
+                    created_at="2026-05-18T14:00:00Z",
+                    started_at="2026-05-18T14:07:00Z",
+                ),
+            ),
+            constrained_threshold_seconds=300,
+        )
+
+        self.assertEqual(summary.queue_wait_status, "capacity_constrained")
+        self.assertTrue(summary.capacity_constrained)
+        self.assertEqual(summary.max_queue_wait_seconds, 420)
+        self.assertIn("meets or exceeds", summary.capacity_reason)
+
+
+class GitHubRunnerQueueWaitReaderTests(unittest.TestCase):
+    def test_reader_builds_summary_from_actions_runs_and_jobs(self) -> None:
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                {"workflow_runs": [{"id": 1001, "name": "CI"}]},
+                {
+                    "jobs": [
+                        _job(
+                            501,
+                            "test",
+                            created_at="2026-05-18T14:00:00Z",
+                            started_at="2026-05-18T14:01:00Z",
+                        ),
+                    ],
+                },
+            )
+        )
+
+        summary = GitHubRunnerQueueWaitReader(
+            transport=transport, clock=_FixedClock()
+        ).read_runner_queue_wait(
+            repository=" cbusillo / launchplane ",
+            workflow_run_limit=10,
+            inventory_capacity_constrained=True,
+            inventory_capacity_reason="all online self-hosted runner lanes are busy",
+        )
+
+        self.assertEqual(summary.repository, "cbusillo/launchplane")
+        self.assertEqual(summary.observed_at, "2026-05-18T14:30:00Z")
+        self.assertEqual(summary.workflow_runs_scanned, 1)
+        self.assertEqual(summary.jobs_scanned, 1)
+        self.assertEqual(summary.jobs[0].workflow_name, "CI")
+        self.assertEqual(summary.jobs[0].queue_wait_seconds, 60)
+        self.assertTrue(summary.inventory_capacity_constrained)
+        self.assertEqual(
+            [request.path for request in transport.requests],
+            [
+                "/repos/cbusillo/launchplane/actions/runs?per_page=10",
+                "/repos/cbusillo/launchplane/actions/runs/1001/jobs?per_page=100&page=1",
+            ],
+        )
+
+    def test_reader_rejects_malformed_jobs_response(self) -> None:
+        reader = GitHubRunnerQueueWaitReader(
+            transport=RecordingMergeTrainGitHubTransport(
+                responses=({"workflow_runs": [{"id": 1001}]}, {"jobs": {}})
+            ),
+            clock=_FixedClock(),
+        )
+
+        with self.assertRaisesRegex(MergeTrainGitHubError, "must include jobs"):
+            reader.read_runner_queue_wait(repository="cbusillo/repo")
+
+
+class RunnerQueueWaitCliTests(unittest.TestCase):
+    def test_cli_prints_runner_queue_wait_json(self) -> None:
+        class _FakeQueueWaitReader:
+            def __init__(self, *, transport: object) -> None:
+                self.transport = transport
+
+            def read_runner_queue_wait(
+                self,
+                *,
+                repository: str,
+                workflow_run_limit: int,
+                constrained_threshold_seconds: int,
+                inventory_capacity_constrained: bool | None,
+                inventory_capacity_reason: str,
+            ) -> object:
+                return GitHubRunnerQueueWaitReader(
+                    transport=RecordingMergeTrainGitHubTransport(
+                        responses=(
+                            {"workflow_runs": [{"id": 1001, "name": "CI"}]},
+                            {
+                                "jobs": [
+                                    _job(
+                                        501,
+                                        "test",
+                                        created_at="2026-05-18T14:00:00Z",
+                                        started_at="2026-05-18T14:02:00Z",
+                                    )
+                                ]
+                            },
+                        )
+                    ),
+                    clock=_FixedClock(),
+                ).read_runner_queue_wait(
+                    repository=repository,
+                    workflow_run_limit=workflow_run_limit,
+                    constrained_threshold_seconds=constrained_threshold_seconds,
+                    inventory_capacity_constrained=inventory_capacity_constrained,
+                    inventory_capacity_reason=inventory_capacity_reason,
+                )
+
+        with (
+            patch("control_plane.cli.UrllibMergeTrainGitHubTransport", return_value=object()),
+            patch("control_plane.cli.GitHubRunnerQueueWaitReader", _FakeQueueWaitReader),
+            patch.dict("os.environ", {"GITHUB_TOKEN": "token"}, clear=True),
+        ):
+            result = CliRunner().invoke(
+                CLI_MAIN,
+                [
+                    "work-graph",
+                    "runner-queue-wait",
+                    "--repository",
+                    "cbusillo/repo",
+                    "--skip-runner-inventory",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["repository"], "cbusillo/repo")
+        self.assertEqual(payload["known_wait_jobs"], 1)
+        self.assertEqual(payload["max_queue_wait_seconds"], 120)
+
+    def test_cli_requires_github_token(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            result = CliRunner().invoke(
+                CLI_MAIN,
+                ["work-graph", "runner-queue-wait", "--repository", "cbusillo/repo"],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Missing GitHub token", result.output)
+
+
+def _job(
+    job_id: int,
+    name: str,
+    *,
+    status: str = "completed",
+    created_at: str = "",
+    started_at: str = "",
+) -> dict[str, object]:
+    return {
+        "id": job_id,
+        "name": name,
+        "status": status,
+        "conclusion": "success",
+        "labels": ["self-hosted", "launchplane"],
+        "runner_name": "launchplane-runner-1",
+        "runner_group_name": "Default",
+        "html_url": f"https://github.com/cbusillo/launchplane/actions/runs/1001/job/{job_id}",
+        "created_at": created_at,
+        "started_at": started_at,
+        "completed_at": "2026-05-18T14:05:00Z",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a typed runner queue-wait contract for GitHub Actions job timing evidence
- add a read-only GitHub REST reader and `work-graph runner-queue-wait` CLI command
- document the queue-wait observation path alongside runner inventory/baseline docs

Closes #710.

## Validation

- `uv run --extra dev ruff check control_plane/contracts/runner_queue_wait.py control_plane/runner_queue_wait_github.py control_plane/cli.py tests/test_runner_queue_wait.py`
- `uv run --extra dev ruff format --check control_plane/contracts/runner_queue_wait.py control_plane/runner_queue_wait_github.py control_plane/cli.py tests/test_runner_queue_wait.py` before formatting, then `uv run --extra dev ruff format ...`
- `uv run --extra dev mypy control_plane/cli.py control_plane/contracts/runner_queue_wait.py control_plane/runner_queue_wait_github.py tests/test_runner_queue_wait.py`
- `uv run python -m unittest tests.test_runner_queue_wait`
- `uv run python -m unittest`
- read-only live smoke: `uv run launchplane work-graph runner-queue-wait --repository cbusillo/launchplane --workflow-run-limit 2 --skip-runner-inventory`
- read-only live smoke with inventory correlation: `uv run launchplane work-graph runner-queue-wait --repository cbusillo/launchplane --workflow-run-limit 2`

JetBrains changed-files inspection surfaced existing frontend CSS findings outside this Python/docs change, so it was not a useful clean signal for this branch.

No live product, provider, or runner mutation was run.