### PR TITLE
Grant terminal-agent product profile reads

### DIFF
--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -842,6 +842,12 @@ post_terminal_agent_grant \
 post_terminal_agent_grant \
   launchplane \
   launchplane \
+  product_profile.read \
+  deploy:terminal-agent-product-profile-read-grant \
+  terminal-agent-product-profile-read
+post_terminal_agent_grant \
+  launchplane \
+  launchplane \
   product_environment.read \
   deploy:terminal-agent-agent-context-product-read-grant \
   terminal-agent-agent-context-product-read

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -136,6 +136,17 @@ def _manifest_payload() -> dict[str, object]:
 
 
 class ProductOnboardingTests(unittest.TestCase):
+    def test_deploy_authz_grants_include_terminal_agent_product_profile_read(
+        self,
+    ) -> None:
+        script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("product_profile.read", script_text)
+        self.assertIn("deploy:terminal-agent-product-profile-read-grant", script_text)
+        self.assertIn("terminal-agent-product-profile-read", script_text)
+
     def test_deploy_odoo_cm_onboarding_manifest_encodes_issue_backed_bootstrap_policy(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- add terminal-agent `product_profile.read` to the deployed authz bootstrap grants
- add a regression test so the read grant stays present
- keep the change read-only and scoped to product-profile inspection

Unblocks #508.

## Validation
- `shellcheck scripts/deploy/ensure-authz-grants.sh`
- `uv run --extra dev ruff check tests/test_product_onboarding.py`
- `uv run --extra dev mypy tests/test_product_onboarding.py`
- `uv run python -m unittest tests.test_product_onboarding`
- `uv run python -m unittest`
- JetBrains changed-file inspection routed to PyCharm but returned unrelated existing `frontend/src/styles.css` findings outside this patch.

No live product, provider, preview cleanup, or VeriReel prod action was run.