### PR TITLE
Allow local operator product profile reads

### DIFF
--- a/control_plane/service_auth.py
+++ b/control_plane/service_auth.py
@@ -74,7 +74,9 @@ AgentConsumerActionSafety = Literal[
     "policy_admin",
 ]
 AgentAuthzDecision = Literal["allowed", "denied"]
-LOCAL_OPERATOR_ALLOWED_ACTIONS = frozenset({"product_config.plan", "product_config.apply"})
+LOCAL_OPERATOR_ALLOWED_ACTIONS = frozenset(
+    {"product_config.plan", "product_config.apply", "product_profile.read"}
+)
 
 
 class TokenVerifier(Protocol):

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -621,6 +621,14 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
                 context="sellyouroutboard-testing",
             )
         )
+        self.assertTrue(
+            policy.allows(
+                identity=identity,
+                action="product_profile.read",
+                product="launchplane",
+                context="launchplane",
+            )
+        )
         self.assertFalse(
             policy.allows(
                 identity=identity,


### PR DESCRIPTION
## Summary
- allow the local-operator credential to perform read-only product-profile inspection
- keep local-operator mutation/admin scope limited to the existing product-config actions
- add a service-auth regression test for the read boundary

Continues the #508 unblocker after #714 confirmed the terminal-agent grant is deployed but the available workstation credential is the local-operator token.

## Validation
- `uv run --extra dev ruff check --diff control_plane/service_auth.py tests/test_service_auth.py`
- `uv run --extra dev ruff check control_plane/service_auth.py tests/test_service_auth.py`
- `uv run --extra dev mypy control_plane/service_auth.py tests/test_service_auth.py`
- `uv run python -m unittest tests.test_service_auth`
- `uv run python -m unittest`
- JetBrains changed-file inspection routed to PyCharm and returned unrelated weak warnings in `tests/test_product_onboarding.py` from the prior merged slice, not this diff.

No live product, provider, preview cleanup, or VeriReel prod action was run.