### PR TITLE
Add runner lane control planner

### DIFF
--- a/control_plane/contracts/runner_lane_control.py
+++ b/control_plane/contracts/runner_lane_control.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselineReadiness
+from control_plane.contracts.runner_lane_inventory import RunnerLaneInventory
+
+
+RunnerLaneControlAction = Literal["create", "drain", "restart", "remove"]
+RunnerLaneControlPlanStatus = Literal["ready", "blocked"]
+RunnerLaneControlBlockerCode = Literal[
+    "action_not_enabled",
+    "baseline_not_ready",
+    "busy_lane_requires_drain_confirmation",
+    "inventory_repository_mismatch",
+    "lane_already_exists",
+    "lane_not_found",
+    "managed_label_missing",
+    "mutate_not_requested",
+    "repository_not_allowed",
+]
+
+
+class RunnerLaneControlPolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    allowed_repositories: tuple[str, ...] = ()
+    required_managed_label: str = "launchplane-managed"
+    allow_create: bool = False
+    allow_drain: bool = False
+    allow_restart: bool = False
+    allow_remove: bool = False
+
+    @model_validator(mode="after")
+    def _normalize_policy(self) -> "RunnerLaneControlPolicy":
+        self.allowed_repositories = _normalized_tokens(self.allowed_repositories)
+        self.required_managed_label = _normalized_token(self.required_managed_label)
+        if not self.required_managed_label:
+            raise ValueError("runner lane control policy requires managed label")
+        return self
+
+
+class RunnerLaneControlRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    action: RunnerLaneControlAction
+    repository: str
+    lane_name: str
+    mutate: bool = False
+    drain_busy_lane: bool = False
+
+    @model_validator(mode="after")
+    def _normalize_request(self) -> "RunnerLaneControlRequest":
+        self.repository = _normalized_token(self.repository)
+        self.lane_name = _required_text(self.lane_name, "runner lane control requires lane_name")
+        if not self.repository:
+            raise ValueError("runner lane control requires repository")
+        return self
+
+
+class RunnerLaneControlBlocker(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: RunnerLaneControlBlockerCode
+    message: str
+
+    @model_validator(mode="after")
+    def _normalize_blocker(self) -> "RunnerLaneControlBlocker":
+        self.message = _required_text(self.message, "runner lane control blocker requires message")
+        return self
+
+
+class RunnerLaneControlPlan(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    status: RunnerLaneControlPlanStatus
+    action: RunnerLaneControlAction
+    repository: str
+    lane_name: str
+    mutate: bool
+    blockers: tuple[RunnerLaneControlBlocker, ...] = ()
+    next_steps: tuple[str, ...] = ()
+    summary: str
+
+    @model_validator(mode="after")
+    def _normalize_plan(self) -> "RunnerLaneControlPlan":
+        self.repository = _required_text(self.repository, "runner lane control plan requires repository")
+        self.lane_name = _required_text(self.lane_name, "runner lane control plan requires lane_name")
+        self.blockers = tuple(sorted(self.blockers, key=lambda blocker: blocker.code))
+        self.next_steps = tuple(step.strip() for step in self.next_steps if step.strip())
+        self.summary = _required_text(self.summary, "runner lane control plan requires summary")
+        if self.status == "ready" and self.blockers:
+            raise ValueError("ready runner lane control plan cannot include blockers")
+        if self.status == "blocked" and not self.blockers:
+            raise ValueError("blocked runner lane control plan requires blockers")
+        return self
+
+
+def plan_runner_lane_control(
+    *,
+    policy: RunnerLaneControlPolicy,
+    request: RunnerLaneControlRequest,
+    inventory: RunnerLaneInventory,
+    baseline_readiness: RunnerLaneBaselineReadiness,
+) -> RunnerLaneControlPlan:
+    blockers: list[RunnerLaneControlBlocker] = []
+    if policy.allowed_repositories and request.repository not in policy.allowed_repositories:
+        blockers.append(
+            _blocker(
+                "repository_not_allowed",
+                f"repository is not opted into runner lane control: {request.repository}",
+            )
+        )
+    if not _action_allowed(policy=policy, action=request.action):
+        blockers.append(
+            _blocker(
+                "action_not_enabled",
+                f"runner lane control action is not enabled by policy: {request.action}",
+            )
+        )
+    if not request.mutate:
+        blockers.append(
+            _blocker(
+                "mutate_not_requested",
+                "runner lane control is dry-run only until mutate is explicitly requested",
+            )
+        )
+    if not baseline_readiness.ready:
+        blockers.append(
+            _blocker(
+                "baseline_not_ready",
+                f"runner lane baseline is not ready: {baseline_readiness.summary}",
+            )
+        )
+
+    if inventory.repository != request.repository:
+        blockers.append(
+            _blocker(
+                "inventory_repository_mismatch",
+                (
+                    "runner lane inventory repository does not match request: "
+                    f"{inventory.repository}"
+                ),
+            )
+        )
+    lane = next((item for item in inventory.lanes if item.name == request.lane_name), None)
+    if request.action == "create" and lane is not None:
+        blockers.append(
+            _blocker("lane_already_exists", f"runner lane already exists: {request.lane_name}")
+        )
+    if request.action != "create" and lane is None:
+        blockers.append(_blocker("lane_not_found", f"runner lane not found: {request.lane_name}"))
+    if request.action in {"drain", "restart", "remove"} and lane is not None:
+        if policy.required_managed_label not in _normalized_tokens(lane.labels):
+            blockers.append(
+                _blocker(
+                    "managed_label_missing",
+                    f"runner lane is missing managed label: {policy.required_managed_label}",
+                )
+            )
+        if lane.busy and request.action in {"drain", "restart", "remove"} and not request.drain_busy_lane:
+            blockers.append(
+                _blocker(
+                    "busy_lane_requires_drain_confirmation",
+                    "busy runner lane requires explicit drain confirmation",
+                )
+            )
+
+    status: RunnerLaneControlPlanStatus = "blocked" if blockers else "ready"
+    return RunnerLaneControlPlan(
+        status=status,
+        action=request.action,
+        repository=request.repository,
+        lane_name=request.lane_name,
+        mutate=request.mutate,
+        blockers=tuple(blockers),
+        next_steps=_next_steps(action=request.action, status=status),
+        summary=(
+            "runner lane control plan is ready"
+            if status == "ready"
+            else "runner lane control plan is blocked"
+        ),
+    )
+
+
+def _action_allowed(*, policy: RunnerLaneControlPolicy, action: RunnerLaneControlAction) -> bool:
+    if action == "create":
+        return policy.allow_create
+    if action == "drain":
+        return policy.allow_drain
+    if action == "restart":
+        return policy.allow_restart
+    return policy.allow_remove
+
+
+def _next_steps(
+    *, action: RunnerLaneControlAction, status: RunnerLaneControlPlanStatus
+) -> tuple[str, ...]:
+    if status == "blocked":
+        return ("resolve blockers before running any host or GitHub runner mutation",)
+    if action == "create":
+        return ("create runner lane through an approved host adapter", "verify GitHub sees the lane online")
+    if action == "drain":
+        return ("stop admitting new jobs to the managed lane", "wait for active jobs to finish")
+    if action == "restart":
+        return ("drain the managed lane", "restart the approved runner service", "verify the lane returns online")
+    return ("drain the managed lane", "remove only the Launchplane-owned runner registration")
+
+
+def _blocker(code: RunnerLaneControlBlockerCode, message: str) -> RunnerLaneControlBlocker:
+    return RunnerLaneControlBlocker(code=code, message=message)
+
+
+def _normalized_tokens(values: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(sorted({normalized for value in values if (normalized := _normalized_token(value))}))
+
+
+def _normalized_token(value: str) -> str:
+    return value.strip().lower()
+
+
+def _required_text(value: str, message: str) -> str:
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise ValueError(message)
+    return normalized_value

--- a/docs/runner-lane-baseline.md
+++ b/docs/runner-lane-baseline.md
@@ -92,3 +92,20 @@ For live products, use a non-production runner or a read-only observation path
 until the operator explicitly approves host changes. VeriReel production must
 not be used as a runner-baseline test surface without explicit operator
 permission.
+
+## Control Planning
+
+Runner control starts with a dry-run plan, not a host mutation. The typed
+contract in `control_plane.contracts.runner_lane_control` requires all of these
+before a plan can become ready:
+
+- the repository is explicitly opted into runner control
+- the requested action is enabled by policy
+- mutate mode is explicitly requested
+- the lane baseline is ready
+- existing lanes carry the managed label, defaulting to `launchplane-managed`
+- busy drain, restart, or removal requests include explicit drain confirmation
+
+The planner does not create, drain, restart, or remove a runner. It only returns
+structured blockers and next steps so a later host adapter can be reviewed
+against a stable policy boundary.

--- a/tests/test_runner_lane_control.py
+++ b/tests/test_runner_lane_control.py
@@ -1,0 +1,187 @@
+import unittest
+
+from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselineObservation
+from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselinePolicy
+from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselineReadiness
+from control_plane.contracts.runner_lane_baseline import evaluate_runner_lane_baseline
+from control_plane.contracts.runner_lane_control import RunnerLaneControlPolicy
+from control_plane.contracts.runner_lane_control import RunnerLaneControlRequest
+from control_plane.contracts.runner_lane_control import plan_runner_lane_control
+from control_plane.contracts.runner_lane_inventory import RunnerLaneInventory
+from control_plane.contracts.runner_lane_inventory import RunnerLaneRecord
+from control_plane.contracts.runner_lane_inventory import build_runner_lane_inventory
+
+
+class RunnerLaneControlPlanTests(unittest.TestCase):
+    def test_dry_run_control_plan_is_blocked_without_mutate_request(self) -> None:
+        plan = plan_runner_lane_control(
+            policy=RunnerLaneControlPolicy(
+                allowed_repositories=("cbusillo/repo",),
+                allow_restart=True,
+            ),
+            request=RunnerLaneControlRequest(
+                action="restart",
+                repository="cbusillo/repo",
+                lane_name="lane-1",
+            ),
+            inventory=_inventory(labels=("self-hosted", "launchplane", "launchplane-managed")),
+            baseline_readiness=_ready_baseline(),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(
+            [blocker.code for blocker in plan.blockers],
+            ["mutate_not_requested"],
+        )
+        self.assertIn("dry-run", plan.blockers[0].message)
+
+    def test_ready_plan_requires_opted_in_repo_managed_lane_and_baseline(self) -> None:
+        plan = plan_runner_lane_control(
+            policy=RunnerLaneControlPolicy(
+                allowed_repositories=("cbusillo/repo",),
+                allow_restart=True,
+            ),
+            request=RunnerLaneControlRequest(
+                action="restart",
+                repository=" cbusillo/repo ",
+                lane_name="lane-1",
+                mutate=True,
+            ),
+            inventory=_inventory(labels=("self-hosted", "launchplane", "launchplane-managed")),
+            baseline_readiness=_ready_baseline(),
+        )
+
+        self.assertEqual(plan.status, "ready")
+        self.assertEqual(plan.blockers, ())
+        self.assertIn("restart the approved runner service", plan.next_steps)
+
+    def test_remove_blocks_unmanaged_busy_lane(self) -> None:
+        plan = plan_runner_lane_control(
+            policy=RunnerLaneControlPolicy(
+                allowed_repositories=("cbusillo/repo",),
+                allow_remove=True,
+            ),
+            request=RunnerLaneControlRequest(
+                action="remove",
+                repository="cbusillo/repo",
+                lane_name="lane-1",
+                mutate=True,
+            ),
+            inventory=_inventory(labels=("self-hosted", "launchplane"), busy=True),
+            baseline_readiness=_ready_baseline(),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(
+            [blocker.code for blocker in plan.blockers],
+            ["busy_lane_requires_drain_confirmation", "managed_label_missing"],
+        )
+
+    def test_control_plan_blocks_when_baseline_is_not_ready(self) -> None:
+        plan = plan_runner_lane_control(
+            policy=RunnerLaneControlPolicy(
+                allowed_repositories=("cbusillo/repo",),
+                allow_drain=True,
+            ),
+            request=RunnerLaneControlRequest(
+                action="drain",
+                repository="cbusillo/repo",
+                lane_name="lane-1",
+                mutate=True,
+            ),
+            inventory=_inventory(labels=("self-hosted", "launchplane", "launchplane-managed")),
+            baseline_readiness=evaluate_runner_lane_baseline(
+                policy=RunnerLaneBaselinePolicy(), observations=()
+            ),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(
+            [blocker.code for blocker in plan.blockers],
+            ["baseline_not_ready"],
+        )
+
+    def test_create_plan_blocks_when_lane_already_exists(self) -> None:
+        plan = plan_runner_lane_control(
+            policy=RunnerLaneControlPolicy(
+                allowed_repositories=("cbusillo/repo",),
+                allow_create=True,
+            ),
+            request=RunnerLaneControlRequest(
+                action="create",
+                repository="cbusillo/repo",
+                lane_name="lane-1",
+                mutate=True,
+            ),
+            inventory=_inventory(labels=("self-hosted", "launchplane", "launchplane-managed")),
+            baseline_readiness=_ready_baseline(),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(
+            [blocker.code for blocker in plan.blockers],
+            ["lane_already_exists"],
+        )
+
+    def test_control_plan_rejects_inventory_for_another_repository(self) -> None:
+        plan = plan_runner_lane_control(
+            policy=RunnerLaneControlPolicy(
+                allowed_repositories=("cbusillo/repo",),
+                allow_restart=True,
+            ),
+            request=RunnerLaneControlRequest(
+                action="restart",
+                repository="cbusillo/repo",
+                lane_name="lane-1",
+                mutate=True,
+            ),
+            inventory=_inventory(
+                repository="cbusillo/other",
+                labels=("self-hosted", "launchplane", "launchplane-managed"),
+            ),
+            baseline_readiness=_ready_baseline(),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(
+            [blocker.code for blocker in plan.blockers],
+            ["inventory_repository_mismatch"],
+        )
+
+
+def _ready_baseline() -> RunnerLaneBaselineReadiness:
+    return evaluate_runner_lane_baseline(
+        policy=RunnerLaneBaselinePolicy(),
+        observations=(
+            RunnerLaneBaselineObservation(
+                runner_name="lane-1",
+                labels=("self-hosted", "launchplane"),
+                docker_config_isolated=True,
+                observed_at="2026-05-18T20:30:00Z",
+            ),
+        ),
+    )
+
+
+def _inventory(
+    *, repository: str = "cbusillo/repo", labels: tuple[str, ...], busy: bool = False
+) -> RunnerLaneInventory:
+    return build_runner_lane_inventory(
+        repository=repository,
+        observed_at="2026-05-18T20:30:00Z",
+        lanes=(
+            RunnerLaneRecord(
+                github_id=1,
+                name="lane-1",
+                repository=repository,
+                status="online",
+                busy=busy,
+                labels=labels,
+                observed_at="2026-05-18T20:30:00Z",
+            ),
+        ),
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a typed runner lane control policy/request/plan contract for create, drain, restart, and remove planning
- fail closed on missing mutate intent, disabled actions, non-opted-in repositories, baseline failures, wrong inventory, unmanaged lanes, existing create targets, and busy lane drain confirmation
- document runner control as dry-run planning before any host adapter or runner mutation exists

Starts #414 with a non-mutating control model only.

## Validation
- `uv run --extra dev ruff check --diff control_plane/contracts/runner_lane_control.py tests/test_runner_lane_control.py`
- `uv run --extra dev ruff check control_plane/contracts/runner_lane_control.py tests/test_runner_lane_control.py`
- `uv run --extra dev mypy control_plane/contracts/runner_lane_control.py tests/test_runner_lane_control.py`
- `uv run python -m unittest tests.test_runner_lane_control`
- `uv run python -m unittest`
- JetBrains changed-file inspection routed to PyCharm and returned existing service-auth warnings from earlier touched files; no runner-control findings were reported.

No runner host action, GitHub runner mutation, provider action, or VeriReel production action was run.