### PR TITLE
Fix runner baseline lane counts

### DIFF
--- a/control_plane/contracts/runner_lane_baseline.py
+++ b/control_plane/contracts/runner_lane_baseline.py
@@ -104,10 +104,9 @@ def evaluate_runner_lane_baseline(
     for observation in sorted(observations, key=lambda lane: lane.runner_name):
         violations.extend(_evaluate_observation(policy=policy, observation=observation))
 
+    observed_lane_names = {observation.runner_name for observation in observations}
     lanes_with_violations = {violation.runner_name for violation in violations}
-    compliant_lanes = len(
-        {observation.runner_name for observation in observations} - lanes_with_violations
-    )
+    compliant_lanes = len(observed_lane_names - lanes_with_violations)
     ready = bool(observations) and not violations
     summary = "runner lane baseline satisfied"
     if not observations:
@@ -116,7 +115,7 @@ def evaluate_runner_lane_baseline(
         summary = "runner lane baseline violations found"
     return RunnerLaneBaselineReadiness(
         ready=ready,
-        observed_lanes=len(observations),
+        observed_lanes=len(observed_lane_names),
         compliant_lanes=compliant_lanes,
         violations=tuple(violations),
         summary=summary,

--- a/docs/runner-lane-baseline.md
+++ b/docs/runner-lane-baseline.md
@@ -41,7 +41,9 @@ No observation means not ready. Unknown Docker credential isolation means not
 ready. Missing labels or configured host guardrails also make the lane not ready.
 Home-directory checks canonicalize observed and allowed paths before comparing
 roots, so traversal segments such as `..` cannot satisfy a configured root by
-string prefix alone.
+string prefix alone. Readiness counts lanes by unique runner name, so duplicate
+observations for the same runner do not inflate the observed or compliant lane
+totals.
 
 ## Operations
 

--- a/tests/test_runner_lane_baseline.py
+++ b/tests/test_runner_lane_baseline.py
@@ -155,6 +155,30 @@ class RunnerLaneBaselineTests(unittest.TestCase):
         self.assertTrue(readiness.ready)
         self.assertEqual(readiness.violations, ())
 
+    def test_readiness_counts_duplicate_runner_observations_once(self) -> None:
+        readiness = evaluate_runner_lane_baseline(
+            policy=RunnerLaneBaselinePolicy(),
+            observations=(
+                RunnerLaneBaselineObservation(
+                    runner_name="launchplane-runner-1",
+                    labels=("self-hosted", "launchplane"),
+                    docker_config_isolated=True,
+                    observed_at="2026-05-18T12:00:00Z",
+                ),
+                RunnerLaneBaselineObservation(
+                    runner_name="launchplane-runner-1",
+                    labels=("self-hosted", "launchplane"),
+                    docker_config_isolated=True,
+                    observed_at="2026-05-18T12:01:00Z",
+                ),
+            ),
+        )
+
+        self.assertTrue(readiness.ready)
+        self.assertEqual(readiness.observed_lanes, 1)
+        self.assertEqual(readiness.compliant_lanes, 1)
+        self.assertEqual(readiness.violations, ())
+
     def test_readiness_rejects_symlinked_home_directory_outside_allowed_roots(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- count runner baseline observed lanes by unique runner name
- add a duplicate-observation regression test
- document that duplicate observations do not inflate readiness totals

## Tests
- uv run --extra dev ruff check control_plane/contracts/runner_lane_baseline.py tests/test_runner_lane_baseline.py
- uv run python -m unittest tests.test_runner_lane_baseline
- uv run python -m unittest

## Inspection
- JetBrains changed_files routed to PyCharm launchplane, but surfaced existing frontend CSS custom-property/font findings unrelated to these Python/docs changes.