### PR TITLE
Add runner control plan CLI

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -96,7 +96,12 @@ from control_plane.contracts.runtime_environment_record import (
 )
 from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselineObservation
 from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselinePolicy
+from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselineReadiness
 from control_plane.contracts.runner_lane_baseline import evaluate_runner_lane_baseline
+from control_plane.contracts.runner_lane_control import RunnerLaneControlAction
+from control_plane.contracts.runner_lane_control import RunnerLaneControlPolicy
+from control_plane.contracts.runner_lane_control import RunnerLaneControlRequest
+from control_plane.contracts.runner_lane_control import plan_runner_lane_control
 from control_plane.contracts.runner_lane_inventory import RunnerLaneInventory
 from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeEnvironmentClass,
@@ -10057,6 +10062,145 @@ def work_graph_runner_baseline_observe(
             sort_keys=True,
         )
     )
+
+
+@work_graph.command("runner-control-plan")
+@click.option(
+    "--action",
+    "control_action",
+    required=True,
+    type=click.Choice(("create", "drain", "restart", "remove")),
+    help="Runner lane control action to plan. The command never mutates hosts.",
+)
+@click.option("--repository", required=True, help="owner/name repository for the runner lane.")
+@click.option("--lane-name", required=True, help="Runner lane name to plan against.")
+@click.option(
+    "--mutate/--dry-run",
+    default=False,
+    show_default=True,
+    help="Set the request mutate intent. This command still emits only a dry-run plan.",
+)
+@click.option(
+    "--drain-busy-lane/--do-not-drain-busy-lane",
+    default=False,
+    show_default=True,
+    help="Whether the request explicitly permits draining a busy managed lane.",
+)
+@click.option(
+    "--allow-create/--disallow-create",
+    default=False,
+    show_default=True,
+    help="Enable create planning in the local policy.",
+)
+@click.option(
+    "--allow-drain/--disallow-drain",
+    default=False,
+    show_default=True,
+    help="Enable drain planning in the local policy.",
+)
+@click.option(
+    "--allow-restart/--disallow-restart",
+    default=False,
+    show_default=True,
+    help="Enable restart planning in the local policy.",
+)
+@click.option(
+    "--allow-remove/--disallow-remove",
+    default=False,
+    show_default=True,
+    help="Enable remove planning in the local policy.",
+)
+@click.option(
+    "--allowed-repository",
+    "allowed_repositories",
+    multiple=True,
+    help="Repository opted into runner lane control. Repeat for each allowed repo.",
+)
+@click.option(
+    "--required-managed-label",
+    default="launchplane-managed",
+    show_default=True,
+    help="Label required on existing lanes before control actions can target them.",
+)
+@click.option(
+    "--inventory-file",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False),
+    required=True,
+    help="RunnerLaneInventory JSON from runner-inventory or an equivalent fixture.",
+)
+@click.option(
+    "--baseline-readiness-file",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False),
+    required=True,
+    help="RunnerLaneBaselineReadiness JSON or runner-baseline-observe output.",
+)
+def work_graph_runner_control_plan(
+    control_action: RunnerLaneControlAction,
+    repository: str,
+    lane_name: str,
+    mutate: bool,
+    drain_busy_lane: bool,
+    allow_create: bool,
+    allow_drain: bool,
+    allow_restart: bool,
+    allow_remove: bool,
+    allowed_repositories: tuple[str, ...],
+    required_managed_label: str,
+    inventory_file: Path,
+    baseline_readiness_file: Path,
+) -> None:
+    try:
+        policy = RunnerLaneControlPolicy(
+            allowed_repositories=allowed_repositories,
+            required_managed_label=required_managed_label,
+            allow_create=allow_create,
+            allow_drain=allow_drain,
+            allow_restart=allow_restart,
+            allow_remove=allow_remove,
+        )
+        request = RunnerLaneControlRequest(
+            action=control_action,
+            repository=repository,
+            lane_name=lane_name,
+            mutate=mutate,
+            drain_busy_lane=drain_busy_lane,
+        )
+        inventory = _load_runner_lane_inventory(inventory_file)
+        baseline_readiness = _load_runner_lane_baseline_readiness(baseline_readiness_file)
+        plan = plan_runner_lane_control(
+            policy=policy,
+            request=request,
+            inventory=inventory,
+            baseline_readiness=baseline_readiness,
+        )
+    except (OSError, JSONDecodeError, ValidationError, ValueError) as error:
+        raise click.ClickException(str(error)) from error
+    click.echo(
+        json.dumps(
+            {
+                "policy": policy.model_dump(mode="json"),
+                "request": request.model_dump(mode="json"),
+                "plan": plan.model_dump(mode="json"),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+def _load_runner_lane_inventory(inventory_file: Path) -> RunnerLaneInventory:
+    return RunnerLaneInventory.model_validate(
+        json.loads(inventory_file.read_text(encoding="utf-8"))
+    )
+
+
+def _load_runner_lane_baseline_readiness(
+    baseline_readiness_file: Path,
+) -> RunnerLaneBaselineReadiness:
+    payload = json.loads(baseline_readiness_file.read_text(encoding="utf-8"))
+    if isinstance(payload, dict) and isinstance(payload.get("readiness"), dict):
+        payload = payload["readiness"]
+    return RunnerLaneBaselineReadiness.model_validate(payload)
 
 
 def _runner_baseline_runner_name(value: str) -> str:

--- a/docs/runner-lane-baseline.md
+++ b/docs/runner-lane-baseline.md
@@ -114,3 +114,23 @@ against a stable policy boundary. Repository values are canonicalized to
 `owner/name` before comparing policy, request, and inventory records, and a
 matching lane name must resolve to exactly one inventory record before the plan
 can target it.
+
+To build the first read-only control plan from saved inventory and baseline
+evidence, run:
+
+```bash
+uv run launchplane work-graph runner-control-plan \
+  --action restart \
+  --repository owner/name \
+  --lane-name launchplane-runner-1 \
+  --allow-restart \
+  --allowed-repository owner/name \
+  --inventory-file runner-inventory.json \
+  --baseline-readiness-file runner-baseline.json
+```
+
+The command does not contact GitHub and does not mutate hosts. It only evaluates
+the typed runner-control policy and request against the supplied inventory and
+baseline readiness JSON. `--mutate` records the operator's explicit mutation
+intent in the request so the planner can tell whether a future host adapter would
+be allowed to proceed, but this CLI command itself remains a dry-run surface.

--- a/tests/test_runner_lane_control.py
+++ b/tests/test_runner_lane_control.py
@@ -1,4 +1,13 @@
+import json
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import cast
+
+from click import Command
+from click.testing import CliRunner
+
+from control_plane.cli import main
 
 from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselineObservation
 from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselinePolicy
@@ -10,6 +19,9 @@ from control_plane.contracts.runner_lane_control import plan_runner_lane_control
 from control_plane.contracts.runner_lane_inventory import RunnerLaneInventory
 from control_plane.contracts.runner_lane_inventory import RunnerLaneRecord
 from control_plane.contracts.runner_lane_inventory import build_runner_lane_inventory
+
+
+CLI_MAIN = cast(Command, main)
 
 
 class RunnerLaneControlPlanTests(unittest.TestCase):
@@ -206,6 +218,101 @@ class RunnerLaneControlPlanTests(unittest.TestCase):
         self.assertEqual(
             [blocker.code for blocker in plan.blockers],
             ["inventory_repository_mismatch"],
+        )
+
+
+class RunnerLaneControlPlanCliTests(unittest.TestCase):
+    def test_cli_builds_runner_control_plan_from_inventory_and_baseline_files(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            inventory_file = Path(temp_dir) / "inventory.json"
+            baseline_file = Path(temp_dir) / "baseline.json"
+            inventory_file.write_text(
+                json.dumps(
+                    _inventory(
+                        repository=" cbusillo / repo ",
+                        labels=("self-hosted", "launchplane", "launchplane-managed"),
+                    ).model_dump(mode="json")
+                ),
+                encoding="utf-8",
+            )
+            baseline_file.write_text(
+                json.dumps({"readiness": _ready_baseline().model_dump(mode="json")}),
+                encoding="utf-8",
+            )
+
+            result = CliRunner().invoke(
+                CLI_MAIN,
+                [
+                    "work-graph",
+                    "runner-control-plan",
+                    "--action",
+                    "restart",
+                    "--repository",
+                    " cbusillo / repo ",
+                    "--lane-name",
+                    "lane-1",
+                    "--mutate",
+                    "--allow-restart",
+                    "--allowed-repository",
+                    "cbusillo/repo",
+                    "--inventory-file",
+                    str(inventory_file),
+                    "--baseline-readiness-file",
+                    str(baseline_file),
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["request"]["repository"], "cbusillo/repo")
+        self.assertEqual(payload["plan"]["status"], "ready")
+        self.assertEqual(payload["plan"]["blockers"], [])
+
+    def test_cli_keeps_runner_control_plan_dry_run_by_default(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            inventory_file = Path(temp_dir) / "inventory.json"
+            baseline_file = Path(temp_dir) / "baseline.json"
+            inventory_file.write_text(
+                json.dumps(
+                    _inventory(
+                        labels=("self-hosted", "launchplane", "launchplane-managed")
+                    ).model_dump(mode="json")
+                ),
+                encoding="utf-8",
+            )
+            baseline_file.write_text(
+                json.dumps(_ready_baseline().model_dump(mode="json")),
+                encoding="utf-8",
+            )
+
+            result = CliRunner().invoke(
+                CLI_MAIN,
+                [
+                    "work-graph",
+                    "runner-control-plan",
+                    "--action",
+                    "restart",
+                    "--repository",
+                    "cbusillo/repo",
+                    "--lane-name",
+                    "lane-1",
+                    "--allow-restart",
+                    "--allowed-repository",
+                    "cbusillo/repo",
+                    "--inventory-file",
+                    str(inventory_file),
+                    "--baseline-readiness-file",
+                    str(baseline_file),
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertFalse(payload["request"]["mutate"])
+        self.assertEqual(payload["plan"]["status"], "blocked")
+        self.assertEqual(
+            [blocker["code"] for blocker in payload["plan"]["blockers"]],
+            ["mutate_not_requested"],
         )
 
 


### PR DESCRIPTION
## Summary
- add a read-only work-graph runner-control-plan command that evaluates runner-control policy/request against saved inventory and baseline readiness evidence
- support runner-baseline-observe output or raw readiness JSON as baseline input
- document the dry-run planner flow and add CLI regression tests

Refs #414.

## Tests
- uv run python -m unittest tests.test_runner_lane_control
- uv run --extra dev ruff check control_plane/cli.py tests/test_runner_lane_control.py
- uv run python -m unittest

## Inspection
- JetBrains changed_files routed to PyCharm launchplane, but surfaced existing frontend CSS custom-property/font findings unrelated to these Python/docs changes.