### PR TITLE
Fail closed runner and local operator controls

### DIFF
--- a/control_plane/contracts/runner_lane_control.py
+++ b/control_plane/contracts/runner_lane_control.py
@@ -90,8 +90,12 @@ class RunnerLaneControlPlan(BaseModel):
 
     @model_validator(mode="after")
     def _normalize_plan(self) -> "RunnerLaneControlPlan":
-        self.repository = _required_text(self.repository, "runner lane control plan requires repository")
-        self.lane_name = _required_text(self.lane_name, "runner lane control plan requires lane_name")
+        self.repository = _required_text(
+            self.repository, "runner lane control plan requires repository"
+        )
+        self.lane_name = _required_text(
+            self.lane_name, "runner lane control plan requires lane_name"
+        )
         self.blockers = tuple(sorted(self.blockers, key=lambda blocker: blocker.code))
         self.next_steps = tuple(step.strip() for step in self.next_steps if step.strip())
         self.summary = _required_text(self.summary, "runner lane control plan requires summary")
@@ -111,7 +115,7 @@ def plan_runner_lane_control(
 ) -> RunnerLaneControlPlan:
     blockers: list[RunnerLaneControlBlocker] = []
     inventory_repository = _normalized_repository(inventory.repository)
-    if policy.allowed_repositories and request.repository not in policy.allowed_repositories:
+    if not policy.allowed_repositories or request.repository not in policy.allowed_repositories:
         blockers.append(
             _blocker(
                 "repository_not_allowed",
@@ -173,7 +177,11 @@ def plan_runner_lane_control(
                     f"runner lane is missing managed label: {policy.required_managed_label}",
                 )
             )
-        if lane.busy and request.action in {"drain", "restart", "remove"} and not request.drain_busy_lane:
+        if (
+            lane.busy
+            and request.action in {"drain", "restart", "remove"}
+            and not request.drain_busy_lane
+        ):
             blockers.append(
                 _blocker(
                     "busy_lane_requires_drain_confirmation",
@@ -214,11 +222,18 @@ def _next_steps(
     if status == "blocked":
         return ("resolve blockers before running any host or GitHub runner mutation",)
     if action == "create":
-        return ("create runner lane through an approved host adapter", "verify GitHub sees the lane online")
+        return (
+            "create runner lane through an approved host adapter",
+            "verify GitHub sees the lane online",
+        )
     if action == "drain":
         return ("stop admitting new jobs to the managed lane", "wait for active jobs to finish")
     if action == "restart":
-        return ("drain the managed lane", "restart the approved runner service", "verify the lane returns online")
+        return (
+            "drain the managed lane",
+            "restart the approved runner service",
+            "verify the lane returns online",
+        )
     return ("drain the managed lane", "remove only the Launchplane-owned runner registration")
 
 
@@ -233,7 +248,9 @@ def _normalized_repositories(values: tuple[str, ...]) -> tuple[str, ...]:
 
 
 def _normalized_tokens(values: tuple[str, ...]) -> tuple[str, ...]:
-    return tuple(sorted({normalized for value in values if (normalized := _normalized_token(value))}))
+    return tuple(
+        sorted({normalized for value in values if (normalized := _normalized_token(value))})
+    )
 
 
 def _normalized_repository(value: str) -> str:

--- a/control_plane/service_auth.py
+++ b/control_plane/service_auth.py
@@ -74,9 +74,7 @@ AgentConsumerActionSafety = Literal[
     "policy_admin",
 ]
 AgentAuthzDecision = Literal["allowed", "denied"]
-LOCAL_OPERATOR_ALLOWED_ACTIONS = frozenset(
-    {"product_config.plan", "product_config.apply", "product_profile.read"}
-)
+LOCAL_OPERATOR_ALLOWED_ACTIONS = frozenset({"product_config.plan", "product_config.apply"})
 
 
 class TokenVerifier(Protocol):

--- a/docs/runner-lane-baseline.md
+++ b/docs/runner-lane-baseline.md
@@ -101,7 +101,8 @@ Runner control starts with a dry-run plan, not a host mutation. The typed
 contract in `control_plane.contracts.runner_lane_control` requires all of these
 before a plan can become ready:
 
-- the repository is explicitly opted into runner control
+- the repository allow-list is non-empty and explicitly opts the repository into
+  runner control
 - the requested action is enabled by policy
 - mutate mode is explicitly requested
 - the lane baseline is ready

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -187,9 +187,10 @@ idempotency records; the defaults are `local-owner-agent` and
 non-empty `reason`; apply is rejected until the service has recorded a matching
 local-operator dry-run for the same product config payload. These requests still
 use Launchplane records, redacted responses, runtime key-safety policy, and
-managed secret storage. The local-operator identity is not accepted for authz
-policy administration, so the credential cannot rewrite its own permission
-model.
+managed secret storage. The local-operator identity is scoped to product-config
+plan/apply and is not accepted for product-profile reads or authz policy
+administration, so the credential cannot enumerate product profiles or rewrite
+its own permission model.
 
 `GET /v1/every-code/summary` returns a compact agent-safe projection of Every
 Code work requests. It requires `every_code_work_request.read` for

--- a/tests/test_runner_lane_control.py
+++ b/tests/test_runner_lane_control.py
@@ -92,6 +92,25 @@ class RunnerLaneControlPlanTests(unittest.TestCase):
         self.assertEqual(plan.repository, "cbusillo/repo")
         self.assertEqual(plan.blockers, ())
 
+    def test_control_plan_blocks_when_allowed_repositories_are_empty(self) -> None:
+        plan = plan_runner_lane_control(
+            policy=RunnerLaneControlPolicy(allow_restart=True),
+            request=RunnerLaneControlRequest(
+                action="restart",
+                repository="cbusillo/repo",
+                lane_name="lane-1",
+                mutate=True,
+            ),
+            inventory=_inventory(labels=("self-hosted", "launchplane", "launchplane-managed")),
+            baseline_readiness=_ready_baseline(),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(
+            [blocker.code for blocker in plan.blockers],
+            ["repository_not_allowed"],
+        )
+
     def test_control_plan_blocks_when_lane_name_is_ambiguous(self) -> None:
         plan = plan_runner_lane_control(
             policy=RunnerLaneControlPolicy(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -6720,6 +6720,47 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(unrelated_status, 401)
         self.assertEqual(unrelated_payload["error"]["code"], "authentication_required")
 
+    def test_local_operator_token_cannot_read_product_profiles(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
+                },
+                clear=True,
+            ),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            FilesystemRecordStore(state_dir=state_dir).write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            list_status, list_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/product-profiles",
+                authorization="Bearer local-operator-token",
+            )
+            show_status, show_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/product-profiles/sellyouroutboard",
+                authorization="Bearer local-operator-token",
+            )
+
+        self.assertEqual(list_status, 403)
+        self.assertEqual(list_payload["error"]["code"], "authorization_denied")
+        self.assertEqual(show_status, 403)
+        self.assertEqual(show_payload["error"]["code"], "authorization_denied")
+
     def test_every_code_worker_token_can_rerun_terminal_request(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(
             {
@@ -11923,7 +11964,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 control_plane_root_path=root,
             )
 
-            with patch("control_plane.service.dispatch_generic_web_promotion_workflow") as dispatch_mock:
+            with patch(
+                "control_plane.service.dispatch_generic_web_promotion_workflow"
+            ) as dispatch_mock:
                 status_code, payload = _invoke_app(
                     app,
                     method="POST",

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -621,7 +621,7 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
                 context="sellyouroutboard-testing",
             )
         )
-        self.assertTrue(
+        self.assertFalse(
             policy.allows(
                 identity=identity,
                 action="product_profile.read",


### PR DESCRIPTION
## Summary
- fail closed when runner-control policy has no repository allow-list
- remove local-operator product-profile read from the blanket local operator action set
- document the tightened runner-control and local-operator boundaries
- add regression coverage for both audited authz/control gaps

## Validation
- `uv run python -m unittest tests.test_runner_lane_control tests.test_service_auth tests.test_service.LaunchplaneServiceTests.test_local_operator_token_cannot_read_product_profiles`
- `uv run --extra dev ruff check control_plane/contracts/runner_lane_control.py control_plane/service_auth.py tests/test_runner_lane_control.py tests/test_service_auth.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/contracts/runner_lane_control.py control_plane/service_auth.py tests/test_runner_lane_control.py tests/test_service_auth.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`

## Notes
- Repo-wide `ruff format --check .` still reports the existing formatting baseline outside this change; changed files are formatted.
- JetBrains changed-files inspection returned stale cached results, so fresh IDE findings were unavailable locally.
