### PR TITLE
Move launchplane request action to Node 24

### DIFF
--- a/.github/actions/launchplane-request/action.yml
+++ b/.github/actions/launchplane-request/action.yml
@@ -101,5 +101,5 @@ outputs:
     description: Raw Launchplane response body.
 
 runs:
-  using: node20
+  using: node24
   main: dist/index.js

--- a/tests/test_launchplane_request_action.py
+++ b/tests/test_launchplane_request_action.py
@@ -8,9 +8,16 @@ import unittest
 
 
 ACTION_ENTRYPOINT = Path(".github/actions/launchplane-request/dist/index.js")
+ACTION_METADATA = Path(".github/actions/launchplane-request/action.yml")
 
 
 class LaunchplaneRequestActionTests(unittest.TestCase):
+    def test_action_metadata_uses_supported_node_runtime(self) -> None:
+        self.assertIn(
+            "using: node24",
+            ACTION_METADATA.read_text(encoding="utf-8"),
+        )
+
     def run_action(
         self,
         *,


### PR DESCRIPTION
## Summary

- move the shared `launchplane-request` JavaScript action metadata from `node20` to `node24`
- add a regression test that asserts the action metadata stays on the supported runtime

## Verification

- `uv run python -m unittest tests.test_launchplane_request_action`
- `uv run --extra dev ruff check --diff tests/test_launchplane_request_action.py`
- `uv run --extra dev ruff check tests/test_launchplane_request_action.py`
- `ruby -e 'require "yaml"; YAML.load_file(".github/actions/launchplane-request/action.yml"); puts "yaml-ok"'`
- `node --check .github/actions/launchplane-request/dist/index.js`
- `git diff --check`
- JetBrains changed-files inspection ran; it reported pre-existing frontend CSS findings outside the files changed here.

Refs #723

Docs checked: GitHub action metadata syntax lists `node24` as a valid JavaScript action runtime.
