### PR TITLE
Add generic web rollback planner

### DIFF
--- a/control_plane/contracts/generic_web_rollback.py
+++ b/control_plane/contracts/generic_web_rollback.py
@@ -1,0 +1,437 @@
+from __future__ import annotations
+
+from typing import Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.backup_gate_record import BackupGateRecord
+from control_plane.contracts.deployment_record import DeploymentRecord
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductLaneProfile,
+)
+from control_plane.contracts.promotion_record import (
+    ArtifactIdentityReference,
+    BackupGateEvidence,
+    HealthcheckEvidence,
+)
+from control_plane.workflows.ship import utc_now_timestamp
+
+GenericWebRollbackPlanStatus = Literal["ready", "blocked"]
+GenericWebRollbackBlockerCode = Literal[
+    "backup_gate_missing",
+    "backup_gate_not_passed",
+    "backup_gate_scope_mismatch",
+    "deployment_scope_mismatch",
+    "health_evidence_failed",
+    "missing_rollback_target",
+    "mutable_artifact_reference",
+    "target_deploy_not_passed",
+]
+
+
+class GenericWebRollbackPlanReader(Protocol):
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord: ...
+
+    def read_deployment_record(self, record_id: str) -> DeploymentRecord: ...
+
+    def read_backup_gate_record(self, record_id: str) -> BackupGateRecord: ...
+
+
+class GenericWebRollbackPlanStore(GenericWebRollbackPlanReader, Protocol):
+    def write_generic_web_rollback_plan_record(
+        self, record: "GenericWebRollbackPlanRecord"
+    ) -> object: ...
+
+
+class GenericWebRollbackPlanRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    instance: str = "prod"
+    rollback_deployment_record_id: str
+    backup_record_id: str = ""
+    backup_required: bool = False
+    verify_health: bool = True
+    timeout_seconds: int | None = Field(default=None, ge=1)
+    no_cache: bool = False
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "GenericWebRollbackPlanRequest":
+        self.product = self.product.strip()
+        self.instance = self.instance.strip().lower()
+        self.rollback_deployment_record_id = self.rollback_deployment_record_id.strip()
+        self.backup_record_id = self.backup_record_id.strip()
+        if not self.product:
+            raise ValueError("generic web rollback plan requires product")
+        if not self.instance:
+            raise ValueError("generic web rollback plan requires instance")
+        if not self.rollback_deployment_record_id:
+            raise ValueError("generic web rollback plan requires rollback_deployment_record_id")
+        if self.backup_required and not self.backup_record_id:
+            raise ValueError(
+                "generic web rollback plan requires backup_record_id when backup_required=true"
+            )
+        return self
+
+
+class GenericWebRollbackBlocker(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: GenericWebRollbackBlockerCode
+    message: str
+
+    @model_validator(mode="after")
+    def _validate_blocker(self) -> "GenericWebRollbackBlocker":
+        self.message = self.message.strip()
+        if not self.message:
+            raise ValueError("generic web rollback blocker requires message")
+        return self
+
+
+class GenericWebRollbackDeployPlan(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    product: str
+    instance: str
+    artifact_id: str
+    source_git_ref: str
+    timeout_seconds: int | None = Field(default=None, ge=1)
+    no_cache: bool = False
+
+    @model_validator(mode="after")
+    def _validate_plan(self) -> "GenericWebRollbackDeployPlan":
+        self.product = self.product.strip()
+        self.instance = self.instance.strip()
+        self.artifact_id = self.artifact_id.strip()
+        self.source_git_ref = self.source_git_ref.strip()
+        if not self.product:
+            raise ValueError("generic web rollback deploy plan requires product")
+        if not self.instance:
+            raise ValueError("generic web rollback deploy plan requires instance")
+        if not self.artifact_id:
+            raise ValueError("generic web rollback deploy plan requires artifact_id")
+        if not self.source_git_ref:
+            raise ValueError("generic web rollback deploy plan requires source_git_ref")
+        return self
+
+
+class GenericWebRollbackPlanRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    plan_id: str
+    product: str
+    context: str
+    instance: str
+    status: GenericWebRollbackPlanStatus
+    rollback_deployment_record_id: str
+    artifact_identity: ArtifactIdentityReference | None = None
+    source_git_ref: str = ""
+    planned_deploy: GenericWebRollbackDeployPlan | None = None
+    backup_record_id: str = ""
+    backup_gate: BackupGateEvidence = Field(default_factory=BackupGateEvidence)
+    target_health: HealthcheckEvidence = Field(default_factory=HealthcheckEvidence)
+    blockers: tuple[GenericWebRollbackBlocker, ...] = ()
+    created_at: str
+    summary: str
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "GenericWebRollbackPlanRecord":
+        self.plan_id = _required_text(
+            self.plan_id, "generic web rollback plan record requires plan_id"
+        )
+        self.product = _required_text(
+            self.product, "generic web rollback plan record requires product"
+        )
+        self.context = _required_text(
+            self.context, "generic web rollback plan record requires context"
+        )
+        self.instance = _required_text(
+            self.instance, "generic web rollback plan record requires instance"
+        )
+        self.rollback_deployment_record_id = _required_text(
+            self.rollback_deployment_record_id,
+            "generic web rollback plan record requires rollback_deployment_record_id",
+        )
+        self.source_git_ref = self.source_git_ref.strip()
+        self.backup_record_id = self.backup_record_id.strip()
+        self.created_at = _required_text(
+            self.created_at, "generic web rollback plan record requires created_at"
+        )
+        self.summary = _required_text(
+            self.summary, "generic web rollback plan record requires summary"
+        )
+        self.blockers = tuple(sorted(self.blockers, key=lambda blocker: blocker.code))
+        if self.status == "ready":
+            if self.blockers:
+                raise ValueError("ready generic web rollback plan cannot include blockers")
+            if self.artifact_identity is None or self.planned_deploy is None:
+                raise ValueError(
+                    "ready generic web rollback plan requires artifact identity and deploy plan"
+                )
+        if self.status == "blocked" and not self.blockers:
+            raise ValueError("blocked generic web rollback plan requires blockers")
+        return self
+
+
+def build_generic_web_rollback_plan(
+    *,
+    record_store: GenericWebRollbackPlanReader,
+    request: GenericWebRollbackPlanRequest,
+) -> GenericWebRollbackPlanRecord:
+    profile, lane = _resolve_generic_web_profile_lane(
+        record_store=record_store,
+        product=request.product,
+        instance=request.instance,
+    )
+    blockers: list[GenericWebRollbackBlocker] = []
+    deployment_record = _read_rollback_deployment_record(
+        record_store=record_store,
+        request=request,
+        blockers=blockers,
+    )
+    backup_gate = _resolve_backup_gate(
+        record_store=record_store,
+        request=request,
+        lane=lane,
+        blockers=blockers,
+    )
+
+    artifact_identity: ArtifactIdentityReference | None = None
+    planned_deploy: GenericWebRollbackDeployPlan | None = None
+    source_git_ref = ""
+    target_health = HealthcheckEvidence()
+    if deployment_record is not None:
+        artifact_id = _immutable_artifact_id(profile=profile, deployment_record=deployment_record)
+        if artifact_id:
+            artifact_identity = ArtifactIdentityReference(artifact_id=artifact_id)
+        else:
+            artifact_identity = deployment_record.artifact_identity
+        source_git_ref = deployment_record.source_git_ref
+        target_health = deployment_record.destination_health
+        _validate_rollback_target(
+            profile=profile,
+            lane=lane,
+            deployment_record=deployment_record,
+            blockers=blockers,
+        )
+        if artifact_identity is not None and not blockers:
+            planned_deploy = GenericWebRollbackDeployPlan(
+                product=profile.product,
+                instance=lane.instance,
+                artifact_id=artifact_identity.artifact_id,
+                source_git_ref=source_git_ref,
+                timeout_seconds=request.timeout_seconds,
+                no_cache=request.no_cache,
+            )
+
+    status: GenericWebRollbackPlanStatus = "blocked" if blockers else "ready"
+    return GenericWebRollbackPlanRecord(
+        plan_id=_generic_web_rollback_plan_id(
+            context=lane.context,
+            instance=lane.instance,
+            deployment_record_id=request.rollback_deployment_record_id,
+        ),
+        product=profile.product,
+        context=lane.context,
+        instance=lane.instance,
+        status=status,
+        rollback_deployment_record_id=request.rollback_deployment_record_id,
+        artifact_identity=artifact_identity,
+        source_git_ref=source_git_ref,
+        planned_deploy=planned_deploy,
+        backup_record_id=request.backup_record_id,
+        backup_gate=backup_gate,
+        target_health=target_health,
+        blockers=tuple(blockers),
+        created_at=utc_now_timestamp(),
+        summary=(
+            "generic web rollback plan is ready"
+            if status == "ready"
+            else "generic web rollback plan is blocked"
+        ),
+    )
+
+
+def execute_generic_web_rollback_plan(
+    *,
+    record_store: GenericWebRollbackPlanStore,
+    request: GenericWebRollbackPlanRequest,
+) -> GenericWebRollbackPlanRecord:
+    plan = build_generic_web_rollback_plan(record_store=record_store, request=request)
+    record_store.write_generic_web_rollback_plan_record(plan)
+    return plan
+
+
+def _read_rollback_deployment_record(
+    *,
+    record_store: GenericWebRollbackPlanReader,
+    request: GenericWebRollbackPlanRequest,
+    blockers: list[GenericWebRollbackBlocker],
+) -> DeploymentRecord | None:
+    try:
+        return record_store.read_deployment_record(request.rollback_deployment_record_id)
+    except FileNotFoundError:
+        blockers.append(
+            _blocker(
+                "missing_rollback_target",
+                "generic web rollback target deployment record was not found",
+            )
+        )
+        return None
+
+
+def _resolve_backup_gate(
+    *,
+    record_store: GenericWebRollbackPlanReader,
+    request: GenericWebRollbackPlanRequest,
+    lane: ProductLaneProfile,
+    blockers: list[GenericWebRollbackBlocker],
+) -> BackupGateEvidence:
+    if not request.backup_record_id:
+        if request.backup_required:
+            blockers.append(
+                _blocker(
+                    "backup_gate_missing",
+                    "generic web rollback requires backup_record_id when backup_required=true",
+                )
+            )
+        return BackupGateEvidence(required=request.backup_required, status="skipped", evidence={})
+    try:
+        backup_record = record_store.read_backup_gate_record(request.backup_record_id)
+    except FileNotFoundError:
+        blockers.append(
+            _blocker(
+                "backup_gate_missing",
+                f"generic web rollback backup gate record was not found: {request.backup_record_id}",
+            )
+        )
+        return BackupGateEvidence(required=request.backup_required, status="fail", evidence={})
+    if backup_record.context != lane.context or backup_record.instance != lane.instance:
+        blockers.append(
+            _blocker(
+                "backup_gate_scope_mismatch",
+                "generic web rollback backup gate record does not match destination lane",
+            )
+        )
+    if backup_record.required and backup_record.status != "pass":
+        blockers.append(
+            _blocker(
+                "backup_gate_not_passed",
+                f"generic web rollback backup gate is not passing: {backup_record.record_id}",
+            )
+        )
+    if request.backup_required and not backup_record.required:
+        blockers.append(
+            _blocker(
+                "backup_gate_not_passed",
+                f"generic web rollback backup gate is marked required=false: {backup_record.record_id}",
+            )
+        )
+    return BackupGateEvidence(
+        required=backup_record.required or request.backup_required,
+        status=backup_record.status,
+        evidence=dict(backup_record.evidence),
+    )
+
+
+def _validate_rollback_target(
+    *,
+    profile: LaunchplaneProductProfileRecord,
+    lane: ProductLaneProfile,
+    deployment_record: DeploymentRecord,
+    blockers: list[GenericWebRollbackBlocker],
+) -> None:
+    if deployment_record.context != lane.context or deployment_record.instance != lane.instance:
+        blockers.append(
+            _blocker(
+                "deployment_scope_mismatch",
+                "generic web rollback target deployment record does not match destination lane",
+            )
+        )
+    if deployment_record.deploy.status != "pass":
+        blockers.append(
+            _blocker(
+                "target_deploy_not_passed",
+                "generic web rollback target deployment record is not passing",
+            )
+        )
+    if deployment_record.destination_health.status == "fail":
+        blockers.append(
+            _blocker(
+                "health_evidence_failed",
+                "generic web rollback target deployment record has failed health evidence",
+            )
+        )
+    if deployment_record.artifact_identity is None:
+        blockers.append(
+            _blocker(
+                "missing_rollback_target",
+                "generic web rollback target deployment record has no artifact identity",
+            )
+        )
+        return
+    if not _immutable_artifact_id(profile=profile, deployment_record=deployment_record):
+        blockers.append(
+            _blocker(
+                "mutable_artifact_reference",
+                "generic web rollback target must use an immutable image digest",
+            )
+        )
+
+
+def _resolve_generic_web_profile_lane(
+    *,
+    record_store: GenericWebRollbackPlanReader,
+    product: str,
+    instance: str,
+) -> tuple[LaunchplaneProductProfileRecord, ProductLaneProfile]:
+    profile = record_store.read_product_profile_record(product)
+    if profile.driver_id != "generic-web":
+        raise ValueError(
+            f"Product {profile.product!r} is configured for driver {profile.driver_id!r}, not generic-web."
+        )
+    for lane in profile.lanes:
+        if lane.instance == instance:
+            return profile, lane
+    raise ValueError(
+        f"Product {profile.product!r} has no generic-web lane for instance {instance!r}."
+    )
+
+
+def _immutable_artifact_id(
+    *, profile: LaunchplaneProductProfileRecord, deployment_record: DeploymentRecord
+) -> str:
+    if deployment_record.artifact_identity is None:
+        return ""
+    artifact_id = deployment_record.artifact_identity.artifact_id.strip()
+    image_repository = profile.image.repository.strip().rstrip("/")
+    if artifact_id.startswith("sha256:"):
+        return f"{image_repository}@{artifact_id}"
+    if artifact_id.startswith(f"{image_repository}@sha256:"):
+        return artifact_id
+    return ""
+
+
+def _generic_web_rollback_plan_id(*, context: str, instance: str, deployment_record_id: str) -> str:
+    return "-".join(
+        (
+            "generic-web-rollback-plan",
+            context.strip().lower(),
+            instance.strip().lower(),
+            deployment_record_id.strip().lower(),
+        )
+    )
+
+
+def _blocker(code: GenericWebRollbackBlockerCode, message: str) -> GenericWebRollbackBlocker:
+    return GenericWebRollbackBlocker(code=code, message=message)
+
+
+def _required_text(value: str, message: str) -> str:
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise ValueError(message)
+    return normalized_value

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -20,6 +20,7 @@ from control_plane.contracts.every_code_work_request import (
     claim_every_code_work_request,
 )
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
+from control_plane.contracts.generic_web_rollback import GenericWebRollbackPlanRecord
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidateRecord
 from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlanRecord
@@ -807,6 +808,29 @@ class FilesystemRecordStore:
             ),
             reverse=True,
         )
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def write_generic_web_rollback_plan_record(self, record: GenericWebRollbackPlanRecord) -> Path:
+        return self._write_model("generic_web_rollback_plans", record.plan_id, record)
+
+    def list_generic_web_rollback_plan_records(
+        self,
+        *,
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[GenericWebRollbackPlanRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                GenericWebRollbackPlanRecord, "generic_web_rollback_plans"
+            )
+            if (not context_name or record.context == context_name)
+            and (not instance_name or record.instance == instance_name)
+        ]
+        records.sort(key=lambda record: (record.created_at, record.plan_id), reverse=True)
         if limit is not None:
             records = records[:limit]
         return tuple(records)

--- a/control_plane/storage/migrations/versions/f6c7d8e9a0b1_add_generic_web_rollback_plans.py
+++ b/control_plane/storage/migrations/versions/f6c7d8e9a0b1_add_generic_web_rollback_plans.py
@@ -1,0 +1,51 @@
+"""add generic web rollback plans
+
+Revision ID: f6c7d8e9a0b1
+Revises: f5b6c7d8e9a0
+Create Date: 2026-05-19 00:35:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "f6c7d8e9a0b1"
+down_revision: str | None = "f5b6c7d8e9a0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "launchplane_generic_web_rollback_plans"
+_CONTEXT_INSTANCE_INDEX = "launchplane_generic_web_rollback_plans_context_instance_idx"
+
+
+def upgrade() -> None:
+    op.create_table(
+        _TABLE,
+        sa.Column("plan_id", sa.String(), nullable=False),
+        sa.Column("product", sa.String(), nullable=False),
+        sa.Column("context", sa.String(), nullable=False),
+        sa.Column("instance", sa.String(), nullable=False),
+        sa.Column("created_at", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("rollback_deployment_record_id", sa.String(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("plan_id"),
+    )
+    op.create_index(
+        _CONTEXT_INSTANCE_INDEX,
+        _TABLE,
+        ["context", "instance", sa.text("created_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(_CONTEXT_INSTANCE_INDEX, table_name=_TABLE)
+    op.drop_table(_TABLE)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -36,6 +36,7 @@ from control_plane.contracts.every_code_work_request import (
     claim_every_code_work_request,
 )
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
+from control_plane.contracts.generic_web_rollback import GenericWebRollbackPlanRecord
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
 from control_plane.contracts.merge_train_batch import (
@@ -147,6 +148,27 @@ class LaunchplaneDeploymentRow(Base):
     source_git_ref: Mapped[str] = mapped_column(String, nullable=False)
     deploy_started_at: Mapped[str] = mapped_column(String, nullable=False)
     deploy_finished_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneGenericWebRollbackPlanRow(Base):
+    __tablename__ = "launchplane_generic_web_rollback_plans"
+    __table_args__ = (
+        Index(
+            "launchplane_generic_web_rollback_plans_context_instance_idx",
+            "context",
+            "instance",
+            desc("created_at"),
+        ),
+    )
+
+    plan_id: Mapped[str] = mapped_column(String, primary_key=True)
+    product: Mapped[str] = mapped_column(String, nullable=False)
+    context: Mapped[str] = mapped_column(String, nullable=False)
+    instance: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    rollback_deployment_record_id: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -1408,6 +1430,43 @@ class PostgresRecordStore(HumanSessionStore):
                 LaunchplaneDeploymentRow.deploy_finished_at.desc(),
                 LaunchplaneDeploymentRow.deploy_started_at.desc(),
                 LaunchplaneDeploymentRow.record_id.desc(),
+            ),
+            limit=limit,
+        )
+
+    def write_generic_web_rollback_plan_record(self, record: GenericWebRollbackPlanRecord) -> None:
+        self._write_row(
+            LaunchplaneGenericWebRollbackPlanRow(
+                plan_id=record.plan_id,
+                product=record.product,
+                context=record.context,
+                instance=record.instance,
+                created_at=record.created_at,
+                status=record.status,
+                rollback_deployment_record_id=record.rollback_deployment_record_id,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def list_generic_web_rollback_plan_records(
+        self,
+        *,
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[GenericWebRollbackPlanRecord, ...]:
+        filters: list[object] = []
+        if context_name:
+            filters.append(LaunchplaneGenericWebRollbackPlanRow.context == context_name)
+        if instance_name:
+            filters.append(LaunchplaneGenericWebRollbackPlanRow.instance == instance_name)
+        return self._list_models(
+            model_type=GenericWebRollbackPlanRecord,
+            orm_model=LaunchplaneGenericWebRollbackPlanRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneGenericWebRollbackPlanRow.created_at.desc(),
+                LaunchplaneGenericWebRollbackPlanRow.plan_id.desc(),
             ),
             limit=limit,
         )

--- a/docs/dokploy-service-deployments.md
+++ b/docs/dokploy-service-deployments.md
@@ -172,13 +172,34 @@ Promotion uses the same artifact identity and target records. When health URLs
 exist, Launchplane verifies the source and destination lane health around the
 deployment and writes promotion evidence.
 
-Rollback is another Launchplane-owned deployment to a previous immutable image
-reference. Operators should choose the previous good image from Launchplane
-deployment, promotion, inventory, or release-tuple evidence and redeploy that
-exact digest. Do not roll back by clicking Dokploy to a mutable tag or by
-changing product-repo workflow state. A future product-specific rollback route
-can add one-click selection and product smoke evidence, but the durable rollback
-source remains the previous immutable image identity.
+Rollback begins with a Launchplane-owned rollback plan. The generic-web planner
+is a safe-write contract: it reads the product profile, destination lane, a
+Launchplane deployment record selected as the rollback target, and optional
+backup-gate evidence, then writes a rollback-plan record. It does not mutate
+Dokploy or trigger a product workflow.
+
+Required planner input:
+
+- `product`
+- destination `instance`, usually `prod`
+- `rollback_deployment_record_id`, pointing at the previous good deployment
+  record for that same context and instance
+- optional `backup_record_id` when the product/operator requires backup-gate
+  evidence before stable recovery
+
+The planner fails closed when the rollback target is missing, belongs to a
+different context or instance, has a failed deploy, has failed health evidence,
+or does not reference the product image repository by immutable `@sha256:`
+digest. If `backup_required=true`, the request must name a stored backup-gate
+record, and that record must match the destination lane and have `status=pass`.
+
+The produced `GenericWebRollbackPlanRecord` stores the selected immutable
+artifact identity, source git ref, planned generic-web deploy payload, backup
+gate evidence, target health evidence, blockers, and summary. A later explicit
+apply path can consume the ready plan and call the normal generic-web deploy
+route, but operators must not roll back by clicking Dokploy to a mutable tag or
+changing product-repo workflow state. The durable rollback source remains the
+Launchplane deployment record and its immutable image digest.
 
 ## Discord Blue Target
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -413,6 +413,13 @@ state/
   `rollback` and `rollback_health` fields. The selected rollback source is the
   DB-backed `testing` release tuple; operators must not supply unrecorded image
   refs or source SHAs.
+- Generic-web rollback planning writes `GenericWebRollbackPlanRecord` entries
+  under `generic_web_rollback_plans` in file-backed state and
+  `launchplane_generic_web_rollback_plans` in DB-backed state. These records are
+  safe-write plans, not provider mutations. They store the destination lane,
+  selected deployment-record id, immutable artifact identity, source git ref,
+  planned deploy payload, backup-gate evidence, target health evidence, and any
+  blockers that prevent a rollback apply.
 - Direct `ship` and `promote` execution fail closed if the referenced artifact
   id does not already have a stored manifest in control-plane state.
 - Artifact manifests may also carry `addon_selectors` metadata so operators can

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -16,6 +16,10 @@ from control_plane.contracts.deployment_record import DeploymentRecord, Resolved
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
+from control_plane.contracts.generic_web_rollback import (
+    GenericWebRollbackDeployPlan,
+    GenericWebRollbackPlanRecord,
+)
 from control_plane.contracts.merge_train_batch import (
     MergeTrainBatchCandidate,
     MergeTrainBatchCandidateRecord,
@@ -49,6 +53,7 @@ from control_plane.contracts.product_profile_record import (
 )
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
+    BackupGateEvidence,
     DeploymentEvidence,
     HealthcheckEvidence,
     PostDeployUpdateEvidence,
@@ -907,6 +912,52 @@ class FilesystemRecordStoreTests(unittest.TestCase):
                     "deployment-20260413T182231Z-opw-prod",
                     "deployment-20260411T182231Z-opw-prod",
                 ],
+            )
+
+    def test_write_and_list_generic_web_rollback_plan_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            older_record = GenericWebRollbackPlanRecord(
+                plan_id="rollback-plan-older",
+                product="sellyouroutboard",
+                context="sellyouroutboard-testing",
+                instance="prod",
+                status="ready",
+                rollback_deployment_record_id="deployment-syo-prod-older",
+                artifact_identity=ArtifactIdentityReference(
+                    artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:older"
+                ),
+                planned_deploy=GenericWebRollbackDeployPlan(
+                    product="sellyouroutboard",
+                    instance="prod",
+                    artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:older",
+                    source_git_ref="older",
+                ),
+                source_git_ref="older",
+                backup_gate=BackupGateEvidence(required=False, status="skipped"),
+                target_health=HealthcheckEvidence(status="pass"),
+                created_at="2026-05-01T21:00:00Z",
+                summary="generic web rollback plan is ready",
+            )
+            newer_record = older_record.model_copy(
+                update={
+                    "plan_id": "rollback-plan-newer",
+                    "rollback_deployment_record_id": "deployment-syo-prod-newer",
+                    "created_at": "2026-05-01T22:00:00Z",
+                }
+            )
+
+            written_path = store.write_generic_web_rollback_plan_record(older_record)
+            store.write_generic_web_rollback_plan_record(newer_record)
+
+            self.assertTrue(written_path.exists())
+            listed_records = store.list_generic_web_rollback_plan_records(
+                context_name="sellyouroutboard-testing", instance_name="prod"
+            )
+            self.assertEqual(
+                [record.plan_id for record in listed_records],
+                ["rollback-plan-newer", "rollback-plan-older"],
             )
 
     def test_artifacts_ingest_writes_manifest(self) -> None:

--- a/tests/test_generic_web_rollback.py
+++ b/tests/test_generic_web_rollback.py
@@ -1,0 +1,264 @@
+import unittest
+from typing import Literal, cast
+
+from pydantic import ValidationError
+
+from control_plane.contracts.backup_gate_record import BackupGateRecord
+from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
+from control_plane.contracts.generic_web_rollback import (
+    GenericWebRollbackPlanRequest,
+    build_generic_web_rollback_plan,
+    execute_generic_web_rollback_plan,
+)
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductImageProfile,
+    ProductLaneProfile,
+)
+from control_plane.contracts.promotion_record import ArtifactIdentityReference, HealthcheckEvidence
+from control_plane.contracts.runtime_identity import RuntimeIdentity
+from control_plane.contracts.ship_request import ShipRequest
+from control_plane.workflows.ship import build_deployment_record
+
+
+class _GenericWebRollbackStore:
+    def __init__(self, profile: LaunchplaneProductProfileRecord) -> None:
+        self.profile = profile
+        self.deployments: dict[str, DeploymentRecord] = {}
+        self.backup_gates: dict[str, BackupGateRecord] = {}
+        self.rollback_plans: list[object] = []
+
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
+        if product != self.profile.product:
+            raise FileNotFoundError(product)
+        return self.profile
+
+    def read_deployment_record(self, record_id: str) -> DeploymentRecord:
+        try:
+            return self.deployments[record_id]
+        except KeyError as exc:
+            raise FileNotFoundError(record_id) from exc
+
+    def read_backup_gate_record(self, record_id: str) -> BackupGateRecord:
+        try:
+            return self.backup_gates[record_id]
+        except KeyError as exc:
+            raise FileNotFoundError(record_id) from exc
+
+    def write_generic_web_rollback_plan_record(self, record: object) -> None:
+        self.rollback_plans.append(record)
+
+
+def _profile() -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord(
+        product="sellyouroutboard",
+        display_name="SellYourOutboard.com",
+        repository="cbusillo/sellyouroutboard",
+        driver_id="generic-web",
+        image=ProductImageProfile(repository="ghcr.io/cbusillo/sellyouroutboard"),
+        runtime_port=3000,
+        health_path="/api/health",
+        lanes=(
+            ProductLaneProfile(
+                instance="testing",
+                context="sellyouroutboard-testing",
+                base_url="https://testing.sellyouroutboard.com",
+            ),
+            ProductLaneProfile(
+                instance="prod",
+                context="sellyouroutboard-testing",
+                base_url="https://www.sellyouroutboard.com",
+            ),
+        ),
+        updated_at="2026-05-01T21:00:00Z",
+        source="test",
+    )
+
+
+def _request(**overrides: object) -> GenericWebRollbackPlanRequest:
+    payload: dict[str, object] = {
+        "product": "sellyouroutboard",
+        "instance": "prod",
+        "rollback_deployment_record_id": "deployment-syo-prod-previous",
+    }
+    payload.update(overrides)
+    return GenericWebRollbackPlanRequest.model_validate(payload)
+
+
+def _deployment_record(**overrides: object) -> DeploymentRecord:
+    artifact_id = cast(
+        str, overrides.pop("artifact_id", "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123")
+    )
+    source_git_ref = cast(str, overrides.pop("source_git_ref", "abc123"))
+    context = cast(str, overrides.pop("context", "sellyouroutboard-testing"))
+    instance = cast(str, overrides.pop("instance", "prod"))
+    destination_health = overrides.pop("destination_health", HealthcheckEvidence(status="pass"))
+    deploy_status = cast(
+        Literal["pending", "pass", "fail", "skipped"], overrides.pop("deploy_status", "pass")
+    )
+    runtime_identity = RuntimeIdentity(
+        product="sellyouroutboard",
+        context=context,
+        instance=instance,
+        deployment_record_id="deployment-syo-prod-previous",
+        artifact_id=artifact_id,
+        source_git_ref=source_git_ref,
+    )
+    ship_request = ShipRequest(
+        artifact_id=artifact_id,
+        context=context,
+        instance=instance,
+        source_git_ref=source_git_ref,
+        target_name="syo-prod-app",
+        target_type="application",
+        deploy_mode="dokploy-application-api",
+        verify_health=False,
+        destination_health=HealthcheckEvidence(status="skipped"),
+    )
+    deployment = build_deployment_record(
+        request=ship_request,
+        record_id="deployment-syo-prod-previous",
+        deployment_id="control-plane-dokploy",
+        deployment_status=deploy_status,
+        started_at="2026-05-01T21:00:00Z",
+        finished_at="2026-05-01T21:01:00Z",
+        resolved_target=ResolvedTargetEvidence(
+            target_type="application",
+            target_id="app-123",
+            target_name="syo-prod-app",
+        ),
+        runtime_identity=runtime_identity,
+    )
+    return deployment.model_copy(
+        update={
+            "artifact_identity": ArtifactIdentityReference(artifact_id=artifact_id),
+            "destination_health": destination_health,
+            **overrides,
+        }
+    )
+
+
+def _backup_gate(**overrides: object) -> BackupGateRecord:
+    payload: dict[str, object] = {
+        "record_id": "backup-syo-prod-pass",
+        "context": "sellyouroutboard-testing",
+        "instance": "prod",
+        "created_at": "2026-05-01T20:59:00Z",
+        "source": "test",
+        "required": True,
+        "status": "pass",
+        "evidence": {"snapshot": "syo-prod-20260501"},
+    }
+    payload.update(overrides)
+    return BackupGateRecord.model_validate(payload)
+
+
+class GenericWebRollbackPlanTests(unittest.TestCase):
+    def test_builds_ready_plan_from_previous_good_deployment_record(self) -> None:
+        store = _GenericWebRollbackStore(_profile())
+        store.deployments["deployment-syo-prod-previous"] = _deployment_record()
+
+        plan = build_generic_web_rollback_plan(record_store=store, request=_request())
+
+        self.assertEqual(plan.status, "ready")
+        self.assertEqual(plan.context, "sellyouroutboard-testing")
+        self.assertEqual(
+            plan.artifact_identity,
+            ArtifactIdentityReference(
+                artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123"
+            ),
+        )
+        self.assertIsNotNone(plan.planned_deploy)
+        planned_deploy = plan.planned_deploy
+        assert planned_deploy is not None
+        self.assertEqual(
+            planned_deploy.artifact_id,
+            "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+        )
+        self.assertEqual(planned_deploy.source_git_ref, "abc123")
+        self.assertEqual(plan.backup_gate.status, "skipped")
+
+    def test_execute_writes_ready_plan_record(self) -> None:
+        store = _GenericWebRollbackStore(_profile())
+        store.deployments["deployment-syo-prod-previous"] = _deployment_record()
+
+        plan = execute_generic_web_rollback_plan(record_store=store, request=_request())
+
+        self.assertEqual(plan.status, "ready")
+        self.assertEqual(store.rollback_plans, [plan])
+
+    def test_blocks_missing_rollback_target(self) -> None:
+        store = _GenericWebRollbackStore(_profile())
+
+        plan = build_generic_web_rollback_plan(record_store=store, request=_request())
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(plan.planned_deploy, None)
+        self.assertEqual([blocker.code for blocker in plan.blockers], ["missing_rollback_target"])
+
+    def test_blocks_failed_health_evidence(self) -> None:
+        store = _GenericWebRollbackStore(_profile())
+        store.deployments["deployment-syo-prod-previous"] = _deployment_record(
+            destination_health=HealthcheckEvidence(
+                verified=True,
+                urls=("https://www.sellyouroutboard.com/api/health",),
+                timeout_seconds=60,
+                status="fail",
+            )
+        )
+
+        plan = build_generic_web_rollback_plan(record_store=store, request=_request())
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(plan.target_health.status, "fail")
+        self.assertEqual([blocker.code for blocker in plan.blockers], ["health_evidence_failed"])
+
+    def test_blocks_backup_gate_required_but_missing(self) -> None:
+        store = _GenericWebRollbackStore(_profile())
+        store.deployments["deployment-syo-prod-previous"] = _deployment_record()
+
+        plan = build_generic_web_rollback_plan(
+            record_store=store,
+            request=_request(backup_required=True, backup_record_id="backup-syo-prod-pass"),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(plan.backup_record_id, "backup-syo-prod-pass")
+        self.assertEqual([blocker.code for blocker in plan.blockers], ["backup_gate_missing"])
+
+    def test_request_rejects_backup_required_without_record_id(self) -> None:
+        with self.assertRaises(ValidationError) as caught:
+            _request(backup_required=True)
+
+        self.assertIn("requires backup_record_id", str(caught.exception))
+
+    def test_allows_passing_backup_gate_for_destination_lane(self) -> None:
+        store = _GenericWebRollbackStore(_profile())
+        store.deployments["deployment-syo-prod-previous"] = _deployment_record()
+        store.backup_gates["backup-syo-prod-pass"] = _backup_gate()
+
+        plan = build_generic_web_rollback_plan(
+            record_store=store,
+            request=_request(backup_required=True, backup_record_id="backup-syo-prod-pass"),
+        )
+
+        self.assertEqual(plan.status, "ready")
+        self.assertEqual(plan.backup_gate.status, "pass")
+        self.assertEqual(plan.backup_gate.evidence, {"snapshot": "syo-prod-20260501"})
+
+    def test_blocks_mutable_artifact_reference(self) -> None:
+        store = _GenericWebRollbackStore(_profile())
+        store.deployments["deployment-syo-prod-previous"] = _deployment_record(
+            artifact_id="ghcr.io/cbusillo/sellyouroutboard:latest"
+        )
+
+        plan = build_generic_web_rollback_plan(record_store=store, request=_request())
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(
+            [blocker.code for blocker in plan.blockers], ["mutable_artifact_reference"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -31,6 +31,10 @@ from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
 from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
+from control_plane.contracts.generic_web_rollback import (
+    GenericWebRollbackDeployPlan,
+    GenericWebRollbackPlanRecord,
+)
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.idempotency_record import build_launchplane_idempotency_record_id
 from control_plane.contracts.merge_train_batch import (
@@ -94,7 +98,9 @@ from control_plane.contracts.product_profile_record import (
 )
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
+    BackupGateEvidence,
     DeploymentEvidence,
+    HealthcheckEvidence,
     PromotionRecord,
 )
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
@@ -187,6 +193,33 @@ def _deployment_record(*, record_id: str, started_at: str, finished_at: str) -> 
             started_at=started_at,
             finished_at=finished_at,
         ),
+    )
+
+
+def _generic_web_rollback_plan_record(
+    *, plan_id: str, created_at: str
+) -> GenericWebRollbackPlanRecord:
+    return GenericWebRollbackPlanRecord(
+        plan_id=plan_id,
+        product="sellyouroutboard",
+        context="sellyouroutboard-testing",
+        instance="prod",
+        status="ready",
+        rollback_deployment_record_id="deployment-syo-prod-previous",
+        artifact_identity=ArtifactIdentityReference(
+            artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123"
+        ),
+        planned_deploy=GenericWebRollbackDeployPlan(
+            product="sellyouroutboard",
+            instance="prod",
+            artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+            source_git_ref="abc123",
+        ),
+        source_git_ref="abc123",
+        backup_gate=BackupGateEvidence(required=False, status="skipped"),
+        target_health=HealthcheckEvidence(status="pass"),
+        created_at=created_at,
+        summary="generic web rollback plan is ready",
     )
 
 
@@ -1052,6 +1085,36 @@ class PostgresRecordStoreTests(unittest.TestCase):
         resolved_target = loaded_record.resolved_target
         assert resolved_target is not None
         self.assertEqual(resolved_target.target_id, "compose-123")
+
+    def test_write_and_list_generic_web_rollback_plan_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_generic_web_rollback_plan_record(
+                _generic_web_rollback_plan_record(
+                    plan_id="rollback-plan-older",
+                    created_at="2026-05-01T21:00:00Z",
+                )
+            )
+            store.write_generic_web_rollback_plan_record(
+                _generic_web_rollback_plan_record(
+                    plan_id="rollback-plan-newer",
+                    created_at="2026-05-01T22:00:00Z",
+                )
+            )
+            listed_records = store.list_generic_web_rollback_plan_records(
+                context_name="sellyouroutboard-testing", instance_name="prod"
+            )
+            store.close()
+
+        self.assertEqual(
+            [record.plan_id for record in listed_records],
+            ["rollback-plan-newer", "rollback-plan-older"],
+        )
 
     def test_list_preview_records_filters_and_limits(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add a safe-write generic-web rollback planner contract that resolves a rollback target from Launchplane deployment records
- persist rollback plan records in filesystem and DB-backed storage, with Alembic migration coverage
- document generic-web rollback inputs, safety checks, produced records, and backup-gate behavior

## Validation
- `uv run --extra dev ruff check control_plane/contracts/generic_web_rollback.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/f6c7d8e9a0b1_add_generic_web_rollback_plans.py tests/test_generic_web_rollback.py tests/test_filesystem_store.py tests/test_postgres_store.py`
- `uv run --extra dev ruff format --check control_plane/contracts/generic_web_rollback.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/f6c7d8e9a0b1_add_generic_web_rollback_plans.py tests/test_generic_web_rollback.py tests/test_filesystem_store.py tests/test_postgres_store.py`
- `uv run --extra dev mypy control_plane/contracts/generic_web_rollback.py control_plane/storage/filesystem.py control_plane/storage/postgres.py tests/test_generic_web_rollback.py tests/test_filesystem_store.py tests/test_postgres_store.py`
- `uv run python -m unittest tests.test_generic_web_rollback tests.test_filesystem_store tests.test_postgres_store.PostgresRecordStoreTests.test_write_and_list_generic_web_rollback_plan_records tests.test_postgres_store.PostgresRecordStoreTests.test_alembic_baseline_creates_schema_used_by_record_store tests.test_postgres_store.PostgresRecordStoreTests.test_alembic_baseline_downgrades_to_empty_schema`
- `uv run python -m unittest`

## Inspection
- JetBrains changed-files inspection still reports existing `CliRunner` typing warnings in broad test files and SQLAlchemy generic helper inspection errors in `control_plane/storage/postgres.py`; the new rollback contract warnings were cleaned up, and Ruff/mypy/unit gates pass.

Closes #511.
