### PR TITLE
Fix preview decision environment fallback

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -9985,14 +9985,12 @@ def work_graph_runner_queue_wait(
 @click.option(
     "--event-name",
     type=click.Choice(("pull_request", "pull_request_target", "workflow_dispatch")),
-    default="",
     help="GitHub event name. Defaults to GITHUB_EVENT_NAME when set.",
 )
 @click.option("--action", "event_action", default="", help="GitHub event action.")
 @click.option(
     "--operation",
-    type=click.Choice(("refresh", "destroy", "")),
-    default="",
+    type=click.Choice(("refresh", "destroy")),
     help="Manual workflow_dispatch preview operation.",
 )
 @click.option("--repository", default="", help="Current owner/name repository.")
@@ -10025,9 +10023,9 @@ def work_graph_runner_queue_wait(
 )
 def work_graph_preview_workflow_decision(
     event_file: Path | None,
-    event_name: PreviewWorkflowEventName | str,
+    event_name: PreviewWorkflowEventName | str | None,
     event_action: str,
-    operation: PreviewWorkflowOperation | str,
+    operation: PreviewWorkflowOperation | str | None,
     repository: str,
     anchor_repo: str,
     anchor_pr_number: int | None,
@@ -10330,9 +10328,9 @@ def _load_preview_workflow_github_event(event_file: Path | None) -> dict[str, ob
 def _build_preview_workflow_event(
     *,
     github_event: dict[str, object],
-    event_name: PreviewWorkflowEventName | str,
+    event_name: PreviewWorkflowEventName | str | None,
     event_action: str,
-    operation: PreviewWorkflowOperation | str,
+    operation: PreviewWorkflowOperation | str | None,
     repository: str,
     anchor_repo: str,
     anchor_pr_number: int | None,
@@ -10356,11 +10354,13 @@ def _build_preview_workflow_event(
     resolved_labels = label_names or _preview_workflow_label_names(
         pull_request.get("labels")
     )
-    resolved_event_name = event_name.strip() or os.environ.get("GITHUB_EVENT_NAME", "")
+    resolved_event_name = _preview_workflow_string(event_name) or os.environ.get(
+        "GITHUB_EVENT_NAME", ""
+    )
     resolved_action = event_action.strip() or _preview_workflow_string(
         github_event.get("action")
     )
-    resolved_operation = operation.strip() or _preview_workflow_string(
+    resolved_operation = _preview_workflow_string(operation) or _preview_workflow_string(
         input_payload.get("operation")
     )
     resolved_repository = repository.strip() or _preview_workflow_repository_name(

--- a/tests/test_preview_workflow_contract.py
+++ b/tests/test_preview_workflow_contract.py
@@ -204,6 +204,58 @@ class PreviewWorkflowDecisionCliTests(unittest.TestCase):
             "preview-workflow:sell-your-outboard:sellyouroutboard-testing:refresh:pr-105:123456:2",
         )
 
+    def test_cli_uses_github_environment_when_event_options_are_omitted(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            event_file = Path(temp_dir) / "event.json"
+            event_file.write_text(
+                json.dumps(
+                    {
+                        "action": "synchronize",
+                        "repository": {"full_name": "cbusillo/sellyouroutboard"},
+                        "pull_request": {
+                            "number": 108,
+                            "labels": [{"name": "preview"}],
+                            "base": {
+                                "repo": {"full_name": "cbusillo/sellyouroutboard"},
+                            },
+                            "head": {
+                                "repo": {"full_name": "cbusillo/sellyouroutboard"},
+                                "sha": "def456",
+                            },
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = CliRunner().invoke(
+                CLI_MAIN,
+                [
+                    "work-graph",
+                    "preview-workflow-decision",
+                    "--actor",
+                    "cbusillo",
+                    "--product",
+                    "sell-your-outboard",
+                    "--context",
+                    "sellyouroutboard-testing",
+                    "--run-id",
+                    "123459",
+                    "--run-attempt",
+                    "1",
+                ],
+                env={
+                    "GITHUB_EVENT_NAME": "pull_request",
+                    "GITHUB_EVENT_PATH": str(event_file),
+                },
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["event"]["anchor_pr_number"], 108)
+        self.assertEqual(payload["event"]["event_name"], "pull_request")
+        self.assertEqual(payload["decision"]["operation"], "refresh")
+
     def test_cli_reports_unsupported_notice_without_untrusted_checkout(self) -> None:
         result = CliRunner().invoke(
             CLI_MAIN,


### PR DESCRIPTION
## Summary
- Fix `work-graph preview-workflow-decision` so omitted choice options can fall back to `GITHUB_EVENT_NAME` / event payload inputs.
- Add a CLI regression covering the documented GitHub Actions environment mode.

## Validation
- `uv run --extra dev ruff check --diff control_plane/cli.py tests/test_preview_workflow_contract.py`
- `uv run --extra dev ruff check control_plane/cli.py tests/test_preview_workflow_contract.py`
- `uv run --extra dev mypy control_plane/cli.py tests/test_preview_workflow_contract.py`
- `uv run python -m unittest tests.test_preview_workflow_contract`
- `uv run python -m unittest`

JetBrains changed-files inspection was run and returned existing frontend CSS inspection noise unrelated to these Python changes.
