### PR TITLE
Expose artifact provenance in lane read models

### DIFF
--- a/control_plane/contracts/lane_summary.py
+++ b/control_plane/contracts/lane_summary.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, ConfigDict
 
+from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.data_provenance import DataProvenance
 from control_plane.contracts.deployment_record import DeploymentRecord
@@ -19,6 +20,7 @@ class LaunchplaneLaneSummary(BaseModel):
     context: str
     instance: str
     inventory: EnvironmentInventory | None = None
+    artifact_manifest: ArtifactIdentityManifest | None = None
     release_tuple: ReleaseTupleRecord | None = None
     latest_deployment: DeploymentRecord | None = None
     latest_promotion: PromotionRecord | None = None

--- a/control_plane/contracts/product_environment_read_model.py
+++ b/control_plane/contracts/product_environment_read_model.py
@@ -5,6 +5,7 @@ from typing import Literal, Protocol
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
 from control_plane.contracts.data_provenance import DataProvenance, FreshnessStatus
 from control_plane.contracts.driver_descriptor import DriverActionDescriptor, DriverDescriptor
 from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
@@ -130,6 +131,7 @@ class ProductTargetSummary(BaseModel):
     target_type: str = ""
     target_name: str = ""
     target_id_recorded: bool = False
+    artifact_manifest: ArtifactIdentityManifest | None = None
     expected_runtime_identity: RuntimeIdentity | None = None
     observed_runtime_identity: RuntimeIdentity | None = None
     runtime_identity_status: RuntimeIdentityStatus = "unchecked"
@@ -1486,6 +1488,7 @@ def _target_summary(lane_summary: LaunchplaneLaneSummary | None) -> ProductTarge
         destination_health = lane_summary.latest_deployment.destination_health
     if lane_summary.dokploy_target is None:
         return ProductTargetSummary(
+            artifact_manifest=lane_summary.artifact_manifest,
             expected_runtime_identity=expected_identity,
             observed_runtime_identity=destination_health.observed_runtime_identity
             if destination_health is not None
@@ -1502,6 +1505,7 @@ def _target_summary(lane_summary: LaunchplaneLaneSummary | None) -> ProductTarge
         target_type=lane_summary.dokploy_target.target_type,
         target_name=lane_summary.dokploy_target.target_name,
         target_id_recorded=lane_summary.dokploy_target_id is not None,
+        artifact_manifest=lane_summary.artifact_manifest,
         expected_runtime_identity=expected_identity,
         observed_runtime_identity=destination_health.observed_runtime_identity
         if destination_health is not None

--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 from fnmatch import fnmatchcase
 from typing import Literal, Protocol, cast
 
+from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.data_provenance import DataProvenance, FreshnessStatus
 from control_plane.contracts.deployment_record import DeploymentRecord
@@ -46,6 +47,10 @@ class _ListProductProfileRecords(Protocol):
 
 class _ReadLaneSummary(Protocol):
     def __call__(self, *, context_name: str, instance_name: str) -> LaunchplaneLaneSummary: ...
+
+
+class _ReadArtifactManifest(Protocol):
+    def __call__(self, artifact_id: str) -> ArtifactIdentityManifest: ...
 
 
 class _ReadEnvironmentInventory(Protocol):
@@ -122,6 +127,13 @@ def _read_lane_summary_method(record_store: object) -> _ReadLaneSummary | None:
     return cast(
         _ReadLaneSummary | None,
         _callable_store_method(record_store, "read_lane_summary"),
+    )
+
+
+def _read_artifact_manifest_method(record_store: object) -> _ReadArtifactManifest | None:
+    return cast(
+        _ReadArtifactManifest | None,
+        _callable_store_method(record_store, "read_artifact_manifest"),
     )
 
 
@@ -208,6 +220,17 @@ def _optional_read_environment_inventory(
 ) -> EnvironmentInventory | None:
     try:
         return method(context_name=context_name, instance_name=instance_name)
+    except FileNotFoundError:
+        return None
+
+
+def _optional_read_artifact_manifest(
+    method: _ReadArtifactManifest, *, artifact_id: str
+) -> ArtifactIdentityManifest | None:
+    if not artifact_id.strip():
+        return None
+    try:
+        return method(artifact_id.strip())
     except FileNotFoundError:
         return None
 
@@ -1076,6 +1099,16 @@ def _read_lane_summary(
         latest_deployment=latest_deployment,
     ):
         inventory = None
+    artifact_manifest = None
+    read_artifact_manifest = _read_artifact_manifest_method(record_store)
+    if read_artifact_manifest is not None:
+        artifact_manifest = _optional_read_artifact_manifest(
+            read_artifact_manifest,
+            artifact_id=_lane_artifact_id(
+                inventory=inventory,
+                latest_deployment=latest_deployment,
+            ),
+        )
     latest_promotion = None
     list_promotions = _list_promotion_records_method(record_store)
     if list_promotions is not None:
@@ -1107,6 +1140,7 @@ def _read_lane_summary(
         context=context_name,
         instance=instance_name,
         inventory=inventory,
+        artifact_manifest=artifact_manifest,
         release_tuple=release_tuple,
         latest_deployment=latest_deployment,
         latest_promotion=latest_promotion,
@@ -1130,6 +1164,20 @@ def _inventory_is_older_than_deployment(
     if inventory_updated_at is None or deployment_recorded_at is None:
         return inventory.deployment_record_id != latest_deployment.record_id
     return inventory_updated_at < deployment_recorded_at
+
+
+def _lane_artifact_id(
+    *,
+    inventory: EnvironmentInventory | None,
+    latest_deployment: DeploymentRecord | None,
+) -> str:
+    if inventory is not None and inventory.artifact_identity is not None:
+        inventory_artifact_id = inventory.artifact_identity.artifact_id.strip()
+        if inventory_artifact_id:
+            return inventory_artifact_id
+    if latest_deployment is not None and latest_deployment.artifact_identity is not None:
+        return latest_deployment.artifact_identity.artifact_id.strip()
+    return ""
 
 
 def _list_preview_summaries(

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -923,6 +923,20 @@ def _artifact_id_from_model(model: BaseModel) -> str:
     return artifact_id if isinstance(artifact_id, str) else ""
 
 
+def _artifact_id_for_lane(
+    *,
+    inventory: EnvironmentInventory | None,
+    latest_deployment: DeploymentRecord | None,
+) -> str:
+    if inventory is not None and inventory.artifact_identity is not None:
+        inventory_artifact_id = inventory.artifact_identity.artifact_id.strip()
+        if inventory_artifact_id:
+            return inventory_artifact_id
+    if latest_deployment is not None and latest_deployment.artifact_identity is not None:
+        return latest_deployment.artifact_identity.artifact_id.strip()
+    return ""
+
+
 def _human_session_payload(session: LaunchplaneHumanSession) -> PayloadDict:
     return {
         "session_id": session.session_id,
@@ -2708,17 +2722,33 @@ class PostgresRecordStore(HumanSessionStore):
                 instance_name=instance_name,
             ),
         )
+        inventory = self._read_optional_model(
+            model_type=EnvironmentInventory,
+            orm_model=LaunchplaneInventoryRow,
+            filters=(
+                LaunchplaneInventoryRow.context == context_name,
+                LaunchplaneInventoryRow.instance == instance_name,
+            ),
+        )
+        latest_deployment = next(
+            iter(
+                self.list_deployment_records(
+                    context_name=context_name,
+                    instance_name=instance_name,
+                    limit=1,
+                )
+            ),
+            None,
+        )
+        artifact_manifest = self._read_optional_artifact_manifest(
+            inventory=inventory,
+            latest_deployment=latest_deployment,
+        )
         return LaunchplaneLaneSummary(
             context=context_name,
             instance=instance_name,
-            inventory=self._read_optional_model(
-                model_type=EnvironmentInventory,
-                orm_model=LaunchplaneInventoryRow,
-                filters=(
-                    LaunchplaneInventoryRow.context == context_name,
-                    LaunchplaneInventoryRow.instance == instance_name,
-                ),
-            ),
+            inventory=inventory,
+            artifact_manifest=artifact_manifest,
             release_tuple=self._read_optional_model(
                 model_type=ReleaseTupleRecord,
                 orm_model=LaunchplaneReleaseTupleRow,
@@ -2727,16 +2757,7 @@ class PostgresRecordStore(HumanSessionStore):
                     LaunchplaneReleaseTupleRow.channel == instance_name,
                 ),
             ),
-            latest_deployment=next(
-                iter(
-                    self.list_deployment_records(
-                        context_name=context_name,
-                        instance_name=instance_name,
-                        limit=1,
-                    )
-                ),
-                None,
-            ),
+            latest_deployment=latest_deployment,
             latest_promotion=next(
                 iter(
                     self.list_promotion_records(
@@ -2787,6 +2808,23 @@ class PostgresRecordStore(HumanSessionStore):
                 instance_name=instance_name,
             ),
         )
+
+    def _read_optional_artifact_manifest(
+        self,
+        *,
+        inventory: EnvironmentInventory | None,
+        latest_deployment: DeploymentRecord | None,
+    ) -> ArtifactIdentityManifest | None:
+        artifact_id = _artifact_id_for_lane(
+            inventory=inventory,
+            latest_deployment=latest_deployment,
+        )
+        if not artifact_id:
+            return None
+        try:
+            return self.read_artifact_manifest(artifact_id)
+        except FileNotFoundError:
+            return None
 
     def write_odoo_instance_override_record(self, record: OdooInstanceOverrideRecord) -> None:
         self._write_row(

--- a/docs/records.md
+++ b/docs/records.md
@@ -431,6 +431,11 @@ state/
   `odoo-shared-addons`, and `disable_odoo_online` stay support/dependency repos,
   while Launchplane records the immutable image/build refs used to produce an
   artifact.
+- Lane and driver read models expose the current lane's stored artifact manifest
+  when the inventory or latest deployment points to one. Operators can inspect
+  the Odoo base-image digests/tags/source refs and `odoo-devkit` provenance from
+  Launchplane read evidence without treating support repos as release-tuple
+  owners.
 - For a second product such as VeriReel, the first Launchplane onboarding slice
   should ingest deployment evidence from that product's existing release
   workflows into this record shape before Launchplane owns the deploy execution.

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -2048,6 +2048,7 @@ env_var = "GH_TOKEN"
                 )
             )
             store.ensure_schema()
+            store.write_artifact_manifest(_artifact_manifest())
             store.write_environment_inventory(_inventory_record())
             store.write_deployment_record(
                 _deployment_record(
@@ -2105,6 +2106,10 @@ env_var = "GH_TOKEN"
         inventory_artifact_identity = inventory.artifact_identity
         assert inventory_artifact_identity is not None
         self.assertEqual(inventory_artifact_identity.artifact_id, "artifact-20260420-a1b2c3d4")
+        artifact_manifest = summary.artifact_manifest
+        assert artifact_manifest is not None
+        self.assertEqual(artifact_manifest.artifact_id, "artifact-20260420-a1b2c3d4")
+        self.assertEqual(artifact_manifest.image.repository, "ghcr.io/cbusillo/odoo-tenant-opw")
         release_tuple = summary.release_tuple
         assert release_tuple is not None
         self.assertEqual(release_tuple.channel, "testing")

--- a/tests/test_product_environment_read_model.py
+++ b/tests/test_product_environment_read_model.py
@@ -6,6 +6,13 @@ from types import SimpleNamespace
 from typing import cast
 import unittest
 
+from control_plane.contracts.artifact_identity import (
+    ArtifactBaseImageProvenance,
+    ArtifactBuildProvenance,
+    ArtifactBuildToolProvenance,
+    ArtifactIdentityManifest,
+    ArtifactImageReference,
+)
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.product_environment_read_model import (
@@ -160,6 +167,35 @@ class _RuntimeIdentityReadModelStore(_PreviewRecordStore):
     ) -> None:
         super().__init__(profile, ())
         self._inventory = inventory
+        self._artifact_manifest = ArtifactIdentityManifest(
+            artifact_id="ghcr.io/every/example-site@sha256:abc123",
+            source_commit="abc123",
+            enterprise_base_digest="sha256:enterprise",
+            image=ArtifactImageReference(
+                repository="ghcr.io/every/example-site",
+                digest="sha256:abc123",
+            ),
+            build_provenance=ArtifactBuildProvenance(
+                base_images=(
+                    ArtifactBaseImageProvenance(
+                        role="runtime",
+                        image=ArtifactImageReference(
+                            repository="ghcr.io/cbusillo/odoo-runtime",
+                            digest="sha256:runtime",
+                        ),
+                        source_repository="cbusillo/odoo-docker",
+                        source_ref="1111111111111111111111111111111111111111",
+                    ),
+                ),
+                build_tools=(
+                    ArtifactBuildToolProvenance(
+                        name="odoo-devkit",
+                        source_repository="cbusillo/odoo-devkit",
+                        source_ref="2222222222222222222222222222222222222222",
+                    ),
+                ),
+            ),
+        )
 
     def read_environment_inventory(
         self, *, context_name: str, instance_name: str
@@ -167,6 +203,11 @@ class _RuntimeIdentityReadModelStore(_PreviewRecordStore):
         if context_name == self._inventory.context and instance_name == self._inventory.instance:
             return self._inventory
         raise FileNotFoundError(f"{context_name}/{instance_name}")
+
+    def read_artifact_manifest(self, artifact_id: str) -> ArtifactIdentityManifest:
+        if artifact_id == self._artifact_manifest.artifact_id:
+            return self._artifact_manifest
+        raise FileNotFoundError(artifact_id)
 
 
 class _ActivityRecordStore(_PreviewRecordStore):
@@ -781,6 +822,51 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
         self.assertEqual(detail.target.expected_runtime_identity, expected)
         self.assertEqual(detail.target.observed_runtime_identity, expected)
         self.assertEqual(detail.target.runtime_identity_status, "match")
+
+    def test_driver_lane_summary_exposes_artifact_build_provenance(self) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(
+            _site_profile_payload(preview_enabled=False)
+        )
+        inventory = EnvironmentInventory(
+            context="example-site-prod",
+            instance="prod",
+            artifact_identity=ArtifactIdentityReference(
+                artifact_id="ghcr.io/every/example-site@sha256:abc123"
+            ),
+            source_git_ref="abc123",
+            deploy=DeploymentEvidence(
+                target_name="example-site-prod",
+                target_type="application",
+                deploy_mode="dokploy-application-api",
+                deployment_id="control-plane-dokploy",
+                status="pass",
+                started_at="2026-05-02T10:00:00Z",
+                finished_at="2026-05-02T10:01:00Z",
+            ),
+            updated_at="2026-05-02T10:01:00Z",
+            deployment_record_id="deployment-prod-1",
+        )
+        store = _RuntimeIdentityReadModelStore(profile, inventory)
+
+        detail = build_product_environment_detail(
+            record_store=store,
+            product="example-site",
+            environment="prod",
+            action_allowed=lambda *_: False,
+        )
+
+        artifact_manifest = detail.target.artifact_manifest
+        assert artifact_manifest is not None
+        self.assertEqual(
+            artifact_manifest.build_provenance.base_images[0].source_repository,
+            "cbusillo/odoo-docker",
+        )
+        self.assertEqual(
+            artifact_manifest.build_provenance.build_tools[0].name,
+            "odoo-devkit",
+        )
+        self.assertIn("odoo-devkit", detail.model_dump_json())
+
 
     def test_product_environment_config_status_reports_expected_key_states(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- expose stored artifact manifests on lane summaries and product target read models
- teach driver/Postgres lane summaries to resolve the manifest from inventory or latest deployment artifact identity
- document the operator-facing provenance read evidence and cover it in product environment/Postgres tests

Refs #513.

## Validation
- `uv run --extra dev ruff check control_plane/storage/postgres.py control_plane/contracts/lane_summary.py control_plane/contracts/product_environment_read_model.py control_plane/drivers/registry.py tests/test_postgres_store.py tests/test_product_environment_read_model.py`
- `uv run --extra dev mypy control_plane/storage/postgres.py control_plane/contracts/lane_summary.py control_plane/contracts/product_environment_read_model.py control_plane/drivers/registry.py tests/test_postgres_store.py tests/test_product_environment_read_model.py`
- `uv run python -m unittest tests.test_product_environment_read_model tests.test_postgres_store tests.test_driver_descriptors tests.test_odoo_artifact_publish tests.test_release_tuples`
- `uv run python -m unittest`

## Inspection
- JetBrains changed-files inspection still reports pre-existing weak/type warnings in `product_environment_read_model.py` and Click test helper typing; no new behavior blocker found.
