### PR TITLE
Document Odoo base image promotion owner

### DIFF
--- a/docs/records.md
+++ b/docs/records.md
@@ -431,6 +431,13 @@ state/
   `odoo-shared-addons`, and `disable_odoo_online` stay support/dependency repos,
   while Launchplane records the immutable image/build refs used to produce an
   artifact.
+- `odoo-docker` owns Odoo base-image build and promotion across its own
+  candidate, testing, and stable image tracks. Launchplane does not create a
+  separate base-image promotion record today; it consumes the selected
+  base-image digest, tag, source repository, and source ref from the artifact
+  manifest and carries that evidence through deploy, inventory, and read-model
+  records. Add a Launchplane-owned base-image promotion record only if
+  Launchplane starts deciding or executing those image-track promotions itself.
 - Lane and driver read models expose the current lane's stored artifact manifest
   when the inventory or latest deployment points to one. Operators can inspect
   the Odoo base-image digests/tags/source refs and `odoo-devkit` provenance from

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+from unittest import TestCase
+
+
+class DocsContractsTests(TestCase):
+    def test_odoo_base_image_promotion_owner_is_documented(self) -> None:
+        records_doc = Path("docs/records.md").read_text(encoding="utf-8")
+
+        self.assertIn("odoo-docker` owns Odoo base-image build and promotion", records_doc)
+        self.assertIn("candidate, testing, and stable image tracks", records_doc)
+        self.assertIn("Launchplane does not create a", records_doc)
+        self.assertIn("separate base-image promotion record today", records_doc)
+        self.assertIn("Add a Launchplane-owned base-image promotion record only if", records_doc)


### PR DESCRIPTION
## Summary
- document `odoo-docker` as the owner of Odoo base-image candidate/testing/stable promotion
- clarify that Launchplane consumes selected base-image provenance from artifact manifests instead of creating a first-class base-image promotion record today
- add a docs contract test so the ownership boundary stays explicit

Closes #728.

## Validation
- `uv run --extra dev ruff check tests/test_docs_contracts.py`
- `uv run --extra dev mypy tests/test_docs_contracts.py`
- `uv run python -m unittest tests.test_docs_contracts`
- `uv run python -m unittest`

## Inspection
- JetBrains changed-files inspection reported known unrelated frontend CSS findings; this branch only changes `docs/records.md` and `tests/test_docs_contracts.py`.
