### PR TITLE
Add Odoo preview runtime planner

### DIFF
--- a/control_plane/contracts/odoo_preview_runtime_plan.py
+++ b/control_plane/contracts/odoo_preview_runtime_plan.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+OdooPreviewRuntimeOperation = Literal["refresh", "destroy"]
+OdooPreviewRuntimeStrategy = Literal[
+    "isolated_dokploy_compose",
+    "staged_compose_mvp",
+    "unknown",
+]
+OdooPreviewRuntimePlanStatus = Literal["ready", "blocked"]
+OdooPreviewRuntimeTargetKind = Literal["preview", "testing", "stable", "prod", "unknown"]
+OdooPreviewRuntimeBindingSource = Literal[
+    "runtime_environment",
+    "managed_secret",
+    "generated",
+    "artifact_manifest",
+    "default",
+]
+OdooPreviewRuntimeBindingScope = Literal["preview", "non_prod", "prod"]
+OdooPreviewRuntimeBlockerCode = Literal[
+    "default_credential_binding",
+    "destroy_target_missing",
+    "provider_capability_missing",
+    "runtime_env_missing",
+    "runtime_strategy_not_isolated",
+    "runtime_target_not_preview",
+    "runtime_target_slug_mismatch",
+    "preview_url_missing",
+    "prod_secret_binding",
+    "refresh_artifact_missing",
+    "refresh_source_missing",
+]
+
+
+_SENSITIVE_DEFAULT_KEYS = frozenset(
+    {
+        "ADMIN_PASSWD",
+        "ODOO_ADMIN_PASSWORD",
+        "ODOO_DB_PASSWORD",
+        "ODOO_MASTER_PASSWORD",
+        "POSTGRES_PASSWORD",
+    }
+)
+
+
+class OdooPreviewProviderCapabilities(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    can_create_compose: bool = False
+    can_update_compose_env: bool = False
+    can_deploy_compose: bool = False
+    can_bind_domain: bool = False
+    can_delete_compose: bool = False
+    can_delete_domain: bool = False
+
+
+class OdooPreviewRuntimeBindingEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    source: OdooPreviewRuntimeBindingSource
+    scope: OdooPreviewRuntimeBindingScope = "preview"
+    present: bool = True
+
+    @model_validator(mode="after")
+    def _normalize_binding(self) -> "OdooPreviewRuntimeBindingEvidence":
+        self.key = _required_text(self.key, "Odoo preview runtime binding requires key")
+        return self
+
+
+class OdooPreviewRuntimeTargetEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    target_type: Literal["dokploy_compose"] = "dokploy_compose"
+    target_id: str
+    target_name: str
+    context: str
+    instance: str
+    environment_kind: OdooPreviewRuntimeTargetKind = "unknown"
+    domain: str = ""
+
+    @model_validator(mode="after")
+    def _normalize_target(self) -> "OdooPreviewRuntimeTargetEvidence":
+        self.target_id = _required_text(
+            self.target_id, "Odoo preview runtime target requires target_id"
+        )
+        self.target_name = _required_text(
+            self.target_name, "Odoo preview runtime target requires target_name"
+        )
+        self.context = _required_text(self.context, "Odoo preview runtime target requires context")
+        self.instance = _required_text(
+            self.instance, "Odoo preview runtime target requires instance"
+        )
+        self.domain = self.domain.strip().lower()
+        return self
+
+
+class OdooPreviewRuntimePlanRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    operation: OdooPreviewRuntimeOperation
+    product: str
+    repository: str
+    pr_number: int = Field(ge=1)
+    preview_slug: str
+    preview_url: str = ""
+    strategy: OdooPreviewRuntimeStrategy = "unknown"
+    image_reference: str = ""
+    source_git_ref: str = ""
+    target: OdooPreviewRuntimeTargetEvidence | None = None
+    provider_capabilities: OdooPreviewProviderCapabilities = Field(
+        default_factory=OdooPreviewProviderCapabilities
+    )
+    runtime_bindings: tuple[OdooPreviewRuntimeBindingEvidence, ...] = ()
+    required_runtime_keys: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def _normalize_request(self) -> "OdooPreviewRuntimePlanRequest":
+        self.product = _required_text(self.product, "Odoo preview runtime plan requires product")
+        self.repository = _required_text(
+            self.repository, "Odoo preview runtime plan requires repository"
+        )
+        self.preview_slug = _required_text(
+            self.preview_slug, "Odoo preview runtime plan requires preview_slug"
+        )
+        self.preview_url = self.preview_url.strip()
+        self.image_reference = self.image_reference.strip()
+        self.source_git_ref = self.source_git_ref.strip()
+        self.required_runtime_keys = _normalized_unique_texts(self.required_runtime_keys)
+        return self
+
+
+class OdooPreviewRuntimeBlocker(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: OdooPreviewRuntimeBlockerCode
+    message: str
+
+    @model_validator(mode="after")
+    def _normalize_blocker(self) -> "OdooPreviewRuntimeBlocker":
+        self.message = _required_text(self.message, "Odoo preview runtime blocker requires message")
+        return self
+
+
+class OdooPreviewRuntimeAction(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    action: str
+    target: str
+
+    @model_validator(mode="after")
+    def _normalize_action(self) -> "OdooPreviewRuntimeAction":
+        self.action = _required_text(self.action, "Odoo preview runtime action requires action")
+        self.target = _required_text(self.target, "Odoo preview runtime action requires target")
+        return self
+
+
+class OdooPreviewRuntimePlan(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    status: OdooPreviewRuntimePlanStatus
+    operation: OdooPreviewRuntimeOperation
+    product: str
+    repository: str
+    pr_number: int = Field(ge=1)
+    preview_slug: str
+    preview_url: str
+    strategy: OdooPreviewRuntimeStrategy
+    target: OdooPreviewRuntimeTargetEvidence | None = None
+    blockers: tuple[OdooPreviewRuntimeBlocker, ...] = ()
+    planned_actions: tuple[OdooPreviewRuntimeAction, ...] = ()
+    rollback_actions: tuple[OdooPreviewRuntimeAction, ...] = ()
+    summary: str
+
+    @model_validator(mode="after")
+    def _normalize_plan(self) -> "OdooPreviewRuntimePlan":
+        self.product = _required_text(self.product, "Odoo preview runtime plan requires product")
+        self.repository = _required_text(
+            self.repository, "Odoo preview runtime plan requires repository"
+        )
+        self.preview_slug = _required_text(
+            self.preview_slug, "Odoo preview runtime plan requires preview_slug"
+        )
+        self.preview_url = self.preview_url.strip()
+        self.blockers = tuple(sorted(self.blockers, key=lambda blocker: blocker.code))
+        self.summary = _required_text(self.summary, "Odoo preview runtime plan requires summary")
+        if self.status == "ready" and self.blockers:
+            raise ValueError("ready Odoo preview runtime plan cannot include blockers")
+        if self.status == "blocked" and not self.blockers:
+            raise ValueError("blocked Odoo preview runtime plan requires blockers")
+        return self
+
+
+def plan_odoo_preview_runtime(*, request: OdooPreviewRuntimePlanRequest) -> OdooPreviewRuntimePlan:
+    blockers: list[OdooPreviewRuntimeBlocker] = []
+
+    if request.strategy != "isolated_dokploy_compose":
+        blockers.append(
+            _blocker(
+                "runtime_strategy_not_isolated",
+                "Odoo preview runtime requires an isolated per-PR Dokploy compose strategy.",
+            )
+        )
+    if not request.preview_url:
+        blockers.append(
+            _blocker(
+                "preview_url_missing",
+                "Odoo preview runtime requires a resolved public preview URL before provider apply.",
+            )
+        )
+
+    _validate_provider_capabilities(request=request, blockers=blockers)
+    _validate_runtime_bindings(request=request, blockers=blockers)
+    if request.target is not None:
+        _validate_preview_target(request=request, blockers=blockers)
+    elif request.operation == "destroy":
+        blockers.append(
+            _blocker(
+                "destroy_target_missing",
+                "Odoo preview destroy requires matching preview runtime target evidence.",
+            )
+        )
+
+    if request.operation == "refresh":
+        if not request.image_reference:
+            blockers.append(
+                _blocker(
+                    "refresh_artifact_missing",
+                    "Odoo preview refresh requires an immutable image reference.",
+                )
+            )
+        if not request.source_git_ref:
+            blockers.append(
+                _blocker(
+                    "refresh_source_missing",
+                    "Odoo preview refresh requires source revision evidence.",
+                )
+            )
+
+    status: OdooPreviewRuntimePlanStatus = "blocked" if blockers else "ready"
+    planned_actions, rollback_actions = _actions_for_request(request=request, status=status)
+    return OdooPreviewRuntimePlan(
+        status=status,
+        operation=request.operation,
+        product=request.product,
+        repository=request.repository,
+        pr_number=request.pr_number,
+        preview_slug=request.preview_slug,
+        preview_url=request.preview_url,
+        strategy=request.strategy,
+        target=request.target,
+        blockers=tuple(blockers),
+        planned_actions=planned_actions,
+        rollback_actions=rollback_actions,
+        summary=(
+            "Odoo preview runtime plan is ready"
+            if status == "ready"
+            else "Odoo preview runtime plan is blocked"
+        ),
+    )
+
+
+def _validate_provider_capabilities(
+    *, request: OdooPreviewRuntimePlanRequest, blockers: list[OdooPreviewRuntimeBlocker]
+) -> None:
+    capabilities = request.provider_capabilities
+    required = {
+        "refresh": (
+            ("can_create_compose", capabilities.can_create_compose),
+            ("can_update_compose_env", capabilities.can_update_compose_env),
+            ("can_deploy_compose", capabilities.can_deploy_compose),
+            ("can_bind_domain", capabilities.can_bind_domain),
+            ("can_delete_compose", capabilities.can_delete_compose),
+            ("can_delete_domain", capabilities.can_delete_domain),
+        ),
+        "destroy": (
+            ("can_delete_compose", capabilities.can_delete_compose),
+            ("can_delete_domain", capabilities.can_delete_domain),
+        ),
+    }[request.operation]
+    missing = tuple(name for name, enabled in required if not enabled)
+    if missing:
+        blockers.append(
+            _blocker(
+                "provider_capability_missing",
+                "Odoo preview runtime provider capabilities are missing: " + ", ".join(missing),
+            )
+        )
+
+
+def _validate_runtime_bindings(
+    *, request: OdooPreviewRuntimePlanRequest, blockers: list[OdooPreviewRuntimeBlocker]
+) -> None:
+    present_bindings = {binding.key for binding in request.runtime_bindings if binding.present}
+    missing = tuple(key for key in request.required_runtime_keys if key not in present_bindings)
+    if missing:
+        blockers.append(
+            _blocker(
+                "runtime_env_missing",
+                "Odoo preview runtime is missing required runtime bindings: " + ", ".join(missing),
+            )
+        )
+    prod_bindings = tuple(
+        binding.key
+        for binding in request.runtime_bindings
+        if binding.present and binding.scope == "prod"
+    )
+    if prod_bindings:
+        blockers.append(
+            _blocker(
+                "prod_secret_binding",
+                "Odoo preview runtime cannot use prod-scoped bindings: " + ", ".join(prod_bindings),
+            )
+        )
+    default_sensitive = tuple(
+        binding.key
+        for binding in request.runtime_bindings
+        if binding.present
+        and binding.source == "default"
+        and binding.key.upper() in _SENSITIVE_DEFAULT_KEYS
+    )
+    if default_sensitive:
+        blockers.append(
+            _blocker(
+                "default_credential_binding",
+                "Odoo preview runtime cannot use default sensitive credentials: "
+                + ", ".join(default_sensitive),
+            )
+        )
+
+
+def _validate_preview_target(
+    *, request: OdooPreviewRuntimePlanRequest, blockers: list[OdooPreviewRuntimeBlocker]
+) -> None:
+    assert request.target is not None
+    target = request.target
+    if target.environment_kind != "preview":
+        blockers.append(
+            _blocker(
+                "runtime_target_not_preview",
+                f"Odoo preview runtime target is not preview-scoped: {target.environment_kind}",
+            )
+        )
+    preview_token = f"pr-{request.pr_number}"
+    haystack = " ".join(
+        (
+            target.target_id.lower(),
+            target.target_name.lower(),
+            target.instance.lower(),
+            target.domain.lower(),
+        )
+    )
+    if request.preview_slug.lower() not in haystack and preview_token not in haystack:
+        blockers.append(
+            _blocker(
+                "runtime_target_slug_mismatch",
+                "Odoo preview runtime target does not match the requested preview slug or PR number.",
+            )
+        )
+
+
+def _actions_for_request(
+    *, request: OdooPreviewRuntimePlanRequest, status: OdooPreviewRuntimePlanStatus
+) -> tuple[tuple[OdooPreviewRuntimeAction, ...], tuple[OdooPreviewRuntimeAction, ...]]:
+    if status != "ready":
+        return (), ()
+    if request.operation == "destroy":
+        target = _target_label(request=request)
+        return (
+            (
+                OdooPreviewRuntimeAction(action="delete_preview_domain", target=target),
+                OdooPreviewRuntimeAction(action="delete_preview_compose", target=target),
+            ),
+            (),
+        )
+    target = _target_label(request=request)
+    return (
+        (
+            OdooPreviewRuntimeAction(action="create_or_reuse_preview_compose", target=target),
+            OdooPreviewRuntimeAction(action="render_preview_runtime_env", target=target),
+            OdooPreviewRuntimeAction(action="bind_preview_domain", target=request.preview_url),
+            OdooPreviewRuntimeAction(action="deploy_preview_compose", target=target),
+            OdooPreviewRuntimeAction(action="run_preview_smoke", target=request.preview_url),
+        ),
+        (
+            OdooPreviewRuntimeAction(
+                action="delete_created_preview_domain", target=request.preview_url
+            ),
+            OdooPreviewRuntimeAction(action="delete_created_preview_compose", target=target),
+        ),
+    )
+
+
+def _target_label(*, request: OdooPreviewRuntimePlanRequest) -> str:
+    if request.target is None:
+        return f"{request.product}-{request.preview_slug}"
+    return request.target.target_id
+
+
+def _blocker(code: OdooPreviewRuntimeBlockerCode, message: str) -> OdooPreviewRuntimeBlocker:
+    return OdooPreviewRuntimeBlocker(code=code, message=message)
+
+
+def _required_text(value: str, message: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(message)
+    return normalized
+
+
+def _normalized_unique_texts(values: tuple[str, ...]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    for raw_value in values:
+        value = raw_value.strip()
+        if not value:
+            raise ValueError("Odoo preview runtime keys must be non-empty")
+        if value not in normalized:
+            normalized.append(value)
+    return tuple(normalized)

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -149,16 +149,25 @@ generic-web previews.
 The preview-verification route accepts optional checked URL evidence and returns
 a typed `odoo_preview_verification` result while only mutating Launchplane
 preview-generation records.
-Odoo is the only current generic-web-based driver allowed to use the staged
-compose preview MVP: if its product profile uses `preview.data_transport_mode =
-"bootstrap"` and its template lane is a Dokploy `compose` target, preview refresh
-updates and deploys that configured compose target instead of creating a
-generic-web application. Odoo preview inventory and destroy read compose domains
-with `/api/domain.byComposeId` and delete only domains whose hostnames match the
-preview slug template. This exception is route-scoped to Odoo preview refresh,
-inventory, destroy, and readiness; it does not grant Odoo products access to
+Odoo's staged compose preview MVP is now historical compatibility evidence, not
+the target runtime architecture. That path updated and deployed the configured
+compose target when the product profile used `preview.data_transport_mode =
+"bootstrap"` and its template lane was a Dokploy `compose` target; inventory and
+destroy read compose domains with `/api/domain.byComposeId` and deleted only
+domains whose hostnames matched the preview slug template. This exception remains
+route-scoped to Odoo preview refresh, inventory, destroy, and readiness while the
+isolated runtime migration lands; it does not grant Odoo products access to
 stable generic-web deploy or promotion routes, and it does not make compose
 templates valid for generic-web products.
+The isolated Odoo preview replacement starts with the
+`plan_odoo_preview_runtime` contract. It must return `ready` before provider
+apply code can create, update, deploy, or destroy a PR runtime. The planner fails
+closed unless the strategy is an isolated per-PR Dokploy compose runtime, the
+public preview URL is already resolved, required preview-safe runtime bindings are
+present, default sensitive Odoo credentials are absent, provider capabilities
+include rollback/delete operations, and destroy evidence points to a preview
+runtime matching the requested preview slug or PR number. Stable, testing, prod,
+or slug-mismatched targets are blocked before any provider mutation.
 For the CM staged preview contract, Odoo preview refresh also runs Launchplane-
 owned smoke before reporting `refresh_status="pass"`: image artifact evidence,
 source revision evidence, module install/update evidence from rendered Odoo env,

--- a/tests/test_odoo_preview_runtime_plan.py
+++ b/tests/test_odoo_preview_runtime_plan.py
@@ -1,0 +1,183 @@
+import unittest
+
+from control_plane.contracts.odoo_preview_runtime_plan import (
+    OdooPreviewProviderCapabilities,
+    OdooPreviewRuntimeBindingEvidence,
+    OdooPreviewRuntimePlanRequest,
+    OdooPreviewRuntimeTargetEvidence,
+    plan_odoo_preview_runtime,
+)
+
+
+def _capabilities() -> OdooPreviewProviderCapabilities:
+    return OdooPreviewProviderCapabilities(
+        can_create_compose=True,
+        can_update_compose_env=True,
+        can_deploy_compose=True,
+        can_bind_domain=True,
+        can_delete_compose=True,
+        can_delete_domain=True,
+    )
+
+
+def _preview_target() -> OdooPreviewRuntimeTargetEvidence:
+    return OdooPreviewRuntimeTargetEvidence(
+        target_id="compose-cm-pr-45",
+        target_name="cm-odoo-preview-pr-45",
+        context="cm-preview",
+        instance="pr-45",
+        environment_kind="preview",
+        domain="pr-45.cm-preview.example.test",
+    )
+
+
+def _bindings() -> tuple[OdooPreviewRuntimeBindingEvidence, ...]:
+    return (
+        OdooPreviewRuntimeBindingEvidence(
+            key="WEB_BASE_URL",
+            source="runtime_environment",
+            scope="preview",
+        ),
+        OdooPreviewRuntimeBindingEvidence(
+            key="ODOO_ADMIN_PASSWORD",
+            source="managed_secret",
+            scope="preview",
+        ),
+        OdooPreviewRuntimeBindingEvidence(
+            key="ODOO_MASTER_PASSWORD",
+            source="managed_secret",
+            scope="preview",
+        ),
+    )
+
+
+def _request(**overrides: object) -> OdooPreviewRuntimePlanRequest:
+    payload = {
+        "operation": "refresh",
+        "product": "odoo-tenant-cm",
+        "repository": "cbusillo/odoo-tenant-cm",
+        "pr_number": 45,
+        "preview_slug": "pr-45",
+        "preview_url": "https://pr-45.cm-preview.example.test",
+        "strategy": "isolated_dokploy_compose",
+        "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+        "source_git_ref": "abc123",
+        "target": _preview_target(),
+        "provider_capabilities": _capabilities(),
+        "runtime_bindings": _bindings(),
+        "required_runtime_keys": (
+            "WEB_BASE_URL",
+            "ODOO_ADMIN_PASSWORD",
+            "ODOO_MASTER_PASSWORD",
+        ),
+    }
+    payload.update(overrides)
+    return OdooPreviewRuntimePlanRequest.model_validate(payload)
+
+
+class OdooPreviewRuntimePlanTests(unittest.TestCase):
+    def test_refresh_plan_is_ready_for_isolated_preview_runtime(self) -> None:
+        plan = plan_odoo_preview_runtime(request=_request())
+
+        self.assertEqual(plan.status, "ready")
+        self.assertEqual(plan.blockers, ())
+        self.assertEqual(
+            [action.action for action in plan.planned_actions],
+            [
+                "create_or_reuse_preview_compose",
+                "render_preview_runtime_env",
+                "bind_preview_domain",
+                "deploy_preview_compose",
+                "run_preview_smoke",
+            ],
+        )
+        self.assertEqual(
+            [action.action for action in plan.rollback_actions],
+            ["delete_created_preview_domain", "delete_created_preview_compose"],
+        )
+
+    def test_stage_compose_strategy_blocks_refresh(self) -> None:
+        plan = plan_odoo_preview_runtime(request=_request(strategy="staged_compose_mvp"))
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertIn("runtime_strategy_not_isolated", {blocker.code for blocker in plan.blockers})
+
+    def test_destroy_requires_preview_scoped_matching_target(self) -> None:
+        plan = plan_odoo_preview_runtime(
+            request=_request(
+                operation="destroy",
+                target=OdooPreviewRuntimeTargetEvidence(
+                    target_id="compose-cm-testing",
+                    target_name="cm-testing",
+                    context="cm",
+                    instance="testing",
+                    environment_kind="testing",
+                    domain="testing.cm.example.test",
+                ),
+            )
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertIn("runtime_target_not_preview", {blocker.code for blocker in plan.blockers})
+        self.assertIn("runtime_target_slug_mismatch", {blocker.code for blocker in plan.blockers})
+
+    def test_destroy_plan_deletes_only_matching_preview_runtime(self) -> None:
+        plan = plan_odoo_preview_runtime(request=_request(operation="destroy"))
+
+        self.assertEqual(plan.status, "ready")
+        self.assertEqual(
+            [action.action for action in plan.planned_actions],
+            ["delete_preview_domain", "delete_preview_compose"],
+        )
+        self.assertTrue(all(action.target == "compose-cm-pr-45" for action in plan.planned_actions))
+
+    def test_prod_scoped_secret_blocks_public_preview(self) -> None:
+        bindings = (
+            *_bindings(),
+            OdooPreviewRuntimeBindingEvidence(
+                key="SMTP_PASSWORD",
+                source="managed_secret",
+                scope="prod",
+            ),
+        )
+
+        plan = plan_odoo_preview_runtime(request=_request(runtime_bindings=bindings))
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertIn("prod_secret_binding", {blocker.code for blocker in plan.blockers})
+
+    def test_default_odoo_credentials_block_public_preview(self) -> None:
+        bindings = tuple(
+            binding for binding in _bindings() if binding.key != "ODOO_ADMIN_PASSWORD"
+        ) + (
+            OdooPreviewRuntimeBindingEvidence(
+                key="ODOO_ADMIN_PASSWORD",
+                source="default",
+                scope="preview",
+            ),
+        )
+
+        plan = plan_odoo_preview_runtime(request=_request(runtime_bindings=bindings))
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertIn("default_credential_binding", {blocker.code for blocker in plan.blockers})
+
+    def test_missing_provider_rollback_capability_blocks_refresh(self) -> None:
+        capabilities = _capabilities().model_copy(update={"can_delete_compose": False})
+
+        plan = plan_odoo_preview_runtime(request=_request(provider_capabilities=capabilities))
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertIn("provider_capability_missing", {blocker.code for blocker in plan.blockers})
+
+    def test_missing_runtime_binding_blocks_refresh(self) -> None:
+        plan = plan_odoo_preview_runtime(
+            request=_request(required_runtime_keys=("WEB_BASE_URL", "ODOO_DB_PASSWORD"))
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertIn("runtime_env_missing", {blocker.code for blocker in plan.blockers})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a fail-closed Odoo preview runtime planning contract for isolated per-PR Dokploy compose runtimes
- cover refresh, destroy, staged-compose blocking, target safety, provider rollback capability, prod secret, default credential, and missing runtime binding cases
- update driver docs to mark staged compose preview as historical compatibility evidence and document the isolated runtime gate

## Validation
- `uv run python -m unittest tests.test_odoo_preview_runtime_plan`
- `uv run --extra dev ruff check control_plane/contracts/odoo_preview_runtime_plan.py tests/test_odoo_preview_runtime_plan.py`
- `uv run --extra dev ruff format --check control_plane/contracts/odoo_preview_runtime_plan.py tests/test_odoo_preview_runtime_plan.py`
- `uv run --extra dev mypy control_plane/contracts/odoo_preview_runtime_plan.py tests/test_odoo_preview_runtime_plan.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`

## Inspection
- JetBrains changed-files inspection attempted twice:
  - first result: `stale_results`, cached total 0, findings withheld
  - second result: `capture_incomplete`, total 0 problems shown

Refs #495
