### PR TITLE
Add Odoo preview Dokploy dry-run plan

### DIFF
--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -1,0 +1,415 @@
+from __future__ import annotations
+
+from typing import Literal
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.odoo_preview_runtime_plan import (
+    OdooPreviewRuntimeOperation,
+    OdooPreviewRuntimePlan,
+    OdooPreviewRuntimePlanStatus,
+)
+
+
+OdooPreviewDokployDryRunStatus = OdooPreviewRuntimePlanStatus
+OdooPreviewDokployDryRunBlockerCode = Literal[
+    "endpoint_path_missing",
+    "preview_url_invalid",
+    "runtime_plan_not_ready",
+]
+OdooPreviewDokployOperationName = Literal[
+    "compose_create",
+    "compose_update_raw_source",
+    "compose_update_env",
+    "domain_lookup",
+    "domain_create_or_update",
+    "compose_deploy",
+    "smoke_check",
+    "domain_delete",
+    "compose_delete",
+]
+
+
+class OdooPreviewDokployEndpointSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    compose_create_path: str = ""
+    compose_update_path: str = "/api/compose.update"
+    compose_deploy_path: str = "/api/compose.deploy"
+    compose_redeploy_path: str = "/api/compose.redeploy"
+    compose_delete_path: str = ""
+    domain_by_compose_path: str = "/api/domain.byComposeId"
+    domain_create_path: str = "/api/domain.create"
+    domain_update_path: str = "/api/domain.update"
+    domain_delete_path: str = "/api/domain.delete"
+
+    @model_validator(mode="after")
+    def _normalize_paths(self) -> "OdooPreviewDokployEndpointSpec":
+        for field_name in type(self).model_fields:
+            raw_value = getattr(self, field_name)
+            value = raw_value.strip()
+            if value and not value.startswith("/api/"):
+                raise ValueError(f"Dokploy endpoint path must start with /api/: {field_name}")
+            setattr(self, field_name, value)
+        return self
+
+
+class OdooPreviewDokployDryRunRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    runtime_plan: OdooPreviewRuntimePlan
+    endpoint_spec: OdooPreviewDokployEndpointSpec = Field(
+        default_factory=OdooPreviewDokployEndpointSpec
+    )
+    no_cache: bool = False
+    runtime_port: int = Field(default=8069, ge=1)
+    compose_name: str = ""
+    environment_id: str = ""
+
+    @model_validator(mode="after")
+    def _normalize_request(self) -> "OdooPreviewDokployDryRunRequest":
+        self.compose_name = self.compose_name.strip()
+        self.environment_id = self.environment_id.strip()
+        return self
+
+
+class OdooPreviewDokployDryRunBlocker(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: OdooPreviewDokployDryRunBlockerCode
+    message: str
+
+    @model_validator(mode="after")
+    def _normalize_blocker(self) -> "OdooPreviewDokployDryRunBlocker":
+        self.message = _required_text(self.message, "Odoo preview dry-run blocker requires message")
+        return self
+
+
+class OdooPreviewDokployOperation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: OdooPreviewDokployOperationName
+    method: Literal["GET", "POST", "LOCAL"]
+    path: str = ""
+    target: str
+    payload_keys: tuple[str, ...] = ()
+    secret_payload: bool = False
+
+    @model_validator(mode="after")
+    def _normalize_operation(self) -> "OdooPreviewDokployOperation":
+        self.path = self.path.strip()
+        if self.method != "LOCAL" and not self.path:
+            raise ValueError("Dokploy API operation requires path")
+        self.target = _required_text(self.target, "Dokploy operation requires target")
+        self.payload_keys = _normalized_unique_texts(self.payload_keys)
+        return self
+
+
+class OdooPreviewDokployDryRunPlan(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: OdooPreviewDokployDryRunStatus
+    dry_run: Literal[True] = True
+    operation: OdooPreviewRuntimeOperation
+    product: str
+    repository: str
+    preview_slug: str
+    preview_url: str
+    domain_host: str = ""
+    compose_ref: str
+    compose_name: str
+    blockers: tuple[OdooPreviewDokployDryRunBlocker, ...] = ()
+    operations: tuple[OdooPreviewDokployOperation, ...] = ()
+    rollback_operations: tuple[OdooPreviewDokployOperation, ...] = ()
+    summary: str
+
+    @model_validator(mode="after")
+    def _normalize_plan(self) -> "OdooPreviewDokployDryRunPlan":
+        self.product = _required_text(self.product, "Odoo preview dry-run plan requires product")
+        self.repository = _required_text(
+            self.repository, "Odoo preview dry-run plan requires repository"
+        )
+        self.preview_slug = _required_text(
+            self.preview_slug, "Odoo preview dry-run plan requires preview_slug"
+        )
+        self.preview_url = self.preview_url.strip()
+        self.domain_host = self.domain_host.strip().lower()
+        self.compose_ref = _required_text(
+            self.compose_ref, "Odoo preview dry-run plan requires compose_ref"
+        )
+        self.compose_name = _required_text(
+            self.compose_name, "Odoo preview dry-run plan requires compose_name"
+        )
+        self.blockers = tuple(sorted(self.blockers, key=lambda blocker: blocker.code))
+        self.summary = _required_text(self.summary, "Odoo preview dry-run plan requires summary")
+        if self.status == "ready" and self.blockers:
+            raise ValueError("ready Odoo preview dry-run plan cannot include blockers")
+        if self.status == "blocked" and not self.blockers:
+            raise ValueError("blocked Odoo preview dry-run plan requires blockers")
+        if self.status == "blocked" and (self.operations or self.rollback_operations):
+            raise ValueError("blocked Odoo preview dry-run plan cannot include operations")
+        return self
+
+
+def build_odoo_preview_dokploy_dry_run(
+    *, request: OdooPreviewDokployDryRunRequest
+) -> OdooPreviewDokployDryRunPlan:
+    runtime_plan = request.runtime_plan
+    compose_ref = _compose_ref(runtime_plan=runtime_plan)
+    compose_name = _compose_name(runtime_plan=runtime_plan, requested_name=request.compose_name)
+    blockers: list[OdooPreviewDokployDryRunBlocker] = []
+
+    if runtime_plan.status != "ready":
+        blockers.append(
+            _blocker(
+                "runtime_plan_not_ready",
+                "Odoo preview Dokploy dry-run requires a ready runtime plan.",
+            )
+        )
+    domain_host = _domain_host(runtime_plan.preview_url)
+    if not domain_host:
+        blockers.append(
+            _blocker(
+                "preview_url_invalid",
+                "Odoo preview Dokploy dry-run requires a preview URL with a hostname.",
+            )
+        )
+
+    missing_paths = _missing_endpoint_paths(request=request)
+    if missing_paths:
+        blockers.append(
+            _blocker(
+                "endpoint_path_missing",
+                "Odoo preview Dokploy dry-run is missing explicit endpoint paths: "
+                + ", ".join(missing_paths),
+            )
+        )
+
+    status: OdooPreviewDokployDryRunStatus = "blocked" if blockers else "ready"
+    operations: tuple[OdooPreviewDokployOperation, ...] = ()
+    rollback_operations: tuple[OdooPreviewDokployOperation, ...] = ()
+    if status == "ready":
+        operations = _operations(request=request, compose_ref=compose_ref, domain_host=domain_host)
+        rollback_operations = _rollback_operations(
+            request=request,
+            compose_ref=compose_ref,
+            domain_host=domain_host,
+        )
+
+    return OdooPreviewDokployDryRunPlan(
+        status=status,
+        operation=runtime_plan.operation,
+        product=runtime_plan.product,
+        repository=runtime_plan.repository,
+        preview_slug=runtime_plan.preview_slug,
+        preview_url=runtime_plan.preview_url,
+        domain_host=domain_host,
+        compose_ref=compose_ref,
+        compose_name=compose_name,
+        blockers=tuple(blockers),
+        operations=operations,
+        rollback_operations=rollback_operations,
+        summary=(
+            "Odoo preview Dokploy dry-run plan is ready"
+            if status == "ready"
+            else "Odoo preview Dokploy dry-run plan is blocked"
+        ),
+    )
+
+
+def _missing_endpoint_paths(*, request: OdooPreviewDokployDryRunRequest) -> tuple[str, ...]:
+    spec = request.endpoint_spec
+    runtime_plan = request.runtime_plan
+    missing: list[str] = []
+    if runtime_plan.operation == "refresh":
+        if runtime_plan.target is None and not spec.compose_create_path:
+            missing.append("compose_create_path")
+        if not spec.compose_update_path:
+            missing.append("compose_update_path")
+        if not spec.domain_by_compose_path:
+            missing.append("domain_by_compose_path")
+        if not spec.domain_create_path:
+            missing.append("domain_create_path")
+        if not spec.domain_update_path:
+            missing.append("domain_update_path")
+        deploy_path = spec.compose_redeploy_path if request.no_cache else spec.compose_deploy_path
+        if not deploy_path:
+            missing.append("compose_redeploy_path" if request.no_cache else "compose_deploy_path")
+        if runtime_plan.target is None and not spec.domain_delete_path:
+            missing.append("domain_delete_path")
+        if runtime_plan.target is None and not spec.compose_delete_path:
+            missing.append("compose_delete_path")
+    else:
+        if not spec.domain_by_compose_path:
+            missing.append("domain_by_compose_path")
+        if not spec.domain_delete_path:
+            missing.append("domain_delete_path")
+        if not spec.compose_delete_path:
+            missing.append("compose_delete_path")
+    return tuple(missing)
+
+
+def _operations(
+    *, request: OdooPreviewDokployDryRunRequest, compose_ref: str, domain_host: str
+) -> tuple[OdooPreviewDokployOperation, ...]:
+    runtime_plan = request.runtime_plan
+    spec = request.endpoint_spec
+    if runtime_plan.operation == "destroy":
+        return (
+            OdooPreviewDokployOperation(
+                name="domain_lookup",
+                method="GET",
+                path=spec.domain_by_compose_path,
+                target=compose_ref,
+                payload_keys=("composeId",),
+            ),
+            OdooPreviewDokployOperation(
+                name="domain_delete",
+                method="POST",
+                path=spec.domain_delete_path,
+                target=domain_host,
+                payload_keys=("domainId",),
+            ),
+            OdooPreviewDokployOperation(
+                name="compose_delete",
+                method="POST",
+                path=spec.compose_delete_path,
+                target=compose_ref,
+                payload_keys=("composeId",),
+            ),
+        )
+
+    operations: list[OdooPreviewDokployOperation] = []
+    if runtime_plan.target is None:
+        operations.append(
+            OdooPreviewDokployOperation(
+                name="compose_create",
+                method="POST",
+                path=spec.compose_create_path,
+                target=_compose_name(
+                    runtime_plan=runtime_plan, requested_name=request.compose_name
+                ),
+                payload_keys=("name", "environmentId"),
+            )
+        )
+    operations.extend(
+        (
+            OdooPreviewDokployOperation(
+                name="compose_update_raw_source",
+                method="POST",
+                path=spec.compose_update_path,
+                target=compose_ref,
+                payload_keys=(
+                    "composeId",
+                    "name",
+                    "environmentId",
+                    "sourceType",
+                    "composePath",
+                    "composeFile",
+                ),
+            ),
+            OdooPreviewDokployOperation(
+                name="compose_update_env",
+                method="POST",
+                path=spec.compose_update_path,
+                target=compose_ref,
+                payload_keys=("composeId", "env"),
+                secret_payload=True,
+            ),
+            OdooPreviewDokployOperation(
+                name="domain_lookup",
+                method="GET",
+                path=spec.domain_by_compose_path,
+                target=compose_ref,
+                payload_keys=("composeId",),
+            ),
+            OdooPreviewDokployOperation(
+                name="domain_create_or_update",
+                method="POST",
+                path=f"{spec.domain_create_path}|{spec.domain_update_path}",
+                target=domain_host,
+                payload_keys=("host", "port", "composeId", "serviceName", "domainType"),
+            ),
+            OdooPreviewDokployOperation(
+                name="compose_deploy",
+                method="POST",
+                path=spec.compose_redeploy_path if request.no_cache else spec.compose_deploy_path,
+                target=compose_ref,
+                payload_keys=("composeId",),
+            ),
+            OdooPreviewDokployOperation(
+                name="smoke_check",
+                method="LOCAL",
+                target=runtime_plan.preview_url,
+            ),
+        )
+    )
+    return tuple(operations)
+
+
+def _rollback_operations(
+    *, request: OdooPreviewDokployDryRunRequest, compose_ref: str, domain_host: str
+) -> tuple[OdooPreviewDokployOperation, ...]:
+    if request.runtime_plan.operation == "destroy" or request.runtime_plan.target is not None:
+        return ()
+    spec = request.endpoint_spec
+    return (
+        OdooPreviewDokployOperation(
+            name="domain_delete",
+            method="POST",
+            path=spec.domain_delete_path,
+            target=domain_host,
+            payload_keys=("domainId",),
+        ),
+        OdooPreviewDokployOperation(
+            name="compose_delete",
+            method="POST",
+            path=spec.compose_delete_path,
+            target=compose_ref,
+            payload_keys=("composeId",),
+        ),
+    )
+
+
+def _compose_ref(*, runtime_plan: OdooPreviewRuntimePlan) -> str:
+    if runtime_plan.target is not None:
+        return runtime_plan.target.target_id
+    return f"${{created.composeId:{runtime_plan.product}-{runtime_plan.preview_slug}}}"
+
+
+def _compose_name(*, runtime_plan: OdooPreviewRuntimePlan, requested_name: str) -> str:
+    if requested_name.strip():
+        return requested_name.strip()
+    if runtime_plan.target is not None:
+        return runtime_plan.target.target_name
+    return f"{runtime_plan.product}-{runtime_plan.preview_slug}"
+
+
+def _domain_host(preview_url: str) -> str:
+    parsed = urlparse(preview_url.strip())
+    return (parsed.hostname or "").strip().lower()
+
+
+def _blocker(
+    code: OdooPreviewDokployDryRunBlockerCode, message: str
+) -> OdooPreviewDokployDryRunBlocker:
+    return OdooPreviewDokployDryRunBlocker(code=code, message=message)
+
+
+def _required_text(value: str, message: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(message)
+    return normalized
+
+
+def _normalized_unique_texts(values: tuple[str, ...]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    for raw_value in values:
+        value = raw_value.strip()
+        if not value:
+            raise ValueError("Odoo preview Dokploy operation payload keys must be non-empty")
+        if value not in normalized:
+            normalized.append(value)
+    return tuple(normalized)

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -168,6 +168,14 @@ present, default sensitive Odoo credentials are absent, provider capabilities
 include rollback/delete operations, and destroy evidence points to a preview
 runtime matching the requested preview slug or PR number. Stable, testing, prod,
 or slug-mismatched targets are blocked before any provider mutation.
+`build_odoo_preview_dokploy_dry_run` is the provider-facing bridge from that
+ready runtime plan to Dokploy operation intent. It is dry-run only: blocked
+runtime plans produce no operations, create/delete endpoint paths must be
+explicitly configured before composing new runtime actions, env updates are
+marked as secret-bearing payloads, and create rollback lists only the newly
+created preview domain and compose runtime. This keeps the API uncertainty around
+Dokploy compose create/delete visible until the exact provider contract is
+verified.
 For the CM staged preview contract, Odoo preview refresh also runs Launchplane-
 owned smoke before reporting `refresh_status="pass"`: image artifact evidence,
 source revision evidence, module install/update evidence from rendered Odoo env,

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -1,0 +1,200 @@
+import unittest
+from typing import Literal
+
+from control_plane.contracts.odoo_preview_runtime_plan import (
+    OdooPreviewProviderCapabilities,
+    OdooPreviewRuntimeBindingEvidence,
+    OdooPreviewRuntimePlan,
+    OdooPreviewRuntimePlanRequest,
+    OdooPreviewRuntimeTargetEvidence,
+    plan_odoo_preview_runtime,
+)
+from control_plane.workflows.odoo_preview_runtime import (
+    OdooPreviewDokployDryRunRequest,
+    OdooPreviewDokployEndpointSpec,
+    build_odoo_preview_dokploy_dry_run,
+)
+
+
+def _capabilities() -> OdooPreviewProviderCapabilities:
+    return OdooPreviewProviderCapabilities(
+        can_create_compose=True,
+        can_update_compose_env=True,
+        can_deploy_compose=True,
+        can_bind_domain=True,
+        can_delete_compose=True,
+        can_delete_domain=True,
+    )
+
+
+def _endpoint_spec() -> OdooPreviewDokployEndpointSpec:
+    return OdooPreviewDokployEndpointSpec(
+        compose_create_path="/api/compose.create",
+        compose_delete_path="/api/compose.delete",
+    )
+
+
+def _bindings() -> tuple[OdooPreviewRuntimeBindingEvidence, ...]:
+    return (
+        OdooPreviewRuntimeBindingEvidence(
+            key="WEB_BASE_URL",
+            source="runtime_environment",
+            scope="preview",
+        ),
+        OdooPreviewRuntimeBindingEvidence(
+            key="ODOO_ADMIN_PASSWORD",
+            source="managed_secret",
+            scope="preview",
+        ),
+    )
+
+
+def _target() -> OdooPreviewRuntimeTargetEvidence:
+    return OdooPreviewRuntimeTargetEvidence(
+        target_id="compose-cm-pr-45",
+        target_name="cm-pr-45",
+        context="cm-preview",
+        instance="pr-45",
+        environment_kind="preview",
+        domain="pr-45.cm-preview.example.test",
+    )
+
+
+def _runtime_plan(
+    *,
+    operation: Literal["refresh", "destroy"] = "refresh",
+    target: OdooPreviewRuntimeTargetEvidence | None = None,
+) -> OdooPreviewRuntimePlan:
+    return plan_odoo_preview_runtime(
+        request=OdooPreviewRuntimePlanRequest(
+            operation=operation,
+            product="odoo-tenant-cm",
+            repository="cbusillo/odoo-tenant-cm",
+            pr_number=45,
+            preview_slug="pr-45",
+            preview_url="https://pr-45.cm-preview.example.test",
+            strategy="isolated_dokploy_compose",
+            image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+            source_git_ref="abc123",
+            target=target,
+            provider_capabilities=_capabilities(),
+            runtime_bindings=_bindings(),
+            required_runtime_keys=("WEB_BASE_URL", "ODOO_ADMIN_PASSWORD"),
+        )
+    )
+
+
+class OdooPreviewDokployDryRunTests(unittest.TestCase):
+    def test_refresh_create_dry_run_requires_explicit_create_and_delete_paths(self) -> None:
+        plan = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(runtime_plan=_runtime_plan())
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertIn("endpoint_path_missing", {blocker.code for blocker in plan.blockers})
+        self.assertEqual(plan.operations, ())
+
+    def test_refresh_create_dry_run_renders_ordered_provider_operations(self) -> None:
+        plan = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=_runtime_plan(),
+                endpoint_spec=_endpoint_spec(),
+                environment_id="env-cm-preview",
+            )
+        )
+
+        self.assertEqual(plan.status, "ready")
+        self.assertEqual(plan.domain_host, "pr-45.cm-preview.example.test")
+        self.assertEqual(
+            [operation.name for operation in plan.operations],
+            [
+                "compose_create",
+                "compose_update_raw_source",
+                "compose_update_env",
+                "domain_lookup",
+                "domain_create_or_update",
+                "compose_deploy",
+                "smoke_check",
+            ],
+        )
+        self.assertEqual(
+            [operation.name for operation in plan.rollback_operations],
+            ["domain_delete", "compose_delete"],
+        )
+        self.assertTrue(
+            any(
+                operation.secret_payload
+                for operation in plan.operations
+                if operation.name == "compose_update_env"
+            )
+        )
+
+    def test_refresh_existing_runtime_does_not_plan_delete_rollback(self) -> None:
+        plan = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=_runtime_plan(target=_target()),
+                endpoint_spec=OdooPreviewDokployEndpointSpec(),
+            )
+        )
+
+        self.assertEqual(plan.status, "ready")
+        self.assertEqual(plan.compose_ref, "compose-cm-pr-45")
+        self.assertEqual(plan.operations[0].name, "compose_update_raw_source")
+        self.assertEqual(plan.rollback_operations, ())
+
+    def test_destroy_dry_run_renders_domain_then_compose_delete(self) -> None:
+        plan = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=_runtime_plan(operation="destroy", target=_target()),
+                endpoint_spec=_endpoint_spec(),
+            )
+        )
+
+        self.assertEqual(plan.status, "ready")
+        self.assertEqual(
+            [operation.name for operation in plan.operations],
+            ["domain_lookup", "domain_delete", "compose_delete"],
+        )
+        self.assertEqual(plan.rollback_operations, ())
+
+    def test_blocked_runtime_plan_blocks_provider_dry_run(self) -> None:
+        runtime_plan = plan_odoo_preview_runtime(
+            request=OdooPreviewRuntimePlanRequest(
+                operation="refresh",
+                product="odoo-tenant-cm",
+                repository="cbusillo/odoo-tenant-cm",
+                pr_number=45,
+                preview_slug="pr-45",
+                strategy="staged_compose_mvp",
+                provider_capabilities=_capabilities(),
+            )
+        )
+
+        plan = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=runtime_plan,
+                endpoint_spec=_endpoint_spec(),
+            )
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertIn("runtime_plan_not_ready", {blocker.code for blocker in plan.blockers})
+
+    def test_no_cache_refresh_uses_redeploy_endpoint(self) -> None:
+        plan = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=_runtime_plan(target=_target()),
+                endpoint_spec=OdooPreviewDokployEndpointSpec(),
+                no_cache=True,
+            )
+        )
+
+        deploy_operations = tuple(
+            operation for operation in plan.operations if operation.name == "compose_deploy"
+        )
+        self.assertEqual(len(deploy_operations), 1)
+        self.assertEqual(deploy_operations[0].path, "/api/compose.redeploy")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a non-mutating Dokploy dry-run bridge for ready Odoo preview runtime plans
- require explicit compose create/delete endpoint paths before planning new runtime create/delete actions
- render ordered provider intent for refresh, destroy, rollback cleanup, no-cache redeploy, and secret-bearing env update payloads
- document the dry-run bridge as the next isolated-runtime migration gate

## Validation
- `uv run python -m unittest tests.test_odoo_preview_runtime tests.test_odoo_preview_runtime_plan`
- `uv run --extra dev ruff check control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py`
- `uv run --extra dev ruff format --check control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py`
- `uv run --extra dev mypy control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`

## Inspection
- JetBrains changed-files inspection ran through PyCharm 2026.1.2 but returned broad existing frontend CSS findings in `frontend/src/styles.css`, not findings in this PR's touched Odoo/backend files.

Refs #495
