### PR TITLE
Default Odoo preview Dokploy compose endpoints

### DIFF
--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -34,11 +34,11 @@ OdooPreviewDokployOperationName = Literal[
 class OdooPreviewDokployEndpointSpec(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    compose_create_path: str = ""
+    compose_create_path: str = "/api/compose.create"
     compose_update_path: str = "/api/compose.update"
     compose_deploy_path: str = "/api/compose.deploy"
     compose_redeploy_path: str = "/api/compose.redeploy"
-    compose_delete_path: str = ""
+    compose_delete_path: str = "/api/compose.delete"
     domain_by_compose_path: str = "/api/domain.byComposeId"
     domain_create_path: str = "/api/domain.create"
     domain_update_path: str = "/api/domain.update"
@@ -63,6 +63,7 @@ class OdooPreviewDokployDryRunRequest(BaseModel):
         default_factory=OdooPreviewDokployEndpointSpec
     )
     no_cache: bool = False
+    delete_volumes: bool = True
     runtime_port: int = Field(default=8069, ge=1)
     compose_name: str = ""
     environment_id: str = ""
@@ -276,7 +277,7 @@ def _operations(
                 method="POST",
                 path=spec.compose_delete_path,
                 target=compose_ref,
-                payload_keys=("composeId",),
+                payload_keys=("composeId", "deleteVolumes"),
             ),
         )
 
@@ -290,7 +291,7 @@ def _operations(
                 target=_compose_name(
                     runtime_plan=runtime_plan, requested_name=request.compose_name
                 ),
-                payload_keys=("name", "environmentId"),
+                payload_keys=("name", "appName", "environmentId", "composeType"),
             )
         )
     operations.extend(
@@ -367,7 +368,7 @@ def _rollback_operations(
             method="POST",
             path=spec.compose_delete_path,
             target=compose_ref,
-            payload_keys=("composeId",),
+            payload_keys=("composeId", "deleteVolumes"),
         ),
     )
 

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -170,12 +170,13 @@ runtime matching the requested preview slug or PR number. Stable, testing, prod,
 or slug-mismatched targets are blocked before any provider mutation.
 `build_odoo_preview_dokploy_dry_run` is the provider-facing bridge from that
 ready runtime plan to Dokploy operation intent. It is dry-run only: blocked
-runtime plans produce no operations, create/delete endpoint paths must be
-explicitly configured before composing new runtime actions, env updates are
-marked as secret-bearing payloads, and create rollback lists only the newly
-created preview domain and compose runtime. This keeps the API uncertainty around
-Dokploy compose create/delete visible until the exact provider contract is
-verified.
+runtime plans produce no operations, env updates are marked as secret-bearing
+payloads, and create rollback lists only the newly created preview domain and
+compose runtime. The dry-run uses Dokploy's documented `/api/compose.create` and
+`/api/compose.delete` endpoints by default, but still blocks if a product/profile
+clears those paths. Preview compose delete intent includes `deleteVolumes` so the
+eventual apply path removes per-PR database and filestore volumes instead of
+leaving orphaned runtime state.
 For the CM staged preview contract, Odoo preview refresh also runs Launchplane-
 owned smoke before reporting `refresh_status="pass"`: image artifact evidence,
 source revision evidence, module install/update evidence from rendered Odoo env,

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -28,10 +28,7 @@ def _capabilities() -> OdooPreviewProviderCapabilities:
 
 
 def _endpoint_spec() -> OdooPreviewDokployEndpointSpec:
-    return OdooPreviewDokployEndpointSpec(
-        compose_create_path="/api/compose.create",
-        compose_delete_path="/api/compose.delete",
-    )
+    return OdooPreviewDokployEndpointSpec()
 
 
 def _bindings() -> tuple[OdooPreviewRuntimeBindingEvidence, ...]:
@@ -85,9 +82,15 @@ def _runtime_plan(
 
 
 class OdooPreviewDokployDryRunTests(unittest.TestCase):
-    def test_refresh_create_dry_run_requires_explicit_create_and_delete_paths(self) -> None:
+    def test_refresh_create_dry_run_blocks_missing_create_and_delete_paths(self) -> None:
         plan = build_odoo_preview_dokploy_dry_run(
-            request=OdooPreviewDokployDryRunRequest(runtime_plan=_runtime_plan())
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=_runtime_plan(),
+                endpoint_spec=OdooPreviewDokployEndpointSpec(
+                    compose_create_path="",
+                    compose_delete_path="",
+                ),
+            )
         )
 
         self.assertEqual(plan.status, "blocked")
@@ -105,6 +108,11 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
 
         self.assertEqual(plan.status, "ready")
         self.assertEqual(plan.domain_host, "pr-45.cm-preview.example.test")
+        self.assertEqual(plan.operations[0].path, "/api/compose.create")
+        self.assertEqual(
+            plan.operations[0].payload_keys,
+            ("name", "appName", "environmentId", "composeType"),
+        )
         self.assertEqual(
             [operation.name for operation in plan.operations],
             [
@@ -121,6 +129,9 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
             [operation.name for operation in plan.rollback_operations],
             ["domain_delete", "compose_delete"],
         )
+        compose_delete = plan.rollback_operations[-1]
+        self.assertEqual(compose_delete.path, "/api/compose.delete")
+        self.assertIn("deleteVolumes", compose_delete.payload_keys)
         self.assertTrue(
             any(
                 operation.secret_payload
@@ -155,6 +166,7 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
             [operation.name for operation in plan.operations],
             ["domain_lookup", "domain_delete", "compose_delete"],
         )
+        self.assertIn("deleteVolumes", plan.operations[-1].payload_keys)
         self.assertEqual(plan.rollback_operations, ())
 
     def test_blocked_runtime_plan_blocks_provider_dry_run(self) -> None:


### PR DESCRIPTION
## Summary
- default the Odoo preview dry-run bridge to Dokploy's documented compose create/delete endpoint paths
- include documented compose create payload intent fields: `name`, `appName`, `environmentId`, and `composeType`
- include `deleteVolumes` in preview compose delete intent so per-PR database/filestore volumes are removed when apply is eventually enabled
- keep fail-closed behavior when endpoint paths are explicitly cleared

## Validation
- `uv run python -m unittest tests.test_odoo_preview_runtime tests.test_odoo_preview_runtime_plan`
- `uv run --extra dev ruff check control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py`
- `uv run --extra dev ruff format --check control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py`
- `uv run --extra dev mypy control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`

## Inspection
- JetBrains changed-files inspection ran through PyCharm 2026.1.2 but returned broad existing frontend CSS findings in `frontend/src/styles.css`, not findings in this PR's touched Odoo/backend files.

## Docs Checked
- Dokploy API docs for `POST /api/compose.create`
- Dokploy API docs for `POST /api/compose.delete`

Refs #495
