### PR TITLE
Add Odoo preview apply service route

### DIFF
--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -567,6 +567,15 @@ ODOO_DRIVER = DriverDescriptor(
             writes_records=("preview",),
         ),
         _action(
+            "preview_apply",
+            "Apply isolated preview",
+            "Apply a ready isolated Odoo preview plan to runtime state.",
+            safety="destructive",
+            scope="preview",
+            route_path="/v1/drivers/odoo/preview-apply",
+            authz_action="odoo_preview_apply.execute",
+        ),
+        _action(
             "preview_verification",
             "Record preview verification",
             "Record Odoo product smoke verification for the latest preview generation.",

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -280,6 +280,10 @@ from control_plane.workflows.generic_web_preview import (
     resolve_generic_web_preview_profile,
     preview_pr_number_from_slug,
 )
+from control_plane.workflows.odoo_preview_runtime import (
+    OdooPreviewDokployApplyRequest,
+    execute_odoo_preview_dokploy_apply,
+)
 from control_plane.workflows.product_onboarding import apply_product_onboarding_manifest
 from control_plane.workflows.preview_desired_state import discover_github_preview_desired_state
 from control_plane.workflows.preview_lifecycle import build_preview_lifecycle_plan
@@ -933,6 +937,25 @@ _ODOO_PREVIEW_DESTROY_ROUTE = _DriverRouteExecutionMetadata(
     route_path="/v1/drivers/odoo/preview-destroy",
     envelope_model=GenericWebPreviewDestroyEnvelope,
     denial_message="Workflow cannot destroy Odoo preview state for the requested product/context.",
+)
+
+
+class OdooPreviewApplyEnvelope(_ProductRouteEnvelope):
+    schema_version: int = Field(default=1, ge=1)
+    apply: OdooPreviewDokployApplyRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "OdooPreviewApplyEnvelope":
+        _validate_driver_envelope_product(self.product, label="Odoo preview apply")
+        if self.product.strip() != self.apply.dry_run_plan.product.strip():
+            raise ValueError("Odoo preview apply requires matching product values.")
+        return self
+
+
+_ODOO_PREVIEW_APPLY_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/odoo/preview-apply",
+    envelope_model=OdooPreviewApplyEnvelope,
+    denial_message="Workflow cannot apply Odoo preview provider state for the requested product/context.",
 )
 
 
@@ -11707,6 +11730,62 @@ def create_launchplane_service_app(
                     record_store=record_store,
                     request=odoo_preview_verification_request.verification,
                 )
+            elif path == _ODOO_PREVIEW_APPLY_ROUTE.route_path:
+                odoo_preview_apply_request = (
+                    _ODOO_PREVIEW_APPLY_ROUTE.envelope_model.model_validate(payload)
+                )
+                resolved_driver_context = _resolve_descriptor_product_driver_context(
+                    record_store=record_store,
+                    route_path=path,
+                    product=odoo_preview_apply_request.product,
+                    require_profile=True,
+                )
+                if resolved_driver_context.profile is None:
+                    raise ProductDriverMismatchError(
+                        "Odoo preview apply requires a product profile."
+                    )
+                preview_profile = resolved_driver_context.profile.preview
+                if not preview_profile.enabled or not preview_profile.context.strip():
+                    raise ProductDriverMismatchError(
+                        "Odoo preview apply requires an enabled product preview profile."
+                    )
+                if (
+                    odoo_preview_apply_request.apply.dry_run_plan.repository.strip()
+                    != resolved_driver_context.profile.repository.strip()
+                ):
+                    raise ValueError(
+                        "Odoo preview apply repository does not match product profile."
+                    )
+                preview_context = preview_profile.context
+                authorization_response = _driver_route_authorization_response(
+                    authz_policy=authz_policy,
+                    identity=identity,
+                    route_path=path,
+                    product=odoo_preview_apply_request.product,
+                    context=preview_context,
+                    denial_message=_ODOO_PREVIEW_APPLY_ROUTE.denial_message,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if authorization_response is not None:
+                    return authorization_response
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                driver_result = execute_odoo_preview_dokploy_apply(
+                    control_plane_root=resolved_root,
+                    request=odoo_preview_apply_request.apply,
+                    database_url=database_url,
+                )
+                result = driver_result.model_dump(mode="json")
             elif path == _ODOO_STABLE_VERIFICATION_ROUTE.route_path:
                 odoo_stable_verification_request = (
                     _ODOO_STABLE_VERIFICATION_ROUTE.envelope_model.model_validate(payload)

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -142,10 +142,14 @@ routes for the same lifecycle: `POST /v1/drivers/odoo/preview-desired-state`,
 `POST /v1/drivers/odoo/preview-inventory`,
 `POST /v1/drivers/odoo/preview-readiness`,
 `POST /v1/drivers/odoo/preview-destroy`, and
-`POST /v1/drivers/odoo/preview-verification`. These routes use the generic-web
-preview request schema, live URL derivation, and record writer so Odoo PR
-previews land in the same Launchplane preview and preview-generation records as
-generic-web previews.
+`POST /v1/drivers/odoo/preview-verification`. The lower-level
+`POST /v1/drivers/odoo/preview-apply` route applies a ready isolated-preview
+Dokploy plan to provider state after service authorization and idempotency
+checks. The route returns the adapter's redacted step evidence and keeps secret
+runtime values inside the service boundary. The standard refresh/destroy routes
+use the generic-web preview request schema, live URL derivation, and record
+writer so Odoo PR previews land in the same Launchplane preview and
+preview-generation records as generic-web previews.
 The preview-verification route accepts optional checked URL evidence and returns
 a typed `odoo_preview_verification` result while only mutating Launchplane
 preview-generation records.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -96,6 +96,7 @@ VeriReel product paths:
   - `POST /v1/drivers/odoo/website-bootstrap-override`
   - `POST /v1/drivers/odoo/target-replacement-plan`
   - `POST /v1/drivers/odoo/target-replacement-apply`
+  - `POST /v1/drivers/odoo/preview-apply`
   - `POST /v1/drivers/odoo/stable-verification`
   - `POST /v1/drivers/odoo/prod-backup-gate`
   - `POST /v1/drivers/odoo/prod-promotion`
@@ -1056,6 +1057,8 @@ retries do not collide. The regular cleanup workflow uses
   `generic-web-preview-destroy:<product>:<anchor_pr_number>`
 - Odoo preview refresh driver:
   `odoo-preview-refresh:<product>:<anchor_pr_number>:<sha>`
+- Odoo isolated preview apply driver:
+  `odoo-preview-apply:<product>:<preview_slug>:<operation>:<sha-or-destroy>`
 - Odoo preview destroy driver:
   `odoo-preview-destroy:<product>:<anchor_pr_number>`
 
@@ -1146,7 +1149,18 @@ CLI adapters and expose them over HTTP.
 ### Preview generation evidence
 
 Driver-owned preview verification routes can update those records without
-requiring product workflows to render Launchplane record payloads directly. For
+requiring product workflows to render Launchplane record payloads directly.
+For isolated Odoo preview provider applies,
+`POST /v1/drivers/odoo/preview-apply` accepts the product plus a ready
+`OdooPreviewDokployApplyRequest`, authorizes against
+`odoo_preview_apply.execute` for the requested product/preview context, and
+executes only through the Launchplane service. The request carries runtime env
+values into the service for the adapter, but responses return only redacted step
+evidence, compose/domain identifiers, status, and error summaries. The route is
+idempotency-keyed and intended for approved non-production Odoo preview targets
+while the isolated runtime migration is being exercised.
+
+For
 Odoo preview smoke follow-ups, `POST /v1/drivers/odoo/preview-verification`
 accepts the product, context, anchor repo/PR, `verification_status`,
 `verified_at`, optional checked URLs as an explicit list plus

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -343,6 +343,11 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
                     control_plane_service.GenericWebPreviewDestroyEnvelope,
                     "destroy Odoo",
                 ),
+                "preview_apply": (
+                    control_plane_service._ODOO_PREVIEW_APPLY_ROUTE,
+                    control_plane_service.OdooPreviewApplyEnvelope,
+                    "apply Odoo preview",
+                ),
             },
         )
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -137,6 +137,7 @@ from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewSmokeCheck,
     GenericWebPreviewSmokeResult,
 )
+from control_plane.workflows.odoo_preview_runtime import OdooPreviewDokployApplyResult
 
 StartResponse = Callable[[str, list[tuple[str, str]]], None]
 WsgiApp = Callable[[dict[str, object], StartResponse], Iterable[bytes]]
@@ -13520,6 +13521,192 @@ class LaunchplaneServiceTests(unittest.TestCase):
             tuple_request.checked_urls,
             ("https://pr-42.cm-preview.example.test/cell-mechanic",),
         )
+
+    def test_odoo_preview_apply_route_executes_redacted_apply_request(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["odoo_preview_apply.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            apply_payload = {
+                "dry_run_plan": {
+                    "status": "ready",
+                    "operation": "refresh",
+                    "product": "odoo-tenant-cm",
+                    "repository": "cbusillo/odoo-tenant-cm",
+                    "preview_slug": "pr-42",
+                    "preview_url": "https://pr-42.cm-preview.example.test",
+                    "domain_host": "pr-42.cm-preview.example.test",
+                    "compose_ref": "${created.composeId:cm-odoo-preview-pr-42}",
+                    "compose_name": "cm-odoo-preview-pr-42",
+                    "environment_id": "env-cm-preview",
+                    "summary": "ready isolated Odoo preview apply",
+                },
+                "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                "environment_values": {
+                    "ODOO_DB_NAME": "cm_pr_42",
+                    "ODOO_DB_USER": "odoo",
+                    "ODOO_DB_PASSWORD": "secret-db",
+                    "ODOO_DATA_VOLUME": "cm_pr_42_data",
+                    "ODOO_LOG_VOLUME": "cm_pr_42_logs",
+                    "ODOO_DB_VOLUME": "cm_pr_42_db",
+                    "ODOO_MASTER_PASSWORD": "secret-master",
+                    "ODOO_ADMIN_PASSWORD": "secret-admin",
+                },
+                "wait_for_deploy": False,
+                "smoke_check": False,
+            }
+
+            with patch(
+                "control_plane.service.execute_odoo_preview_dokploy_apply",
+                return_value=OdooPreviewDokployApplyResult(
+                    status="pass",
+                    operation="refresh",
+                    product="odoo-tenant-cm",
+                    repository="cbusillo/odoo-tenant-cm",
+                    preview_slug="pr-42",
+                    preview_url="https://pr-42.cm-preview.example.test",
+                    domain_host="pr-42.cm-preview.example.test",
+                    compose_id="compose-cm-pr-42",
+                    compose_name="cm-odoo-preview-pr-42",
+                    created_compose=True,
+                    domain_id="domain-cm-pr-42",
+                ),
+            ) as apply_driver:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/preview-apply",
+                    payload={
+                        "schema_version": 1,
+                        "product": "odoo-tenant-cm",
+                        "apply": apply_payload,
+                    },
+                    headers={
+                        "Idempotency-Key": "odoo-preview-apply:odoo-tenant-cm:pr-42:refresh:abc123"
+                    },
+                )
+
+            self.assertEqual(status_code, 202)
+            self.assertEqual(payload["result"]["status"], "pass")
+            self.assertEqual(payload["result"]["compose_id"], "compose-cm-pr-42")
+            self.assertNotIn("secret-db", json.dumps(payload))
+            apply_driver.assert_called_once()
+            _, kwargs = apply_driver.call_args
+            self.assertEqual(kwargs["control_plane_root"], root)
+            self.assertIsNone(kwargs["database_url"])
+            self.assertEqual(kwargs["request"].dry_run_plan.environment_id, "env-cm-preview")
+
+    def test_odoo_preview_apply_route_rejects_unauthorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            FilesystemRecordStore(state_dir=state_dir).write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate(
+                    {
+                        "github_actions": [
+                            {
+                                "repository": "cbusillo/launchplane",
+                                "workflow_refs": [
+                                    "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml@refs/heads/main"
+                                ],
+                                "event_names": ["workflow_dispatch"],
+                                "products": ["odoo-tenant-cm"],
+                                "contexts": ["cm"],
+                                "actions": ["preview_refresh.execute"],
+                            }
+                        ]
+                    }
+                ),
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/odoo/preview-apply",
+                payload={
+                    "schema_version": 1,
+                    "product": "odoo-tenant-cm",
+                    "apply": {
+                        "dry_run_plan": {
+                            "status": "ready",
+                            "operation": "refresh",
+                            "product": "odoo-tenant-cm",
+                            "repository": "cbusillo/odoo-tenant-cm",
+                            "preview_slug": "pr-42",
+                            "preview_url": "https://pr-42.cm-preview.example.test",
+                            "domain_host": "pr-42.cm-preview.example.test",
+                            "compose_ref": "${created.composeId:cm-odoo-preview-pr-42}",
+                            "compose_name": "cm-odoo-preview-pr-42",
+                            "environment_id": "env-cm-preview",
+                            "summary": "ready isolated Odoo preview apply",
+                        },
+                        "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                        "environment_values": {
+                            "ODOO_DB_NAME": "cm_pr_42",
+                            "ODOO_DB_USER": "odoo",
+                            "ODOO_DB_PASSWORD": "secret-db",
+                            "ODOO_DATA_VOLUME": "cm_pr_42_data",
+                            "ODOO_LOG_VOLUME": "cm_pr_42_logs",
+                            "ODOO_DB_VOLUME": "cm_pr_42_db",
+                            "ODOO_MASTER_PASSWORD": "secret-master",
+                            "ODOO_ADMIN_PASSWORD": "secret-admin",
+                        },
+                    },
+                },
+                headers={
+                    "Idempotency-Key": "odoo-preview-apply:odoo-tenant-cm:pr-42:refresh:abc123"
+                },
+            )
+
+            self.assertEqual(status_code, 403)
+            self.assertEqual(payload["error"]["code"], "authorization_denied")
 
     def test_odoo_preview_verification_driver_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add the service-backed `POST /v1/drivers/odoo/preview-apply` route for isolated Odoo preview applies
- authorize applies through the Odoo preview context/action, require profile/repository alignment, and keep idempotency before provider execution
- expose the provider-neutral descriptor action and document the service boundary/redacted response contract

## Validation
- `uv run --extra dev ruff format --check tests/test_driver_descriptors.py control_plane/service.py control_plane/drivers/registry.py tests/test_service.py`
- `uv run --extra dev ruff check tests/test_driver_descriptors.py control_plane/service.py control_plane/drivers/registry.py tests/test_service.py`
- `uv run python -m unittest tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_driver_descriptor_endpoints_return_provider_neutral_metadata tests.test_service.LaunchplaneServiceTests.test_odoo_preview_apply_route_executes_redacted_apply_request tests.test_service.LaunchplaneServiceTests.test_odoo_preview_apply_route_rejects_unauthorized_workflow`
- `uv run --extra dev mypy control_plane tests && uv run python -m unittest`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files`
