### PR TITLE
Grant CM manual preview publish inputs

### DIFF
--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -1117,6 +1117,12 @@ post_odoo_cm_preview_grant \
   odoo-cm-preview-artifact-publish-inputs
 post_odoo_cm_preview_grant \
   odoo \
+  odoo_artifact_publish_inputs.read \
+  deploy:odoo-cm-preview-artifact-publish-inputs-manual-grant \
+  odoo-cm-preview-artifact-publish-inputs-manual \
+  workflow_dispatch
+post_odoo_cm_preview_grant \
+  odoo \
   odoo_artifact_publish.write \
   deploy:odoo-cm-preview-artifact-publish-grant \
   odoo-cm-preview-artifact-publish


### PR DESCRIPTION
## Summary
- grant CM Odoo preview workflow_dispatch access to read Odoo artifact publish inputs
- keep the existing pull_request grant unchanged and add only the manual isolated-preview path

## Validation
- shellcheck scripts/deploy/ensure-authz-grants.sh
- git diff --check
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_odoo_artifact_publish_inputs_returns_build_scoped_environment tests.test_service_auth tests.test_authz_grant_service
