### PR TITLE
Retry Odoo preview smoke while routing settles

### DIFF
--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -654,6 +654,7 @@ def _wait_for_smoke_check(*, preview_url: str, health_path: str, timeout_seconds
         headers={"Accept": "application/json, text/plain, */*", "Cache-Control": "no-store"},
     )
     deadline = timeout_seconds
+    last_http_status: int | None = None
     while deadline > 0:
         try:
             with urlopen(request, timeout=min(15, deadline)) as response:
@@ -661,15 +662,16 @@ def _wait_for_smoke_check(*, preview_url: str, health_path: str, timeout_seconds
             if 200 <= response.status < 400:
                 return
         except HTTPError as exc:
-            if exc.code < 500:
-                raise click.ClickException(
-                    f"Odoo preview smoke check returned HTTP {exc.code}."
-                ) from exc
+            last_http_status = exc.code
         except (TimeoutError, URLError, ValueError):
             pass
         sleep_seconds = min(5, deadline)
         time.sleep(sleep_seconds)
         deadline -= sleep_seconds
+    if last_http_status is not None:
+        raise click.ClickException(
+            f"Odoo preview smoke check returned HTTP {last_http_status}."
+        )
     raise click.ClickException(f"Timed out waiting for Odoo preview smoke check {smoke_url}.")
 
 

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -1,6 +1,8 @@
 import unittest
+from email.message import Message
 from typing import Literal
 from unittest.mock import ANY, patch
+from urllib.error import HTTPError
 
 from control_plane.contracts.odoo_preview_runtime_plan import (
     OdooPreviewProviderCapabilities,
@@ -16,6 +18,7 @@ from control_plane.workflows.odoo_preview_runtime import (
     OdooPreviewDokployEndpointSpec,
     build_odoo_preview_dokploy_dry_run,
     execute_odoo_preview_dokploy_apply,
+    _wait_for_smoke_check,
 )
 
 
@@ -387,6 +390,50 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         assert isinstance(delete_payload, dict)
         self.assertEqual(delete_payload["composeId"], "compose-cm-pr-45")
         self.assertTrue(delete_payload["deleteVolumes"])
+
+    def test_smoke_check_retries_transient_http_404(self) -> None:
+        responses: list[HTTPError | _SmokeResponse] = [
+            HTTPError(
+                "https://pr-45.cm-preview.example.test/web/health",
+                404,
+                "Not Found",
+                hdrs=Message(),
+                fp=None,
+            ),
+            _SmokeResponse(status=200),
+        ]
+
+        def _fake_urlopen(*_args: object, **_kwargs: object) -> object:
+            response = responses.pop(0)
+            if isinstance(response, Exception):
+                raise response
+            return response
+
+        with (
+            patch("control_plane.workflows.odoo_preview_runtime.urlopen", side_effect=_fake_urlopen),
+            patch("control_plane.workflows.odoo_preview_runtime.time.sleep") as sleep,
+        ):
+            _wait_for_smoke_check(
+                preview_url="https://pr-45.cm-preview.example.test/",
+                health_path="/web/health",
+                timeout_seconds=10,
+            )
+
+        sleep.assert_called_once_with(5)
+
+
+class _SmokeResponse:
+    def __init__(self, *, status: int) -> None:
+        self.status = status
+
+    def __enter__(self) -> "_SmokeResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return b"ok"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- retry Odoo isolated-preview smoke 4xx responses until the configured timeout instead of failing on the first transient routing 404
- add a regression test for 404 followed by a successful health response

## Validation
- uv run python -m unittest tests.test_odoo_preview_runtime
- uv run --extra dev mypy control_plane tests
- git diff --check
