### PR TITLE
Fix Odoo preview dry-run domain path

### DIFF
--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -786,7 +786,7 @@ def _operations(
             OdooPreviewDokployOperation(
                 name="domain_create_or_update",
                 method="POST",
-                path=f"{spec.domain_create_path}|{spec.domain_update_path}",
+                path=spec.domain_create_path,
                 target=domain_host,
                 payload_keys=("host", "port", "composeId", "serviceName", "domainType"),
             ),

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -153,6 +153,12 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
                 "smoke_check",
             ],
         )
+        domain_operation = next(
+            operation
+            for operation in plan.operations
+            if operation.name == "domain_create_or_update"
+        )
+        self.assertEqual(domain_operation.path, "/api/domain.create")
         self.assertEqual(
             [operation.name for operation in plan.rollback_operations],
             ["domain_delete", "compose_delete"],


### PR DESCRIPTION
## Summary
- expose a concrete Dokploy domain create endpoint in Odoo preview dry-run plans
- pin the provider operation path in the Odoo preview runtime tests

## Tests
- `uv run --extra dev mypy control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py`
- `uv run python -m unittest tests.test_odoo_preview_runtime`
