### PR TITLE
Set isolated Odoo preview runtime identity

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -973,6 +973,8 @@ def _odoo_preview_service_environment_values(
         database_url=database_url,
     )
     environment_values.update(preview_profile.override_env)
+    environment_values["ODOO_PROJECT_NAME"] = plan.compose_name
+    environment_values["ODOO_STACK_NAME"] = plan.compose_name
     environment_values["ODOO_DB_NAME"] = _odoo_preview_identifier(plan.compose_name, suffix="db")
     environment_values["ODOO_DATA_VOLUME"] = _odoo_preview_identifier(
         plan.compose_name, suffix="data"

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -186,8 +186,10 @@ leaving orphaned runtime state.
 `execute_odoo_preview_dokploy_apply` is the first live-provider adapter behind
 that contract. It accepts only a ready dry-run plan plus explicit runtime env
 values, blocks before reading Dokploy credentials when required Odoo env keys are
-missing, renders Launchplane-owned raw compose source, reconciles the preview
-domain, deploys the compose, and returns redacted step evidence. Destroy looks up
+missing, stamps per-preview `ODOO_PROJECT_NAME` and `ODOO_STACK_NAME` values so
+the raw compose does not inherit the template runtime identity, renders
+Launchplane-owned raw compose source, reconciles the preview domain, deploys the
+compose, and returns redacted step evidence. Destroy looks up
 domains for the matching preview compose, deletes the matching preview hostname,
 then deletes the compose with `deleteVolumes`. The adapter is not a generic local
 fallback: shared/provider execution still needs an approved non-production target

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -13693,6 +13693,14 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 applied_request.environment_values["ODOO_DATA_VOLUME"],
                 "cm_odoo_preview_pr_42_data",
             )
+            self.assertEqual(
+                applied_request.environment_values["ODOO_PROJECT_NAME"],
+                "cm-odoo-preview-pr-42",
+            )
+            self.assertEqual(
+                applied_request.environment_values["ODOO_STACK_NAME"],
+                "cm-odoo-preview-pr-42",
+            )
             self.assertNotEqual(
                 applied_request.environment_values["ODOO_DB_PASSWORD"],
                 "caller-secret-must-not-win",


### PR DESCRIPTION
## Summary
- stamp isolated Odoo preview applies with per-preview `ODOO_PROJECT_NAME` and `ODOO_STACK_NAME`
- keep template secrets/runtime values but prevent raw compose identity from falling back to the shared/template runtime
- document the isolated preview runtime identity behavior

## Tests
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_odoo_preview_apply_route_resolves_runtime_environment_values tests.test_odoo_preview_runtime`
- `uv run --extra dev mypy control_plane/service.py tests/test_service.py`
- `npx markdownlint-cli2 docs/driver-descriptors.md`
- `git diff --check`

## Inspection
- JetBrains changed-files inspection reported only existing weak warnings in `tests/test_odoo_preview_runtime.py`, not findings in the files changed by this PR.
