### PR TITLE
Avoid host ports for isolated Odoo previews

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -126,7 +126,11 @@ def _render_odoo_web_traefik_labels(*, domain_hosts: tuple[str, ...], runtime_po
 
 
 def render_odoo_raw_compose_file(
-    *, image_reference: str, domain_hosts: tuple[str, ...] = (), runtime_port: int = 8069
+    *,
+    image_reference: str,
+    domain_hosts: tuple[str, ...] = (),
+    runtime_port: int = 8069,
+    publish_host_ports: bool = True,
 ) -> str:
     normalized_image_reference = image_reference.strip()
     if not normalized_image_reference:
@@ -136,6 +140,12 @@ def render_odoo_raw_compose_file(
     web_route_labels = _render_odoo_web_traefik_labels(
         domain_hosts=domain_hosts, runtime_port=runtime_port
     )
+    web_host_ports = ""
+    if publish_host_ports:
+        web_host_ports = """    ports:
+      - "${ODOO_WEB_HOST_PORT:-8069}:8069"
+      - "${ODOO_LONGPOLL_HOST_PORT:-8072}:8072"
+"""
     # Keep this intentionally close to odoo-devkit/docker-compose.yml. Launchplane
     # renders the image reference directly so Dokploy git checkout state cannot
     # decide what Odoo artifact is deployed.
@@ -189,9 +199,7 @@ services:
     volumes:
       - odoo_data:/volumes/data
       - odoo_logs:/volumes/logs
-    ports:
-      - "${{ODOO_WEB_HOST_PORT:-8069}}:8069"
-      - "${{ODOO_LONGPOLL_HOST_PORT:-8072}}:8072"
+{web_host_ports.rstrip()}
     environment:
       <<: *odoo-env
     healthcheck:

--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -424,6 +424,7 @@ def _execute_refresh(
             image_reference=request.image_reference,
             domain_hosts=(plan.domain_host,),
             runtime_port=plan.runtime_port,
+            publish_host_ports=False,
         )
         control_plane_dokploy.sync_dokploy_compose_raw_source(
             host=host,

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -188,7 +188,8 @@ that contract. It accepts only a ready dry-run plan plus explicit runtime env
 values, blocks before reading Dokploy credentials when required Odoo env keys are
 missing, stamps per-preview `ODOO_PROJECT_NAME` and `ODOO_STACK_NAME` values so
 the raw compose does not inherit the template runtime identity, renders
-Launchplane-owned raw compose source, reconciles the preview domain, deploys the
+Launchplane-owned raw compose source without publishing shared host ports,
+reconciles the preview domain, deploys the
 compose, and returns redacted step evidence. Destroy looks up
 domains for the matching preview compose, deletes the matching preview hostname,
 then deletes the compose with `deleteVolumes`. The adapter is not a generic local

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -2331,6 +2331,18 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
         self.assertNotIn("traefik.http.routers", compose_file)
         self.assertIn("dokploy-network:", compose_file)
 
+    def test_render_odoo_raw_compose_file_can_avoid_host_port_publishing(self) -> None:
+        compose_file = control_plane_dokploy.render_odoo_raw_compose_file(
+            image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+            domain_hosts=("pr-45.cm-preview.example.test",),
+            publish_host_ports=False,
+        )
+
+        self.assertNotIn("ODOO_WEB_HOST_PORT", compose_file)
+        self.assertNotIn("ODOO_LONGPOLL_HOST_PORT", compose_file)
+        self.assertIn("traefik.enable=true", compose_file)
+        self.assertIn(".loadbalancer.server.port=8069", compose_file)
+
     def test_sync_dokploy_compose_raw_source_updates_and_verifies_hash(self) -> None:
         compose_file = control_plane_dokploy.render_odoo_raw_compose_file(
             image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123"

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -313,6 +313,10 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         assert isinstance(create_payload, dict)
         self.assertEqual(create_payload["environmentId"], "env-cm-preview")
         sync_source.assert_called_once()
+        _, sync_kwargs = sync_source.call_args
+        self.assertNotIn("ODOO_WEB_HOST_PORT", sync_kwargs["compose_file"])
+        self.assertNotIn("ODOO_LONGPOLL_HOST_PORT", sync_kwargs["compose_file"])
+        self.assertIn("traefik.enable=true", sync_kwargs["compose_file"])
         update_env.assert_called_once()
         trigger_deployment.assert_called_once_with(
             host="https://dokploy.example",


### PR DESCRIPTION
## Summary
- keep host port publishing as the default Odoo raw-compose behavior for stable targets
- opt isolated Odoo preview apply out of shared host ports so disposable previews route only through Traefik's Docker network
- document the isolated-preview behavior and cover it with compose/apply tests

## Validation
- uv run --extra dev mypy control_plane/dokploy.py control_plane/workflows/odoo_preview_runtime.py tests/test_dokploy.py tests/test_odoo_preview_runtime.py
- uv run python -m unittest tests.test_dokploy.LaunchplaneServiceDeployTests.test_render_odoo_raw_compose_file_pins_artifact_image_and_services tests.test_dokploy.LaunchplaneServiceDeployTests.test_render_odoo_raw_compose_file_can_avoid_host_port_publishing tests.test_odoo_preview_runtime.OdooPreviewDokployDryRunTests.test_apply_refresh_creates_updates_deploys_and_smokes_compose
- npx markdownlint-cli2 docs/driver-descriptors.md
- git diff --check
- uv run python -m unittest

## Notes
- JetBrains changed-file inspection still reports pre-existing service/test warnings outside this patch surface.