### PR TITLE
Use letsencrypt for Odoo preview compose domains

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -1180,7 +1180,7 @@ def ensure_compose_web_domain_route(
         "port": runtime_port,
         "https": True,
         "applicationId": None,
-        "certificateType": "none",
+        "certificateType": "letsencrypt",
         "customCertResolver": None,
         "composeId": normalized_compose_id,
         "serviceName": "web",

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -2429,6 +2429,8 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
         self.assertEqual(update_payload["domainType"], "compose")
         self.assertEqual(update_payload["serviceName"], "web")
         self.assertEqual(update_payload["port"], 8069)
+        self.assertEqual(update_payload["https"], True)
+        self.assertEqual(update_payload["certificateType"], "letsencrypt")
         self.assertEqual(update_payload["path"], "/")
         self.assertEqual(update_payload["internalPath"], "/")
 
@@ -2460,6 +2462,8 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
         self.assertEqual(create_payload["composeId"], "compose-cm-testing")
         self.assertEqual(create_payload["serviceName"], "web")
         self.assertEqual(create_payload["port"], 8069)
+        self.assertEqual(create_payload["https"], True)
+        self.assertEqual(create_payload["certificateType"], "letsencrypt")
 
     def test_service_render_authz_policy_uses_explicit_policy_source(self) -> None:
         runner = CliRunner()


### PR DESCRIPTION
## Summary
- set Odoo isolated preview compose domains to Dokploy certificateType=letsencrypt when HTTPS is enabled
- assert create/update domain payloads carry the TLS certificate type

## Validation
- uv run --extra dev mypy control_plane/dokploy.py tests/test_dokploy.py
- uv run --extra dev ruff check control_plane/dokploy.py tests/test_dokploy.py
- uv run python -m unittest tests.test_dokploy.LaunchplaneServiceDeployTests.test_ensure_compose_web_domain_route_updates_existing_route tests.test_dokploy.LaunchplaneServiceDeployTests.test_ensure_compose_web_domain_route_creates_missing_route
- uv run python -m unittest tests.test_dokploy