### PR TITLE
Preserve existing Odoo preview domains on smoke failure

### DIFF
--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -402,6 +402,7 @@ def _execute_refresh(
 ) -> OdooPreviewDokployApplyResult:
     plan = request.dry_run_plan
     created_compose_id = ""
+    resolved_compose_id = ""
     domain_id = ""
     steps: list[OdooPreviewDokployApplyStep] = []
     try:
@@ -411,6 +412,7 @@ def _execute_refresh(
             plan=plan,
             steps=steps,
         )
+        resolved_compose_id = compose_id
         created_compose_id = (
             compose_id if plan.compose_ref.startswith("${created.composeId:") else ""
         )
@@ -498,7 +500,7 @@ def _execute_refresh(
         rollback_errors = _rollback_created_runtime(
             host=host,
             token=token,
-            domain_id=domain_id,
+            domain_id=domain_id if created_compose_id else "",
             compose_id=created_compose_id,
             delete_volumes=plan.delete_volumes,
         )
@@ -507,7 +509,7 @@ def _execute_refresh(
             status="fail",
             error_message=str(exc),
             domain_id=domain_id,
-            compose_id=created_compose_id,
+            compose_id=resolved_compose_id,
             created_compose=bool(created_compose_id),
             steps=tuple(steps),
             rollback_errors=rollback_errors,

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -4,6 +4,8 @@ from typing import Literal
 from unittest.mock import ANY, patch
 from urllib.error import HTTPError
 
+import click
+
 from control_plane.contracts.odoo_preview_runtime_plan import (
     OdooPreviewProviderCapabilities,
     OdooPreviewRuntimeBindingEvidence,
@@ -351,6 +353,70 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         self.assertEqual(result.status, "blocked")
         self.assertIn("ODOO_DB_USER", result.error_message)
         read_dokploy_config.assert_not_called()
+
+    def test_apply_existing_refresh_smoke_failure_preserves_existing_domain(self) -> None:
+        dry_run = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=_runtime_plan(target=_target()),
+                endpoint_spec=_endpoint_spec(),
+            )
+        )
+
+        with (
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={"composeId": "compose-cm-pr-45", "environmentId": "env-cm-preview"},
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.sync_dokploy_compose_raw_source",
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.update_dokploy_target_env",
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.ensure_compose_web_domain_route",
+                return_value="domain-cm-pr-45",
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.latest_deployment_for_target",
+                return_value={"deploymentId": "before"},
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.trigger_deployment",
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.wait_for_target_deployment",
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime._wait_for_smoke_check",
+                side_effect=click.ClickException("smoke failed"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime._delete_domain",
+            ) as delete_domain,
+            patch(
+                "control_plane.workflows.odoo_preview_runtime._delete_compose",
+            ) as delete_compose,
+        ):
+            result = execute_odoo_preview_dokploy_apply(
+                control_plane_root=ANY,
+                request=OdooPreviewDokployApplyRequest(
+                    dry_run_plan=dry_run,
+                    image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                    environment_values=_environment_values(),
+                ),
+            )
+
+        self.assertEqual(result.status, "fail")
+        self.assertEqual(result.compose_id, "compose-cm-pr-45")
+        self.assertEqual(result.domain_id, "domain-cm-pr-45")
+        self.assertFalse(result.created_compose)
+        delete_domain.assert_not_called()
+        delete_compose.assert_not_called()
 
     def test_apply_destroy_deletes_domain_then_compose_with_volumes(self) -> None:
         dry_run = build_odoo_preview_dokploy_dry_run(


### PR DESCRIPTION
## Summary
- preserve existing Dokploy compose/domain state when isolated Odoo preview smoke checks fail
- keep rollback destructive only for composes created by the current apply attempt
- return the resolved compose id on failed existing-runtime refreshes for diagnostics

## Tests
- `uv run python -m unittest tests.test_odoo_preview_runtime`
- `uv run --extra dev mypy control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py`
- `uv run --extra dev ruff check --diff control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py`
- `uv run --extra dev ruff check control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py`
- `uv run python -m unittest`

JetBrains changed-files inspection still reports pre-existing duplicate-code/test warning noise outside this patch area.
