### PR TITLE
Let Dokploy own Odoo preview routing

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -112,16 +112,6 @@ def _render_odoo_web_traefik_labels(*, domain_hosts: tuple[str, ...], runtime_po
                 f"Odoo Traefik label rendering received an invalid domain host: {domain_host}"
             )
         seen_hosts.add(domain_host)
-        route_name = _traefik_route_name(domain_host=domain_host)
-        lines.extend(
-            (
-                f'      - "traefik.http.routers.{route_name}.rule=Host(`{domain_host}`)"',
-                f'      - "traefik.http.routers.{route_name}.entrypoints=websecure"',
-                f'      - "traefik.http.routers.{route_name}.tls.certResolver=letsencrypt"',
-                f'      - "traefik.http.routers.{route_name}.service={route_name}"',
-                f'      - "traefik.http.services.{route_name}.loadbalancer.server.port={runtime_port}"',
-            )
-        )
     return "\n".join(lines) + "\n"
 
 
@@ -1180,7 +1170,7 @@ def ensure_compose_web_domain_route(
         "port": runtime_port,
         "https": True,
         "applicationId": None,
-        "certificateType": "letsencrypt",
+        "certificateType": "none",
         "customCertResolver": None,
         "composeId": normalized_compose_id,
         "serviceName": "web",

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -189,8 +189,9 @@ values, blocks before reading Dokploy credentials when required Odoo env keys ar
 missing, stamps per-preview `ODOO_PROJECT_NAME` and `ODOO_STACK_NAME` values so
 the raw compose does not inherit the template runtime identity, renders
 Launchplane-owned raw compose source without publishing shared host ports,
-reconciles the preview domain, deploys the
-compose, and returns redacted step evidence. Destroy looks up
+keeps the raw compose limited to Dokploy network attachment labels so Dokploy's
+compose-domain records own the HTTP/HTTPS routers, reconciles the preview domain,
+deploys the compose, and returns redacted step evidence. Destroy looks up
 domains for the matching preview compose, deletes the matching preview hostname,
 then deletes the compose with `deleteVolumes`. The adapter is not a generic local
 fallback: shared/provider execution still needs an approved non-production target

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -2315,13 +2315,9 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
         self.assertIn("name: ${ODOO_PROJECT_NAME:-odoo}", compose_file)
         self.assertIn("dokploy-network:", compose_file)
         self.assertIn("traefik.enable=true", compose_file)
-        self.assertIn(
-            "traefik.http.routers.launchplane-odoo-web-cm-testing-shinycomputers-com-",
-            compose_file,
-        )
-        self.assertIn(".rule=Host(`cm-testing.shinycomputers.com`)", compose_file)
-        self.assertIn(".entrypoints=websecure", compose_file)
-        self.assertIn(".loadbalancer.server.port=8069", compose_file)
+        self.assertIn("traefik.docker.network=dokploy-network", compose_file)
+        self.assertNotIn("traefik.http.routers", compose_file)
+        self.assertNotIn("traefik.http.services", compose_file)
 
     def test_render_odoo_raw_compose_file_omits_traefik_labels_without_domains(self) -> None:
         compose_file = control_plane_dokploy.render_odoo_raw_compose_file(
@@ -2341,7 +2337,8 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
         self.assertNotIn("ODOO_WEB_HOST_PORT", compose_file)
         self.assertNotIn("ODOO_LONGPOLL_HOST_PORT", compose_file)
         self.assertIn("traefik.enable=true", compose_file)
-        self.assertIn(".loadbalancer.server.port=8069", compose_file)
+        self.assertNotIn("traefik.http.routers", compose_file)
+        self.assertNotIn("traefik.http.services", compose_file)
 
     def test_sync_dokploy_compose_raw_source_updates_and_verifies_hash(self) -> None:
         compose_file = control_plane_dokploy.render_odoo_raw_compose_file(
@@ -2430,7 +2427,7 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
         self.assertEqual(update_payload["serviceName"], "web")
         self.assertEqual(update_payload["port"], 8069)
         self.assertEqual(update_payload["https"], True)
-        self.assertEqual(update_payload["certificateType"], "letsencrypt")
+        self.assertEqual(update_payload["certificateType"], "none")
         self.assertEqual(update_payload["path"], "/")
         self.assertEqual(update_payload["internalPath"], "/")
 
@@ -2463,7 +2460,7 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
         self.assertEqual(create_payload["serviceName"], "web")
         self.assertEqual(create_payload["port"], 8069)
         self.assertEqual(create_payload["https"], True)
-        self.assertEqual(create_payload["certificateType"], "letsencrypt")
+        self.assertEqual(create_payload["certificateType"], "none")
 
     def test_service_render_authz_policy_uses_explicit_policy_source(self) -> None:
         runner = CliRunner()


### PR DESCRIPTION
## Summary
- stop rendering duplicate Launchplane HTTPS router labels into isolated Odoo raw compose files
- reconcile preview compose domains with Dokploy-owned TLS defaults
- document that compose-domain records own Odoo preview HTTP/HTTPS routing

## Validation
- uv run python -m unittest tests.test_dokploy.LaunchplaneServiceDeployTests.test_render_odoo_raw_compose_file_pins_artifact_image_and_services tests.test_dokploy.LaunchplaneServiceDeployTests.test_render_odoo_raw_compose_file_omits_traefik_labels_without_domains tests.test_dokploy.LaunchplaneServiceDeployTests.test_render_odoo_raw_compose_file_can_avoid_host_port_publishing tests.test_dokploy.LaunchplaneServiceDeployTests.test_ensure_compose_web_domain_route_updates_existing_route tests.test_dokploy.LaunchplaneServiceDeployTests.test_ensure_compose_web_domain_route_creates_missing_route
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest

Part of #495.