### PR TITLE
Create Odoo preview composes on template server

### DIFF
--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -406,22 +406,31 @@ def _execute_refresh(
     domain_id = ""
     steps: list[OdooPreviewDokployApplyStep] = []
     try:
+        template_payload = control_plane_dokploy.fetch_dokploy_target_payload(
+            host=host,
+            token=token,
+            target_type="compose",
+            target_id=plan.compose_ref,
+        )
         compose_id = _resolve_or_create_compose(
             host=host,
             token=token,
             plan=plan,
+            template_payload=template_payload,
             steps=steps,
         )
         resolved_compose_id = compose_id
         created_compose_id = (
             compose_id if plan.compose_ref.startswith("${created.composeId:") else ""
         )
-        target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
-            host=host,
-            token=token,
-            target_type="compose",
-            target_id=compose_id,
-        )
+        target_payload = template_payload
+        if compose_id != plan.compose_ref:
+            target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
+                host=host,
+                token=token,
+                target_type="compose",
+                target_id=compose_id,
+            )
         compose_file = request.compose_file or control_plane_dokploy.render_odoo_raw_compose_file(
             image_reference=request.image_reference,
             domain_hosts=(plan.domain_host,),
@@ -563,12 +572,18 @@ def _resolve_or_create_compose(
     host: str,
     token: str,
     plan: OdooPreviewDokployDryRunPlan,
+    template_payload: JsonObject,
     steps: list[OdooPreviewDokployApplyStep],
 ) -> str:
     if not plan.compose_ref.startswith("${created.composeId:"):
         return plan.compose_ref
     if not plan.environment_id:
         raise click.ClickException("Odoo preview compose create requires environment_id.")
+    server_id = str(template_payload.get("serverId") or "").strip()
+    if not server_id:
+        raise click.ClickException(
+            "Odoo preview compose create requires the template compose serverId."
+        )
     created = control_plane_dokploy.dokploy_request(
         host=host,
         token=token,
@@ -579,6 +594,7 @@ def _resolve_or_create_compose(
             "appName": plan.compose_name,
             "description": f"Launchplane Odoo preview {plan.preview_slug}",
             "environmentId": plan.environment_id,
+            "serverId": server_id,
             "composeType": "docker-compose",
         },
     )

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -191,7 +191,8 @@ the raw compose does not inherit the template runtime identity, renders
 Launchplane-owned raw compose source without publishing shared host ports,
 keeps the raw compose limited to Dokploy network attachment labels so Dokploy's
 compose-domain records own the HTTP/HTTPS routers, reconciles the preview domain,
-deploys the compose, and returns redacted step evidence. Destroy looks up
+creates new preview composes on the template compose's Dokploy server, deploys
+the compose, and returns redacted step evidence. Destroy looks up
 domains for the matching preview compose, deletes the matching preview hostname,
 then deletes the compose with `deleteVolumes`. The adapter is not a generic local
 fallback: shared/provider execution still needs an approved non-production target

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -271,7 +271,18 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
             ),
             patch(
                 "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.fetch_dokploy_target_payload",
-                return_value={"composeId": "compose-cm-pr-45", "environmentId": "env-cm-preview"},
+                side_effect=(
+                    {
+                        "composeId": "compose-template",
+                        "environmentId": "env-cm-preview",
+                        "serverId": "server-nonprod",
+                    },
+                    {
+                        "composeId": "compose-cm-pr-45",
+                        "environmentId": "env-cm-preview",
+                        "serverId": "server-nonprod",
+                    },
+                ),
             ),
             patch(
                 "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.sync_dokploy_compose_raw_source",
@@ -314,6 +325,7 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         self.assertIsInstance(create_payload, dict)
         assert isinstance(create_payload, dict)
         self.assertEqual(create_payload["environmentId"], "env-cm-preview")
+        self.assertEqual(create_payload["serverId"], "server-nonprod")
         sync_source.assert_called_once()
         _, sync_kwargs = sync_source.call_args
         self.assertNotIn("ODOO_WEB_HOST_PORT", sync_kwargs["compose_file"])
@@ -369,7 +381,11 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
             ),
             patch(
                 "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.fetch_dokploy_target_payload",
-                return_value={"composeId": "compose-cm-pr-45", "environmentId": "env-cm-preview"},
+                return_value={
+                    "composeId": "compose-cm-pr-45",
+                    "environmentId": "env-cm-preview",
+                    "serverId": "server-nonprod",
+                },
             ),
             patch(
                 "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.sync_dokploy_compose_raw_source",
@@ -417,6 +433,41 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         self.assertFalse(result.created_compose)
         delete_domain.assert_not_called()
         delete_compose.assert_not_called()
+
+    def test_apply_refresh_blocks_create_without_template_server_id(self) -> None:
+        dry_run = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=_runtime_plan(),
+                endpoint_spec=_endpoint_spec(),
+                environment_id="env-cm-preview",
+            )
+        )
+
+        with (
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={"composeId": "compose-template", "environmentId": "env-cm-preview"},
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.dokploy_request",
+            ) as dokploy_request,
+        ):
+            result = execute_odoo_preview_dokploy_apply(
+                control_plane_root=ANY,
+                request=OdooPreviewDokployApplyRequest(
+                    dry_run_plan=dry_run,
+                    image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                    environment_values=_environment_values(),
+                ),
+            )
+
+        self.assertEqual(result.status, "fail")
+        self.assertIn("serverId", result.error_message)
+        dokploy_request.assert_not_called()
 
     def test_apply_destroy_deletes_domain_then_compose_with_volumes(self) -> None:
         dry_run = build_odoo_preview_dokploy_dry_run(


### PR DESCRIPTION
## Summary
- fetch the template compose payload before creating isolated Odoo preview composes
- require and pass the template compose `serverId` into Dokploy compose creation
- document that new preview composes are created on the template compose server

## Validation
- uv run python -m unittest tests.test_odoo_preview_runtime.OdooPreviewDokployDryRunTests.test_apply_refresh_creates_updates_deploys_and_smokes_compose tests.test_odoo_preview_runtime.OdooPreviewDokployDryRunTests.test_apply_refresh_blocks_create_without_template_server_id tests.test_odoo_preview_runtime.OdooPreviewDokployDryRunTests.test_apply_existing_refresh_smoke_failure_preserves_existing_domain
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest

Part of #495.