### PR TITLE
Grant OPW isolated preview workflow access

### DIFF
--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -880,6 +880,24 @@ post_odoo_cm_preview_grant() {
     '*'
 }
 
+post_odoo_opw_preview_grant() {
+  local product_name="$1"
+  local action_name="$2"
+  local source_label="$3"
+  local idempotency_suffix="$4"
+  local event_name="${5:-pull_request}"
+  post_grant \
+    cbusillo/odoo-tenant-opw \
+    odoo-preview.yml \
+    "$product_name" \
+    opw \
+    "$action_name" \
+    "$source_label" \
+    "$idempotency_suffix" \
+    "$event_name" \
+    '*'
+}
+
 apply_product_onboarding \
   discord-blue
 apply_verireel_onboarding
@@ -1158,4 +1176,22 @@ post_odoo_cm_preview_grant \
   odoo_preview_apply.execute \
   deploy:odoo-cm-preview-apply-manual-grant \
   odoo-cm-preview-apply-manual \
+  workflow_dispatch
+post_odoo_opw_preview_grant \
+  odoo \
+  odoo_artifact_publish_inputs.read \
+  deploy:odoo-opw-preview-artifact-publish-inputs-manual-grant \
+  odoo-opw-preview-artifact-publish-inputs-manual \
+  workflow_dispatch
+post_odoo_opw_preview_grant \
+  odoo \
+  odoo_artifact_publish.write \
+  deploy:odoo-opw-preview-artifact-publish-grant \
+  odoo-opw-preview-artifact-publish \
+  workflow_dispatch
+post_odoo_opw_preview_grant \
+  odoo-tenant-opw \
+  odoo_preview_apply.execute \
+  deploy:odoo-opw-preview-apply-manual-grant \
+  odoo-opw-preview-apply-manual \
   workflow_dispatch

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -136,6 +136,118 @@ def _manifest_payload() -> dict[str, object]:
 
 
 class ProductOnboardingTests(unittest.TestCase):
+    def test_deploy_authz_grants_include_opw_manual_preview_workflow(
+        self,
+    ) -> None:
+        script_path = Path("scripts/deploy/ensure-authz-grants.sh")
+        extractor = """
+set -euo pipefail
+PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
+"""
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            captured_bin_directory = temporary_directory / "bin"
+            captured_bin_directory.mkdir()
+            (captured_bin_directory / "curl").write_text(
+                "#!/usr/bin/env bash\n"
+                "case \"$*\" in\n"
+                "  *github.invalid/oidc*) printf '{\"value\":\"oidc-token\"}' ;;\n"
+                "  *)\n"
+                "    output_file=''\n"
+                "    request_payload=''\n"
+                "    while [ \"$#\" -gt 0 ]; do\n"
+                "      case \"$1\" in\n"
+                "        -o) shift; output_file=\"$1\" ;;\n"
+                "        --data) shift; request_payload=\"$1\" ;;\n"
+                "      esac\n"
+                "      shift || true\n"
+                "    done\n"
+                "    if printf '%s' \"$request_payload\" | grep -q 'odoo-tenant-opw/.github/workflows/odoo-preview.yml'; then\n"
+                "      printf '%s\\n%s\\n' \"$request_payload\" '---END-GRANT---' >> \"$CAPTURED_GRANTS\"\n"
+                "    fi\n"
+                "    if [ -n \"$output_file\" ]; then\n"
+                "      printf '{\"status\":\"ok\"}' > \"$output_file\"\n"
+                "    fi\n"
+                "    printf '200'\n"
+                "    ;;\n"
+                "esac\n"
+            )
+            (captured_bin_directory / "mktemp").write_text(
+                "#!/usr/bin/env bash\n"
+                "printf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
+            )
+            (captured_bin_directory / "curl").chmod(0o755)
+            (captured_bin_directory / "mktemp").chmod(0o755)
+            captured_grants = temporary_directory / "grants.jsonl"
+            captured_grants.touch()
+            captured_response_file = temporary_directory / "response.json"
+            env = {
+                **os.environ,
+                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
+                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://github.invalid/oidc",
+                "GITHUB_REPOSITORY": "cbusillo/launchplane",
+                "GITHUB_SHA": "test-sha",
+                "LAUNCHPLANE_SERVICE_AUDIENCE": "launchplane-service",
+                "LAUNCHPLANE_SERVICE_URL": "https://launchplane.example.invalid",
+                "DISCORD_BLUE_DOKPLOY_TARGET_ID": "app-discord-blue",
+                "ODOO_CM_TESTING_DOKPLOY_TARGET_ID": "compose-cm-testing",
+                "ODOO_CM_PROD_DOKPLOY_TARGET_ID": "compose-cm-prod",
+                "ODOO_OPW_TESTING_DOKPLOY_TARGET_ID": "compose-opw-testing",
+                "ODOO_OPW_PROD_DOKPLOY_TARGET_ID": "compose-opw-prod",
+                "CAPTURED_GRANTS": str(captured_grants),
+                "CAPTURED_RESPONSE_FILE": str(captured_response_file),
+                "CAPTURED_BIN_DIR": str(captured_bin_directory),
+            }
+
+            result = subprocess.run(
+                ["bash", "-c", extractor],
+                check=False,
+                cwd=script_path.parent.parent.parent,
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            grants = [
+                json.loads(grant_text)["grant"]
+                for grant_text in captured_grants.read_text().split("---END-GRANT---")
+                if grant_text.strip()
+            ]
+
+        grant_index = {
+            (grant["products"][0], grant["actions"][0], grant["source_label"]): grant
+            for grant in grants
+        }
+        expected_grants = {
+            (
+                "odoo",
+                "odoo_artifact_publish_inputs.read",
+                "deploy:odoo-opw-preview-artifact-publish-inputs-manual-grant",
+            ),
+            (
+                "odoo",
+                "odoo_artifact_publish.write",
+                "deploy:odoo-opw-preview-artifact-publish-grant",
+            ),
+            (
+                "odoo-tenant-opw",
+                "odoo_preview_apply.execute",
+                "deploy:odoo-opw-preview-apply-manual-grant",
+            ),
+        }
+
+        self.assertLessEqual(expected_grants, set(grant_index))
+        for key in expected_grants:
+            grant = grant_index[key]
+            self.assertEqual(grant["repository"], "cbusillo/odoo-tenant-opw")
+            self.assertEqual(grant["contexts"], ["opw"])
+            self.assertEqual(grant["event_names"], ["workflow_dispatch"])
+            self.assertEqual(
+                grant["workflow_refs"],
+                ["cbusillo/odoo-tenant-opw/.github/workflows/odoo-preview.yml@*"],
+            )
+
     def test_deploy_authz_grants_include_terminal_agent_product_profile_read(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- add OPW odoo-preview workflow authz grants for artifact publish inputs, artifact publish, and isolated preview apply
- cover the deploy grant script with a regression test for the OPW workflow grant tuple

## Validation
- bash -n scripts/deploy/ensure-authz-grants.sh
- uv run --extra dev ruff check tests/test_product_onboarding.py
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest tests.test_product_onboarding
- JetBrains changed-files inspection: only unrelated weak warnings in tests/test_odoo_preview_runtime.py