### PR TITLE
Enable OPW isolated preview profile

### DIFF
--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -594,6 +594,19 @@ apply_odoo_opw_onboarding() {
               }
             }
           ],
+          preview: {
+            enabled: true,
+            context: "opw",
+            enable_label: "preview",
+            slug_template: "pr-{number}",
+            app_name_prefix: "odoo-tenant-opw",
+            template_instance: "testing",
+            override_env: {
+              ODOO_INSTALL_MODULES: "opw_custom"
+            },
+            preview_url_env_keys: ["WEB_BASE_URL"],
+            data_transport_mode: "bootstrap"
+          },
           dokploy_targets: (
             (if ($testing_target_id | length) > 0 then
               [

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -691,6 +691,13 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         manifest = ProductOnboardingManifest.model_validate(request_payload["manifest"])
 
         self.assertEqual(manifest.product, "odoo-tenant-opw")
+        self.assertTrue(manifest.preview.enabled)
+        self.assertEqual(manifest.preview.context, "opw")
+        self.assertEqual(manifest.preview.app_name_prefix, "odoo-tenant-opw")
+        self.assertEqual(manifest.preview.template_instance, "testing")
+        self.assertEqual(manifest.preview.override_env["ODOO_INSTALL_MODULES"], "opw_custom")
+        self.assertEqual(manifest.preview.preview_url_env_keys, ("WEB_BASE_URL",))
+        self.assertEqual(manifest.preview.data_transport_mode, "bootstrap")
         policies = {lane.instance: lane.odoo_prelaunch_rebuild for lane in manifest.lanes}
         for instance in ("testing", "prod"):
             self.assertTrue(policies[instance].enabled)


### PR DESCRIPTION
## Summary
- add an enabled OPW preview profile to the deploy-time product onboarding manifest
- assert OPW preview profile fields in the onboarding regression test

## Validation
- bash -n scripts/deploy/ensure-authz-grants.sh
- uv run --extra dev ruff check tests/test_product_onboarding.py
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest tests.test_product_onboarding
- JetBrains changed-files inspection: weak warnings only in existing deploy-script test harness patterns