### PR TITLE
Report Odoo preview apply config blockers

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -954,6 +954,14 @@ class OdooPreviewApplyEnvelope(_ProductRouteEnvelope):
         return self
 
 
+class OdooPreviewApplyConfigError(click.ClickException):
+    def __init__(self, *, context: str, instance: str, missing_keys: tuple[str, ...]) -> None:
+        super().__init__("Odoo preview apply runtime environment is incomplete.")
+        self.context = context
+        self.instance = instance
+        self.missing_keys = tuple(sorted(missing_keys))
+
+
 def _odoo_preview_service_environment_values(
     *,
     control_plane_root_path: Path,
@@ -993,9 +1001,10 @@ def _odoo_preview_service_environment_values(
         key for key in ODOO_PREVIEW_REQUIRED_ENV_KEYS if not environment_values.get(key, "").strip()
     )
     if missing_env_keys:
-        raise click.ClickException(
-            "Odoo preview apply requires DB-backed runtime environment keys for "
-            f"{preview_profile.context}/{template_instance}: " + ", ".join(missing_env_keys)
+        raise OdooPreviewApplyConfigError(
+            context=preview_profile.context,
+            instance=template_instance,
+            missing_keys=missing_env_keys,
         )
     return environment_values
 
@@ -12589,6 +12598,24 @@ def create_launchplane_service_app(
                     "error": {
                         "code": "product_driver_mismatch",
                         "message": "Product is not configured for the requested driver route.",
+                    },
+                },
+            )
+        except OdooPreviewApplyConfigError as error:
+            return _json_response(
+                start_response=start_response,
+                status_code=400,
+                payload={
+                    "status": "rejected",
+                    "trace_id": request_trace_id,
+                    "error": {
+                        "code": "odoo_preview_runtime_config_incomplete",
+                        "message": "Odoo preview apply runtime environment is incomplete.",
+                    },
+                    "details": {
+                        "context": error.context,
+                        "instance": error.instance,
+                        "missing_keys": list(error.missing_keys),
                     },
                 },
             )

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1160,6 +1160,10 @@ product preview template lane from DB-backed runtime-environment records and
 managed secret overlays, then derives per-preview database and volume names from
 the compose name before invoking the provider adapter. Responses return only
 redacted step evidence, compose/domain identifiers, status, and error summaries.
+If the service-side runtime contract is incomplete before any provider mutation,
+the route returns `odoo_preview_runtime_config_incomplete` with the affected
+context, instance, and missing key names only; it never returns runtime values or
+secret material.
 The route is idempotency-keyed and intended for approved non-production Odoo
 preview targets while the isolated runtime migration is being exercised.
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -13808,7 +13808,19 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 )
 
             self.assertEqual(status_code, 400)
-            self.assertEqual(payload["error"]["code"], "invalid_request")
+            self.assertEqual(
+                payload["error"]["code"], "odoo_preview_runtime_config_incomplete"
+            )
+            self.assertEqual(payload["details"]["context"], "cm")
+            self.assertEqual(payload["details"]["instance"], "testing")
+            self.assertEqual(
+                payload["details"]["missing_keys"],
+                [
+                    "ODOO_ADMIN_PASSWORD",
+                    "ODOO_DB_PASSWORD",
+                    "ODOO_MASTER_PASSWORD",
+                ],
+            )
             apply_driver.assert_not_called()
 
     def test_odoo_preview_apply_route_rejects_unauthorized_workflow(self) -> None:


### PR DESCRIPTION
## Summary
- return a typed redacted error for Odoo preview apply runtime config gaps
- include affected context, instance, and missing key names without values
- document the new service-boundary failure response

## Validation
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_odoo_preview_apply_route_blocks_missing_service_runtime_environment
- uv run --extra dev ruff check control_plane/service.py tests/test_service.py
- uv run --extra dev mypy control_plane tests
- JetBrains changed-files inspection: only existing weak warnings in tests/test_product_onboarding.py