### PR TITLE
Allow Odoo preview runtime secret policy

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -52,6 +52,11 @@ title: Secrets
 - Runtime key-safety gates classify managed secret bindings by binding key and
   Launchplane metadata, not by plaintext value. The initial classification
   contract is `prod_only`, `testing`, `preview`, `non_prod`, and `shared_safe`.
+- Deploy-time runtime key-safety reconciliation classifies Odoo preview runtime
+  secret bindings such as `ODOO_ADMIN_PASSWORD`, `ODOO_DB_PASSWORD`, and
+  `ODOO_MASTER_PASSWORD` as testing-only for the non-production `cm` and `opw`
+  testing contexts. It writes policy metadata only; operators still supply or
+  rotate the secret values through product-config managed secret writes.
 - Shared and production runtime mutations must execute through the deployed
   Launchplane service API or an operator UI path backed by that API. Do not use
   local CLI live-target mutation commands from arbitrary checkouts as a fallback

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -694,6 +694,24 @@ apply_runtime_key_safety_policy() {
             secret_class: "shared_safe",
             allowed_contexts: ["sellyouroutboard"],
             allowed_instances: ["testing", "prod"]
+          },
+          {
+            binding_key: "ODOO_ADMIN_PASSWORD",
+            secret_class: "testing",
+            allowed_contexts: ["cm", "opw"],
+            allowed_instances: ["testing"]
+          },
+          {
+            binding_key: "ODOO_DB_PASSWORD",
+            secret_class: "testing",
+            allowed_contexts: ["cm", "opw"],
+            allowed_instances: ["testing"]
+          },
+          {
+            binding_key: "ODOO_MASTER_PASSWORD",
+            secret_class: "testing",
+            allowed_contexts: ["cm", "opw"],
+            allowed_instances: ["testing"]
           }
         ]
       }'


### PR DESCRIPTION
## Summary
- classify Odoo preview runtime secret bindings as testing-only for cm/opw testing contexts
- document that deploy reconciliation writes only key-safety metadata, not secret values

## Validation
- bash -n scripts/deploy/ensure-authz-grants.sh
- git diff --check
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_runtime_key_safety_policy_endpoint_reconciles_rules tests.test_service.LaunchplaneServiceTests.test_product_config_api_local_operator_apply_writes_meta_config_after_dry_run tests.test_product_onboarding
- JetBrains changed-files inspection: only pre-existing service/test warnings outside touched files