### PR TITLE
Request LetsEncrypt for Odoo preview domains

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -1137,6 +1137,7 @@ def ensure_compose_web_domain_route(
     compose_id: str,
     domain_host: str,
     runtime_port: int,
+    certificate_type: str = "none",
 ) -> str:
     normalized_compose_id = compose_id.strip()
     normalized_domain_host = domain_host.strip()
@@ -1146,6 +1147,7 @@ def ensure_compose_web_domain_route(
         raise click.ClickException("Compose domain route reconciliation requires a domain host.")
     if runtime_port <= 0:
         raise click.ClickException("Compose domain route reconciliation requires a positive port.")
+    normalized_certificate_type = certificate_type.strip() or "none"
 
     raw_domains = dokploy_request(
         host=host,
@@ -1170,7 +1172,7 @@ def ensure_compose_web_domain_route(
         "port": runtime_port,
         "https": True,
         "applicationId": None,
-        "certificateType": "none",
+        "certificateType": normalized_certificate_type,
         "customCertResolver": None,
         "composeId": normalized_compose_id,
         "serviceName": "web",

--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -476,6 +476,7 @@ def _execute_refresh(
             compose_id=compose_id,
             domain_host=plan.domain_host,
             runtime_port=plan.runtime_port,
+            certificate_type="letsencrypt",
         )
         steps.append(_step("domain_create_or_update", plan.domain_host))
 

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -2462,6 +2462,28 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
         self.assertEqual(create_payload["https"], True)
         self.assertEqual(create_payload["certificateType"], "none")
 
+    def test_ensure_compose_web_domain_route_allows_certificate_type_override(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def fake_dokploy_request(**kwargs: object) -> object:
+            requests.append(dict(kwargs))
+            if kwargs["path"] == "/api/domain.byComposeId":
+                return []
+            return {"domainId": "domain-created"}
+
+        with patch("control_plane.dokploy.dokploy_request", side_effect=fake_dokploy_request):
+            control_plane_dokploy.ensure_compose_web_domain_route(
+                host="https://dokploy.example.com",
+                token="token-123",
+                compose_id="compose-cm-testing",
+                domain_host="cm-testing.shinycomputers.com",
+                runtime_port=8069,
+                certificate_type="letsencrypt",
+            )
+
+        create_payload = cast("dict[str, object]", requests[1]["payload"])
+        self.assertEqual(create_payload["certificateType"], "letsencrypt")
+
     def test_service_render_authz_policy_uses_explicit_policy_source(self) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -308,7 +308,7 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
             patch(
                 "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.ensure_compose_web_domain_route",
                 return_value="domain-cm-pr-45",
-            ),
+            ) as ensure_domain,
             patch(
                 "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.latest_deployment_for_target",
                 return_value={"deploymentId": "before"},
@@ -355,6 +355,14 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
             target_type="compose",
             target_id="compose-cm-pr-45",
             no_cache=False,
+        )
+        ensure_domain.assert_called_once_with(
+            host="https://dokploy.example",
+            token="token",
+            compose_id="compose-cm-pr-45",
+            domain_host="pr-45.cm-preview.example.test",
+            runtime_port=8069,
+            certificate_type="letsencrypt",
         )
         wait_deploy.assert_called_once()
         smoke_check.assert_called_once()


### PR DESCRIPTION
## Summary
- let compose domain reconciliation accept an explicit certificate type while preserving the existing default
- have Odoo isolated preview apply request LetsEncrypt for Dokploy compose domains
- cover the domain payload override and Odoo apply call in tests

## Validation
- uv run python -m unittest tests.test_dokploy.LaunchplaneServiceDeployTests.test_ensure_compose_web_domain_route_creates_missing_route tests.test_dokploy.LaunchplaneServiceDeployTests.test_ensure_compose_web_domain_route_allows_certificate_type_override tests.test_odoo_preview_runtime.OdooPreviewDokployDryRunTests.test_apply_refresh_creates_updates_deploys_and_smokes_compose
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest tests.test_dokploy tests.test_odoo_preview_runtime
- JetBrains changed-files inspection