### PR TITLE
Default Odoo preview domains to edge TLS

### DIFF
--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -420,6 +420,10 @@ def _execute_refresh(
     domain_id = ""
     steps: list[OdooPreviewDokployApplyStep] = []
     try:
+        if creating_compose and not plan.template_compose_id:
+            raise click.ClickException(
+                "Odoo preview compose create requires template_compose_id."
+            )
         source_compose_id = plan.template_compose_id if creating_compose else plan.compose_ref
         target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
             host=host,
@@ -476,7 +480,6 @@ def _execute_refresh(
             compose_id=compose_id,
             domain_host=plan.domain_host,
             runtime_port=plan.runtime_port,
-            certificate_type="letsencrypt",
         )
         steps.append(_step("domain_create_or_update", plan.domain_host))
 

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -362,10 +362,43 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
             compose_id="compose-cm-pr-45",
             domain_host="pr-45.cm-preview.example.test",
             runtime_port=8069,
-            certificate_type="letsencrypt",
         )
         wait_deploy.assert_called_once()
         smoke_check.assert_called_once()
+
+    def test_apply_create_blocks_missing_template_compose_id_before_provider_fetch(
+        self,
+    ) -> None:
+        dry_run = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=_runtime_plan(),
+                endpoint_spec=_endpoint_spec(),
+                environment_id="env-cm-preview",
+                template_compose_id="compose-template",
+            )
+        ).model_copy(update={"template_compose_id": ""})
+
+        with (
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.fetch_dokploy_target_payload",
+            ) as fetch_target_payload,
+        ):
+            result = execute_odoo_preview_dokploy_apply(
+                control_plane_root=ANY,
+                request=OdooPreviewDokployApplyRequest(
+                    dry_run_plan=dry_run,
+                    image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                    environment_values=_environment_values(),
+                ),
+            )
+
+        self.assertEqual(result.status, "fail")
+        self.assertIn("template_compose_id", result.error_message)
+        fetch_target_payload.assert_not_called()
 
     def test_apply_blocks_missing_runtime_env_before_provider_calls(self) -> None:
         dry_run = build_odoo_preview_dokploy_dry_run(


### PR DESCRIPTION
## Summary
- stop forcing Dokploy-managed LetsEncrypt for isolated Odoo preview compose domains
- keep Dokploy domain route reconciliation on its default `certificateType=none`, so edge TLS can be owned by NPM+/the external edge
- fail early when a create-from-template apply plan is missing `template_compose_id`

## Validation
- `uv run python -m unittest tests.test_odoo_preview_runtime.OdooPreviewDokployDryRunTests.test_apply_refresh_creates_updates_deploys_and_smokes_compose tests.test_odoo_preview_runtime.OdooPreviewDokployDryRunTests.test_apply_create_blocks_missing_template_compose_id_before_provider_fetch tests.test_dokploy.LaunchplaneServiceDeployTests.test_ensure_compose_web_domain_route_creates_missing_route tests.test_dokploy.LaunchplaneServiceDeployTests.test_ensure_compose_web_domain_route_allows_certificate_type_override`
- `uv run --extra dev mypy control_plane tests && uv run python -m unittest tests.test_odoo_preview_runtime tests.test_dokploy`
- JetBrains changed-files inspection attempted twice; first returned `stale_results`, second returned `capture_incomplete` with zero problems shown.
