### PR TITLE
Harden Odoo preview closeout paths

### DIFF
--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -558,12 +558,16 @@ def _execute_destroy(
         for domain_id in domain_ids:
             _delete_domain(host=host, token=token, domain_id=domain_id)
             steps.append(_step("domain_delete", domain_id))
-        _delete_compose(
-            host=host,
-            token=token,
-            compose_id=compose_id,
-            delete_volumes=plan.delete_volumes,
-        )
+        try:
+            _delete_compose(
+                host=host,
+                token=token,
+                compose_id=compose_id,
+                delete_volumes=plan.delete_volumes,
+            )
+        except click.ClickException as exc:
+            if domain_ids or not _is_compose_delete_not_found(exc):
+                raise
         steps.append(_step("compose_delete", compose_id))
         return _apply_result(
             request=request,
@@ -659,6 +663,11 @@ def _delete_compose(*, host: str, token: str, compose_id: str, delete_volumes: b
         method="POST",
         payload={"composeId": compose_id, "deleteVolumes": delete_volumes},
     )
+
+
+def _is_compose_delete_not_found(exc: click.ClickException) -> bool:
+    message = str(exc).lower()
+    return "/api/compose.delete" in message and "404" in message
 
 
 def _rollback_created_runtime(

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -191,14 +191,17 @@ the raw compose does not inherit the template runtime identity, renders
 Launchplane-owned raw compose source without publishing shared host ports,
 keeps the raw compose limited to Dokploy network attachment labels so Dokploy's
 compose-domain records own the HTTP/HTTPS routers, reconciles the preview domain,
-requires fresh-create dry-runs to carry the template compose id, creates new
+and defaults preview domain certificate management to `none` so public TLS is
+owned by the external edge wildcard certificate rather than Dokploy ACME.
+Fresh-create dry-runs must carry the template compose id; apply creates new
 preview composes on that template compose's Dokploy server, deploys the compose,
-and returns redacted step evidence. Destroy looks up
-domains for the matching preview compose, deletes the matching preview hostname,
-then deletes the compose with `deleteVolumes`. The adapter is not a generic local
-fallback: shared/provider execution still needs an approved non-production target
-and a caller surface that sources Launchplane-managed Dokploy credentials without
-printing secret values.
+and returns redacted step evidence. Destroy looks up domains for the matching
+preview compose, deletes the matching preview hostname, then deletes the compose
+with `deleteVolumes`; if the domain lookup is already empty and Dokploy reports
+the compose missing, destroy treats the runtime as already clean. The adapter is
+not a generic local fallback: shared/provider execution still needs an approved
+non-production target and a caller surface that sources Launchplane-managed
+Dokploy credentials without printing secret values.
 For the CM staged preview contract, Odoo preview refresh also runs Launchplane-
 owned smoke before reporting `refresh_status="pass"`: image artifact evidence,
 source revision evidence, module install/update evidence from rendered Odoo env,

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -1143,6 +1143,10 @@ post_launchplane_preview_lifecycle_grants \
   odoo-tenant-cm \
   cm \
   odoo-cm
+post_launchplane_preview_lifecycle_grants \
+  odoo-tenant-opw \
+  opw \
+  odoo-opw
 post_verireel_preview_grant \
   preview-control-plane.yml \
   preview_pr_feedback.write \
@@ -1219,6 +1223,33 @@ post_odoo_opw_preview_grant \
   odoo_artifact_publish.write \
   deploy:odoo-opw-preview-artifact-publish-grant \
   odoo-opw-preview-artifact-publish \
+  workflow_dispatch
+post_odoo_opw_preview_grant \
+  odoo-tenant-opw \
+  preview_refresh.execute \
+  deploy:odoo-opw-preview-refresh-grant \
+  odoo-opw-preview-refresh
+post_odoo_opw_preview_grant \
+  odoo-tenant-opw \
+  preview_pr_feedback.write \
+  deploy:odoo-opw-preview-pr-feedback-grant \
+  odoo-opw-preview-pr-feedback
+post_odoo_opw_preview_grant \
+  odoo-tenant-opw \
+  preview_pr_feedback.write \
+  deploy:odoo-opw-preview-unsupported-feedback-grant \
+  odoo-opw-preview-unsupported-feedback \
+  pull_request_target
+post_odoo_opw_preview_grant \
+  odoo-tenant-opw \
+  preview_destroy.execute \
+  deploy:odoo-opw-preview-destroy-pr-grant \
+  odoo-opw-preview-destroy-pr
+post_odoo_opw_preview_grant \
+  odoo-tenant-opw \
+  preview_destroy.execute \
+  deploy:odoo-opw-preview-destroy-manual-grant \
+  odoo-opw-preview-destroy-manual \
   workflow_dispatch
 post_odoo_opw_preview_grant \
   odoo-tenant-opw \

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -578,6 +578,51 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         self.assertEqual(delete_payload["composeId"], "compose-cm-pr-45")
         self.assertTrue(delete_payload["deleteVolumes"])
 
+    def test_apply_destroy_treats_missing_compose_without_domains_as_clean(self) -> None:
+        dry_run = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=_runtime_plan(operation="destroy", target=_target()),
+                endpoint_spec=_endpoint_spec(),
+            )
+        )
+        requests: list[dict[str, object]] = []
+
+        def _fake_dokploy_request(**kwargs: object) -> object:
+            requests.append(dict(kwargs))
+            if kwargs["path"] == "/api/domain.byComposeId":
+                return []
+            if kwargs["path"] == "/api/compose.delete":
+                raise click.ClickException(
+                    "Dokploy API POST /api/compose.delete failed (404): Not Found"
+                )
+            return {}
+
+        with (
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.dokploy_request",
+                side_effect=_fake_dokploy_request,
+            ),
+        ):
+            result = execute_odoo_preview_dokploy_apply(
+                control_plane_root=ANY,
+                request=OdooPreviewDokployApplyRequest(
+                    dry_run_plan=dry_run,
+                    image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                    environment_values=_environment_values(),
+                ),
+            )
+
+        self.assertEqual(result.status, "pass")
+        self.assertEqual(result.error_message, "")
+        self.assertEqual(
+            [request["path"] for request in requests],
+            ["/api/domain.byComposeId", "/api/compose.delete"],
+        )
+
     def test_smoke_check_retries_transient_http_404(self) -> None:
         responses: list[HTTPError | _SmokeResponse] = [
             HTTPError(

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -224,25 +224,50 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                 "odoo",
                 "odoo_artifact_publish_inputs.read",
                 "deploy:odoo-opw-preview-artifact-publish-inputs-manual-grant",
-            ),
+            ): ["workflow_dispatch"],
             (
                 "odoo",
                 "odoo_artifact_publish.write",
                 "deploy:odoo-opw-preview-artifact-publish-grant",
-            ),
+            ): ["workflow_dispatch"],
+            (
+                "odoo-tenant-opw",
+                "preview_refresh.execute",
+                "deploy:odoo-opw-preview-refresh-grant",
+            ): ["pull_request"],
+            (
+                "odoo-tenant-opw",
+                "preview_pr_feedback.write",
+                "deploy:odoo-opw-preview-pr-feedback-grant",
+            ): ["pull_request"],
+            (
+                "odoo-tenant-opw",
+                "preview_pr_feedback.write",
+                "deploy:odoo-opw-preview-unsupported-feedback-grant",
+            ): ["pull_request_target"],
+            (
+                "odoo-tenant-opw",
+                "preview_destroy.execute",
+                "deploy:odoo-opw-preview-destroy-pr-grant",
+            ): ["pull_request"],
+            (
+                "odoo-tenant-opw",
+                "preview_destroy.execute",
+                "deploy:odoo-opw-preview-destroy-manual-grant",
+            ): ["workflow_dispatch"],
             (
                 "odoo-tenant-opw",
                 "odoo_preview_apply.execute",
                 "deploy:odoo-opw-preview-apply-manual-grant",
-            ),
+            ): ["workflow_dispatch"],
         }
 
-        self.assertLessEqual(expected_grants, set(grant_index))
-        for key in expected_grants:
+        self.assertLessEqual(set(expected_grants), set(grant_index))
+        for key, event_names in expected_grants.items():
             grant = grant_index[key]
             self.assertEqual(grant["repository"], "cbusillo/odoo-tenant-opw")
             self.assertEqual(grant["contexts"], ["opw"])
-            self.assertEqual(grant["event_names"], ["workflow_dispatch"])
+            self.assertEqual(grant["event_names"], event_names)
             self.assertEqual(
                 grant["workflow_refs"],
                 ["cbusillo/odoo-tenant-opw/.github/workflows/odoo-preview.yml@*"],


### PR DESCRIPTION
## Summary
- grant OPW the same non-manual preview lifecycle permissions as CM for refresh, feedback, cleanup, and destroy paths
- make isolated Odoo preview destroy idempotent when domain lookup is empty and Dokploy reports the compose is already missing
- document edge-owned TLS as the default for Odoo preview domains, plus the already-clean destroy behavior

## Validation
- `bash -n scripts/deploy/ensure-authz-grants.sh`
- `uv run python -m unittest tests.test_product_onboarding tests.test_odoo_preview_runtime`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest tests.test_product_onboarding tests.test_odoo_preview_runtime tests.test_dokploy`
- JetBrains changed-files inspection attempted; reported unrelated pre-existing frontend CSS findings outside this change set
