### PR TITLE
Retire staged Odoo generic preview path

### DIFF
--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -36,29 +36,7 @@ from control_plane.workflows.ship import generate_deployment_record_id, utc_now_
 
 
 _SECRET_SHAPED_RUNTIME_ENV_KEY_PARTS = {"PASSWORD", "TOKEN", "SECRET", "KEY"}
-_ODOO_COMPOSE_STAGE_PREVIEW_DRIVER_ID = "odoo"
-_ODOO_COMPOSE_STAGE_PREVIEW_MODE = "bootstrap"
-_ODOO_COMPOSE_STAGE_PREVIEW_TARGET_TYPE = "compose"
-_ARTIFACT_IMAGE_REFERENCE_ENV_KEY = "DOCKER_IMAGE_REFERENCE"
-_ODOO_COMPOSE_STAGE_PREVIEW_REQUIRED_ENV_KEYS = (
-    "ODOO_DB_NAME",
-    "ODOO_DB_USER",
-    "ODOO_DB_PASSWORD",
-    "ODOO_DATA_VOLUME",
-    "ODOO_LOG_VOLUME",
-    "ODOO_DB_VOLUME",
-    "ODOO_MASTER_PASSWORD",
-    "ODOO_ADMIN_PASSWORD",
-)
-_ODOO_COMPOSE_STAGE_PREVIEW_MIN_DEPLOY_TIMEOUT_SECONDS = 30
-_ODOO_COMPOSE_STAGE_PREVIEW_HEALTH_TIMEOUT_SECONDS = 120
 _PREVIEW_BASE_URL_ENV_KEY = "LAUNCHPLANE_PREVIEW_BASE_URL"
-_ODOO_COMPOSE_STAGE_PREVIEW_SMOKE_PATHS = (
-    ("web_health", "/web/health"),
-    ("cm_website_health", "/cm-website/health"),
-    ("cell_mechanic_page", "/cell-mechanic"),
-)
-_ODOO_COMPOSE_STAGE_PREVIEW_MODULE_KEYS = ("ODOO_INSTALL_MODULES", "ODOO_UPDATE_MODULES")
 
 
 class GenericWebPreviewProfileStore(Protocol):
@@ -625,111 +603,6 @@ def _delete_domain(*, host: str, token: str, domain_id: str) -> None:
     )
 
 
-def _ensure_compose_domain(
-    *, host: str, token: str, compose_id: str, preview_host: str, runtime_port: int
-) -> tuple[str, tuple[str, ...]]:
-    raw_domains = control_plane_dokploy.dokploy_request(
-        host=host,
-        token=token,
-        path="/api/domain.byComposeId",
-        query={"composeId": compose_id},
-    )
-    domains = raw_domains if isinstance(raw_domains, list) else []
-    existing: JsonObject | None = None
-    stale_domain_ids: list[str] = []
-    for raw_domain in domains:
-        domain = control_plane_dokploy.as_json_object(raw_domain)
-        if domain is None:
-            continue
-        domain_host = str(domain.get("host") or "").strip()
-        domain_id = str(domain.get("domainId") or "").strip()
-        if domain_host == preview_host and domain_id:
-            existing = domain
-            continue
-        if domain_id:
-            stale_domain_ids.append(domain_id)
-    payload: JsonObject = {
-        "host": preview_host,
-        "path": "/",
-        "internalPath": "/",
-        "port": runtime_port,
-        "https": True,
-        "applicationId": None,
-        "certificateType": "none",
-        "customCertResolver": None,
-        "composeId": compose_id,
-        "serviceName": "web",
-        "domainType": "compose",
-        "previewDeploymentId": None,
-        "stripPath": False,
-    }
-    if existing is not None:
-        existing_domain_id = str(existing.get("domainId") or "").strip()
-        update_payload: JsonObject = {"domainId": existing_domain_id, **payload}
-        control_plane_dokploy.dokploy_request(
-            host=host,
-            token=token,
-            path="/api/domain.update",
-            method="POST",
-            payload=update_payload,
-        )
-        return "", tuple(stale_domain_ids)
-    created = control_plane_dokploy.dokploy_request(
-        host=host,
-        token=token,
-        path="/api/domain.create",
-        method="POST",
-        payload=payload,
-    )
-    created_domain = control_plane_dokploy.as_json_object(created)
-    return str((created_domain or {}).get("domainId") or "").strip(), tuple(stale_domain_ids)
-
-
-def _preview_slug_from_compose_domain(
-    *, profile: LaunchplaneProductProfileRecord, domain_host: str
-) -> str:
-    host = domain_host.strip().split(":", 1)[0]
-    slug_prefix = _preview_slug_prefix(profile.preview.slug_template)
-    if not host.startswith(slug_prefix):
-        return ""
-    slug = host.split(".", 1)[0]
-    if (
-        preview_pr_number_from_slug(
-            preview_slug=slug,
-            slug_template=profile.preview.slug_template,
-        )
-        is None
-    ):
-        return ""
-    return slug
-
-
-def _compose_preview_domains(
-    *, host: str, token: str, compose_id: str, profile: LaunchplaneProductProfileRecord
-) -> tuple[JsonObject, ...]:
-    raw_domains = control_plane_dokploy.dokploy_request(
-        host=host,
-        token=token,
-        path="/api/domain.byComposeId",
-        query={"composeId": compose_id},
-    )
-    if not isinstance(raw_domains, list):
-        return ()
-    domains: list[JsonObject] = []
-    for raw_domain in raw_domains:
-        domain = control_plane_dokploy.as_json_object(raw_domain)
-        if domain is None:
-            continue
-        domain_host = str(domain.get("host") or "").strip()
-        domain_id = str(domain.get("domainId") or "").strip()
-        if domain_id and _preview_slug_from_compose_domain(
-            profile=profile,
-            domain_host=domain_host,
-        ):
-            domains.append(domain)
-    return tuple(domains)
-
-
 def _delete_application(*, host: str, token: str, application_id: str) -> None:
     control_plane_dokploy.dokploy_request(
         host=host,
@@ -796,7 +669,6 @@ def _read_template_payload(
     *,
     control_plane_root: Path,
     template_lane: ProductLaneProfile,
-    allow_compose_template: bool = False,
 ) -> tuple[control_plane_dokploy.DokployTargetDefinition | None, JsonObject | None, str]:
     source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
         control_plane_root=control_plane_root,
@@ -814,18 +686,17 @@ def _read_template_payload(
             None,
             f"No Dokploy target definition found for {template_lane.context}/{template_lane.instance}.",
         )
-    if target_definition.target_type == "compose" and not allow_compose_template:
+    if target_definition.target_type == "compose":
         return (
             target_definition,
             None,
             "Generic web preview readiness requires the template lane to be a Dokploy application.",
         )
-    if target_definition.target_type not in {"application", "compose"}:
+    if target_definition.target_type != "application":
         return (
             target_definition,
             None,
-            "Generic web preview readiness requires the template lane to be a "
-            "Dokploy application or an explicitly supported staged Odoo compose target.",
+            "Generic web preview readiness requires the template lane to be a Dokploy application.",
         )
     if not target_definition.target_id.strip():
         return (
@@ -841,25 +712,6 @@ def _read_template_payload(
         target_id=target_definition.target_id,
     )
     return target_definition, payload, ""
-
-
-def _profile_allows_odoo_compose_stage_preview(*, profile: LaunchplaneProductProfileRecord) -> bool:
-    return (
-        profile.driver_id.strip() == _ODOO_COMPOSE_STAGE_PREVIEW_DRIVER_ID
-        and profile.preview.data_transport_mode == _ODOO_COMPOSE_STAGE_PREVIEW_MODE
-    )
-
-
-def _uses_odoo_compose_stage_preview(
-    *,
-    profile: LaunchplaneProductProfileRecord,
-    target_definition: control_plane_dokploy.DokployTargetDefinition | None,
-) -> bool:
-    return (
-        _profile_allows_odoo_compose_stage_preview(profile=profile)
-        and target_definition is not None
-        and target_definition.target_type == _ODOO_COMPOSE_STAGE_PREVIEW_TARGET_TYPE
-    )
 
 
 def _transport_summary(
@@ -958,61 +810,6 @@ def _render_preview_env_text(
         "",
         updates=updates,
     )
-
-
-def _render_odoo_compose_stage_preview_env_text(
-    *,
-    control_plane_root: Path,
-    profile: LaunchplaneProductProfileRecord,
-    template_lane: ProductLaneProfile,
-    template_payload: JsonObject,
-    preview_url: str,
-    image_reference: str,
-    runtime_identity: RuntimeIdentity | None = None,
-) -> str:
-    template_env = control_plane_dokploy.parse_dokploy_env_text(
-        str(template_payload.get("env") or "")
-    )
-    desired_env = dict(template_env)
-    desired_env.update(
-        _optional_runtime_environment_values(
-            control_plane_root=control_plane_root,
-            context_name=template_lane.context,
-            instance_name=template_lane.instance,
-        )
-    )
-    desired_env.update(profile.preview.override_env)
-    desired_env[_ARTIFACT_IMAGE_REFERENCE_ENV_KEY] = image_reference
-    preview_host = _preview_host(preview_url)
-    for key in profile.preview.preview_url_env_keys:
-        desired_env[key] = preview_url
-    for key in profile.preview.preview_domain_env_keys:
-        desired_env[key] = preview_host
-    if runtime_identity is not None:
-        desired_env.update(runtime_identity_env(runtime_identity))
-    return control_plane_dokploy.serialize_dokploy_env_text(desired_env)
-
-
-def _optional_runtime_environment_values(
-    *, control_plane_root: Path, context_name: str, instance_name: str
-) -> dict[str, str]:
-    try:
-        return control_plane_runtime_environments.resolve_runtime_environment_values(
-            control_plane_root=control_plane_root,
-            context_name=context_name,
-            instance_name=instance_name,
-        )
-    except click.ClickException as exc:
-        message = str(exc)
-        if message.startswith("Missing Launchplane runtime environment authority"):
-            return {}
-        if message.startswith("Missing DB-backed Launchplane runtime environment records"):
-            return {}
-        if message.startswith("Runtime environments file has no context definition"):
-            return {}
-        if message.startswith("Runtime environments file has no instance definition"):
-            return {}
-        raise
 
 
 def _runtime_environment_key_requires_secret_store(key_name: str) -> bool:
@@ -1128,149 +925,6 @@ def _wait_for_preview_health(*, preview_url: str, health_path: str, timeout_seco
     raise click.ClickException(f"Timed out waiting for {health_url} to report healthy.")
 
 
-def _preview_url_with_path(*, preview_url: str, path: str) -> str:
-    parsed = urlparse(preview_url.rstrip("/"))
-    return parsed._replace(path=path, params="", query="", fragment="").geturl()
-
-
-def _fetch_preview_smoke_path(*, preview_url: str, path: str, timeout_seconds: int) -> None:
-    smoke_url = _preview_url_with_path(preview_url=preview_url, path=path)
-    request = Request(
-        smoke_url,
-        headers={
-            "Accept": "application/json, text/html, text/plain, */*",
-            "Cache-Control": "no-store",
-        },
-    )
-    deadline = timeout_seconds
-    last_error = "is not reachable"
-    while deadline > 0:
-        try:
-            with urlopen(request, timeout=min(15, deadline)) as response:
-                response.read()
-            if 200 <= response.status < 400:
-                return
-            last_error = f"returned HTTP {response.status}"
-        except HTTPError as exc:
-            last_error = f"returned HTTP {exc.code}"
-        except (TimeoutError, URLError, ValueError):
-            last_error = "is not reachable"
-        sleep_seconds = min(5, deadline)
-        time.sleep(sleep_seconds)
-        deadline -= sleep_seconds
-    raise click.ClickException(f"Odoo preview smoke path {path} {last_error}.")
-
-
-def _pass_smoke_check(*, check_id: str, message: str) -> GenericWebPreviewSmokeCheck:
-    return GenericWebPreviewSmokeCheck(check_id=check_id, status="pass", message=message)
-
-
-def _fail_smoke_check(*, check_id: str, message: str) -> GenericWebPreviewSmokeCheck:
-    return GenericWebPreviewSmokeCheck(check_id=check_id, status="fail", message=message)
-
-
-def _failure_summary_from_smoke_checks(checks: tuple[GenericWebPreviewSmokeCheck, ...]) -> str:
-    for check in checks:
-        if check.status == "fail":
-            return f"Odoo preview smoke failed: {check.message}"
-    return "Odoo preview smoke failed."
-
-
-def _odoo_compose_stage_preview_smoke_result(
-    *,
-    checked_at: str,
-    request: GenericWebPreviewRefreshRequest,
-    env_text: str,
-    preview_url: str,
-    timeout_seconds: int,
-) -> GenericWebPreviewSmokeResult:
-    checks: list[GenericWebPreviewSmokeCheck] = []
-    if request.image_reference.strip():
-        checks.append(
-            _pass_smoke_check(
-                check_id="artifact_image_reference",
-                message="Preview image artifact reference is present.",
-            )
-        )
-    else:
-        checks.append(
-            _fail_smoke_check(
-                check_id="artifact_image_reference",
-                message="Preview image artifact reference is missing.",
-            )
-        )
-    if request.anchor_head_sha.strip():
-        checks.append(
-            _pass_smoke_check(
-                check_id="anchor_head_sha",
-                message="Preview source revision is present.",
-            )
-        )
-    else:
-        checks.append(
-            _fail_smoke_check(
-                check_id="anchor_head_sha",
-                message="Preview source revision is missing.",
-            )
-        )
-
-    rendered_env = control_plane_dokploy.parse_dokploy_env_text(env_text)
-    configured_module_keys = tuple(
-        key for key in _ODOO_COMPOSE_STAGE_PREVIEW_MODULE_KEYS if rendered_env.get(key, "").strip()
-    )
-    if configured_module_keys:
-        checks.append(
-            _pass_smoke_check(
-                check_id="module_install_update_evidence",
-                message="Odoo module install/update evidence is captured in rendered env.",
-            )
-        )
-    else:
-        checks.append(
-            _fail_smoke_check(
-                check_id="module_install_update_evidence",
-                message="Odoo module install/update evidence is missing.",
-            )
-        )
-
-    for check_id, path in _ODOO_COMPOSE_STAGE_PREVIEW_SMOKE_PATHS:
-        try:
-            if path == "/web/health":
-                _wait_for_preview_health(
-                    preview_url=preview_url,
-                    health_path=path,
-                    timeout_seconds=timeout_seconds,
-                )
-            else:
-                _fetch_preview_smoke_path(
-                    preview_url=preview_url,
-                    path=path,
-                    timeout_seconds=timeout_seconds,
-                )
-        except click.ClickException as exc:
-            checks.append(_fail_smoke_check(check_id=check_id, message=str(exc)))
-        else:
-            checks.append(
-                _pass_smoke_check(
-                    check_id=check_id,
-                    message=f"Odoo preview smoke path {path} responded successfully.",
-                )
-            )
-
-    smoke_checks = tuple(checks)
-    smoke_status: Literal["pass", "fail"] = (
-        "fail" if any(check.status == "fail" for check in smoke_checks) else "pass"
-    )
-    return GenericWebPreviewSmokeResult(
-        smoke_status=smoke_status,
-        checked_at=checked_at,
-        checks=smoke_checks,
-        failure_summary=""
-        if smoke_status == "pass"
-        else _failure_summary_from_smoke_checks(smoke_checks),
-    )
-
-
 def evaluate_generic_web_preview_readiness(
     *,
     control_plane_root: Path,
@@ -1320,9 +974,6 @@ def evaluate_generic_web_preview_readiness(
         target_definition, template_payload, target_error = _read_template_payload(
             control_plane_root=control_plane_root,
             template_lane=template_lane,
-            allow_compose_template=_profile_allows_odoo_compose_stage_preview(
-                profile=resolved_profile
-            ),
         )
     except click.ClickException as exc:
         target_error = str(exc)
@@ -1359,61 +1010,18 @@ def evaluate_generic_web_preview_readiness(
 
     assert target_definition is not None
     assert template_payload is not None
-    uses_odoo_compose_stage_preview = _uses_odoo_compose_stage_preview(
-        profile=resolved_profile,
-        target_definition=target_definition,
-    )
-    if target_definition.target_type == "compose" and not uses_odoo_compose_stage_preview:
-        checks.append(
-            GenericWebPreviewReadinessCheck(
-                check_id="template_target",
-                status="blocked",
-                message=(
-                    "Compose template lanes are supported only for the staged Odoo "
-                    "bootstrap preview path."
-                ),
-            )
-        )
-        return GenericWebPreviewReadinessResult(
-            readiness_status="blocked",
-            checked_at=checked_at,
-            product=resolved_profile.product,
-            context=resolved_profile.preview.context,
-            template_context=template_lane.context,
-            template_instance=template_lane.instance,
-            template_target_type=target_definition.target_type,
-            template_target_id=target_definition.target_id,
-            template_target_name=target_definition.target_name,
-            source=request.source,
-            missing_template_env_keys=(),
-            missing_provider_fields=(),
-            transport=_transport_summary(profile=resolved_profile),
-            checks=tuple(checks),
-        )
     env_map = control_plane_dokploy.parse_dokploy_env_text(str(template_payload.get("env") or ""))
-    if uses_odoo_compose_stage_preview:
-        env_map.update(
-            _optional_runtime_environment_values(
-                control_plane_root=control_plane_root,
-                context_name=template_lane.context,
-                instance_name=template_lane.instance,
-            )
-        )
     required_env_parts = (
         *resolved_profile.preview.required_template_env_keys,
         *resolved_profile.preview.copied_env_keys,
     )
-    if uses_odoo_compose_stage_preview:
-        required_env_parts = (*required_env_parts, *_ODOO_COMPOSE_STAGE_PREVIEW_REQUIRED_ENV_KEYS)
     required_env_keys = tuple(dict.fromkeys(required_env_parts))
     missing_env_keys = tuple(key for key in required_env_keys if not env_map.get(key, "").strip())
-    missing_provider_fields: tuple[str, ...] = ()
-    if not uses_odoo_compose_stage_preview:
-        missing_provider_fields = tuple(
-            field
-            for field in resolved_profile.preview.required_provider_fields
-            if _is_blank(_field_value(template_payload, field))
-        )
+    missing_provider_fields = tuple(
+        field
+        for field in resolved_profile.preview.required_provider_fields
+        if _is_blank(_field_value(template_payload, field))
+    )
 
     if missing_env_keys:
         checks.append(
@@ -1446,11 +1054,7 @@ def evaluate_generic_web_preview_readiness(
             GenericWebPreviewReadinessCheck(
                 check_id="template_provider_fields",
                 status="pass",
-                message=(
-                    "Staged Odoo compose preview uses Launchplane-rendered compose source."
-                    if uses_odoo_compose_stage_preview
-                    else "Template lane includes required provider fields."
-                ),
+                message="Template lane includes required provider fields.",
             )
         )
     checks.append(
@@ -1558,51 +1162,10 @@ def execute_generic_web_preview_refresh(
         target_definition, template_application, target_error = _read_template_payload(
             control_plane_root=control_plane_root,
             template_lane=template_lane,
-            allow_compose_template=_profile_allows_odoo_compose_stage_preview(
-                profile=resolved_profile
-            ),
         )
         if target_error or template_application is None or target_definition is None:
             raise click.ClickException(
                 target_error or "Generic web preview template payload is unavailable."
-            )
-        if _uses_odoo_compose_stage_preview(
-            profile=resolved_profile,
-            target_definition=target_definition,
-        ):
-            application_id, smoke = _execute_odoo_compose_stage_preview_refresh(
-                control_plane_root=control_plane_root,
-                record_store=record_store,
-                request=request,
-                profile=resolved_profile,
-                template_lane=template_lane,
-                target_definition=target_definition,
-                template_payload=template_application,
-                preview_url=preview_url,
-                runtime_identity=_build_preview_runtime_identity(
-                    profile=resolved_profile,
-                    preview_slug=request.preview_slug,
-                    image_reference=request.image_reference,
-                    anchor_head_sha=request.anchor_head_sha,
-                ),
-            )
-            finished_at = utc_now_timestamp()
-            refresh_status: Literal["pass", "blocked", "fail"] = (
-                "pass" if smoke.smoke_status == "pass" else "fail"
-            )
-            return GenericWebPreviewRefreshResult(
-                refresh_status=refresh_status,
-                refresh_started_at=started_at,
-                refresh_finished_at=finished_at,
-                product=resolved_profile.product,
-                context=resolved_profile.preview.context,
-                preview_slug=request.preview_slug,
-                application_name=application_name,
-                application_id=application_id,
-                preview_url=preview_url,
-                readiness=readiness,
-                smoke=smoke,
-                error_message="" if refresh_status == "pass" else smoke.failure_summary,
             )
         _enforce_preview_copied_runtime_key_safety(
             record_store=record_store,
@@ -1720,107 +1283,6 @@ def execute_generic_web_preview_refresh(
         preview_url=preview_url,
         readiness=readiness,
     )
-
-
-def _execute_odoo_compose_stage_preview_refresh(
-    *,
-    control_plane_root: Path,
-    record_store: GenericWebPreviewProfileStore,
-    request: GenericWebPreviewRefreshRequest,
-    profile: LaunchplaneProductProfileRecord,
-    template_lane: ProductLaneProfile,
-    target_definition: control_plane_dokploy.DokployTargetDefinition,
-    template_payload: JsonObject,
-    preview_url: str,
-    runtime_identity: RuntimeIdentity | None = None,
-) -> tuple[str, GenericWebPreviewSmokeResult]:
-    _enforce_preview_copied_runtime_key_safety(
-        record_store=record_store,
-        profile=profile,
-        template_lane=template_lane,
-        template_application=template_payload,
-        preview_slug=request.preview_slug,
-    )
-    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
-    compose_name = (
-        target_definition.target_name.strip()
-        or str(template_payload.get("name") or "").strip()
-        or f"{template_lane.context}-{template_lane.instance}"
-    )
-    compose_file = control_plane_dokploy.render_odoo_raw_compose_file(
-        image_reference=request.image_reference
-    )
-    control_plane_dokploy.sync_dokploy_compose_raw_source(
-        host=host,
-        token=token,
-        compose_id=target_definition.target_id,
-        compose_name=compose_name,
-        target_payload=template_payload,
-        compose_file=compose_file,
-    )
-    env_text = _render_odoo_compose_stage_preview_env_text(
-        control_plane_root=control_plane_root,
-        profile=profile,
-        template_lane=template_lane,
-        template_payload=template_payload,
-        preview_url=preview_url,
-        image_reference=request.image_reference,
-        runtime_identity=runtime_identity,
-    )
-    control_plane_dokploy.update_dokploy_target_env(
-        host=host,
-        token=token,
-        target_type="compose",
-        target_id=target_definition.target_id,
-        target_payload=template_payload,
-        env_text=env_text,
-    )
-    _ensure_compose_domain(
-        host=host,
-        token=token,
-        compose_id=target_definition.target_id,
-        preview_host=_preview_host(preview_url),
-        runtime_port=profile.runtime_port,
-    )
-    latest_before = control_plane_dokploy.latest_deployment_for_target(
-        host=host,
-        token=token,
-        target_type="compose",
-        target_id=target_definition.target_id,
-    )
-    control_plane_dokploy.trigger_deployment(
-        host=host,
-        token=token,
-        target_type="compose",
-        target_id=target_definition.target_id,
-        no_cache=request.no_cache,
-    )
-    health_timeout_seconds = min(
-        request.timeout_seconds,
-        _ODOO_COMPOSE_STAGE_PREVIEW_HEALTH_TIMEOUT_SECONDS,
-    )
-    deployment_timeout_seconds = max(
-        _ODOO_COMPOSE_STAGE_PREVIEW_MIN_DEPLOY_TIMEOUT_SECONDS,
-        request.timeout_seconds - health_timeout_seconds,
-    )
-    control_plane_dokploy.wait_for_target_deployment(
-        host=host,
-        token=token,
-        target_type="compose",
-        target_id=target_definition.target_id,
-        before_key=control_plane_dokploy.deployment_key(latest_before),
-        timeout_seconds=deployment_timeout_seconds,
-    )
-    smoke = _odoo_compose_stage_preview_smoke_result(
-        checked_at=utc_now_timestamp(),
-        request=request,
-        env_text=env_text,
-        preview_url=preview_url,
-        timeout_seconds=health_timeout_seconds,
-    )
-    return target_definition.target_id, smoke
-
-
 def discover_generic_web_preview_desired_state(
     *,
     control_plane_root: Path,
@@ -1865,50 +1327,6 @@ def execute_generic_web_preview_inventory(
         )
     app_name_prefix = effective_preview_app_name_prefix(profile=resolved_profile)
     host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
-    template_lane = _template_lane(profile=resolved_profile)
-    if template_lane is not None and _profile_allows_odoo_compose_stage_preview(
-        profile=resolved_profile
-    ):
-        target_definition, _template_payload, target_error = _read_template_payload(
-            control_plane_root=control_plane_root,
-            template_lane=template_lane,
-            allow_compose_template=True,
-        )
-        if target_error:
-            raise click.ClickException(target_error)
-        if target_definition is not None and _uses_odoo_compose_stage_preview(
-            profile=resolved_profile,
-            target_definition=target_definition,
-        ):
-            compose_preview_items: list[GenericWebPreviewInventoryItem] = []
-            for domain in _compose_preview_domains(
-                host=host,
-                token=token,
-                compose_id=target_definition.target_id,
-                profile=resolved_profile,
-            ):
-                domain_host = str(domain.get("host") or "").strip()
-                compose_preview_items.append(
-                    GenericWebPreviewInventoryItem(
-                        applicationId=target_definition.target_id,
-                        applicationName=target_definition.target_name,
-                        previewSlug=_preview_slug_from_compose_domain(
-                            profile=resolved_profile,
-                            domain_host=domain_host,
-                        ),
-                        providerType="compose-domain",
-                        domainId=str(domain.get("domainId") or "").strip(),
-                        domainHost=domain_host,
-                    )
-                )
-            return GenericWebPreviewInventoryResult(
-                product=resolved_profile.product,
-                context=resolved_profile.preview.context,
-                source=request.source,
-                app_name_prefix=app_name_prefix,
-                previews=tuple(sorted(compose_preview_items, key=lambda item: item.previewSlug)),
-            )
-
     raw_projects = control_plane_dokploy.dokploy_request(
         host=host,
         token=token,
@@ -1964,74 +1382,6 @@ def execute_generic_web_preview_destroy(
         preview_slug=request.preview_slug,
     )
     host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
-    template_lane = _template_lane(profile=resolved_profile)
-    if template_lane is not None and _profile_allows_odoo_compose_stage_preview(
-        profile=resolved_profile
-    ):
-        target_definition, _template_payload, target_error = _read_template_payload(
-            control_plane_root=control_plane_root,
-            template_lane=template_lane,
-            allow_compose_template=True,
-        )
-        if target_error:
-            raise click.ClickException(target_error)
-        if target_definition is not None and _uses_odoo_compose_stage_preview(
-            profile=resolved_profile,
-            target_definition=target_definition,
-        ):
-            compose_cleanup_errors: list[str] = []
-            deleted_domain_ids: list[str] = []
-            for domain in _compose_preview_domains(
-                host=host,
-                token=token,
-                compose_id=target_definition.target_id,
-                profile=resolved_profile,
-            ):
-                domain_host = str(domain.get("host") or "").strip()
-                if (
-                    _preview_slug_from_compose_domain(
-                        profile=resolved_profile,
-                        domain_host=domain_host,
-                    )
-                    != request.preview_slug
-                ):
-                    continue
-                domain_id = str(domain.get("domainId") or "").strip()
-                if not domain_id:
-                    continue
-                try:
-                    _delete_domain(host=host, token=token, domain_id=domain_id)
-                    deleted_domain_ids.append(domain_id)
-                except click.ClickException as exc:
-                    compose_cleanup_errors.append(f"domain cleanup failed: {exc}")
-            finished_at = utc_now_timestamp()
-            if compose_cleanup_errors:
-                return GenericWebPreviewDestroyResult(
-                    destroy_status="fail",
-                    destroy_started_at=started_at,
-                    destroy_finished_at=finished_at,
-                    product=resolved_profile.product,
-                    context=resolved_profile.preview.context,
-                    preview_slug=request.preview_slug,
-                    application_name=application_name,
-                    application_id=target_definition.target_id,
-                    provider_type="compose-domain",
-                    domain_ids=tuple(deleted_domain_ids),
-                    error_message="; ".join(compose_cleanup_errors),
-                )
-            return GenericWebPreviewDestroyResult(
-                destroy_status="pass",
-                destroy_started_at=started_at,
-                destroy_finished_at=finished_at,
-                product=resolved_profile.product,
-                context=resolved_profile.preview.context,
-                preview_slug=request.preview_slug,
-                application_name=application_name,
-                application_id=target_definition.target_id,
-                provider_type="compose-domain",
-                domain_ids=tuple(deleted_domain_ids),
-            )
-
     application = _find_application_by_name(
         host=host,
         token=token,

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -155,16 +155,12 @@ Launchplane preview and preview-generation records as generic-web previews.
 The preview-verification route accepts optional checked URL evidence and returns
 a typed `odoo_preview_verification` result while only mutating Launchplane
 preview-generation records.
-Odoo's staged compose preview MVP is now historical compatibility evidence, not
-the target runtime architecture. That path updated and deployed the configured
-compose target when the product profile used `preview.data_transport_mode =
-"bootstrap"` and its template lane was a Dokploy `compose` target; inventory and
-destroy read compose domains with `/api/domain.byComposeId` and deleted only
-domains whose hostnames matched the preview slug template. This exception remains
-route-scoped to Odoo preview refresh, inventory, destroy, and readiness while the
-isolated runtime migration lands; it does not grant Odoo products access to
-stable generic-web deploy or promotion routes, and it does not make compose
-templates valid for generic-web products.
+Odoo's staged compose preview MVP is now retired. Generic-web preview readiness
+blocks compose template lanes, including historical Odoo bootstrap-mode compose
+profiles; Odoo PR previews must enter through `plan_odoo_preview_runtime` and
+`execute_odoo_preview_dokploy_apply`. Historical inventory and destroy evidence
+may still contain `providerType="compose-domain"`, but new Odoo preview provider
+mutation is isolated-runtime only.
 The isolated Odoo preview replacement starts with the
 `plan_odoo_preview_runtime` contract. It must return `ready` before provider
 apply code can create, update, deploy, or destroy a PR runtime. The planner fails
@@ -202,13 +198,13 @@ the compose missing, destroy treats the runtime as already clean. The adapter is
 not a generic local fallback: shared/provider execution still needs an approved
 non-production target and a caller surface that sources Launchplane-managed
 Dokploy credentials without printing secret values.
-For the CM staged preview contract, Odoo preview refresh also runs Launchplane-
-owned smoke before reporting `refresh_status="pass"`: image artifact evidence,
-source revision evidence, module install/update evidence from rendered Odoo env,
-`/web/health`, `/cm-website/health`, and `/cell-mechanic`. Passing smoke records
-the preview generation as `ready` with deploy, verify, and overall health status
-`pass`; failed smoke records a concise verification failure so PR feedback does
-not advertise ready before the checks pass.
+Odoo isolated preview apply also runs Launchplane-owned smoke before reporting a
+ready apply result. The apply path requires image artifact evidence, source
+revision evidence, rendered Odoo module evidence, and successful preview health
+checks. Passing smoke records the preview generation as `ready` with deploy,
+verify, and overall health status `pass`; failed smoke records a concise
+verification failure so PR feedback does not advertise ready before the checks
+pass.
 The verification route is a Launchplane-owned evidence ingress for follow-up
 browser or product smoke checks: it marks the latest preview generation ready or
 failed through the same preview-generation records without mutating provider

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -474,7 +474,7 @@ apply_odoo_cm_onboarding() {
               ODOO_INSTALL_MODULES: "cm_custom,cm_website"
             },
             preview_url_env_keys: ["WEB_BASE_URL"],
-            data_transport_mode: "bootstrap"
+            data_transport_mode: "driver"
           },
           dokploy_targets: (
             (if ($target_id | length) > 0 then
@@ -605,7 +605,7 @@ apply_odoo_opw_onboarding() {
               ODOO_INSTALL_MODULES: "opw_custom"
             },
             preview_url_env_keys: ["WEB_BASE_URL"],
-            data_transport_mode: "bootstrap"
+            data_transport_mode: "driver"
           },
           dokploy_targets: (
             (if ($testing_target_id | length) > 0 then

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -30,7 +30,6 @@ from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewInventoryRequest,
     GenericWebPreviewReadinessRequest,
     GenericWebPreviewRefreshRequest,
-    GenericWebPreviewRefreshResult,
     discover_generic_web_preview_desired_state,
     evaluate_generic_web_preview_readiness,
     execute_generic_web_preview_destroy,
@@ -352,53 +351,18 @@ class GenericWebPreviewTests(unittest.TestCase):
         self.assertEqual(result.app_name_prefix, "syo-preview")
         self.assertEqual([item.previewSlug for item in result.previews], ["preview-42-site"])
 
-    def test_execute_generic_web_preview_inventory_lists_odoo_compose_domains(self) -> None:
+    def test_execute_generic_web_preview_inventory_ignores_retired_odoo_compose_domains(self) -> None:
         store = _GenericWebPreviewStore(_odoo_compose_profile())
         requests: list[dict[str, object]] = []
 
         def _fake_dokploy_request(**kwargs: object) -> object:
             requests.append(dict(kwargs))
-            path = kwargs["path"]
-            if path == "/api/domain.byComposeId":
-                return [
-                    {
-                        "domainId": "domain-stable",
-                        "host": "cm-testing.shinycomputers.com",
-                    },
-                    {
-                        "domainId": "domain-preview",
-                        "host": "pr-28.cm-preview.shinycomputers.com",
-                    },
-                ]
-            return {}
+            return [{"environments": [{"applications": []}]}]
 
         with (
             patch(
                 "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
                 return_value=("https://dokploy.example", "token"),
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.fetch_dokploy_target_payload",
-                return_value={
-                    "composeId": "compose-cm-testing",
-                    "name": "cm-testing",
-                    "env": "ODOO_DB_NAME=cm\nODOO_DB_USER=odoo\nODOO_DB_PASSWORD=password\nODOO_DATA_VOLUME=data\nODOO_LOG_VOLUME=logs\nODOO_DB_VOLUME=db\nODOO_MASTER_PASSWORD=master\nODOO_ADMIN_PASSWORD=admin\n",
-                },
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
-                return_value=DokploySourceOfTruth(
-                    schema_version=1,
-                    targets=(
-                        DokployTargetDefinition(
-                            context="cm",
-                            instance="testing",
-                            target_type="compose",
-                            target_id="compose-cm-testing",
-                            target_name="cm-testing",
-                        ),
-                    ),
-                ),
             ),
             patch(
                 "control_plane.workflows.generic_web_preview.control_plane_dokploy.dokploy_request",
@@ -411,10 +375,8 @@ class GenericWebPreviewTests(unittest.TestCase):
                 request=GenericWebPreviewInventoryRequest(product="odoo-tenant-cm"),
             )
 
-        self.assertEqual([item.previewSlug for item in result.previews], ["pr-28"])
-        self.assertEqual(result.previews[0].providerType, "compose-domain")
-        self.assertEqual(result.previews[0].domainId, "domain-preview")
-        self.assertEqual([request["path"] for request in requests], ["/api/domain.byComposeId"])
+        self.assertEqual(result.previews, ())
+        self.assertEqual([request["path"] for request in requests], ["/api/project.all"])
 
     def test_evaluate_generic_web_preview_readiness_passes_with_template_contract(self) -> None:
         store = _GenericWebPreviewStore(_profile())
@@ -561,7 +523,7 @@ class GenericWebPreviewTests(unittest.TestCase):
         read_dokploy_config.assert_not_called()
         fetch_dokploy_target_payload.assert_not_called()
 
-    def test_evaluate_generic_web_preview_readiness_allows_odoo_compose_stage_template(
+    def test_evaluate_generic_web_preview_readiness_blocks_retired_odoo_compose_template(
         self,
     ) -> None:
         store = _GenericWebPreviewStore(_odoo_compose_profile())
@@ -584,31 +546,17 @@ class GenericWebPreviewTests(unittest.TestCase):
                 return_value=source,
             ),
             patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
-                return_value=("https://dokploy.example", "token"),
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.fetch_dokploy_target_payload",
+                "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.resolve_runtime_context_values",
                 return_value={
-                    "composeId": "compose-cm-testing",
-                    "name": "cm-testing",
-                    "environmentId": "env-1",
-                    "env": (
-                        "ODOO_DB_NAME=cm_preview\n"
-                        "ODOO_DB_USER=odoo\n"
-                        "ODOO_DB_PASSWORD=safe\n"
-                        "ODOO_DATA_VOLUME=cm_data\n"
-                        "ODOO_LOG_VOLUME=cm_logs\n"
-                        "ODOO_DB_VOLUME=cm_db\n"
-                        "ODOO_MASTER_PASSWORD=safe-master\n"
-                        "ODOO_ADMIN_PASSWORD=safe-admin\n"
-                    ),
+                    "LAUNCHPLANE_PREVIEW_BASE_URL": "https://cm-preview.shinycomputers.com"
                 },
             ),
             patch(
-                "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.resolve_runtime_environment_values",
-                return_value={},
-            ),
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config"
+            ) as read_dokploy_config,
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.fetch_dokploy_target_payload"
+            ) as fetch_dokploy_target_payload,
         ):
             result = evaluate_generic_web_preview_readiness(
                 control_plane_root=Path("."),
@@ -617,15 +565,15 @@ class GenericWebPreviewTests(unittest.TestCase):
                 checked_at="2026-05-09T15:00:00Z",
             )
 
-        self.assertEqual(result.readiness_status, "pass")
+        self.assertEqual(result.readiness_status, "blocked")
         self.assertEqual(result.template_target_type, "compose")
         self.assertEqual(result.template_target_id, "compose-cm-testing")
-        self.assertEqual(result.transport.data_transport_mode, "bootstrap")
-        self.assertEqual(result.missing_provider_fields, ())
         self.assertEqual(
-            result.checks[1].message,
-            "Staged Odoo compose preview uses Launchplane-rendered compose source.",
+            result.checks[0].message,
+            "Generic web preview readiness requires the template lane to be a Dokploy application.",
         )
+        read_dokploy_config.assert_not_called()
+        fetch_dokploy_target_payload.assert_not_called()
 
     def test_evaluate_generic_web_preview_readiness_blocks_non_odoo_compose_template(
         self,
@@ -650,6 +598,12 @@ class GenericWebPreviewTests(unittest.TestCase):
                 return_value=source,
             ),
             patch(
+                "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.resolve_runtime_context_values",
+                return_value={
+                    "LAUNCHPLANE_PREVIEW_BASE_URL": "https://cm-preview.shinycomputers.com"
+                },
+            ),
+            patch(
                 "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config"
             ) as read_dokploy_config,
             patch(
@@ -671,123 +625,6 @@ class GenericWebPreviewTests(unittest.TestCase):
         )
         read_dokploy_config.assert_not_called()
         fetch_dokploy_target_payload.assert_not_called()
-
-    def test_evaluate_generic_web_preview_readiness_blocks_odoo_compose_missing_safe_env(
-        self,
-    ) -> None:
-        store = _GenericWebPreviewStore(_odoo_compose_profile())
-        source = DokploySourceOfTruth(
-            schema_version=1,
-            targets=(
-                DokployTargetDefinition(
-                    context="cm",
-                    instance="testing",
-                    target_type="compose",
-                    target_id="compose-cm-testing",
-                    target_name="cm-testing",
-                ),
-            ),
-        )
-
-        with (
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
-                return_value=source,
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
-                return_value=("https://dokploy.example", "token"),
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.fetch_dokploy_target_payload",
-                return_value={
-                    "composeId": "compose-cm-testing",
-                    "name": "cm-testing",
-                    "environmentId": "env-1",
-                    "env": "ODOO_DB_NAME=cm_preview\nODOO_DB_USER=odoo\n",
-                },
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.resolve_runtime_environment_values",
-                return_value={},
-            ),
-        ):
-            result = evaluate_generic_web_preview_readiness(
-                control_plane_root=Path("."),
-                record_store=store,
-                request=GenericWebPreviewReadinessRequest(product="odoo-tenant-cm"),
-                checked_at="2026-05-09T15:00:00Z",
-            )
-
-        self.assertEqual(result.readiness_status, "blocked")
-        self.assertEqual(
-            result.missing_template_env_keys,
-            (
-                "ODOO_DB_PASSWORD",
-                "ODOO_DATA_VOLUME",
-                "ODOO_LOG_VOLUME",
-                "ODOO_DB_VOLUME",
-                "ODOO_MASTER_PASSWORD",
-                "ODOO_ADMIN_PASSWORD",
-            ),
-        )
-
-    def test_evaluate_generic_web_preview_readiness_accepts_odoo_compose_runtime_env(
-        self,
-    ) -> None:
-        store = _GenericWebPreviewStore(_odoo_compose_profile())
-        source = DokploySourceOfTruth(
-            schema_version=1,
-            targets=(
-                DokployTargetDefinition(
-                    context="cm",
-                    instance="testing",
-                    target_type="compose",
-                    target_id="compose-cm-testing",
-                    target_name="cm-testing",
-                ),
-            ),
-        )
-
-        with (
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
-                return_value=source,
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
-                return_value=("https://dokploy.example", "token"),
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.fetch_dokploy_target_payload",
-                return_value={
-                    "composeId": "compose-cm-testing",
-                    "name": "cm-testing",
-                    "environmentId": "env-1",
-                    "env": "ODOO_DB_NAME=cm_preview\nODOO_DB_USER=odoo\n",
-                },
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.resolve_runtime_environment_values",
-                return_value={
-                    "ODOO_DB_PASSWORD": "safe",
-                    "ODOO_DATA_VOLUME": "cm_data",
-                    "ODOO_LOG_VOLUME": "cm_logs",
-                    "ODOO_DB_VOLUME": "cm_db",
-                    "ODOO_MASTER_PASSWORD": "safe-master",
-                    "ODOO_ADMIN_PASSWORD": "safe-admin",
-                },
-            ),
-        ):
-            result = evaluate_generic_web_preview_readiness(
-                control_plane_root=Path("."),
-                record_store=store,
-                request=GenericWebPreviewReadinessRequest(product="odoo-tenant-cm"),
-                checked_at="2026-05-09T15:00:00Z",
-            )
-
-        self.assertEqual(result.readiness_status, "pass")
-        self.assertEqual(result.missing_template_env_keys, ())
 
     def test_execute_generic_web_preview_refresh_blocks_before_provider_mutation(self) -> None:
         store = _GenericWebPreviewStore(_profile())
@@ -1247,7 +1084,7 @@ class GenericWebPreviewTests(unittest.TestCase):
         self.assertIn("secret_class_not_allowed", result.error_message)
         dokploy_request.assert_not_called()
 
-    def test_execute_generic_web_preview_refresh_derives_odoo_compose_preview_url(
+    def test_execute_generic_web_preview_refresh_blocks_retired_odoo_compose_template(
         self,
     ) -> None:
         store = _GenericWebPreviewStore(_odoo_compose_profile())
@@ -1263,69 +1100,11 @@ class GenericWebPreviewTests(unittest.TestCase):
                 ),
             ),
         )
-        env_updates: list[str] = []
-
-        def _fake_fetch(**kwargs: object) -> dict[str, object]:
-            self.assertEqual(kwargs["target_type"], "compose")
-            self.assertEqual(kwargs["target_id"], "compose-cm-testing")
-            return {
-                "composeId": "compose-cm-testing",
-                "name": "cm-testing",
-                "environmentId": "env-1",
-                "sourceType": "raw",
-                "composePath": "docker-compose.yml",
-                "composeFile": "",
-                "env": (
-                    "ODOO_DB_NAME=cm_preview\n"
-                    "ODOO_DB_USER=odoo\n"
-                    "ODOO_DB_PASSWORD=safe\n"
-                    "ODOO_DATA_VOLUME=cm_data\n"
-                    "ODOO_LOG_VOLUME=cm_logs\n"
-                    "ODOO_DB_VOLUME=cm_db\n"
-                    "ODOO_MASTER_PASSWORD=safe-master\n"
-                    "ODOO_ADMIN_PASSWORD=safe-admin\n"
-                    "WEB_BASE_URL=https://testing.cm.example.test\n"
-                ),
-            }
-
-        def _fake_update_env(**kwargs: object) -> None:
-            env_updates.append(str(kwargs["env_text"]))
-
-        domain_requests: list[dict[str, object]] = []
-
-        def _fake_dokploy_request(**kwargs: object) -> object:
-            domain_requests.append(dict(kwargs))
-            path = kwargs["path"]
-            if path == "/api/domain.byComposeId":
-                return [
-                    {
-                        "domainId": "domain-testing",
-                        "host": "cm-testing.shinycomputers.com",
-                        "serviceName": "web",
-                        "port": 8069,
-                        "domainType": "compose",
-                    }
-                ]
-            if path == "/api/domain.create":
-                return {"domainId": "domain-preview"}
-            return {}
 
         with (
             patch(
                 "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
                 return_value=source,
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
-                return_value=("https://dokploy.example", "token"),
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.fetch_dokploy_target_payload",
-                side_effect=_fake_fetch,
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.resolve_runtime_environment_values",
-                return_value={"ODOO_PROJECT_NAME": "cm-pr-28"},
             ),
             patch(
                 "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.resolve_runtime_context_values",
@@ -1334,40 +1113,11 @@ class GenericWebPreviewTests(unittest.TestCase):
                 },
             ),
             patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.sync_dokploy_compose_raw_source",
-            ) as sync_raw_source,
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config"
+            ) as read_dokploy_config,
             patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.update_dokploy_target_env",
-                side_effect=_fake_update_env,
-            ) as update_env,
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.dokploy_request",
-                side_effect=_fake_dokploy_request,
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.latest_deployment_for_target",
-                return_value={"deploymentId": "before"},
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.trigger_deployment",
-            ) as trigger_deployment,
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.wait_for_target_deployment",
-            ) as wait_for_deployment,
-            patch(
-                "control_plane.workflows.generic_web_preview._wait_for_preview_health"
-            ) as wait_health,
-            patch(
-                "control_plane.workflows.generic_web_preview._fetch_preview_smoke_path"
-            ) as fetch_smoke_path,
-            patch(
-                "control_plane.workflows.generic_web_preview.utc_now_timestamp",
-                side_effect=[
-                    "2026-05-09T15:00:00Z",
-                    "2026-05-09T15:00:04Z",
-                    "2026-05-09T15:00:05Z",
-                ],
-            ),
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.dokploy_request"
+            ) as dokploy_request,
         ):
             result = execute_generic_web_preview_refresh(
                 control_plane_root=Path("."),
@@ -1379,105 +1129,12 @@ class GenericWebPreviewTests(unittest.TestCase):
                     anchor_head_sha="abc123",
                     timeout_seconds=240,
                 ),
-            )
-
-        self.assertEqual(result.refresh_status, "pass")
-        self.assertIsNotNone(result.smoke)
-        self.assertEqual(result.smoke.smoke_status if result.smoke else "", "pass")
-        self.assertEqual(result.application_id, "compose-cm-testing")
-        sync_raw_source.assert_called_once()
-        _, sync_kwargs = sync_raw_source.call_args
-        self.assertEqual(sync_kwargs["compose_id"], "compose-cm-testing")
-        self.assertIn(
-            "image: ghcr.io/cbusillo/odoo-tenant-cm:sha",
-            str(sync_kwargs["compose_file"]),
-        )
-        update_env.assert_called_once()
-        self.assertEqual(len(env_updates), 1)
-        self.assertIn("ODOO_DB_NAME=cm_preview", env_updates[0])
-        self.assertIn("ODOO_PROJECT_NAME=cm-pr-28", env_updates[0])
-        self.assertIn("ODOO_INSTALL_MODULES=cm_custom,cm_website", env_updates[0])
-        self.assertIn("WEB_BASE_URL=https://pr-28.cm-preview.shinycomputers.com", env_updates[0])
-        self.assertIn("DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/odoo-tenant-cm:sha", env_updates[0])
-        self.assertIn("LAUNCHPLANE_RUNTIME_IDENTITY_JSON=", env_updates[0])
-        self.assertIn("LAUNCHPLANE_DEPLOYMENT_RECORD_ID=", env_updates[0])
-        self.assertIn("LAUNCHPLANE_ARTIFACT_ID=ghcr.io/cbusillo/odoo-tenant-cm:sha", env_updates[0])
-        self.assertIn("LAUNCHPLANE_SOURCE_GIT_REF=abc123", env_updates[0])
-        self.assertEqual(
-            [request["path"] for request in domain_requests],
-            ["/api/domain.byComposeId", "/api/domain.create"],
-        )
-        self.assertEqual(
-            domain_requests[1]["payload"],
-            {
-                "host": "pr-28.cm-preview.shinycomputers.com",
-                "path": "/",
-                "internalPath": "/",
-                "port": 8069,
-                "https": True,
-                "applicationId": None,
-                "certificateType": "none",
-                "customCertResolver": None,
-                "composeId": "compose-cm-testing",
-                "serviceName": "web",
-                "domainType": "compose",
-                "previewDeploymentId": None,
-                "stripPath": False,
-            },
-        )
-        trigger_deployment.assert_called_once_with(
-            host="https://dokploy.example",
-            token="token",
-            target_type="compose",
-            target_id="compose-cm-testing",
-            no_cache=False,
-        )
-        wait_for_deployment.assert_called_once()
-        _, wait_kwargs = wait_for_deployment.call_args
-        self.assertEqual(wait_kwargs["timeout_seconds"], 120)
-        wait_health.assert_called_once_with(
-            preview_url="https://pr-28.cm-preview.shinycomputers.com",
-            health_path="/web/health",
-            timeout_seconds=120,
-        )
-        self.assertEqual(
-            [call.kwargs["path"] for call in fetch_smoke_path.call_args_list],
-            ["/cm-website/health", "/cell-mechanic"],
         )
 
-    def test_execute_generic_web_preview_refresh_fails_odoo_health_smoke(self) -> None:
-        result = self._execute_odoo_compose_stage_preview_with_smoke_failure(
-            health_failure=click.ClickException("Timed out waiting for health."),
-            anchor_head_sha="abc123",
-        )
-
-        self.assertEqual(result.refresh_status, "fail")
-        self.assertIsNotNone(result.smoke)
-        self.assertEqual(result.smoke.smoke_status if result.smoke else "", "fail")
-        self.assertIn("Timed out waiting for health", result.error_message)
-
-    def test_execute_generic_web_preview_refresh_fails_odoo_page_smoke(self) -> None:
-        result = self._execute_odoo_compose_stage_preview_with_smoke_failure(
-            page_failures={"/cell-mechanic": click.ClickException("HTTP 404")},
-            anchor_head_sha="abc123",
-        )
-
-        self.assertEqual(result.refresh_status, "fail")
-        self.assertIsNotNone(result.smoke)
-        failed_checks = (
-            [check.check_id for check in result.smoke.checks if check.status == "fail"]
-            if result.smoke
-            else []
-        )
-        self.assertEqual(failed_checks, ["cell_mechanic_page"])
-
-    def test_execute_generic_web_preview_refresh_fails_odoo_missing_revision_evidence(
-        self,
-    ) -> None:
-        result = self._execute_odoo_compose_stage_preview_with_smoke_failure(anchor_head_sha="")
-
-        self.assertEqual(result.refresh_status, "fail")
-        self.assertIn("source revision is missing", result.error_message)
+        self.assertEqual(result.refresh_status, "blocked")
+        self.assertEqual(result.error_message, "Generic web preview readiness blocked refresh.")
+        read_dokploy_config.assert_not_called()
+        dokploy_request.assert_not_called()
 
     def test_execute_generic_web_preview_refresh_rejects_missing_artifact_evidence(self) -> None:
         with self.assertRaises(ValueError):
@@ -1485,152 +1142,6 @@ class GenericWebPreviewTests(unittest.TestCase):
                 product="odoo-tenant-cm",
                 preview_slug="pr-28",
                 image_reference="",
-            )
-
-    def test_execute_generic_web_preview_refresh_fails_odoo_missing_module_evidence(
-        self,
-    ) -> None:
-        base_profile = _odoo_compose_profile()
-        result = self._execute_odoo_compose_stage_preview_with_smoke_failure(
-            profile=base_profile.model_copy(
-                update={"preview": base_profile.preview.model_copy(update={"override_env": {}})}
-            ),
-            anchor_head_sha="abc123",
-        )
-
-        self.assertEqual(result.refresh_status, "fail")
-        self.assertIn("module install/update evidence is missing", result.error_message)
-
-    def _execute_odoo_compose_stage_preview_with_smoke_failure(
-        self,
-        *,
-        profile: LaunchplaneProductProfileRecord | None = None,
-        anchor_head_sha: str = "abc123",
-        health_failure: click.ClickException | None = None,
-        page_failures: dict[str, click.ClickException] | None = None,
-    ) -> GenericWebPreviewRefreshResult:
-        resolved_profile = profile or _odoo_compose_profile()
-        store = _GenericWebPreviewStore(resolved_profile)
-        source = DokploySourceOfTruth(
-            schema_version=1,
-            targets=(
-                DokployTargetDefinition(
-                    context="cm",
-                    instance="testing",
-                    target_type="compose",
-                    target_id="compose-cm-testing",
-                    target_name="cm-testing",
-                ),
-            ),
-        )
-
-        def _fake_fetch(**kwargs: object) -> dict[str, object]:
-            return {
-                "composeId": "compose-cm-testing",
-                "name": "cm-testing",
-                "environmentId": "env-1",
-                "sourceType": "raw",
-                "composePath": "docker-compose.yml",
-                "composeFile": "",
-                "env": (
-                    "ODOO_DB_NAME=cm_preview\n"
-                    "ODOO_DB_USER=odoo\n"
-                    "ODOO_DB_PASSWORD=safe\n"
-                    "ODOO_DATA_VOLUME=cm_data\n"
-                    "ODOO_LOG_VOLUME=cm_logs\n"
-                    "ODOO_DB_VOLUME=cm_db\n"
-                    "ODOO_MASTER_PASSWORD=safe-master\n"
-                    "ODOO_ADMIN_PASSWORD=safe-admin\n"
-                    "WEB_BASE_URL=https://testing.cm.example.test\n"
-                ),
-            }
-
-        def _fake_dokploy_request(**kwargs: object) -> object:
-            if kwargs["path"] == "/api/domain.byComposeId":
-                return []
-            if kwargs["path"] == "/api/domain.create":
-                return {"domainId": "domain-preview"}
-            return {}
-
-        def _fake_wait_health(**kwargs: object) -> None:
-            if health_failure is not None:
-                raise health_failure
-
-        def _fake_fetch_smoke_path(**kwargs: object) -> None:
-            failure = (page_failures or {}).get(str(kwargs["path"]))
-            if failure is not None:
-                raise failure
-
-        with (
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
-                return_value=source,
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
-                return_value=("https://dokploy.example", "token"),
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.fetch_dokploy_target_payload",
-                side_effect=_fake_fetch,
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.resolve_runtime_environment_values",
-                return_value={"ODOO_PROJECT_NAME": "cm-pr-28"},
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.resolve_runtime_context_values",
-                return_value={
-                    "LAUNCHPLANE_PREVIEW_BASE_URL": "https://cm-preview.shinycomputers.com"
-                },
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.sync_dokploy_compose_raw_source",
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.update_dokploy_target_env",
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.dokploy_request",
-                side_effect=_fake_dokploy_request,
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.latest_deployment_for_target",
-                return_value={"deploymentId": "before"},
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.trigger_deployment",
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.wait_for_target_deployment",
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview._wait_for_preview_health",
-                side_effect=_fake_wait_health,
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview._fetch_preview_smoke_path",
-                side_effect=_fake_fetch_smoke_path,
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.utc_now_timestamp",
-                side_effect=[
-                    "2026-05-09T15:00:00Z",
-                    "2026-05-09T15:00:04Z",
-                    "2026-05-09T15:00:05Z",
-                ],
-            ),
-        ):
-            return execute_generic_web_preview_refresh(
-                control_plane_root=Path("."),
-                record_store=store,
-                request=GenericWebPreviewRefreshRequest(
-                    product="odoo-tenant-cm",
-                    preview_slug="pr-28",
-                    image_reference="ghcr.io/cbusillo/odoo-tenant-cm:sha",
-                    anchor_head_sha=anchor_head_sha,
-                    timeout_seconds=240,
-                ),
             )
 
     def test_execute_generic_web_preview_refresh_allows_preview_safe_copied_secret_key(
@@ -1862,57 +1373,18 @@ class GenericWebPreviewTests(unittest.TestCase):
         self.assertIn("syo-preview-preview-42-site", result.error_message)
         self.assertEqual([request["path"] for request in requests], ["/api/project.all"])
 
-    def test_execute_generic_web_preview_destroy_deletes_odoo_compose_domain(self) -> None:
+    def test_execute_generic_web_preview_destroy_ignores_retired_odoo_compose_domains(self) -> None:
         store = _GenericWebPreviewStore(_odoo_compose_profile())
         requests: list[dict[str, object]] = []
 
         def _fake_dokploy_request(**kwargs: object) -> object:
             requests.append(dict(kwargs))
-            path = kwargs["path"]
-            if path == "/api/domain.byComposeId":
-                return [
-                    {
-                        "domainId": "domain-stable",
-                        "host": "cm-testing.shinycomputers.com",
-                    },
-                    {
-                        "domainId": "domain-pr-28",
-                        "host": "pr-28.cm-preview.shinycomputers.com",
-                    },
-                    {
-                        "domainId": "domain-pr-29",
-                        "host": "pr-29.cm-preview.shinycomputers.com",
-                    },
-                ]
-            return {}
+            return [{"environments": [{"applications": []}]}]
 
         with (
             patch(
                 "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
                 return_value=("https://dokploy.example", "token"),
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.fetch_dokploy_target_payload",
-                return_value={
-                    "composeId": "compose-cm-testing",
-                    "name": "cm-testing",
-                    "env": "ODOO_DB_NAME=cm\nODOO_DB_USER=odoo\nODOO_DB_PASSWORD=password\nODOO_DATA_VOLUME=data\nODOO_LOG_VOLUME=logs\nODOO_DB_VOLUME=db\nODOO_MASTER_PASSWORD=master\nODOO_ADMIN_PASSWORD=admin\n",
-                },
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
-                return_value=DokploySourceOfTruth(
-                    schema_version=1,
-                    targets=(
-                        DokployTargetDefinition(
-                            context="cm",
-                            instance="testing",
-                            target_type="compose",
-                            target_id="compose-cm-testing",
-                            target_name="cm-testing",
-                        ),
-                    ),
-                ),
             ),
             patch(
                 "control_plane.workflows.generic_web_preview.control_plane_dokploy.dokploy_request",
@@ -1933,15 +1405,11 @@ class GenericWebPreviewTests(unittest.TestCase):
                 ),
             )
 
-        self.assertEqual(result.destroy_status, "pass")
-        self.assertEqual(result.provider_type, "compose-domain")
-        self.assertEqual(result.application_id, "compose-cm-testing")
-        self.assertEqual(result.domain_ids, ("domain-pr-28",))
-        delete_requests = [
-            request for request in requests if request["path"] == "/api/domain.delete"
-        ]
-        self.assertEqual(len(delete_requests), 1)
-        self.assertEqual(delete_requests[0]["payload"], {"domainId": "domain-pr-28"})
+        self.assertEqual(result.destroy_status, "fail")
+        self.assertEqual(result.provider_type, "application")
+        self.assertEqual(result.application_id, "")
+        self.assertIn("cm-odoo-preview-pr-28", result.error_message)
+        self.assertEqual([request["path"] for request in requests], ["/api/project.all"])
 
 
 if __name__ == "__main__":

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -722,7 +722,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertEqual(manifest.preview.template_instance, "testing")
         self.assertEqual(manifest.preview.override_env["ODOO_INSTALL_MODULES"], "opw_custom")
         self.assertEqual(manifest.preview.preview_url_env_keys, ("WEB_BASE_URL",))
-        self.assertEqual(manifest.preview.data_transport_mode, "bootstrap")
+        self.assertEqual(manifest.preview.data_transport_mode, "driver")
         policies = {lane.instance: lane.odoo_prelaunch_rebuild for lane in manifest.lanes}
         for instance in ("testing", "prod"):
             self.assertTrue(policies[instance].enabled)


### PR DESCRIPTION
## Summary
- Remove the retired generic-web staged Odoo compose preview exception.
- Keep generic-web compose template lanes fail-closed and move CM/OPW preview manifests to driver transport.
- Update docs/tests to make isolated Odoo preview runtimes the only live Odoo PR preview path.

## Verification
- `bash -n scripts/deploy/ensure-authz-grants.sh`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest tests.test_generic_web_preview tests.test_product_onboarding tests.test_odoo_preview_runtime tests.test_odoo_preview_runtime_plan`
- `uv run python -m unittest`
- `git diff --check`
- JetBrains changed-files inspection: clean
