### PR TITLE
Document operator UI GET health probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ uv run python -m unittest
 Frontend validation currently covers TypeScript and the production Vite build.
 Lint, formatting, and component tests are not introduced yet.
 
+When checking the served operator UI, use a browser or `GET /ui` request. Some
+server paths may not answer `HEAD /ui` the same way as the app shell, so a
+failed `HEAD` probe is not enough evidence that the UI is unavailable.
+
 Runtime authority should come from Launchplane DB records in steady state.
 Launchplane-managed secrets, runtime-environment records, tracked Dokploy
 target records, and Dokploy target-id records are DB-backed concerns;

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -133,6 +133,10 @@ as a compatibility alias. Built assets live under `/ui/assets/...`, while
 `/ui/*` falls back to the app shell so the frontend can own client-side routes.
 Versioned API ingress remains under `/v1`.
 
+Validate the operator UI shell with browser navigation or `GET /ui`. Do not use
+`HEAD /ui` as the only availability check, because static app-shell fallback
+behavior can differ between request methods.
+
 `POST /v1/every-code/github-webhook` is the only unauthenticated write route.
 It trusts the request body through GitHub webhook HMAC verification instead of
 OIDC. The route requires `X-Hub-Signature-256`, `X-GitHub-Delivery`, and


### PR DESCRIPTION
## Summary

- Document that operator UI availability checks should use browser navigation or GET /ui.
- Warn that HEAD /ui alone is not reliable evidence for the static app shell.


## Tests
- git diff --check
