### PR TITLE
Expose merge train controller state in admission

### DIFF
--- a/control_plane/contracts/merge_train_admission.py
+++ b/control_plane/contracts/merge_train_admission.py
@@ -5,7 +5,18 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidateRecord
+from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlanRecord
 from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
+from control_plane.contracts.merge_train_stack_collapse import (
+    MergeTrainStackCollapsePlanRecord,
+)
+from control_plane.workflows.merge_train_controller import (
+    MergeTrainControllerDecision,
+)
+from control_plane.workflows.merge_train_controller import (
+    decide_merge_train_controller_record_action,
+)
 
 
 MergeTrainAdmissionStatus = Literal["admitted", "deferred"]
@@ -33,6 +44,11 @@ class MergeTrainAdmissionDecision(BaseModel):
     latest_run_id: str = ""
     latest_run_status: str = ""
     latest_run_recorded_at: str = ""
+    controller_action: str = ""
+    controller_reason: str = ""
+    controller_candidate_record_id: str = ""
+    controller_landing_plan_record_id: str = ""
+    controller_stack_collapse_plan_record_id: str = ""
     detail: str
 
     @model_validator(mode="after")
@@ -52,6 +68,13 @@ class MergeTrainAdmissionDecision(BaseModel):
         self.latest_run_id = self.latest_run_id.strip()
         self.latest_run_status = self.latest_run_status.strip()
         self.latest_run_recorded_at = self.latest_run_recorded_at.strip()
+        self.controller_action = self.controller_action.strip()
+        self.controller_reason = self.controller_reason.strip()
+        self.controller_candidate_record_id = self.controller_candidate_record_id.strip()
+        self.controller_landing_plan_record_id = self.controller_landing_plan_record_id.strip()
+        self.controller_stack_collapse_plan_record_id = (
+            self.controller_stack_collapse_plan_record_id.strip()
+        )
         self.detail = _normalize_required_value(
             self.detail, "merge train admission decision requires detail"
         )
@@ -68,6 +91,7 @@ def evaluate_merge_train_admission(
     base_branch: str,
     requested_at: str,
     latest_run: MergeTrainRunRecord | None,
+    controller_decision: MergeTrainControllerDecision | None = None,
     poll_interval_seconds: int = 60,
     backoff_seconds: int = 300,
 ) -> MergeTrainAdmissionDecision:
@@ -92,6 +116,7 @@ def evaluate_merge_train_admission(
             reason_code="no_prior_run",
             requested_at=normalized_requested_at,
             next_allowed_at=normalized_requested_at,
+            controller_decision=controller_decision,
             detail="No prior merge-train run exists for this repository/base branch.",
         )
 
@@ -109,6 +134,7 @@ def evaluate_merge_train_admission(
             requested_at=normalized_requested_at,
             next_allowed_at=normalized_requested_at,
             latest_run=latest_run,
+            controller_decision=controller_decision,
             detail="Latest merge-train record is dry-run evidence and does not throttle the scheduler.",
         )
 
@@ -121,6 +147,7 @@ def evaluate_merge_train_admission(
             requested_at=normalized_requested_at,
             next_allowed_at=normalized_requested_at,
             latest_run=latest_run,
+            controller_decision=controller_decision,
             detail="Latest merge-train mutation requires a fresh read before another decision.",
         )
 
@@ -131,6 +158,7 @@ def evaluate_merge_train_admission(
             requested_time=requested_time,
             requested_at=normalized_requested_at,
             latest_run=latest_run,
+            controller_decision=controller_decision,
             interval_seconds=poll_interval_seconds,
             elapsed_reason_code="poll_interval_elapsed",
             pending_reason_code="poll_interval_pending",
@@ -144,6 +172,7 @@ def evaluate_merge_train_admission(
         requested_time=requested_time,
         requested_at=normalized_requested_at,
         latest_run=latest_run,
+        controller_decision=controller_decision,
         interval_seconds=backoff_seconds,
         elapsed_reason_code="backoff_elapsed",
         pending_reason_code="backoff_pending",
@@ -159,6 +188,7 @@ def _interval_decision(
     requested_time: datetime,
     requested_at: str,
     latest_run: MergeTrainRunRecord,
+    controller_decision: MergeTrainControllerDecision | None,
     interval_seconds: int,
     elapsed_reason_code: MergeTrainAdmissionReason,
     pending_reason_code: MergeTrainAdmissionReason,
@@ -176,6 +206,7 @@ def _interval_decision(
             requested_at=requested_at,
             next_allowed_at=_format_timestamp(requested_time),
             latest_run=latest_run,
+            controller_decision=controller_decision,
             detail=elapsed_detail,
         )
     return _decision(
@@ -186,6 +217,7 @@ def _interval_decision(
         requested_at=requested_at,
         next_allowed_at=_format_timestamp(next_allowed_time),
         latest_run=latest_run,
+        controller_decision=controller_decision,
         detail=pending_detail,
     )
 
@@ -200,6 +232,7 @@ def _decision(
     next_allowed_at: str,
     detail: str,
     latest_run: MergeTrainRunRecord | None = None,
+    controller_decision: MergeTrainControllerDecision | None = None,
 ) -> MergeTrainAdmissionDecision:
     return MergeTrainAdmissionDecision(
         repository=repository,
@@ -211,7 +244,31 @@ def _decision(
         latest_run_id=latest_run.run_id if latest_run is not None else "",
         latest_run_status=latest_run.status if latest_run is not None else "",
         latest_run_recorded_at=latest_run.recorded_at if latest_run is not None else "",
+        controller_action=controller_decision.action if controller_decision else "",
+        controller_reason=controller_decision.reason if controller_decision else "",
+        controller_candidate_record_id=controller_decision.candidate_record_id
+        if controller_decision
+        else "",
+        controller_landing_plan_record_id=controller_decision.landing_plan_record_id
+        if controller_decision
+        else "",
+        controller_stack_collapse_plan_record_id=(
+            controller_decision.stack_collapse_plan_record_id if controller_decision else ""
+        ),
         detail=detail,
+    )
+
+
+def build_merge_train_controller_admission_decision(
+    *,
+    candidate_records: tuple[MergeTrainBatchCandidateRecord, ...],
+    landing_plan_records: tuple[MergeTrainBatchLandingPlanRecord, ...],
+    stack_collapse_plan_records: tuple[MergeTrainStackCollapsePlanRecord, ...],
+) -> MergeTrainControllerDecision:
+    return decide_merge_train_controller_record_action(
+        candidate_records=candidate_records,
+        landing_plan_records=landing_plan_records,
+        stack_collapse_plan_records=stack_collapse_plan_records,
     )
 
 

--- a/control_plane/merge_train_admission.py
+++ b/control_plane/merge_train_admission.py
@@ -2,15 +2,50 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidateRecord
+from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlanRecord
 from control_plane.contracts.merge_train_admission import MergeTrainAdmissionDecision
+from control_plane.contracts.merge_train_admission import (
+    build_merge_train_controller_admission_decision,
+)
 from control_plane.contracts.merge_train_admission import evaluate_merge_train_admission
 from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
+from control_plane.contracts.merge_train_stack_collapse import (
+    MergeTrainStackCollapsePlanRecord,
+)
 
 
 class MergeTrainRunHistoryStore(Protocol):
     def latest_merge_train_run_record(
         self, *, repository: str, base_branch: str
     ) -> MergeTrainRunRecord | None: ...
+
+    def list_merge_train_batch_candidate_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeTrainBatchCandidateRecord, ...]: ...
+
+    def list_merge_train_batch_landing_plan_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeTrainBatchLandingPlanRecord, ...]: ...
+
+    def list_merge_train_stack_collapse_plan_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeTrainStackCollapsePlanRecord, ...]: ...
 
 
 def evaluate_merge_train_admission_from_store(
@@ -22,6 +57,29 @@ def evaluate_merge_train_admission_from_store(
     poll_interval_seconds: int = 60,
     backoff_seconds: int = 300,
 ) -> MergeTrainAdmissionDecision:
+    candidate_records = store.list_merge_train_batch_candidate_records(
+        repository=repository,
+        base_branch=base_branch,
+        status="active",
+        limit=25,
+    )
+    landing_plan_records = store.list_merge_train_batch_landing_plan_records(
+        repository=repository,
+        base_branch=base_branch,
+        status="active",
+        limit=25,
+    )
+    stack_collapse_plan_records = store.list_merge_train_stack_collapse_plan_records(
+        repository=repository,
+        base_branch=base_branch,
+        status="active",
+        limit=25,
+    )
+    controller_decision = build_merge_train_controller_admission_decision(
+        candidate_records=candidate_records,
+        landing_plan_records=landing_plan_records,
+        stack_collapse_plan_records=stack_collapse_plan_records,
+    )
     return evaluate_merge_train_admission(
         repository=repository,
         base_branch=base_branch,
@@ -30,6 +88,7 @@ def evaluate_merge_train_admission_from_store(
             repository=repository,
             base_branch=base_branch,
         ),
+        controller_decision=controller_decision,
         poll_interval_seconds=poll_interval_seconds,
         backoff_seconds=backoff_seconds,
     )

--- a/tests/test_merge_train_admission.py
+++ b/tests/test_merge_train_admission.py
@@ -1,8 +1,18 @@
 import unittest
 
+from control_plane.contracts.merge_train_admission import (
+    build_merge_train_controller_admission_decision,
+)
 from control_plane.contracts.merge_train_admission import evaluate_merge_train_admission
+from control_plane.contracts.merge_train_batch import build_merge_train_batch_candidate
+from control_plane.contracts.merge_train_batch import build_merge_train_batch_candidate_record
+from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidateRecord
+from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlanRecord
 from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
 from control_plane.contracts.merge_train_run_record import build_merge_train_run_record
+from control_plane.contracts.merge_train_stack_collapse import (
+    MergeTrainStackCollapsePlanRecord,
+)
 from control_plane.merge_train import MergeTrainDryRunSnapshot
 from control_plane.merge_train import MergeTrainPullRequestSnapshot
 from control_plane.merge_train import MergeTrainCheckStatus
@@ -38,8 +48,14 @@ class _NoopClient:
 
 
 class _RunHistoryStore:
-    def __init__(self, latest_run: MergeTrainRunRecord | None) -> None:
+    def __init__(
+        self,
+        latest_run: MergeTrainRunRecord | None,
+        *,
+        candidate_records: tuple[MergeTrainBatchCandidateRecord, ...] = (),
+    ) -> None:
         self.latest_run = latest_run
+        self.candidate_records = candidate_records
         self.requests: list[tuple[str, str]] = []
 
     def latest_merge_train_run_record(
@@ -47,6 +63,36 @@ class _RunHistoryStore:
     ) -> MergeTrainRunRecord | None:
         self.requests.append((repository, base_branch))
         return self.latest_run
+
+    def list_merge_train_batch_candidate_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeTrainBatchCandidateRecord, ...]:
+        return self.candidate_records
+
+    def list_merge_train_batch_landing_plan_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeTrainBatchLandingPlanRecord, ...]:
+        return ()
+
+    def list_merge_train_stack_collapse_plan_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeTrainStackCollapsePlanRecord, ...]:
+        return ()
 
 
 class MergeTrainAdmissionTests(unittest.TestCase):
@@ -170,6 +216,41 @@ class MergeTrainAdmissionTests(unittest.TestCase):
         self.assertTrue(decision.admitted)
         self.assertEqual(store.requests, [("cbusillo/sellyouroutboard", "main")])
 
+    def test_includes_controller_record_decision(self) -> None:
+        candidate_record = _candidate_record(status="ready_for_checks")
+
+        controller_decision = build_merge_train_controller_admission_decision(
+            candidate_records=(candidate_record,),
+            landing_plan_records=(),
+            stack_collapse_plan_records=(),
+        )
+        decision = evaluate_merge_train_admission(
+            repository="cbusillo/sellyouroutboard",
+            base_branch="main",
+            requested_at="2026-05-09T02:10:00Z",
+            latest_run=None,
+            controller_decision=controller_decision,
+        )
+
+        self.assertTrue(decision.admitted)
+        self.assertEqual(decision.controller_action, "observe_candidate")
+        self.assertEqual(decision.controller_candidate_record_id, candidate_record.record_id)
+
+    def test_reads_controller_records_from_store(self) -> None:
+        candidate_record = _candidate_record(status="planned")
+        store = _RunHistoryStore(None, candidate_records=(candidate_record,))
+
+        decision = evaluate_merge_train_admission_from_store(
+            store=store,
+            repository="cbusillo/sellyouroutboard",
+            base_branch="main",
+            requested_at="2026-05-09T02:10:00Z",
+        )
+
+        self.assertTrue(decision.admitted)
+        self.assertEqual(decision.controller_action, "build_candidate")
+        self.assertEqual(decision.controller_candidate_record_id, candidate_record.record_id)
+
 
 def _run_record(
     *,
@@ -185,6 +266,7 @@ def _run_record(
     snapshot = MergeTrainDryRunSnapshot(
         repository="cbusillo/sellyouroutboard",
         base_branch="main",
+        base_sha="base-main",
         pull_requests=(pull_request,),
     )
     dry_run_result = build_merge_train_dry_run_result(policy=policy, snapshot=snapshot)
@@ -207,6 +289,36 @@ def _run_record(
         snapshot=snapshot,
         dry_run_result=dry_run_result,
         worker_step_result=worker_step_result,
+    )
+
+
+def _candidate_record(*, status: str) -> MergeTrainBatchCandidateRecord:
+    policy = build_test_merge_train_policy()
+    pull_request = _pull_request(42)
+    snapshot = MergeTrainDryRunSnapshot(
+        repository="cbusillo/sellyouroutboard",
+        base_branch="main",
+        base_sha="base-main",
+        pull_requests=(pull_request,),
+    )
+    dry_run_result = build_merge_train_dry_run_result(policy=policy, snapshot=snapshot)
+    candidate = build_merge_train_batch_candidate(
+        dry_run_result=dry_run_result,
+        base_sha=snapshot.base_sha,
+        policy_sha256=policy.policy_sha256,
+        created_at="2026-05-09T02:00:00Z",
+    ).model_copy(
+        update={
+            "candidate_sha": "candidate-sha" if status != "planned" else "",
+            "required_checks_status": "pending" if status == "ready_for_checks" else "unknown",
+            "status": status,
+            "updated_at": "2026-05-09T02:00:00Z",
+        }
+    )
+    return build_merge_train_batch_candidate_record(
+        candidate=candidate,
+        source="test:admission-controller-record",
+        updated_at="2026-05-09T02:00:00Z",
     )
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -36,6 +36,7 @@ from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
 from control_plane.contracts.merge_train_policy import parse_merge_train_policy_toml
 from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidate
 from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlan
+from control_plane.contracts.merge_train_batch import build_merge_train_batch_candidate
 from control_plane.contracts.merge_train_batch import build_merge_train_batch_candidate_record
 from control_plane.contracts.odoo_instance_override_record import OdooConfigParameterOverride
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
@@ -3735,6 +3736,62 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["admission"]["latest_run_id"], wait_record.run_id)
         self.assertEqual(payload["admission"]["latest_run_status"], "waiting")
         self.assertEqual(payload["admission"]["next_allowed_at"], "2999-01-01T00:01:00Z")
+
+    def test_merge_train_admission_service_reports_controller_record_state(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir)
+            _seed_merge_train_policy(state_dir)
+            policy = build_test_merge_train_policy()
+            snapshot = _FakeMergeTrainSnapshotReader(transport=object()).read_merge_train_snapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+            )
+            dry_run_result = build_merge_train_dry_run_result(policy=policy, snapshot=snapshot)
+            candidate = build_merge_train_batch_candidate(
+                dry_run_result=dry_run_result,
+                base_sha=snapshot.base_sha,
+                policy_sha256=policy.policy_sha256,
+                created_at="2026-05-20T12:00:00Z",
+            ).model_copy(
+                update={
+                    "candidate_sha": "candidate-sha",
+                    "required_checks_status": "pending",
+                    "status": "ready_for_checks",
+                    "updated_at": "2026-05-20T12:01:00Z",
+                }
+            )
+            candidate_record = build_merge_train_batch_candidate_record(
+                candidate=candidate,
+                source="test:admission-controller-state",
+                updated_at="2026-05-20T12:01:00Z",
+            )
+            store.write_merge_train_batch_candidate_record(candidate_record)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                side_effect=AssertionError("admission must not read GitHub"),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/work-graph/merge-train/admission",
+                    query_string="repository=cbusillo/sellyouroutboard&base_branch=main",
+                )
+
+        self.assertEqual(status_code, 200)
+        self.assertEqual(payload["admission"]["status"], "admitted")
+        self.assertEqual(payload["admission"]["controller_action"], "observe_candidate")
+        self.assertEqual(
+            payload["admission"]["controller_candidate_record_id"],
+            candidate_record.record_id,
+        )
+        self.assertEqual(payload["admission"]["controller_landing_plan_record_id"], "")
 
     def test_merge_train_admission_service_rejects_unauthorized_identity(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- Add controller record state to the merge-train admission response so schedulers can see pending full-train work from DB records.
- Keep the admission endpoint GitHub-read-free while exposing candidate, landing-plan, and stack-collapse record ids.
- Cover contract and service behavior with focused tests.

Refs #605

## Tests
- `uv run --extra dev ruff check --diff control_plane/contracts/merge_train_admission.py control_plane/merge_train_admission.py tests/test_merge_train_admission.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/contracts/merge_train_admission.py control_plane/merge_train_admission.py tests/test_merge_train_admission.py tests/test_service.py`
- `uv run --extra dev mypy control_plane/contracts/merge_train_admission.py control_plane/merge_train_admission.py tests/test_merge_train_admission.py tests/test_service.py`
- `uv run python -m unittest tests.test_merge_train_admission tests.test_merge_train_controller tests.test_service.LaunchplaneServiceTests.test_merge_train_admission_service_admits_without_prior_run tests.test_service.LaunchplaneServiceTests.test_merge_train_admission_service_defers_recent_wait_run tests.test_service.LaunchplaneServiceTests.test_merge_train_admission_service_reports_controller_record_state tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_advances_unstacked_batch_flow tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_stops_after_candidate_failure tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_advances_stacked_batch_flow`
