### PR TITLE
Add merge train controller runner mode

### DIFF
--- a/.github/workflows/merge-train-runner.yml
+++ b/.github/workflows/merge-train-runner.yml
@@ -22,6 +22,16 @@ name: Merge Train Runner
         type: boolean
         required: false
         default: false
+      runner_mode:
+        description: >-
+          Which admitted scheduler entrypoint to call: level1 or controller.
+          Scheduled runs use LAUNCHPLANE_MERGE_TRAIN_RUNNER_MODE instead.
+        type: choice
+        required: false
+        default: level1
+        options:
+          - level1
+          - controller
       batch_candidate_mode:
         description: >-
           Optional batch-candidate phase to run instead of the Level 1 worker:
@@ -108,6 +118,12 @@ jobs:
             github.event_name != 'schedule' && inputs.mutate
           ) && 'true' ||
           'false'
+        }}
+      MERGE_TRAIN_RUNNER_MODE: >-
+        ${{
+          github.event_name == 'schedule' &&
+          (vars.LAUNCHPLANE_MERGE_TRAIN_RUNNER_MODE || 'level1') ||
+          (inputs.runner_mode || 'level1')
         }}
       MERGE_TRAIN_BATCH_CANDIDATE_MODE: >-
         ${{
@@ -232,13 +248,30 @@ jobs:
             echo
             echo "- Repository: ${MERGE_TRAIN_REPOSITORY}"
             echo "- Base branch: ${MERGE_TRAIN_BASE_BRANCH}"
+            echo "- Runner mode: ${MERGE_TRAIN_RUNNER_MODE}"
             echo "- Status: ${admission_status}"
             echo "- Reason: ${reason_code}"
             echo "- Next allowed: ${next_allowed_at}"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Run one merge-train pass
+      - name: Validate merge-train runner mode
         if: steps.admission.outputs.admission_status == 'admitted'
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$MERGE_TRAIN_RUNNER_MODE" in
+            level1|controller) ;;
+            *)
+              echo "Unsupported merge-train runner mode:" \
+                "${MERGE_TRAIN_RUNNER_MODE}" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Run one merge-train pass
+        if: >-
+          steps.admission.outputs.admission_status == 'admitted' &&
+          env.MERGE_TRAIN_RUNNER_MODE == 'level1'
         shell: bash
         env:
           SERVICE_ORIGIN: ${{ steps.admission.outputs.service_origin }}
@@ -323,11 +356,91 @@ jobs:
             selected_modes+=("stack-collapse:${MERGE_TRAIN_STACK_COLLAPSE_MODE}")
           fi
 
+          if [ "${MERGE_TRAIN_RUNNER_MODE}" = "controller" ] && \
+             [ "${#selected_modes[@]}" -gt 0 ]; then
+            echo "Controller mode cannot be combined with phase inputs." >&2
+            printf 'Selected modes: %s\n' "${selected_modes[*]}" >&2
+            exit 1
+          fi
+
           if [ "${#selected_modes[@]}" -gt 1 ]; then
             echo "Only one merge-train phase may run per workflow dispatch." >&2
             printf 'Selected modes: %s\n' "${selected_modes[*]}" >&2
             exit 1
           fi
+
+      - name: Run one merge-train controller action
+        if: >-
+          steps.admission.outputs.admission_status == 'admitted' &&
+          env.MERGE_TRAIN_RUNNER_MODE == 'controller'
+        shell: bash
+        env:
+          SERVICE_ORIGIN: ${{ steps.admission.outputs.service_origin }}
+          SERVICE_AUDIENCE: ${{ steps.admission.outputs.service_audience }}
+        run: |
+          set -euo pipefail
+          oidc_token="$({
+            curl -fsSL \
+              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
+            | jq -r '.value'
+          })"
+          request_payload="$({
+            jq -n \
+              --arg repository "$MERGE_TRAIN_REPOSITORY" \
+              --arg base_branch "$MERGE_TRAIN_BASE_BRANCH" \
+              --argjson mutate "$MERGE_TRAIN_MUTATE" \
+              '{
+                schema_version: 1,
+                repository: $repository,
+                base_branch: $base_branch,
+                mutate: $mutate
+              }'
+          })"
+          response_file="launchplane-merge-train-controller-run-once.json"
+          controller_url="${SERVICE_ORIGIN}/v1/work-graph/merge-train"
+          controller_url="${controller_url}/controller/run-once"
+          status_code="$(curl -sS \
+            -o "$response_file" \
+            -w '%{http_code}' \
+            -X POST \
+            -H "Authorization: Bearer ${oidc_token}" \
+            -H 'Content-Type: application/json' \
+            --data "$request_payload" \
+            "$controller_url")"
+          if [ "$status_code" != "202" ]; then
+            cat "$response_file" >&2
+            echo "Merge-train controller run-once failed" \
+              "with HTTP ${status_code}." >&2
+            exit 1
+          fi
+
+          jq . "$response_file"
+          {
+            echo
+            echo '## Launchplane merge train controller'
+            echo
+            echo "- Mode: $(jq -r '.result.mode' "$response_file")"
+            controller_action="$(
+              jq -r '.result.controller_action // "unknown"' "$response_file"
+            )"
+            candidate_record="$(
+              jq -r '.records.merge_train_batch_candidate_record_id // ""' \
+                "$response_file"
+            )"
+            landing_record="$(
+              jq -r '.records.merge_train_batch_landing_plan_record_id // ""' \
+                "$response_file"
+            )"
+            stack_record="$(
+              jq -r '.records.merge_train_stack_collapse_plan_record_id // ""' \
+                "$response_file"
+            )"
+            echo "- Controller action: ${controller_action}"
+            echo "- Candidate record: ${candidate_record}"
+            echo "- Landing-plan record: ${landing_record}"
+            echo "- Stack-collapse record: ${stack_record}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run one batch-candidate phase
         if: >-

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -480,6 +480,14 @@ The route is policy-backed and authorized through the repository policy's
 `service_authz`, but it is store-only: it does not require a GitHub token, does
 not read GitHub, and does not write run records.
 
+The GitHub Actions scheduler in `.github/workflows/merge-train-runner.yml` uses
+that admission route before every worker call. It defaults to the Level 1
+`run-once` route for compatibility, and can call the full controller exactly
+once per admitted pass when manual dispatch sets `runner_mode: controller` or a
+scheduled run sets the repository variable `LAUNCHPLANE_MERGE_TRAIN_RUNNER_MODE`
+to `controller`. The scheduler still writes at most one Launchplane worker
+result per pass; the five-minute schedule is the retry loop.
+
 The merge step is allowed only from a fresh dry-run result whose next action is
 `merge`. The merge request must use the selected pull request's observed
 `head_sha` as the GitHub merge `sha` guard and the repository policy's

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -278,12 +278,15 @@ PR head.
 
 `.github/workflows/merge-train-runner.yml` is the first external scheduler for
 this route. It mints a GitHub Actions OIDC token for the Launchplane service,
-reads admission, and calls `run-once` only when the decision is `admitted`.
-Repository and base-branch selection come from workflow inputs or repository
-variables, not service code. Manual dispatch defaults to dry-run mode; scheduled
-runs also dry-run unless the repository variable `LAUNCHPLANE_MERGE_TRAIN_MUTATE`
-is set to `true`. This keeps activation explicit after setting
-`LAUNCHPLANE_MERGE_TRAIN_REPOSITORY`.
+reads admission, and calls one worker entrypoint only when the decision is
+`admitted`. Repository and base-branch selection come from workflow inputs or
+repository variables, not service code. Manual dispatch defaults to dry-run mode;
+scheduled runs also dry-run unless the repository variable
+`LAUNCHPLANE_MERGE_TRAIN_MUTATE` is set to `true`. The default runner mode calls
+the Level 1 `run-once` route. Manual dispatch or the scheduled repository
+variable `LAUNCHPLANE_MERGE_TRAIN_RUNNER_MODE=controller` switches an admitted
+pass to one full-controller `run-once` call instead. This keeps activation
+explicit after setting `LAUNCHPLANE_MERGE_TRAIN_REPOSITORY`.
 Workflow dispatches may select at most one non-`none` phase input across
 batch-candidate, batch-landing, and stack-collapse modes; the runner validates
 that exclusivity before any phase step mutates state.


### PR DESCRIPTION
## Summary
- add a `runner_mode` switch to the merge-train runner so admitted passes can call the full controller once
- keep scheduled activation explicit through `LAUNCHPLANE_MERGE_TRAIN_RUNNER_MODE=controller`
- document the controller scheduler path and compatibility default

## Verification
- `docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/merge-train-runner.yml`
- `uv run --extra dev mypy control_plane/merge_train_admission.py tests/test_merge_train_admission.py tests/test_service.py`
- `uv run python -m unittest tests.test_merge_train_admission tests.test_merge_train_controller tests.test_service.LaunchplaneServiceTests.test_merge_train_admission_service_reports_controller_record_state tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_advances_unstacked_batch_flow tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_stops_after_candidate_failure tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_advances_stacked_batch_flow`
