### PR TITLE
Expose merge train controller status read model

### DIFF
--- a/control_plane/merge_train_admission.py
+++ b/control_plane/merge_train_admission.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from pydantic import BaseModel, ConfigDict
+
 from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidateRecord
 from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlanRecord
 from control_plane.contracts.merge_train_admission import MergeTrainAdmissionDecision
@@ -13,6 +15,44 @@ from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
 from control_plane.contracts.merge_train_stack_collapse import (
     MergeTrainStackCollapsePlanRecord,
 )
+
+
+class MergeTrainControllerRecords(BaseModel):
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    candidate_records: tuple[MergeTrainBatchCandidateRecord, ...]
+    landing_plan_records: tuple[MergeTrainBatchLandingPlanRecord, ...]
+    stack_collapse_plan_records: tuple[MergeTrainStackCollapsePlanRecord, ...]
+
+
+class MergeTrainControllerRecordSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    record_id: str
+    record_type: str
+    status: str
+    updated_at: str
+    batch_id: str = ""
+    pull_request_numbers: tuple[int, ...] = ()
+    candidate_sha: str = ""
+    required_checks_status: str = ""
+    planned_count: int = 0
+    merged_count: int = 0
+    blocked_count: int = 0
+    stale_count: int = 0
+    skipped_count: int = 0
+
+
+class MergeTrainControllerStatusReadModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = 1
+    repository: str
+    base_branch: str
+    generated_at: str
+    admission: MergeTrainAdmissionDecision
+    latest_run: MergeTrainRunRecord | None = None
+    controller_records: tuple[MergeTrainControllerRecordSummary, ...]
 
 
 class MergeTrainRunHistoryStore(Protocol):
@@ -57,28 +97,13 @@ def evaluate_merge_train_admission_from_store(
     poll_interval_seconds: int = 60,
     backoff_seconds: int = 300,
 ) -> MergeTrainAdmissionDecision:
-    candidate_records = store.list_merge_train_batch_candidate_records(
-        repository=repository,
-        base_branch=base_branch,
-        status="active",
-        limit=25,
-    )
-    landing_plan_records = store.list_merge_train_batch_landing_plan_records(
-        repository=repository,
-        base_branch=base_branch,
-        status="active",
-        limit=25,
-    )
-    stack_collapse_plan_records = store.list_merge_train_stack_collapse_plan_records(
-        repository=repository,
-        base_branch=base_branch,
-        status="active",
-        limit=25,
+    controller_records = _list_active_controller_records(
+        store=store, repository=repository, base_branch=base_branch
     )
     controller_decision = build_merge_train_controller_admission_decision(
-        candidate_records=candidate_records,
-        landing_plan_records=landing_plan_records,
-        stack_collapse_plan_records=stack_collapse_plan_records,
+        candidate_records=controller_records.candidate_records,
+        landing_plan_records=controller_records.landing_plan_records,
+        stack_collapse_plan_records=controller_records.stack_collapse_plan_records,
     )
     return evaluate_merge_train_admission(
         repository=repository,
@@ -92,3 +117,149 @@ def evaluate_merge_train_admission_from_store(
         poll_interval_seconds=poll_interval_seconds,
         backoff_seconds=backoff_seconds,
     )
+
+
+def build_merge_train_controller_status_read_model(
+    *,
+    store: MergeTrainRunHistoryStore,
+    repository: str,
+    base_branch: str,
+    generated_at: str,
+    poll_interval_seconds: int = 60,
+    backoff_seconds: int = 300,
+) -> MergeTrainControllerStatusReadModel:
+    controller_records = _list_active_controller_records(
+        store=store, repository=repository, base_branch=base_branch
+    )
+    controller_decision = build_merge_train_controller_admission_decision(
+        candidate_records=controller_records.candidate_records,
+        landing_plan_records=controller_records.landing_plan_records,
+        stack_collapse_plan_records=controller_records.stack_collapse_plan_records,
+    )
+    latest_run = store.latest_merge_train_run_record(
+        repository=repository,
+        base_branch=base_branch,
+    )
+    admission = evaluate_merge_train_admission(
+        repository=repository,
+        base_branch=base_branch,
+        requested_at=generated_at,
+        latest_run=latest_run,
+        controller_decision=controller_decision,
+        poll_interval_seconds=poll_interval_seconds,
+        backoff_seconds=backoff_seconds,
+    )
+    return MergeTrainControllerStatusReadModel(
+        repository=repository,
+        base_branch=base_branch,
+        generated_at=generated_at,
+        admission=admission,
+        latest_run=latest_run,
+        controller_records=_summarize_controller_records(
+            controller_records=controller_records,
+        ),
+    )
+
+
+def _list_active_controller_records(
+    *, store: MergeTrainRunHistoryStore, repository: str, base_branch: str
+) -> MergeTrainControllerRecords:
+    return MergeTrainControllerRecords(
+        candidate_records=store.list_merge_train_batch_candidate_records(
+            repository=repository,
+            base_branch=base_branch,
+            status="active",
+            limit=25,
+        ),
+        landing_plan_records=store.list_merge_train_batch_landing_plan_records(
+            repository=repository,
+            base_branch=base_branch,
+            status="active",
+            limit=25,
+        ),
+        stack_collapse_plan_records=store.list_merge_train_stack_collapse_plan_records(
+            repository=repository,
+            base_branch=base_branch,
+            status="active",
+            limit=25,
+        ),
+    )
+
+
+def _summarize_controller_records(
+    *, controller_records: MergeTrainControllerRecords
+) -> tuple[MergeTrainControllerRecordSummary, ...]:
+    summaries = [
+        *(_candidate_summary(record) for record in controller_records.candidate_records),
+        *(_landing_plan_summary(record) for record in controller_records.landing_plan_records),
+        *(
+            _stack_collapse_summary(record)
+            for record in controller_records.stack_collapse_plan_records
+        ),
+    ]
+    return tuple(
+        sorted(summaries, key=lambda summary: (summary.updated_at, summary.record_id), reverse=True)
+    )
+
+
+def _candidate_summary(
+    record: MergeTrainBatchCandidateRecord,
+) -> MergeTrainControllerRecordSummary:
+    candidate = record.candidate
+    return MergeTrainControllerRecordSummary(
+        record_id=record.record_id,
+        record_type="batch_candidate",
+        status=candidate.status,
+        updated_at=record.updated_at,
+        batch_id=candidate.batch_id,
+        pull_request_numbers=tuple(entry.pull_request_number for entry in candidate.entries),
+        candidate_sha=candidate.candidate_sha,
+        required_checks_status=candidate.required_checks_status,
+    )
+
+
+def _landing_plan_summary(
+    record: MergeTrainBatchLandingPlanRecord,
+) -> MergeTrainControllerRecordSummary:
+    entries = record.landing_plan.entries
+    return MergeTrainControllerRecordSummary(
+        record_id=record.record_id,
+        record_type="batch_landing_plan",
+        status=_dominant_landing_status(record),
+        updated_at=record.updated_at,
+        batch_id=record.landing_plan.batch_id,
+        pull_request_numbers=tuple(entry.pull_request_number for entry in entries),
+        candidate_sha=record.landing_plan.candidate_sha,
+        planned_count=sum(1 for entry in entries if entry.status == "planned"),
+        merged_count=sum(1 for entry in entries if entry.status == "merged"),
+        blocked_count=sum(1 for entry in entries if entry.status == "blocked"),
+        stale_count=sum(1 for entry in entries if entry.status == "stale"),
+        skipped_count=sum(1 for entry in entries if entry.status == "skipped"),
+    )
+
+
+def _stack_collapse_summary(
+    record: MergeTrainStackCollapsePlanRecord,
+) -> MergeTrainControllerRecordSummary:
+    plan = record.plan
+    return MergeTrainControllerRecordSummary(
+        record_id=record.record_id,
+        record_type="stack_collapse_plan",
+        status=plan.status,
+        updated_at=record.updated_at,
+        pull_request_numbers=tuple(entry.pull_request_number for entry in plan.entries),
+        planned_count=sum(1 for mutation in plan.mutations if mutation.status == "planned"),
+        merged_count=sum(1 for mutation in plan.mutations if mutation.status == "mutated"),
+        blocked_count=sum(1 for mutation in plan.mutations if mutation.status == "blocked"),
+        stale_count=sum(1 for mutation in plan.mutations if mutation.status == "stale"),
+    )
+
+
+def _dominant_landing_status(record: MergeTrainBatchLandingPlanRecord) -> str:
+    statuses = {entry.status for entry in record.landing_plan.entries}
+    if not statuses:
+        return "empty"
+    for status in ("blocked", "stale", "merging", "planned", "skipped"):
+        if status in statuses:
+            return status
+    return "merged"

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -97,6 +97,7 @@ from control_plane.contracts.merge_train_stack_collapse import (
 )
 from control_plane.contracts.merge_train_run_record import build_merge_train_run_record
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
+from control_plane.merge_train_admission import build_merge_train_controller_status_read_model
 from control_plane.merge_train_admission import evaluate_merge_train_admission_from_store
 from control_plane.merge_train_policy_source import (
     MergeTrainPolicyStoreMissingError,
@@ -381,6 +382,7 @@ from control_plane.workflows.verireel_preview_driver import (
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 _EVERY_CODE_GITHUB_WEBHOOK_ROUTE = "/v1/every-code/github-webhook"
 _MERGE_TRAIN_ADMISSION_ROUTE = "/v1/work-graph/merge-train/admission"
+_MERGE_TRAIN_CONTROLLER_STATUS_ROUTE = "/v1/work-graph/merge-train/controller/status"
 _MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-candidate/run-once"
 _MERGE_TRAIN_BATCH_LANDING_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-landing/run-once"
 _MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/stack-collapse/run-once"
@@ -2515,6 +2517,8 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "launchplane_service.read", {}
     if path == _MERGE_TRAIN_ADMISSION_ROUTE:
         return "merge_train.admission", {}
+    if path == _MERGE_TRAIN_CONTROLLER_STATUS_ROUTE:
+        return "merge_train.controller_status", {}
     if len(segments) == 3 and segments == ["v1", "work-graph", "snapshot"]:
         return "work_graph.rank", {}
     if len(segments) == 2 and segments == ["v1", "repo-product-mapping"]:
@@ -7875,6 +7879,52 @@ def create_launchplane_service_app(
                             "status": "ok",
                             "trace_id": request_trace_id,
                             "admission": admission_decision.model_dump(mode="json"),
+                        },
+                    )
+                if action == "merge_train.controller_status":
+                    status_request = MergeTrainAdmissionEnvelope.model_validate(
+                        {
+                            "repository": str((query.get("repository") or [""])[0] or ""),
+                            "base_branch": str((query.get("base_branch") or ["main"])[0] or ""),
+                        }
+                    )
+                    policy_record = resolve_merge_train_policy_record(record_store)
+                    policy = policy_record.policy
+                    repository_policy = policy.find_repository_policy(
+                        repository=status_request.repository,
+                        base_branch=status_request.base_branch,
+                    )
+                    if not authz_policy.allows(
+                        identity=identity,
+                        action=repository_policy.service_authz.action,
+                        product=repository_policy.service_authz.product,
+                        context=repository_policy.service_authz.context,
+                    ):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=403,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "authorization_denied",
+                                    "message": "Workflow cannot read the requested merge train controller status.",
+                                },
+                            },
+                        )
+                    read_model = build_merge_train_controller_status_read_model(
+                        store=record_store,
+                        repository=status_request.repository,
+                        base_branch=status_request.base_branch,
+                        generated_at=_utc_now_timestamp(),
+                    )
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=200,
+                        payload={
+                            "status": "ok",
+                            "trace_id": request_trace_id,
+                            "controller_status": read_model.model_dump(mode="json"),
                         },
                     )
                 if action == "product_profile.read":

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -480,6 +480,13 @@ The route is policy-backed and authorized through the repository policy's
 `service_authz`, but it is store-only: it does not require a GitHub token, does
 not read GitHub, and does not write run records.
 
+Operator views can read the broader stored controller state from
+`GET /v1/work-graph/merge-train/controller/status?repository=owner/name&base_branch=main`.
+That route returns the same admission decision plus the latest Level 1 run record
+and compact summaries for active batch candidates, landing plans, and stack
+collapse plans. It is also store-only, so it can power dashboards and status
+summaries without consuming GitHub API capacity or advancing the train.
+
 The GitHub Actions scheduler in `.github/workflows/merge-train-runner.yml` uses
 that admission route before every worker call. It defaults to the Level 1
 `run-once` route for compatibility, and can call the full controller exactly

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -78,8 +78,10 @@ VeriReel product paths:
   - `GET /v1/repo-product-mapping`
   - `GET /v1/work-graph/snapshot`
   - `GET /v1/work-graph/merge-train/admission`
+  - `GET /v1/work-graph/merge-train/controller/status`
   - `POST /v1/work-graph/rank`
   - `POST /v1/work-graph/merge-train/run-once`
+  - `POST /v1/work-graph/merge-train/controller/run-once`
 - product driver routes:
   - `POST /v1/drivers/generic-web/deploy`
   - `POST /v1/drivers/generic-web/prod-promotion`
@@ -237,6 +239,14 @@ same merge-train repository policy and `service_authz` scope as `run-once`, but
 performs no GitHub reads and no storage writes. Schedulers use this route to
 pace calls into `run-once`; execution still re-reads GitHub before any dry-run or
 mutation.
+
+`GET /v1/work-graph/merge-train/controller/status` returns the operator read
+model for the same repository/base branch. It uses the same authorization as the
+policy route, performs no GitHub reads, and composes stored scheduler admission,
+latest Level 1 run history, active batch candidates, landing plans, and
+stack-collapse plans. Operators can use this route to see the current controller
+action, durable record ids, PR numbers, candidate SHA/check state, and compact
+entry counts without invoking a worker mutation.
 
 `POST /v1/work-graph/merge-train/controller/run-once` is the operator-facing
 one-action controller for the full batch train. Request payloads name

--- a/tests/test_merge_train_admission.py
+++ b/tests/test_merge_train_admission.py
@@ -4,6 +4,9 @@ from control_plane.contracts.merge_train_admission import (
     build_merge_train_controller_admission_decision,
 )
 from control_plane.contracts.merge_train_admission import evaluate_merge_train_admission
+from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingEntry
+from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlan
+from control_plane.contracts.merge_train_batch import build_merge_train_batch_landing_plan_record
 from control_plane.contracts.merge_train_batch import build_merge_train_batch_candidate
 from control_plane.contracts.merge_train_batch import build_merge_train_batch_candidate_record
 from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidateRecord
@@ -13,6 +16,7 @@ from control_plane.contracts.merge_train_run_record import build_merge_train_run
 from control_plane.contracts.merge_train_stack_collapse import (
     MergeTrainStackCollapsePlanRecord,
 )
+from control_plane.merge_train_admission import build_merge_train_controller_status_read_model
 from control_plane.merge_train import MergeTrainDryRunSnapshot
 from control_plane.merge_train import MergeTrainPullRequestSnapshot
 from control_plane.merge_train import MergeTrainCheckStatus
@@ -53,9 +57,11 @@ class _RunHistoryStore:
         latest_run: MergeTrainRunRecord | None,
         *,
         candidate_records: tuple[MergeTrainBatchCandidateRecord, ...] = (),
+        landing_plan_records: tuple[MergeTrainBatchLandingPlanRecord, ...] = (),
     ) -> None:
         self.latest_run = latest_run
         self.candidate_records = candidate_records
+        self.landing_plan_records = landing_plan_records
         self.requests: list[tuple[str, str]] = []
 
     def latest_merge_train_run_record(
@@ -82,7 +88,7 @@ class _RunHistoryStore:
         status: str = "",
         limit: int | None = None,
     ) -> tuple[MergeTrainBatchLandingPlanRecord, ...]:
-        return ()
+        return self.landing_plan_records
 
     def list_merge_train_stack_collapse_plan_records(
         self,
@@ -251,6 +257,32 @@ class MergeTrainAdmissionTests(unittest.TestCase):
         self.assertEqual(decision.controller_action, "build_candidate")
         self.assertEqual(decision.controller_candidate_record_id, candidate_record.record_id)
 
+    def test_builds_controller_status_read_model_from_store_records(self) -> None:
+        candidate_record = _candidate_record(status="passed")
+        landing_plan_record = _landing_plan_record(candidate_record)
+        latest_run = _run_record(recorded_at="2026-05-09T02:00:00Z")
+        store = _RunHistoryStore(
+            latest_run,
+            candidate_records=(candidate_record,),
+            landing_plan_records=(landing_plan_record,),
+        )
+
+        read_model = build_merge_train_controller_status_read_model(
+            store=store,
+            repository="cbusillo/sellyouroutboard",
+            base_branch="main",
+            generated_at="2026-05-09T02:10:00Z",
+        )
+
+        self.assertEqual(read_model.admission.controller_action, "land_batch")
+        self.assertEqual(read_model.latest_run, latest_run)
+        self.assertEqual(len(read_model.controller_records), 2)
+        self.assertEqual(read_model.controller_records[0].record_type, "batch_landing_plan")
+        self.assertEqual(read_model.controller_records[0].planned_count, 1)
+        self.assertEqual(read_model.controller_records[0].merged_count, 1)
+        self.assertEqual(read_model.controller_records[1].record_type, "batch_candidate")
+        self.assertEqual(read_model.controller_records[1].pull_request_numbers, (42,))
+
 
 def _run_record(
     *,
@@ -319,6 +351,47 @@ def _candidate_record(*, status: str) -> MergeTrainBatchCandidateRecord:
         candidate=candidate,
         source="test:admission-controller-record",
         updated_at="2026-05-09T02:00:00Z",
+    )
+
+
+def _landing_plan_record(
+    candidate_record: MergeTrainBatchCandidateRecord,
+) -> MergeTrainBatchLandingPlanRecord:
+    candidate = candidate_record.candidate
+    plan = MergeTrainBatchLandingPlan(
+        plan_id="merge-train-landing-plan-test",
+        batch_id=candidate.batch_id,
+        repository=candidate.repository,
+        base_branch=candidate.base_branch,
+        candidate_ref=candidate.candidate_ref,
+        candidate_sha=candidate.candidate_sha or "candidate-sha",
+        policy_key=candidate.policy_key,
+        policy_sha256=candidate.policy_sha256,
+        entries=(
+            MergeTrainBatchLandingEntry(
+                pull_request_number=42,
+                position=1,
+                expected_head_sha="head-42",
+                expected_base_sha=candidate.base_sha,
+                merge_method="merge",
+                status="planned",
+            ),
+            MergeTrainBatchLandingEntry(
+                pull_request_number=43,
+                position=2,
+                expected_head_sha="head-43",
+                expected_base_sha=candidate.base_sha,
+                merge_method="merge",
+                status="merged",
+                merge_commit_sha="merge-43",
+            ),
+        ),
+        created_at="2026-05-09T02:05:00Z",
+    )
+    return build_merge_train_batch_landing_plan_record(
+        landing_plan=plan,
+        source="test:admission-controller-landing-plan",
+        updated_at="2026-05-09T02:05:00Z",
     )
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3793,6 +3793,69 @@ class LaunchplaneServiceTests(unittest.TestCase):
         )
         self.assertEqual(payload["admission"]["controller_landing_plan_record_id"], "")
 
+    def test_merge_train_controller_status_service_reports_active_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir)
+            _seed_merge_train_policy(state_dir)
+            policy = build_test_merge_train_policy()
+            snapshot = _FakeMergeTrainSnapshotReader(transport=object()).read_merge_train_snapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+            )
+            dry_run_result = build_merge_train_dry_run_result(policy=policy, snapshot=snapshot)
+            candidate = build_merge_train_batch_candidate(
+                dry_run_result=dry_run_result,
+                base_sha=snapshot.base_sha,
+                policy_sha256=policy.policy_sha256,
+                created_at="2026-05-20T12:00:00Z",
+            ).model_copy(
+                update={
+                    "candidate_sha": "candidate-sha",
+                    "required_checks_status": "pending",
+                    "status": "ready_for_checks",
+                    "updated_at": "2026-05-20T12:01:00Z",
+                }
+            )
+            candidate_record = build_merge_train_batch_candidate_record(
+                candidate=candidate,
+                source="test:controller-status-read-model",
+                updated_at="2026-05-20T12:01:00Z",
+            )
+            store.write_merge_train_batch_candidate_record(candidate_record)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                side_effect=AssertionError("status must not read GitHub"),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/work-graph/merge-train/controller/status",
+                    query_string="repository=cbusillo/sellyouroutboard&base_branch=main",
+                )
+
+        self.assertEqual(status_code, 200)
+        controller_status = payload["controller_status"]
+        self.assertEqual(controller_status["repository"], "cbusillo/sellyouroutboard")
+        self.assertEqual(controller_status["base_branch"], "main")
+        self.assertEqual(controller_status["admission"]["controller_action"], "observe_candidate")
+        self.assertIsNone(controller_status["latest_run"])
+        self.assertEqual(len(controller_status["controller_records"]), 1)
+        self.assertEqual(
+            controller_status["controller_records"][0]["record_id"],
+            candidate_record.record_id,
+        )
+        self.assertEqual(
+            controller_status["controller_records"][0]["pull_request_numbers"],
+            [1],
+        )
+
     def test_merge_train_admission_service_rejects_unauthorized_identity(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"


### PR DESCRIPTION
## Summary
- add a store-only `GET /v1/work-graph/merge-train/controller/status` read model
- summarize latest admission, latest Level 1 run, active candidates, landing plans, and stack-collapse plans
- document the new operator route and extend focused service/read-model tests

## Verification
- `uv run --extra dev mypy control_plane/merge_train_admission.py control_plane/service.py tests/test_merge_train_admission.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/merge_train_admission.py control_plane/service.py tests/test_merge_train_admission.py tests/test_service.py`
- `uv run python -m unittest tests.test_merge_train_admission tests.test_service.LaunchplaneServiceTests.test_merge_train_admission_service_reports_controller_record_state tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_status_service_reports_active_records`
- JetBrains inspection on changed Python files: only pre-existing `service.py` type warnings and static-method test suggestions remained after removing new duplicate-code findings.
