### PR TITLE
Validate merge train controller status policy

### DIFF
--- a/control_plane/merge_train_admission.py
+++ b/control_plane/merge_train_admission.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Literal, Protocol
 
 from pydantic import BaseModel, ConfigDict
 
@@ -15,6 +15,8 @@ from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
 from control_plane.contracts.merge_train_stack_collapse import (
     MergeTrainStackCollapsePlanRecord,
 )
+
+MergeTrainControllerPolicyStatus = Literal["current", "stale", "unchecked"]
 
 
 class MergeTrainControllerRecords(BaseModel):
@@ -32,6 +34,10 @@ class MergeTrainControllerRecordSummary(BaseModel):
     record_type: str
     status: str
     updated_at: str
+    policy_key: str = ""
+    policy_sha256: str = ""
+    policy_status: MergeTrainControllerPolicyStatus = "unchecked"
+    stale_reason: str = ""
     batch_id: str = ""
     pull_request_numbers: tuple[int, ...] = ()
     candidate_sha: str = ""
@@ -50,6 +56,8 @@ class MergeTrainControllerStatusReadModel(BaseModel):
     repository: str
     base_branch: str
     generated_at: str
+    current_policy_key: str = ""
+    current_policy_sha256: str = ""
     admission: MergeTrainAdmissionDecision
     latest_run: MergeTrainRunRecord | None = None
     controller_records: tuple[MergeTrainControllerRecordSummary, ...]
@@ -94,16 +102,23 @@ def evaluate_merge_train_admission_from_store(
     repository: str,
     base_branch: str,
     requested_at: str,
+    current_policy_key: str = "",
+    current_policy_sha256: str = "",
     poll_interval_seconds: int = 60,
     backoff_seconds: int = 300,
 ) -> MergeTrainAdmissionDecision:
     controller_records = _list_active_controller_records(
         store=store, repository=repository, base_branch=base_branch
     )
+    actionable_records = _filter_actionable_controller_records(
+        controller_records=controller_records,
+        current_policy_key=current_policy_key,
+        current_policy_sha256=current_policy_sha256,
+    )
     controller_decision = build_merge_train_controller_admission_decision(
-        candidate_records=controller_records.candidate_records,
-        landing_plan_records=controller_records.landing_plan_records,
-        stack_collapse_plan_records=controller_records.stack_collapse_plan_records,
+        candidate_records=actionable_records.candidate_records,
+        landing_plan_records=actionable_records.landing_plan_records,
+        stack_collapse_plan_records=actionable_records.stack_collapse_plan_records,
     )
     return evaluate_merge_train_admission(
         repository=repository,
@@ -125,16 +140,23 @@ def build_merge_train_controller_status_read_model(
     repository: str,
     base_branch: str,
     generated_at: str,
+    current_policy_key: str = "",
+    current_policy_sha256: str = "",
     poll_interval_seconds: int = 60,
     backoff_seconds: int = 300,
 ) -> MergeTrainControllerStatusReadModel:
     controller_records = _list_active_controller_records(
         store=store, repository=repository, base_branch=base_branch
     )
+    actionable_records = _filter_actionable_controller_records(
+        controller_records=controller_records,
+        current_policy_key=current_policy_key,
+        current_policy_sha256=current_policy_sha256,
+    )
     controller_decision = build_merge_train_controller_admission_decision(
-        candidate_records=controller_records.candidate_records,
-        landing_plan_records=controller_records.landing_plan_records,
-        stack_collapse_plan_records=controller_records.stack_collapse_plan_records,
+        candidate_records=actionable_records.candidate_records,
+        landing_plan_records=actionable_records.landing_plan_records,
+        stack_collapse_plan_records=actionable_records.stack_collapse_plan_records,
     )
     latest_run = store.latest_merge_train_run_record(
         repository=repository,
@@ -153,10 +175,14 @@ def build_merge_train_controller_status_read_model(
         repository=repository,
         base_branch=base_branch,
         generated_at=generated_at,
+        current_policy_key=current_policy_key,
+        current_policy_sha256=current_policy_sha256,
         admission=admission,
         latest_run=latest_run,
         controller_records=_summarize_controller_records(
             controller_records=controller_records,
+            current_policy_key=current_policy_key,
+            current_policy_sha256=current_policy_sha256,
         ),
     )
 
@@ -187,13 +213,34 @@ def _list_active_controller_records(
 
 
 def _summarize_controller_records(
-    *, controller_records: MergeTrainControllerRecords
+    *,
+    controller_records: MergeTrainControllerRecords,
+    current_policy_key: str = "",
+    current_policy_sha256: str = "",
 ) -> tuple[MergeTrainControllerRecordSummary, ...]:
     summaries = [
-        *(_candidate_summary(record) for record in controller_records.candidate_records),
-        *(_landing_plan_summary(record) for record in controller_records.landing_plan_records),
         *(
-            _stack_collapse_summary(record)
+            _candidate_summary(
+                record,
+                current_policy_key=current_policy_key,
+                current_policy_sha256=current_policy_sha256,
+            )
+            for record in controller_records.candidate_records
+        ),
+        *(
+            _landing_plan_summary(
+                record,
+                current_policy_key=current_policy_key,
+                current_policy_sha256=current_policy_sha256,
+            )
+            for record in controller_records.landing_plan_records
+        ),
+        *(
+            _stack_collapse_summary(
+                record,
+                current_policy_key=current_policy_key,
+                current_policy_sha256=current_policy_sha256,
+            )
             for record in controller_records.stack_collapse_plan_records
         ),
     ]
@@ -204,13 +251,26 @@ def _summarize_controller_records(
 
 def _candidate_summary(
     record: MergeTrainBatchCandidateRecord,
+    *,
+    current_policy_key: str = "",
+    current_policy_sha256: str = "",
 ) -> MergeTrainControllerRecordSummary:
     candidate = record.candidate
+    policy_status, stale_reason = _policy_status_fields(
+        policy_key=candidate.policy_key,
+        policy_sha256=candidate.policy_sha256,
+        current_policy_key=current_policy_key,
+        current_policy_sha256=current_policy_sha256,
+    )
     return MergeTrainControllerRecordSummary(
         record_id=record.record_id,
         record_type="batch_candidate",
         status=candidate.status,
         updated_at=record.updated_at,
+        policy_key=candidate.policy_key,
+        policy_sha256=candidate.policy_sha256,
+        policy_status=policy_status,
+        stale_reason=stale_reason,
         batch_id=candidate.batch_id,
         pull_request_numbers=tuple(entry.pull_request_number for entry in candidate.entries),
         candidate_sha=candidate.candidate_sha,
@@ -220,16 +280,30 @@ def _candidate_summary(
 
 def _landing_plan_summary(
     record: MergeTrainBatchLandingPlanRecord,
+    *,
+    current_policy_key: str = "",
+    current_policy_sha256: str = "",
 ) -> MergeTrainControllerRecordSummary:
     entries = record.landing_plan.entries
+    plan = record.landing_plan
+    policy_status, stale_reason = _policy_status_fields(
+        policy_key=plan.policy_key,
+        policy_sha256=plan.policy_sha256,
+        current_policy_key=current_policy_key,
+        current_policy_sha256=current_policy_sha256,
+    )
     return MergeTrainControllerRecordSummary(
         record_id=record.record_id,
         record_type="batch_landing_plan",
         status=_dominant_landing_status(record),
         updated_at=record.updated_at,
-        batch_id=record.landing_plan.batch_id,
+        policy_key=plan.policy_key,
+        policy_sha256=plan.policy_sha256,
+        policy_status=policy_status,
+        stale_reason=stale_reason,
+        batch_id=plan.batch_id,
         pull_request_numbers=tuple(entry.pull_request_number for entry in entries),
-        candidate_sha=record.landing_plan.candidate_sha,
+        candidate_sha=plan.candidate_sha,
         planned_count=sum(1 for entry in entries if entry.status == "planned"),
         merged_count=sum(1 for entry in entries if entry.status == "merged"),
         blocked_count=sum(1 for entry in entries if entry.status == "blocked"),
@@ -240,13 +314,26 @@ def _landing_plan_summary(
 
 def _stack_collapse_summary(
     record: MergeTrainStackCollapsePlanRecord,
+    *,
+    current_policy_key: str = "",
+    current_policy_sha256: str = "",
 ) -> MergeTrainControllerRecordSummary:
     plan = record.plan
+    policy_status, stale_reason = _policy_status_fields(
+        policy_key=plan.policy_key,
+        policy_sha256=plan.policy_sha256,
+        current_policy_key=current_policy_key,
+        current_policy_sha256=current_policy_sha256,
+    )
     return MergeTrainControllerRecordSummary(
         record_id=record.record_id,
         record_type="stack_collapse_plan",
         status=plan.status,
         updated_at=record.updated_at,
+        policy_key=plan.policy_key,
+        policy_sha256=plan.policy_sha256,
+        policy_status=policy_status,
+        stale_reason=stale_reason,
         pull_request_numbers=tuple(entry.pull_request_number for entry in plan.entries),
         planned_count=sum(1 for mutation in plan.mutations if mutation.status == "planned"),
         merged_count=sum(1 for mutation in plan.mutations if mutation.status == "mutated"),
@@ -263,3 +350,76 @@ def _dominant_landing_status(record: MergeTrainBatchLandingPlanRecord) -> str:
         if status in statuses:
             return status
     return "merged"
+
+
+def _filter_actionable_controller_records(
+    *,
+    controller_records: MergeTrainControllerRecords,
+    current_policy_key: str,
+    current_policy_sha256: str,
+) -> MergeTrainControllerRecords:
+    if not current_policy_key and not current_policy_sha256:
+        return controller_records
+    return MergeTrainControllerRecords(
+        candidate_records=tuple(
+            record
+            for record in controller_records.candidate_records
+            if _policy_is_current(
+                policy_key=record.candidate.policy_key,
+                policy_sha256=record.candidate.policy_sha256,
+                current_policy_key=current_policy_key,
+                current_policy_sha256=current_policy_sha256,
+            )
+        ),
+        landing_plan_records=tuple(
+            record
+            for record in controller_records.landing_plan_records
+            if _policy_is_current(
+                policy_key=record.landing_plan.policy_key,
+                policy_sha256=record.landing_plan.policy_sha256,
+                current_policy_key=current_policy_key,
+                current_policy_sha256=current_policy_sha256,
+            )
+        ),
+        stack_collapse_plan_records=tuple(
+            record
+            for record in controller_records.stack_collapse_plan_records
+            if _policy_is_current(
+                policy_key=record.plan.policy_key,
+                policy_sha256=record.plan.policy_sha256,
+                current_policy_key=current_policy_key,
+                current_policy_sha256=current_policy_sha256,
+            )
+        ),
+    )
+
+
+def _policy_status_fields(
+    *,
+    policy_key: str,
+    policy_sha256: str,
+    current_policy_key: str,
+    current_policy_sha256: str,
+) -> tuple[MergeTrainControllerPolicyStatus, str]:
+    if not current_policy_key and not current_policy_sha256:
+        return "unchecked", ""
+    if _policy_is_current(
+        policy_key=policy_key,
+        policy_sha256=policy_sha256,
+        current_policy_key=current_policy_key,
+        current_policy_sha256=current_policy_sha256,
+    ):
+        return "current", ""
+    if policy_key != current_policy_key:
+        return "stale", "policy_key_mismatch"
+    return "stale", "policy_digest_mismatch"
+
+
+def _policy_is_current(
+    *,
+    policy_key: str,
+    policy_sha256: str,
+    current_policy_key: str,
+    current_policy_sha256: str,
+) -> bool:
+    return policy_key == current_policy_key and policy_sha256 == current_policy_sha256

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -7871,6 +7871,8 @@ def create_launchplane_service_app(
                         repository=admission_request.repository,
                         base_branch=admission_request.base_branch,
                         requested_at=_utc_now_timestamp(),
+                        current_policy_key=repository_policy.policy_key,
+                        current_policy_sha256=policy_record.policy_sha256,
                     )
                     return _json_response(
                         start_response=start_response,
@@ -7917,6 +7919,8 @@ def create_launchplane_service_app(
                         repository=status_request.repository,
                         base_branch=status_request.base_branch,
                         generated_at=_utc_now_timestamp(),
+                        current_policy_key=repository_policy.policy_key,
+                        current_policy_sha256=policy_record.policy_sha256,
                     )
                     return _json_response(
                         start_response=start_response,

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -484,8 +484,11 @@ Operator views can read the broader stored controller state from
 `GET /v1/work-graph/merge-train/controller/status?repository=owner/name&base_branch=main`.
 That route returns the same admission decision plus the latest Level 1 run record
 and compact summaries for active batch candidates, landing plans, and stack
-collapse plans. It is also store-only, so it can power dashboards and status
-summaries without consuming GitHub API capacity or advancing the train.
+collapse plans. Stored controller records only influence the advertised
+controller action when their policy key and digest match the active repository
+policy; stale records remain visible in the summaries with a stale reason. It is
+also store-only, so it can power dashboards and status summaries without
+consuming GitHub API capacity or advancing the train.
 
 The GitHub Actions scheduler in `.github/workflows/merge-train-runner.yml` uses
 that admission route before every worker call. It defaults to the Level 1

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -244,7 +244,9 @@ mutation.
 model for the same repository/base branch. It uses the same authorization as the
 policy route, performs no GitHub reads, and composes stored scheduler admission,
 latest Level 1 run history, active batch candidates, landing plans, and
-stack-collapse plans. Operators can use this route to see the current controller
+stack-collapse plans. Only records that match the active repository policy key
+and digest can drive the advertised controller action; stale records stay visible
+with a stale reason. Operators can use this route to see the current controller
 action, durable record ids, PR numbers, candidate SHA/check state, and compact
 entry counts without invoking a worker mutation.
 

--- a/tests/test_merge_train_admission.py
+++ b/tests/test_merge_train_admission.py
@@ -257,6 +257,23 @@ class MergeTrainAdmissionTests(unittest.TestCase):
         self.assertEqual(decision.controller_action, "build_candidate")
         self.assertEqual(decision.controller_candidate_record_id, candidate_record.record_id)
 
+    def test_ignores_stale_policy_controller_records_for_admission(self) -> None:
+        candidate_record = _candidate_record(status="planned")
+        store = _RunHistoryStore(None, candidate_records=(candidate_record,))
+
+        decision = evaluate_merge_train_admission_from_store(
+            store=store,
+            repository="cbusillo/sellyouroutboard",
+            base_branch="main",
+            requested_at="2026-05-09T02:10:00Z",
+            current_policy_key=candidate_record.candidate.policy_key,
+            current_policy_sha256="new-policy-digest",
+        )
+
+        self.assertTrue(decision.admitted)
+        self.assertEqual(decision.controller_action, "idle")
+        self.assertEqual(decision.controller_candidate_record_id, "")
+
     def test_builds_controller_status_read_model_from_store_records(self) -> None:
         candidate_record = _candidate_record(status="passed")
         landing_plan_record = _landing_plan_record(candidate_record)
@@ -282,6 +299,30 @@ class MergeTrainAdmissionTests(unittest.TestCase):
         self.assertEqual(read_model.controller_records[0].merged_count, 1)
         self.assertEqual(read_model.controller_records[1].record_type, "batch_candidate")
         self.assertEqual(read_model.controller_records[1].pull_request_numbers, (42,))
+
+    def test_controller_status_marks_stale_policy_records_without_action(self) -> None:
+        candidate_record = _candidate_record(status="planned")
+        store = _RunHistoryStore(None, candidate_records=(candidate_record,))
+
+        read_model = build_merge_train_controller_status_read_model(
+            store=store,
+            repository="cbusillo/sellyouroutboard",
+            base_branch="main",
+            generated_at="2026-05-09T02:10:00Z",
+            current_policy_key=candidate_record.candidate.policy_key,
+            current_policy_sha256="new-policy-digest",
+        )
+
+        self.assertEqual(read_model.current_policy_key, candidate_record.candidate.policy_key)
+        self.assertEqual(read_model.current_policy_sha256, "new-policy-digest")
+        self.assertEqual(read_model.admission.controller_action, "idle")
+        self.assertEqual(len(read_model.controller_records), 1)
+        self.assertEqual(read_model.controller_records[0].record_id, candidate_record.record_id)
+        self.assertEqual(read_model.controller_records[0].policy_status, "stale")
+        self.assertEqual(
+            read_model.controller_records[0].stale_reason,
+            "policy_digest_mismatch",
+        )
 
 
 def _run_record(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3793,6 +3793,62 @@ class LaunchplaneServiceTests(unittest.TestCase):
         )
         self.assertEqual(payload["admission"]["controller_landing_plan_record_id"], "")
 
+    def test_merge_train_admission_service_ignores_stale_policy_controller_records(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir)
+            _seed_merge_train_policy(state_dir)
+            policy = build_test_merge_train_policy()
+            snapshot = _FakeMergeTrainSnapshotReader(transport=object()).read_merge_train_snapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+            )
+            dry_run_result = build_merge_train_dry_run_result(policy=policy, snapshot=snapshot)
+            candidate = build_merge_train_batch_candidate(
+                dry_run_result=dry_run_result,
+                base_sha=snapshot.base_sha,
+                policy_sha256=policy.policy_sha256,
+                created_at="2026-05-20T12:00:00Z",
+            ).model_copy(
+                update={
+                    "candidate_sha": "candidate-sha",
+                    "policy_sha256": "old-policy-digest",
+                    "required_checks_status": "pending",
+                    "status": "ready_for_checks",
+                    "updated_at": "2026-05-20T12:01:00Z",
+                }
+            )
+            candidate_record = build_merge_train_batch_candidate_record(
+                candidate=candidate,
+                source="test:admission-controller-stale-policy",
+                updated_at="2026-05-20T12:01:00Z",
+            )
+            store.write_merge_train_batch_candidate_record(candidate_record)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                side_effect=AssertionError("admission must not read GitHub"),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/work-graph/merge-train/admission",
+                    query_string="repository=cbusillo/sellyouroutboard&base_branch=main",
+                )
+
+        self.assertEqual(status_code, 200)
+        self.assertEqual(payload["admission"]["status"], "admitted")
+        self.assertEqual(payload["admission"]["controller_action"], "idle")
+        self.assertEqual(payload["admission"]["controller_candidate_record_id"], "")
+        self.assertEqual(payload["admission"]["controller_landing_plan_record_id"], "")
+
     def test_merge_train_controller_status_service_reports_active_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -3844,6 +3900,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
         controller_status = payload["controller_status"]
         self.assertEqual(controller_status["repository"], "cbusillo/sellyouroutboard")
         self.assertEqual(controller_status["base_branch"], "main")
+        self.assertEqual(controller_status["current_policy_key"], candidate.policy_key)
+        self.assertEqual(controller_status["current_policy_sha256"], policy.policy_sha256)
         self.assertEqual(controller_status["admission"]["controller_action"], "observe_candidate")
         self.assertIsNone(controller_status["latest_run"])
         self.assertEqual(len(controller_status["controller_records"]), 1)
@@ -3851,9 +3909,73 @@ class LaunchplaneServiceTests(unittest.TestCase):
             controller_status["controller_records"][0]["record_id"],
             candidate_record.record_id,
         )
+        self.assertEqual(controller_status["controller_records"][0]["policy_status"], "current")
+        self.assertEqual(controller_status["controller_records"][0]["stale_reason"], "")
         self.assertEqual(
             controller_status["controller_records"][0]["pull_request_numbers"],
             [1],
+        )
+
+    def test_merge_train_controller_status_service_marks_stale_policy_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir)
+            _seed_merge_train_policy(state_dir)
+            policy = build_test_merge_train_policy()
+            snapshot = _FakeMergeTrainSnapshotReader(transport=object()).read_merge_train_snapshot(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+            )
+            dry_run_result = build_merge_train_dry_run_result(policy=policy, snapshot=snapshot)
+            candidate = build_merge_train_batch_candidate(
+                dry_run_result=dry_run_result,
+                base_sha=snapshot.base_sha,
+                policy_sha256=policy.policy_sha256,
+                created_at="2026-05-20T12:00:00Z",
+            ).model_copy(
+                update={
+                    "candidate_sha": "candidate-sha",
+                    "policy_sha256": "old-policy-digest",
+                    "required_checks_status": "pending",
+                    "status": "ready_for_checks",
+                    "updated_at": "2026-05-20T12:01:00Z",
+                }
+            )
+            candidate_record = build_merge_train_batch_candidate_record(
+                candidate=candidate,
+                source="test:controller-status-stale-policy",
+                updated_at="2026-05-20T12:01:00Z",
+            )
+            store.write_merge_train_batch_candidate_record(candidate_record)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                side_effect=AssertionError("status must not read GitHub"),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/work-graph/merge-train/controller/status",
+                    query_string="repository=cbusillo/sellyouroutboard&base_branch=main",
+                )
+
+        self.assertEqual(status_code, 200)
+        controller_status = payload["controller_status"]
+        self.assertEqual(controller_status["admission"]["controller_action"], "idle")
+        self.assertEqual(len(controller_status["controller_records"]), 1)
+        self.assertEqual(
+            controller_status["controller_records"][0]["record_id"],
+            candidate_record.record_id,
+        )
+        self.assertEqual(controller_status["controller_records"][0]["policy_status"], "stale")
+        self.assertEqual(
+            controller_status["controller_records"][0]["stale_reason"],
+            "policy_digest_mismatch",
         )
 
     def test_merge_train_admission_service_rejects_unauthorized_identity(self) -> None:


### PR DESCRIPTION
## Summary
- validate merge train controller records against the active repository policy before using them for admission/status actions
- keep stale records visible in controller status summaries with policy metadata and stale reasons
- document the policy validation behavior for the admission/status read models

## Verification
- `uv run --extra dev ruff check control_plane/merge_train_admission.py control_plane/service.py tests/test_merge_train_admission.py tests/test_service.py docs/merge-train-policy.md docs/service-boundary.md --diff`
- `uv run --extra dev ruff check control_plane/merge_train_admission.py control_plane/service.py tests/test_merge_train_admission.py tests/test_service.py docs/merge-train-policy.md docs/service-boundary.md`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest tests.test_merge_train_admission tests.test_service`
- JetBrains changed-files inspection: reported pre-existing broad service.py type warnings and static-method suggestions in test helpers
