### PR TITLE
Add merge train PR feedback records

### DIFF
--- a/control_plane/contracts/merge_train_pr_feedback_record.py
+++ b/control_plane/contracts/merge_train_pr_feedback_record.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+MergeTrainPrFeedbackEvent = Literal[
+    "queued",
+    "building",
+    "waiting",
+    "blocked",
+    "stale_policy",
+    "completed",
+]
+MergeTrainPrFeedbackDeliveryStatus = Literal["delivered", "skipped", "failed"]
+
+
+class MergeTrainPrFeedbackRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    feedback_id: str
+    repository: str
+    base_branch: str
+    pull_request_number: int = Field(gt=0)
+    pull_request_url: str
+    event: MergeTrainPrFeedbackEvent
+    marker: str
+    comment_markdown: str
+    source: str
+    recorded_at: str
+    policy_key: str = ""
+    policy_sha256: str = ""
+    controller_action: str = ""
+    controller_record_id: str = ""
+    delivery_status: MergeTrainPrFeedbackDeliveryStatus
+    delivery_action: str = ""
+    comment_id: int = 0
+    comment_url: str = ""
+    error_message: str = ""
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "MergeTrainPrFeedbackRecord":
+        if not self.feedback_id.strip():
+            raise ValueError("merge train PR feedback requires feedback_id")
+        self.repository = _normalize_repository(self.repository)
+        self.base_branch = _normalize_required_value(
+            self.base_branch, "merge train PR feedback requires base_branch"
+        )
+        self.pull_request_url = _normalize_required_value(
+            self.pull_request_url, "merge train PR feedback requires pull_request_url"
+        )
+        self.marker = _normalize_required_value(
+            self.marker, "merge train PR feedback requires marker"
+        )
+        self.comment_markdown = _normalize_required_value(
+            self.comment_markdown,
+            "merge train PR feedback requires comment_markdown",
+        )
+        self.source = _normalize_required_value(
+            self.source, "merge train PR feedback requires source"
+        )
+        self.recorded_at = _normalize_required_value(
+            self.recorded_at, "merge train PR feedback requires recorded_at"
+        )
+        self.policy_key = self.policy_key.strip()
+        self.policy_sha256 = self.policy_sha256.strip()
+        self.controller_action = self.controller_action.strip()
+        self.controller_record_id = self.controller_record_id.strip()
+        self.delivery_action = self.delivery_action.strip()
+        self.comment_url = self.comment_url.strip()
+        self.error_message = self.error_message.strip()
+        return self
+
+
+def build_merge_train_pr_feedback_id(
+    *,
+    repository: str,
+    base_branch: str,
+    pull_request_number: int,
+    event: MergeTrainPrFeedbackEvent,
+    marker: str,
+    recorded_at: str,
+) -> str:
+    normalized_repository = _normalize_repository(repository).replace("/", "-")
+    normalized_base = _slug(base_branch)
+    identity = _feedback_identity_digest(
+        repository=repository,
+        base_branch=base_branch,
+        pull_request_number=pull_request_number,
+        event=event,
+        marker=marker,
+        recorded_at=recorded_at,
+    )
+    return (
+        "merge-train-pr-feedback-"
+        f"{normalized_repository}-{normalized_base}-pr-{pull_request_number}-{identity}"
+    )
+
+
+def merge_train_pr_feedback_marker(
+    *, repository: str, base_branch: str, pull_request_number: int
+) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            {
+                "repository": _normalize_repository(repository),
+                "base_branch": _normalize_required_value(base_branch, "base_branch"),
+                "pull_request_number": pull_request_number,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+    return f"<!-- launchplane-merge-train:{digest} -->"
+
+
+def _feedback_identity_digest(
+    *,
+    repository: str,
+    base_branch: str,
+    pull_request_number: int,
+    event: str,
+    marker: str,
+    recorded_at: str,
+) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            {
+                "repository": _normalize_repository(repository),
+                "base_branch": _normalize_required_value(base_branch, "base_branch"),
+                "pull_request_number": pull_request_number,
+                "event": event.strip(),
+                "marker": marker.strip(),
+                "recorded_at": _normalize_required_value(recorded_at, "recorded_at"),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+
+
+def _normalize_repository(repository: str) -> str:
+    normalized = repository.strip()
+    if not normalized or "/" not in normalized:
+        raise ValueError("merge train PR feedback requires owner/name repository")
+    return normalized
+
+
+def _normalize_required_value(value: str, message: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(message)
+    return normalized
+
+
+def _slug(value: str) -> str:
+    normalized = "".join(
+        character.lower() if character.isalnum() else "-" for character in value.strip()
+    ).strip("-")
+    return normalized or "default"

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -97,6 +97,12 @@ from control_plane.contracts.merge_train_stack_collapse import (
 )
 from control_plane.contracts.merge_train_run_record import build_merge_train_run_record
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
+from control_plane.contracts.merge_train_pr_feedback_record import (
+    MergeTrainPrFeedbackEvent,
+    MergeTrainPrFeedbackRecord,
+    build_merge_train_pr_feedback_id,
+    merge_train_pr_feedback_marker,
+)
 from control_plane.merge_train_admission import build_merge_train_controller_status_read_model
 from control_plane.merge_train_admission import evaluate_merge_train_admission_from_store
 from control_plane.merge_train_policy_source import (
@@ -299,9 +305,13 @@ from control_plane.workflows.preview_pr_feedback import (
     handle_every_code_preview_validation_comment,
 )
 from control_plane.workflows.launchplane import (
+    create_github_issue_comment,
+    find_github_issue_comment_by_marker,
     find_preview_record,
+    _github_comment_url,
     launchplane_anchor_repo_context,
     resolve_launchplane_github_token,
+    update_github_issue_comment,
     verify_github_webhook_signature,
 )
 from control_plane.workflows.odoo_artifact_publish import (
@@ -387,6 +397,7 @@ _MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-
 _MERGE_TRAIN_BATCH_LANDING_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-landing/run-once"
 _MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/stack-collapse/run-once"
 _MERGE_TRAIN_CONTROLLER_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/controller/run-once"
+_MERGE_TRAIN_PR_FEEDBACK_ROUTE = "/v1/work-graph/merge-train/pr-feedback"
 _MERGE_TRAIN_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/run-once"
 _EVERY_CODE_GITHUB_WEBHOOK_SECRET_ENV_KEY = "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET"
 
@@ -540,6 +551,36 @@ class MergeTrainAdmissionEnvelope(BaseModel):
             raise ValueError("merge train repository must be owner/name")
         if not self.base_branch:
             raise ValueError("merge train admission requires base_branch")
+        return self
+
+
+class MergeTrainPrFeedbackEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    repository: str
+    base_branch: str = "main"
+    pull_request_number: int = Field(gt=0)
+    event: MergeTrainPrFeedbackEvent
+    source: str = ""
+    controller_action: str = ""
+    controller_record_id: str = ""
+    message: str = ""
+
+    @model_validator(mode="after")
+    def _validate_envelope(self) -> "MergeTrainPrFeedbackEnvelope":
+        self.repository = self.repository.strip()
+        self.base_branch = self.base_branch.strip()
+        self.source = self.source.strip()
+        self.controller_action = self.controller_action.strip()
+        self.controller_record_id = self.controller_record_id.strip()
+        self.message = self.message.strip()
+        if not self.repository:
+            raise ValueError("merge train PR feedback requires repository")
+        if "/" not in self.repository:
+            raise ValueError("merge train repository must be owner/name")
+        if not self.base_branch:
+            raise ValueError("merge train PR feedback requires base_branch")
         return self
 
 
@@ -2599,6 +2640,7 @@ def _build_write_routes() -> frozenset[str]:
         _MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE,
         _MERGE_TRAIN_BATCH_LANDING_RUN_ONCE_ROUTE,
         _MERGE_TRAIN_CONTROLLER_RUN_ONCE_ROUTE,
+        _MERGE_TRAIN_PR_FEEDBACK_ROUTE,
         _MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE,
         _MERGE_TRAIN_RUN_ONCE_ROUTE,
         "/v1/agent/write-intents/evaluate",
@@ -2902,6 +2944,31 @@ def _merge_train_stack_collapse_plan_record_store(
     raise TypeError("record store does not support merge train stack collapse plans")
 
 
+class _MergeTrainPrFeedbackRecordStore(Protocol):
+    def write_merge_train_pr_feedback_record(
+        self, record: MergeTrainPrFeedbackRecord
+    ) -> object: ...
+
+    def list_merge_train_pr_feedback_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        pr_number: int | None = None,
+        limit: int | None = None,
+    ) -> tuple[MergeTrainPrFeedbackRecord, ...]: ...
+
+
+def _merge_train_pr_feedback_record_store(
+    record_store: object,
+) -> _MergeTrainPrFeedbackRecordStore:
+    if hasattr(record_store, "write_merge_train_pr_feedback_record") and hasattr(
+        record_store, "list_merge_train_pr_feedback_records"
+    ):
+        return cast(_MergeTrainPrFeedbackRecordStore, record_store)
+    raise TypeError("record store does not support merge train PR feedback records")
+
+
 def _merge_train_snapshot_has_stack_topology(
     *, snapshot: MergeTrainDryRunSnapshot, dry_run_result: MergeTrainDryRunResult
 ) -> bool:
@@ -2920,6 +2987,138 @@ def _merge_train_snapshot_has_stack_topology(
             )
         )
     return False
+
+
+def _build_merge_train_pr_feedback_record(
+    *,
+    request: MergeTrainPrFeedbackEnvelope,
+    policy_key: str,
+    policy_sha256: str,
+    token: str,
+    recorded_at: str,
+) -> MergeTrainPrFeedbackRecord:
+    marker = merge_train_pr_feedback_marker(
+        repository=request.repository,
+        base_branch=request.base_branch,
+        pull_request_number=request.pull_request_number,
+    )
+    comment_markdown = _render_merge_train_pr_feedback_markdown(
+        marker=marker,
+        request=request,
+    )
+    delivery_status: Literal["delivered", "skipped", "failed"] = "skipped"
+    delivery_action = ""
+    comment_id = 0
+    comment_url = ""
+    error_message = ""
+    owner, repo = request.repository.split("/", 1)
+    if not token:
+        error_message = "Configured merge train GitHub token is not available."
+    else:
+        try:
+            existing_comment = find_github_issue_comment_by_marker(
+                owner=owner,
+                repo=repo,
+                issue_number=request.pull_request_number,
+                token=token,
+                marker=marker,
+            )
+            if existing_comment is not None:
+                existing_comment_id = existing_comment.get("id")
+                if not isinstance(existing_comment_id, int):
+                    raise click.ClickException(
+                        "Existing merge train feedback comment is missing a numeric id."
+                    )
+                updated_comment = update_github_issue_comment(
+                    owner=owner,
+                    repo=repo,
+                    comment_id=existing_comment_id,
+                    token=token,
+                    body=comment_markdown,
+                )
+                delivery_action = "updated_comment"
+                comment_id = existing_comment_id
+                comment_url = _github_comment_url(updated_comment)
+            else:
+                created_comment = create_github_issue_comment(
+                    owner=owner,
+                    repo=repo,
+                    issue_number=request.pull_request_number,
+                    token=token,
+                    body=comment_markdown,
+                )
+                created_comment_id = created_comment.get("id")
+                delivery_action = "created_comment"
+                comment_id = created_comment_id if isinstance(created_comment_id, int) else 0
+                comment_url = _github_comment_url(created_comment)
+            delivery_status = "delivered"
+        except click.ClickException as exc:
+            delivery_status = "failed"
+            error_message = str(exc)
+    return MergeTrainPrFeedbackRecord(
+        feedback_id=build_merge_train_pr_feedback_id(
+            repository=request.repository,
+            base_branch=request.base_branch,
+            pull_request_number=request.pull_request_number,
+            event=request.event,
+            marker=marker,
+            recorded_at=recorded_at,
+        ),
+        repository=request.repository,
+        base_branch=request.base_branch,
+        pull_request_number=request.pull_request_number,
+        pull_request_url=(
+            f"https://github.com/{request.repository}/pull/{request.pull_request_number}"
+        ),
+        event=request.event,
+        marker=marker,
+        comment_markdown=comment_markdown,
+        source=request.source or "service:merge-train-pr-feedback",
+        recorded_at=recorded_at,
+        policy_key=policy_key,
+        policy_sha256=policy_sha256,
+        controller_action=request.controller_action,
+        controller_record_id=request.controller_record_id,
+        delivery_status=delivery_status,
+        delivery_action=delivery_action,
+        comment_id=comment_id,
+        comment_url=comment_url,
+        error_message=error_message,
+    )
+
+
+def _render_merge_train_pr_feedback_markdown(
+    *, marker: str, request: MergeTrainPrFeedbackEnvelope
+) -> str:
+    event_titles = {
+        "queued": "Launchplane queued this pull request in the merge train.",
+        "building": "Launchplane is building a merge-train candidate.",
+        "waiting": "Launchplane is waiting before the next merge-train step.",
+        "blocked": "Launchplane blocked the merge-train step for this pull request.",
+        "stale_policy": "Launchplane parked this merge-train record because policy changed.",
+        "completed": "Launchplane completed the merge-train step for this pull request.",
+    }
+    lines = [
+        marker,
+        event_titles[request.event],
+        "",
+        f"- Repository: `{request.repository}`",
+        f"- Base branch: `{request.base_branch}`",
+        f"- Pull request: #{request.pull_request_number}",
+    ]
+    if request.controller_action:
+        lines.append(f"- Controller action: `{request.controller_action}`")
+    if request.controller_record_id:
+        lines.append(f"- Controller record: `{request.controller_record_id}`")
+    if request.message:
+        lines.extend(["", request.message])
+    lines.extend(
+        [
+            "",
+            "Launchplane manages this comment and will update it as the train moves.",
+        ]
+    )
+    return "\n".join(lines)
 
 
 def _read_merge_train_batch_candidate_record(
@@ -8395,6 +8594,71 @@ def create_launchplane_service_app(
                 )
                 record_store.write_merge_train_run_record(run_record)
                 result["merge_train_run_id"] = run_record.run_id
+            elif path == _MERGE_TRAIN_PR_FEEDBACK_ROUTE:
+                feedback_request = MergeTrainPrFeedbackEnvelope.model_validate(payload)
+                policy_record = resolve_merge_train_policy_record(record_store)
+                policy = policy_record.policy
+                repository_policy = policy.find_repository_policy(
+                    repository=feedback_request.repository,
+                    base_branch=feedback_request.base_branch,
+                )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action=repository_policy.service_authz.action,
+                    product=repository_policy.service_authz.product,
+                    context=repository_policy.service_authz.context,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot write merge train PR feedback.",
+                            },
+                        },
+                    )
+                token_env = repository_policy.github_token.env_var
+                if not token_env:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "github_token_not_configured",
+                                "message": "Merge train policy does not define a GitHub token environment variable.",
+                            },
+                        },
+                    )
+                token = os.environ.get(token_env, "").strip()
+                if not token:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "github_token_not_configured",
+                                "message": "Configured merge train GitHub token is not available.",
+                            },
+                        },
+                    )
+                feedback_store = _merge_train_pr_feedback_record_store(record_store)
+                feedback_record = _build_merge_train_pr_feedback_record(
+                    request=feedback_request,
+                    policy_key=repository_policy.policy_key,
+                    policy_sha256=policy_record.policy_sha256,
+                    token=token,
+                    recorded_at=_utc_now_timestamp(),
+                )
+                feedback_store.write_merge_train_pr_feedback_record(feedback_record)
+                result = {"feedback": feedback_record.model_dump(mode="json")}
+                driver_result = {"feedback": feedback_record.model_dump(mode="json")}
             elif path == _MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE:
                 batch_request = MergeTrainBatchCandidateRunOnceEnvelope.model_validate(payload)
                 policy_record = resolve_merge_train_policy_record(record_store)

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -29,6 +29,9 @@ from control_plane.contracts.merge_train_stack_collapse import (
 )
 from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
+from control_plane.contracts.merge_train_pr_feedback_record import (
+    MergeTrainPrFeedbackRecord,
+)
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.odoo_stable_bootstrap_operation import (
     OdooStableBootstrapOperationRecord,
@@ -183,6 +186,36 @@ class FilesystemRecordStore:
 
     def write_merge_train_policy_record(self, record: MergeTrainPolicyRecord) -> Path:
         return self._write_model("launchplane_merge_train_policies", record.record_id, record)
+
+    def write_merge_train_pr_feedback_record(
+        self, record: MergeTrainPrFeedbackRecord
+    ) -> Path:
+        return self._write_model(
+            "launchplane_merge_train_pr_feedback", record.feedback_id, record
+        )
+
+    def list_merge_train_pr_feedback_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        pr_number: int | None = None,
+        limit: int | None = None,
+    ) -> tuple[MergeTrainPrFeedbackRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                MergeTrainPrFeedbackRecord,
+                "launchplane_merge_train_pr_feedback",
+            )
+            if (not repository or record.repository == repository)
+            and (not base_branch or record.base_branch == base_branch)
+            and (pr_number is None or record.pull_request_number == pr_number)
+        ]
+        records.sort(key=lambda record: (record.recorded_at, record.feedback_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
 
     def write_merge_train_batch_candidate_record(
         self, record: MergeTrainBatchCandidateRecord

--- a/control_plane/storage/migrations/versions/f7d8e9a0b1c2_add_merge_train_pr_feedback.py
+++ b/control_plane/storage/migrations/versions/f7d8e9a0b1c2_add_merge_train_pr_feedback.py
@@ -1,0 +1,51 @@
+"""add merge train PR feedback records
+
+Revision ID: f7d8e9a0b1c2
+Revises: f6c7d8e9a0b1
+Create Date: 2026-05-20 14:30:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "f7d8e9a0b1c2"
+down_revision: str | None = "f6c7d8e9a0b1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "launchplane_merge_train_pr_feedback"
+_PR_INDEX = "launchplane_merge_train_pr_feedback_pr_idx"
+
+
+def upgrade() -> None:
+    op.create_table(
+        _TABLE,
+        sa.Column("feedback_id", sa.String(), nullable=False),
+        sa.Column("repository", sa.String(), nullable=False),
+        sa.Column("base_branch", sa.String(), nullable=False),
+        sa.Column("pull_request_number", sa.Integer(), nullable=False),
+        sa.Column("event", sa.String(), nullable=False),
+        sa.Column("delivery_status", sa.String(), nullable=False),
+        sa.Column("recorded_at", sa.String(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("feedback_id"),
+    )
+    op.create_index(
+        _PR_INDEX,
+        _TABLE,
+        ["repository", "base_branch", "pull_request_number", sa.text("recorded_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(_PR_INDEX, table_name=_TABLE)
+    op.drop_table(_TABLE)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -48,6 +48,9 @@ from control_plane.contracts.merge_train_stack_collapse import (
 )
 from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
+from control_plane.contracts.merge_train_pr_feedback_record import (
+    MergeTrainPrFeedbackRecord,
+)
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.odoo_stable_bootstrap_operation import (
     OdooStableBootstrapOperationRecord,
@@ -640,6 +643,28 @@ class LaunchplaneMergeTrainPolicyRow(Base):
     source: Mapped[str] = mapped_column(String, nullable=False)
     updated_at: Mapped[str] = mapped_column(String, nullable=False)
     policy_sha256: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneMergeTrainPrFeedbackRow(Base):
+    __tablename__ = "launchplane_merge_train_pr_feedback"
+    __table_args__ = (
+        Index(
+            "launchplane_merge_train_pr_feedback_pr_idx",
+            "repository",
+            "base_branch",
+            "pull_request_number",
+            desc("recorded_at"),
+        ),
+    )
+
+    feedback_id: Mapped[str] = mapped_column(String, primary_key=True)
+    repository: Mapped[str] = mapped_column(String, nullable=False)
+    base_branch: Mapped[str] = mapped_column(String, nullable=False)
+    pull_request_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    event: Mapped[str] = mapped_column(String, nullable=False)
+    delivery_status: Mapped[str] = mapped_column(String, nullable=False)
+    recorded_at: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -1927,6 +1952,48 @@ class PostgresRecordStore(HumanSessionStore):
             )
         )
 
+    def write_merge_train_pr_feedback_record(
+        self, record: MergeTrainPrFeedbackRecord
+    ) -> None:
+        self._write_row(
+            LaunchplaneMergeTrainPrFeedbackRow(
+                feedback_id=record.feedback_id,
+                repository=record.repository,
+                base_branch=record.base_branch,
+                pull_request_number=record.pull_request_number,
+                event=record.event,
+                delivery_status=record.delivery_status,
+                recorded_at=record.recorded_at,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def list_merge_train_pr_feedback_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        pr_number: int | None = None,
+        limit: int | None = None,
+    ) -> tuple[MergeTrainPrFeedbackRecord, ...]:
+        filters: list[object] = []
+        if repository:
+            filters.append(LaunchplaneMergeTrainPrFeedbackRow.repository == repository)
+        if base_branch:
+            filters.append(LaunchplaneMergeTrainPrFeedbackRow.base_branch == base_branch)
+        if pr_number is not None:
+            filters.append(LaunchplaneMergeTrainPrFeedbackRow.pull_request_number == pr_number)
+        return self._list_models(
+            model_type=MergeTrainPrFeedbackRecord,
+            orm_model=LaunchplaneMergeTrainPrFeedbackRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneMergeTrainPrFeedbackRow.recorded_at.desc(),
+                LaunchplaneMergeTrainPrFeedbackRow.feedback_id.desc(),
+            ),
+            limit=limit,
+        )
+
     def write_merge_train_batch_candidate_record(
         self, record: MergeTrainBatchCandidateRecord
     ) -> None:
@@ -3046,6 +3113,7 @@ class PostgresRecordStore(HumanSessionStore):
             "preview_pr_feedback": 0,
             "every_code_preview_gates": 0,
             "agent_write_intents": 0,
+            "merge_train_pr_feedback": 0,
             "merge_train_batch_candidates": 0,
             "merge_train_batch_landing_plans": 0,
             "merge_train_stack_collapse_plans": 0,
@@ -3121,6 +3189,10 @@ class PostgresRecordStore(HumanSessionStore):
             for run_record in filesystem_store.list_merge_train_run_records():
                 self.write_merge_train_run_record(run_record)
                 counts["merge_train_runs"] += 1
+        if hasattr(filesystem_store, "list_merge_train_pr_feedback_records"):
+            for feedback_record in filesystem_store.list_merge_train_pr_feedback_records():
+                self.write_merge_train_pr_feedback_record(feedback_record)
+                counts["merge_train_pr_feedback"] += 1
         if hasattr(filesystem_store, "list_merge_train_batch_candidate_records"):
             for candidate_record in filesystem_store.list_merge_train_batch_candidate_records():
                 self.write_merge_train_batch_candidate_record(candidate_record)

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -456,6 +456,17 @@ stop on terminal or attention states: `batch_landed`, `candidate_failed`,
 should include `error.code`, `trace_id`, and the retry/stop recommendation, not
 the original request body.
 
+Schedulers and operators report train progress through
+`POST /v1/work-graph/merge-train/pr-feedback`. The route accepts a
+repository/base selector, pull request number, feedback event, and optional
+controller action, record id, and message. Launchplane renders one managed
+comment per PR with a hidden marker and updates that same comment as the train
+moves through queued, waiting, blocked, stale-policy, and completed states. Each
+call also writes a `launchplane_merge_train_pr_feedback` record so delivery
+status, rendered markdown, and GitHub comment identity remain auditable. Callers
+must keep the message public-safe: no tokens, raw headers, private API base URLs,
+local paths, or unchecked provider responses.
+
 The batch-landing service endpoint
 `POST /v1/work-graph/merge-train/batch-landing/run-once` owns that PR-native
 landing phase. It accepts `mode: plan` with a passed candidate record id and

--- a/docs/records.md
+++ b/docs/records.md
@@ -766,6 +766,13 @@ preflights.
   metadata, trace id, recorded timestamp, and optional one-step worker result.
   The record is evidence for a single Level 1 ordered-queue service call, not
   queue authority for a later pass.
+- Merge train pull-request feedback is persisted as
+  `launchplane_merge_train_pr_feedback` records. Each record stores the
+  repository/base branch, PR number/url, feedback event, hidden managed-comment
+  marker, rendered public markdown, policy key and digest, controller action
+  metadata, delivery status, GitHub comment id/url, and error detail when
+  delivery fails. These records are audit evidence for the PR-facing feedback
+  surface; the current PR comment remains managed through GitHub by marker.
 - Full batch train candidates are persisted as
   `launchplane_merge_train_batch_candidates` records. Each record stores the
   repository/base branch, observed base SHA, ordered PR entries, candidate ref,

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -81,6 +81,7 @@ VeriReel product paths:
   - `GET /v1/work-graph/merge-train/controller/status`
   - `POST /v1/work-graph/rank`
   - `POST /v1/work-graph/merge-train/run-once`
+  - `POST /v1/work-graph/merge-train/pr-feedback`
   - `POST /v1/work-graph/merge-train/controller/run-once`
 - product driver routes:
   - `POST /v1/drivers/generic-web/deploy`
@@ -232,6 +233,17 @@ repository policy, resolves its GitHub token from that policy's
 policy or token is available. The route is dry-run by default; `mutate: true`
 applies at most one worker transition from one fresh snapshot. This route is the
 deployed sequential baseline, not the full batch train target.
+
+`POST /v1/work-graph/merge-train/pr-feedback` writes the public pull-request
+feedback surface for train progress. It uses the same repository/base policy and
+`service_authz` scope as `run-once`, resolves the same GitHub token, and creates
+or updates one Launchplane-managed issue comment per PR using a hidden marker.
+Accepted calls persist a `launchplane_merge_train_pr_feedback` record with the
+rendered markdown, event, controller action metadata, delivery status, and
+GitHub comment id/url. The route fails closed when authorization or token
+configuration is missing; callers should use it for queued, waiting, blocked,
+stale-policy, and completed transition summaries instead of writing ad hoc
+comments from scheduler scripts.
 
 `GET /v1/work-graph/merge-train/admission` returns the stored-history scheduler
 admission decision for a requested `repository` and `base_branch`. It uses the

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -30,6 +30,9 @@ from control_plane.contracts.merge_train_batch import (
     build_merge_train_batch_id,
     build_merge_train_batch_landing_plan,
 )
+from control_plane.contracts.merge_train_pr_feedback_record import (
+    MergeTrainPrFeedbackRecord,
+)
 from control_plane.contracts.merge_train_stack_collapse import (
     MergeTrainStackCollapseEntry,
     MergeTrainStackCollapseMutation,
@@ -238,6 +241,70 @@ def _merge_train_stack_collapse_plan_record(
 
 
 class FilesystemRecordStoreTests(unittest.TestCase):
+    def test_write_and_list_merge_train_pr_feedback_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            older_record = MergeTrainPrFeedbackRecord(
+                feedback_id="merge-train-pr-feedback-example-repo-main-pr-7-old",
+                repository="example/repo",
+                base_branch="main",
+                pull_request_number=7,
+                pull_request_url="https://github.com/example/repo/pull/7",
+                event="queued",
+                marker="<!-- launchplane-merge-train:abc -->",
+                comment_markdown="<!-- launchplane-merge-train:abc -->\nQueued.",
+                source="test",
+                recorded_at="2026-05-20T12:00:00Z",
+                delivery_status="delivered",
+                delivery_action="created_comment",
+                comment_id=100,
+                comment_url="https://github.com/example/repo/pull/7#issuecomment-100",
+            )
+            newer_record = older_record.model_copy(
+                update={
+                    "feedback_id": "merge-train-pr-feedback-example-repo-main-pr-7-new",
+                    "event": "waiting",
+                    "recorded_at": "2026-05-20T12:05:00Z",
+                    "delivery_action": "updated_comment",
+                    "comment_id": 101,
+                    "comment_url": "https://github.com/example/repo/pull/7#issuecomment-101",
+                }
+            )
+            other_record = older_record.model_copy(
+                update={
+                    "feedback_id": "merge-train-pr-feedback-example-repo-main-pr-8",
+                    "pull_request_number": 8,
+                    "pull_request_url": "https://github.com/example/repo/pull/8",
+                    "recorded_at": "2026-05-20T12:10:00Z",
+                }
+            )
+
+            written_path = store.write_merge_train_pr_feedback_record(older_record)
+            store.write_merge_train_pr_feedback_record(newer_record)
+            store.write_merge_train_pr_feedback_record(other_record)
+            listed_records = store.list_merge_train_pr_feedback_records(
+                repository="example/repo",
+                base_branch="main",
+                pr_number=7,
+            )
+            limited_records = store.list_merge_train_pr_feedback_records(
+                repository="example/repo",
+                base_branch="main",
+                limit=1,
+            )
+
+        self.assertEqual(
+            written_path.relative_to(state_dir).as_posix(),
+            "launchplane_merge_train_pr_feedback/"
+            "merge-train-pr-feedback-example-repo-main-pr-7-old.json",
+        )
+        self.assertEqual(
+            [record.feedback_id for record in listed_records],
+            [newer_record.feedback_id, older_record.feedback_id],
+        )
+        self.assertEqual([record.feedback_id for record in limited_records], [other_record.feedback_id])
+
     def test_write_and_list_every_code_preview_gate_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name)

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -2463,6 +2463,7 @@ env_var = "GH_TOKEN"
                     "preview_pr_feedback": 1,
                     "every_code_preview_gates": 0,
                     "agent_write_intents": 0,
+                    "merge_train_pr_feedback": 0,
                     "merge_train_batch_candidates": 1,
                     "merge_train_batch_landing_plans": 1,
                     "merge_train_stack_collapse_plans": 1,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1810,6 +1810,176 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 503)
         self.assertEqual(payload["error"]["code"], "github_token_not_configured")
 
+    def test_merge_train_pr_feedback_service_creates_managed_comment(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            policy_record = _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with (
+                patch(
+                    "control_plane.service.find_github_issue_comment_by_marker",
+                    return_value=None,
+                ) as find_comment,
+                patch(
+                    "control_plane.service.create_github_issue_comment",
+                    return_value={
+                        "id": 123,
+                        "html_url": "https://github.com/cbusillo/sellyouroutboard/pull/7#issuecomment-123",
+                    },
+                ) as create_comment,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/pr-feedback",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "pull_request_number": 7,
+                        "event": "waiting",
+                        "controller_action": "observe_candidate",
+                        "controller_record_id": "candidate-1",
+                        "message": "Waiting for required checks to settle.",
+                    },
+                )
+            records = FilesystemRecordStore(state_dir).list_merge_train_pr_feedback_records(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pr_number=7,
+            )
+
+        self.assertEqual(status_code, 202)
+        feedback = payload["result"]["feedback"]
+        self.assertEqual(feedback["delivery_status"], "delivered")
+        self.assertEqual(feedback["delivery_action"], "created_comment")
+        self.assertEqual(feedback["comment_id"], 123)
+        self.assertEqual(feedback["policy_sha256"], policy_record.policy_sha256)
+        self.assertIn("launchplane-merge-train", feedback["marker"])
+        self.assertIn("Waiting for required checks", feedback["comment_markdown"])
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].comment_id, 123)
+        self.assertEqual(records[0].delivery_action, "created_comment")
+        find_comment.assert_called_once()
+        create_comment.assert_called_once()
+
+    def test_merge_train_pr_feedback_service_updates_managed_comment(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with (
+                patch(
+                    "control_plane.service.find_github_issue_comment_by_marker",
+                    return_value={"id": 456, "body": "old body"},
+                ) as find_comment,
+                patch(
+                    "control_plane.service.update_github_issue_comment",
+                    return_value={
+                        "id": 456,
+                        "html_url": "https://github.com/cbusillo/sellyouroutboard/pull/7#issuecomment-456",
+                    },
+                ) as update_comment,
+                patch("control_plane.service.create_github_issue_comment") as create_comment,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/pr-feedback",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "pull_request_number": 7,
+                        "event": "completed",
+                    },
+                )
+            records = FilesystemRecordStore(state_dir).list_merge_train_pr_feedback_records(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pr_number=7,
+            )
+
+        self.assertEqual(status_code, 202)
+        feedback = payload["result"]["feedback"]
+        self.assertEqual(feedback["delivery_status"], "delivered")
+        self.assertEqual(feedback["delivery_action"], "updated_comment")
+        self.assertEqual(feedback["comment_id"], 456)
+        self.assertEqual(records[0].delivery_action, "updated_comment")
+        find_comment.assert_called_once()
+        update_comment.assert_called_once()
+        create_comment.assert_not_called()
+
+    def test_merge_train_pr_feedback_service_rejects_unauthorized_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/pr-feedback",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "pull_request_number": 7,
+                        "event": "blocked",
+                    },
+                )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_merge_train_pr_feedback_service_rejects_missing_token(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch.dict("os.environ", {}, clear=True):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/pr-feedback",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "pull_request_number": 7,
+                        "event": "blocked",
+                    },
+                )
+
+        self.assertEqual(status_code, 503)
+        self.assertEqual(payload["error"]["code"], "github_token_not_configured")
+
     def test_merge_train_run_once_service_rejects_unsupported_policy(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(
             {


### PR DESCRIPTION
## Summary
- Add durable merge-train PR feedback records for one managed GitHub comment per PR.
- Add filesystem/Postgres storage plus Alembic migration for feedback delivery evidence.
- Add `POST /v1/work-graph/merge-train/pr-feedback` and document the service/record contract.

## Verification
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff check --diff control_plane/contracts/merge_train_pr_feedback_record.py control_plane/service.py control_plane/storage/filesystem.py control_plane/storage/postgres.py tests/test_filesystem_store.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/contracts/merge_train_pr_feedback_record.py control_plane/service.py control_plane/storage/filesystem.py control_plane/storage/postgres.py tests/test_filesystem_store.py tests/test_service.py`
- `uv run python -m unittest tests.test_filesystem_store tests.test_service.LaunchplaneServiceTests.test_merge_train_pr_feedback_service_creates_managed_comment tests.test_service.LaunchplaneServiceTests.test_merge_train_pr_feedback_service_updates_managed_comment tests.test_service.LaunchplaneServiceTests.test_merge_train_pr_feedback_service_rejects_unauthorized_identity tests.test_service.LaunchplaneServiceTests.test_merge_train_pr_feedback_service_rejects_missing_token`
- `LAUNCHPLANE_DATABASE_URL=sqlite+pysqlite:///$tmpdb uv run alembic upgrade head && ... downgrade f6c7d8e9a0b1 && ... upgrade head`

JetBrains changed-files inspection returned stale cached results with findings withheld.
