### PR TITLE
Post merge train controller feedback

### DIFF
--- a/.github/workflows/merge-train-runner.yml
+++ b/.github/workflows/merge-train-runner.yml
@@ -268,6 +268,12 @@ jobs:
               ;;
           esac
 
+      - name: Checkout runner helpers
+        if: >-
+          steps.admission.outputs.admission_status == 'admitted' &&
+          env.MERGE_TRAIN_RUNNER_MODE == 'controller'
+        uses: actions/checkout@v6
+
       - name: Run one merge-train pass
         if: >-
           steps.admission.outputs.admission_status == 'admitted' &&
@@ -416,6 +422,34 @@ jobs:
           fi
 
           jq . "$response_file"
+          feedback_payloads="launchplane-merge-train-controller-feedback.json"
+          python3 scripts/merge_train_controller_feedback.py \
+            --response-file "$response_file" \
+            > "$feedback_payloads"
+          feedback_count="$(jq 'length' "$feedback_payloads")"
+          if [ "$feedback_count" -gt 0 ]; then
+            feedback_url="${SERVICE_ORIGIN}/v1/work-graph/merge-train/pr-feedback"
+            feedback_index=0
+            while IFS= read -r feedback_payload; do
+              feedback_index="$((feedback_index + 1))"
+              feedback_response="launchplane-merge-train-feedback-${feedback_index}.json"
+              feedback_status="$(curl -sS \
+                -o "$feedback_response" \
+                -w '%{http_code}' \
+                -X POST \
+                -H "Authorization: Bearer ${oidc_token}" \
+                -H 'Content-Type: application/json' \
+                --data "$feedback_payload" \
+                "$feedback_url")"
+              if [ "$feedback_status" != "202" ]; then
+                cat "$feedback_response" >&2
+                echo "Merge-train PR feedback failed" \
+                  "with HTTP ${feedback_status}." >&2
+                exit 1
+              fi
+              jq . "$feedback_response"
+            done < <(jq -c '.[]' "$feedback_payloads")
+          fi
           {
             echo
             echo '## Launchplane merge train controller'
@@ -440,6 +474,7 @@ jobs:
             echo "- Candidate record: ${candidate_record}"
             echo "- Landing-plan record: ${landing_record}"
             echo "- Stack-collapse record: ${stack_record}"
+            echo "- Feedback payloads: ${feedback_count}"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run one batch-candidate phase

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -506,8 +506,11 @@ that admission route before every worker call. It defaults to the Level 1
 `run-once` route for compatibility, and can call the full controller exactly
 once per admitted pass when manual dispatch sets `runner_mode: controller` or a
 scheduled run sets the repository variable `LAUNCHPLANE_MERGE_TRAIN_RUNNER_MODE`
-to `controller`. The scheduler still writes at most one Launchplane worker
-result per pass; the five-minute schedule is the retry loop.
+to `controller`. Controller-mode runs render conservative PR feedback payloads
+from the controller response and post them through the managed feedback endpoint,
+so queued PRs get one evolving Launchplane status comment as the train builds,
+waits, blocks, or completes. The scheduler still writes at most one Launchplane
+worker result per pass; the five-minute schedule is the retry loop.
 
 The merge step is allowed only from a fresh dry-run result whose next action is
 `merge`. The merge request must use the selected pull request's observed

--- a/scripts/merge_train_controller_feedback.py
+++ b/scripts/merge_train_controller_feedback.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ATTENTION_ACTIONS = {
+    "block",
+    "candidate_failed",
+    "candidate_stopped",
+    "stack_unsupported",
+    "update_branch",
+}
+BUILDING_ACTIONS = {
+    "admit_collapsed_root",
+    "build_candidate",
+    "execute_stack_collapse",
+    "land_batch",
+    "observe_candidate",
+    "plan_candidate",
+    "plan_landing",
+    "plan_stack_collapse",
+}
+WAITING_ACTIONS = {"wait_for_checks", "wait_for_root_checks"}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Render merge-train controller PR feedback payloads."
+    )
+    parser.add_argument("--response-file", required=True, type=Path)
+    parser.add_argument("--source", default="workflow:merge-train-runner")
+    args = parser.parse_args()
+
+    response = json.loads(args.response_file.read_text(encoding="utf-8"))
+    payloads = build_feedback_payloads(response=response, source=args.source)
+    json.dump(payloads, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    print(f"Rendered {len(payloads)} feedback payload(s).", file=sys.stderr)
+    return 0
+
+
+def build_feedback_payloads(
+    *, response: dict[str, Any], source: str = "workflow:merge-train-runner"
+) -> list[dict[str, object]]:
+    result = _as_dict(response.get("result"))
+    records = _as_dict(response.get("records"))
+    repository = _required_string(result.get("repository"), "repository")
+    base_branch = _required_string(result.get("base_branch"), "base_branch")
+    controller_action = _required_string(result.get("controller_action"), "controller_action")
+    event = _feedback_event(controller_action=controller_action, result=result)
+    if event == "skip":
+        return []
+
+    pull_request_numbers = _pull_request_numbers(result)
+    if not pull_request_numbers:
+        return []
+
+    controller_record_id = _controller_record_id(records)
+    message = _feedback_message(
+        controller_action=controller_action,
+        event=event,
+        result=result,
+        controller_record_id=controller_record_id,
+    )
+    return [
+        {
+            "schema_version": 1,
+            "repository": repository,
+            "base_branch": base_branch,
+            "pull_request_number": pull_request_number,
+            "event": event,
+            "controller_action": controller_action,
+            "controller_record_id": controller_record_id,
+            "message": message,
+            "source": source,
+        }
+        for pull_request_number in pull_request_numbers
+    ]
+
+
+def _feedback_event(*, controller_action: str, result: dict[str, Any]) -> str:
+    candidate = _as_dict(result.get("candidate"))
+    landing_plan = _as_dict(result.get("landing_plan"))
+    candidate_status = _string(candidate.get("status"))
+    required_checks_status = _string(candidate.get("required_checks_status"))
+
+    if controller_action in {"idle", "candidate_stopped"} and candidate_status == "stale":
+        return "stale_policy"
+    if controller_action == "batch_landed" or _landing_plan_complete(landing_plan):
+        return "completed"
+    if candidate_status in {"blocked", "failed", "stale"}:
+        return "blocked" if candidate_status != "stale" else "stale_policy"
+    if required_checks_status in {"pending", "unknown"}:
+        return "waiting"
+    if controller_action in WAITING_ACTIONS:
+        return "waiting"
+    if controller_action in ATTENTION_ACTIONS:
+        return "blocked"
+    if controller_action in BUILDING_ACTIONS:
+        return "building"
+    return "skip"
+
+
+def _feedback_message(
+    *,
+    controller_action: str,
+    event: str,
+    result: dict[str, Any],
+    controller_record_id: str,
+) -> str:
+    if event == "completed":
+        return "Launchplane finished the merge-train step for this pull request."
+    if event == "stale_policy":
+        return "Launchplane stopped using this train record because policy changed."
+    if event == "blocked":
+        detail = _blocking_detail(result)
+        if detail:
+            return f"Launchplane needs attention before the train can continue: {detail}"
+        return "Launchplane needs attention before the train can continue."
+    if event == "waiting":
+        return "Launchplane is waiting for required checks or fresh GitHub state."
+    if controller_record_id:
+        return f"Launchplane is advancing `{controller_action}` with `{controller_record_id}`."
+    return f"Launchplane is advancing `{controller_action}` for this train pass."
+
+
+def _blocking_detail(result: dict[str, Any]) -> str:
+    dry_run_result = _as_dict(result.get("dry_run_result"))
+    detail = _string(dry_run_result.get("next_action_detail"))
+    if detail:
+        return detail
+    candidate = _as_dict(result.get("candidate"))
+    required_checks_status = _string(candidate.get("required_checks_status"))
+    if required_checks_status == "fail":
+        return "candidate required checks failed"
+    return ""
+
+
+def _pull_request_numbers(result: dict[str, Any]) -> list[int]:
+    containers = (
+        _as_dict(result.get("landing_plan")).get("entries"),
+        _as_dict(result.get("candidate")).get("entries"),
+        _as_dict(result.get("stack_collapse_plan")).get("entries"),
+    )
+    seen: set[int] = set()
+    numbers: list[int] = []
+    for container in containers:
+        for entry in _as_list(container):
+            number = _as_dict(entry).get("pull_request_number")
+            if isinstance(number, int) and number > 0 and number not in seen:
+                seen.add(number)
+                numbers.append(number)
+    return numbers
+
+
+def _controller_record_id(records: dict[str, Any]) -> str:
+    for key in (
+        "merge_train_batch_landing_plan_record_id",
+        "merge_train_batch_candidate_record_id",
+        "merge_train_stack_collapse_plan_record_id",
+        "merge_train_run_id",
+    ):
+        value = _string(records.get(key))
+        if value:
+            return value
+    return ""
+
+
+def _landing_plan_complete(landing_plan: dict[str, Any]) -> bool:
+    entries = _as_list(landing_plan.get("entries"))
+    return bool(entries) and all(
+        _string(_as_dict(entry).get("status")) == "merged" for entry in entries
+    )
+
+
+def _required_string(value: object, field_name: str) -> str:
+    normalized = _string(value)
+    if not normalized:
+        raise ValueError(f"controller response missing {field_name}")
+    return normalized
+
+
+def _string(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _as_dict(value: object) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: object) -> list[object]:
+    return value if isinstance(value, list) else []
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_merge_train_controller_feedback.py
+++ b/tests/test_merge_train_controller_feedback.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+from unittest import TestCase
+
+
+def _load_feedback_module() -> ModuleType:
+    module_path = (
+        Path(__file__).resolve().parents[1] / "scripts" / "merge_train_controller_feedback.py"
+    )
+    spec = importlib.util.spec_from_file_location("merge_train_controller_feedback", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+feedback = _load_feedback_module()
+
+
+class MergeTrainControllerFeedbackTests(TestCase):
+    def test_build_feedback_payloads_emits_building_candidate_entries(self) -> None:
+        response: dict[str, Any] = {
+            "result": {
+                "repository": "cbusillo/example",
+                "base_branch": "main",
+                "controller_action": "plan_candidate",
+                "candidate": {
+                    "status": "planned",
+                    "entries": [
+                        {"pull_request_number": 7},
+                        {"pull_request_number": 8},
+                    ],
+                },
+            },
+            "records": {"merge_train_batch_candidate_record_id": "candidate-123"},
+        }
+
+        payloads = feedback.build_feedback_payloads(response=response)
+
+        self.assertEqual([7, 8], [payload["pull_request_number"] for payload in payloads])
+        self.assertEqual({"building"}, {payload["event"] for payload in payloads})
+        self.assertEqual(
+            {"candidate-123"}, {payload["controller_record_id"] for payload in payloads}
+        )
+        self.assertEqual(
+            {"workflow:merge-train-runner"}, {payload["source"] for payload in payloads}
+        )
+
+    def test_build_feedback_payloads_marks_pending_checks_waiting(self) -> None:
+        response: dict[str, Any] = {
+            "result": {
+                "repository": "cbusillo/example",
+                "base_branch": "main",
+                "controller_action": "observe_candidate",
+                "candidate": {
+                    "status": "building",
+                    "required_checks_status": "pending",
+                    "entries": [{"pull_request_number": 7}],
+                },
+            },
+            "records": {"merge_train_batch_candidate_record_id": "candidate-123"},
+        }
+
+        payloads = feedback.build_feedback_payloads(response=response)
+
+        self.assertEqual(1, len(payloads))
+        self.assertEqual("waiting", payloads[0]["event"])
+        self.assertIn("waiting", payloads[0]["message"])
+
+    def test_build_feedback_payloads_marks_merged_landing_plan_completed(self) -> None:
+        response: dict[str, Any] = {
+            "result": {
+                "repository": "cbusillo/example",
+                "base_branch": "main",
+                "controller_action": "land_batch",
+                "landing_plan": {
+                    "status": "completed",
+                    "entries": [
+                        {"pull_request_number": 7, "status": "merged"},
+                        {"pull_request_number": 8, "status": "merged"},
+                    ],
+                },
+            },
+            "records": {"merge_train_batch_landing_plan_record_id": "landing-plan-123"},
+        }
+
+        payloads = feedback.build_feedback_payloads(response=response)
+
+        self.assertEqual([7, 8], [payload["pull_request_number"] for payload in payloads])
+        self.assertEqual({"completed"}, {payload["event"] for payload in payloads})
+
+    def test_build_feedback_payloads_skips_actions_without_pr_numbers(self) -> None:
+        response: dict[str, Any] = {
+            "result": {
+                "repository": "cbusillo/example",
+                "base_branch": "main",
+                "controller_action": "plan_candidate",
+                "candidate": {"status": "planned", "entries": []},
+            },
+            "records": {"merge_train_batch_candidate_record_id": "candidate-123"},
+        }
+
+        self.assertEqual([], feedback.build_feedback_payloads(response=response))
+
+    def test_build_feedback_payloads_skips_unknown_actions(self) -> None:
+        response: dict[str, Any] = {
+            "result": {
+                "repository": "cbusillo/example",
+                "base_branch": "main",
+                "controller_action": "unknown_future_action",
+                "candidate": {"entries": [{"pull_request_number": 7}]},
+            },
+            "records": {},
+        }
+
+        self.assertEqual([], feedback.build_feedback_payloads(response=response))


### PR DESCRIPTION
## Summary
- wire controller-mode merge-train runner passes to post managed PR feedback
- add a small helper that maps controller responses into conservative feedback events
- document scheduler feedback behavior

## Verification
- `uv run python -m unittest tests.test_merge_train_controller_feedback tests.test_service.LaunchplaneServiceTests.test_merge_train_pr_feedback_service_creates_managed_comment`
- `uv run --extra dev ruff check scripts/merge_train_controller_feedback.py tests/test_merge_train_controller_feedback.py`
- `uv run --extra dev ruff format --check scripts/merge_train_controller_feedback.py tests/test_merge_train_controller_feedback.py`
- `uv run --extra dev mypy scripts/merge_train_controller_feedback.py tests/test_merge_train_controller_feedback.py`
- `docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/merge-train-runner.yml`
- `yamllint .github/workflows/merge-train-runner.yml`
- `git diff --check`

JetBrains changed-files inspection was run; it reported existing project findings outside the touched files.
