### PR TITLE
Post feedback for manual merge train phases

### DIFF
--- a/.github/workflows/merge-train-runner.yml
+++ b/.github/workflows/merge-train-runner.yml
@@ -271,7 +271,10 @@ jobs:
       - name: Checkout runner helpers
         if: >-
           steps.admission.outputs.admission_status == 'admitted' &&
-          env.MERGE_TRAIN_RUNNER_MODE == 'controller'
+          (env.MERGE_TRAIN_RUNNER_MODE == 'controller' ||
+          env.MERGE_TRAIN_BATCH_CANDIDATE_MODE != 'none' ||
+          env.MERGE_TRAIN_BATCH_LANDING_MODE != 'none' ||
+          env.MERGE_TRAIN_STACK_COLLAPSE_MODE != 'none')
         uses: actions/checkout@v6
 
       - name: Run one merge-train pass
@@ -478,6 +481,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run one batch-candidate phase
+        id: batch_candidate
         if: >-
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_BATCH_CANDIDATE_MODE != 'none'
@@ -543,6 +547,7 @@ jobs:
           fi
 
           jq . "$response_file"
+          echo "response_file=${response_file}" >> "$GITHUB_OUTPUT"
           {
             echo
             echo '## Launchplane merge train batch candidate'
@@ -568,6 +573,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run one stack-collapse phase
+        id: stack_collapse
         if: >-
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_STACK_COLLAPSE_MODE != 'none'
@@ -632,6 +638,7 @@ jobs:
           fi
 
           jq . "$response_file"
+          echo "response_file=${response_file}" >> "$GITHUB_OUTPUT"
           {
             echo
             echo '## Launchplane merge train stack collapse'
@@ -659,6 +666,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run one batch-landing phase
+        id: batch_landing
         if: >-
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_BATCH_LANDING_MODE != 'none'
@@ -734,6 +742,7 @@ jobs:
           fi
 
           jq . "$response_file"
+          echo "response_file=${response_file}" >> "$GITHUB_OUTPUT"
           {
             echo
             echo '## Launchplane merge train batch landing'
@@ -749,6 +758,86 @@ jobs:
             )"
             echo "- Landing-plan record: ${plan_record}"
             echo "- Entry statuses: ${entry_statuses}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post manual phase PR feedback
+        if: >-
+          steps.admission.outputs.admission_status == 'admitted' &&
+          env.MERGE_TRAIN_RUNNER_MODE == 'level1' &&
+          (steps.batch_candidate.outputs.response_file != '' ||
+          steps.stack_collapse.outputs.response_file != '' ||
+          steps.batch_landing.outputs.response_file != '')
+        shell: bash
+        env:
+          SERVICE_ORIGIN: ${{ steps.admission.outputs.service_origin }}
+          SERVICE_AUDIENCE: ${{ steps.admission.outputs.service_audience }}
+          BATCH_CANDIDATE_RESPONSE: >-
+            ${{ steps.batch_candidate.outputs.response_file }}
+          STACK_COLLAPSE_RESPONSE: >-
+            ${{ steps.stack_collapse.outputs.response_file }}
+          BATCH_LANDING_RESPONSE: >-
+            ${{ steps.batch_landing.outputs.response_file }}
+        run: |
+          set -euo pipefail
+          phase=""
+          response_file=""
+          if [ -n "${BATCH_CANDIDATE_RESPONSE}" ]; then
+            phase="batch-candidate"
+            response_file="${BATCH_CANDIDATE_RESPONSE}"
+          elif [ -n "${STACK_COLLAPSE_RESPONSE}" ]; then
+            phase="stack-collapse"
+            response_file="${STACK_COLLAPSE_RESPONSE}"
+          elif [ -n "${BATCH_LANDING_RESPONSE}" ]; then
+            phase="batch-landing"
+            response_file="${BATCH_LANDING_RESPONSE}"
+          fi
+          if [ -z "$phase" ] || [ -z "$response_file" ]; then
+            echo "No manual phase response file found."
+            exit 0
+          fi
+
+          feedback_payloads="launchplane-merge-train-${phase}-feedback.json"
+          python3 scripts/merge_train_controller_feedback.py \
+            --response-file "$response_file" \
+            --phase "$phase" \
+            --source "workflow:merge-train-runner:${phase}" \
+            > "$feedback_payloads"
+          feedback_count="$(jq 'length' "$feedback_payloads")"
+          if [ "$feedback_count" -gt 0 ]; then
+            oidc_token="$({
+              curl -fsSL \
+                -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+                "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
+              | jq -r '.value'
+            })"
+            feedback_url="${SERVICE_ORIGIN}/v1/work-graph/merge-train/pr-feedback"
+            feedback_index=0
+            while IFS= read -r feedback_payload; do
+              feedback_index="$((feedback_index + 1))"
+              feedback_response="launchplane-manual-phase-feedback-${feedback_index}.json"
+              feedback_status="$(curl -sS \
+                -o "$feedback_response" \
+                -w '%{http_code}' \
+                -X POST \
+                -H "Authorization: Bearer ${oidc_token}" \
+                -H 'Content-Type: application/json' \
+                --data "$feedback_payload" \
+                "$feedback_url")"
+              if [ "$feedback_status" != "202" ]; then
+                cat "$feedback_response" >&2
+                echo "Merge-train manual phase feedback failed" \
+                  "with HTTP ${feedback_status}." >&2
+                exit 1
+              fi
+              jq . "$feedback_response"
+            done < <(jq -c '.[]' "$feedback_payloads")
+          fi
+          {
+            echo
+            echo '## Launchplane merge train manual phase feedback'
+            echo
+            echo "- Phase: ${phase}"
+            echo "- Feedback payloads: ${feedback_count}"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Record deferred decision

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -506,8 +506,9 @@ that admission route before every worker call. It defaults to the Level 1
 `run-once` route for compatibility, and can call the full controller exactly
 once per admitted pass when manual dispatch sets `runner_mode: controller` or a
 scheduled run sets the repository variable `LAUNCHPLANE_MERGE_TRAIN_RUNNER_MODE`
-to `controller`. Controller-mode runs render conservative PR feedback payloads
-from the controller response and post them through the managed feedback endpoint,
+to `controller`. Controller-mode runs and manually dispatched batch-candidate,
+stack-collapse, or batch-landing phases render conservative PR feedback payloads
+from their worker responses and post them through the managed feedback endpoint,
 so queued PRs get one evolving Launchplane status comment as the train builds,
 waits, blocks, or completes. The scheduler still writes at most one Launchplane
 worker result per pass; the five-minute schedule is the retry loop.

--- a/scripts/merge_train_controller_feedback.py
+++ b/scripts/merge_train_controller_feedback.py
@@ -34,10 +34,15 @@ def main() -> int:
     )
     parser.add_argument("--response-file", required=True, type=Path)
     parser.add_argument("--source", default="workflow:merge-train-runner")
+    parser.add_argument(
+        "--phase",
+        choices=("controller", "batch-candidate", "stack-collapse", "batch-landing"),
+        default="controller",
+    )
     args = parser.parse_args()
 
     response = json.loads(args.response_file.read_text(encoding="utf-8"))
-    payloads = build_feedback_payloads(response=response, source=args.source)
+    payloads = build_feedback_payloads(response=response, source=args.source, phase=args.phase)
     json.dump(payloads, sys.stdout, indent=2, sort_keys=True)
     sys.stdout.write("\n")
     print(f"Rendered {len(payloads)} feedback payload(s).", file=sys.stderr)
@@ -45,13 +50,16 @@ def main() -> int:
 
 
 def build_feedback_payloads(
-    *, response: dict[str, Any], source: str = "workflow:merge-train-runner"
+    *,
+    response: dict[str, Any],
+    source: str = "workflow:merge-train-runner",
+    phase: str = "controller",
 ) -> list[dict[str, object]]:
     result = _as_dict(response.get("result"))
     records = _as_dict(response.get("records"))
     repository = _required_string(result.get("repository"), "repository")
     base_branch = _required_string(result.get("base_branch"), "base_branch")
-    controller_action = _required_string(result.get("controller_action"), "controller_action")
+    controller_action = _controller_action(result=result, phase=phase)
     event = _feedback_event(controller_action=controller_action, result=result)
     if event == "skip":
         return []
@@ -81,6 +89,33 @@ def build_feedback_payloads(
         }
         for pull_request_number in pull_request_numbers
     ]
+
+
+def _controller_action(*, result: dict[str, Any], phase: str) -> str:
+    explicit_action = _string(result.get("controller_action"))
+    if explicit_action:
+        return explicit_action
+
+    mode = _required_string(result.get("mode"), "mode")
+    phase_actions: dict[tuple[str, str], str] = {
+        ("batch-candidate", "plan"): _batch_candidate_plan_action(result),
+        ("batch-candidate", "build"): "build_candidate",
+        ("batch-candidate", "observe"): "observe_candidate",
+        ("stack-collapse", "execute"): "execute_stack_collapse",
+        ("stack-collapse", "admit"): "admit_collapsed_root",
+        ("batch-landing", "plan"): "plan_landing",
+        ("batch-landing", "land"): "land_batch",
+    }
+    action = phase_actions.get((phase, mode))
+    if not action:
+        raise ValueError(f"unsupported merge train feedback phase/mode {phase}:{mode}")
+    return action
+
+
+def _batch_candidate_plan_action(result: dict[str, Any]) -> str:
+    if _as_dict(result.get("stack_collapse_plan")):
+        return "plan_stack_collapse"
+    return "plan_candidate"
 
 
 def _feedback_event(*, controller_action: str, result: dict[str, Any]) -> str:

--- a/tests/test_merge_train_controller_feedback.py
+++ b/tests/test_merge_train_controller_feedback.py
@@ -119,3 +119,60 @@ class MergeTrainControllerFeedbackTests(TestCase):
         }
 
         self.assertEqual([], feedback.build_feedback_payloads(response=response))
+
+    def test_build_feedback_payloads_infers_candidate_plan_action(self) -> None:
+        response: dict[str, Any] = {
+            "result": {
+                "repository": "cbusillo/example",
+                "base_branch": "main",
+                "mode": "plan",
+                "candidate": {
+                    "status": "planned",
+                    "entries": [{"pull_request_number": 7}],
+                },
+            },
+            "records": {"merge_train_batch_candidate_record_id": "candidate-123"},
+        }
+
+        payloads = feedback.build_feedback_payloads(response=response, phase="batch-candidate")
+
+        self.assertEqual(1, len(payloads))
+        self.assertEqual("plan_candidate", payloads[0]["controller_action"])
+
+    def test_build_feedback_payloads_infers_stack_plan_action(self) -> None:
+        response: dict[str, Any] = {
+            "result": {
+                "repository": "cbusillo/example",
+                "base_branch": "main",
+                "mode": "plan",
+                "stack_collapse_plan": {
+                    "status": "planned",
+                    "entries": [{"pull_request_number": 7}],
+                },
+            },
+            "records": {"merge_train_stack_collapse_plan_record_id": "stack-123"},
+        }
+
+        payloads = feedback.build_feedback_payloads(response=response, phase="batch-candidate")
+
+        self.assertEqual(1, len(payloads))
+        self.assertEqual("plan_stack_collapse", payloads[0]["controller_action"])
+
+    def test_build_feedback_payloads_infers_landing_action(self) -> None:
+        response: dict[str, Any] = {
+            "result": {
+                "repository": "cbusillo/example",
+                "base_branch": "main",
+                "mode": "plan",
+                "landing_plan": {
+                    "status": "planned",
+                    "entries": [{"pull_request_number": 7, "status": "planned"}],
+                },
+            },
+            "records": {"merge_train_batch_landing_plan_record_id": "landing-123"},
+        }
+
+        payloads = feedback.build_feedback_payloads(response=response, phase="batch-landing")
+
+        self.assertEqual(1, len(payloads))
+        self.assertEqual("plan_landing", payloads[0]["controller_action"])


### PR DESCRIPTION
## Summary
- post managed PR feedback after manually dispatched batch-candidate, stack-collapse, and batch-landing phases
- let the feedback helper infer controller actions from direct phase responses
- document that manual phase runs now update the same evolving Launchplane PR comment

## Verification
- `uv run python -m unittest tests.test_merge_train_controller_feedback tests.test_service.LaunchplaneServiceTests.test_merge_train_pr_feedback_service_creates_managed_comment`
- `uv run --extra dev ruff check scripts/merge_train_controller_feedback.py tests/test_merge_train_controller_feedback.py`
- `uv run --extra dev ruff format --check scripts/merge_train_controller_feedback.py tests/test_merge_train_controller_feedback.py`
- `uv run --extra dev mypy scripts/merge_train_controller_feedback.py tests/test_merge_train_controller_feedback.py`
- `docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/merge-train-runner.yml`
- `yamllint .github/workflows/merge-train-runner.yml`
- `git diff --check`
- JetBrains changed-files inspection: clean
