### PR TITLE
Harden merge train feedback idempotency

### DIFF
--- a/.github/workflows/merge-train-runner.yml
+++ b/.github/workflows/merge-train-runner.yml
@@ -436,11 +436,18 @@ jobs:
             while IFS= read -r feedback_payload; do
               feedback_index="$((feedback_index + 1))"
               feedback_response="launchplane-merge-train-feedback-${feedback_index}.json"
+              feedback_payload_digest="$(
+                printf '%s' "$feedback_payload" | sha256sum | cut -d' ' -f1
+              )"
+              feedback_idempotency_key="merge-train-feedback:controller"
+              feedback_idempotency_key="${feedback_idempotency_key}:${GITHUB_RUN_ID}"
+              feedback_idempotency_key="${feedback_idempotency_key}:${feedback_payload_digest}"
               feedback_status="$(curl -sS \
                 -o "$feedback_response" \
                 -w '%{http_code}' \
                 -X POST \
                 -H "Authorization: Bearer ${oidc_token}" \
+                -H "Idempotency-Key: ${feedback_idempotency_key}" \
                 -H 'Content-Type: application/json' \
                 --data "$feedback_payload" \
                 "$feedback_url")"
@@ -815,11 +822,18 @@ jobs:
             while IFS= read -r feedback_payload; do
               feedback_index="$((feedback_index + 1))"
               feedback_response="launchplane-manual-phase-feedback-${feedback_index}.json"
+              feedback_payload_digest="$(
+                printf '%s' "$feedback_payload" | sha256sum | cut -d' ' -f1
+              )"
+              feedback_idempotency_key="merge-train-feedback:${phase}"
+              feedback_idempotency_key="${feedback_idempotency_key}:${GITHUB_RUN_ID}"
+              feedback_idempotency_key="${feedback_idempotency_key}:${feedback_payload_digest}"
               feedback_status="$(curl -sS \
                 -o "$feedback_response" \
                 -w '%{http_code}' \
                 -X POST \
                 -H "Authorization: Bearer ${oidc_token}" \
+                -H "Idempotency-Key: ${feedback_idempotency_key}" \
                 -H 'Content-Type: application/json' \
                 --data "$feedback_payload" \
                 "$feedback_url")"

--- a/control_plane/contracts/merge_train_pr_feedback_record.py
+++ b/control_plane/contracts/merge_train_pr_feedback_record.py
@@ -84,6 +84,7 @@ def build_merge_train_pr_feedback_id(
     event: MergeTrainPrFeedbackEvent,
     marker: str,
     recorded_at: str,
+    response_trace_id: str = "",
 ) -> str:
     normalized_repository = _normalize_repository(repository).replace("/", "-")
     normalized_base = _slug(base_branch)
@@ -94,6 +95,7 @@ def build_merge_train_pr_feedback_id(
         event=event,
         marker=marker,
         recorded_at=recorded_at,
+        response_trace_id=response_trace_id,
     )
     return (
         "merge-train-pr-feedback-"
@@ -126,6 +128,7 @@ def _feedback_identity_digest(
     event: str,
     marker: str,
     recorded_at: str,
+    response_trace_id: str = "",
 ) -> str:
     return hashlib.sha256(
         json.dumps(
@@ -136,6 +139,7 @@ def _feedback_identity_digest(
                 "event": event.strip(),
                 "marker": marker.strip(),
                 "recorded_at": _normalize_required_value(recorded_at, "recorded_at"),
+                "response_trace_id": response_trace_id.strip(),
             },
             sort_keys=True,
             separators=(",", ":"),

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2996,6 +2996,7 @@ def _build_merge_train_pr_feedback_record(
     policy_sha256: str,
     token: str,
     recorded_at: str,
+    response_trace_id: str,
 ) -> MergeTrainPrFeedbackRecord:
     marker = merge_train_pr_feedback_marker(
         repository=request.repository,
@@ -3063,6 +3064,7 @@ def _build_merge_train_pr_feedback_record(
             event=request.event,
             marker=marker,
             recorded_at=recorded_at,
+            response_trace_id=response_trace_id,
         ),
         repository=request.repository,
         base_branch=request.base_branch,
@@ -8596,6 +8598,17 @@ def create_launchplane_service_app(
                 result["merge_train_run_id"] = run_record.run_id
             elif path == _MERGE_TRAIN_PR_FEEDBACK_ROUTE:
                 feedback_request = MergeTrainPrFeedbackEnvelope.model_validate(payload)
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
                 policy_record = resolve_merge_train_policy_record(record_store)
                 policy = policy_record.policy
                 repository_policy = policy.find_repository_policy(
@@ -8655,6 +8668,7 @@ def create_launchplane_service_app(
                     policy_sha256=policy_record.policy_sha256,
                     token=token,
                     recorded_at=_utc_now_timestamp(),
+                    response_trace_id=request_trace_id,
                 )
                 feedback_store.write_merge_train_pr_feedback_record(feedback_record)
                 result = {"feedback": feedback_record.model_dump(mode="json")}

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1926,6 +1926,142 @@ class LaunchplaneServiceTests(unittest.TestCase):
         update_comment.assert_called_once()
         create_comment.assert_not_called()
 
+    def test_merge_train_pr_feedback_service_replays_idempotent_request(self) -> None:
+        request_payload = {
+            "schema_version": 1,
+            "repository": "cbusillo/sellyouroutboard",
+            "base_branch": "main",
+            "pull_request_number": 7,
+            "event": "waiting",
+            "controller_action": "observe_candidate",
+            "controller_record_id": "candidate-1",
+            "message": "Waiting for required checks to settle.",
+        }
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with (
+                patch(
+                    "control_plane.service.find_github_issue_comment_by_marker",
+                    return_value=None,
+                ) as find_comment,
+                patch(
+                    "control_plane.service.create_github_issue_comment",
+                    return_value={
+                        "id": 123,
+                        "html_url": "https://github.com/cbusillo/sellyouroutboard/pull/7#issuecomment-123",
+                    },
+                ) as create_comment,
+            ):
+                first_status, first_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/pr-feedback",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "merge-train-pr-feedback-7-waiting"},
+                )
+                replay_status, replay_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/pr-feedback",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "merge-train-pr-feedback-7-waiting"},
+                )
+            records = FilesystemRecordStore(state_dir).list_merge_train_pr_feedback_records(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pr_number=7,
+            )
+
+        self.assertEqual(first_status, 202)
+        self.assertEqual(replay_status, 202)
+        self.assertTrue(replay_payload["replayed"])
+        self.assertEqual(
+            replay_payload["result"]["feedback"]["feedback_id"],
+            first_payload["result"]["feedback"]["feedback_id"],
+        )
+        self.assertEqual(len(records), 1)
+        find_comment.assert_called_once()
+        create_comment.assert_called_once()
+
+    def test_merge_train_pr_feedback_service_preserves_same_second_updates(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with (
+                patch(
+                    "control_plane.service.find_github_issue_comment_by_marker",
+                    return_value={"id": 456, "body": "old body"},
+                ),
+                patch(
+                    "control_plane.service.update_github_issue_comment",
+                    return_value={
+                        "id": 456,
+                        "html_url": "https://github.com/cbusillo/sellyouroutboard/pull/7#issuecomment-456",
+                    },
+                ),
+                patch(
+                    "control_plane.service._utc_now_timestamp",
+                    return_value="2026-05-20T15:00:00Z",
+                ),
+            ):
+                first_status, first_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/pr-feedback",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "pull_request_number": 7,
+                        "event": "waiting",
+                    },
+                )
+                second_status, second_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/pr-feedback",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "pull_request_number": 7,
+                        "event": "waiting",
+                        "message": "Still waiting after a rerun.",
+                    },
+                )
+            records = FilesystemRecordStore(state_dir).list_merge_train_pr_feedback_records(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                pr_number=7,
+            )
+
+        self.assertEqual(first_status, 202)
+        self.assertEqual(second_status, 202)
+        self.assertNotEqual(
+            first_payload["result"]["feedback"]["feedback_id"],
+            second_payload["result"]["feedback"]["feedback_id"],
+        )
+        self.assertEqual(len(records), 2)
+
     def test_merge_train_pr_feedback_service_rejects_unauthorized_identity(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -14220,9 +14356,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 )
 
             self.assertEqual(status_code, 400)
-            self.assertEqual(
-                payload["error"]["code"], "odoo_preview_runtime_config_incomplete"
-            )
+            self.assertEqual(payload["error"]["code"], "odoo_preview_runtime_config_incomplete")
             self.assertEqual(payload["details"]["context"], "cm")
             self.assertEqual(payload["details"]["instance"], "testing")
             self.assertEqual(


### PR DESCRIPTION
## Summary
- replay merge-train PR feedback requests through the service idempotency store before posting comments
- include the service response trace in feedback record IDs so same-second events keep distinct audit records
- send payload-derived idempotency keys from scheduled controller and manual phase feedback workflow calls

## Tests
- docker run --rm -v "/Users/cbusillo/Developer/launchplane:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/merge-train-runner.yml
- yamllint .github/workflows/merge-train-runner.yml
- git diff --check
- uv run --extra dev ruff check control_plane/contracts/merge_train_pr_feedback_record.py control_plane/service.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/contracts/merge_train_pr_feedback_record.py control_plane/service.py tests/test_service.py
- uv run --extra dev mypy control_plane/contracts/merge_train_pr_feedback_record.py control_plane/service.py tests/test_service.py tests/test_filesystem_store.py
- uv run python -m unittest tests.test_filesystem_store tests.test_service.LaunchplaneServiceTests.test_merge_train_pr_feedback_service_creates_managed_comment tests.test_service.LaunchplaneServiceTests.test_merge_train_pr_feedback_service_updates_managed_comment tests.test_service.LaunchplaneServiceTests.test_merge_train_pr_feedback_service_replays_idempotent_request tests.test_service.LaunchplaneServiceTests.test_merge_train_pr_feedback_service_preserves_same_second_updates tests.test_service.LaunchplaneServiceTests.test_merge_train_pr_feedback_service_rejects_unauthorized_identity tests.test_service.LaunchplaneServiceTests.test_merge_train_pr_feedback_service_rejects_missing_token