### PR TITLE
Expose merge train controller status in operator UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1369,6 +1369,7 @@ function StateFixtureGallery({
           onSelectProduct={() => undefined}
           onWorkGraphFilterChange={setFixtureWorkGraphFilter}
           onWorkGraphModeChange={setFixtureWorkGraphMode}
+          readMergeTrainStatus={fixtureMergeTrainControllerStatus}
         />
       </div>
       <div className="fixture-grid">
@@ -1486,6 +1487,76 @@ function StateFixtureGallery({
       />
     </section>
   );
+}
+
+function fixtureMergeTrainControllerStatus(
+  repository = "cbusillo/launchplane",
+  baseBranch = "main",
+) {
+  const policyKey = `${repository}:${baseBranch}`;
+  return Promise.resolve({
+    status: "ok",
+    trace_id: "fixture-trace-merge-train-status",
+    controller_status: {
+      schema_version: 1,
+      repository,
+      base_branch: baseBranch,
+      generated_at: "2026-05-20T16:20:00Z",
+      current_policy_key: policyKey,
+      current_policy_sha256: "fixture-policy-sha256",
+      admission: {
+        schema_version: 1,
+        repository,
+        base_branch: baseBranch,
+        status: "admitted",
+        reason_code: "poll_interval_elapsed",
+        requested_at: "2026-05-20T16:20:00Z",
+        next_allowed_at: "2026-05-20T16:20:00Z",
+        latest_run_id: "merge-train-run-fixture",
+        latest_run_status: "waiting",
+        latest_run_recorded_at: "2026-05-20T16:14:00Z",
+        controller_action: "observe_candidate",
+        controller_reason: "candidate checks are still pending",
+        controller_candidate_record_id: "merge-train-batch-candidate-fixture",
+        controller_landing_plan_record_id: "",
+        controller_stack_collapse_plan_record_id: "",
+        detail:
+          "Merge-train poll interval has elapsed for the latest wait boundary.",
+      },
+      latest_run: {
+        run_id: "merge-train-run-fixture",
+        repository,
+        base_branch: baseBranch,
+        mode: "mutate",
+        status: "waiting",
+        recorded_at: "2026-05-20T16:14:00Z",
+        required_checks_status: "pending",
+        reread_required: false,
+        poll_required: true,
+      },
+      controller_records: [
+        {
+          record_id: "merge-train-batch-candidate-fixture",
+          record_type: "batch_candidate",
+          status: "active",
+          updated_at: "2026-05-20T16:14:00Z",
+          policy_key: policyKey,
+          policy_sha256: "fixture-policy-sha256",
+          policy_status: "current",
+          stale_reason: "",
+          batch_id: "merge-train-batch-fixture",
+          pull_request_numbers: [762, 763, 764],
+          candidate_sha: "abc123fixture",
+          required_checks_status: "pending",
+          planned_count: 3,
+          merged_count: 1,
+          blocked_count: 0,
+          stale_count: 0,
+          skipped_count: 0,
+        },
+      ],
+    },
+  });
 }
 
 function fixtureGenericWebPromotionDryRun(): Promise<GenericWebProdPromotionPayload> {

--- a/frontend/src/MergeTrainControllerPanel.tsx
+++ b/frontend/src/MergeTrainControllerPanel.tsx
@@ -1,0 +1,377 @@
+import { GitMerge, ListChecks, RefreshCw, Route } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import { LaunchplaneApiError, readMergeTrainControllerStatus } from "./api";
+import { formatTime } from "./format";
+import { MetricTile, PanelHead } from "./panel-ui";
+import { SkeletonRows, StateBlock, StatusIcon, StatusPill } from "./status-ui";
+import type {
+  MergeTrainControllerRecordSummary,
+  MergeTrainControllerStatus,
+  ProductSiteOverview,
+  Status,
+  WorkGraphQueueItem,
+} from "./types";
+
+type MergeTrainTarget = {
+  repository: string;
+  baseBranch: string;
+  label: string;
+};
+type MergeTrainStatusReader = (
+  repository: string,
+  baseBranch: string,
+  signal?: AbortSignal,
+) => Promise<{ controller_status: MergeTrainControllerStatus }>;
+
+const DEFAULT_BASE_BRANCH = "main";
+
+export function MergeTrainControllerPanel({
+  products,
+  selectedProduct,
+  workGraphItems,
+  loading,
+  readStatus = readMergeTrainControllerStatus,
+}: {
+  products: ProductSiteOverview[];
+  selectedProduct: ProductSiteOverview | null;
+  workGraphItems: WorkGraphQueueItem[];
+  loading: boolean;
+  readStatus?: MergeTrainStatusReader;
+}) {
+  const targets = useMemo(
+    () => mergeTrainTargets(products, workGraphItems),
+    [products, workGraphItems],
+  );
+  const preferredTarget = preferredMergeTrainTarget(targets, selectedProduct);
+  const [targetKey, setTargetKey] = useState(() =>
+    targetKeyFor(preferredTarget),
+  );
+  const [status, setStatus] = useState<MergeTrainControllerStatus | null>(null);
+  const [statusLoading, setStatusLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [traceId, setTraceId] = useState("");
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  useEffect(() => {
+    if (!targets.length) {
+      setTargetKey("");
+      return;
+    }
+    if (!targets.some((target) => targetKeyFor(target) === targetKey)) {
+      setTargetKey(targetKeyFor(preferredTarget));
+    }
+  }, [preferredTarget, targetKey, targets]);
+
+  const selectedTarget =
+    targets.find((target) => targetKeyFor(target) === targetKey) ??
+    preferredTarget;
+
+  useEffect(() => {
+    if (!selectedTarget) {
+      setStatus(null);
+      setError("");
+      setTraceId("");
+      setStatusLoading(false);
+      return;
+    }
+    const controller = new AbortController();
+    setStatusLoading(true);
+    setError("");
+    setTraceId("");
+    readStatus(
+      selectedTarget.repository,
+      selectedTarget.baseBranch,
+      controller.signal,
+    )
+      .then((payload) => {
+        if (!controller.signal.aborted) {
+          setStatus(payload.controller_status);
+        }
+      })
+      .catch((apiError: unknown) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setStatus(null);
+        if (apiError instanceof LaunchplaneApiError) {
+          setError(apiError.message);
+          setTraceId(apiError.traceId);
+        } else if (apiError instanceof Error) {
+          setError(apiError.message);
+          setTraceId("");
+        } else {
+          setError("Merge train controller status request failed.");
+          setTraceId("");
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setStatusLoading(false);
+        }
+      });
+    return () => controller.abort();
+  }, [readStatus, selectedTarget, refreshKey]);
+
+  const admissionStatus = status?.admission.status ?? "unknown";
+  const panelStatus = error ? "fail" : controllerPanelStatus(status);
+  const currentRecords = status?.controller_records.filter(
+    (record) => record.policy_status === "current",
+  );
+  const staleRecords = status?.controller_records.filter(
+    (record) => record.policy_status === "stale",
+  );
+
+  return (
+    <section className="merge-train-panel" aria-busy={loading || statusLoading}>
+      <PanelHead
+        eyebrow="merge train"
+        title="Controller status"
+        right={<StatusPill status={panelStatus} />}
+      />
+      <div className="merge-train-toolbar">
+        <label className="merge-train-target">
+          <span>Repository</span>
+          <select
+            value={selectedTarget ? targetKeyFor(selectedTarget) : ""}
+            onChange={(event) => setTargetKey(event.target.value)}
+            disabled={!targets.length || statusLoading}
+            aria-label="Merge train repository"
+          >
+            {targets.map((target) => (
+              <option key={targetKeyFor(target)} value={targetKeyFor(target)}>
+                {target.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          className="icon-button"
+          type="button"
+          title="Refresh merge train controller status"
+          aria-label="Refresh merge train controller status"
+          onClick={() => setRefreshKey((value) => value + 1)}
+          disabled={!selectedTarget || statusLoading}
+        >
+          <RefreshCw size={16} className={statusLoading ? "spin" : ""} />
+        </button>
+      </div>
+      {loading || statusLoading ? <SkeletonRows /> : null}
+      {!selectedTarget && !loading ? (
+        <StateBlock icon={<Route size={18} />} title="No merge train target" />
+      ) : null}
+      {error ? (
+        <div className="merge-train-alert">
+          <StatusIcon status="fail" />
+          <span>{error}</span>
+          {traceId ? <code>{traceId}</code> : null}
+        </div>
+      ) : null}
+      {status && !statusLoading ? (
+        <>
+          <div className="merge-train-metrics">
+            <MetricTile
+              label="Admission"
+              value={admissionStatus}
+              status={statusForAdmission(admissionStatus)}
+            />
+            <MetricTile
+              label="Action"
+              value={status.admission.controller_action || "idle"}
+              status={statusForControllerAction(
+                status.admission.controller_action,
+              )}
+            />
+            <MetricTile
+              label="Records"
+              value={String(currentRecords?.length ?? 0)}
+              status={currentRecords?.length ? "pending" : "pass"}
+            />
+            <MetricTile
+              label="Stale"
+              value={String(staleRecords?.length ?? 0)}
+              status={staleRecords?.length ? "blocked" : "pass"}
+            />
+          </div>
+          <div className="merge-train-summary">
+            <span>
+              <GitMerge size={15} aria-hidden="true" />
+              <strong>{status.repository}</strong>
+              <code>{status.base_branch}</code>
+            </span>
+            <span>
+              {status.admission.detail || status.admission.controller_reason}
+            </span>
+            <code>{formatTime(status.generated_at)}</code>
+          </div>
+          {status.latest_run ? (
+            <div className="merge-train-latest-run">
+              <ListChecks size={15} aria-hidden="true" />
+              <span>
+                <strong>{status.latest_run.status}</strong>
+                <code>{status.latest_run.run_id}</code>
+              </span>
+              <span>
+                {status.latest_run.required_checks_status || "checks unknown"}
+              </span>
+              <code>{formatTime(status.latest_run.recorded_at)}</code>
+            </div>
+          ) : null}
+          <div className="merge-train-record-list">
+            {status.controller_records.length ? (
+              status.controller_records
+                .slice(0, 4)
+                .map((record) => (
+                  <MergeTrainRecordRow key={record.record_id} record={record} />
+                ))
+            ) : (
+              <StateBlock
+                icon={<GitMerge size={18} />}
+                title="No active records"
+              />
+            )}
+          </div>
+        </>
+      ) : null}
+    </section>
+  );
+}
+
+function MergeTrainRecordRow({
+  record,
+}: {
+  record: MergeTrainControllerRecordSummary;
+}) {
+  const status = record.policy_status === "stale" ? "blocked" : "pending";
+  return (
+    <div className="merge-train-record-row" data-policy={record.policy_status}>
+      <StatusIcon status={status} />
+      <span>
+        <strong>{recordLabel(record.record_type)}</strong>
+        <code>{record.record_id}</code>
+      </span>
+      <span className="merge-train-record-meta">
+        {record.pull_request_numbers.length ? (
+          <code>PR {record.pull_request_numbers.join(", ")}</code>
+        ) : null}
+        {record.batch_id ? <code>{record.batch_id}</code> : null}
+        <code>{record.status}</code>
+        {record.required_checks_status ? (
+          <code>{record.required_checks_status}</code>
+        ) : null}
+      </span>
+      <span className="merge-train-record-progress">
+        {record.planned_count
+          ? `${record.merged_count}/${record.planned_count} merged`
+          : ""}
+        {record.blocked_count ? ` ${record.blocked_count} blocked` : ""}
+        {record.stale_reason || ""}
+      </span>
+      <code>{formatTime(record.updated_at)}</code>
+    </div>
+  );
+}
+
+function mergeTrainTargets(
+  products: ProductSiteOverview[],
+  workGraphItems: WorkGraphQueueItem[],
+): MergeTrainTarget[] {
+  const targetByKey = new Map<string, MergeTrainTarget>();
+  for (const product of products) {
+    addTarget(targetByKey, {
+      repository: product.repository,
+      baseBranch: DEFAULT_BASE_BRANCH,
+      label: product.display_name || product.product || product.repository,
+    });
+  }
+  for (const item of workGraphItems) {
+    addTarget(targetByKey, {
+      repository: item.repository,
+      baseBranch: DEFAULT_BASE_BRANCH,
+      label: item.product_display_name || item.product || item.repository,
+    });
+  }
+  return [...targetByKey.values()].sort((left, right) =>
+    left.label.localeCompare(right.label),
+  );
+}
+
+function addTarget(
+  targetByKey: Map<string, MergeTrainTarget>,
+  target: MergeTrainTarget,
+) {
+  if (!target.repository.trim()) {
+    return;
+  }
+  const key = targetKeyFor(target);
+  if (!targetByKey.has(key)) {
+    targetByKey.set(key, {
+      repository: target.repository.trim(),
+      baseBranch: target.baseBranch.trim() || DEFAULT_BASE_BRANCH,
+      label: target.label.trim() || target.repository.trim(),
+    });
+  }
+}
+
+function preferredMergeTrainTarget(
+  targets: MergeTrainTarget[],
+  selectedProduct: ProductSiteOverview | null,
+): MergeTrainTarget | null {
+  if (selectedProduct?.repository) {
+    const selected = targets.find(
+      (target) => target.repository === selectedProduct.repository,
+    );
+    if (selected) {
+      return selected;
+    }
+  }
+  return targets[0] ?? null;
+}
+
+function targetKeyFor(target: MergeTrainTarget | null): string {
+  return target ? `${target.repository}:${target.baseBranch}` : "";
+}
+
+function controllerPanelStatus(
+  status: MergeTrainControllerStatus | null,
+): Status | string {
+  if (!status) {
+    return "unknown";
+  }
+  if (
+    status.controller_records.some(
+      (record) => record.policy_status === "stale",
+    ) ||
+    status.admission.controller_action.includes("failed")
+  ) {
+    return "blocked";
+  }
+  return statusForAdmission(status.admission.status);
+}
+
+function statusForAdmission(status: string): Status | string {
+  if (status === "admitted") {
+    return "pending";
+  }
+  if (status === "deferred") {
+    return "unknown";
+  }
+  return "unknown";
+}
+
+function statusForControllerAction(action: string): Status | string {
+  if (!action || action === "idle") {
+    return "pass";
+  }
+  if (action.includes("failed") || action.includes("unsupported")) {
+    return "blocked";
+  }
+  if (action.includes("wait") || action.includes("observe")) {
+    return "unknown";
+  }
+  return "pending";
+}
+
+function recordLabel(recordType: string): string {
+  return recordType.replaceAll("_", " ");
+}

--- a/frontend/src/ProductInventoryCockpit.tsx
+++ b/frontend/src/ProductInventoryCockpit.tsx
@@ -1,6 +1,7 @@
 import { PanelsTopLeft } from "lucide-react";
 
 import { EveryCodeQueue } from "./EveryCodeQueue";
+import { MergeTrainControllerPanel } from "./MergeTrainControllerPanel";
 import { MetricTile, PanelHead } from "./panel-ui";
 import { StateBlock, SkeletonRows, StatusPill } from "./status-ui";
 import { TrustBadge } from "./TrustBadge";
@@ -8,6 +9,7 @@ import { TrustBadge } from "./TrustBadge";
 import type {
   EveryCodeWorkRequestRecord,
   ProductSiteOverview,
+  MergeTrainControllerStatus,
   WorkGraphQueueItem,
 } from "./types";
 import {
@@ -29,6 +31,7 @@ export function ProductInventoryCockpit({
   onSelectProduct,
   onWorkGraphFilterChange,
   onWorkGraphModeChange,
+  readMergeTrainStatus,
 }: {
   products: ProductSiteOverview[];
   selectedProduct: ProductSiteOverview | null;
@@ -42,6 +45,11 @@ export function ProductInventoryCockpit({
   onSelectProduct: (product: ProductSiteOverview) => void;
   onWorkGraphFilterChange: (filter: WorkGraphFilter) => void;
   onWorkGraphModeChange: (mode: WorkGraphMode) => void;
+  readMergeTrainStatus?: (
+    repository: string,
+    baseBranch: string,
+    signal?: AbortSignal,
+  ) => Promise<{ controller_status: MergeTrainControllerStatus }>;
 }) {
   const activeWork = workRequests.filter((request) =>
     ["queued", "claimed", "running", "blocked"].includes(request.state),
@@ -144,6 +152,13 @@ export function ProductInventoryCockpit({
         loading={loading}
         onFilterChange={onWorkGraphFilterChange}
         onModeChange={onWorkGraphModeChange}
+      />
+      <MergeTrainControllerPanel
+        products={products}
+        selectedProduct={selectedProduct}
+        workGraphItems={workGraphItems}
+        loading={loading}
+        readStatus={readMergeTrainStatus}
       />
       <EveryCodeQueue requests={activeWork} loading={loading} />
     </section>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -10,6 +10,7 @@ import type {
   GenericWebPromotionWorkflowPayload,
   GenericWebPromotionWorkflowRequest,
   LogoutPayload,
+  MergeTrainControllerStatusPayload,
   ProductConfigApplyPayload,
   ProductConfigApplyRequest,
   ProductConfigApplyResponsePayload,
@@ -158,6 +159,23 @@ export function rankWorkGraphSnapshot(
     snapshot,
     limit,
   });
+}
+
+export function readMergeTrainControllerStatus(
+  repository: string,
+  baseBranch: string,
+  signal?: AbortSignal,
+): Promise<MergeTrainControllerStatusPayload> {
+  const params = new URLSearchParams({
+    repository,
+    base_branch: baseBranch,
+  });
+  return requestJson<MergeTrainControllerStatusPayload>(
+    `/v1/work-graph/merge-train/controller/status?${params.toString()}`,
+    "GET",
+    undefined,
+    signal,
+  );
 }
 
 export function applyProductConfig(

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -293,7 +293,7 @@ p {
   display: grid;
   grid-template-columns:
     minmax(220px, 0.64fr) minmax(280px, 1.08fr) minmax(280px, 1fr)
-    minmax(260px, 0.82fr);
+    minmax(280px, 1fr) minmax(260px, 0.82fr);
   gap: 1px;
   overflow: hidden;
   border: 1px solid var(--hair);
@@ -303,6 +303,7 @@ p {
 .cockpit-summary,
 .product-inventory-table,
 .work-graph-queue,
+.merge-train-panel,
 .every-code-queue {
   min-width: 0;
   background: var(--bg-1);
@@ -322,6 +323,7 @@ p {
 
 .product-inventory-table,
 .work-graph-queue,
+.merge-train-panel,
 .every-code-queue {
   display: grid;
   align-content: start;
@@ -547,6 +549,188 @@ p {
 
 .work-graph-hidden {
   color: var(--fg-faint);
+}
+
+.merge-train-panel {
+  grid-template-rows: auto auto auto;
+}
+
+.merge-train-toolbar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: end;
+}
+
+.merge-train-target {
+  display: grid;
+  gap: 4px;
+  color: var(--fg-faint);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.merge-train-target select {
+  min-width: 0;
+  min-height: 34px;
+  border: 1px solid var(--hair);
+  border-radius: 6px;
+  background: var(--bg-2);
+  color: var(--fg);
+  padding: 0 9px;
+}
+
+.merge-train-alert,
+.merge-train-summary,
+.merge-train-latest-run,
+.merge-train-record-row {
+  min-width: 0;
+  border: 1px solid var(--hair-soft);
+  border-radius: 6px;
+  background: var(--bg-2);
+}
+
+.merge-train-alert {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  gap: 8px;
+  align-items: center;
+  color: var(--fg-muted);
+  padding: 9px;
+}
+
+.merge-train-alert code {
+  grid-column: 2;
+  overflow: hidden;
+  color: var(--fg-faint);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.merge-train-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--hair-soft);
+  border-radius: 6px;
+  background: var(--hair-soft);
+}
+
+.merge-train-summary {
+  display: grid;
+  gap: 7px;
+  padding: 10px;
+}
+
+.merge-train-summary > span:first-child,
+.merge-train-latest-run,
+.merge-train-record-row {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.merge-train-summary span,
+.merge-train-summary strong,
+.merge-train-summary code,
+.merge-train-latest-run span,
+.merge-train-latest-run strong,
+.merge-train-latest-run code,
+.merge-train-record-row span,
+.merge-train-record-row strong,
+.merge-train-record-row code {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.merge-train-summary > span:nth-child(2) {
+  color: var(--fg-muted);
+  font-size: 12px;
+}
+
+.merge-train-summary code,
+.merge-train-latest-run code,
+.merge-train-record-row code {
+  color: var(--fg-faint);
+}
+
+.merge-train-latest-run {
+  padding: 9px;
+}
+
+.merge-train-latest-run > span:first-of-type {
+  display: grid;
+  gap: 2px;
+}
+
+.merge-train-latest-run > span:nth-of-type(2) {
+  color: var(--fg-muted);
+}
+
+.merge-train-latest-run > code {
+  grid-column: 2 / -1;
+}
+
+.merge-train-record-list {
+  display: grid;
+  gap: 7px;
+}
+
+.merge-train-record-row {
+  grid-template-columns: 18px minmax(0, 1fr);
+  align-items: start;
+  padding: 9px;
+}
+
+.merge-train-record-row[data-policy="stale"] {
+  border-color: color-mix(in oklab, var(--status-fail) 44%, var(--hair));
+}
+
+.merge-train-record-row > span:first-of-type {
+  display: grid;
+  gap: 2px;
+}
+
+.merge-train-record-meta,
+.merge-train-record-progress,
+.merge-train-record-row > code {
+  grid-column: 2;
+}
+
+.merge-train-record-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.merge-train-record-meta code {
+  max-width: 100%;
+  border: 1px solid var(--hair);
+  border-radius: 999px;
+  background: var(--bg-1);
+  padding: 2px 7px;
+  font-size: 10px;
+}
+
+.merge-train-record-progress {
+  color: var(--fg-muted);
+  font-size: 12px;
+}
+
+@media (max-width: 520px) {
+  .merge-train-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .merge-train-summary > span:nth-child(2),
+  .merge-train-record-progress {
+    overflow: visible;
+    white-space: normal;
+  }
 }
 
 .lane-grid {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -814,6 +814,75 @@ export interface WorkGraphRankPayload {
   };
 }
 
+export interface MergeTrainAdmissionDecision {
+  schema_version: number;
+  repository: string;
+  base_branch: string;
+  status: "admitted" | "deferred" | string;
+  reason_code: string;
+  requested_at: string;
+  next_allowed_at: string;
+  latest_run_id: string;
+  latest_run_status: string;
+  latest_run_recorded_at: string;
+  controller_action: string;
+  controller_reason: string;
+  controller_candidate_record_id: string;
+  controller_landing_plan_record_id: string;
+  controller_stack_collapse_plan_record_id: string;
+  detail: string;
+}
+
+export interface MergeTrainRunRecord {
+  run_id: string;
+  repository: string;
+  base_branch: string;
+  mode: string;
+  status: string;
+  recorded_at: string;
+  required_checks_status: string;
+  reread_required?: boolean;
+  poll_required?: boolean;
+}
+
+export interface MergeTrainControllerRecordSummary {
+  record_id: string;
+  record_type: string;
+  status: string;
+  updated_at: string;
+  policy_key: string;
+  policy_sha256: string;
+  policy_status: "current" | "stale" | "unchecked" | string;
+  stale_reason: string;
+  batch_id: string;
+  pull_request_numbers: number[];
+  candidate_sha: string;
+  required_checks_status: string;
+  planned_count: number;
+  merged_count: number;
+  blocked_count: number;
+  stale_count: number;
+  skipped_count: number;
+}
+
+export interface MergeTrainControllerStatus {
+  schema_version: number;
+  repository: string;
+  base_branch: string;
+  generated_at: string;
+  current_policy_key: string;
+  current_policy_sha256: string;
+  admission: MergeTrainAdmissionDecision;
+  latest_run: MergeTrainRunRecord | null;
+  controller_records: MergeTrainControllerRecordSummary[];
+}
+
+export interface MergeTrainControllerStatusPayload {
+  status: "ok";
+  trace_id: string;
+  controller_status: MergeTrainControllerStatus;
+}
+
 export interface GenericWebProdPromotionRequest {
   schema_version: 1;
   product: string;


### PR DESCRIPTION
## Summary
- add a merge train controller status panel to the operator cockpit
- wire it to `GET /v1/work-graph/merge-train/controller/status`
- include fixture coverage for the new panel and responsive layout rules

## Verification
- `pnpm --dir frontend validate`
- `git diff --check`
- Browser fixture review at desktop and narrow/mobile widths
- JetBrains changed-files inspection run; findings were pre-existing CSS token/font-family warnings outside the new panel block
