### PR TITLE
Use policy targets for merge train controller UI

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -393,6 +393,7 @@ _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 _EVERY_CODE_GITHUB_WEBHOOK_ROUTE = "/v1/every-code/github-webhook"
 _MERGE_TRAIN_ADMISSION_ROUTE = "/v1/work-graph/merge-train/admission"
 _MERGE_TRAIN_CONTROLLER_STATUS_ROUTE = "/v1/work-graph/merge-train/controller/status"
+_MERGE_TRAIN_POLICY_TARGETS_ROUTE = "/v1/work-graph/merge-train/policy-targets"
 _MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-candidate/run-once"
 _MERGE_TRAIN_BATCH_LANDING_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-landing/run-once"
 _MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/stack-collapse/run-once"
@@ -2560,6 +2561,8 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "merge_train.admission", {}
     if path == _MERGE_TRAIN_CONTROLLER_STATUS_ROUTE:
         return "merge_train.controller_status", {}
+    if path == _MERGE_TRAIN_POLICY_TARGETS_ROUTE:
+        return "merge_train.policy_targets", {}
     if len(segments) == 3 and segments == ["v1", "work-graph", "snapshot"]:
         return "work_graph.rank", {}
     if len(segments) == 2 and segments == ["v1", "repo-product-mapping"]:
@@ -8130,6 +8133,44 @@ def create_launchplane_service_app(
                             "status": "ok",
                             "trace_id": request_trace_id,
                             "controller_status": read_model.model_dump(mode="json"),
+                        },
+                    )
+                if action == "merge_train.policy_targets":
+                    policy_record = resolve_merge_train_policy_record(record_store)
+                    targets = []
+                    for repository_policy in policy_record.policy.policies:
+                        if not authz_policy.allows(
+                            identity=identity,
+                            action=repository_policy.service_authz.action,
+                            product=repository_policy.service_authz.product,
+                            context=repository_policy.service_authz.context,
+                        ):
+                            continue
+                        targets.append(
+                            {
+                                "repository": repository_policy.repository,
+                                "base_branch": repository_policy.base_branch,
+                                "policy_key": repository_policy.policy_key,
+                                "service_authz": repository_policy.service_authz.model_dump(
+                                    mode="json"
+                                ),
+                            }
+                        )
+                    targets.sort(
+                        key=lambda target: (target["repository"], target["base_branch"])
+                    )
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=200,
+                        payload={
+                            "status": "ok",
+                            "trace_id": request_trace_id,
+                            "policy": {
+                                "record_id": policy_record.record_id,
+                                "updated_at": policy_record.updated_at,
+                                "policy_sha256": policy_record.policy_sha256,
+                            },
+                            "targets": targets,
                         },
                     )
                 if action == "product_profile.read":

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -77,6 +77,7 @@ VeriReel product paths:
   - `GET /v1/agent/context`
   - `GET /v1/repo-product-mapping`
   - `GET /v1/work-graph/snapshot`
+  - `GET /v1/work-graph/merge-train/policy-targets`
   - `GET /v1/work-graph/merge-train/admission`
   - `GET /v1/work-graph/merge-train/controller/status`
   - `POST /v1/work-graph/rank`
@@ -244,6 +245,12 @@ GitHub comment id/url. The route fails closed when authorization or token
 configuration is missing; callers should use it for queued, waiting, blocked,
 stale-policy, and completed transition summaries instead of writing ad hoc
 comments from scheduler scripts.
+
+`GET /v1/work-graph/merge-train/policy-targets` returns the authorized
+repository/base-branch targets from the active DB-backed merge-train policy. It
+performs no GitHub reads or mutations and is the source of truth for operator UI
+target selection; callers should not infer merge-train targets from product
+inventory or work-graph awareness items.
 
 `GET /v1/work-graph/merge-train/admission` returns the stored-history scheduler
 admission decision for a requested `repository` and `base_branch`. It uses the

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1370,6 +1370,7 @@ function StateFixtureGallery({
           onWorkGraphFilterChange={setFixtureWorkGraphFilter}
           onWorkGraphModeChange={setFixtureWorkGraphMode}
           readMergeTrainStatus={fixtureMergeTrainControllerStatus}
+          readMergeTrainPolicyTargets={fixtureMergeTrainPolicyTargets}
         />
       </div>
       <div className="fixture-grid">
@@ -1556,6 +1557,40 @@ function fixtureMergeTrainControllerStatus(
         },
       ],
     },
+  });
+}
+
+function fixtureMergeTrainPolicyTargets() {
+  return Promise.resolve({
+    status: "ok",
+    trace_id: "fixture-trace-merge-train-policy-targets",
+    policy: {
+      record_id: "merge-train-policy-fixture",
+      updated_at: "2026-05-20T16:18:00Z",
+      policy_sha256: "fixture-policy-sha256",
+    },
+    targets: [
+      {
+        repository: "cbusillo/launchplane",
+        base_branch: "main",
+        policy_key: "cbusillo/launchplane:main",
+        service_authz: {
+          action: "merge_train.run_once",
+          product: "launchplane",
+          context: "launchplane",
+        },
+      },
+      {
+        repository: "cbusillo/sellyouroutboard",
+        base_branch: "release",
+        policy_key: "cbusillo/sellyouroutboard:release",
+        service_authz: {
+          action: "merge_train.run_once",
+          product: "launchplane",
+          context: "launchplane",
+        },
+      },
+    ],
   });
 }
 

--- a/frontend/src/MergeTrainControllerPanel.tsx
+++ b/frontend/src/MergeTrainControllerPanel.tsx
@@ -1,13 +1,18 @@
 import { GitMerge, ListChecks, RefreshCw, Route } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
-import { LaunchplaneApiError, readMergeTrainControllerStatus } from "./api";
+import {
+  LaunchplaneApiError,
+  readMergeTrainControllerStatus,
+  readMergeTrainPolicyTargets,
+} from "./api";
 import { formatTime } from "./format";
 import { MetricTile, PanelHead } from "./panel-ui";
 import { SkeletonRows, StateBlock, StatusIcon, StatusPill } from "./status-ui";
 import type {
   MergeTrainControllerRecordSummary,
   MergeTrainControllerStatus,
+  MergeTrainPolicyTarget,
   ProductSiteOverview,
   Status,
   WorkGraphQueueItem,
@@ -23,8 +28,9 @@ type MergeTrainStatusReader = (
   baseBranch: string,
   signal?: AbortSignal,
 ) => Promise<{ controller_status: MergeTrainControllerStatus }>;
-
-const DEFAULT_BASE_BRANCH = "main";
+type MergeTrainPolicyTargetsReader = (
+  signal?: AbortSignal,
+) => Promise<{ targets: MergeTrainPolicyTarget[] }>;
 
 export function MergeTrainControllerPanel({
   products,
@@ -32,16 +38,22 @@ export function MergeTrainControllerPanel({
   workGraphItems,
   loading,
   readStatus = readMergeTrainControllerStatus,
+  readPolicyTargets = readMergeTrainPolicyTargets,
 }: {
   products: ProductSiteOverview[];
   selectedProduct: ProductSiteOverview | null;
   workGraphItems: WorkGraphQueueItem[];
   loading: boolean;
   readStatus?: MergeTrainStatusReader;
+  readPolicyTargets?: MergeTrainPolicyTargetsReader;
 }) {
+  const [policyTargets, setPolicyTargets] = useState<MergeTrainPolicyTarget[]>(
+    [],
+  );
+  const [targetsLoading, setTargetsLoading] = useState(false);
   const targets = useMemo(
-    () => mergeTrainTargets(products, workGraphItems),
-    [products, workGraphItems],
+    () => mergeTrainTargets(policyTargets, products, workGraphItems),
+    [policyTargets, products, workGraphItems],
   );
   const preferredTarget = preferredMergeTrainTarget(targets, selectedProduct);
   const [targetKey, setTargetKey] = useState(() =>
@@ -52,6 +64,42 @@ export function MergeTrainControllerPanel({
   const [error, setError] = useState("");
   const [traceId, setTraceId] = useState("");
   const [refreshKey, setRefreshKey] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setTargetsLoading(true);
+    setError("");
+    setTraceId("");
+    readPolicyTargets(controller.signal)
+      .then((payload) => {
+        if (!controller.signal.aborted) {
+          setPolicyTargets(payload.targets);
+        }
+      })
+      .catch((apiError: unknown) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setPolicyTargets([]);
+        setStatus(null);
+        if (apiError instanceof LaunchplaneApiError) {
+          setError(apiError.message);
+          setTraceId(apiError.traceId);
+        } else if (apiError instanceof Error) {
+          setError(apiError.message);
+          setTraceId("");
+        } else {
+          setError("Merge train policy target request failed.");
+          setTraceId("");
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setTargetsLoading(false);
+        }
+      });
+    return () => controller.abort();
+  }, [readPolicyTargets, refreshKey]);
 
   useEffect(() => {
     if (!targets.length) {
@@ -123,7 +171,10 @@ export function MergeTrainControllerPanel({
   );
 
   return (
-    <section className="merge-train-panel" aria-busy={loading || statusLoading}>
+    <section
+      className="merge-train-panel"
+      aria-busy={loading || targetsLoading || statusLoading}
+    >
       <PanelHead
         eyebrow="merge train"
         title="Controller status"
@@ -135,7 +186,7 @@ export function MergeTrainControllerPanel({
           <select
             value={selectedTarget ? targetKeyFor(selectedTarget) : ""}
             onChange={(event) => setTargetKey(event.target.value)}
-            disabled={!targets.length || statusLoading}
+            disabled={!targets.length || targetsLoading || statusLoading}
             aria-label="Merge train repository"
           >
             {targets.map((target) => (
@@ -151,13 +202,16 @@ export function MergeTrainControllerPanel({
           title="Refresh merge train controller status"
           aria-label="Refresh merge train controller status"
           onClick={() => setRefreshKey((value) => value + 1)}
-          disabled={!selectedTarget || statusLoading}
+          disabled={targetsLoading || statusLoading}
         >
-          <RefreshCw size={16} className={statusLoading ? "spin" : ""} />
+          <RefreshCw
+            size={16}
+            className={targetsLoading || statusLoading ? "spin" : ""}
+          />
         </button>
       </div>
-      {loading || statusLoading ? <SkeletonRows /> : null}
-      {!selectedTarget && !loading ? (
+      {loading || targetsLoading || statusLoading ? <SkeletonRows /> : null}
+      {!selectedTarget && !loading && !targetsLoading ? (
         <StateBlock icon={<Route size={18} />} title="No merge train target" />
       ) : null}
       {error ? (
@@ -273,44 +327,67 @@ function MergeTrainRecordRow({
 }
 
 function mergeTrainTargets(
+  policyTargets: MergeTrainPolicyTarget[],
   products: ProductSiteOverview[],
   workGraphItems: WorkGraphQueueItem[],
 ): MergeTrainTarget[] {
-  const targetByKey = new Map<string, MergeTrainTarget>();
+  const labelsByRepository = mergeTrainLabelsByRepository(
+    products,
+    workGraphItems,
+  );
+  return policyTargets
+    .filter((target) => target.repository.trim() && target.base_branch.trim())
+    .map((target) => ({
+      repository: target.repository.trim(),
+      baseBranch: target.base_branch.trim(),
+      label: targetLabel(target, labelsByRepository),
+    }))
+    .sort((left, right) => left.label.localeCompare(right.label));
+}
+
+function mergeTrainLabelsByRepository(
+  products: ProductSiteOverview[],
+  workGraphItems: WorkGraphQueueItem[],
+): Map<string, string> {
+  const labelsByRepository = new Map<string, string>();
   for (const product of products) {
-    addTarget(targetByKey, {
-      repository: product.repository,
-      baseBranch: DEFAULT_BASE_BRANCH,
-      label: product.display_name || product.product || product.repository,
-    });
+    setRepositoryLabel(
+      labelsByRepository,
+      product.repository,
+      product.display_name || product.product || product.repository,
+    );
   }
   for (const item of workGraphItems) {
-    addTarget(targetByKey, {
-      repository: item.repository,
-      baseBranch: DEFAULT_BASE_BRANCH,
-      label: item.product_display_name || item.product || item.repository,
-    });
+    setRepositoryLabel(
+      labelsByRepository,
+      item.repository,
+      item.product_display_name || item.product || item.repository,
+    );
   }
-  return [...targetByKey.values()].sort((left, right) =>
-    left.label.localeCompare(right.label),
+  return labelsByRepository;
+}
+
+function setRepositoryLabel(
+  labelsByRepository: Map<string, string>,
+  repository: string,
+  label: string,
+) {
+  const normalizedRepository = repository.trim();
+  if (!normalizedRepository || labelsByRepository.has(normalizedRepository)) {
+    return;
+  }
+  labelsByRepository.set(
+    normalizedRepository,
+    label.trim() || normalizedRepository,
   );
 }
 
-function addTarget(
-  targetByKey: Map<string, MergeTrainTarget>,
-  target: MergeTrainTarget,
-) {
-  if (!target.repository.trim()) {
-    return;
-  }
-  const key = targetKeyFor(target);
-  if (!targetByKey.has(key)) {
-    targetByKey.set(key, {
-      repository: target.repository.trim(),
-      baseBranch: target.baseBranch.trim() || DEFAULT_BASE_BRANCH,
-      label: target.label.trim() || target.repository.trim(),
-    });
-  }
+function targetLabel(
+  target: MergeTrainPolicyTarget,
+  labelsByRepository: Map<string, string>,
+): string {
+  const label = labelsByRepository.get(target.repository) ?? target.repository;
+  return `${label} (${target.base_branch})`;
 }
 
 function preferredMergeTrainTarget(

--- a/frontend/src/ProductInventoryCockpit.tsx
+++ b/frontend/src/ProductInventoryCockpit.tsx
@@ -10,6 +10,7 @@ import type {
   EveryCodeWorkRequestRecord,
   ProductSiteOverview,
   MergeTrainControllerStatus,
+  MergeTrainPolicyTarget,
   WorkGraphQueueItem,
 } from "./types";
 import {
@@ -32,6 +33,7 @@ export function ProductInventoryCockpit({
   onWorkGraphFilterChange,
   onWorkGraphModeChange,
   readMergeTrainStatus,
+  readMergeTrainPolicyTargets,
 }: {
   products: ProductSiteOverview[];
   selectedProduct: ProductSiteOverview | null;
@@ -50,6 +52,9 @@ export function ProductInventoryCockpit({
     baseBranch: string,
     signal?: AbortSignal,
   ) => Promise<{ controller_status: MergeTrainControllerStatus }>;
+  readMergeTrainPolicyTargets?: (
+    signal?: AbortSignal,
+  ) => Promise<{ targets: MergeTrainPolicyTarget[] }>;
 }) {
   const activeWork = workRequests.filter((request) =>
     ["queued", "claimed", "running", "blocked"].includes(request.state),
@@ -159,6 +164,7 @@ export function ProductInventoryCockpit({
         workGraphItems={workGraphItems}
         loading={loading}
         readStatus={readMergeTrainStatus}
+        readPolicyTargets={readMergeTrainPolicyTargets}
       />
       <EveryCodeQueue requests={activeWork} loading={loading} />
     </section>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -11,6 +11,7 @@ import type {
   GenericWebPromotionWorkflowRequest,
   LogoutPayload,
   MergeTrainControllerStatusPayload,
+  MergeTrainPolicyTargetsPayload,
   ProductConfigApplyPayload,
   ProductConfigApplyRequest,
   ProductConfigApplyResponsePayload,
@@ -172,6 +173,17 @@ export function readMergeTrainControllerStatus(
   });
   return requestJson<MergeTrainControllerStatusPayload>(
     `/v1/work-graph/merge-train/controller/status?${params.toString()}`,
+    "GET",
+    undefined,
+    signal,
+  );
+}
+
+export function readMergeTrainPolicyTargets(
+  signal?: AbortSignal,
+): Promise<MergeTrainPolicyTargetsPayload> {
+  return requestJson<MergeTrainPolicyTargetsPayload>(
+    "/v1/work-graph/merge-train/policy-targets",
     "GET",
     undefined,
     signal,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -883,6 +883,28 @@ export interface MergeTrainControllerStatusPayload {
   controller_status: MergeTrainControllerStatus;
 }
 
+export interface MergeTrainPolicyTarget {
+  repository: string;
+  base_branch: string;
+  policy_key: string;
+  service_authz: {
+    action: string;
+    product: string;
+    context: string;
+  };
+}
+
+export interface MergeTrainPolicyTargetsPayload {
+  status: "ok";
+  trace_id: string;
+  policy: {
+    record_id: string;
+    updated_at: string;
+    policy_sha256: string;
+  };
+  targets: MergeTrainPolicyTarget[];
+}
+
 export interface GenericWebProdPromotionRequest {
   schema_version: 1;
   product: string;

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -461,6 +461,34 @@ def _seed_merge_train_policy(
     return record
 
 
+def _merge_train_policy_table(repository: str, base_branch: str = "main") -> str:
+    return f"""[[policies]]
+repository = "{repository}"
+base_branch = "{base_branch}"
+enqueue_label = "ready-to-merge"
+blocked_label = "merge-blocked"
+stack_child_disposition_label = "stack-landed"
+merge_method = "merge"
+failure_policy = "pause_train"
+
+[policies.enqueue]
+label_required = true
+allowed_actor_roles = ["repo_owner", "repo_admin"]
+
+[policies.merge_identity]
+kind = "github_actions_oidc"
+name = "launchplane-merge-train"
+
+[policies.service_authz]
+action = "merge_train.run_once"
+product = "launchplane"
+context = "launchplane"
+
+[policies.github_token]
+env_var = "GH_TOKEN"
+"""
+
+
 def _merge_train_run_record(
     *,
     recorded_at: str,
@@ -4038,6 +4066,78 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["admission"]["repository"], "cbusillo/codex-skills")
         self.assertEqual(payload["admission"]["base_branch"], "main")
         self.assertEqual(payload["admission"]["status"], "admitted")
+
+    def test_merge_train_policy_targets_service_lists_authorized_policy_targets(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            policy_record = _seed_merge_train_policy(
+                state_dir,
+                policy=MergeTrainPolicyRecord(
+                    record_id="merge-train-policy-targets-test",
+                    status="active",
+                    source="test",
+                    updated_at="2026-05-13T21:00:00Z",
+                    policy=parse_merge_train_policy_toml(
+                        "\n\n".join(
+                            (
+                                "schema_version = 1",
+                                _merge_train_policy_table(
+                                    "cbusillo/sellyouroutboard", "release"
+                                ),
+                                _merge_train_policy_table(
+                                    "cbusillo/codex-skills", "main"
+                                ),
+                            )
+                        )
+                    ),
+                ),
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                side_effect=AssertionError("policy target reads must not read GitHub"),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/work-graph/merge-train/policy-targets",
+                )
+
+        self.assertEqual(status_code, 200)
+        self.assertEqual(payload["policy"]["record_id"], policy_record.record_id)
+        self.assertEqual(payload["policy"]["policy_sha256"], policy_record.policy_sha256)
+        self.assertEqual(
+            payload["targets"],
+            [
+                {
+                    "repository": "cbusillo/codex-skills",
+                    "base_branch": "main",
+                    "policy_key": "cbusillo/codex-skills:main",
+                    "service_authz": {
+                        "action": "merge_train.run_once",
+                        "product": "launchplane",
+                        "context": "launchplane",
+                    },
+                },
+                {
+                    "repository": "cbusillo/sellyouroutboard",
+                    "base_branch": "release",
+                    "policy_key": "cbusillo/sellyouroutboard:release",
+                    "service_authz": {
+                        "action": "merge_train.run_once",
+                        "product": "launchplane",
+                        "context": "launchplane",
+                    },
+                },
+            ],
+        )
 
     def test_merge_train_admission_service_admits_without_prior_run(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add a read-only merge train policy-targets API so operator clients discover repository/base targets from the active policy
- update the controller-status panel to use policy targets instead of inferring from product inventory or work-graph awareness items
- document the new route and add fixture coverage for a non-main merge train base branch

## Verification
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_merge_train_policy_targets_service_lists_authorized_policy_targets tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_status_service_reports_active_records
- uv run --extra dev mypy control_plane/service.py tests/test_service.py
- pnpm --dir frontend validate
- git diff --check
- browser fixture review: policy target options were `Launchplane (main)` and `SellYourOutboard (release)`, OPW awareness-only repo absent, no mobile overflow detected

## Inspection
- JetBrains changed-files inspection ran; it reported pre-existing CSS custom-property/font-family findings in `frontend/src/styles.css`, with no new TypeScript/service findings from this change.
