### PR TITLE
Allow operator merge train policy target reads

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -8138,13 +8138,20 @@ def create_launchplane_service_app(
                 if action == "merge_train.policy_targets":
                     policy_record = resolve_merge_train_policy_record(record_store)
                     targets = []
+                    local_operator_can_read_targets = authz_policy.allows(
+                        identity=identity,
+                        action=action,
+                        product="launchplane",
+                        context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                    )
                     for repository_policy in policy_record.policy.policies:
-                        if not authz_policy.allows(
+                        service_authz_allowed = authz_policy.allows(
                             identity=identity,
                             action=repository_policy.service_authz.action,
                             product=repository_policy.service_authz.product,
                             context=repository_policy.service_authz.context,
-                        ):
+                        )
+                        if not service_authz_allowed and not local_operator_can_read_targets:
                             continue
                         targets.append(
                             {

--- a/control_plane/service_auth.py
+++ b/control_plane/service_auth.py
@@ -74,7 +74,13 @@ AgentConsumerActionSafety = Literal[
     "policy_admin",
 ]
 AgentAuthzDecision = Literal["allowed", "denied"]
-LOCAL_OPERATOR_ALLOWED_ACTIONS = frozenset({"product_config.plan", "product_config.apply"})
+LOCAL_OPERATOR_ALLOWED_ACTIONS = frozenset(
+    {
+        "merge_train.policy_targets",
+        "product_config.plan",
+        "product_config.apply",
+    }
+)
 
 
 class TokenVerifier(Protocol):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -4139,6 +4139,48 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ],
         )
 
+    def test_merge_train_policy_targets_service_allows_local_operator_visibility(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(
+                state_dir,
+                policy=MergeTrainPolicyRecord(
+                    record_id="merge-train-policy-targets-local-operator-test",
+                    status="active",
+                    source="test",
+                    updated_at="2026-05-13T21:00:00Z",
+                    policy=build_test_merge_train_policy_with_codex_skills(),
+                ),
+            )
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-token",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-read",
+                },
+            ):
+                app = create_launchplane_service_app(
+                    state_dir=state_dir,
+                    verifier=_StubVerifier(_merge_train_service_identity()),
+                    authz_policy=LaunchplaneAuthzPolicy(),
+                    control_plane_root_path=Path(temporary_directory_name),
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/work-graph/merge-train/policy-targets",
+                    authorization="Bearer local-token",
+                )
+
+        self.assertEqual(status_code, 200)
+        self.assertEqual(
+            [(target["repository"], target["base_branch"]) for target in payload["targets"]],
+            [("cbusillo/codex-skills", "main"), ("cbusillo/sellyouroutboard", "main")],
+        )
+
     def test_merge_train_admission_service_admits_without_prior_run(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -629,6 +629,14 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
                 context="launchplane",
             )
         )
+        self.assertTrue(
+            policy.allows(
+                identity=identity,
+                action="merge_train.policy_targets",
+                product="launchplane",
+                context="launchplane",
+            )
+        )
         self.assertFalse(
             policy.allows(
                 identity=identity,


### PR DESCRIPTION
## Summary
- allow local operator credentials to read merge train policy targets
- let the policy-targets read model include all active policy targets for operators while preserving per-policy auth filtering for workflow identities
- add focused service/authz coverage for operator target visibility

## Verification
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_merge_train_policy_targets_service_lists_authorized_policy_targets tests.test_service.LaunchplaneServiceTests.test_merge_train_policy_targets_service_allows_local_operator_visibility tests.test_service_auth.LaunchplaneAuthzPolicyBoundaryTests.test_local_operator_policy_allows_only_product_config_actions
- uv run --extra dev mypy control_plane/service.py control_plane/service_auth.py tests/test_service.py tests/test_service_auth.py
- git diff --check

## Inspection
- JetBrains changed-files inspection ran and reported existing findings in `frontend/src/App.tsx`, `frontend/src/api.ts`, and unrelated sections of `control_plane/service.py`; no new finding was tied to this small authz visibility change.
