### PR TITLE
Skip merge train feedback on controller dry runs

### DIFF
--- a/.github/workflows/merge-train-runner.yml
+++ b/.github/workflows/merge-train-runner.yml
@@ -430,6 +430,9 @@ jobs:
             --response-file "$response_file" \
             > "$feedback_payloads"
           feedback_count="$(jq 'length' "$feedback_payloads")"
+          if [ "$MERGE_TRAIN_MUTATE" != "true" ]; then
+            feedback_count=0
+          fi
           if [ "$feedback_count" -gt 0 ]; then
             feedback_url="${SERVICE_ORIGIN}/v1/work-graph/merge-train/pr-feedback"
             feedback_index=0

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -506,11 +506,12 @@ that admission route before every worker call. It defaults to the Level 1
 `run-once` route for compatibility, and can call the full controller exactly
 once per admitted pass when manual dispatch sets `runner_mode: controller` or a
 scheduled run sets the repository variable `LAUNCHPLANE_MERGE_TRAIN_RUNNER_MODE`
-to `controller`. Controller-mode runs and manually dispatched batch-candidate,
-stack-collapse, or batch-landing phases render conservative PR feedback payloads
-from their worker responses and post them through the managed feedback endpoint,
-so queued PRs get one evolving Launchplane status comment as the train builds,
-waits, blocks, or completes. The scheduler still writes at most one Launchplane
+to `controller`. Controller-mode mutate runs and manually dispatched
+batch-candidate, stack-collapse, or batch-landing phases render conservative PR
+feedback payloads from their worker responses and post them through the managed
+feedback endpoint, so queued PRs get one evolving Launchplane status comment as
+the train builds, waits, blocks, or completes. Controller-mode dry-runs do not
+deliver feedback comments. The scheduler still writes at most one Launchplane
 worker result per pass; the five-minute schedule is the retry loop.
 
 The merge step is allowed only from a fresh dry-run result whose next action is

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -318,6 +318,8 @@ the Level 1 `run-once` route. Manual dispatch or the scheduled repository
 variable `LAUNCHPLANE_MERGE_TRAIN_RUNNER_MODE=controller` switches an admitted
 pass to one full-controller `run-once` call instead. This keeps activation
 explicit after setting `LAUNCHPLANE_MERGE_TRAIN_REPOSITORY`.
+Controller-mode dry-runs do not deliver PR feedback comments; feedback delivery
+is reserved for mutate runs and explicit manual phase workflows.
 Workflow dispatches may select at most one non-`none` phase input across
 batch-candidate, batch-landing, and stack-collapse modes; the runner validates
 that exclusivity before any phase step mutates state.


### PR DESCRIPTION
## Summary
- prevent controller-mode dry-run scheduler passes from posting managed PR feedback comments
- document that controller dry-runs may render feedback payloads locally but only mutate-mode/controller or explicit manual phase workflows deliver comments
- removed the accidental dry-run feedback comment from codex-skills#59 before this patch

## Verification
- git diff --check
- workflow-lint will validate the GitHub Actions YAML in PR checks

## Notes
- `bash -n .github/workflows/merge-train-runner.yml` was attempted and is not a valid signal because the workflow YAML contains embedded shell heredocs; it failed parsing the YAML as a shell script.
