### PR TITLE
Grant scheduled merge train admission

### DIFF
--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -974,8 +974,17 @@ post_grant \
   launchplane \
   launchplane \
   merge_train.run_once \
-  deploy:merge-train-runner-grant \
-  merge-train-runner
+  deploy:merge-train-runner-manual-grant \
+  merge-train-runner-manual
+post_grant \
+  "$GITHUB_REPOSITORY" \
+  merge-train-runner.yml \
+  launchplane \
+  launchplane \
+  merge_train.run_once \
+  deploy:merge-train-runner-schedule-grant \
+  merge-train-runner-schedule \
+  schedule
 post_grant \
   "$GITHUB_REPOSITORY" \
   merge-train-policy-import.yml \

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -136,6 +136,19 @@ def _manifest_payload() -> dict[str, object]:
 
 
 class ProductOnboardingTests(unittest.TestCase):
+    def test_deploy_authz_grants_include_scheduled_merge_train_runner(
+        self,
+    ) -> None:
+        script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("deploy:merge-train-runner-manual-grant", script_text)
+        self.assertIn("merge-train-runner-manual", script_text)
+        self.assertIn("deploy:merge-train-runner-schedule-grant", script_text)
+        self.assertIn("merge-train-runner-schedule", script_text)
+        self.assertIn("schedule", script_text)
+
     def test_deploy_authz_grants_include_opw_manual_preview_workflow(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- add a schedule-scoped merge-train runner authz grant alongside the manual workflow_dispatch grant
- keep the runner grant tied to the same `merge_train.run_once` service action used by admission/controller execution
- cover the deploy reconciliation script so future grant edits keep both manual and scheduled runner paths visible

## Verification
- bash -n scripts/deploy/ensure-authz-grants.sh
- git diff --check
- uv run --extra dev mypy tests/test_product_onboarding.py
- uv run python -m unittest tests.test_product_onboarding

## Context
A controller-mode dry-run scheduled pass for `cbusillo/codex-skills:main` failed at admission with `authorization_denied` because the deployed grant only covered `workflow_dispatch` for `merge-train-runner.yml`.
