### PR TITLE
Ignore terminal merge train landing history

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -3198,6 +3198,7 @@ def _latest_merge_train_batch_candidate_record(
 def _latest_passed_merge_train_batch_candidate_record(
     *,
     record_store: _MergeTrainBatchCandidateRecordStore,
+    landing_plan_record_store: _MergeTrainBatchLandingPlanRecordStore,
     repository: str,
     base_branch: str,
 ) -> MergeTrainBatchCandidateRecord | None:
@@ -3211,6 +3212,15 @@ def _latest_passed_merge_train_batch_candidate_record(
     if latest_record is None:
         return None
     if latest_record.candidate.status != "passed":
+        return None
+    completed_landing_record = _latest_completed_merge_train_batch_landing_plan_record(
+        record_store=landing_plan_record_store,
+        repository=repository,
+        base_branch=base_branch,
+        batch_id=latest_record.candidate.batch_id,
+        candidate_sha=latest_record.candidate.candidate_sha,
+    )
+    if completed_landing_record is not None:
         return None
     return latest_record
 
@@ -9396,6 +9406,7 @@ def create_launchplane_service_app(
                     if active_candidate_record is None:
                         passed_candidate_record = _latest_passed_merge_train_batch_candidate_record(
                             record_store=candidate_store,
+                            landing_plan_record_store=landing_store,
                             repository=controller_request.repository,
                             base_branch=controller_request.base_branch,
                         )

--- a/control_plane/workflows/merge_train_controller.py
+++ b/control_plane/workflows/merge_train_controller.py
@@ -92,18 +92,12 @@ def decide_merge_train_controller_record_action(
             batch_id=passed_candidate_record.candidate.batch_id,
             candidate_sha=passed_candidate_record.candidate.candidate_sha,
         )
-        if completed_landing_record is not None:
+        if completed_landing_record is None:
             return MergeTrainControllerDecision(
-                action="batch_landed",
-                reason="passed candidate already has a completed landing plan",
+                action="plan_landing",
+                reason="latest passed candidate needs a landing plan",
                 candidate_record_id=passed_candidate_record.record_id,
-                landing_plan_record_id=completed_landing_record.record_id,
             )
-        return MergeTrainControllerDecision(
-            action="plan_landing",
-            reason="latest passed candidate needs a landing plan",
-            candidate_record_id=passed_candidate_record.record_id,
-        )
 
     waiting_collapse_record = latest_merge_train_stack_collapse_plan_record(
         stack_collapse_plan_records,

--- a/tests/test_merge_train_controller.py
+++ b/tests/test_merge_train_controller.py
@@ -143,7 +143,7 @@ class MergeTrainControllerDecisionTests(unittest.TestCase):
         self.assertEqual(decision.action, "land_batch")
         self.assertEqual(decision.landing_plan_record_id, landing_record.record_id)
 
-    def test_decision_reports_terminal_landed_batch(self) -> None:
+    def test_decision_ignores_terminal_landed_batch(self) -> None:
         passed_record = _candidate_record(status="passed", candidate_sha="candidate-sha")
         merged_landing_record = _landing_plan_record(
             candidate=passed_record.candidate,
@@ -158,8 +158,8 @@ class MergeTrainControllerDecisionTests(unittest.TestCase):
             stack_collapse_plan_records=(),
         )
 
-        self.assertEqual(decision.action, "batch_landed")
-        self.assertEqual(decision.landing_plan_record_id, "landing-merged")
+        self.assertEqual(decision.action, "idle")
+        self.assertEqual(decision.landing_plan_record_id, "")
 
     def test_decision_supports_stack_collapse_records(self) -> None:
         planned_record = _stack_collapse_record(status="planned")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2480,7 +2480,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 ).list_merge_train_batch_landing_plan_records(
                     repository="cbusillo/sellyouroutboard", base_branch="main"
                 )
-                retire_status, retire_payload = _invoke_app(
+                terminal_fallthrough_status, terminal_fallthrough_payload = _invoke_app(
                     app,
                     method="POST",
                     path="/v1/work-graph/merge-train/controller/run-once",
@@ -2488,7 +2488,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "schema_version": 1,
                         "repository": "cbusillo/sellyouroutboard",
                         "base_branch": "main",
-                        "mutate": True,
+                        "mutate": False,
                     },
                 )
                 landing_records_after_retire = FilesystemRecordStore(
@@ -2546,16 +2546,16 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(land_status, 202)
         self.assertEqual(land_payload["result"]["controller_action"], "land_batch")
         self.assertEqual(land_payload["result"]["landing_plan"]["entries"][0]["status"], "merged")
-        self.assertEqual(retire_status, 202)
-        self.assertEqual(retire_payload["result"]["controller_action"], "batch_landed")
-        self.assertEqual(retire_payload["result"]["mode"], "dry-run")
-        self.assertEqual(
-            retire_payload["result"]["merge_train_batch_landing_plan_record_id"],
-            land_payload["records"]["merge_train_batch_landing_plan_record_id"],
-        )
         self.assertEqual(
             tuple(record.record_id for record in landing_records_after_retire),
             tuple(record.record_id for record in landing_records_before_retire),
+        )
+        self.assertEqual(terminal_fallthrough_status, 202)
+        self.assertEqual(
+            terminal_fallthrough_payload["result"]["controller_action"], "plan_candidate"
+        )
+        self.assertNotIn(
+            "merge_train_batch_landing_plan_record_id", terminal_fallthrough_payload["result"]
         )
         self.assertEqual(next_observe_status, 202)
         self.assertEqual(next_observe_payload["result"]["controller_action"], "plan_landing")


### PR DESCRIPTION
## Summary
- stop treating fully merged landing-plan history as the next controller action
- let controller dry-runs fall through to the current GitHub queue after terminal batches
- update service/controller tests around terminal landing-plan behavior

## Verification
- uv run --extra dev mypy control_plane/service.py control_plane/workflows/merge_train_controller.py tests/test_service.py tests/test_merge_train_controller.py
- uv run python -m unittest tests.test_merge_train_controller tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_advances_unstacked_batch_flow tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_status_service_reports_active_records
- git diff --check
