### PR TITLE
Ignore stale merge train stack records

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -9544,11 +9544,6 @@ def create_launchplane_service_app(
                             plan_status="waiting_for_root_checks",
                         )
                         if waiting_collapse_record is not None:
-                            _validate_merge_train_stack_collapse_record_for_controller(
-                                collapse_record=waiting_collapse_record,
-                                policy_key=repository_policy.policy_key,
-                                policy_sha256=policy_record.policy_sha256,
-                            )
                             snapshot = GitHubMergeTrainSnapshotReader(
                                 transport=transport
                             ).read_merge_train_snapshot(
@@ -9573,6 +9568,11 @@ def create_launchplane_service_app(
                             ):
                                 waiting_collapse_record = None
                             else:
+                                _validate_merge_train_stack_collapse_record_for_controller(
+                                    collapse_record=waiting_collapse_record,
+                                    policy_key=repository_policy.policy_key,
+                                    policy_sha256=policy_record.policy_sha256,
+                                )
                                 root_snapshot = snapshot.model_copy(
                                     update={"pull_requests": (root_pull_request,)}
                                 )
@@ -9635,46 +9635,68 @@ def create_launchplane_service_app(
                                 )
                             )
                             if planned_collapse_record is not None:
-                                _validate_merge_train_stack_collapse_record_for_controller(
-                                    collapse_record=planned_collapse_record,
-                                    policy_key=repository_policy.policy_key,
-                                    policy_sha256=policy_record.policy_sha256,
+                                snapshot = GitHubMergeTrainSnapshotReader(
+                                    transport=transport
+                                ).read_merge_train_snapshot(
+                                    repository=controller_request.repository,
+                                    base_branch=controller_request.base_branch,
                                 )
-                                result = {
-                                    "repository": controller_request.repository,
-                                    "base_branch": controller_request.base_branch,
-                                    "mode": "dry-run"
-                                    if not controller_request.mutate
-                                    else "execute_stack_collapse",
-                                    "controller_action": "execute_stack_collapse",
-                                    "merge_train_stack_collapse_plan_record_id": planned_collapse_record.record_id,
-                                }
-                                if controller_request.mutate:
-                                    executed_plan = execute_merge_train_stack_collapse_plan(
-                                        plan=planned_collapse_record.plan,
-                                        branch_client=github_client,
-                                        updated_at=recorded_at,
-                                    )
-                                    executed_record = build_merge_train_stack_collapse_plan_record(
-                                        plan=executed_plan,
-                                        source=f"service:controller:stack-collapse-execute:{request_trace_id}",
-                                        updated_at=recorded_at,
-                                    )
-                                    collapse_store.write_merge_train_stack_collapse_plan_record(
-                                        executed_record
-                                    )
-                                    result["merge_train_stack_collapse_plan_record_id"] = (
-                                        executed_record.record_id
-                                    )
-                                    result["stack_collapse_plan"] = executed_plan.model_dump(
-                                        mode="json"
-                                    )
+                                root_pull_request = next(
+                                    (
+                                        pull_request
+                                        for pull_request in snapshot.pull_requests
+                                        if pull_request.number
+                                        == planned_collapse_record.plan.root_pull_request_number
+                                    ),
+                                    None,
+                                )
+                                if (
+                                    root_pull_request is None
+                                    or root_pull_request.head_sha
+                                    != planned_collapse_record.plan.root_initial_head_sha
+                                ):
+                                    planned_collapse_record = None
                                 else:
-                                    result["stack_collapse_plan"] = (
-                                        planned_collapse_record.plan.model_dump(mode="json")
+                                    _validate_merge_train_stack_collapse_record_for_controller(
+                                        collapse_record=planned_collapse_record,
+                                        policy_key=repository_policy.policy_key,
+                                        policy_sha256=policy_record.policy_sha256,
                                     )
-                                driver_result = result
-                            else:
+                                    result = {
+                                        "repository": controller_request.repository,
+                                        "base_branch": controller_request.base_branch,
+                                        "mode": "dry-run"
+                                        if not controller_request.mutate
+                                        else "execute_stack_collapse",
+                                        "controller_action": "execute_stack_collapse",
+                                        "merge_train_stack_collapse_plan_record_id": planned_collapse_record.record_id,
+                                    }
+                                    if controller_request.mutate:
+                                        executed_plan = execute_merge_train_stack_collapse_plan(
+                                            plan=planned_collapse_record.plan,
+                                            branch_client=github_client,
+                                            updated_at=recorded_at,
+                                        )
+                                        executed_record = build_merge_train_stack_collapse_plan_record(
+                                            plan=executed_plan,
+                                            source=f"service:controller:stack-collapse-execute:{request_trace_id}",
+                                            updated_at=recorded_at,
+                                        )
+                                        collapse_store.write_merge_train_stack_collapse_plan_record(
+                                            executed_record
+                                        )
+                                        result["merge_train_stack_collapse_plan_record_id"] = (
+                                            executed_record.record_id
+                                        )
+                                        result["stack_collapse_plan"] = executed_plan.model_dump(
+                                            mode="json"
+                                        )
+                                    else:
+                                        result["stack_collapse_plan"] = (
+                                            planned_collapse_record.plan.model_dump(mode="json")
+                                        )
+                                    driver_result = result
+                            if planned_collapse_record is None:
                                 snapshot = GitHubMergeTrainSnapshotReader(
                                     transport=transport
                                 ).read_merge_train_snapshot(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -32,6 +32,7 @@ from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFee
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane.contracts.merge_train_policy import MergeTrainPolicy
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
 from control_plane.contracts.merge_train_policy import parse_merge_train_policy_toml
 from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidate
@@ -487,6 +488,40 @@ context = "launchplane"
 [policies.github_token]
 env_var = "GH_TOKEN"
 """
+
+
+def _merge_train_policy_with_label(
+    *, repository: str = "cbusillo/sellyouroutboard", enqueue_label: str = "ready-to-merge"
+) -> MergeTrainPolicy:
+    return parse_merge_train_policy_toml(
+        f"""schema_version = 1
+
+[[policies]]
+repository = "{repository}"
+base_branch = "main"
+enqueue_label = "{enqueue_label}"
+blocked_label = "merge-blocked"
+stack_child_disposition_label = "stack-landed"
+merge_method = "merge"
+failure_policy = "pause_train"
+
+[policies.enqueue]
+label_required = true
+allowed_actor_roles = ["repo_owner", "repo_admin"]
+
+[policies.merge_identity]
+kind = "github_actions_oidc"
+name = "launchplane-merge-train"
+
+[policies.service_authz]
+action = "merge_train.run_once"
+product = "launchplane"
+context = "launchplane"
+
+[policies.github_token]
+env_var = "GH_TOKEN"
+"""
+    )
 
 
 def _merge_train_run_record(
@@ -2829,6 +2864,83 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "mutate": False,
                     },
                 )
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["controller_action"], "plan_stack_collapse")
+        self.assertNotIn("merge_train_stack_collapse_plan_record_id", payload["result"])
+
+    def test_merge_train_controller_ignores_stale_waiting_stack_root_after_policy_change(
+        self,
+    ) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with (
+                patch(
+                    "control_plane.service.GitHubMergeTrainSnapshotReader",
+                    _FakeStackedMergeTrainSnapshotReader,
+                ),
+                patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient),
+            ):
+                _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+                _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+            _seed_merge_train_policy(
+                state_dir,
+                policy=MergeTrainPolicyRecord(
+                    record_id="merge-train-policy-20260513T220000Z-test",
+                    status="active",
+                    source="test",
+                    updated_at="2026-05-13T20:00:00Z",
+                    policy=_merge_train_policy_with_label(enqueue_label="ready-for-train"),
+                ),
+            )
+            _seed_merge_train_policy(state_dir)
+            with (
+                patch(
+                    "control_plane.service.GitHubMergeTrainSnapshotReader",
+                    _FakeMovedRootStackedMergeTrainSnapshotReader,
+                ),
+                patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": False,
+                    },
+                )
 
         self.assertEqual(status_code, 202)
         self.assertEqual(payload["result"]["controller_action"], "plan_stack_collapse")
@@ -2874,7 +2986,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     policy=build_test_merge_train_policy(repository="cbusillo/codex-skills"),
                 ),
             )
-            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
+            with (
+                patch(
+                    "control_plane.service.GitHubMergeTrainSnapshotReader",
+                    _FakeStackedMergeTrainSnapshotReader,
+                ),
+                patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient),
+            ):
                 status_code, payload = _invoke_app(
                     app,
                     method="POST",
@@ -2931,7 +3049,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     policy=build_test_merge_train_policy_with_codex_skills(),
                 ),
             )
-            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
+            with (
+                patch(
+                    "control_plane.service.GitHubMergeTrainSnapshotReader",
+                    _FakeStackedMergeTrainSnapshotReader,
+                ),
+                patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient),
+            ):
                 status_code, payload = _invoke_app(
                     app,
                     method="POST",


### PR DESCRIPTION
## Summary
- validate live stack-collapse roots before trusting stored waiting/planned stack records
- ignore stale stack history when the root PR moved or disappeared so controller dry-runs can read the current queue
- keep planned stack records fail-closed when the root is still current but policy digest drifted

## Tests
- uv run --extra dev mypy control_plane/service.py tests/test_service.py
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_ignores_stale_waiting_stack_root tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_ignores_stale_waiting_stack_root_after_policy_change tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_rejects_planned_stack_after_policy_digest_changes tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_advances_stacked_batch_flow tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_advances_unstacked_batch_flow tests.test_merge_train_controller
- git diff --check