### PR TITLE
Report controller validation diagnostics

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -12975,7 +12975,21 @@ def create_launchplane_service_app(
                 trace_id=request_trace_id,
                 path=path,
             )
-        except ValidationError:
+        except ValidationError as error:
+            if path == _MERGE_TRAIN_CONTROLLER_RUN_ONCE_ROUTE:
+                message = str(error).strip() or "Request payload failed validation."
+                return _json_response(
+                    start_response=start_response,
+                    status_code=400,
+                    payload={
+                        "status": "rejected",
+                        "trace_id": request_trace_id,
+                        "error": {
+                            "code": "merge_train_controller_invalid_state",
+                            "message": message,
+                        },
+                    },
+                )
             return _json_response(
                 start_response=start_response,
                 status_code=400,
@@ -13045,7 +13059,21 @@ def create_launchplane_service_app(
                     },
                 },
             )
-        except (ValueError, click.ClickException):
+        except (ValueError, click.ClickException) as error:
+            if path == _MERGE_TRAIN_CONTROLLER_RUN_ONCE_ROUTE:
+                message = str(error).strip() or "Merge train controller request could not be completed."
+                return _json_response(
+                    start_response=start_response,
+                    status_code=400,
+                    payload={
+                        "status": "rejected",
+                        "trace_id": request_trace_id,
+                        "error": {
+                            "code": "merge_train_controller_invalid_state",
+                            "message": message,
+                        },
+                    },
+                )
             return _json_response(
                 start_response=start_response,
                 status_code=400,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2881,7 +2881,40 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertIn("merge_train_stack_collapse_plan_record_id", plan_payload["records"])
         self.assertEqual(status_code, 400)
-        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(payload["error"]["code"], "merge_train_controller_invalid_state")
+        self.assertEqual(
+            payload["error"]["message"],
+            "merge train stack collapse policy digest no longer matches",
+        )
+
+    def test_merge_train_controller_reports_validation_error_message(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/work-graph/merge-train/controller/run-once",
+                payload={
+                    "schema_version": 1,
+                    "repository": "not-a-repository",
+                    "base_branch": "main",
+                    "mutate": False,
+                },
+            )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "merge_train_controller_invalid_state")
+        self.assertIn(
+            "merge train repository must be owner/name", payload["error"]["message"]
+        )
 
     def test_merge_train_stack_collapse_service_executes_existing_plan_record(self) -> None:
         with (

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3007,7 +3007,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertIn("merge_train_batch_candidate_record_id", plan_payload["records"])
         self.assertEqual(status_code, 400)
-        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(payload["error"]["code"], "merge_train_controller_invalid_state")
+        self.assertEqual(
+            payload["error"]["message"],
+            "merge train policy not found for cbusillo/sellyouroutboard:main",
+        )
 
     def test_merge_train_controller_rejects_planned_stack_after_policy_digest_changes(
         self,


### PR DESCRIPTION
## Summary
- Return controller-specific invalid-state messages for controller run-once validation and ValueError failures.
- Preserve generic invalid_request behavior for the other service routes.
- Add regression coverage for controller validation diagnostics and policy-drift diagnostics.

## Tests
- uv run --extra dev mypy control_plane/service.py tests/test_service.py
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_rejects_planned_stack_after_policy_digest_changes tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_reports_validation_error_message tests.test_merge_train_controller
- git diff --check

JetBrains changed-files inspection still reports pre-existing frontend CSS token/font-family findings outside this patch.