### PR TITLE
Let idle merge train runs supersede stale admission records

### DIFF
--- a/control_plane/merge_train_admission.py
+++ b/control_plane/merge_train_admission.py
@@ -110,8 +110,13 @@ def evaluate_merge_train_admission_from_store(
     controller_records = _list_active_controller_records(
         store=store, repository=repository, base_branch=base_branch
     )
+    latest_run = store.latest_merge_train_run_record(
+        repository=repository,
+        base_branch=base_branch,
+    )
     actionable_records = _filter_actionable_controller_records(
         controller_records=controller_records,
+        latest_run=latest_run,
         current_policy_key=current_policy_key,
         current_policy_sha256=current_policy_sha256,
     )
@@ -124,10 +129,7 @@ def evaluate_merge_train_admission_from_store(
         repository=repository,
         base_branch=base_branch,
         requested_at=requested_at,
-        latest_run=store.latest_merge_train_run_record(
-            repository=repository,
-            base_branch=base_branch,
-        ),
+        latest_run=latest_run,
         controller_decision=controller_decision,
         poll_interval_seconds=poll_interval_seconds,
         backoff_seconds=backoff_seconds,
@@ -148,8 +150,13 @@ def build_merge_train_controller_status_read_model(
     controller_records = _list_active_controller_records(
         store=store, repository=repository, base_branch=base_branch
     )
+    latest_run = store.latest_merge_train_run_record(
+        repository=repository,
+        base_branch=base_branch,
+    )
     actionable_records = _filter_actionable_controller_records(
         controller_records=controller_records,
+        latest_run=latest_run,
         current_policy_key=current_policy_key,
         current_policy_sha256=current_policy_sha256,
     )
@@ -157,10 +164,6 @@ def build_merge_train_controller_status_read_model(
         candidate_records=actionable_records.candidate_records,
         landing_plan_records=actionable_records.landing_plan_records,
         stack_collapse_plan_records=actionable_records.stack_collapse_plan_records,
-    )
-    latest_run = store.latest_merge_train_run_record(
-        repository=repository,
-        base_branch=base_branch,
     )
     admission = evaluate_merge_train_admission(
         repository=repository,
@@ -355,9 +358,19 @@ def _dominant_landing_status(record: MergeTrainBatchLandingPlanRecord) -> str:
 def _filter_actionable_controller_records(
     *,
     controller_records: MergeTrainControllerRecords,
+    latest_run: MergeTrainRunRecord | None,
     current_policy_key: str,
     current_policy_sha256: str,
 ) -> MergeTrainControllerRecords:
+    if _latest_idle_run_supersedes_controller_records(
+        latest_run=latest_run,
+        controller_records=controller_records,
+    ):
+        return MergeTrainControllerRecords(
+            candidate_records=(),
+            landing_plan_records=(),
+            stack_collapse_plan_records=(),
+        )
     if not current_policy_key and not current_policy_sha256:
         return _filter_terminal_candidate_stop_records(controller_records)
     policy_current_records = MergeTrainControllerRecords(
@@ -393,6 +406,30 @@ def _filter_actionable_controller_records(
         ),
     )
     return _filter_terminal_candidate_stop_records(policy_current_records)
+
+
+def _latest_idle_run_supersedes_controller_records(
+    *,
+    latest_run: MergeTrainRunRecord | None,
+    controller_records: MergeTrainControllerRecords,
+) -> bool:
+    if latest_run is None or latest_run.status != "idle" or latest_run.intended_next_action != "idle":
+        return False
+    latest_record_update = _latest_controller_record_update(controller_records)
+    if not latest_record_update:
+        return False
+    return latest_run.recorded_at >= latest_record_update
+
+
+def _latest_controller_record_update(controller_records: MergeTrainControllerRecords) -> str:
+    updated_at_values = (
+        tuple(record.updated_at for record in controller_records.candidate_records)
+        + tuple(record.updated_at for record in controller_records.landing_plan_records)
+        + tuple(record.updated_at for record in controller_records.stack_collapse_plan_records)
+    )
+    if not updated_at_values:
+        return ""
+    return max(updated_at_values)
 
 
 def _filter_terminal_candidate_stop_records(

--- a/tests/test_merge_train_admission.py
+++ b/tests/test_merge_train_admission.py
@@ -306,6 +306,61 @@ class MergeTrainAdmissionTests(unittest.TestCase):
         self.assertEqual(decision.controller_landing_plan_record_id, "")
         self.assertEqual(decision.controller_stack_collapse_plan_record_id, "")
 
+    def test_latest_idle_run_supersedes_older_controller_records_for_admission(self) -> None:
+        candidate_record = _candidate_record(status="passed")
+        landing_plan_record = _landing_plan_record(candidate_record)
+        stack_collapse_record = _stack_collapse_record(status="waiting_for_root_checks")
+        latest_run = _idle_run_record(recorded_at="2026-05-09T02:10:00Z")
+        store = _RunHistoryStore(
+            latest_run,
+            candidate_records=(candidate_record,),
+            landing_plan_records=(landing_plan_record,),
+            stack_collapse_plan_records=(stack_collapse_record,),
+        )
+
+        decision = evaluate_merge_train_admission_from_store(
+            store=store,
+            repository="cbusillo/sellyouroutboard",
+            base_branch="main",
+            requested_at="2026-05-09T02:10:00Z",
+            current_policy_key=candidate_record.candidate.policy_key,
+            current_policy_sha256=candidate_record.candidate.policy_sha256,
+        )
+
+        self.assertTrue(decision.admitted)
+        self.assertEqual(decision.controller_action, "idle")
+        self.assertEqual(decision.controller_landing_plan_record_id, "")
+        self.assertEqual(decision.controller_stack_collapse_plan_record_id, "")
+
+    def test_older_idle_run_does_not_supersede_newer_controller_records(self) -> None:
+        candidate_record = _candidate_record(status="passed")
+        landing_plan_record = _landing_plan_record(candidate_record)
+        stack_collapse_record = _stack_collapse_record(status="waiting_for_root_checks")
+        latest_run = _idle_run_record(recorded_at="2026-05-09T02:00:00Z")
+        store = _RunHistoryStore(
+            latest_run,
+            candidate_records=(candidate_record,),
+            landing_plan_records=(landing_plan_record,),
+            stack_collapse_plan_records=(stack_collapse_record,),
+        )
+
+        decision = evaluate_merge_train_admission_from_store(
+            store=store,
+            repository="cbusillo/sellyouroutboard",
+            base_branch="main",
+            requested_at="2026-05-09T02:10:00Z",
+            current_policy_key=candidate_record.candidate.policy_key,
+            current_policy_sha256=candidate_record.candidate.policy_sha256,
+        )
+
+        self.assertTrue(decision.admitted)
+        self.assertEqual(decision.controller_action, "land_batch")
+        self.assertEqual(decision.controller_landing_plan_record_id, landing_plan_record.record_id)
+        self.assertEqual(
+            decision.controller_stack_collapse_plan_record_id,
+            stack_collapse_record.record_id,
+        )
+
     def test_builds_controller_status_read_model_from_store_records(self) -> None:
         candidate_record = _candidate_record(status="passed")
         landing_plan_record = _landing_plan_record(candidate_record)
@@ -383,6 +438,33 @@ class MergeTrainAdmissionTests(unittest.TestCase):
             {"batch_candidate", "batch_landing_plan", "stack_collapse_plan"},
         )
 
+    def test_controller_status_keeps_idle_superseded_records_visible(self) -> None:
+        candidate_record = _candidate_record(status="passed")
+        landing_plan_record = _landing_plan_record(candidate_record)
+        stack_collapse_record = _stack_collapse_record(status="waiting_for_root_checks")
+        store = _RunHistoryStore(
+            _idle_run_record(recorded_at="2026-05-09T02:10:00Z"),
+            candidate_records=(candidate_record,),
+            landing_plan_records=(landing_plan_record,),
+            stack_collapse_plan_records=(stack_collapse_record,),
+        )
+
+        read_model = build_merge_train_controller_status_read_model(
+            store=store,
+            repository="cbusillo/sellyouroutboard",
+            base_branch="main",
+            generated_at="2026-05-09T02:10:00Z",
+            current_policy_key=candidate_record.candidate.policy_key,
+            current_policy_sha256=candidate_record.candidate.policy_sha256,
+        )
+
+        self.assertEqual(read_model.admission.controller_action, "idle")
+        self.assertEqual(len(read_model.controller_records), 3)
+        self.assertEqual(
+            {summary.record_type for summary in read_model.controller_records},
+            {"batch_candidate", "batch_landing_plan", "stack_collapse_plan"},
+        )
+
 
 def _run_record(
     *,
@@ -421,6 +503,19 @@ def _run_record(
         snapshot=snapshot,
         dry_run_result=dry_run_result,
         worker_step_result=worker_step_result,
+    )
+
+
+def _idle_run_record(*, recorded_at: str) -> MergeTrainRunRecord:
+    return _run_record(recorded_at=recorded_at).model_copy(
+        update={
+            "status": "idle",
+            "intended_next_action": "idle",
+            "selected_pr_number": None,
+            "selected_head_sha": "",
+            "selected_mergeable": "",
+            "selected_required_checks_status": "",
+        }
     )
 
 


### PR DESCRIPTION
## Summary
- Treat a latest idle merge-train run as newer controller evidence for admission when older stored candidate/landing/stack-collapse records are still active.
- Keep superseded records visible in the controller status read model while making admission report `idle`.
- Add regression coverage for newer idle runs, older idle runs, and read-model visibility.

## Verification
- `uv run --extra dev mypy control_plane/merge_train_admission.py tests/test_merge_train_admission.py`
- `uv run python -m unittest tests.test_merge_train_admission`
- `git diff --check`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files` surfaced pre-existing `control_plane/service.py` / `tests/test_service.py` warnings, not warnings in changed files.
