### PR TITLE
Expose merge train dry-run queue status

### DIFF
--- a/control_plane/merge_train_admission.py
+++ b/control_plane/merge_train_admission.py
@@ -49,6 +49,29 @@ class MergeTrainControllerRecordSummary(BaseModel):
     skipped_count: int = 0
 
 
+class MergeTrainDryRunQueueEntrySummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    pull_request_number: int
+    title: str = ""
+    url: str = ""
+    eligible: bool = False
+    ineligible_reasons: tuple[str, ...] = ()
+    mergeable: str = ""
+    required_checks_status: str = ""
+
+
+class MergeTrainLatestDryRunSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    intended_next_action: str
+    next_action_detail: str
+    queue_count: int
+    eligible_count: int
+    selected_pr_number: int | None = None
+    queue_entries: tuple[MergeTrainDryRunQueueEntrySummary, ...] = ()
+
+
 class MergeTrainControllerStatusReadModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -60,6 +83,7 @@ class MergeTrainControllerStatusReadModel(BaseModel):
     current_policy_sha256: str = ""
     admission: MergeTrainAdmissionDecision
     latest_run: MergeTrainRunRecord | None = None
+    latest_dry_run: MergeTrainLatestDryRunSummary | None = None
     controller_records: tuple[MergeTrainControllerRecordSummary, ...]
 
 
@@ -182,6 +206,7 @@ def build_merge_train_controller_status_read_model(
         current_policy_sha256=current_policy_sha256,
         admission=admission,
         latest_run=latest_run,
+        latest_dry_run=_summarize_latest_dry_run(latest_run),
         controller_records=_summarize_controller_records(
             controller_records=controller_records,
             current_policy_key=current_policy_key,
@@ -213,6 +238,74 @@ def _list_active_controller_records(
             limit=25,
         ),
     )
+
+
+def _summarize_latest_dry_run(
+    latest_run: MergeTrainRunRecord | None,
+) -> MergeTrainLatestDryRunSummary | None:
+    if latest_run is None or latest_run.mode != "dry_run":
+        return None
+    dry_run_result = latest_run.dry_run_result
+    queue_payload = dry_run_result.get("queue")
+    queue_entries = _summarize_dry_run_queue(queue_payload)
+    return MergeTrainLatestDryRunSummary(
+        intended_next_action=_string_field(dry_run_result, "intended_next_action"),
+        next_action_detail=_string_field(dry_run_result, "next_action_detail"),
+        queue_count=len(queue_entries),
+        eligible_count=sum(1 for entry in queue_entries if entry.eligible),
+        selected_pr_number=_selected_pr_number(dry_run_result.get("selected_pr")),
+        queue_entries=queue_entries,
+    )
+
+
+def _summarize_dry_run_queue(payload: object) -> tuple[MergeTrainDryRunQueueEntrySummary, ...]:
+    if not isinstance(payload, list | tuple):
+        return ()
+    entries: list[MergeTrainDryRunQueueEntrySummary] = []
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        entries.append(
+            MergeTrainDryRunQueueEntrySummary(
+                pull_request_number=_int_field(item, "number"),
+                title=_string_field(item, "title"),
+                url=_string_field(item, "url"),
+                eligible=_bool_field(item, "eligible"),
+                ineligible_reasons=_string_tuple_field(item, "ineligible_reasons"),
+                mergeable=_string_field(item, "mergeable"),
+                required_checks_status=_string_field(item, "required_checks_status"),
+            )
+        )
+    return tuple(entries)
+
+
+def _selected_pr_number(payload: object) -> int | None:
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get("number")
+    return value if isinstance(value, int) else None
+
+
+def _string_field(payload: dict[str, object], key: str) -> str:
+    value = payload.get(key)
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _bool_field(payload: dict[str, object], key: str) -> bool:
+    value = payload.get(key)
+    return value if isinstance(value, bool) else False
+
+
+def _int_field(payload: dict[str, object], key: str) -> int:
+    value = payload.get(key)
+    return value if isinstance(value, int) else 0
+
+
+def _string_tuple_field(payload: dict[str, object], key: str) -> tuple[str, ...]:
+    value = payload.get(key)
+    if not isinstance(value, list | tuple):
+        return ()
+    return tuple(item.strip() for item in value if isinstance(item, str) and item.strip())
 
 
 def _summarize_controller_records(

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -495,7 +495,10 @@ Operator views can read the broader stored controller state from
 `GET /v1/work-graph/merge-train/controller/status?repository=owner/name&base_branch=main`.
 That route returns the same admission decision plus the latest Level 1 run record
 and compact summaries for active batch candidates, landing plans, and stack
-collapse plans. Stored controller records only influence the advertised
+collapse plans. When the latest run is dry-run evidence, the response also
+includes a compact queue summary with the intended next action, selected PR,
+eligible count, queued count, and visible ineligible reasons from the persisted
+dry-run payload. Stored controller records only influence the advertised
 controller action when their policy key and digest match the active repository
 policy; stale records remain visible in the summaries with a stale reason. It is
 also store-only, so it can power dashboards and status summaries without

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1535,6 +1535,33 @@ function fixtureMergeTrainControllerStatus(
         reread_required: false,
         poll_required: true,
       },
+      latest_dry_run: {
+        intended_next_action: "wait_for_checks",
+        next_action_detail: "Candidate checks are still pending.",
+        queue_count: 3,
+        eligible_count: 3,
+        selected_pr_number: 762,
+        queue_entries: [
+          {
+            pull_request_number: 762,
+            title: "Post merge train controller feedback",
+            url: "https://github.com/cbusillo/launchplane/pull/762",
+            eligible: true,
+            ineligible_reasons: [],
+            mergeable: "mergeable",
+            required_checks_status: "pending",
+          },
+          {
+            pull_request_number: 763,
+            title: "Post feedback for manual merge train phases",
+            url: "https://github.com/cbusillo/launchplane/pull/763",
+            eligible: true,
+            ineligible_reasons: [],
+            mergeable: "mergeable",
+            required_checks_status: "pass",
+          },
+        ],
+      },
       controller_records: [
         {
           record_id: "merge-train-batch-candidate-fixture",

--- a/frontend/src/MergeTrainControllerPanel.tsx
+++ b/frontend/src/MergeTrainControllerPanel.tsx
@@ -12,6 +12,7 @@ import { SkeletonRows, StateBlock, StatusIcon, StatusPill } from "./status-ui";
 import type {
   MergeTrainControllerRecordSummary,
   MergeTrainControllerStatus,
+  MergeTrainDryRunQueueEntrySummary,
   MergeTrainPolicyTarget,
   ProductSiteOverview,
   Status,
@@ -271,6 +272,9 @@ export function MergeTrainControllerPanel({
               <code>{formatTime(status.latest_run.recorded_at)}</code>
             </div>
           ) : null}
+          {status.latest_dry_run ? (
+            <MergeTrainDryRunSummary status={status} />
+          ) : null}
           <div className="merge-train-record-list">
             {status.controller_records.length ? (
               status.controller_records
@@ -288,6 +292,67 @@ export function MergeTrainControllerPanel({
         </>
       ) : null}
     </section>
+  );
+}
+
+function MergeTrainDryRunSummary({
+  status,
+}: {
+  status: MergeTrainControllerStatus;
+}) {
+  const dryRun = status.latest_dry_run;
+  if (!dryRun) {
+    return null;
+  }
+  const visibleEntries = dryRun.queue_entries.slice(0, 3);
+  return (
+    <div className="merge-train-dry-run">
+      <span>
+        <Route size={15} aria-hidden="true" />
+        <strong>
+          {dryRun.next_action_detail || dryRun.intended_next_action}
+        </strong>
+        <code>{dryRun.intended_next_action}</code>
+      </span>
+      <span className="merge-train-record-meta">
+        <code>{dryRun.queue_count} queued</code>
+        <code>{dryRun.eligible_count} eligible</code>
+        {dryRun.selected_pr_number ? (
+          <code>selected PR {dryRun.selected_pr_number}</code>
+        ) : null}
+      </span>
+      {visibleEntries.length ? (
+        <div className="merge-train-dry-run-entries">
+          {visibleEntries.map((entry) => (
+            <MergeTrainDryRunEntry
+              key={entry.pull_request_number}
+              entry={entry}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function MergeTrainDryRunEntry({
+  entry,
+}: {
+  entry: MergeTrainDryRunQueueEntrySummary;
+}) {
+  return (
+    <span className="merge-train-dry-run-entry" data-eligible={entry.eligible}>
+      <StatusIcon status={entry.eligible ? "pass" : "blocked"} />
+      <strong>PR {entry.pull_request_number}</strong>
+      <span>{entry.title}</span>
+      <code>
+        {entry.eligible
+          ? `${entry.mergeable || "mergeable"} / ${
+              entry.required_checks_status || "checks unknown"
+            }`
+          : entry.ineligible_reasons.join(", ") || "not eligible"}
+      </code>
+    </span>
   );
 }
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -583,6 +583,7 @@ p {
 .merge-train-alert,
 .merge-train-summary,
 .merge-train-latest-run,
+.merge-train-dry-run,
 .merge-train-record-row {
   min-width: 0;
   border: 1px solid var(--hair-soft);
@@ -625,6 +626,7 @@ p {
 
 .merge-train-summary > span:first-child,
 .merge-train-latest-run,
+.merge-train-dry-run > span:first-child,
 .merge-train-record-row {
   display: grid;
   grid-template-columns: 18px minmax(0, 1fr) auto;
@@ -638,6 +640,9 @@ p {
 .merge-train-latest-run span,
 .merge-train-latest-run strong,
 .merge-train-latest-run code,
+.merge-train-dry-run span,
+.merge-train-dry-run strong,
+.merge-train-dry-run code,
 .merge-train-record-row span,
 .merge-train-record-row strong,
 .merge-train-record-row code {
@@ -660,6 +665,30 @@ p {
 
 .merge-train-latest-run {
   padding: 9px;
+}
+
+.merge-train-dry-run {
+  display: grid;
+  gap: 8px;
+  padding: 9px;
+}
+
+.merge-train-dry-run-entries {
+  display: grid;
+  gap: 5px;
+}
+
+.merge-train-dry-run-entry {
+  display: grid;
+  grid-template-columns: 18px auto minmax(0, 1fr) minmax(118px, auto);
+  gap: 7px;
+  align-items: center;
+  color: var(--fg-muted);
+  font-size: 12px;
+}
+
+.merge-train-dry-run-entry[data-eligible="false"] code {
+  color: var(--status-fail);
 }
 
 .merge-train-latest-run > span:first-of-type {
@@ -727,9 +756,19 @@ p {
   }
 
   .merge-train-summary > span:nth-child(2),
+  .merge-train-dry-run-entry,
   .merge-train-record-progress {
     overflow: visible;
     white-space: normal;
+  }
+
+  .merge-train-dry-run-entry {
+    grid-template-columns: 18px minmax(0, 1fr);
+  }
+
+  .merge-train-dry-run-entry > span,
+  .merge-train-dry-run-entry > code {
+    grid-column: 2;
   }
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -845,6 +845,25 @@ export interface MergeTrainRunRecord {
   poll_required?: boolean;
 }
 
+export interface MergeTrainDryRunQueueEntrySummary {
+  pull_request_number: number;
+  title: string;
+  url: string;
+  eligible: boolean;
+  ineligible_reasons: string[];
+  mergeable: string;
+  required_checks_status: string;
+}
+
+export interface MergeTrainLatestDryRunSummary {
+  intended_next_action: string;
+  next_action_detail: string;
+  queue_count: number;
+  eligible_count: number;
+  selected_pr_number: number | null;
+  queue_entries: MergeTrainDryRunQueueEntrySummary[];
+}
+
 export interface MergeTrainControllerRecordSummary {
   record_id: string;
   record_type: string;
@@ -874,6 +893,7 @@ export interface MergeTrainControllerStatus {
   current_policy_sha256: string;
   admission: MergeTrainAdmissionDecision;
   latest_run: MergeTrainRunRecord | null;
+  latest_dry_run: MergeTrainLatestDryRunSummary | null;
   controller_records: MergeTrainControllerRecordSummary[];
 }
 

--- a/tests/test_merge_train_admission.py
+++ b/tests/test_merge_train_admission.py
@@ -465,6 +465,42 @@ class MergeTrainAdmissionTests(unittest.TestCase):
             {"batch_candidate", "batch_landing_plan", "stack_collapse_plan"},
         )
 
+    def test_controller_status_summarizes_latest_dry_run_queue(self) -> None:
+        latest_run = _idle_run_record(recorded_at="2026-05-09T02:10:00Z")
+        store = _RunHistoryStore(latest_run)
+
+        read_model = build_merge_train_controller_status_read_model(
+            store=store,
+            repository="cbusillo/sellyouroutboard",
+            base_branch="main",
+            generated_at="2026-05-09T02:10:00Z",
+        )
+
+        self.assertIsNotNone(read_model.latest_dry_run)
+        assert read_model.latest_dry_run is not None
+        self.assertEqual(read_model.latest_dry_run.intended_next_action, "idle")
+        self.assertEqual(read_model.latest_dry_run.queue_count, 1)
+        self.assertEqual(read_model.latest_dry_run.eligible_count, 0)
+        self.assertIsNone(read_model.latest_dry_run.selected_pr_number)
+        self.assertEqual(
+            read_model.latest_dry_run.queue_entries[0].pull_request_number,
+            42,
+        )
+
+    def test_controller_status_omits_latest_dry_run_summary_for_mutations(self) -> None:
+        store = _RunHistoryStore(
+            _run_record(recorded_at="2026-05-09T02:10:00Z", mutation="wait")
+        )
+
+        read_model = build_merge_train_controller_status_read_model(
+            store=store,
+            repository="cbusillo/sellyouroutboard",
+            base_branch="main",
+            generated_at="2026-05-09T02:10:00Z",
+        )
+
+        self.assertIsNone(read_model.latest_dry_run)
+
 
 def _run_record(
     *,
@@ -507,7 +543,31 @@ def _run_record(
 
 
 def _idle_run_record(*, recorded_at: str) -> MergeTrainRunRecord:
-    return _run_record(recorded_at=recorded_at).model_copy(
+    run_record = _run_record(recorded_at=recorded_at)
+    queue = run_record.dry_run_result.get("queue")
+    idle_queue = (
+        tuple(
+            {
+                **entry,
+                "eligible": False,
+                "ineligible_reasons": ("missing ready-to-merge label",),
+                "labels": (),
+            }
+            for entry in queue
+            if isinstance(entry, dict)
+        )
+        if isinstance(queue, list | tuple)
+        else ()
+    )
+    dry_run_result = {
+        **run_record.dry_run_result,
+        "intended_next_action": "idle",
+        "next_action_detail": "No eligible pull requests are queued.",
+        "queue_order": [],
+        "queue": idle_queue,
+        "selected_pr": None,
+    }
+    return run_record.model_copy(
         update={
             "status": "idle",
             "intended_next_action": "idle",
@@ -515,6 +575,7 @@ def _idle_run_record(*, recorded_at: str) -> MergeTrainRunRecord:
             "selected_head_sha": "",
             "selected_mergeable": "",
             "selected_required_checks_status": "",
+            "dry_run_result": dry_run_result,
         }
     )
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -4693,6 +4693,39 @@ class LaunchplaneServiceTests(unittest.TestCase):
             [1],
         )
 
+    def test_merge_train_controller_status_service_reports_dry_run_queue(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir)
+            _seed_merge_train_policy(state_dir)
+            run_record = _merge_train_run_record(recorded_at="2026-05-20T12:00:00Z")
+            store.write_merge_train_run_record(run_record)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                side_effect=AssertionError("status must not read GitHub"),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/work-graph/merge-train/controller/status",
+                    query_string="repository=cbusillo/sellyouroutboard&base_branch=main",
+                )
+
+        self.assertEqual(status_code, 200)
+        latest_dry_run = payload["controller_status"]["latest_dry_run"]
+        self.assertEqual(latest_dry_run["intended_next_action"], "merge")
+        self.assertEqual(latest_dry_run["queue_count"], 1)
+        self.assertEqual(latest_dry_run["eligible_count"], 1)
+        self.assertEqual(latest_dry_run["selected_pr_number"], 1)
+        self.assertEqual(latest_dry_run["queue_entries"][0]["pull_request_number"], 1)
+        self.assertEqual(latest_dry_run["queue_entries"][0]["eligible"], True)
+
     def test_merge_train_controller_status_service_marks_stale_policy_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"


### PR DESCRIPTION
## Summary
- Add `latest_dry_run` to the merge-train controller status read model so operators can see intended action, queue size, eligible count, selected PR, and ineligible reasons from persisted dry-run evidence.
- Render the dry-run queue summary in the operator controller status panel and update fixtures/types/styles.
- Document the controller-status route's dry-run queue summary behavior.

## Verification
- `uv run --extra dev mypy control_plane/merge_train_admission.py tests/test_merge_train_admission.py tests/test_service.py`
- `uv run python -m unittest tests.test_merge_train_admission tests.test_service`
- `pnpm --dir frontend validate`
- `git diff --check`
- Browser fixture review at desktop and mobile widths using DOM/layout inspection; screenshot capture was stale/blank, but the live DOM showed the controller panel and dry-run queue content in viewport.
- JetBrains changed-files inspection reported weak warnings for duplicate-code/test-helper style only; no blocking errors.
