### PR TITLE
Reflow failed merge train candidates

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -3312,6 +3312,28 @@ def _validate_merge_train_candidate_record_for_controller(
         raise ValueError("merge train candidate policy digest no longer matches")
 
 
+def _merge_train_candidate_matches_dry_run_queue(
+    *, candidate: MergeTrainBatchCandidate, dry_run_result: MergeTrainDryRunResult, base_sha: str
+) -> bool:
+    if candidate.repository != dry_run_result.repository:
+        return False
+    if candidate.base_branch != dry_run_result.base_branch:
+        return False
+    if candidate.base_sha != base_sha:
+        return False
+    candidate_entries = tuple(
+        (entry.pull_request_number, entry.head_sha) for entry in candidate.entries
+    )
+    queue_by_number = {entry.number: entry for entry in dry_run_result.queue}
+    current_entries: list[tuple[int, str]] = []
+    for pull_request_number in dry_run_result.queue_order:
+        queue_entry = queue_by_number[pull_request_number]
+        if not queue_entry.eligible:
+            return False
+        current_entries.append((queue_entry.number, queue_entry.head_sha))
+    return candidate_entries == tuple(current_entries)
+
+
 def _validate_merge_train_landing_record_for_controller(
     *,
     landing_record: MergeTrainBatchLandingPlanRecord,
@@ -8177,9 +8199,7 @@ def create_launchplane_service_app(
                                 ),
                             }
                         )
-                    targets.sort(
-                        key=lambda target: (target["repository"], target["base_branch"])
-                    )
+                    targets.sort(key=lambda target: (target["repository"], target["base_branch"]))
                     return _json_response(
                         start_response=start_response,
                         status_code=200,
@@ -9430,17 +9450,88 @@ def create_launchplane_service_app(
                         except ValueError as error:
                             raise MergeTrainControllerRequestError(str(error)) from error
                         if active_candidate_record.candidate.status == "failed":
-                            result = {
-                                "repository": controller_request.repository,
-                                "base_branch": controller_request.base_branch,
-                                "mode": "dry-run",
-                                "controller_action": "candidate_failed",
-                                "merge_train_batch_candidate_record_id": active_candidate_record.record_id,
-                                "candidate": active_candidate_record.candidate.model_dump(
-                                    mode="json"
-                                ),
-                            }
-                            driver_result = result
+                            snapshot = GitHubMergeTrainSnapshotReader(
+                                transport=transport
+                            ).read_merge_train_snapshot(
+                                repository=controller_request.repository,
+                                base_branch=controller_request.base_branch,
+                            )
+                            dry_run_result = build_merge_train_dry_run_result(
+                                policy=policy, snapshot=snapshot
+                            )
+                            if (
+                                dry_run_result.intended_next_action == "merge"
+                                and not _merge_train_candidate_matches_dry_run_queue(
+                                    candidate=active_candidate_record.candidate,
+                                    dry_run_result=dry_run_result,
+                                    base_sha=snapshot.base_sha,
+                                )
+                            ):
+                                controller_action = "plan_candidate"
+                                candidate = build_merge_train_batch_candidate(
+                                    dry_run_result=dry_run_result,
+                                    base_sha=snapshot.base_sha,
+                                    policy_sha256=policy_record.policy_sha256,
+                                    created_at=recorded_at,
+                                )
+                                result = {
+                                    "repository": candidate.repository,
+                                    "base_branch": candidate.base_branch,
+                                    "mode": "dry-run"
+                                    if not controller_request.mutate
+                                    else controller_action,
+                                    "controller_action": controller_action,
+                                    "superseded_merge_train_batch_candidate_record_id": active_candidate_record.record_id,
+                                    "dry_run_result": dry_run_result.model_dump(mode="json"),
+                                    "candidate": candidate.model_dump(mode="json"),
+                                }
+                                if controller_request.mutate:
+                                    batch_records = (
+                                        candidate_store.list_merge_train_batch_candidate_records(
+                                            repository=controller_request.repository,
+                                            base_branch=controller_request.base_branch,
+                                            status="active",
+                                            limit=25,
+                                        )
+                                    )
+                                    for batch_record in batch_records:
+                                        if (
+                                            batch_record.candidate.batch_id
+                                            == active_candidate_record.candidate.batch_id
+                                        ):
+                                            candidate_store.write_merge_train_batch_candidate_record(
+                                                batch_record.model_copy(
+                                                    update={"status": "superseded"}
+                                                )
+                                            )
+                                    candidate_record = build_merge_train_batch_candidate_record(
+                                        candidate=candidate,
+                                        source=(
+                                            "service:controller:candidate-reflow:"
+                                            f"{request_trace_id}"
+                                        ),
+                                        updated_at=recorded_at,
+                                    )
+                                    candidate_store.write_merge_train_batch_candidate_record(
+                                        candidate_record
+                                    )
+                                    result["merge_train_batch_candidate_record_id"] = (
+                                        candidate_record.record_id
+                                    )
+                                driver_result = result
+                            else:
+                                result = {
+                                    "repository": controller_request.repository,
+                                    "base_branch": controller_request.base_branch,
+                                    "mode": "dry-run",
+                                    "controller_action": "candidate_failed",
+                                    "merge_train_batch_candidate_record_id": active_candidate_record.record_id,
+                                    "dry_run_result": dry_run_result.model_dump(mode="json"),
+                                    "candidate": active_candidate_record.candidate.model_dump(
+                                        mode="json"
+                                    ),
+                                }
+                                driver_result = result
                         else:
                             if active_candidate_record.candidate.status in {
                                 "planned",
@@ -9510,9 +9601,7 @@ def create_launchplane_service_app(
                                     policy_sha256=policy_record.policy_sha256,
                                 )
                             except ValueError as error:
-                                raise MergeTrainControllerRequestError(
-                                    str(error)
-                                ) from error
+                                raise MergeTrainControllerRequestError(str(error)) from error
                             result = {
                                 "repository": controller_request.repository,
                                 "base_branch": controller_request.base_branch,
@@ -9596,9 +9685,7 @@ def create_launchplane_service_app(
                                         policy_sha256=policy_record.policy_sha256,
                                     )
                                 except ValueError as error:
-                                    raise MergeTrainControllerRequestError(
-                                        str(error)
-                                    ) from error
+                                    raise MergeTrainControllerRequestError(str(error)) from error
                                 root_snapshot = snapshot.model_copy(
                                     update={"pull_requests": (root_pull_request,)}
                                 )
@@ -13149,7 +13236,9 @@ def create_launchplane_service_app(
             )
         except (ValueError, click.ClickException) as error:
             if path == _MERGE_TRAIN_CONTROLLER_RUN_ONCE_ROUTE:
-                message = str(error).strip() or "Merge train controller request could not be completed."
+                message = (
+                    str(error).strip() or "Merge train controller request could not be completed."
+                )
                 return _json_response(
                     start_response=start_response,
                     status_code=400,

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -149,6 +149,12 @@ smaller batches/one-at-a-time validation to identify the blocking PR. Once a
 blocker is identified, Launchplane applies `blocked_label` and either pauses or
 reflows later entries according to `failure_policy`.
 
+A failed candidate remains a stop state while the current eligible queue and
+base SHA still match that candidate. If the eligible queue changes, for example
+because a new queued PR repairs train validation, the controller may supersede
+the failed candidate batch lineage and plan a replacement candidate from the
+fresh snapshot.
+
 ## Example Policy Entries
 
 The example below is documentation/import material only. It is not packaged as a
@@ -432,8 +438,10 @@ Controller actions have these retry/stop semantics:
   Mutate once, then call again.
 - `observe_candidate`: A built candidate needs check observation. Mutate or
   dry-run later until checks pass, fail, or remain pending.
-- `candidate_failed`: Candidate checks failed. Stop and surface the candidate
-  record id and failed check evidence.
+- `candidate_failed`: Candidate checks failed and still matches the current
+  eligible queue. Stop and surface the candidate record id and failed check
+  evidence. If the eligible queue/base changes, the next controller action may
+  become `plan_candidate` for a superseding candidate.
 - `plan_landing`: A passed candidate is ready for PR-native landing-plan
   creation. Mutate once, then call again.
 - `land_batch`: A landing plan is ready to merge original PRs in order. Mutate

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -354,6 +354,38 @@ class _FakeMergeTrainSnapshotReader:
         )
 
 
+class _FakeExpandedMergeTrainSnapshotReader(_FakeMergeTrainSnapshotReader):
+    def read_merge_train_snapshot(
+        self, *, repository: str, base_branch: str
+    ) -> MergeTrainDryRunSnapshot:
+        base_snapshot = super().read_merge_train_snapshot(
+            repository=repository, base_branch=base_branch
+        )
+        return base_snapshot.model_copy(
+            update={
+                "pull_requests": (
+                    *base_snapshot.pull_requests,
+                    MergeTrainPullRequestSnapshot(
+                        number=2,
+                        url=f"https://github.com/{repository}/pull/2",
+                        title="Validation fix",
+                        created_at="2026-05-08T10:05:00Z",
+                        labels=("ready-to-merge",),
+                        actor_role="repo_admin",
+                        head_sha="head-2",
+                        head_ref="feature/validation-fix",
+                        head_repository=repository,
+                        base_ref=base_branch,
+                        base_repository=repository,
+                        base_sha="base-main",
+                        mergeable="mergeable",
+                        required_checks_status="pass",
+                    ),
+                )
+            }
+        )
+
+
 class _FakeEmptyMergeTrainSnapshotReader:
     def __init__(self, *, transport: object) -> None:
         self.transport = transport
@@ -2672,7 +2704,107 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     },
                 )
             with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
-                stop_status, stop_payload = _invoke_app(
+                with patch(
+                    "control_plane.service.GitHubMergeTrainSnapshotReader",
+                    _FakeMergeTrainSnapshotReader,
+                ):
+                    stop_status, stop_payload = _invoke_app(
+                        app,
+                        method="POST",
+                        path="/v1/work-graph/merge-train/controller/run-once",
+                        payload={
+                            "schema_version": 1,
+                            "repository": "cbusillo/sellyouroutboard",
+                            "base_branch": "main",
+                            "mutate": True,
+                        },
+                    )
+
+        self.assertEqual(failed_status, 202)
+        self.assertEqual(failed_payload["result"]["controller_action"], "observe_candidate")
+        self.assertEqual(failed_payload["result"]["candidate"]["status"], "failed")
+        self.assertEqual(stop_status, 202)
+        self.assertEqual(stop_payload["result"]["controller_action"], "candidate_failed")
+        self.assertEqual(stop_payload["result"]["candidate"]["status"], "failed")
+
+    def test_merge_train_controller_reflows_failed_candidate_after_queue_changes(
+        self,
+    ) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with (
+                patch(
+                    "control_plane.service.GitHubMergeTrainSnapshotReader",
+                    _FakeMergeTrainSnapshotReader,
+                ),
+                patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient),
+            ):
+                _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+                _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+            with patch(
+                "control_plane.service.GitHubMergeTrainClient",
+                _FakeFailingMergeTrainGitHubClient,
+            ):
+                _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+            with (
+                patch(
+                    "control_plane.service.GitHubMergeTrainSnapshotReader",
+                    _FakeExpandedMergeTrainSnapshotReader,
+                ),
+                patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient),
+            ):
+                reflow_status, reflow_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+                build_status, build_payload = _invoke_app(
                     app,
                     method="POST",
                     path="/v1/work-graph/merge-train/controller/run-once",
@@ -2684,12 +2816,25 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     },
                 )
 
-        self.assertEqual(failed_status, 202)
-        self.assertEqual(failed_payload["result"]["controller_action"], "observe_candidate")
-        self.assertEqual(failed_payload["result"]["candidate"]["status"], "failed")
-        self.assertEqual(stop_status, 202)
-        self.assertEqual(stop_payload["result"]["controller_action"], "candidate_failed")
-        self.assertEqual(stop_payload["result"]["candidate"]["status"], "failed")
+        self.assertEqual(reflow_status, 202)
+        self.assertEqual(reflow_payload["result"]["controller_action"], "plan_candidate")
+        self.assertEqual(
+            [
+                entry["pull_request_number"]
+                for entry in reflow_payload["result"]["candidate"]["entries"]
+            ],
+            [1, 2],
+        )
+        self.assertIn("superseded_merge_train_batch_candidate_record_id", reflow_payload["result"])
+        self.assertEqual(build_status, 202)
+        self.assertEqual(build_payload["result"]["controller_action"], "build_candidate")
+        self.assertEqual(
+            [
+                entry["pull_request_number"]
+                for entry in build_payload["result"]["candidate"]["entries"]
+            ],
+            [1, 2],
+        )
 
     def test_merge_train_controller_returns_idle_without_eligible_pull_requests(
         self,
@@ -3130,6 +3275,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             payload["error"]["message"],
             "merge train stack collapse policy digest no longer matches",
         )
+
     def test_merge_train_controller_reports_validation_error_message(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -3155,9 +3301,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 400)
         self.assertEqual(payload["status"], "rejected")
         self.assertEqual(payload["error"]["code"], "merge_train_controller_invalid_state")
-        self.assertIn(
-            "merge train repository must be owner/name", payload["error"]["message"]
-        )
+        self.assertIn("merge train repository must be owner/name", payload["error"]["message"])
 
     def test_merge_train_stack_collapse_service_executes_existing_plan_record(self) -> None:
         with (
@@ -4359,12 +4503,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "\n\n".join(
                             (
                                 "schema_version = 1",
-                                _merge_train_policy_table(
-                                    "cbusillo/sellyouroutboard", "release"
-                                ),
-                                _merge_train_policy_table(
-                                    "cbusillo/codex-skills", "main"
-                                ),
+                                _merge_train_policy_table("cbusillo/sellyouroutboard", "release"),
+                                _merge_train_policy_table("cbusillo/codex-skills", "main"),
                             )
                         )
                     ),


### PR DESCRIPTION
## Summary
- let controller re-plan a failed batch candidate when the current eligible queue/base no longer matches the failed batch
- supersede the failed batch lineage before writing the replacement candidate in mutate mode
- document failed-candidate reflow behavior and add service coverage

## Verification
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_stops_after_candidate_failure tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_reflows_failed_candidate_after_queue_changes tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_advances_unstacked_batch_flow
- uv run --extra dev mypy control_plane/service.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_service.py
- uv run --extra dev ruff check control_plane/service.py tests/test_service.py docs/merge-train-policy.md
- git diff --check

JetBrains changed-files inspection still reports pre-existing frontend CSS custom-property/font-family findings outside this backend change.