### PR TITLE
Fix merge train reflow supersession

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -3377,6 +3377,29 @@ def _merge_train_candidate_matches_dry_run_queue(
     return candidate_entries == tuple(current_entries)
 
 
+def _supersede_active_merge_train_batch_candidate_records(
+    *,
+    record_store: _MergeTrainBatchCandidateRecordStore,
+    repository: str,
+    base_branch: str,
+    batch_id: str,
+    replacement_record_id: str,
+) -> None:
+    records = record_store.list_merge_train_batch_candidate_records(
+        repository=repository,
+        base_branch=base_branch,
+        status="active",
+    )
+    for record in records:
+        if record.record_id == replacement_record_id:
+            continue
+        if record.candidate.batch_id != batch_id:
+            continue
+        record_store.write_merge_train_batch_candidate_record(
+            record.model_copy(update={"status": "superseded"})
+        )
+
+
 def _validate_merge_train_landing_record_for_controller(
     *,
     landing_record: MergeTrainBatchLandingPlanRecord,
@@ -9544,24 +9567,13 @@ def create_launchplane_service_app(
                                     result["merge_train_batch_candidate_record_id"] = (
                                         candidate_record.record_id
                                     )
-                                    batch_records = (
-                                        candidate_store.list_merge_train_batch_candidate_records(
-                                            repository=controller_request.repository,
-                                            base_branch=controller_request.base_branch,
-                                            status="active",
-                                            limit=25,
-                                        )
+                                    _supersede_active_merge_train_batch_candidate_records(
+                                        record_store=candidate_store,
+                                        repository=controller_request.repository,
+                                        base_branch=controller_request.base_branch,
+                                        batch_id=active_candidate_record.candidate.batch_id,
+                                        replacement_record_id=candidate_record.record_id,
                                     )
-                                    for batch_record in batch_records:
-                                        if (
-                                            batch_record.candidate.batch_id
-                                            == active_candidate_record.candidate.batch_id
-                                        ):
-                                            candidate_store.write_merge_train_batch_candidate_record(
-                                                batch_record.model_copy(
-                                                    update={"status": "superseded"}
-                                                )
-                                            )
                                 driver_result = result
                             else:
                                 result = {

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -36,6 +36,7 @@ from control_plane.contracts.merge_train_policy import MergeTrainPolicy
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
 from control_plane.contracts.merge_train_policy import parse_merge_train_policy_toml
 from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidate
+from control_plane.contracts.merge_train_batch import MergeTrainBatchEntry
 from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidateRecord
 from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlan
 from control_plane.contracts.merge_train_batch import build_merge_train_batch_candidate
@@ -311,6 +312,28 @@ class _CandidateReflowWriteFailingFilesystemRecordStore(FilesystemRecordStore):
         candidate_record = cast(MergeTrainBatchCandidateRecord, record)
         if "candidate-reflow" in candidate_record.source:
             raise RuntimeError("candidate reflow persistence unavailable")
+        return super().write_merge_train_batch_candidate_record(candidate_record)
+
+
+class _SameBatchIdReflowFilesystemRecordStore(FilesystemRecordStore):
+    def write_merge_train_batch_candidate_record(self, record: object) -> Path:
+        candidate_record = cast(MergeTrainBatchCandidateRecord, record)
+        if "candidate-reflow" in candidate_record.source:
+            records = self.list_merge_train_batch_candidate_records(
+                repository=candidate_record.candidate.repository,
+                base_branch=candidate_record.candidate.base_branch,
+                status="active",
+            )
+            failed_record = next(
+                record for record in records if record.candidate.status == "failed"
+            )
+            candidate_record = candidate_record.model_copy(
+                update={
+                    "candidate": candidate_record.candidate.model_copy(
+                        update={"batch_id": failed_record.candidate.batch_id}
+                    )
+                }
+            )
         return super().write_merge_train_batch_candidate_record(candidate_record)
 
 
@@ -2959,6 +2982,190 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ],
             [1, 2],
         )
+
+    def test_merge_train_controller_reflow_keeps_replacement_with_same_batch_id(
+        self,
+    ) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with (
+                patch(
+                    "control_plane.service.GitHubMergeTrainSnapshotReader",
+                    _FakeMergeTrainSnapshotReader,
+                ),
+                patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient),
+            ):
+                _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+                _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+            with patch(
+                "control_plane.service.GitHubMergeTrainClient",
+                _FakeFailingMergeTrainGitHubClient,
+            ):
+                _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+            same_batch_store = _SameBatchIdReflowFilesystemRecordStore(state_dir)
+            with (
+                patch("control_plane.service.build_record_store", return_value=same_batch_store),
+                patch(
+                    "control_plane.service.GitHubMergeTrainSnapshotReader",
+                    _FakeExpandedMergeTrainSnapshotReader,
+                ),
+                patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient),
+            ):
+                reflow_app = create_launchplane_service_app(
+                    state_dir=state_dir,
+                    verifier=_StubVerifier(_merge_train_service_identity()),
+                    authz_policy=_merge_train_service_policy(),
+                    control_plane_root_path=Path(temporary_directory_name),
+                )
+                reflow_status, reflow_payload = _invoke_app(
+                    reflow_app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+            candidate_records = FilesystemRecordStore(
+                state_dir
+            ).list_merge_train_batch_candidate_records(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+            )
+
+        replacement_record_id = reflow_payload["result"][
+            "merge_train_batch_candidate_record_id"
+        ]
+        replacement_record = next(
+            record for record in candidate_records if record.record_id == replacement_record_id
+        )
+        old_batch_records = tuple(
+            record
+            for record in candidate_records
+            if record.candidate.batch_id == replacement_record.candidate.batch_id
+        )
+
+        self.assertEqual(reflow_status, 202)
+        self.assertEqual(replacement_record.status, "active")
+        self.assertEqual(replacement_record.candidate.status, "planned")
+        self.assertTrue(
+            any(
+                record.status == "superseded" and record.candidate.status == "failed"
+                for record in old_batch_records
+            )
+        )
+
+    def test_merge_train_reflow_supersedes_all_matching_active_candidate_records(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir)
+            candidate = MergeTrainBatchCandidate(
+                batch_id="batch-old",
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                base_sha="base-main",
+                policy_key="sellyouroutboard-main",
+                policy_sha256="policy-digest",
+                candidate_ref="launchplane/train/cbusillo-sellyouroutboard/main/batch-old",
+                status="failed",
+                entries=(
+                    MergeTrainBatchEntry(
+                        pull_request_number=1,
+                        position=1,
+                        head_sha="head-1",
+                        title="Ready PR",
+                        url="https://github.com/cbusillo/sellyouroutboard/pull/1",
+                    ),
+                ),
+                created_at="2026-05-21T00:00:00Z",
+                updated_at="2026-05-21T00:00:00Z",
+            )
+            for index in range(30):
+                old_record = build_merge_train_batch_candidate_record(
+                    candidate=candidate.model_copy(
+                        update={"updated_at": f"2026-05-21T00:{index:02d}:00Z"}
+                    ),
+                    source=f"test:old:{index}",
+                    updated_at=f"2026-05-21T00:{index:02d}:00Z",
+                )
+                store.write_merge_train_batch_candidate_record(old_record)
+            replacement_record = build_merge_train_batch_candidate_record(
+                candidate=candidate.model_copy(
+                    update={
+                        "status": "planned",
+                        "updated_at": "2026-05-21T01:00:00Z",
+                    }
+                ),
+                source="test:replacement",
+                updated_at="2026-05-21T01:00:00Z",
+            )
+            store.write_merge_train_batch_candidate_record(replacement_record)
+
+            control_plane_service._supersede_active_merge_train_batch_candidate_records(
+                record_store=store,
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                batch_id="batch-old",
+                replacement_record_id=replacement_record.record_id,
+            )
+
+            active_records = store.list_merge_train_batch_candidate_records(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                status="active",
+            )
+            superseded_records = store.list_merge_train_batch_candidate_records(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                status="superseded",
+            )
+
+        self.assertEqual([record.record_id for record in active_records], [replacement_record.record_id])
+        self.assertEqual(len(superseded_records), 30)
 
     def test_merge_train_controller_keeps_failed_candidate_when_reflow_write_fails(
         self,


### PR DESCRIPTION
## Summary
- keep failed-candidate reflow replacement records active even if they share the old batch id
- retire all matching active candidate records instead of only the newest 25
- add regression coverage for same-batch replacement safety and full active-record retirement

## Verification
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_reflows_failed_candidate_after_queue_changes tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_reflow_keeps_replacement_with_same_batch_id tests.test_service.LaunchplaneServiceTests.test_merge_train_reflow_supersedes_all_matching_active_candidate_records tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_keeps_failed_candidate_when_reflow_write_fails`
- `uv run --extra dev mypy control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff check --diff control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/service.py tests/test_service.py`
- `git diff --check`
- JetBrains changed-files inspection run; it reports pre-existing broad service/test warnings unrelated to this patch.

Refs #607
