### PR TITLE
Add read-only grouped GitHub issue inbox

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -63,6 +63,8 @@ jobs:
       LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER: ${{ vars.LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER }}
       LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT: ${{ vars.LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT }}
       LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT: ${{ vars.LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT }}
+      LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_REPOSITORIES: ${{ vars.LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_REPOSITORIES }}
+      LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_LIMIT: ${{ vars.LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_LIMIT }}
       LAUNCHPLANE_WORK_GRAPH_GH_BINARY: ${{ vars.LAUNCHPLANE_WORK_GRAPH_GH_BINARY }}
       LAUNCHPLANE_ENABLE_EVERY_CODE_RUNTIME_SECRETS: ${{ vars.LAUNCHPLANE_ENABLE_EVERY_CODE_RUNTIME_SECRETS }}
       DISCORD_BLUE_DOKPLOY_TARGET_ID: ${{ vars.DISCORD_BLUE_DOKPLOY_TARGET_ID }}
@@ -251,6 +253,8 @@ jobs:
                 --arg work_graph_project_number "${LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER:-}" \
                 --arg work_graph_project_limit "${LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT:-}" \
                 --arg work_graph_project_signal_limit "${LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT:-}" \
+                --arg work_graph_issue_inbox_repositories "${LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_REPOSITORIES:-}" \
+                --arg work_graph_issue_inbox_limit "${LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_LIMIT:-}" \
                 --arg work_graph_gh_binary "${LAUNCHPLANE_WORK_GRAPH_GH_BINARY:-}" \
                 --arg work_graph_gh_token "${LAUNCHPLANE_WORK_GRAPH_GH_TOKEN:-}" \
                 --arg enable_every_code_runtime_secrets "${LAUNCHPLANE_ENABLE_EVERY_CODE_RUNTIME_SECRETS:-}" \
@@ -305,6 +309,8 @@ jobs:
                         LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER: $work_graph_project_number,
                         LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT: $work_graph_project_limit,
                         LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT: $work_graph_project_signal_limit,
+                        LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_REPOSITORIES: $work_graph_issue_inbox_repositories,
+                        LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_LIMIT: $work_graph_issue_inbox_limit,
                         LAUNCHPLANE_WORK_GRAPH_GH_BINARY: $work_graph_gh_binary,
                         GH_TOKEN: $work_graph_gh_token
                       }

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -225,10 +225,16 @@ from control_plane.work_graph_github_projects import (
     build_github_project_planning_facts,
     load_github_project_planning_facts_config_from_env,
 )
+from control_plane.work_graph_issue_inbox import (
+    build_github_issue_inbox_read_model,
+    load_github_issue_inbox_config_from_env,
+)
 from control_plane.work_graph_service import (
+    WorkGraphIssueInboxProvider,
     WorkGraphPlanningFactsProvider,
 )
 from control_plane.work_graph_http import (
+    handle_work_graph_issue_inbox_read,
     handle_repo_product_mapping_read,
     handle_work_graph_snapshot_read,
     rank_work_graph_snapshot,
@@ -713,6 +719,8 @@ _LAUNCHPLANE_SELF_DEPLOY_OAUTH_ENV_KEYS = frozenset(
         "LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER",
         "LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT",
         "LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT",
+        "LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_REPOSITORIES",
+        "LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_LIMIT",
         "LAUNCHPLANE_WORK_GRAPH_GH_BINARY",
         "GH_TOKEN",
     }
@@ -2569,6 +2577,8 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "merge_train.policy_targets", {}
     if len(segments) == 3 and segments == ["v1", "work-graph", "snapshot"]:
         return "work_graph.rank", {}
+    if len(segments) == 4 and segments == ["v1", "work-graph", "github", "issues"]:
+        return "work_graph.issue_inbox", {}
     if len(segments) == 2 and segments == ["v1", "repo-product-mapping"]:
         return "product_environment.read", {"repo_product_mapping": "true"}
     if len(segments) == 2 and segments == ["v1", "product-profiles"]:
@@ -7216,6 +7226,7 @@ def create_launchplane_service_app(
     github_oauth_client: GitHubOAuthClient | None = None,
     human_session_store: HumanSessionStore | None = None,
     work_graph_planning_facts_provider: WorkGraphPlanningFactsProvider | None = None,
+    work_graph_issue_inbox_provider: WorkGraphIssueInboxProvider | None = None,
 ) -> _WsgiApp:
     resolved_root = control_plane_root_path or control_plane_root()
     ui_static_root = resolved_root / "control_plane" / "ui_static"
@@ -8138,6 +8149,15 @@ def create_launchplane_service_app(
                         work_request_store=_every_code_work_request_store(record_store),
                         planning_facts_provider=work_graph_planning_facts_provider,
                         utc_now=_utc_now_timestamp,
+                        json_response=_json_response,
+                        start_response=start_response,
+                    )
+                if action == "work_graph.issue_inbox":
+                    return handle_work_graph_issue_inbox_read(
+                        authz_policy=authz_policy,
+                        identity=identity,
+                        trace_id=request_trace_id,
+                        issue_inbox_provider=work_graph_issue_inbox_provider,
                         json_response=_json_response,
                         start_response=start_response,
                     )
@@ -13383,12 +13403,27 @@ def serve_launchplane_service(
         if work_graph_project_config is not None
         else None
     )
+    work_graph_issue_inbox_config = load_github_issue_inbox_config_from_env(
+        dict(os.environ),
+        project_config=work_graph_project_config,
+    )
+    work_graph_issue_inbox_provider = (
+        (
+            lambda: build_github_issue_inbox_read_model(
+                generated_at=_utc_now_timestamp(),
+                config=work_graph_issue_inbox_config,
+            )
+        )
+        if work_graph_issue_inbox_config is not None
+        else None
+    )
     application = create_launchplane_service_app(
         state_dir=state_dir,
         verifier=verifier,
         authz_policy=authz_policy,
         database_url=database_url,
         work_graph_planning_facts_provider=work_graph_planning_facts_provider,
+        work_graph_issue_inbox_provider=work_graph_issue_inbox_provider,
     )
     with make_server(
         host,

--- a/control_plane/work_graph_github_projects.py
+++ b/control_plane/work_graph_github_projects.py
@@ -51,6 +51,23 @@ class GitHubProjectPlanningFactsConfig:
 def build_github_project_planning_facts(
     config: GitHubProjectPlanningFactsConfig,
 ) -> tuple[WorkGraphPlanningIssueFacts, ...]:
+    facts = _load_github_project_planning_facts(config)
+    return _enrich_planning_facts_with_github_signals(config=config, facts=facts)
+
+
+def build_github_project_issue_keys(
+    config: GitHubProjectPlanningFactsConfig,
+) -> tuple[str, ...]:
+    return tuple(
+        f"{fact.repository}#{fact.number}"
+        for fact in _load_github_project_planning_facts(config)
+        if not fact.is_pull_request
+    )
+
+
+def _load_github_project_planning_facts(
+    config: GitHubProjectPlanningFactsConfig,
+) -> tuple[WorkGraphPlanningIssueFacts, ...]:
     payload = _run_gh_json(
         (
             config.gh_binary,
@@ -76,7 +93,7 @@ def build_github_project_planning_facts(
         fact = _project_item_to_planning_facts(item)
         if fact is not None:
             facts.append(fact)
-    return _enrich_planning_facts_with_github_signals(config=config, facts=tuple(facts))
+    return tuple(facts)
 
 
 def load_github_project_planning_facts_config_from_env(
@@ -397,3 +414,9 @@ def _string(value: object) -> str:
 
 def _as_object(value: object) -> dict[str, Any] | None:
     return value if isinstance(value, dict) else None
+
+
+github_labels = _labels
+github_positive_int = _positive_int
+github_string = _string
+github_as_object = _as_object

--- a/control_plane/work_graph_http.py
+++ b/control_plane/work_graph_http.py
@@ -2,12 +2,20 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import TypeAlias
 from control_plane.contracts.product_environment_read_model import (
     ActionAllowed,
     ProductReadModelStore,
 )
-from control_plane.service_auth import LaunchplaneAuthzPolicy, LaunchplaneIdentity
+from control_plane.service_auth import (
+    GitHubActionsIdentity,
+    GitHubHumanIdentity,
+    LaunchplaneAuthzPolicy,
+    LocalOperatorIdentity,
+    TerminalAgentIdentity,
+)
 from control_plane.work_graph_service import (
+    WorkGraphIssueInboxProvider,
     WorkGraphPlanningFactsProvider,
     WorkGraphRankEnvelope,
     WorkGraphWorkRequestStore,
@@ -20,6 +28,9 @@ from control_plane.work_graph_service import (
 JsonResponse = Callable[..., list[bytes]]
 StartResponse = Callable[[str, list[tuple[str, str]]], None]
 UtcNow = Callable[[], str]
+ResolvedLaunchplaneIdentity: TypeAlias = (
+    GitHubActionsIdentity | GitHubHumanIdentity | TerminalAgentIdentity | LocalOperatorIdentity
+)
 
 LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 
@@ -33,7 +44,7 @@ class WorkGraphRankResult:
 def handle_work_graph_snapshot_read(
     *,
     authz_policy: LaunchplaneAuthzPolicy,
-    identity: LaunchplaneIdentity,
+    identity: ResolvedLaunchplaneIdentity,
     trace_id: str,
     product_store: ProductReadModelStore,
     work_request_store: WorkGraphWorkRequestStore,
@@ -82,10 +93,67 @@ def handle_work_graph_snapshot_read(
     )
 
 
+def handle_work_graph_issue_inbox_read(
+    *,
+    authz_policy: LaunchplaneAuthzPolicy,
+    identity: ResolvedLaunchplaneIdentity,
+    trace_id: str,
+    issue_inbox_provider: WorkGraphIssueInboxProvider | None,
+    json_response: JsonResponse,
+    start_response: StartResponse,
+) -> list[bytes]:
+    if not authz_policy.allows(
+        identity=identity,
+        action="work_graph.rank",
+        product="launchplane",
+        context=LAUNCHPLANE_SERVICE_CONTEXT,
+    ):
+        return json_response(
+            start_response=start_response,
+            status_code=403,
+            payload={
+                "status": "rejected",
+                "trace_id": trace_id,
+                "error": {
+                    "code": "authorization_denied",
+                    "message": "Workflow cannot read the Launchplane GitHub issue inbox.",
+                },
+            },
+        )
+    if issue_inbox_provider is None:
+        return json_response(
+            start_response=start_response,
+            status_code=200,
+            payload={
+                "status": "ok",
+                "trace_id": trace_id,
+                "configured": False,
+                "inbox": {
+                    "schema_version": 1,
+                    "generated_at": "",
+                    "project_configured": False,
+                    "repository_count": 0,
+                    "issue_count": 0,
+                    "repositories": [],
+                },
+            },
+        )
+    return json_response(
+        start_response=start_response,
+        status_code=200,
+        payload={
+            "status": "ok",
+            "trace_id": trace_id,
+            "configured": True,
+            "inbox": issue_inbox_provider().model_dump(mode="json"),
+        },
+    )
+
+
 def handle_repo_product_mapping_read(
     *,
     authz_policy: LaunchplaneAuthzPolicy,
-    identity: LaunchplaneIdentity,
+    identity: ResolvedLaunchplaneIdentity,
     trace_id: str,
     product_store: ProductReadModelStore,
     work_request_store: WorkGraphWorkRequestStore,
@@ -131,7 +199,7 @@ def handle_repo_product_mapping_read(
 def rank_work_graph_snapshot(
     *,
     authz_policy: LaunchplaneAuthzPolicy,
-    identity: LaunchplaneIdentity,
+    identity: ResolvedLaunchplaneIdentity,
     payload: dict[str, object],
 ) -> WorkGraphRankResult | None:
     rank_request = WorkGraphRankEnvelope.model_validate(payload)
@@ -169,9 +237,11 @@ def work_graph_rank_denied_response(
 def _work_graph_product_action_allowed(
     *,
     authz_policy: LaunchplaneAuthzPolicy,
-    identity: LaunchplaneIdentity,
+    identity: ResolvedLaunchplaneIdentity,
 ) -> ActionAllowed:
-    def action_allowed(requested_action: str, requested_product: str, requested_context: str) -> bool:
+    def action_allowed(
+        requested_action: str, requested_product: str, requested_context: str
+    ) -> bool:
         return authz_policy.allows(
             identity=identity,
             action=requested_action,

--- a/control_plane/work_graph_issue_inbox.py
+++ b/control_plane/work_graph_issue_inbox.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import click
+from pydantic import BaseModel, ConfigDict, Field
+
+from control_plane.work_graph_github_projects import (
+    GitHubProjectPlanningFactsConfig,
+    build_github_project_issue_keys,
+    github_as_object,
+    github_labels,
+    github_positive_int,
+    github_string,
+)
+
+
+IssueInboxProjectStatus = Literal["present", "missing", "unconfigured"]
+_REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+class GitHubIssueInboxIssue(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    repository: str
+    number: int = Field(ge=1)
+    title: str = ""
+    url: str = ""
+    state: str = "open"
+    labels: tuple[str, ...] = ()
+    author: str = ""
+    created_at: str = ""
+    updated_at: str = ""
+    project_status: IssueInboxProjectStatus = "unconfigured"
+    present_in_project: bool | None = None
+
+
+class GitHubIssueInboxRepositoryGroup(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    repository: str
+    issue_count: int = Field(ge=0)
+    present_in_project_count: int = Field(ge=0)
+    missing_from_project_count: int = Field(ge=0)
+    issues: tuple[GitHubIssueInboxIssue, ...] = ()
+
+
+class GitHubIssueInboxReadModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    generated_at: str
+    project_configured: bool = False
+    repository_count: int = Field(ge=0)
+    issue_count: int = Field(ge=0)
+    repositories: tuple[GitHubIssueInboxRepositoryGroup, ...] = ()
+
+
+@dataclass(frozen=True)
+class GitHubIssueInboxConfig:
+    repositories: tuple[str, ...]
+    limit_per_repo: int = 100
+    gh_binary: str = "gh"
+    project_config: GitHubProjectPlanningFactsConfig | None = None
+
+    def __post_init__(self) -> None:
+        if not self.repositories:
+            raise ValueError("GitHub issue inbox requires at least one repository")
+        for repository in self.repositories:
+            if _normalize_repository(repository) != repository:
+                raise ValueError("GitHub issue inbox repositories must be owner/repo values")
+        if self.limit_per_repo < 1:
+            raise ValueError("GitHub issue inbox requires a positive per-repo limit")
+        if not self.gh_binary.strip():
+            raise ValueError("GitHub issue inbox requires a gh binary")
+
+
+def load_github_issue_inbox_config_from_env(
+    environ: dict[str, str],
+    *,
+    project_config: GitHubProjectPlanningFactsConfig | None = None,
+) -> GitHubIssueInboxConfig | None:
+    raw_repositories = environ.get("LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_REPOSITORIES", "")
+    repositories = _parse_repository_inventory(raw_repositories)
+    if not repositories:
+        return None
+    return GitHubIssueInboxConfig(
+        repositories=repositories,
+        limit_per_repo=_int_env_value(
+            environ,
+            name="LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_LIMIT",
+            default=100,
+        ),
+        gh_binary=environ.get("LAUNCHPLANE_WORK_GRAPH_GH_BINARY", "gh").strip() or "gh",
+        project_config=project_config,
+    )
+
+
+def build_github_issue_inbox_read_model(
+    *,
+    generated_at: str,
+    config: GitHubIssueInboxConfig,
+) -> GitHubIssueInboxReadModel:
+    project_issue_keys = _project_issue_keys(config.project_config)
+    project_configured = config.project_config is not None
+    groups = tuple(
+        _repository_group(
+            config=config,
+            repository=repository,
+            project_configured=project_configured,
+            project_issue_keys=project_issue_keys,
+        )
+        for repository in config.repositories
+    )
+    return GitHubIssueInboxReadModel(
+        generated_at=generated_at,
+        project_configured=project_configured,
+        repository_count=len(groups),
+        issue_count=sum(group.issue_count for group in groups),
+        repositories=groups,
+    )
+
+
+def _repository_group(
+    *,
+    config: GitHubIssueInboxConfig,
+    repository: str,
+    project_configured: bool,
+    project_issue_keys: frozenset[str],
+) -> GitHubIssueInboxRepositoryGroup:
+    issues = tuple(
+        sorted(
+            (
+                _issue_from_gh_payload(
+                    repository=repository,
+                    raw_issue=raw_issue,
+                    project_configured=project_configured,
+                    project_issue_keys=project_issue_keys,
+                )
+                for raw_issue in _list_open_issues(config=config, repository=repository)
+            ),
+            key=lambda issue: issue.number,
+        )
+    )
+    return GitHubIssueInboxRepositoryGroup(
+        repository=repository,
+        issue_count=len(issues),
+        present_in_project_count=sum(1 for issue in issues if issue.present_in_project is True),
+        missing_from_project_count=sum(1 for issue in issues if issue.present_in_project is False),
+        issues=issues,
+    )
+
+
+def _list_open_issues(
+    *, config: GitHubIssueInboxConfig, repository: str
+) -> tuple[dict[str, Any], ...]:
+    payload = _run_gh_json_array(
+        (
+            config.gh_binary,
+            "issue",
+            "list",
+            "--repo",
+            repository,
+            "--state",
+            "open",
+            "--limit",
+            str(config.limit_per_repo),
+            "--json",
+            "number,title,url,state,labels,updatedAt,createdAt,author",
+        )
+    )
+    return tuple(
+        raw_issue for raw_issue in (github_as_object(item) for item in payload) if raw_issue
+    )
+
+
+def _issue_from_gh_payload(
+    *,
+    repository: str,
+    raw_issue: dict[str, Any],
+    project_configured: bool,
+    project_issue_keys: frozenset[str],
+) -> GitHubIssueInboxIssue:
+    number = github_positive_int(raw_issue.get("number"))
+    if number is None:
+        raise click.ClickException(f"GitHub issue list returned an invalid issue for {repository}.")
+    key = f"{repository}#{number}"
+    present_in_project: bool | None = None
+    project_status: IssueInboxProjectStatus = "unconfigured"
+    if project_configured:
+        present_in_project = key.lower() in project_issue_keys
+        project_status = "present" if present_in_project else "missing"
+    author = github_as_object(raw_issue.get("author"))
+    return GitHubIssueInboxIssue(
+        key=key,
+        repository=repository,
+        number=number,
+        title=github_string(raw_issue.get("title")),
+        url=github_string(raw_issue.get("url")),
+        state=github_string(raw_issue.get("state")) or "open",
+        labels=github_labels(raw_issue.get("labels")),
+        author=github_string(author.get("login")) if author is not None else "",
+        created_at=github_string(raw_issue.get("createdAt") or raw_issue.get("created_at")),
+        updated_at=github_string(raw_issue.get("updatedAt") or raw_issue.get("updated_at")),
+        project_status=project_status,
+        present_in_project=present_in_project,
+    )
+
+
+def _project_issue_keys(
+    project_config: GitHubProjectPlanningFactsConfig | None,
+) -> frozenset[str]:
+    if project_config is None:
+        return frozenset()
+    return frozenset(key.lower() for key in build_github_project_issue_keys(project_config))
+
+
+def _run_gh_json_array(command: Sequence[str]) -> list[object]:
+    try:
+        result = subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as error:
+        raise click.ClickException("GitHub CLI is required for work graph issue inbox.") from error
+    except subprocess.CalledProcessError as error:
+        detail = (error.stderr or error.stdout or str(error)).strip()
+        raise click.ClickException(f"GitHub issue inbox could not be loaded: {detail}") from error
+    try:
+        payload: object = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise click.ClickException("GitHub issue list returned invalid JSON.") from error
+    if not isinstance(payload, list):
+        raise click.ClickException("GitHub issue list did not return an array.")
+    return payload
+
+
+def _parse_repository_inventory(value: str) -> tuple[str, ...]:
+    repositories: list[str] = []
+    seen: set[str] = set()
+    for raw_repository in re.split(r"[,\n]", value):
+        repository = _normalize_repository(raw_repository)
+        if not repository:
+            continue
+        if repository.lower() in seen:
+            continue
+        if not _REPOSITORY_PATTERN.fullmatch(repository):
+            raise click.ClickException(
+                "LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_REPOSITORIES must contain "
+                "comma or newline separated owner/repo values."
+            )
+        seen.add(repository.lower())
+        repositories.append(repository)
+    return tuple(repositories)
+
+
+def _int_env_value(environ: dict[str, str], *, name: str, default: int) -> int:
+    value = environ.get(name, "").strip()
+    if not value:
+        return default
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise click.ClickException(f"{name} must be a positive integer.") from error
+    if parsed < 1:
+        raise click.ClickException(f"{name} must be a positive integer.")
+    return parsed
+
+
+def _normalize_repository(value: str) -> str:
+    return value.strip().strip("/")

--- a/control_plane/work_graph_service.py
+++ b/control_plane/work_graph_service.py
@@ -22,9 +22,11 @@ from control_plane.contracts.work_graph_read_model import (
     build_work_graph_queue,
     build_work_graph_snapshot_from_repo_mapping,
 )
+from control_plane.work_graph_issue_inbox import GitHubIssueInboxReadModel
 
 
 WorkGraphPlanningFactsProvider = Callable[[], tuple[WorkGraphPlanningIssueFacts, ...]]
+WorkGraphIssueInboxProvider = Callable[[], GitHubIssueInboxReadModel]
 
 
 class WorkGraphWorkRequestStore(Protocol):

--- a/docs/work-graph-read-model.md
+++ b/docs/work-graph-read-model.md
@@ -146,6 +146,41 @@ on unauthenticated runtime `gh` reads. A configured Project or signal source tha
 cannot be read fails the snapshot request instead of silently dropping Project
 fields.
 
+## GitHub Issue Inbox
+
+Launchplane can also expose a read-only grouped GitHub issue inbox for an
+explicit repository inventory:
+
+```sh
+GET /v1/work-graph/github/issues
+```
+
+The route uses the same `work_graph.rank` authorization as the snapshot route
+and never writes GitHub or Launchplane state. Enable it with
+`LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_REPOSITORIES`, a comma or newline separated
+list of `owner/repo` values. `LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_LIMIT` bounds
+the open issue reads per repository and defaults to `100`. The provider shells
+out to:
+
+```sh
+gh issue list --repo <owner>/<repo> --state open --limit <limit> \
+  --json number,title,url,state,labels,updatedAt,createdAt,author
+```
+
+The response groups results by configured `owner/repo`, includes empty groups so
+the configured inventory is visible, and gives every issue a stable key in the
+form `owner/repo#number` plus the source URL. If Code Plans Project env is also
+configured, the inbox reads Project item-list once to build membership and each
+issue is marked with `present_in_project: true` and
+`project_status: "present"` or `present_in_project: false` and
+`project_status: "missing"`. Without Project env, issues use
+`project_status: "unconfigured"` and `present_in_project: null`.
+
+Forks and private repositories are supported only through explicit inventory and
+the runtime `GH_TOKEN` permissions. Launchplane does not owner-wide search,
+fetch issue bodies, infer product ownership from inbox membership, or mutate
+Project membership from this read model.
+
 ## Boundary
 
 Do not store copied issue bodies as Launchplane authority. Project fields may be

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -84,6 +84,7 @@ from control_plane.contracts.runtime_key_safety_policy import (
 )
 from control_plane.contracts.secret_record import SecretBinding
 from control_plane.contracts.work_graph_read_model import WorkGraphPlanningIssueFacts
+from control_plane.work_graph_issue_inbox import GitHubIssueInboxReadModel
 from control_plane.merge_train import MergeTrainDryRunSnapshot, MergeTrainPullRequestSnapshot
 from control_plane.merge_train import MergeTrainCheckStatus
 from control_plane.merge_train import build_merge_train_dry_run_result
@@ -3075,9 +3076,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 base_branch="main",
             )
 
-        replacement_record_id = reflow_payload["result"][
-            "merge_train_batch_candidate_record_id"
-        ]
+        replacement_record_id = reflow_payload["result"]["merge_train_batch_candidate_record_id"]
         replacement_record = next(
             record for record in candidate_records if record.record_id == replacement_record_id
         )
@@ -3164,7 +3163,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 status="superseded",
             )
 
-        self.assertEqual([record.record_id for record in active_records], [replacement_record.record_id])
+        self.assertEqual(
+            [record.record_id for record in active_records], [replacement_record.record_id]
+        )
         self.assertEqual(len(superseded_records), 30)
 
     def test_merge_train_controller_keeps_failed_candidate_when_reflow_write_fails(
@@ -9169,6 +9170,95 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 app,
                 method="GET",
                 path="/v1/work-graph/snapshot",
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_work_graph_issue_inbox_returns_provider_payload(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": ["*"],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["work_graph.rank"],
+                    }
+                ]
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(
+                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
+                ),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+                work_graph_issue_inbox_provider=lambda: GitHubIssueInboxReadModel.model_validate(
+                    {
+                        "generated_at": "2026-05-21T12:00:00Z",
+                        "project_configured": True,
+                        "repository_count": 1,
+                        "issue_count": 1,
+                        "repositories": [
+                            {
+                                "repository": "cbusillo/launchplane",
+                                "issue_count": 1,
+                                "present_in_project_count": 0,
+                                "missing_from_project_count": 1,
+                                "issues": [
+                                    {
+                                        "key": "cbusillo/launchplane#697",
+                                        "repository": "cbusillo/launchplane",
+                                        "number": 697,
+                                        "title": "Add read-only grouped GitHub issue inbox",
+                                        "url": "https://github.com/cbusillo/launchplane/issues/697",
+                                        "state": "OPEN",
+                                        "project_status": "missing",
+                                        "present_in_project": False,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/work-graph/github/issues",
+            )
+
+        self.assertEqual(status_code, 200)
+        self.assertTrue(payload["configured"])
+        inbox = payload["inbox"]
+        self.assertEqual(inbox["repository_count"], 1)
+        self.assertEqual(inbox["repositories"][0]["issues"][0]["key"], "cbusillo/launchplane#697")
+        self.assertIs(inbox["repositories"][0]["issues"][0]["present_in_project"], False)
+
+    def test_work_graph_issue_inbox_rejects_unauthorized_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+                work_graph_issue_inbox_provider=lambda: GitHubIssueInboxReadModel.model_validate(
+                    {
+                        "generated_at": "2026-05-21T12:00:00Z",
+                        "repository_count": 0,
+                        "issue_count": 0,
+                    }
+                ),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/work-graph/github/issues",
             )
 
         self.assertEqual(status_code, 403)

--- a/tests/test_work_graph_issue_inbox.py
+++ b/tests/test_work_graph_issue_inbox.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+import click
+
+from control_plane.work_graph_github_projects import GitHubProjectPlanningFactsConfig
+from control_plane.work_graph_issue_inbox import (
+    GitHubIssueInboxConfig,
+    build_github_issue_inbox_read_model,
+    load_github_issue_inbox_config_from_env,
+)
+from tests.test_work_graph_github_projects import _write_fake_gh_sequence
+
+
+class GitHubIssueInboxTests(unittest.TestCase):
+    def test_build_issue_inbox_groups_open_issues_and_project_membership(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            directory = Path(temporary_directory_name)
+            args_file = directory / "args.txt"
+            fake_gh = _write_fake_gh_sequence(
+                directory,
+                responses=[
+                    {
+                        "stdout": {
+                            "items": [
+                                {
+                                    "content": {
+                                        "number": 7,
+                                        "repository": "cbusillo/launchplane",
+                                        "title": "Inbox item",
+                                        "type": "Issue",
+                                        "url": "https://github.com/cbusillo/launchplane/issues/7",
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "stdout": [
+                            {
+                                "number": 8,
+                                "title": "Missing from project",
+                                "url": "https://github.com/cbusillo/launchplane/issues/8",
+                                "state": "OPEN",
+                                "labels": [{"name": "plan"}],
+                                "author": {"login": "alice"},
+                                "createdAt": "2026-05-21T10:00:00Z",
+                                "updatedAt": "2026-05-21T11:00:00Z",
+                            },
+                            {
+                                "number": 7,
+                                "title": "Inbox item",
+                                "url": "https://github.com/cbusillo/launchplane/issues/7",
+                                "state": "OPEN",
+                                "labels": ["ready"],
+                                "author": {"login": "code"},
+                                "createdAt": "2026-05-21T09:00:00Z",
+                                "updatedAt": "2026-05-21T12:00:00Z",
+                            },
+                        ]
+                    },
+                    {"stdout": []},
+                ],
+            )
+            previous_args = os.environ.get("FAKE_GH_ARGS")
+            os.environ["FAKE_GH_ARGS"] = str(args_file)
+            try:
+                inbox = build_github_issue_inbox_read_model(
+                    generated_at="2026-05-21T12:00:00Z",
+                    config=GitHubIssueInboxConfig(
+                        repositories=("cbusillo/launchplane", "cbusillo/private-fork"),
+                        limit_per_repo=25,
+                        gh_binary=str(fake_gh),
+                        project_config=GitHubProjectPlanningFactsConfig(
+                            owner="cbusillo",
+                            project_number=4,
+                            limit=50,
+                            gh_binary=str(fake_gh),
+                        ),
+                    ),
+                )
+            finally:
+                if previous_args is None:
+                    os.environ.pop("FAKE_GH_ARGS", None)
+                else:
+                    os.environ["FAKE_GH_ARGS"] = previous_args
+            recorded_args = args_file.read_text().splitlines()
+
+        self.assertTrue(inbox.project_configured)
+        self.assertEqual(inbox.repository_count, 2)
+        self.assertEqual(inbox.issue_count, 2)
+        launchplane_group = inbox.repositories[0]
+        self.assertEqual(launchplane_group.repository, "cbusillo/launchplane")
+        self.assertEqual(launchplane_group.present_in_project_count, 1)
+        self.assertEqual(launchplane_group.missing_from_project_count, 1)
+        self.assertEqual([issue.number for issue in launchplane_group.issues], [7, 8])
+        self.assertEqual(launchplane_group.issues[0].key, "cbusillo/launchplane#7")
+        self.assertEqual(launchplane_group.issues[0].project_status, "present")
+        self.assertEqual(launchplane_group.issues[1].project_status, "missing")
+        self.assertEqual(launchplane_group.issues[1].labels, ("plan",))
+        self.assertEqual(inbox.repositories[1].repository, "cbusillo/private-fork")
+        self.assertEqual(inbox.repositories[1].issue_count, 0)
+        self.assertIn("issue", recorded_args)
+        self.assertIn("cbusillo/private-fork", recorded_args)
+
+    def test_build_issue_inbox_returns_empty_unconfigured_project_groups(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            directory = Path(temporary_directory_name)
+            args_file = directory / "args.txt"
+            fake_gh = _write_fake_gh_sequence(directory, responses=[{"stdout": []}])
+            previous_args = os.environ.get("FAKE_GH_ARGS")
+            os.environ["FAKE_GH_ARGS"] = str(args_file)
+            try:
+                inbox = build_github_issue_inbox_read_model(
+                    generated_at="2026-05-21T12:00:00Z",
+                    config=GitHubIssueInboxConfig(
+                        repositories=("cbusillo/launchplane",),
+                        gh_binary=str(fake_gh),
+                    ),
+                )
+            finally:
+                if previous_args is None:
+                    os.environ.pop("FAKE_GH_ARGS", None)
+                else:
+                    os.environ["FAKE_GH_ARGS"] = previous_args
+
+        self.assertFalse(inbox.project_configured)
+        self.assertEqual(inbox.issue_count, 0)
+        self.assertEqual(inbox.repositories[0].repository, "cbusillo/launchplane")
+        self.assertEqual(inbox.repositories[0].issues, ())
+
+    def test_load_issue_inbox_config_from_env_parses_inventory_and_limit(self) -> None:
+        config = load_github_issue_inbox_config_from_env(
+            {
+                "LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_REPOSITORIES": " cbusillo/launchplane,\ncbusillo/code,cbusillo/launchplane ",
+                "LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_LIMIT": "25",
+                "LAUNCHPLANE_WORK_GRAPH_GH_BINARY": "/opt/bin/gh",
+            }
+        )
+
+        self.assertIsNotNone(config)
+        assert config is not None
+        self.assertEqual(config.repositories, ("cbusillo/launchplane", "cbusillo/code"))
+        self.assertEqual(config.limit_per_repo, 25)
+        self.assertEqual(config.gh_binary, "/opt/bin/gh")
+
+    def test_load_issue_inbox_config_from_env_rejects_invalid_repository(self) -> None:
+        with self.assertRaises(click.ClickException):
+            load_github_issue_inbox_config_from_env(
+                {"LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_REPOSITORIES": "cbusillo"}
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a read-only GitHub issue inbox provider grouped by configured owner/repo inventory
- expose `GET /v1/work-graph/github/issues` using existing `work_graph.rank` authorization
- forward inbox env through self-deploy and document the config/contract

## Tests
- `uv run python -m unittest tests.test_work_graph_issue_inbox tests.test_work_graph_github_projects tests.test_service.LaunchplaneServiceTests.test_work_graph_issue_inbox_returns_provider_payload tests.test_service.LaunchplaneServiceTests.test_work_graph_issue_inbox_rejects_unauthorized_identity`
- `uv run mypy control_plane/work_graph_issue_inbox.py control_plane/work_graph_github_projects.py control_plane/work_graph_http.py control_plane/work_graph_service.py control_plane/service.py tests/test_work_graph_issue_inbox.py tests/test_work_graph_github_projects.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/work_graph_issue_inbox.py control_plane/work_graph_github_projects.py control_plane/work_graph_http.py control_plane/work_graph_service.py control_plane/service.py tests/test_work_graph_issue_inbox.py tests/test_work_graph_github_projects.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/work_graph_issue_inbox.py control_plane/work_graph_github_projects.py control_plane/work_graph_http.py control_plane/work_graph_service.py control_plane/service.py tests/test_work_graph_issue_inbox.py tests/test_work_graph_github_projects.py tests/test_service.py`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files` (pre-existing service/test warnings only)

Closes #697
