### PR TITLE
Reconcile GitHub issue inbox into Code Plans

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -228,9 +228,11 @@ from control_plane.work_graph_github_projects import (
 from control_plane.work_graph_issue_inbox import (
     build_github_issue_inbox_read_model,
     load_github_issue_inbox_config_from_env,
+    reconcile_github_issue_inbox,
 )
 from control_plane.work_graph_service import (
     WorkGraphIssueInboxProvider,
+    WorkGraphIssueInboxReconcileProvider,
     WorkGraphPlanningFactsProvider,
 )
 from control_plane.work_graph_http import (
@@ -238,6 +240,8 @@ from control_plane.work_graph_http import (
     handle_repo_product_mapping_read,
     handle_work_graph_snapshot_read,
     rank_work_graph_snapshot,
+    reconcile_work_graph_issue_inbox,
+    work_graph_issue_inbox_reconcile_denied_response,
     work_graph_rank_denied_response,
 )
 from control_plane.merge_train import MergeTrainDryRunResult
@@ -2668,6 +2672,7 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/every-code/pr-feedback",
         "/v1/every-code/pr-feedback/status",
         "/v1/every-code/preview-gates",
+        "/v1/work-graph/github/issues/reconcile",
         "/v1/work-graph/rank",
         "/v1/evidence/deployments",
         "/v1/evidence/backup-gates",
@@ -7227,6 +7232,7 @@ def create_launchplane_service_app(
     human_session_store: HumanSessionStore | None = None,
     work_graph_planning_facts_provider: WorkGraphPlanningFactsProvider | None = None,
     work_graph_issue_inbox_provider: WorkGraphIssueInboxProvider | None = None,
+    work_graph_issue_inbox_reconcile_provider: WorkGraphIssueInboxReconcileProvider | None = None,
 ) -> _WsgiApp:
     resolved_root = control_plane_root_path or control_plane_root()
     ui_static_root = resolved_root / "control_plane" / "ui_static"
@@ -10202,6 +10208,21 @@ def create_launchplane_service_app(
                     )
                 result = work_graph_rank_result.result
                 driver_result = work_graph_rank_result.driver_result
+            elif path == "/v1/work-graph/github/issues/reconcile":
+                reconcile_result = reconcile_work_graph_issue_inbox(
+                    authz_policy=authz_policy,
+                    identity=identity,
+                    payload=payload,
+                    issue_inbox_reconcile_provider=work_graph_issue_inbox_reconcile_provider,
+                )
+                if reconcile_result is None:
+                    return work_graph_issue_inbox_reconcile_denied_response(
+                        trace_id=request_trace_id,
+                        json_response=_json_response,
+                        start_response=start_response,
+                    )
+                result = reconcile_result.model_dump(mode="json")
+                driver_result = {"reconcile": result}
             elif path == "/v1/evidence/deployments":
                 deployment_request = DeploymentEvidenceEnvelope.model_validate(payload)
                 if not authz_policy.allows(
@@ -13417,6 +13438,17 @@ def serve_launchplane_service(
         if work_graph_issue_inbox_config is not None
         else None
     )
+    work_graph_issue_inbox_reconcile_provider = (
+        (
+            lambda request: reconcile_github_issue_inbox(
+                generated_at=_utc_now_timestamp(),
+                config=work_graph_issue_inbox_config,
+                request=request,
+            )
+        )
+        if work_graph_issue_inbox_config is not None
+        else None
+    )
     application = create_launchplane_service_app(
         state_dir=state_dir,
         verifier=verifier,
@@ -13424,6 +13456,7 @@ def serve_launchplane_service(
         database_url=database_url,
         work_graph_planning_facts_provider=work_graph_planning_facts_provider,
         work_graph_issue_inbox_provider=work_graph_issue_inbox_provider,
+        work_graph_issue_inbox_reconcile_provider=work_graph_issue_inbox_reconcile_provider,
     )
     with make_server(
         host,

--- a/control_plane/service_auth.py
+++ b/control_plane/service_auth.py
@@ -79,6 +79,7 @@ LOCAL_OPERATOR_ALLOWED_ACTIONS = frozenset(
         "merge_train.policy_targets",
         "product_config.plan",
         "product_config.apply",
+        "work_graph.issue_inbox.reconcile",
     }
 )
 
@@ -324,7 +325,11 @@ def action_safety(action: str) -> AgentConsumerActionSafety:
         return "prod"
     if normalized_action.endswith(".read") or normalized_action == "work_graph.rank":
         return "read"
-    if normalized_action.endswith(".write") or "rerun" in action_parts:
+    if (
+        normalized_action.endswith(".write")
+        or "rerun" in action_parts
+        or "reconcile" in action_parts
+    ):
         return "safe_write"
     return "mutation"
 

--- a/control_plane/work_graph_http.py
+++ b/control_plane/work_graph_http.py
@@ -16,12 +16,17 @@ from control_plane.service_auth import (
 )
 from control_plane.work_graph_service import (
     WorkGraphIssueInboxProvider,
+    WorkGraphIssueInboxReconcileProvider,
     WorkGraphPlanningFactsProvider,
     WorkGraphRankEnvelope,
     WorkGraphWorkRequestStore,
     build_repo_product_mapping_service_payload,
     build_work_graph_rank_result,
     build_work_graph_snapshot_service_payload,
+)
+from control_plane.work_graph_issue_inbox import (
+    GitHubIssueInboxReconcileRequest,
+    GitHubIssueInboxReconcileResult,
 )
 
 
@@ -150,6 +155,29 @@ def handle_work_graph_issue_inbox_read(
     )
 
 
+def reconcile_work_graph_issue_inbox(
+    *,
+    authz_policy: LaunchplaneAuthzPolicy,
+    identity: ResolvedLaunchplaneIdentity,
+    payload: dict[str, object],
+    issue_inbox_reconcile_provider: WorkGraphIssueInboxReconcileProvider | None,
+) -> GitHubIssueInboxReconcileResult | None:
+    request = GitHubIssueInboxReconcileRequest.model_validate(payload)
+    required_action = (
+        "work_graph.rank" if request.mode == "dry_run" else "work_graph.issue_inbox.reconcile"
+    )
+    if not authz_policy.allows(
+        identity=identity,
+        action=required_action,
+        product="launchplane",
+        context=LAUNCHPLANE_SERVICE_CONTEXT,
+    ):
+        return None
+    if issue_inbox_reconcile_provider is None:
+        raise ValueError("GitHub issue inbox reconciliation is not configured.")
+    return issue_inbox_reconcile_provider(request)
+
+
 def handle_repo_product_mapping_read(
     *,
     authz_policy: LaunchplaneAuthzPolicy,
@@ -229,6 +257,26 @@ def work_graph_rank_denied_response(
             "error": {
                 "code": "authorization_denied",
                 "message": "Workflow cannot rank Launchplane work graph snapshots.",
+            },
+        },
+    )
+
+
+def work_graph_issue_inbox_reconcile_denied_response(
+    *,
+    trace_id: str,
+    json_response: JsonResponse,
+    start_response: StartResponse,
+) -> list[bytes]:
+    return json_response(
+        start_response=start_response,
+        status_code=403,
+        payload={
+            "status": "rejected",
+            "trace_id": trace_id,
+            "error": {
+                "code": "authorization_denied",
+                "message": "Workflow cannot reconcile the Launchplane GitHub issue inbox.",
             },
         },
     )

--- a/control_plane/work_graph_issue_inbox.py
+++ b/control_plane/work_graph_issue_inbox.py
@@ -62,6 +62,41 @@ class GitHubIssueInboxReadModel(BaseModel):
     repositories: tuple[GitHubIssueInboxRepositoryGroup, ...] = ()
 
 
+class GitHubIssueInboxReconcileRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    mode: Literal["dry_run", "apply"] = "dry_run"
+
+
+class GitHubIssueInboxReconcileItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    repository: str
+    number: int = Field(ge=1)
+    title: str = ""
+    url: str = ""
+    action: Literal["would_add", "added", "already_present", "failed", "skipped"]
+    detail: str = ""
+
+
+class GitHubIssueInboxReconcileResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    generated_at: str
+    mode: Literal["dry_run", "apply"]
+    repository_count: int = Field(ge=0)
+    issue_count: int = Field(ge=0)
+    added_count: int = Field(default=0, ge=0)
+    already_present_count: int = Field(default=0, ge=0)
+    skipped_count: int = Field(default=0, ge=0)
+    failed_count: int = Field(default=0, ge=0)
+    would_add_count: int = Field(default=0, ge=0)
+    items: tuple[GitHubIssueInboxReconcileItem, ...] = ()
+
+
 @dataclass(frozen=True)
 class GitHubIssueInboxConfig:
     repositories: tuple[str, ...]
@@ -124,6 +159,54 @@ def build_github_issue_inbox_read_model(
         repository_count=len(groups),
         issue_count=sum(group.issue_count for group in groups),
         repositories=groups,
+    )
+
+
+def reconcile_github_issue_inbox(
+    *,
+    generated_at: str,
+    config: GitHubIssueInboxConfig,
+    request: GitHubIssueInboxReconcileRequest,
+) -> GitHubIssueInboxReconcileResult:
+    if config.project_config is None:
+        raise click.ClickException(
+            "Configure LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER and "
+            "LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER before reconciling the issue inbox."
+        )
+    inbox = build_github_issue_inbox_read_model(generated_at=generated_at, config=config)
+    open_project_issues = tuple(
+        issue
+        for group in inbox.repositories
+        for issue in group.issues
+        if issue.present_in_project is not None
+    )
+    if request.mode == "dry_run":
+        items = tuple(
+            _reconcile_item(issue=issue, action="would_add")
+            for issue in open_project_issues
+            if issue.present_in_project is False
+        )
+    else:
+        current_issue_keys = _project_issue_keys(config.project_config)
+        items = tuple(
+            _apply_issue_reconcile_item(
+                config=config,
+                issue=issue,
+                current_issue_keys=current_issue_keys,
+            )
+            for issue in open_project_issues
+        )
+    return GitHubIssueInboxReconcileResult(
+        generated_at=generated_at,
+        mode=request.mode,
+        repository_count=inbox.repository_count,
+        issue_count=inbox.issue_count,
+        added_count=sum(1 for item in items if item.action == "added"),
+        already_present_count=sum(1 for item in items if item.action == "already_present"),
+        skipped_count=sum(1 for item in items if item.action == "skipped"),
+        failed_count=sum(1 for item in items if item.action == "failed"),
+        would_add_count=sum(1 for item in items if item.action == "would_add"),
+        items=items,
     )
 
 
@@ -219,6 +302,85 @@ def _project_issue_keys(
     if project_config is None:
         return frozenset()
     return frozenset(key.lower() for key in build_github_project_issue_keys(project_config))
+
+
+def _apply_issue_reconcile_item(
+    *,
+    config: GitHubIssueInboxConfig,
+    issue: GitHubIssueInboxIssue,
+    current_issue_keys: frozenset[str],
+) -> GitHubIssueInboxReconcileItem:
+    if issue.key.lower() in current_issue_keys:
+        return _reconcile_item(issue=issue, action="already_present")
+    if not issue.url.strip():
+        return _reconcile_item(
+            issue=issue,
+            action="skipped",
+            detail="GitHub issue has no URL to add to the configured Project.",
+        )
+    try:
+        _project_item_add(config=config, issue=issue)
+    except FileNotFoundError as error:
+        raise click.ClickException(
+            "GitHub CLI is required for work graph issue inbox reconciliation."
+        ) from error
+    except subprocess.CalledProcessError as error:
+        return _reconcile_item(
+            issue=issue,
+            action="failed",
+            detail=_redacted_gh_error(error),
+        )
+    return _reconcile_item(issue=issue, action="added")
+
+
+def _project_item_add(*, config: GitHubIssueInboxConfig, issue: GitHubIssueInboxIssue) -> None:
+    assert config.project_config is not None
+    subprocess.run(
+        (
+            config.gh_binary,
+            "project",
+            "item-add",
+            str(config.project_config.project_number),
+            "--owner",
+            config.project_config.owner,
+            "--url",
+            issue.url,
+            "--format",
+            "json",
+        ),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _reconcile_item(
+    *,
+    issue: GitHubIssueInboxIssue,
+    action: Literal["would_add", "added", "already_present", "failed", "skipped"],
+    detail: str = "",
+) -> GitHubIssueInboxReconcileItem:
+    return GitHubIssueInboxReconcileItem(
+        key=issue.key,
+        repository=issue.repository,
+        number=issue.number,
+        title=issue.title,
+        url=issue.url,
+        action=action,
+        detail=detail,
+    )
+
+
+def _redacted_gh_error(error: subprocess.CalledProcessError) -> str:
+    detail = (error.stderr or error.stdout or str(error)).strip()
+    return (
+        re.sub(
+            r"(?i)(gh[pousr]_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+|bearer\s+[A-Za-z0-9._-]+)",
+            "[redacted]",
+            detail,
+        )
+        or "GitHub Project item-add failed."
+    )
 
 
 def _run_gh_json_array(command: Sequence[str]) -> list[object]:

--- a/control_plane/work_graph_service.py
+++ b/control_plane/work_graph_service.py
@@ -23,10 +23,17 @@ from control_plane.contracts.work_graph_read_model import (
     build_work_graph_snapshot_from_repo_mapping,
 )
 from control_plane.work_graph_issue_inbox import GitHubIssueInboxReadModel
+from control_plane.work_graph_issue_inbox import (
+    GitHubIssueInboxReconcileRequest,
+    GitHubIssueInboxReconcileResult,
+)
 
 
 WorkGraphPlanningFactsProvider = Callable[[], tuple[WorkGraphPlanningIssueFacts, ...]]
 WorkGraphIssueInboxProvider = Callable[[], GitHubIssueInboxReadModel]
+WorkGraphIssueInboxReconcileProvider = Callable[
+    [GitHubIssueInboxReconcileRequest], GitHubIssueInboxReconcileResult
+]
 
 
 class WorkGraphWorkRequestStore(Protocol):

--- a/docs/work-graph-read-model.md
+++ b/docs/work-graph-read-model.md
@@ -148,8 +148,8 @@ fields.
 
 ## GitHub Issue Inbox
 
-Launchplane can also expose a read-only grouped GitHub issue inbox for an
-explicit repository inventory:
+Launchplane can expose a read-only grouped GitHub issue inbox for an explicit
+repository inventory:
 
 ```sh
 GET /v1/work-graph/github/issues
@@ -178,8 +178,36 @@ issue is marked with `present_in_project: true` and
 
 Forks and private repositories are supported only through explicit inventory and
 the runtime `GH_TOKEN` permissions. Launchplane does not owner-wide search,
-fetch issue bodies, infer product ownership from inbox membership, or mutate
-Project membership from this read model.
+fetch issue bodies, or infer product ownership from inbox membership.
+
+When Code Plans Project env is configured, Launchplane can also reconcile the
+inbox into that Project:
+
+```sh
+POST /v1/work-graph/github/issues/reconcile
+```
+
+The request is a small mode selector:
+
+```json
+{"mode": "dry_run"}
+```
+
+`dry_run` uses `work_graph.rank` authorization and returns the missing open
+issues that would be added. `apply` requires
+`work_graph.issue_inbox.reconcile`, rechecks Project membership before each
+issue add, and shells out to:
+
+```sh
+gh project item-add <project-number> --owner <project-owner> --url <issue-url> \
+  --format json
+```
+
+Apply responses record counts for `added`, `already_present`, `skipped`, and
+`failed` items. Re-running apply against an already reconciled inbox reports
+`already_present` instead of creating duplicate Project items. GitHub CLI
+failures are reported per item with redacted stderr/stdout detail so one failed
+issue does not hide successful additions for the same reconciliation pass.
 
 ## Boundary
 

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -968,6 +968,10 @@ post_grant \
   work_graph.rank \
   deploy:work-graph-snapshot-validate-grant \
   work-graph-snapshot-validate
+post_product_config_human_grant \
+  work_graph.issue_inbox.reconcile \
+  deploy:work-graph-issue-inbox-human-reconcile-grant \
+  work-graph-issue-inbox-human-reconcile
 post_grant \
   "$GITHUB_REPOSITORY" \
   merge-train-runner.yml \

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -85,6 +85,7 @@ from control_plane.contracts.runtime_key_safety_policy import (
 from control_plane.contracts.secret_record import SecretBinding
 from control_plane.contracts.work_graph_read_model import WorkGraphPlanningIssueFacts
 from control_plane.work_graph_issue_inbox import GitHubIssueInboxReadModel
+from control_plane.work_graph_issue_inbox import GitHubIssueInboxReconcileResult
 from control_plane.merge_train import MergeTrainDryRunSnapshot, MergeTrainPullRequestSnapshot
 from control_plane.merge_train import MergeTrainCheckStatus
 from control_plane.merge_train import build_merge_train_dry_run_result
@@ -9263,6 +9264,161 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_work_graph_issue_inbox_reconcile_dry_run_returns_missing_items(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": ["*"],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["work_graph.rank"],
+                    }
+                ]
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(
+                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
+                ),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+                work_graph_issue_inbox_reconcile_provider=lambda request: (
+                    GitHubIssueInboxReconcileResult.model_validate(
+                        {
+                            "generated_at": "2026-05-21T12:00:00Z",
+                            "mode": request.mode,
+                            "repository_count": 1,
+                            "issue_count": 1,
+                            "would_add_count": 1,
+                            "items": [
+                                {
+                                    "key": "cbusillo/launchplane#698",
+                                    "repository": "cbusillo/launchplane",
+                                    "number": 698,
+                                    "title": "Reconcile missing GitHub issues into Code Plans",
+                                    "url": "https://github.com/cbusillo/launchplane/issues/698",
+                                    "action": "would_add",
+                                }
+                            ],
+                        }
+                    )
+                ),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/work-graph/github/issues/reconcile",
+                payload={"mode": "dry_run"},
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["reconcile"]["mode"], "dry_run")
+        self.assertEqual(payload["result"]["reconcile"]["items"][0]["action"], "would_add")
+
+    def test_work_graph_issue_inbox_reconcile_apply_requires_reconcile_action(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": ["*"],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["work_graph.rank"],
+                    }
+                ]
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(
+                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
+                ),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+                work_graph_issue_inbox_reconcile_provider=lambda request: (
+                    GitHubIssueInboxReconcileResult.model_validate(
+                        {
+                            "generated_at": "2026-05-21T12:00:00Z",
+                            "mode": request.mode,
+                            "repository_count": 0,
+                            "issue_count": 0,
+                        }
+                    )
+                ),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/work-graph/github/issues/reconcile",
+                payload={"mode": "apply"},
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_work_graph_issue_inbox_reconcile_apply_returns_counts(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": ["*"],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["work_graph.issue_inbox.reconcile"],
+                    }
+                ]
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(
+                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
+                ),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+                work_graph_issue_inbox_reconcile_provider=lambda request: (
+                    GitHubIssueInboxReconcileResult.model_validate(
+                        {
+                            "generated_at": "2026-05-21T12:00:00Z",
+                            "mode": request.mode,
+                            "repository_count": 1,
+                            "issue_count": 1,
+                            "added_count": 1,
+                            "items": [
+                                {
+                                    "key": "cbusillo/launchplane#698",
+                                    "repository": "cbusillo/launchplane",
+                                    "number": 698,
+                                    "url": "https://github.com/cbusillo/launchplane/issues/698",
+                                    "action": "added",
+                                }
+                            ],
+                        }
+                    )
+                ),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/work-graph/github/issues/reconcile",
+                payload={"mode": "apply"},
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["reconcile"]["added_count"], 1)
+        self.assertEqual(payload["result"]["reconcile"]["items"][0]["action"], "added")
 
     def test_repo_product_mapping_returns_managed_and_awareness_repos(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(

--- a/tests/test_work_graph_issue_inbox.py
+++ b/tests/test_work_graph_issue_inbox.py
@@ -10,8 +10,10 @@ import click
 from control_plane.work_graph_github_projects import GitHubProjectPlanningFactsConfig
 from control_plane.work_graph_issue_inbox import (
     GitHubIssueInboxConfig,
+    GitHubIssueInboxReconcileRequest,
     build_github_issue_inbox_read_model,
     load_github_issue_inbox_config_from_env,
+    reconcile_github_issue_inbox,
 )
 from tests.test_work_graph_github_projects import _write_fake_gh_sequence
 
@@ -132,6 +134,240 @@ class GitHubIssueInboxTests(unittest.TestCase):
         self.assertEqual(inbox.issue_count, 0)
         self.assertEqual(inbox.repositories[0].repository, "cbusillo/launchplane")
         self.assertEqual(inbox.repositories[0].issues, ())
+
+    def test_reconcile_issue_inbox_dry_run_lists_missing_open_issues(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            directory = Path(temporary_directory_name)
+            fake_gh = _write_fake_gh_sequence(
+                directory,
+                responses=[
+                    {
+                        "stdout": {
+                            "items": [
+                                {
+                                    "content": {
+                                        "number": 7,
+                                        "repository": "cbusillo/launchplane",
+                                        "title": "Already planned",
+                                        "type": "Issue",
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "stdout": [
+                            {
+                                "number": 7,
+                                "title": "Already planned",
+                                "url": "https://github.com/cbusillo/launchplane/issues/7",
+                            },
+                            {
+                                "number": 8,
+                                "title": "Missing issue",
+                                "url": "https://github.com/cbusillo/launchplane/issues/8",
+                            },
+                        ]
+                    },
+                    {"stdout": []},
+                ],
+            )
+            result = reconcile_github_issue_inbox(
+                generated_at="2026-05-21T12:00:00Z",
+                config=GitHubIssueInboxConfig(
+                    repositories=("cbusillo/launchplane",),
+                    gh_binary=str(fake_gh),
+                    project_config=GitHubProjectPlanningFactsConfig(
+                        owner="cbusillo",
+                        project_number=4,
+                        gh_binary=str(fake_gh),
+                    ),
+                ),
+                request=GitHubIssueInboxReconcileRequest(mode="dry_run"),
+            )
+
+        self.assertEqual(result.mode, "dry_run")
+        self.assertEqual(result.would_add_count, 1)
+        self.assertEqual(result.items[0].key, "cbusillo/launchplane#8")
+        self.assertEqual(result.items[0].title, "Missing issue")
+        self.assertEqual(result.items[0].action, "would_add")
+
+    def test_reconcile_issue_inbox_apply_adds_missing_and_skips_duplicates(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            directory = Path(temporary_directory_name)
+            args_file = directory / "args.txt"
+            fake_gh = _write_fake_gh_sequence(
+                directory,
+                responses=[
+                    {"stdout": {"items": []}},
+                    {
+                        "stdout": [
+                            {
+                                "number": 8,
+                                "title": "Missing issue",
+                                "url": "https://github.com/cbusillo/launchplane/issues/8",
+                            },
+                            {
+                                "number": 9,
+                                "title": "Race already added",
+                                "url": "https://github.com/cbusillo/launchplane/issues/9",
+                            },
+                        ]
+                    },
+                    {
+                        "stdout": {
+                            "items": [
+                                {
+                                    "content": {
+                                        "number": 9,
+                                        "repository": "cbusillo/launchplane",
+                                        "type": "Issue",
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {"stdout": {"id": "PVTI_added"}},
+                ],
+            )
+            previous_args = os.environ.get("FAKE_GH_ARGS")
+            os.environ["FAKE_GH_ARGS"] = str(args_file)
+            try:
+                result = reconcile_github_issue_inbox(
+                    generated_at="2026-05-21T12:00:00Z",
+                    config=GitHubIssueInboxConfig(
+                        repositories=("cbusillo/launchplane",),
+                        gh_binary=str(fake_gh),
+                        project_config=GitHubProjectPlanningFactsConfig(
+                            owner="cbusillo",
+                            project_number=4,
+                            gh_binary=str(fake_gh),
+                        ),
+                    ),
+                    request=GitHubIssueInboxReconcileRequest(mode="apply"),
+                )
+            finally:
+                if previous_args is None:
+                    os.environ.pop("FAKE_GH_ARGS", None)
+                else:
+                    os.environ["FAKE_GH_ARGS"] = previous_args
+            recorded_args = args_file.read_text().splitlines()
+
+        self.assertEqual(result.added_count, 1)
+        self.assertEqual(result.already_present_count, 1)
+        actions_by_key = {item.key: item.action for item in result.items}
+        self.assertEqual(actions_by_key["cbusillo/launchplane#8"], "added")
+        self.assertEqual(actions_by_key["cbusillo/launchplane#9"], "already_present")
+        self.assertIn("item-add", recorded_args)
+        self.assertIn("https://github.com/cbusillo/launchplane/issues/8", recorded_args)
+
+    def test_reconcile_issue_inbox_apply_reports_partial_failure_with_redaction(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            directory = Path(temporary_directory_name)
+            fake_gh = _write_fake_gh_sequence(
+                directory,
+                responses=[
+                    {"stdout": {"items": []}},
+                    {
+                        "stdout": [
+                            {
+                                "number": 8,
+                                "title": "Missing issue",
+                                "url": "https://github.com/cbusillo/launchplane/issues/8",
+                            }
+                        ]
+                    },
+                    {"stdout": {"items": []}},
+                    {
+                        "stdout": {},
+                        "exit_code": 1,
+                        "stderr": "GraphQL failed for ghp_supersecret",
+                    },
+                ],
+            )
+            result = reconcile_github_issue_inbox(
+                generated_at="2026-05-21T12:00:00Z",
+                config=GitHubIssueInboxConfig(
+                    repositories=("cbusillo/launchplane",),
+                    gh_binary=str(fake_gh),
+                    project_config=GitHubProjectPlanningFactsConfig(
+                        owner="cbusillo",
+                        project_number=4,
+                        gh_binary=str(fake_gh),
+                    ),
+                ),
+                request=GitHubIssueInboxReconcileRequest(mode="apply"),
+            )
+
+        self.assertEqual(result.failed_count, 1)
+        self.assertEqual(result.items[0].action, "failed")
+        self.assertIn("[redacted]", result.items[0].detail)
+        self.assertNotIn("ghp_supersecret", result.items[0].detail)
+
+    def test_reconcile_issue_inbox_apply_reports_empty_and_already_present(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            directory = Path(temporary_directory_name)
+            fake_gh = _write_fake_gh_sequence(
+                directory,
+                responses=[
+                    {
+                        "stdout": {
+                            "items": [
+                                {
+                                    "content": {
+                                        "number": 8,
+                                        "repository": "cbusillo/launchplane",
+                                        "type": "Issue",
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "stdout": [
+                            {
+                                "number": 8,
+                                "title": "Already planned",
+                                "url": "https://github.com/cbusillo/launchplane/issues/8",
+                            }
+                        ]
+                    },
+                    {"stdout": []},
+                    {
+                        "stdout": {
+                            "items": [
+                                {
+                                    "content": {
+                                        "number": 8,
+                                        "repository": "cbusillo/launchplane",
+                                        "type": "Issue",
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                ],
+            )
+            result = reconcile_github_issue_inbox(
+                generated_at="2026-05-21T12:00:00Z",
+                config=GitHubIssueInboxConfig(
+                    repositories=("cbusillo/launchplane", "cbusillo/empty"),
+                    gh_binary=str(fake_gh),
+                    project_config=GitHubProjectPlanningFactsConfig(
+                        owner="cbusillo",
+                        project_number=4,
+                        gh_binary=str(fake_gh),
+                    ),
+                ),
+                request=GitHubIssueInboxReconcileRequest(mode="apply"),
+            )
+
+        self.assertEqual(result.repository_count, 2)
+        self.assertEqual(result.issue_count, 1)
+        self.assertEqual(result.added_count, 0)
+        self.assertEqual(result.already_present_count, 1)
+        self.assertEqual(result.failed_count, 0)
+        self.assertEqual(result.items[0].action, "already_present")
 
     def test_load_issue_inbox_config_from_env_parses_inventory_and_limit(self) -> None:
         config = load_github_issue_inbox_config_from_env(


### PR DESCRIPTION
## Summary
- add a read/apply reconciliation contract for the GitHub issue inbox into Code Plans
- expose `POST /v1/work-graph/github/issues/reconcile` with dry-run and apply modes
- grant the apply action to configured human operators and document the route

## Verification
- `uv run python -m unittest tests.test_work_graph_issue_inbox tests.test_service.LaunchplaneServiceTests.test_work_graph_issue_inbox_reconcile_dry_run_returns_missing_items tests.test_service.LaunchplaneServiceTests.test_work_graph_issue_inbox_reconcile_apply_requires_reconcile_action tests.test_service.LaunchplaneServiceTests.test_work_graph_issue_inbox_reconcile_apply_returns_counts`
- `uv run --extra dev mypy control_plane/work_graph_issue_inbox.py control_plane/work_graph_http.py control_plane/work_graph_service.py control_plane/service.py control_plane/service_auth.py tests/test_work_graph_issue_inbox.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/work_graph_issue_inbox.py control_plane/work_graph_http.py control_plane/work_graph_service.py control_plane/service.py control_plane/service_auth.py tests/test_work_graph_issue_inbox.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/work_graph_issue_inbox.py control_plane/work_graph_http.py control_plane/work_graph_service.py control_plane/service.py control_plane/service_auth.py tests/test_work_graph_issue_inbox.py tests/test_service.py`
- `bash -n scripts/deploy/ensure-authz-grants.sh && shellcheck scripts/deploy/ensure-authz-grants.sh`
- JetBrains changed-files inspection: existing warnings only in broad service/test files; no new reconciler errors surfaced

Refs #698
