### PR TITLE
Add GitHub issue inbox UI hygiene

### DIFF
--- a/control_plane/work_graph_github_projects.py
+++ b/control_plane/work_graph_github_projects.py
@@ -51,8 +51,14 @@ class GitHubProjectPlanningFactsConfig:
 def build_github_project_planning_facts(
     config: GitHubProjectPlanningFactsConfig,
 ) -> tuple[WorkGraphPlanningIssueFacts, ...]:
-    facts = _load_github_project_planning_facts(config)
+    facts = build_github_project_item_facts(config)
     return _enrich_planning_facts_with_github_signals(config=config, facts=facts)
+
+
+def build_github_project_item_facts(
+    config: GitHubProjectPlanningFactsConfig,
+) -> tuple[WorkGraphPlanningIssueFacts, ...]:
+    return _load_github_project_planning_facts(config)
 
 
 def build_github_project_issue_keys(
@@ -60,7 +66,7 @@ def build_github_project_issue_keys(
 ) -> tuple[str, ...]:
     return tuple(
         f"{fact.repository}#{fact.number}"
-        for fact in _load_github_project_planning_facts(config)
+        for fact in build_github_project_item_facts(config)
         if not fact.is_pull_request
     )
 

--- a/control_plane/work_graph_issue_inbox.py
+++ b/control_plane/work_graph_issue_inbox.py
@@ -10,8 +10,10 @@ from typing import Any, Literal
 import click
 from pydantic import BaseModel, ConfigDict, Field
 
+from control_plane.contracts.work_graph_read_model import WorkGraphPlanningIssueFacts
 from control_plane.work_graph_github_projects import (
     GitHubProjectPlanningFactsConfig,
+    build_github_project_item_facts,
     build_github_project_issue_keys,
     github_as_object,
     github_labels,
@@ -20,7 +22,7 @@ from control_plane.work_graph_github_projects import (
 )
 
 
-IssueInboxProjectStatus = Literal["present", "missing", "unconfigured"]
+IssueInboxProjectStatus = Literal["present", "missing", "stale", "closed", "unconfigured"]
 _REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
 
@@ -59,6 +61,7 @@ class GitHubIssueInboxReadModel(BaseModel):
     project_configured: bool = False
     repository_count: int = Field(ge=0)
     issue_count: int = Field(ge=0)
+    stale_project_item_count: int = Field(default=0, ge=0)
     repositories: tuple[GitHubIssueInboxRepositoryGroup, ...] = ()
 
 
@@ -142,7 +145,9 @@ def build_github_issue_inbox_read_model(
     generated_at: str,
     config: GitHubIssueInboxConfig,
 ) -> GitHubIssueInboxReadModel:
-    project_issue_keys = _project_issue_keys(config.project_config)
+    project_facts = _project_facts(config.project_config)
+    project_issue_keys = _project_issue_keys_from_facts(project_facts)
+    open_issue_keys: set[str] = set()
     project_configured = config.project_config is not None
     groups = tuple(
         _repository_group(
@@ -150,14 +155,23 @@ def build_github_issue_inbox_read_model(
             repository=repository,
             project_configured=project_configured,
             project_issue_keys=project_issue_keys,
+            open_issue_keys=open_issue_keys,
         )
         for repository in config.repositories
+    )
+    groups = _append_stale_project_items(
+        groups=groups,
+        project_facts=project_facts,
+        open_issue_keys=frozenset(open_issue_keys),
     )
     return GitHubIssueInboxReadModel(
         generated_at=generated_at,
         project_configured=project_configured,
         repository_count=len(groups),
         issue_count=sum(group.issue_count for group in groups),
+        stale_project_item_count=sum(
+            1 for group in groups for issue in group.issues if issue.project_status in {"stale", "closed"}
+        ),
         repositories=groups,
     )
 
@@ -216,6 +230,7 @@ def _repository_group(
     repository: str,
     project_configured: bool,
     project_issue_keys: frozenset[str],
+    open_issue_keys: set[str],
 ) -> GitHubIssueInboxRepositoryGroup:
     issues = tuple(
         sorted(
@@ -231,8 +246,78 @@ def _repository_group(
             key=lambda issue: issue.number,
         )
     )
+    open_issue_keys.update(issue.key.lower() for issue in issues)
     return GitHubIssueInboxRepositoryGroup(
         repository=repository,
+        issue_count=len(issues),
+        present_in_project_count=sum(1 for issue in issues if issue.present_in_project is True),
+        missing_from_project_count=sum(1 for issue in issues if issue.present_in_project is False),
+        issues=issues,
+    )
+
+
+def _append_stale_project_items(
+    *,
+    groups: tuple[GitHubIssueInboxRepositoryGroup, ...],
+    project_facts: tuple[WorkGraphPlanningIssueFacts, ...],
+    open_issue_keys: frozenset[str],
+) -> tuple[GitHubIssueInboxRepositoryGroup, ...]:
+    if not project_facts:
+        return groups
+    stale_by_repository: dict[str, list[GitHubIssueInboxIssue]] = {}
+    for fact in project_facts:
+        key = f"{fact.repository}#{fact.number}"
+        if fact.is_pull_request or key.lower() in open_issue_keys:
+            continue
+        state = str(fact.state or "closed")
+        project_status: IssueInboxProjectStatus = "closed" if fact.state == "closed" else "stale"
+        stale_by_repository.setdefault(fact.repository, []).append(
+            GitHubIssueInboxIssue(
+                key=key,
+                repository=fact.repository,
+                number=fact.number,
+                title=fact.title,
+                url=fact.url,
+                state=state,
+                labels=fact.labels,
+                updated_at=fact.updated_at,
+                project_status=project_status,
+                present_in_project=True,
+            )
+        )
+    if not stale_by_repository:
+        return groups
+    configured_repositories = {group.repository.lower() for group in groups}
+    updated_groups = [
+        _group_with_stale_items(group, stale_by_repository.pop(group.repository, []))
+        for group in groups
+    ]
+    for repository in sorted(stale_by_repository):
+        if repository.lower() in configured_repositories:
+            continue
+        updated_groups.append(
+            _group_with_stale_items(
+                GitHubIssueInboxRepositoryGroup(
+                    repository=repository,
+                    issue_count=0,
+                    present_in_project_count=0,
+                    missing_from_project_count=0,
+                ),
+                stale_by_repository[repository],
+            )
+        )
+    return tuple(updated_groups)
+
+
+def _group_with_stale_items(
+    group: GitHubIssueInboxRepositoryGroup,
+    stale_items: list[GitHubIssueInboxIssue],
+) -> GitHubIssueInboxRepositoryGroup:
+    if not stale_items:
+        return group
+    issues = tuple(sorted((*group.issues, *stale_items), key=lambda issue: issue.number))
+    return GitHubIssueInboxRepositoryGroup(
+        repository=group.repository,
         issue_count=len(issues),
         present_in_project_count=sum(1 for issue in issues if issue.present_in_project is True),
         missing_from_project_count=sum(1 for issue in issues if issue.present_in_project is False),
@@ -302,6 +387,24 @@ def _project_issue_keys(
     if project_config is None:
         return frozenset()
     return frozenset(key.lower() for key in build_github_project_issue_keys(project_config))
+
+
+def _project_facts(
+    project_config: GitHubProjectPlanningFactsConfig | None,
+) -> tuple[WorkGraphPlanningIssueFacts, ...]:
+    if project_config is None:
+        return ()
+    return build_github_project_item_facts(project_config)
+
+
+def _project_issue_keys_from_facts(
+    project_facts: tuple[WorkGraphPlanningIssueFacts, ...],
+) -> frozenset[str]:
+    return frozenset(
+        f"{fact.repository}#{fact.number}".lower()
+        for fact in project_facts
+        if not fact.is_pull_request
+    )
 
 
 def _apply_issue_reconcile_item(

--- a/docs/work-graph-read-model.md
+++ b/docs/work-graph-read-model.md
@@ -176,6 +176,12 @@ issue is marked with `present_in_project: true` and
 `project_status: "missing"`. Without Project env, issues use
 `project_status: "unconfigured"` and `present_in_project: null`.
 
+Project-only issue items that are no longer visible in the configured open issue
+inventory remain in the response for operator review. Closed items use
+`project_status: "closed"`; other Project-only items use
+`project_status: "stale"`. The route reports `stale_project_item_count` but does
+not remove or mutate Project items.
+
 Forks and private repositories are supported only through explicit inventory and
 the runtime `GH_TOKEN` permissions. Launchplane does not owner-wide search,
 fetch issue bodies, or infer product ownership from inbox membership.
@@ -190,7 +196,7 @@ POST /v1/work-graph/github/issues/reconcile
 The request is a small mode selector:
 
 ```json
-{"mode": "dry_run"}
+{ "mode": "dry_run" }
 ```
 
 `dry_run` uses `work_graph.rank` authorization and returns the missing open

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,7 @@ import {
   Sun,
   XCircle,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   LaunchplaneApiError,
   listEveryCodeWorkRequests,
@@ -23,9 +23,11 @@ import {
   listProducts,
   listProductProfiles,
   logout,
+  readGitHubIssueInbox,
   readAuthSession,
   readDriverView,
   readProductEnvironmentConfigStatus,
+  reconcileGitHubIssueInbox,
 } from "./api";
 import { ApiErrorPanel, AuthPanel } from "./AuthPanels";
 import { formatTime, labelForStatus } from "./format";
@@ -64,6 +66,10 @@ import type {
   DriverDescriptor,
   DriverView,
   EveryCodeWorkRequestRecord,
+  GitHubIssueInbox,
+  GitHubIssueInboxIssue,
+  GitHubIssueInboxReconcileMode,
+  GitHubIssueInboxReconcileSummary,
   GenericWebProdPromotionPayload,
   GenericWebPromotionWorkflowPayload,
   GenericWebPromotionWorkflowRequest,
@@ -218,6 +224,33 @@ export function App() {
   const [workGraphFilter, setWorkGraphFilter] =
     useState<WorkGraphFilter>("all");
   const [workGraphMode, setWorkGraphMode] = useState<WorkGraphMode>("all");
+  const [issueInbox, setIssueInbox] = useState<GitHubIssueInbox | null>(null);
+  const [issueInboxError, setIssueInboxError] = useState("");
+  const refreshIssueInbox = useCallback(async (signal?: AbortSignal) => {
+    setIssueInboxError("");
+    try {
+      const payload = await readGitHubIssueInbox(signal);
+      if (signal?.aborted) {
+        return;
+      }
+      setIssueInbox(payload.inbox);
+    } catch (apiError) {
+      if (signal?.aborted) {
+        return;
+      }
+      setIssueInbox(null);
+      if (
+        apiError instanceof LaunchplaneApiError &&
+        apiError.statusCode === 404
+      ) {
+        setIssueInboxError("");
+      } else if (apiError instanceof Error) {
+        setIssueInboxError(apiError.message);
+      } else {
+        setIssueInboxError("GitHub issue inbox request failed.");
+      }
+    }
+  }, []);
   const { choices, selected, setSelected } = useProductSelection({
     drivers,
     productProfiles,
@@ -292,6 +325,8 @@ export function App() {
       setConfigStatusError("");
       setWorkRequests([]);
       resetWorkGraph();
+      setIssueInbox(null);
+      setIssueInboxError("");
       setProdView(null);
       setTestingView(null);
       setPreviewView(null);
@@ -350,6 +385,7 @@ export function App() {
           setProductOverviews(productsPayload.products);
           setWorkRequests(workRequestsPayload.requests);
           await refreshWorkGraph(controller.signal);
+          await refreshIssueInbox(controller.signal);
         },
       )
       .catch((apiError: unknown) => {
@@ -372,7 +408,14 @@ export function App() {
       });
 
     return () => controller.abort();
-  }, [authStatus, selected, refreshKey, refreshWorkGraph, resetWorkGraph]);
+  }, [
+    authStatus,
+    selected,
+    refreshKey,
+    refreshWorkGraph,
+    refreshIssueInbox,
+    resetWorkGraph,
+  ]);
 
   useEffect(() => {
     if (authStatus !== "signed_in" || !selectedProductOverview) {
@@ -538,6 +581,8 @@ export function App() {
               workGraphItems={workGraphItems}
               workGraphHiddenCount={workGraphHiddenCount}
               workGraphError={workGraphError}
+              issueInbox={issueInbox}
+              issueInboxError={issueInboxError}
               workGraphFilter={workGraphFilter}
               workGraphMode={workGraphMode}
               loading={loading}
@@ -546,6 +591,10 @@ export function App() {
               }
               onWorkGraphFilterChange={setWorkGraphFilter}
               onWorkGraphModeChange={setWorkGraphMode}
+              onRefreshIssueInbox={() => void refreshIssueInbox()}
+              reconcileIssueInbox={async (mode, signal) =>
+                reconcileGitHubIssueInbox(mode, signal)
+              }
             />
             <ProductOverviewShell
               product={selectedProductOverview}
@@ -1348,6 +1397,69 @@ function StateFixtureGallery({
       ],
     },
   ];
+  const fixtureIssueInbox: GitHubIssueInbox = {
+    schema_version: 1,
+    generated_at: "2026-05-21T12:30:00Z",
+    project_configured: true,
+    repository_count: 3,
+    issue_count: 5,
+    stale_project_item_count: 2,
+    repositories: [
+      {
+        repository: "cbusillo/launchplane",
+        issue_count: 3,
+        present_in_project_count: 2,
+        missing_from_project_count: 1,
+        issues: [
+          fixtureInboxIssue({
+            number: 697,
+            title: "Add read-only grouped GitHub issue inbox",
+            projectStatus: "present",
+          }),
+          fixtureInboxIssue({
+            number: 698,
+            title: "Reconcile missing GitHub issues into Code Plans",
+            projectStatus: "missing",
+          }),
+          fixtureInboxIssue({
+            number: 601,
+            title: "Retired Code Plans follow-up",
+            projectStatus: "closed",
+            state: "closed",
+          }),
+        ],
+      },
+      {
+        repository: "cbusillo/codex-skills",
+        issue_count: 1,
+        present_in_project_count: 1,
+        missing_from_project_count: 0,
+        issues: [
+          fixtureInboxIssue({
+            repository: "cbusillo/codex-skills",
+            number: 127,
+            title: "Update Launchplane merge train guidance",
+            projectStatus: "present",
+          }),
+        ],
+      },
+      {
+        repository: "cbusillo/side-repo-with-a-long-name-for-mobile-layout",
+        issue_count: 1,
+        present_in_project_count: 1,
+        missing_from_project_count: 0,
+        issues: [
+          fixtureInboxIssue({
+            repository: "cbusillo/side-repo-with-a-long-name-for-mobile-layout",
+            number: 12,
+            title:
+              "Project item no longer appears in the configured open issue inventory",
+            projectStatus: "stale",
+          }),
+        ],
+      },
+    ],
+  };
 
   return (
     <section className="fixture-gallery">
@@ -1363,12 +1475,16 @@ function StateFixtureGallery({
           workGraphItems={fixtureWorkGraphItems}
           workGraphHiddenCount={2}
           workGraphError=""
+          issueInbox={fixtureIssueInbox}
+          issueInboxError=""
           workGraphFilter={fixtureWorkGraphFilter}
           workGraphMode={fixtureWorkGraphMode}
           loading={false}
           onSelectProduct={() => undefined}
           onWorkGraphFilterChange={setFixtureWorkGraphFilter}
           onWorkGraphModeChange={setFixtureWorkGraphMode}
+          onRefreshIssueInbox={() => undefined}
+          reconcileIssueInbox={fixtureReconcileIssueInbox}
           readMergeTrainStatus={fixtureMergeTrainControllerStatus}
           readMergeTrainPolicyTargets={fixtureMergeTrainPolicyTargets}
         />
@@ -1585,6 +1701,74 @@ function fixtureMergeTrainControllerStatus(
       ],
     },
   });
+}
+
+function fixtureInboxIssue({
+  repository = "cbusillo/launchplane",
+  number,
+  title,
+  projectStatus,
+  state = "open",
+}: {
+  repository?: string;
+  number: number;
+  title: string;
+  projectStatus: GitHubIssueInboxIssue["project_status"];
+  state?: string;
+}): GitHubIssueInboxIssue {
+  return {
+    key: `${repository}#${number}`,
+    repository,
+    number,
+    title,
+    url: `https://github.com/${repository}/issues/${number}`,
+    state,
+    labels: ["plan"],
+    author: projectStatus === "stale" ? "automation-gh" : "code",
+    created_at: "2026-05-20T12:00:00Z",
+    updated_at: "2026-05-21T12:00:00Z",
+    project_status: projectStatus,
+    present_in_project:
+      projectStatus !== "missing" && projectStatus !== "unconfigured",
+  };
+}
+
+function fixtureReconcileIssueInbox(
+  mode: GitHubIssueInboxReconcileMode,
+): Promise<{ result: { reconcile: GitHubIssueInboxReconcileSummary } }> {
+  const summary: GitHubIssueInboxReconcileSummary = {
+    schema_version: 1,
+    generated_at: "2026-05-21T12:32:00Z",
+    mode,
+    repository_count: 3,
+    issue_count: 5,
+    added_count: mode === "apply" ? 1 : 0,
+    already_present_count: mode === "apply" ? 2 : 0,
+    skipped_count: 0,
+    failed_count: mode === "apply" ? 1 : 0,
+    would_add_count: mode === "dry_run" ? 1 : 0,
+    items: [
+      {
+        key: "cbusillo/launchplane#698",
+        repository: "cbusillo/launchplane",
+        number: 698,
+        title: "Reconcile missing GitHub issues into Code Plans",
+        url: "https://github.com/cbusillo/launchplane/issues/698",
+        action: mode === "dry_run" ? "would_add" : "added",
+        detail: "",
+      },
+      {
+        key: "cbusillo/private-repo#44",
+        repository: "cbusillo/private-repo",
+        number: 44,
+        title: "Project write denied for fixture",
+        url: "https://github.com/cbusillo/private-repo/issues/44",
+        action: mode === "dry_run" ? "would_add" : "failed",
+        detail: mode === "apply" ? "GitHub CLI returned 403." : "",
+      },
+    ],
+  };
+  return Promise.resolve({ result: { reconcile: summary } });
 }
 
 function fixtureMergeTrainPolicyTargets() {

--- a/frontend/src/GitHubIssueInboxPanel.tsx
+++ b/frontend/src/GitHubIssueInboxPanel.tsx
@@ -1,0 +1,248 @@
+import { FolderGit2, PlusCircle, RefreshCw, SearchCheck } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { formatTime } from "./format";
+import { SkeletonRows, StateBlock, StatusIcon, StatusPill } from "./status-ui";
+import type {
+  GitHubIssueInbox,
+  GitHubIssueInboxProjectStatus,
+  GitHubIssueInboxReconcileMode,
+  GitHubIssueInboxReconcileSummary,
+  Status,
+} from "./types";
+
+type ReconcileReader = (
+  mode: GitHubIssueInboxReconcileMode,
+  signal?: AbortSignal,
+) => Promise<{ result: { reconcile: GitHubIssueInboxReconcileSummary } }>;
+
+export function GitHubIssueInboxPanel({
+  inbox,
+  loading,
+  error,
+  onRefresh,
+  reconcile,
+}: {
+  inbox: GitHubIssueInbox | null;
+  loading: boolean;
+  error: string;
+  onRefresh: () => void;
+  reconcile?: ReconcileReader;
+}) {
+  const [lastSummary, setLastSummary] =
+    useState<GitHubIssueInboxReconcileSummary | null>(null);
+  const [actionError, setActionError] = useState("");
+  const [runningMode, setRunningMode] =
+    useState<GitHubIssueInboxReconcileMode | null>(null);
+  const counts = useMemo(() => inboxCounts(inbox), [inbox]);
+  const status: Status | string = error
+    ? "fail"
+    : counts.stale || counts.missing
+      ? "pending"
+      : inbox?.project_configured
+        ? "pass"
+        : "unknown";
+  const canReconcile = Boolean(inbox?.project_configured && reconcile);
+
+  async function runReconcile(mode: GitHubIssueInboxReconcileMode) {
+    if (!reconcile || runningMode) {
+      return;
+    }
+    setRunningMode(mode);
+    setActionError("");
+    const controller = new AbortController();
+    try {
+      const payload = await reconcile(mode, controller.signal);
+      setLastSummary(payload.result.reconcile);
+    } catch (apiError) {
+      if (apiError instanceof Error) {
+        setActionError(apiError.message);
+      } else {
+        setActionError("GitHub issue inbox reconciliation failed.");
+      }
+    } finally {
+      setRunningMode(null);
+    }
+  }
+
+  return (
+    <div className="github-issue-inbox">
+      <div className="queue-head github-inbox-head">
+        <span>GitHub inbox</span>
+        <strong>{inbox ? `${inbox.issue_count} visible` : "unknown"}</strong>
+        <StatusPill status={status} />
+      </div>
+      <div
+        className="github-inbox-actions"
+        aria-label="GitHub issue inbox actions"
+      >
+        <button type="button" onClick={onRefresh} disabled={loading}>
+          <RefreshCw size={15} aria-hidden="true" />
+          Refresh
+        </button>
+        <button
+          type="button"
+          onClick={() => void runReconcile("dry_run")}
+          disabled={!canReconcile || runningMode !== null}
+        >
+          <SearchCheck size={15} aria-hidden="true" />
+          Dry run
+        </button>
+        <button
+          type="button"
+          onClick={() => void runReconcile("apply")}
+          disabled={!canReconcile || runningMode !== null}
+        >
+          <PlusCircle size={15} aria-hidden="true" />
+          Apply
+        </button>
+      </div>
+      {loading && !inbox ? <SkeletonRows /> : null}
+      {error ? (
+        <StateBlock icon={<FolderGit2 size={18} />} title={error} />
+      ) : null}
+      {!loading && !error && !inbox ? (
+        <StateBlock
+          icon={<FolderGit2 size={18} />}
+          title="Inbox not configured"
+        />
+      ) : null}
+      {inbox ? (
+        <>
+          <div className="github-inbox-summary">
+            <span>
+              <strong>{inbox.repository_count}</strong>
+              repos
+            </span>
+            <span>
+              <strong>{counts.present}</strong>
+              present
+            </span>
+            <span>
+              <strong>{counts.missing}</strong>
+              missing
+            </span>
+            <span>
+              <strong>{counts.stale}</strong>
+              stale
+            </span>
+          </div>
+          <div className="github-inbox-sync">
+            <span>Last sync</span>
+            <strong>{formatTime(inbox.generated_at)}</strong>
+          </div>
+        </>
+      ) : null}
+      {lastSummary ? <ReconcileSummary summary={lastSummary} /> : null}
+      {actionError ? (
+        <StateBlock icon={<FolderGit2 size={18} />} title={actionError} />
+      ) : null}
+      {inbox?.repositories.map((repository) => (
+        <div className="github-inbox-group" key={repository.repository}>
+          <div className="github-inbox-group-head">
+            <code>{repository.repository}</code>
+            <span>{repository.issue_count} issues</span>
+          </div>
+          {repository.issues.length ? (
+            repository.issues.map((issue) => (
+              <a
+                className="github-inbox-row"
+                href={issue.url || undefined}
+                key={issue.key}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <span className="github-inbox-title">
+                  <strong>{issue.title || issue.key}</strong>
+                  <code>{issue.key}</code>
+                </span>
+                <span className="github-inbox-meta">
+                  <span>{issue.author || "unknown"}</span>
+                  <span>{formatTime(issue.updated_at)}</span>
+                  <IssueInboxStatusPill status={issue.project_status} />
+                </span>
+              </a>
+            ))
+          ) : (
+            <StateBlock
+              icon={<FolderGit2 size={18} />}
+              title="No open issues"
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ReconcileSummary({
+  summary,
+}: {
+  summary: GitHubIssueInboxReconcileSummary;
+}) {
+  const failureItems = summary.items.filter((item) => item.action === "failed");
+  return (
+    <div className="github-inbox-reconcile-summary">
+      <div>
+        <strong>{summary.mode.replace("_", " ")}</strong>
+        <span>{formatTime(summary.generated_at)}</span>
+      </div>
+      <div className="github-inbox-summary github-inbox-summary-compact">
+        <span>{summary.would_add_count} would add</span>
+        <span>{summary.added_count} added</span>
+        <span>{summary.already_present_count} present</span>
+        <span>{summary.failed_count} failed</span>
+      </div>
+      {failureItems.slice(0, 3).map((item) => (
+        <code className="github-inbox-failure" key={item.key}>
+          {item.key}: {item.detail || "failed"}
+        </code>
+      ))}
+    </div>
+  );
+}
+
+function IssueInboxStatusPill({
+  status,
+}: {
+  status: GitHubIssueInboxProjectStatus;
+}) {
+  const visualStatus = issueInboxVisualStatus(status);
+  return (
+    <span className="status-pill" data-status={visualStatus}>
+      <StatusIcon status={visualStatus} />
+      {status}
+    </span>
+  );
+}
+
+function issueInboxVisualStatus(status: GitHubIssueInboxProjectStatus): Status {
+  if (status === "present") {
+    return "pass";
+  }
+  if (status === "missing") {
+    return "pending";
+  }
+  if (status === "closed") {
+    return "blocked";
+  }
+  if (status === "stale") {
+    return "unknown";
+  }
+  return "skipped";
+}
+
+function inboxCounts(inbox: GitHubIssueInbox | null) {
+  const issues =
+    inbox?.repositories.flatMap((repository) => repository.issues) ?? [];
+  return {
+    present: issues.filter((issue) => issue.project_status === "present")
+      .length,
+    missing: issues.filter((issue) => issue.project_status === "missing")
+      .length,
+    stale: issues.filter(
+      (issue) =>
+        issue.project_status === "stale" || issue.project_status === "closed",
+    ).length,
+  };
+}

--- a/frontend/src/ProductInventoryCockpit.tsx
+++ b/frontend/src/ProductInventoryCockpit.tsx
@@ -1,6 +1,7 @@
 import { PanelsTopLeft } from "lucide-react";
 
 import { EveryCodeQueue } from "./EveryCodeQueue";
+import { GitHubIssueInboxPanel } from "./GitHubIssueInboxPanel";
 import { MergeTrainControllerPanel } from "./MergeTrainControllerPanel";
 import { MetricTile, PanelHead } from "./panel-ui";
 import { StateBlock, SkeletonRows, StatusPill } from "./status-ui";
@@ -8,6 +9,9 @@ import { TrustBadge } from "./TrustBadge";
 
 import type {
   EveryCodeWorkRequestRecord,
+  GitHubIssueInbox,
+  GitHubIssueInboxReconcileMode,
+  GitHubIssueInboxReconcileSummary,
   ProductSiteOverview,
   MergeTrainControllerStatus,
   MergeTrainPolicyTarget,
@@ -26,12 +30,16 @@ export function ProductInventoryCockpit({
   workGraphItems,
   workGraphHiddenCount,
   workGraphError,
+  issueInbox,
+  issueInboxError,
   workGraphFilter,
   workGraphMode,
   loading,
   onSelectProduct,
   onWorkGraphFilterChange,
   onWorkGraphModeChange,
+  onRefreshIssueInbox,
+  reconcileIssueInbox,
   readMergeTrainStatus,
   readMergeTrainPolicyTargets,
 }: {
@@ -41,12 +49,19 @@ export function ProductInventoryCockpit({
   workGraphItems: WorkGraphQueueItem[];
   workGraphHiddenCount: number;
   workGraphError: string;
+  issueInbox: GitHubIssueInbox | null;
+  issueInboxError: string;
   workGraphFilter: WorkGraphFilter;
   workGraphMode: WorkGraphMode;
   loading: boolean;
   onSelectProduct: (product: ProductSiteOverview) => void;
   onWorkGraphFilterChange: (filter: WorkGraphFilter) => void;
   onWorkGraphModeChange: (mode: WorkGraphMode) => void;
+  onRefreshIssueInbox: () => void;
+  reconcileIssueInbox?: (
+    mode: GitHubIssueInboxReconcileMode,
+    signal?: AbortSignal,
+  ) => Promise<{ result: { reconcile: GitHubIssueInboxReconcileSummary } }>;
   readMergeTrainStatus?: (
     repository: string,
     baseBranch: string,
@@ -157,6 +172,13 @@ export function ProductInventoryCockpit({
         loading={loading}
         onFilterChange={onWorkGraphFilterChange}
         onModeChange={onWorkGraphModeChange}
+      />
+      <GitHubIssueInboxPanel
+        inbox={issueInbox}
+        loading={loading}
+        error={issueInboxError}
+        onRefresh={onRefreshIssueInbox}
+        reconcile={reconcileIssueInbox}
       />
       <MergeTrainControllerPanel
         products={products}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -9,6 +9,9 @@ import type {
   GenericWebProdPromotionRequest,
   GenericWebPromotionWorkflowPayload,
   GenericWebPromotionWorkflowRequest,
+  GitHubIssueInboxPayload,
+  GitHubIssueInboxReconcileMode,
+  GitHubIssueInboxReconcilePayload,
   LogoutPayload,
   MergeTrainControllerStatusPayload,
   MergeTrainPolicyTargetsPayload,
@@ -160,6 +163,29 @@ export function rankWorkGraphSnapshot(
     snapshot,
     limit,
   });
+}
+
+export function readGitHubIssueInbox(
+  signal?: AbortSignal,
+): Promise<GitHubIssueInboxPayload> {
+  return requestJson<GitHubIssueInboxPayload>(
+    "/v1/work-graph/github/issues",
+    "GET",
+    undefined,
+    signal,
+  );
+}
+
+export function reconcileGitHubIssueInbox(
+  mode: GitHubIssueInboxReconcileMode,
+  signal?: AbortSignal,
+): Promise<GitHubIssueInboxReconcilePayload> {
+  return requestJson<GitHubIssueInboxReconcilePayload>(
+    "/v1/work-graph/github/issues/reconcile",
+    "POST",
+    { mode },
+    signal,
+  );
 }
 
 export function readMergeTrainControllerStatus(

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -10,9 +10,12 @@
   --fg-strong: #ffffff;
   --fg-muted: #a3a8b0;
   --fg-faint: #747b85;
+  --panel: #15171a;
+  --accent: #6e9bd9;
   --lane-prod: #4fb286;
   --lane-testing: #d4a24a;
   --lane-preview: #6e9bd9;
+  --status-pass: #4fb286;
   --status-ok: #4fb286;
   --status-warn: #d4a24a;
   --status-fail: #d8736b;
@@ -291,9 +294,10 @@ p {
 
 .operator-cockpit {
   display: grid;
-  grid-template-columns:
-    minmax(220px, 0.64fr) minmax(280px, 1.08fr) minmax(280px, 1fr)
-    minmax(280px, 1fr) minmax(260px, 0.82fr);
+  grid-template-columns: minmax(220px, 0.65fr) minmax(280px, 1.05fr) repeat(
+      2,
+      minmax(300px, 1fr)
+    );
   gap: 1px;
   overflow: hidden;
   border: 1px solid var(--hair);
@@ -303,6 +307,7 @@ p {
 .cockpit-summary,
 .product-inventory-table,
 .work-graph-queue,
+.github-issue-inbox,
 .merge-train-panel,
 .every-code-queue {
   min-width: 0;
@@ -323,6 +328,7 @@ p {
 
 .product-inventory-table,
 .work-graph-queue,
+.github-issue-inbox,
 .merge-train-panel,
 .every-code-queue {
   display: grid;
@@ -549,6 +555,175 @@ p {
 
 .work-graph-hidden {
   color: var(--fg-faint);
+}
+
+.github-issue-inbox {
+  max-height: 620px;
+  overflow: auto;
+}
+
+.github-inbox-head {
+  grid-template-columns: auto 1fr auto;
+}
+
+.github-inbox-actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.github-inbox-actions button {
+  display: inline-flex;
+  min-width: 0;
+  min-height: 32px;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 1px solid var(--hair);
+  border-radius: 6px;
+  background: var(--bg-2);
+  color: var(--fg);
+  font-size: 11px;
+}
+
+.github-inbox-actions button:disabled {
+  opacity: 0.52;
+}
+
+.github-inbox-summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.github-inbox-summary span {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+  border: 1px solid var(--hair-soft);
+  border-radius: 6px;
+  background: var(--bg-2);
+  color: var(--fg-faint);
+  padding: 7px 8px;
+  font-size: 11px;
+}
+
+.github-inbox-summary strong {
+  color: var(--fg-strong);
+  font-family: var(--font-mono);
+}
+
+.github-inbox-sync {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  border: 1px solid var(--hair-soft);
+  border-radius: 6px;
+  background: var(--bg-2);
+  color: var(--fg-faint);
+  padding: 7px 8px;
+  font-size: 11px;
+}
+
+.github-inbox-sync strong {
+  overflow: hidden;
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.github-inbox-summary-compact span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.github-inbox-reconcile-summary,
+.github-inbox-group {
+  display: grid;
+  min-width: 0;
+  gap: 7px;
+  border: 1px solid var(--hair-soft);
+  border-radius: 6px;
+  background: var(--bg-2);
+  padding: 8px;
+}
+
+.github-inbox-reconcile-summary > div:first-child,
+.github-inbox-group-head {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.github-inbox-reconcile-summary strong,
+.github-inbox-group-head code {
+  overflow: hidden;
+  color: var(--fg-strong);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.github-inbox-reconcile-summary span,
+.github-inbox-group-head span {
+  color: var(--fg-faint);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.github-inbox-failure {
+  overflow: hidden;
+  color: var(--status-fail);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.github-inbox-row {
+  display: grid;
+  min-width: 0;
+  gap: 6px;
+  border: 1px solid var(--hair-soft);
+  border-radius: 6px;
+  background: var(--bg-1);
+  color: var(--fg);
+  padding: 8px;
+}
+
+.github-inbox-title {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.github-inbox-title strong,
+.github-inbox-title code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.github-inbox-title strong {
+  color: var(--fg-strong);
+}
+
+.github-inbox-title code {
+  color: var(--fg-muted);
+}
+
+.github-inbox-meta {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px 8px;
+  color: var(--fg-faint);
+  font-size: 11px;
 }
 
 .merge-train-panel {
@@ -2373,7 +2548,9 @@ p {
   .cockpit-metrics,
   .product-inventory-row,
   .queue-row,
-  .work-graph-row {
+  .work-graph-row,
+  .github-inbox-actions,
+  .github-inbox-summary {
     grid-template-columns: minmax(0, 1fr);
     align-items: start;
   }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -814,6 +814,93 @@ export interface WorkGraphRankPayload {
   };
 }
 
+export type GitHubIssueInboxProjectStatus =
+  | "present"
+  | "missing"
+  | "stale"
+  | "closed"
+  | "unconfigured";
+
+export interface GitHubIssueInboxIssue {
+  key: string;
+  repository: string;
+  number: number;
+  title: string;
+  url: string;
+  state: string;
+  labels: string[];
+  author: string;
+  created_at: string;
+  updated_at: string;
+  project_status: GitHubIssueInboxProjectStatus;
+  present_in_project: boolean | null;
+}
+
+export interface GitHubIssueInboxRepositoryGroup {
+  repository: string;
+  issue_count: number;
+  present_in_project_count: number;
+  missing_from_project_count: number;
+  issues: GitHubIssueInboxIssue[];
+}
+
+export interface GitHubIssueInbox {
+  schema_version: number;
+  generated_at: string;
+  project_configured: boolean;
+  repository_count: number;
+  issue_count: number;
+  stale_project_item_count: number;
+  repositories: GitHubIssueInboxRepositoryGroup[];
+}
+
+export interface GitHubIssueInboxPayload {
+  status: "ok";
+  trace_id: string;
+  configured: boolean;
+  inbox: GitHubIssueInbox | null;
+}
+
+export type GitHubIssueInboxReconcileMode = "dry_run" | "apply";
+export type GitHubIssueInboxReconcileAction =
+  | "would_add"
+  | "added"
+  | "already_present"
+  | "failed"
+  | "skipped";
+
+export interface GitHubIssueInboxReconcileItem {
+  key: string;
+  repository: string;
+  number: number;
+  title: string;
+  url: string;
+  action: GitHubIssueInboxReconcileAction;
+  detail: string;
+}
+
+export interface GitHubIssueInboxReconcileSummary {
+  schema_version: number;
+  generated_at: string;
+  mode: GitHubIssueInboxReconcileMode;
+  repository_count: number;
+  issue_count: number;
+  added_count: number;
+  already_present_count: number;
+  skipped_count: number;
+  failed_count: number;
+  would_add_count: number;
+  items: GitHubIssueInboxReconcileItem[];
+}
+
+export interface GitHubIssueInboxReconcilePayload {
+  status: "accepted";
+  trace_id: string;
+  result: {
+    reconcile: GitHubIssueInboxReconcileSummary;
+  };
+}
+
 export interface MergeTrainAdmissionDecision {
   schema_version: number;
   repository: string;

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -9204,12 +9204,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "generated_at": "2026-05-21T12:00:00Z",
                         "project_configured": True,
                         "repository_count": 1,
-                        "issue_count": 1,
+                        "issue_count": 2,
+                        "stale_project_item_count": 1,
                         "repositories": [
                             {
                                 "repository": "cbusillo/launchplane",
-                                "issue_count": 1,
-                                "present_in_project_count": 0,
+                                "issue_count": 2,
+                                "present_in_project_count": 1,
                                 "missing_from_project_count": 1,
                                 "issues": [
                                     {
@@ -9221,6 +9222,16 @@ class LaunchplaneServiceTests(unittest.TestCase):
                                         "state": "OPEN",
                                         "project_status": "missing",
                                         "present_in_project": False,
+                                    },
+                                    {
+                                        "key": "cbusillo/launchplane#601",
+                                        "repository": "cbusillo/launchplane",
+                                        "number": 601,
+                                        "title": "Closed Project item",
+                                        "url": "https://github.com/cbusillo/launchplane/issues/601",
+                                        "state": "closed",
+                                        "project_status": "closed",
+                                        "present_in_project": True,
                                     }
                                 ],
                             }
@@ -9238,8 +9249,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertTrue(payload["configured"])
         inbox = payload["inbox"]
         self.assertEqual(inbox["repository_count"], 1)
+        self.assertEqual(inbox["stale_project_item_count"], 1)
         self.assertEqual(inbox["repositories"][0]["issues"][0]["key"], "cbusillo/launchplane#697")
         self.assertIs(inbox["repositories"][0]["issues"][0]["present_in_project"], False)
+        self.assertEqual(inbox["repositories"][0]["issues"][1]["project_status"], "closed")
 
     def test_work_graph_issue_inbox_rejects_unauthorized_identity(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_work_graph_issue_inbox.py
+++ b/tests/test_work_graph_issue_inbox.py
@@ -66,6 +66,21 @@ class GitHubIssueInboxTests(unittest.TestCase):
                         ]
                     },
                     {"stdout": []},
+                    {
+                        "stdout": {
+                            "items": [
+                                {
+                                    "content": {
+                                        "number": 7,
+                                        "repository": "cbusillo/launchplane",
+                                        "title": "Inbox item",
+                                        "type": "Issue",
+                                        "url": "https://github.com/cbusillo/launchplane/issues/7",
+                                    }
+                                }
+                            ]
+                        }
+                    },
                 ],
             )
             previous_args = os.environ.get("FAKE_GH_ARGS")
@@ -135,6 +150,91 @@ class GitHubIssueInboxTests(unittest.TestCase):
         self.assertEqual(inbox.repositories[0].repository, "cbusillo/launchplane")
         self.assertEqual(inbox.repositories[0].issues, ())
 
+    def test_build_issue_inbox_surfaces_project_only_closed_and_stale_items(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            directory = Path(temporary_directory_name)
+            fake_gh = _write_fake_gh_sequence(
+                directory,
+                responses=[
+                    {
+                        "stdout": {
+                            "items": [
+                                {
+                                    "content": {
+                                        "number": 7,
+                                        "repository": "cbusillo/launchplane",
+                                        "title": "Closed plan",
+                                        "type": "Issue",
+                                        "url": "https://github.com/cbusillo/launchplane/issues/7",
+                                    },
+                                    "status": "Done",
+                                },
+                                {
+                                    "content": {
+                                        "number": 12,
+                                        "repository": "cbusillo/side-repo",
+                                        "title": "Untracked repository item",
+                                        "type": "Issue",
+                                        "url": "https://github.com/cbusillo/side-repo/issues/12",
+                                    },
+                                    "status": "In Progress",
+                                },
+                            ]
+                        }
+                    },
+                    {"stdout": []},
+                    {
+                        "stdout": {
+                            "items": [
+                                {
+                                    "content": {
+                                        "number": 7,
+                                        "repository": "cbusillo/launchplane",
+                                        "title": "Closed plan",
+                                        "type": "Issue",
+                                        "url": "https://github.com/cbusillo/launchplane/issues/7",
+                                    },
+                                    "status": "Done",
+                                },
+                                {
+                                    "content": {
+                                        "number": 12,
+                                        "repository": "cbusillo/side-repo",
+                                        "title": "Untracked repository item",
+                                        "type": "Issue",
+                                        "url": "https://github.com/cbusillo/side-repo/issues/12",
+                                    },
+                                    "status": "In Progress",
+                                },
+                            ]
+                        }
+                    },
+                ],
+            )
+            inbox = build_github_issue_inbox_read_model(
+                generated_at="2026-05-21T12:00:00Z",
+                config=GitHubIssueInboxConfig(
+                    repositories=("cbusillo/launchplane",),
+                    gh_binary=str(fake_gh),
+                    project_config=GitHubProjectPlanningFactsConfig(
+                        owner="cbusillo",
+                        project_number=4,
+                        gh_binary=str(fake_gh),
+                    ),
+                ),
+            )
+
+        self.assertEqual(inbox.repository_count, 2)
+        self.assertEqual(inbox.stale_project_item_count, 2)
+        issues = {
+            issue.key: issue
+            for repository_group in inbox.repositories
+            for issue in repository_group.issues
+        }
+        self.assertEqual(issues["cbusillo/launchplane#7"].project_status, "closed")
+        self.assertEqual(issues["cbusillo/side-repo#12"].project_status, "stale")
+        self.assertTrue(issues["cbusillo/side-repo#12"].present_in_project)
+
     def test_reconcile_issue_inbox_dry_run_lists_missing_open_issues(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             directory = Path(temporary_directory_name)
@@ -170,6 +270,20 @@ class GitHubIssueInboxTests(unittest.TestCase):
                         ]
                     },
                     {"stdout": []},
+                    {
+                        "stdout": {
+                            "items": [
+                                {
+                                    "content": {
+                                        "number": 7,
+                                        "repository": "cbusillo/launchplane",
+                                        "title": "Already planned",
+                                        "type": "Issue",
+                                    }
+                                }
+                            ]
+                        }
+                    },
                 ],
             )
             result = reconcile_github_issue_inbox(


### PR DESCRIPTION
## Summary
- surface grouped GitHub issue inbox state in the operator cockpit, including present/missing/stale/closed Project status
- show last sync plus dry-run/apply reconciliation counts and failure details
- retain closed/stale Project-only items in the read model for operator review without automatic removal

## Verification
- uv run python -m unittest tests.test_work_graph_issue_inbox tests.test_service.LaunchplaneServiceTests.test_work_graph_issue_inbox_returns_provider_payload tests.test_service.LaunchplaneServiceTests.test_work_graph_issue_inbox_rejects_unauthorized_identity tests.test_service.LaunchplaneServiceTests.test_work_graph_issue_inbox_reconcile_dry_run_returns_missing_items tests.test_service.LaunchplaneServiceTests.test_work_graph_issue_inbox_reconcile_apply_requires_reconcile_action tests.test_service.LaunchplaneServiceTests.test_work_graph_issue_inbox_reconcile_apply_returns_counts
- uv run --extra dev mypy control_plane/work_graph_issue_inbox.py control_plane/work_graph_github_projects.py tests/test_work_graph_issue_inbox.py tests/test_service.py
- uv run --extra dev ruff check control_plane/work_graph_issue_inbox.py control_plane/work_graph_github_projects.py tests/test_work_graph_issue_inbox.py tests/test_service.py
- pnpm --dir frontend validate
- browser UI review at http://127.0.0.1:5175/ui/?fixtures=1 for desktop and 390px mobile, including apply failure detail and no horizontal overflow
- JetBrains changed-files inspection: remaining findings are pre-existing/generic CSS font-family warnings