### PR TITLE
Harden merge train failed candidate reflow

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -96,6 +96,7 @@ from control_plane.contracts.merge_train_stack_collapse import (
     reconcile_merge_train_stack_children_after_root_landing,
 )
 from control_plane.contracts.merge_train_run_record import build_merge_train_run_record
+from control_plane.contracts.merge_train_policy import MergeTrainPolicy
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
 from control_plane.contracts.merge_train_pr_feedback_record import (
     MergeTrainPrFeedbackEvent,
@@ -252,6 +253,7 @@ from control_plane.merge_train_github import (
     GitHubMergeTrainClient,
     GitHubMergeTrainSnapshotReader,
     MergeTrainGitHubError,
+    MergeTrainGitHubTransport,
     UrllibMergeTrainGitHubTransport,
 )
 from control_plane.workflows.merge_train_worker import (
@@ -3413,6 +3415,74 @@ def _supersede_active_merge_train_batch_candidate_records(
         record_store.write_merge_train_batch_candidate_record(
             record.model_copy(update={"status": "superseded"})
         )
+
+
+def _try_reflow_failed_merge_train_candidate(
+    *,
+    candidate_store: _MergeTrainBatchCandidateRecordStore,
+    active_candidate_record: MergeTrainBatchCandidateRecord,
+    policy: MergeTrainPolicy,
+    policy_sha256: str,
+    transport: MergeTrainGitHubTransport,
+    repository: str,
+    base_branch: str,
+    recorded_at: str,
+    request_trace_id: str,
+    mutate: bool,
+) -> dict[str, object] | None:
+    try:
+        snapshot = GitHubMergeTrainSnapshotReader(transport=transport).read_merge_train_snapshot(
+            repository=repository,
+            base_branch=base_branch,
+        )
+    except Exception:
+        return None
+    dry_run_result = build_merge_train_dry_run_result(policy=policy, snapshot=snapshot)
+    if dry_run_result.intended_next_action != "merge":
+        return None
+    if _merge_train_candidate_matches_dry_run_queue(
+        candidate=active_candidate_record.candidate,
+        dry_run_result=dry_run_result,
+        base_sha=snapshot.base_sha,
+    ):
+        return None
+    candidate = build_merge_train_batch_candidate(
+        dry_run_result=dry_run_result,
+        base_sha=snapshot.base_sha,
+        policy_sha256=policy_sha256,
+        created_at=recorded_at,
+    )
+    result: dict[str, object] = {
+        "repository": candidate.repository,
+        "base_branch": candidate.base_branch,
+        "mode": "dry-run" if not mutate else "plan_candidate",
+        "controller_action": "plan_candidate",
+        "superseded_merge_train_batch_candidate_record_id": active_candidate_record.record_id,
+        "dry_run_result": dry_run_result.model_dump(mode="json"),
+        "candidate": candidate.model_dump(mode="json"),
+    }
+    if mutate:
+        candidate_record = build_merge_train_batch_candidate_record(
+            candidate=candidate,
+            source=f"service:controller:candidate-reflow:{request_trace_id}",
+            updated_at=recorded_at,
+        )
+        candidate_store.write_merge_train_batch_candidate_record(candidate_record)
+        try:
+            _supersede_active_merge_train_batch_candidate_records(
+                record_store=candidate_store,
+                repository=repository,
+                base_branch=base_branch,
+                batch_id=active_candidate_record.candidate.batch_id,
+                replacement_record_id=candidate_record.record_id,
+            )
+        except Exception:
+            candidate_store.write_merge_train_batch_candidate_record(
+                candidate_record.model_copy(update={"status": "superseded"})
+            )
+            raise
+        result["merge_train_batch_candidate_record_id"] = candidate_record.record_id
+    return result
 
 
 def _validate_merge_train_landing_record_for_controller(
@@ -9543,77 +9613,32 @@ def create_launchplane_service_app(
                         except ValueError as error:
                             raise MergeTrainControllerRequestError(str(error)) from error
                         if active_candidate_record.candidate.status == "failed":
-                            snapshot = GitHubMergeTrainSnapshotReader(
-                                transport=transport
-                            ).read_merge_train_snapshot(
+                            reflow_result = _try_reflow_failed_merge_train_candidate(
+                                candidate_store=candidate_store,
+                                active_candidate_record=active_candidate_record,
+                                policy=policy,
+                                policy_sha256=policy_record.policy_sha256,
+                                transport=transport,
                                 repository=controller_request.repository,
                                 base_branch=controller_request.base_branch,
+                                recorded_at=recorded_at,
+                                request_trace_id=request_trace_id,
+                                mutate=controller_request.mutate,
                             )
-                            dry_run_result = build_merge_train_dry_run_result(
-                                policy=policy, snapshot=snapshot
-                            )
-                            if (
-                                dry_run_result.intended_next_action == "merge"
-                                and not _merge_train_candidate_matches_dry_run_queue(
-                                    candidate=active_candidate_record.candidate,
-                                    dry_run_result=dry_run_result,
-                                    base_sha=snapshot.base_sha,
-                                )
-                            ):
-                                controller_action = "plan_candidate"
-                                candidate = build_merge_train_batch_candidate(
-                                    dry_run_result=dry_run_result,
-                                    base_sha=snapshot.base_sha,
-                                    policy_sha256=policy_record.policy_sha256,
-                                    created_at=recorded_at,
-                                )
-                                result = {
-                                    "repository": candidate.repository,
-                                    "base_branch": candidate.base_branch,
-                                    "mode": "dry-run"
-                                    if not controller_request.mutate
-                                    else controller_action,
-                                    "controller_action": controller_action,
-                                    "superseded_merge_train_batch_candidate_record_id": active_candidate_record.record_id,
-                                    "dry_run_result": dry_run_result.model_dump(mode="json"),
-                                    "candidate": candidate.model_dump(mode="json"),
-                                }
-                                if controller_request.mutate:
-                                    candidate_record = build_merge_train_batch_candidate_record(
-                                        candidate=candidate,
-                                        source=(
-                                            "service:controller:candidate-reflow:"
-                                            f"{request_trace_id}"
-                                        ),
-                                        updated_at=recorded_at,
-                                    )
-                                    candidate_store.write_merge_train_batch_candidate_record(
-                                        candidate_record
-                                    )
-                                    result["merge_train_batch_candidate_record_id"] = (
-                                        candidate_record.record_id
-                                    )
-                                    _supersede_active_merge_train_batch_candidate_records(
-                                        record_store=candidate_store,
-                                        repository=controller_request.repository,
-                                        base_branch=controller_request.base_branch,
-                                        batch_id=active_candidate_record.candidate.batch_id,
-                                        replacement_record_id=candidate_record.record_id,
-                                    )
-                                driver_result = result
-                            else:
+                            if reflow_result is None:
                                 result = {
                                     "repository": controller_request.repository,
                                     "base_branch": controller_request.base_branch,
                                     "mode": "dry-run",
                                     "controller_action": "candidate_failed",
                                     "merge_train_batch_candidate_record_id": active_candidate_record.record_id,
-                                    "dry_run_result": dry_run_result.model_dump(mode="json"),
                                     "candidate": active_candidate_record.candidate.model_dump(
                                         mode="json"
                                     ),
                                 }
-                                driver_result = result
+                            else:
+                                result = reflow_result
+                            driver_result = result
                         else:
                             if active_candidate_record.candidate.status in {
                                 "planned",

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -317,6 +317,17 @@ class _CandidateReflowWriteFailingFilesystemRecordStore(FilesystemRecordStore):
         return super().write_merge_train_batch_candidate_record(candidate_record)
 
 
+class _CandidateReflowSupersedeFailingFilesystemRecordStore(FilesystemRecordStore):
+    def write_merge_train_batch_candidate_record(self, record: object) -> Path:
+        candidate_record = cast(MergeTrainBatchCandidateRecord, record)
+        if (
+            candidate_record.status == "superseded"
+            and "candidate-reflow" not in candidate_record.source
+        ):
+            raise RuntimeError("candidate supersession persistence unavailable")
+        return super().write_merge_train_batch_candidate_record(candidate_record)
+
+
 class _SameBatchIdReflowFilesystemRecordStore(FilesystemRecordStore):
     def write_merge_train_batch_candidate_record(self, record: object) -> Path:
         candidate_record = cast(MergeTrainBatchCandidateRecord, record)
@@ -3270,6 +3281,198 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(len(failed_records), 1)
         self.assertEqual(failed_records[0].status, "active")
         self.assertFalse(any("candidate-reflow" in record.source for record in candidate_records))
+
+    def test_merge_train_controller_keeps_terminal_failed_candidate_when_reflow_snapshot_fails(
+        self,
+    ) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with (
+                patch(
+                    "control_plane.service.GitHubMergeTrainSnapshotReader",
+                    _FakeMergeTrainSnapshotReader,
+                ),
+                patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient),
+            ):
+                _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+                _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+            with patch(
+                "control_plane.service.GitHubMergeTrainClient",
+                _FakeFailingMergeTrainGitHubClient,
+            ):
+                _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+
+            class _FailingSnapshotReader:
+                def __init__(self, *, transport: object) -> None:
+                    pass
+
+                def read_merge_train_snapshot(self, *, repository: str, base_branch: str) -> object:
+                    raise RuntimeError("snapshot unavailable")
+
+            with (
+                patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient),
+                patch("control_plane.service.GitHubMergeTrainSnapshotReader", _FailingSnapshotReader),
+            ):
+                status, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+
+        self.assertEqual(status, 202)
+        self.assertEqual(payload["result"]["controller_action"], "candidate_failed")
+        self.assertNotIn("dry_run_result", payload["result"])
+
+    def test_merge_train_controller_supersedes_reflow_candidate_when_old_retire_fails(
+        self,
+    ) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with (
+                patch(
+                    "control_plane.service.GitHubMergeTrainSnapshotReader",
+                    _FakeMergeTrainSnapshotReader,
+                ),
+                patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient),
+            ):
+                _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+                _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+            with patch(
+                "control_plane.service.GitHubMergeTrainClient",
+                _FakeFailingMergeTrainGitHubClient,
+            ):
+                _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+            failing_store = _CandidateReflowSupersedeFailingFilesystemRecordStore(state_dir)
+            with (
+                patch("control_plane.service.build_record_store", return_value=failing_store),
+                patch(
+                    "control_plane.service.GitHubMergeTrainSnapshotReader",
+                    _FakeExpandedMergeTrainSnapshotReader,
+                ),
+                patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient),
+            ):
+                failing_app = create_launchplane_service_app(
+                    state_dir=state_dir,
+                    verifier=_StubVerifier(_merge_train_service_identity()),
+                    authz_policy=_merge_train_service_policy(),
+                    control_plane_root_path=Path(temporary_directory_name),
+                )
+                status, payload = _invoke_app(
+                    failing_app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+            candidate_records = FilesystemRecordStore(
+                state_dir
+            ).list_merge_train_batch_candidate_records(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+            )
+
+        self.assertEqual(status, 500)
+        self.assertEqual(payload["error"]["code"], "internal_error")
+        reflow_records = tuple(
+            record for record in candidate_records if "candidate-reflow" in record.source
+        )
+        self.assertEqual(len(reflow_records), 1)
+        self.assertEqual(reflow_records[0].status, "superseded")
+        failed_records = tuple(
+            record for record in candidate_records if record.candidate.status == "failed"
+        )
+        self.assertEqual(len(failed_records), 1)
+        self.assertEqual(failed_records[0].status, "active")
 
     def test_merge_train_controller_returns_idle_without_eligible_pull_requests(
         self,


### PR DESCRIPTION
## Summary
- keep failed merge-train candidates terminal when opportunistic reflow cannot read a fresh GitHub snapshot
- retire a replacement reflow candidate if old failed-candidate supersession fails, leaving the original active candidate lineage intact
- add focused controller tests for snapshot failure and supersession rollback

## Verification
- `uv run python -m unittest tests.test_merge_train_controller tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_stops_after_candidate_failure tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_reflows_failed_candidate_after_queue_changes tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_reflow_keeps_replacement_with_same_batch_id tests.test_service.LaunchplaneServiceTests.test_merge_train_reflow_supersedes_all_matching_active_candidate_records tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_keeps_failed_candidate_when_reflow_write_fails tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_keeps_terminal_failed_candidate_when_reflow_snapshot_fails tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_supersedes_reflow_candidate_when_old_retire_fails`
- `uv run --extra dev mypy control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff check --diff control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/service.py tests/test_service.py`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files` (reported existing frontend CSS warnings only)

Follow-up to #607.
