### PR TITLE
Extract Dokploy target CLI commands

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -34,8 +34,6 @@ from control_plane.contracts.authz_policy_record import (
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.deployment_record import ResolvedTargetEvidence
-from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
-from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.driver_descriptor import DriverContextView
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.every_code_work_request import build_every_code_work_request_id
@@ -111,6 +109,12 @@ from control_plane.every_code_worker import (
     start_every_code_worker_daemon,
     stop_every_code_worker_daemon,
 )
+from control_plane.cli_dokploy_targets import (
+    dokploy_target_route,
+    register_dokploy_target_commands,
+    summarize_dokploy_target_record,
+    target_id_map,
+)
 from control_plane.cli_runner_lanes import register_runner_lane_commands
 from control_plane.cli_preview_workflow import register_preview_workflow_commands
 from control_plane.cli_product_config import register_product_config_commands
@@ -158,10 +162,6 @@ from control_plane.workflows.launchplane import (
     verify_github_webhook_signature,
 )
 from control_plane.workflows.inventory import build_environment_inventory
-from control_plane.workflows.dokploy_target_adoption import (
-    adopt_dokploy_target,
-    create_dokploy_application_target,
-)
 from control_plane.workflows.odoo_artifact_publish import (
     OdooArtifactPublishRequest,
     OdooArtifactPublishStore,
@@ -8682,85 +8682,6 @@ def _summarize_odoo_instance_override_record(
     }
 
 
-def _normalize_dokploy_target_route_value(*, value: str, option_name: str) -> str:
-    normalized_value = value.strip().lower()
-    if not normalized_value:
-        raise click.ClickException(f"Dokploy target {option_name} must be non-empty.")
-    return normalized_value
-
-
-def _normalize_shopify_protected_store_key(raw_value: str) -> str:
-    normalized_value = raw_value.strip().lower()
-    if not normalized_value:
-        raise click.ClickException("Shopify protected store keys must be non-empty.")
-    return normalized_value
-
-
-def _dokploy_target_route(record: DokployTargetRecord | DokployTargetIdRecord) -> tuple[str, str]:
-    return (record.context.strip().lower(), record.instance.strip().lower())
-
-
-def _find_dokploy_target_record(
-    *,
-    existing_records: tuple[DokployTargetRecord, ...],
-    context_name: str,
-    instance_name: str,
-) -> DokployTargetRecord | None:
-    normalized_route = (context_name.strip().lower(), instance_name.strip().lower())
-    for record in existing_records:
-        if _dokploy_target_route(record) == normalized_route:
-            return record
-    return None
-
-
-def _target_id_map(
-    target_id_records: tuple[DokployTargetIdRecord, ...],
-) -> dict[tuple[str, str], str]:
-    return {_dokploy_target_route(record): record.target_id for record in target_id_records}
-
-
-def _summarize_dokploy_target_record(
-    record: DokployTargetRecord,
-    *,
-    target_id: str = "",
-) -> dict[str, object]:
-    return {
-        "context": record.context,
-        "instance": record.instance,
-        "target_id": target_id,
-        "target_type": record.target_type,
-        "project_name": record.project_name,
-        "target_name": record.target_name,
-        "source_git_ref": record.source_git_ref,
-        "compose_path": record.compose_path,
-        "watch_paths": list(record.watch_paths),
-        "domains": list(record.domains),
-        "require_test_gate": record.require_test_gate,
-        "require_prod_gate": record.require_prod_gate,
-        "healthcheck_enabled": record.healthcheck_enabled,
-        "healthcheck_path": record.healthcheck_path,
-        "env_keys": sorted(record.env.keys()),
-        "env_value_count": len(record.env),
-        "shopify_protected_store_keys": sorted(record.policies.shopify.protected_store_keys),
-        "updated_at": record.updated_at,
-        "source_label": record.source_label,
-    }
-
-
-def _fetch_dokploy_target_payload_for_adoption(
-    host: str,
-    token: str,
-    target_type: str,
-    target_id: str,
-) -> dict[str, control_plane_dokploy.JsonValue]:
-    return control_plane_dokploy.fetch_dokploy_target_payload(
-        host=host,
-        token=token,
-        target_type=target_type,
-        target_id=target_id,
-    )
-
-
 def _mutate_dokploy_payload_for_target_creation(
     host: str,
     token: str,
@@ -8778,147 +8699,6 @@ def _mutate_dokploy_payload_for_target_creation(
     if response_object is None:
         raise click.ClickException(f"Dokploy API POST {path} returned an invalid response.")
     return response_object
-
-
-def _clone_dokploy_target_record(
-    *,
-    target_record: DokployTargetRecord,
-    source_label: str,
-    policies_payload: dict[str, object] | None = None,
-) -> DokployTargetRecord:
-    payload = target_record.model_dump(mode="python")
-    if policies_payload is not None:
-        payload["policies"] = policies_payload
-    payload["updated_at"] = utc_now_timestamp()
-    payload["source_label"] = source_label.strip() or "cli"
-    return DokployTargetRecord.model_validate(payload)
-
-
-def _build_dokploy_target_record_with_shopify_protected_store_keys_added(
-    *,
-    existing_records: tuple[DokployTargetRecord, ...],
-    context_name: str,
-    instance_name: str,
-    keys: tuple[str, ...],
-    source_label: str,
-) -> tuple[DokployTargetRecord, tuple[str, ...], tuple[str, ...]]:
-    normalized_context = _normalize_dokploy_target_route_value(
-        value=context_name, option_name="--context"
-    )
-    normalized_instance = _normalize_dokploy_target_route_value(
-        value=instance_name, option_name="--instance"
-    )
-    target_record = _find_dokploy_target_record(
-        existing_records=existing_records,
-        context_name=normalized_context,
-        instance_name=normalized_instance,
-    )
-    if target_record is None:
-        raise click.ClickException(
-            "Missing DB-backed tracked Dokploy target record for the requested route."
-        )
-
-    requested_keys = tuple(_normalize_shopify_protected_store_key(raw_value) for raw_value in keys)
-    current_keys = list(target_record.policies.shopify.protected_store_keys)
-    current_key_set = {key.strip().lower() for key in current_keys}
-    added_keys: list[str] = []
-    already_present_keys: list[str] = []
-    for requested_key in requested_keys:
-        if requested_key in current_key_set:
-            already_present_keys.append(requested_key)
-            continue
-        current_keys.append(requested_key)
-        current_key_set.add(requested_key)
-        added_keys.append(requested_key)
-
-    record = _clone_dokploy_target_record(
-        target_record=target_record,
-        source_label=source_label,
-        policies_payload={
-            "shopify": {
-                "protected_store_keys": current_keys,
-            }
-        },
-    )
-    return record, tuple(sorted(added_keys)), tuple(sorted(already_present_keys))
-
-
-def _build_dokploy_target_record_with_shopify_protected_store_keys_removed(
-    *,
-    existing_records: tuple[DokployTargetRecord, ...],
-    context_name: str,
-    instance_name: str,
-    keys: tuple[str, ...],
-    source_label: str,
-) -> tuple[DokployTargetRecord, tuple[str, ...], tuple[str, ...]]:
-    normalized_context = _normalize_dokploy_target_route_value(
-        value=context_name, option_name="--context"
-    )
-    normalized_instance = _normalize_dokploy_target_route_value(
-        value=instance_name, option_name="--instance"
-    )
-    target_record = _find_dokploy_target_record(
-        existing_records=existing_records,
-        context_name=normalized_context,
-        instance_name=normalized_instance,
-    )
-    if target_record is None:
-        raise click.ClickException(
-            "Missing DB-backed tracked Dokploy target record for the requested route."
-        )
-
-    requested_keys = tuple(_normalize_shopify_protected_store_key(raw_value) for raw_value in keys)
-    current_keys = list(target_record.policies.shopify.protected_store_keys)
-    current_key_set = {key.strip().lower() for key in current_keys}
-    removed_keys: list[str] = []
-    missing_keys: list[str] = []
-    for requested_key in requested_keys:
-        if requested_key not in current_key_set:
-            missing_keys.append(requested_key)
-            continue
-        current_keys = [
-            existing_key
-            for existing_key in current_keys
-            if existing_key.strip().lower() != requested_key
-        ]
-        current_key_set.remove(requested_key)
-        removed_keys.append(requested_key)
-
-    record = _clone_dokploy_target_record(
-        target_record=target_record,
-        source_label=source_label,
-        policies_payload={
-            "shopify": {
-                "protected_store_keys": current_keys,
-            }
-        },
-    )
-    return record, tuple(sorted(removed_keys)), tuple(sorted(missing_keys))
-
-
-def _build_dokploy_target_record_for_relabel(
-    *,
-    existing_records: tuple[DokployTargetRecord, ...],
-    context_name: str,
-    instance_name: str,
-    source_label: str,
-) -> DokployTargetRecord:
-    normalized_context = _normalize_dokploy_target_route_value(
-        value=context_name, option_name="--context"
-    )
-    normalized_instance = _normalize_dokploy_target_route_value(
-        value=instance_name, option_name="--instance"
-    )
-    target_record = _find_dokploy_target_record(
-        existing_records=existing_records,
-        context_name=normalized_context,
-        instance_name=normalized_instance,
-    )
-    if target_record is None:
-        raise click.ClickException(
-            "Missing DB-backed tracked Dokploy target record for the requested route."
-        )
-    return _clone_dokploy_target_record(target_record=target_record, source_label=source_label)
 
 
 def _odoo_override_name_requires_secret_store(key_name: str) -> bool:
@@ -9307,9 +9087,9 @@ register_storage_secret_commands(cast(click.Group, main))  # type: ignore[redund
 register_product_config_commands(
     cast(click.Group, main),  # type: ignore[redundant-cast]
     summarize_product_profile_record=_summarize_product_profile_record,
-    summarize_dokploy_target_record=_summarize_dokploy_target_record,
-    dokploy_target_route=_dokploy_target_route,
-    target_id_map=_target_id_map,
+    summarize_dokploy_target_record=summarize_dokploy_target_record,
+    dokploy_target_route=dokploy_target_route,
+    target_id_map=target_id_map,
     summarize_runtime_environment_record=summarize_runtime_environment_record,
     summarize_secret_binding_record=_summarize_secret_binding_record,
 )
@@ -9319,6 +9099,12 @@ register_runtime_environment_commands(
     build_live_target_runtime_contract_payload=_build_live_target_runtime_contract_payload,
     sync_live_target_from_tracked_contract=_sync_live_target_from_tracked_contract,
     apply_live_target_runtime_environment=_apply_live_target_runtime_environment,
+)
+register_dokploy_target_commands(
+    cast(click.Group, main),  # type: ignore[redundant-cast]
+    control_plane_root=_control_plane_root,
+    normalize_dokploy_target_type=_normalize_dokploy_target_type,
+    mutate_dokploy_payload_for_target_creation=_mutate_dokploy_payload_for_target_creation,
 )
 
 
@@ -12262,11 +12048,6 @@ def _apply_launchplane_pr_event_intent(
     }
 
 
-@main.group("dokploy-targets")
-def dokploy_targets() -> None:
-    """Tracked Dokploy target record commands."""
-
-
 @main.group("authz-policies")
 def authz_policies() -> None:
     """DB-backed Launchplane authorization policy commands."""
@@ -13060,474 +12841,6 @@ def product_profiles_upsert(
     click.echo(
         json.dumps(
             {"status": "ok", "profile": record.model_dump(mode="json")},
-            indent=2,
-            sort_keys=True,
-        )
-    )
-
-
-@dokploy_targets.command("list")
-@click.option(
-    "--database-url",
-    envvar=_DATABASE_URL_ENV_KEYS,
-    required=True,
-    help="Postgres connection string for Launchplane tracked Dokploy target records.",
-)
-def dokploy_targets_list(database_url: str) -> None:
-    postgres_store = PostgresRecordStore(database_url=database_url)
-    try:
-        records = postgres_store.list_dokploy_target_records()
-        target_id_records = postgres_store.list_dokploy_target_id_records()
-    finally:
-        postgres_store.close()
-    target_ids_by_route = _target_id_map(target_id_records)
-    click.echo(
-        json.dumps(
-            {
-                "status": "ok",
-                "count": len(records),
-                "records": [
-                    _summarize_dokploy_target_record(
-                        record,
-                        target_id=target_ids_by_route.get(_dokploy_target_route(record), ""),
-                    )
-                    for record in records
-                ],
-            },
-            indent=2,
-            sort_keys=True,
-        )
-    )
-
-
-@dokploy_targets.command("show")
-@click.option(
-    "--database-url",
-    envvar=_DATABASE_URL_ENV_KEYS,
-    required=True,
-    help="Postgres connection string for Launchplane tracked Dokploy target records.",
-)
-@click.option("--context", "context_name", required=True)
-@click.option("--instance", "instance_name", required=True)
-def dokploy_targets_show(database_url: str, context_name: str, instance_name: str) -> None:
-    normalized_context = _normalize_dokploy_target_route_value(
-        value=context_name, option_name="--context"
-    )
-    normalized_instance = _normalize_dokploy_target_route_value(
-        value=instance_name, option_name="--instance"
-    )
-    postgres_store = PostgresRecordStore(database_url=database_url)
-    try:
-        record = postgres_store.read_dokploy_target_record(
-            context_name=normalized_context,
-            instance_name=normalized_instance,
-        )
-        target_id_record = postgres_store.read_dokploy_target_id_record(
-            context_name=normalized_context,
-            instance_name=normalized_instance,
-        )
-    finally:
-        postgres_store.close()
-    click.echo(
-        json.dumps(
-            _summarize_dokploy_target_record(record, target_id=target_id_record.target_id),
-            indent=2,
-            sort_keys=True,
-        )
-    )
-
-
-@dokploy_targets.command("adopt")
-@click.option(
-    "--database-url",
-    envvar=_DATABASE_URL_ENV_KEYS,
-    required=True,
-    help="Postgres connection string for Launchplane tracked Dokploy target records.",
-)
-@click.option("--context", "context_name", required=True)
-@click.option("--instance", "instance_name", required=True)
-@click.option(
-    "--target-type",
-    type=click.Choice(["application", "compose"]),
-    required=True,
-    help="Dokploy target type to adopt.",
-)
-@click.option("--target-id", required=True, help="Live Dokploy application or compose id.")
-@click.option("--project-name", default="", help="Override project name stored on the record.")
-@click.option("--target-name", default="", help="Override target name stored on the record.")
-@click.option(
-    "--source-git-ref",
-    default="",
-    help="Override source git ref stored on the record. Defaults to the live provider ref or origin/main.",
-)
-@click.option("--healthcheck-path", default="", help="Healthcheck path stored on the record.")
-@click.option("--domain", "domains", multiple=True, help="Domain stored on the record.")
-@click.option(
-    "--deploy-timeout-seconds",
-    type=int,
-    default=None,
-    help="Optional rollout timeout stored on the record.",
-)
-@click.option("--source-label", default="cli:dokploy-targets:adopt", show_default=True)
-@click.option("--updated-at", default="", help="Override updated timestamp.")
-@click.option("--apply", "apply_changes", is_flag=True, help="Write the adopted records.")
-@click.option(
-    "--control-plane-root",
-    type=click.Path(path_type=Path, file_okay=False),
-    default=None,
-    help="Optional Launchplane repo root used to resolve Dokploy credentials.",
-)
-def dokploy_targets_adopt(
-    database_url: str,
-    context_name: str,
-    instance_name: str,
-    target_type: str,
-    target_id: str,
-    project_name: str,
-    target_name: str,
-    source_git_ref: str,
-    healthcheck_path: str,
-    domains: tuple[str, ...],
-    deploy_timeout_seconds: int | None,
-    source_label: str,
-    updated_at: str,
-    apply_changes: bool,
-    control_plane_root: Path | None,
-) -> None:
-    if deploy_timeout_seconds is not None and deploy_timeout_seconds < 1:
-        raise click.ClickException("--deploy-timeout-seconds must be at least 1.")
-    launchplane_root = control_plane_root or _control_plane_root()
-    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=launchplane_root)
-    postgres_store = PostgresRecordStore(database_url=database_url)
-    postgres_store.ensure_schema()
-    try:
-        result = adopt_dokploy_target(
-            record_store=postgres_store,
-            host=host,
-            token=token,
-            context=context_name,
-            instance=instance_name,
-            target_type=_normalize_dokploy_target_type(target_type),
-            target_id=target_id,
-            project_name=project_name,
-            target_name=target_name,
-            source_git_ref=source_git_ref,
-            healthcheck_path=healthcheck_path,
-            domains=domains,
-            deploy_timeout_seconds=deploy_timeout_seconds,
-            source_label=source_label,
-            updated_at=updated_at,
-            apply=apply_changes,
-            fetch_target_payload=_fetch_dokploy_target_payload_for_adoption,
-        )
-    except ValueError as error:
-        raise click.ClickException(str(error)) from error
-    finally:
-        postgres_store.close()
-    click.echo(
-        json.dumps(
-            {
-                "status": "ok",
-                "mode": "apply" if result.applied else "dry_run",
-                "applied": result.applied,
-                "record": _summarize_dokploy_target_record(
-                    result.target_record,
-                    target_id=result.target_id_record.target_id,
-                ),
-                "provider_fields": result.provider_fields,
-                "warnings": list(result.warnings),
-            },
-            indent=2,
-            sort_keys=True,
-        )
-    )
-
-
-@dokploy_targets.command("create-application")
-@click.option(
-    "--database-url",
-    envvar=_DATABASE_URL_ENV_KEYS,
-    required=True,
-    help="Postgres connection string for Launchplane tracked Dokploy target records.",
-)
-@click.option("--context", "context_name", required=True)
-@click.option("--instance", "instance_name", required=True)
-@click.option("--target-name", required=True, help="Dokploy application display name.")
-@click.option("--project-id", default="", help="Existing Dokploy project id to use.")
-@click.option("--project-name", default="", help="Dokploy project name to create or record.")
-@click.option("--project-description", default="", help="Optional project description.")
-@click.option("--environment-id", default="", help="Existing Dokploy environment id to use.")
-@click.option(
-    "--environment-name",
-    default="",
-    help="Dokploy environment name to create; defaults to --instance.",
-)
-@click.option("--environment-description", default="", help="Optional environment description.")
-@click.option("--server-id", default="", help="Optional Dokploy server id for remote apps.")
-@click.option("--app-name", default="", help="Optional Dokploy internal app name.")
-@click.option("--application-description", default="", help="Optional application description.")
-@click.option("--source-git-ref", default="origin/main", show_default=True)
-@click.option("--healthcheck-path", default="", help="Healthcheck path stored on the record.")
-@click.option("--domain", "domains", multiple=True, help="Domain stored on the record.")
-@click.option(
-    "--deploy-timeout-seconds",
-    type=int,
-    default=None,
-    help="Optional rollout timeout stored on the record.",
-)
-@click.option(
-    "--source-label",
-    default="cli:dokploy-targets:create-application",
-    show_default=True,
-)
-@click.option("--updated-at", default="", help="Override updated timestamp.")
-@click.option(
-    "--apply", "apply_changes", is_flag=True, help="Create provider target and write records."
-)
-@click.option(
-    "--control-plane-root",
-    type=click.Path(path_type=Path, file_okay=False),
-    default=None,
-    help="Optional Launchplane repo root used to resolve Dokploy credentials.",
-)
-def dokploy_targets_create_application(
-    database_url: str,
-    context_name: str,
-    instance_name: str,
-    target_name: str,
-    project_id: str,
-    project_name: str,
-    project_description: str,
-    environment_id: str,
-    environment_name: str,
-    environment_description: str,
-    server_id: str,
-    app_name: str,
-    application_description: str,
-    source_git_ref: str,
-    healthcheck_path: str,
-    domains: tuple[str, ...],
-    deploy_timeout_seconds: int | None,
-    source_label: str,
-    updated_at: str,
-    apply_changes: bool,
-    control_plane_root: Path | None,
-) -> None:
-    if deploy_timeout_seconds is not None and deploy_timeout_seconds < 1:
-        raise click.ClickException("--deploy-timeout-seconds must be at least 1.")
-    launchplane_root = control_plane_root or _control_plane_root()
-    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=launchplane_root)
-    postgres_store = PostgresRecordStore(database_url=database_url)
-    postgres_store.ensure_schema()
-    try:
-        result = create_dokploy_application_target(
-            record_store=postgres_store,
-            host=host,
-            token=token,
-            context=context_name,
-            instance=instance_name,
-            target_name=target_name,
-            project_id=project_id,
-            project_name=project_name,
-            project_description=project_description,
-            environment_id=environment_id,
-            environment_name=environment_name,
-            environment_description=environment_description,
-            server_id=server_id,
-            app_name=app_name,
-            application_description=application_description,
-            source_git_ref=source_git_ref,
-            healthcheck_path=healthcheck_path,
-            domains=domains,
-            deploy_timeout_seconds=deploy_timeout_seconds,
-            source_label=source_label,
-            updated_at=updated_at,
-            apply=apply_changes,
-            mutate_provider=_mutate_dokploy_payload_for_target_creation,
-            fetch_target_payload=_fetch_dokploy_target_payload_for_adoption,
-        )
-    except ValueError as error:
-        raise click.ClickException(str(error)) from error
-    finally:
-        postgres_store.close()
-    click.echo(
-        json.dumps(
-            {
-                "status": "ok",
-                "mode": "apply" if result.applied else "dry_run",
-                "applied": result.applied,
-                "plan": result.plan.model_dump(mode="json"),
-                "project_id": result.project_id,
-                "environment_id": result.environment_id,
-                "record": _summarize_dokploy_target_record(
-                    result.target_record,
-                    target_id=result.target_id_record.target_id,
-                ),
-                "provider_fields": result.provider_fields,
-                "provider_requests": list(result.provider_requests),
-                "warnings": list(result.warnings),
-            },
-            indent=2,
-            sort_keys=True,
-        )
-    )
-
-
-@dokploy_targets.command("put-shopify-protected-store-key")
-@click.option(
-    "--database-url",
-    envvar=_DATABASE_URL_ENV_KEYS,
-    required=True,
-    help="Postgres connection string for Launchplane tracked Dokploy target records.",
-)
-@click.option("--context", "context_name", required=True)
-@click.option("--instance", "instance_name", required=True)
-@click.option(
-    "--key",
-    "keys",
-    multiple=True,
-    required=True,
-    help="Protected Shopify store key to add for this tracked Dokploy target.",
-)
-@click.option("--source-label", default="cli", show_default=True)
-def dokploy_targets_put_shopify_protected_store_key(
-    database_url: str,
-    context_name: str,
-    instance_name: str,
-    keys: tuple[str, ...],
-    source_label: str,
-) -> None:
-    postgres_store = PostgresRecordStore(database_url=database_url)
-    postgres_store.ensure_schema()
-    try:
-        existing_records = postgres_store.list_dokploy_target_records()
-        target_id_records = postgres_store.list_dokploy_target_id_records()
-        record, added_keys, already_present_keys = (
-            _build_dokploy_target_record_with_shopify_protected_store_keys_added(
-                existing_records=existing_records,
-                context_name=context_name,
-                instance_name=instance_name,
-                keys=keys,
-                source_label=source_label,
-            )
-        )
-        postgres_store.write_dokploy_target_record(record)
-    finally:
-        postgres_store.close()
-    target_ids_by_route = _target_id_map(target_id_records)
-    click.echo(
-        json.dumps(
-            {
-                "status": "ok",
-                "record": _summarize_dokploy_target_record(
-                    record,
-                    target_id=target_ids_by_route.get(_dokploy_target_route(record), ""),
-                ),
-                "added_keys": added_keys,
-                "already_present_keys": already_present_keys,
-            },
-            indent=2,
-            sort_keys=True,
-        )
-    )
-
-
-@dokploy_targets.command("unset-shopify-protected-store-key")
-@click.option(
-    "--database-url",
-    envvar=_DATABASE_URL_ENV_KEYS,
-    required=True,
-    help="Postgres connection string for Launchplane tracked Dokploy target records.",
-)
-@click.option("--context", "context_name", required=True)
-@click.option("--instance", "instance_name", required=True)
-@click.option(
-    "--key",
-    "keys",
-    multiple=True,
-    required=True,
-    help="Protected Shopify store key to remove from this tracked Dokploy target.",
-)
-@click.option("--source-label", default="cli", show_default=True)
-def dokploy_targets_unset_shopify_protected_store_key(
-    database_url: str,
-    context_name: str,
-    instance_name: str,
-    keys: tuple[str, ...],
-    source_label: str,
-) -> None:
-    postgres_store = PostgresRecordStore(database_url=database_url)
-    postgres_store.ensure_schema()
-    try:
-        existing_records = postgres_store.list_dokploy_target_records()
-        target_id_records = postgres_store.list_dokploy_target_id_records()
-        record, removed_keys, missing_keys = (
-            _build_dokploy_target_record_with_shopify_protected_store_keys_removed(
-                existing_records=existing_records,
-                context_name=context_name,
-                instance_name=instance_name,
-                keys=keys,
-                source_label=source_label,
-            )
-        )
-        postgres_store.write_dokploy_target_record(record)
-    finally:
-        postgres_store.close()
-    target_ids_by_route = _target_id_map(target_id_records)
-    click.echo(
-        json.dumps(
-            {
-                "status": "ok",
-                "record": _summarize_dokploy_target_record(
-                    record,
-                    target_id=target_ids_by_route.get(_dokploy_target_route(record), ""),
-                ),
-                "removed_keys": removed_keys,
-                "missing_keys": missing_keys,
-            },
-            indent=2,
-            sort_keys=True,
-        )
-    )
-
-
-@dokploy_targets.command("relabel")
-@click.option(
-    "--database-url",
-    envvar=_DATABASE_URL_ENV_KEYS,
-    required=True,
-    help="Postgres connection string for Launchplane tracked Dokploy target records.",
-)
-@click.option("--context", "context_name", required=True)
-@click.option("--instance", "instance_name", required=True)
-@click.option("--source-label", required=True)
-def dokploy_targets_relabel(
-    database_url: str, context_name: str, instance_name: str, source_label: str
-) -> None:
-    postgres_store = PostgresRecordStore(database_url=database_url)
-    postgres_store.ensure_schema()
-    try:
-        existing_records = postgres_store.list_dokploy_target_records()
-        target_id_records = postgres_store.list_dokploy_target_id_records()
-        record = _build_dokploy_target_record_for_relabel(
-            existing_records=existing_records,
-            context_name=context_name,
-            instance_name=instance_name,
-            source_label=source_label,
-        )
-        postgres_store.write_dokploy_target_record(record)
-    finally:
-        postgres_store.close()
-    target_ids_by_route = _target_id_map(target_id_records)
-    click.echo(
-        json.dumps(
-            {
-                "status": "ok",
-                "record": _summarize_dokploy_target_record(
-                    record,
-                    target_id=target_ids_by_route.get(_dokploy_target_route(record), ""),
-                ),
-            },
             indent=2,
             sort_keys=True,
         )

--- a/control_plane/cli_dokploy_targets.py
+++ b/control_plane/cli_dokploy_targets.py
@@ -1,0 +1,753 @@
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Literal
+
+import click
+
+from control_plane import dokploy as control_plane_dokploy
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.workflows.dokploy_target_adoption import (
+    adopt_dokploy_target,
+    create_dokploy_application_target,
+)
+from control_plane.workflows.ship import utc_now_timestamp
+
+
+_DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
+DokployTargetType = Literal["compose", "application"]
+
+
+def register_dokploy_target_commands(
+    main: click.Group,
+    *,
+    control_plane_root: Callable[[], Path],
+    normalize_dokploy_target_type: Callable[[str], DokployTargetType],
+    mutate_dokploy_payload_for_target_creation: Callable[..., dict[str, control_plane_dokploy.JsonValue]],
+) -> None:
+    global _DOKPLOY_TARGET_CALLBACKS
+    _DOKPLOY_TARGET_CALLBACKS = _DokployTargetCallbacks(
+        control_plane_root=control_plane_root,
+        normalize_dokploy_target_type=normalize_dokploy_target_type,
+        mutate_dokploy_payload_for_target_creation=mutate_dokploy_payload_for_target_creation,
+    )
+    main.add_command(dokploy_targets)
+
+
+@click.group("dokploy-targets")
+def dokploy_targets() -> None:
+    """Tracked Dokploy target record commands."""
+
+
+@dokploy_targets.command("list")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane tracked Dokploy target records.",
+)
+def dokploy_targets_list(database_url: str) -> None:
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    try:
+        records = postgres_store.list_dokploy_target_records()
+        target_id_records = postgres_store.list_dokploy_target_id_records()
+    finally:
+        postgres_store.close()
+    target_ids_by_route = target_id_map(target_id_records)
+    click.echo(
+        json.dumps(
+            {
+                "status": "ok",
+                "count": len(records),
+                "records": [
+                    summarize_dokploy_target_record(
+                        record,
+                        target_id=target_ids_by_route.get(dokploy_target_route(record), ""),
+                    )
+                    for record in records
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+@dokploy_targets.command("show")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane tracked Dokploy target records.",
+)
+@click.option("--context", "context_name", required=True)
+@click.option("--instance", "instance_name", required=True)
+def dokploy_targets_show(database_url: str, context_name: str, instance_name: str) -> None:
+    normalized_context = _normalize_dokploy_target_route_value(
+        value=context_name, option_name="--context"
+    )
+    normalized_instance = _normalize_dokploy_target_route_value(
+        value=instance_name, option_name="--instance"
+    )
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    try:
+        record = postgres_store.read_dokploy_target_record(
+            context_name=normalized_context,
+            instance_name=normalized_instance,
+        )
+        target_id_record = postgres_store.read_dokploy_target_id_record(
+            context_name=normalized_context,
+            instance_name=normalized_instance,
+        )
+    finally:
+        postgres_store.close()
+    click.echo(
+        json.dumps(
+            summarize_dokploy_target_record(record, target_id=target_id_record.target_id),
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+@dokploy_targets.command("adopt")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane tracked Dokploy target records.",
+)
+@click.option("--context", "context_name", required=True)
+@click.option("--instance", "instance_name", required=True)
+@click.option(
+    "--target-type",
+    type=click.Choice(["application", "compose"]),
+    required=True,
+    help="Dokploy target type to adopt.",
+)
+@click.option("--target-id", required=True, help="Live Dokploy application or compose id.")
+@click.option("--project-name", default="", help="Override project name stored on the record.")
+@click.option("--target-name", default="", help="Override target name stored on the record.")
+@click.option(
+    "--source-git-ref",
+    default="",
+    help="Override source git ref stored on the record. Defaults to the live provider ref or origin/main.",
+)
+@click.option("--healthcheck-path", default="", help="Healthcheck path stored on the record.")
+@click.option("--domain", "domains", multiple=True, help="Domain stored on the record.")
+@click.option(
+    "--deploy-timeout-seconds",
+    type=int,
+    default=None,
+    help="Optional rollout timeout stored on the record.",
+)
+@click.option("--source-label", default="cli:dokploy-targets:adopt", show_default=True)
+@click.option("--updated-at", default="", help="Override updated timestamp.")
+@click.option("--apply", "apply_changes", is_flag=True, help="Write the adopted records.")
+@click.option(
+    "--control-plane-root",
+    type=click.Path(path_type=Path, file_okay=False),
+    default=None,
+    help="Optional Launchplane repo root used to resolve Dokploy credentials.",
+)
+def dokploy_targets_adopt(
+    database_url: str,
+    context_name: str,
+    instance_name: str,
+    target_type: str,
+    target_id: str,
+    project_name: str,
+    target_name: str,
+    source_git_ref: str,
+    healthcheck_path: str,
+    domains: tuple[str, ...],
+    deploy_timeout_seconds: int | None,
+    source_label: str,
+    updated_at: str,
+    apply_changes: bool,
+    control_plane_root: Path | None,
+) -> None:
+    if deploy_timeout_seconds is not None and deploy_timeout_seconds < 1:
+        raise click.ClickException("--deploy-timeout-seconds must be at least 1.")
+    callbacks = _dokploy_target_callbacks()
+    launchplane_root = control_plane_root or callbacks.control_plane_root()
+    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=launchplane_root)
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    postgres_store.ensure_schema()
+    try:
+        result = adopt_dokploy_target(
+            record_store=postgres_store,
+            host=host,
+            token=token,
+            context=context_name,
+            instance=instance_name,
+            target_type=callbacks.normalize_dokploy_target_type(target_type),
+            target_id=target_id,
+            project_name=project_name,
+            target_name=target_name,
+            source_git_ref=source_git_ref,
+            healthcheck_path=healthcheck_path,
+            domains=domains,
+            deploy_timeout_seconds=deploy_timeout_seconds,
+            source_label=source_label,
+            updated_at=updated_at,
+            apply=apply_changes,
+            fetch_target_payload=_fetch_dokploy_target_payload_for_adoption,
+        )
+    except ValueError as error:
+        raise click.ClickException(str(error)) from error
+    finally:
+        postgres_store.close()
+    click.echo(
+        json.dumps(
+            {
+                "status": "ok",
+                "mode": "apply" if result.applied else "dry_run",
+                "applied": result.applied,
+                "record": summarize_dokploy_target_record(
+                    result.target_record,
+                    target_id=result.target_id_record.target_id,
+                ),
+                "provider_fields": result.provider_fields,
+                "warnings": list(result.warnings),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+@dokploy_targets.command("create-application")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane tracked Dokploy target records.",
+)
+@click.option("--context", "context_name", required=True)
+@click.option("--instance", "instance_name", required=True)
+@click.option("--target-name", required=True, help="Dokploy application display name.")
+@click.option("--project-id", default="", help="Existing Dokploy project id to use.")
+@click.option("--project-name", default="", help="Dokploy project name to create or record.")
+@click.option("--project-description", default="", help="Optional project description.")
+@click.option("--environment-id", default="", help="Existing Dokploy environment id to use.")
+@click.option(
+    "--environment-name",
+    default="",
+    help="Dokploy environment name to create; defaults to --instance.",
+)
+@click.option("--environment-description", default="", help="Optional environment description.")
+@click.option("--server-id", default="", help="Optional Dokploy server id for remote apps.")
+@click.option("--app-name", default="", help="Optional Dokploy internal app name.")
+@click.option("--application-description", default="", help="Optional application description.")
+@click.option("--source-git-ref", default="origin/main", show_default=True)
+@click.option("--healthcheck-path", default="", help="Healthcheck path stored on the record.")
+@click.option("--domain", "domains", multiple=True, help="Domain stored on the record.")
+@click.option(
+    "--deploy-timeout-seconds",
+    type=int,
+    default=None,
+    help="Optional rollout timeout stored on the record.",
+)
+@click.option(
+    "--source-label",
+    default="cli:dokploy-targets:create-application",
+    show_default=True,
+)
+@click.option("--updated-at", default="", help="Override updated timestamp.")
+@click.option(
+    "--apply", "apply_changes", is_flag=True, help="Create provider target and write records."
+)
+@click.option(
+    "--control-plane-root",
+    type=click.Path(path_type=Path, file_okay=False),
+    default=None,
+    help="Optional Launchplane repo root used to resolve Dokploy credentials.",
+)
+def dokploy_targets_create_application(
+    database_url: str,
+    context_name: str,
+    instance_name: str,
+    target_name: str,
+    project_id: str,
+    project_name: str,
+    project_description: str,
+    environment_id: str,
+    environment_name: str,
+    environment_description: str,
+    server_id: str,
+    app_name: str,
+    application_description: str,
+    source_git_ref: str,
+    healthcheck_path: str,
+    domains: tuple[str, ...],
+    deploy_timeout_seconds: int | None,
+    source_label: str,
+    updated_at: str,
+    apply_changes: bool,
+    control_plane_root: Path | None,
+) -> None:
+    if deploy_timeout_seconds is not None and deploy_timeout_seconds < 1:
+        raise click.ClickException("--deploy-timeout-seconds must be at least 1.")
+    callbacks = _dokploy_target_callbacks()
+    launchplane_root = control_plane_root or callbacks.control_plane_root()
+    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=launchplane_root)
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    postgres_store.ensure_schema()
+    try:
+        result = create_dokploy_application_target(
+            record_store=postgres_store,
+            host=host,
+            token=token,
+            context=context_name,
+            instance=instance_name,
+            target_name=target_name,
+            project_id=project_id,
+            project_name=project_name,
+            project_description=project_description,
+            environment_id=environment_id,
+            environment_name=environment_name,
+            environment_description=environment_description,
+            server_id=server_id,
+            app_name=app_name,
+            application_description=application_description,
+            source_git_ref=source_git_ref,
+            healthcheck_path=healthcheck_path,
+            domains=domains,
+            deploy_timeout_seconds=deploy_timeout_seconds,
+            source_label=source_label,
+            updated_at=updated_at,
+            apply=apply_changes,
+            mutate_provider=callbacks.mutate_dokploy_payload_for_target_creation,
+            fetch_target_payload=_fetch_dokploy_target_payload_for_adoption,
+        )
+    except ValueError as error:
+        raise click.ClickException(str(error)) from error
+    finally:
+        postgres_store.close()
+    click.echo(
+        json.dumps(
+            {
+                "status": "ok",
+                "mode": "apply" if result.applied else "dry_run",
+                "applied": result.applied,
+                "plan": result.plan.model_dump(mode="json"),
+                "project_id": result.project_id,
+                "environment_id": result.environment_id,
+                "record": summarize_dokploy_target_record(
+                    result.target_record,
+                    target_id=result.target_id_record.target_id,
+                ),
+                "provider_fields": result.provider_fields,
+                "provider_requests": list(result.provider_requests),
+                "warnings": list(result.warnings),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+@dokploy_targets.command("put-shopify-protected-store-key")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane tracked Dokploy target records.",
+)
+@click.option("--context", "context_name", required=True)
+@click.option("--instance", "instance_name", required=True)
+@click.option(
+    "--key",
+    "keys",
+    multiple=True,
+    required=True,
+    help="Protected Shopify store key to add for this tracked Dokploy target.",
+)
+@click.option("--source-label", default="cli", show_default=True)
+def dokploy_targets_put_shopify_protected_store_key(
+    database_url: str,
+    context_name: str,
+    instance_name: str,
+    keys: tuple[str, ...],
+    source_label: str,
+) -> None:
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    postgres_store.ensure_schema()
+    try:
+        existing_records = postgres_store.list_dokploy_target_records()
+        target_id_records = postgres_store.list_dokploy_target_id_records()
+        record, added_keys, already_present_keys = (
+            _build_dokploy_target_record_with_shopify_protected_store_keys_added(
+                existing_records=existing_records,
+                context_name=context_name,
+                instance_name=instance_name,
+                keys=keys,
+                source_label=source_label,
+            )
+        )
+        postgres_store.write_dokploy_target_record(record)
+    finally:
+        postgres_store.close()
+    target_ids_by_route = target_id_map(target_id_records)
+    click.echo(
+        json.dumps(
+            {
+                "status": "ok",
+                "record": summarize_dokploy_target_record(
+                    record,
+                    target_id=target_ids_by_route.get(dokploy_target_route(record), ""),
+                ),
+                "added_keys": added_keys,
+                "already_present_keys": already_present_keys,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+@dokploy_targets.command("unset-shopify-protected-store-key")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane tracked Dokploy target records.",
+)
+@click.option("--context", "context_name", required=True)
+@click.option("--instance", "instance_name", required=True)
+@click.option(
+    "--key",
+    "keys",
+    multiple=True,
+    required=True,
+    help="Protected Shopify store key to remove from this tracked Dokploy target.",
+)
+@click.option("--source-label", default="cli", show_default=True)
+def dokploy_targets_unset_shopify_protected_store_key(
+    database_url: str,
+    context_name: str,
+    instance_name: str,
+    keys: tuple[str, ...],
+    source_label: str,
+) -> None:
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    postgres_store.ensure_schema()
+    try:
+        existing_records = postgres_store.list_dokploy_target_records()
+        target_id_records = postgres_store.list_dokploy_target_id_records()
+        record, removed_keys, missing_keys = (
+            _build_dokploy_target_record_with_shopify_protected_store_keys_removed(
+                existing_records=existing_records,
+                context_name=context_name,
+                instance_name=instance_name,
+                keys=keys,
+                source_label=source_label,
+            )
+        )
+        postgres_store.write_dokploy_target_record(record)
+    finally:
+        postgres_store.close()
+    target_ids_by_route = target_id_map(target_id_records)
+    click.echo(
+        json.dumps(
+            {
+                "status": "ok",
+                "record": summarize_dokploy_target_record(
+                    record,
+                    target_id=target_ids_by_route.get(dokploy_target_route(record), ""),
+                ),
+                "removed_keys": removed_keys,
+                "missing_keys": missing_keys,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+@dokploy_targets.command("relabel")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane tracked Dokploy target records.",
+)
+@click.option("--context", "context_name", required=True)
+@click.option("--instance", "instance_name", required=True)
+@click.option("--source-label", required=True)
+def dokploy_targets_relabel(
+    database_url: str, context_name: str, instance_name: str, source_label: str
+) -> None:
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    postgres_store.ensure_schema()
+    try:
+        existing_records = postgres_store.list_dokploy_target_records()
+        target_id_records = postgres_store.list_dokploy_target_id_records()
+        record = _build_dokploy_target_record_for_relabel(
+            existing_records=existing_records,
+            context_name=context_name,
+            instance_name=instance_name,
+            source_label=source_label,
+        )
+        postgres_store.write_dokploy_target_record(record)
+    finally:
+        postgres_store.close()
+    target_ids_by_route = target_id_map(target_id_records)
+    click.echo(
+        json.dumps(
+            {
+                "status": "ok",
+                "record": summarize_dokploy_target_record(
+                    record,
+                    target_id=target_ids_by_route.get(dokploy_target_route(record), ""),
+                ),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+def _normalize_dokploy_target_route_value(*, value: str, option_name: str) -> str:
+    normalized_value = value.strip().lower()
+    if not normalized_value:
+        raise click.ClickException(f"Dokploy target {option_name} must be non-empty.")
+    return normalized_value
+
+
+def _normalize_shopify_protected_store_key(raw_value: str) -> str:
+    normalized_value = raw_value.strip().lower()
+    if not normalized_value:
+        raise click.ClickException("Shopify protected store keys must be non-empty.")
+    return normalized_value
+
+
+def dokploy_target_route(record: DokployTargetRecord | DokployTargetIdRecord) -> tuple[str, str]:
+    return (record.context.strip().lower(), record.instance.strip().lower())
+
+
+def _find_dokploy_target_record(
+    *,
+    existing_records: tuple[DokployTargetRecord, ...],
+    context_name: str,
+    instance_name: str,
+) -> DokployTargetRecord | None:
+    normalized_route = (context_name.strip().lower(), instance_name.strip().lower())
+    for record in existing_records:
+        if dokploy_target_route(record) == normalized_route:
+            return record
+    return None
+
+
+def target_id_map(
+    target_id_records: tuple[DokployTargetIdRecord, ...],
+) -> dict[tuple[str, str], str]:
+    return {dokploy_target_route(record): record.target_id for record in target_id_records}
+
+
+def summarize_dokploy_target_record(
+    record: DokployTargetRecord,
+    *,
+    target_id: str = "",
+) -> dict[str, object]:
+    return {
+        "context": record.context,
+        "instance": record.instance,
+        "target_id": target_id,
+        "target_type": record.target_type,
+        "project_name": record.project_name,
+        "target_name": record.target_name,
+        "source_git_ref": record.source_git_ref,
+        "compose_path": record.compose_path,
+        "watch_paths": list(record.watch_paths),
+        "domains": list(record.domains),
+        "require_test_gate": record.require_test_gate,
+        "require_prod_gate": record.require_prod_gate,
+        "healthcheck_enabled": record.healthcheck_enabled,
+        "healthcheck_path": record.healthcheck_path,
+        "env_keys": sorted(record.env.keys()),
+        "env_value_count": len(record.env),
+        "shopify_protected_store_keys": sorted(record.policies.shopify.protected_store_keys),
+        "updated_at": record.updated_at,
+        "source_label": record.source_label,
+    }
+
+
+def _fetch_dokploy_target_payload_for_adoption(
+    host: str,
+    token: str,
+    target_type: str,
+    target_id: str,
+) -> dict[str, control_plane_dokploy.JsonValue]:
+    return control_plane_dokploy.fetch_dokploy_target_payload(
+        host=host,
+        token=token,
+        target_type=target_type,
+        target_id=target_id,
+    )
+
+
+def _clone_dokploy_target_record(
+    *,
+    target_record: DokployTargetRecord,
+    source_label: str,
+    policies_payload: dict[str, object] | None = None,
+) -> DokployTargetRecord:
+    payload = target_record.model_dump(mode="python")
+    if policies_payload is not None:
+        payload["policies"] = policies_payload
+    payload["updated_at"] = utc_now_timestamp()
+    payload["source_label"] = source_label.strip() or "cli"
+    return DokployTargetRecord.model_validate(payload)
+
+
+def _build_dokploy_target_record_with_shopify_protected_store_keys_added(
+    *,
+    existing_records: tuple[DokployTargetRecord, ...],
+    context_name: str,
+    instance_name: str,
+    keys: tuple[str, ...],
+    source_label: str,
+) -> tuple[DokployTargetRecord, tuple[str, ...], tuple[str, ...]]:
+    normalized_context = _normalize_dokploy_target_route_value(
+        value=context_name, option_name="--context"
+    )
+    normalized_instance = _normalize_dokploy_target_route_value(
+        value=instance_name, option_name="--instance"
+    )
+    target_record = _find_dokploy_target_record(
+        existing_records=existing_records,
+        context_name=normalized_context,
+        instance_name=normalized_instance,
+    )
+    if target_record is None:
+        raise click.ClickException(
+            "Missing DB-backed tracked Dokploy target record for the requested route."
+        )
+
+    requested_keys = tuple(_normalize_shopify_protected_store_key(raw_value) for raw_value in keys)
+    current_keys = list(target_record.policies.shopify.protected_store_keys)
+    current_key_set = {key.strip().lower() for key in current_keys}
+    added_keys: list[str] = []
+    already_present_keys: list[str] = []
+    for requested_key in requested_keys:
+        if requested_key in current_key_set:
+            already_present_keys.append(requested_key)
+            continue
+        current_keys.append(requested_key)
+        current_key_set.add(requested_key)
+        added_keys.append(requested_key)
+
+    record = _clone_dokploy_target_record(
+        target_record=target_record,
+        source_label=source_label,
+        policies_payload={
+            "shopify": {
+                "protected_store_keys": current_keys,
+            }
+        },
+    )
+    return record, tuple(sorted(added_keys)), tuple(sorted(already_present_keys))
+
+
+def _build_dokploy_target_record_with_shopify_protected_store_keys_removed(
+    *,
+    existing_records: tuple[DokployTargetRecord, ...],
+    context_name: str,
+    instance_name: str,
+    keys: tuple[str, ...],
+    source_label: str,
+) -> tuple[DokployTargetRecord, tuple[str, ...], tuple[str, ...]]:
+    normalized_context = _normalize_dokploy_target_route_value(
+        value=context_name, option_name="--context"
+    )
+    normalized_instance = _normalize_dokploy_target_route_value(
+        value=instance_name, option_name="--instance"
+    )
+    target_record = _find_dokploy_target_record(
+        existing_records=existing_records,
+        context_name=normalized_context,
+        instance_name=normalized_instance,
+    )
+    if target_record is None:
+        raise click.ClickException(
+            "Missing DB-backed tracked Dokploy target record for the requested route."
+        )
+
+    requested_keys = tuple(_normalize_shopify_protected_store_key(raw_value) for raw_value in keys)
+    current_keys = list(target_record.policies.shopify.protected_store_keys)
+    current_key_set = {key.strip().lower() for key in current_keys}
+    removed_keys: list[str] = []
+    missing_keys: list[str] = []
+    for requested_key in requested_keys:
+        if requested_key not in current_key_set:
+            missing_keys.append(requested_key)
+            continue
+        current_keys = [
+            existing_key
+            for existing_key in current_keys
+            if existing_key.strip().lower() != requested_key
+        ]
+        current_key_set.remove(requested_key)
+        removed_keys.append(requested_key)
+
+    record = _clone_dokploy_target_record(
+        target_record=target_record,
+        source_label=source_label,
+        policies_payload={
+            "shopify": {
+                "protected_store_keys": current_keys,
+            }
+        },
+    )
+    return record, tuple(sorted(removed_keys)), tuple(sorted(missing_keys))
+
+
+def _build_dokploy_target_record_for_relabel(
+    *,
+    existing_records: tuple[DokployTargetRecord, ...],
+    context_name: str,
+    instance_name: str,
+    source_label: str,
+) -> DokployTargetRecord:
+    normalized_context = _normalize_dokploy_target_route_value(
+        value=context_name, option_name="--context"
+    )
+    normalized_instance = _normalize_dokploy_target_route_value(
+        value=instance_name, option_name="--instance"
+    )
+    target_record = _find_dokploy_target_record(
+        existing_records=existing_records,
+        context_name=normalized_context,
+        instance_name=normalized_instance,
+    )
+    if target_record is None:
+        raise click.ClickException(
+            "Missing DB-backed tracked Dokploy target record for the requested route."
+        )
+    return _clone_dokploy_target_record(target_record=target_record, source_label=source_label)
+
+
+class _DokployTargetCallbacks:
+    def __init__(
+        self,
+        *,
+        control_plane_root: Callable[[], Path],
+        normalize_dokploy_target_type: Callable[[str], DokployTargetType],
+        mutate_dokploy_payload_for_target_creation: Callable[..., dict[str, control_plane_dokploy.JsonValue]],
+    ) -> None:
+        self.control_plane_root = control_plane_root
+        self.normalize_dokploy_target_type = normalize_dokploy_target_type
+        self.mutate_dokploy_payload_for_target_creation = mutate_dokploy_payload_for_target_creation
+
+
+_DOKPLOY_TARGET_CALLBACKS: _DokployTargetCallbacks | None = None
+
+
+def _dokploy_target_callbacks() -> _DokployTargetCallbacks:
+    if _DOKPLOY_TARGET_CALLBACKS is None:
+        raise click.ClickException("Dokploy target CLI callbacks were not registered.")
+    return _DOKPLOY_TARGET_CALLBACKS


### PR DESCRIPTION
## Summary
- Extract the `dokploy-targets` CLI group into `control_plane.cli_dokploy_targets`.
- Preserve existing list/show/adopt/create-application/policy/relabel command names, options, JSON output, and dry-run/apply behavior.
- Reuse exported Dokploy target route/map/summarizer helpers for product onboarding output.

Refs #421

## Verification
- `uv run python -m unittest tests.test_dokploy.DokployConfigTests.test_dokploy_targets_put_shopify_protected_store_key_updates_record tests.test_dokploy.DokployConfigTests.test_dokploy_targets_unset_shopify_protected_store_key_reports_missing_keys tests.test_dokploy.DokployConfigTests.test_dokploy_targets_put_shopify_protected_store_key_requires_existing_record tests.test_dokploy_target_adoption.DokployTargetAdoptionTests.test_cli_adopt_uses_live_source_ref_by_default tests.test_dokploy_target_adoption.DokployTargetAdoptionTests.test_cli_adopt_defaults_to_dry_run tests.test_dokploy_target_adoption.DokployTargetAdoptionTests.test_cli_adopt_apply_writes_records`
- `uv run python -m unittest tests.test_dokploy.DokployConfigTests.test_dokploy_targets_list_and_show_include_shopify_policy_metadata tests.test_dokploy_target_adoption.DokployTargetAdoptionTests.test_cli_create_application_dry_run_outputs_plan`
- `uv run --extra dev mypy control_plane/cli.py control_plane/cli_dokploy_targets.py tests/test_dokploy.py tests/test_dokploy_target_adoption.py`
- `uv run --extra dev ruff check --diff control_plane/cli.py control_plane/cli_dokploy_targets.py tests/test_dokploy.py tests/test_dokploy_target_adoption.py`
- `uv run --extra dev ruff check control_plane/cli.py control_plane/cli_dokploy_targets.py tests/test_dokploy.py tests/test_dokploy_target_adoption.py`
- `uv run launchplane dokploy-targets --help`
- `uv run launchplane dokploy-targets adopt --help`
- JetBrains changed-file inspection: existing weak warnings in `control_plane/cli.py`; no new hard issue in the extracted module.
