### PR TITLE
Extract promotion and ship CLI

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -68,6 +68,10 @@ from control_plane.cli_policy_profiles import (
     register_policy_profile_commands,
     summarize_product_profile_record,
 )
+from control_plane.cli_promotion_ship import (
+    PromotionShipCliCallbacks,
+    register_promotion_ship_commands,
+)
 from control_plane.cli_product_config import register_product_config_commands
 from control_plane.cli_runtime_environments import (
     register_runtime_environment_commands,
@@ -106,11 +110,6 @@ from control_plane.workflows.odoo_prod_backup_gate import (
 from control_plane.workflows.odoo_prod_rollback import (
     OdooProdRollbackRequest,
     execute_odoo_prod_rollback,
-)
-from control_plane.workflows.promote import (
-    build_executed_promotion_record,
-    build_promotion_record,
-    generate_promotion_record_id,
 )
 from control_plane.workflows.runtime_identity_health import (
     wait_for_healthcheck_with_retry,
@@ -8529,6 +8528,34 @@ register_policy_profile_commands(
         post_launchplane_service_json=lambda **kwargs: _post_launchplane_service_json(**kwargs),
     ),
 )
+register_promotion_ship_commands(
+    cast(click.Group, main),  # type: ignore[redundant-cast]
+    callbacks=PromotionShipCliCallbacks(
+        store_factory=lambda *args, **kwargs: _store(*args, **kwargs),
+        load_json_file=lambda input_file: _load_json_file(input_file),
+        normalize_dokploy_target_type=lambda target_type: _normalize_dokploy_target_type(
+            target_type
+        ),
+        resolve_native_promotion_request=lambda **kwargs: _resolve_native_promotion_request(
+            **kwargs
+        ),
+        require_artifact_id=lambda **kwargs: _require_artifact_id(**kwargs),
+        resolve_backup_gate_for_promotion=lambda **kwargs: _resolve_backup_gate_for_promotion(
+            **kwargs
+        ),
+        read_artifact_manifest=lambda **kwargs: _read_artifact_manifest(**kwargs),
+        read_source_release_tuple_for_promotion=(
+            lambda **kwargs: _read_source_release_tuple_for_promotion(**kwargs)
+        ),
+        resolve_ship_request_for_promotion=lambda **kwargs: _resolve_ship_request_for_promotion(
+            **kwargs
+        ),
+        execute_ship=lambda **kwargs: _execute_ship(**kwargs),
+        write_environment_inventory=lambda **kwargs: _write_environment_inventory(**kwargs),
+        write_promoted_release_tuple=lambda **kwargs: _write_promoted_release_tuple(**kwargs),
+        resolve_native_ship_request=lambda **kwargs: _resolve_native_ship_request(**kwargs),
+    ),
+)
 
 
 @odoo_artifacts.command("publish")
@@ -8685,282 +8712,3 @@ register_launchplane_preview_commands(
         json_object=_json_object,
     ),
 )
-
-
-@main.group()
-def promote() -> None:
-    """Promotion workflow commands."""
-
-
-@promote.command("record")
-@click.option(
-    "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
-)
-@click.option("--database-url", default="", show_default=False)
-@click.option("--record-id", required=True)
-@click.option("--artifact-id", required=True)
-@click.option("--backup-record-id", default="", show_default=False)
-@click.option("--context", "context_name", required=True)
-@click.option("--from-instance", "from_instance_name", required=True)
-@click.option("--to-instance", "to_instance_name", required=True)
-@click.option("--target-name", required=True)
-@click.option("--target-type", type=click.Choice(["compose", "application"]), required=True)
-@click.option("--deploy-mode", required=True)
-@click.option("--deployment-id", default="", show_default=False)
-def promote_record(
-    state_dir: Path,
-    database_url: str,
-    record_id: str,
-    artifact_id: str,
-    backup_record_id: str,
-    context_name: str,
-    from_instance_name: str,
-    to_instance_name: str,
-    target_name: str,
-    target_type: str,
-    deploy_mode: str,
-    deployment_id: str,
-) -> None:
-    record = build_promotion_record(
-        record_id=record_id,
-        artifact_id=artifact_id,
-        backup_record_id=backup_record_id,
-        context_name=context_name,
-        from_instance_name=from_instance_name,
-        to_instance_name=to_instance_name,
-        target_name=target_name,
-        target_type=_normalize_dokploy_target_type(target_type),
-        deploy_mode=deploy_mode,
-        deployment_id=deployment_id,
-    )
-    record_path = _store(state_dir, database_url=database_url).write_promotion_record(record)
-    click.echo(record_path)
-
-
-@promote.command("resolve")
-@click.option("--context", "context_name", required=True)
-@click.option("--from-instance", "from_instance_name", required=True)
-@click.option("--to-instance", "to_instance_name", required=True)
-@click.option("--artifact-id", required=True)
-@click.option("--backup-record-id", required=True)
-@click.option("--source-ref", "source_git_ref", default="")
-@click.option("--wait/--no-wait", default=True, show_default=True)
-@click.option("--timeout", "timeout_override_seconds", type=int, default=None)
-@click.option("--verify-health/--no-verify-health", default=True)
-@click.option("--health-timeout", "health_timeout_override_seconds", type=int, default=None)
-@click.option("--dry-run", is_flag=True, default=False)
-@click.option("--no-cache", is_flag=True, default=False)
-@click.option("--allow-dirty", is_flag=True, default=False)
-def promote_resolve(
-    context_name: str,
-    from_instance_name: str,
-    to_instance_name: str,
-    artifact_id: str,
-    backup_record_id: str,
-    source_git_ref: str,
-    wait: bool,
-    timeout_override_seconds: int | None,
-    verify_health: bool,
-    health_timeout_override_seconds: int | None,
-    dry_run: bool,
-    no_cache: bool,
-    allow_dirty: bool,
-) -> None:
-    request = _resolve_native_promotion_request(
-        context_name=context_name,
-        from_instance_name=from_instance_name,
-        to_instance_name=to_instance_name,
-        artifact_id=artifact_id,
-        backup_record_id=backup_record_id,
-        source_git_ref=source_git_ref,
-        wait=wait,
-        timeout_override_seconds=timeout_override_seconds,
-        verify_health=verify_health,
-        health_timeout_override_seconds=health_timeout_override_seconds,
-        dry_run=dry_run,
-        no_cache=no_cache,
-        allow_dirty=allow_dirty,
-    )
-    click.echo(json.dumps(request.model_dump(mode="json"), indent=2, sort_keys=True))
-
-
-@promote.command("execute")
-@click.option(
-    "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
-)
-@click.option("--database-url", default="", show_default=False)
-@click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
-@click.option("--env-file", type=click.Path(exists=True, path_type=Path), default=None)
-def promote_execute(
-    state_dir: Path,
-    database_url: str,
-    input_file: Path,
-    env_file: Path | None,
-) -> None:
-    request = PromotionRequest.model_validate(_load_json_file(input_file))
-    record_store = _store(state_dir, database_url=database_url)
-    resolved_artifact_id = _require_artifact_id(requested_artifact_id=request.artifact_id)
-    _read_artifact_manifest(
-        record_store=record_store,
-        artifact_id=resolved_artifact_id,
-    )
-    normalized_request = request.model_copy(update={"artifact_id": resolved_artifact_id})
-    resolved_request, _backup_gate_record = _resolve_backup_gate_for_promotion(
-        request=normalized_request,
-        record_store=record_store,
-    )
-    source_release_tuple = _read_source_release_tuple_for_promotion(
-        record_store=record_store,
-        request=resolved_request,
-    )
-    record_id = generate_promotion_record_id(
-        context_name=resolved_request.context,
-        from_instance_name=resolved_request.from_instance,
-        to_instance_name=resolved_request.to_instance,
-    )
-    if resolved_request.dry_run:
-        _resolve_ship_request_for_promotion(request=resolved_request)
-        click.echo(
-            json.dumps(
-                build_executed_promotion_record(
-                    request=resolved_request,
-                    record_id=record_id,
-                    deployment_id="",
-                    deployment_status="pending",
-                ).model_dump(mode="json"),
-                indent=2,
-                sort_keys=True,
-            )
-        )
-        return
-
-    pending_record = build_executed_promotion_record(
-        request=resolved_request,
-        record_id=record_id,
-        deployment_id="",
-        deployment_status="pending",
-    )
-    record_path = record_store.write_promotion_record(pending_record)
-
-    try:
-        ship_request = _resolve_ship_request_for_promotion(request=resolved_request)
-        _record_path, deployment_record = _execute_ship(
-            state_dir=state_dir,
-            database_url=database_url,
-            env_file=env_file,
-            request=ship_request,
-            mint_release_tuple=False,
-        )
-        if not isinstance(deployment_record, DeploymentRecord):
-            raise click.ClickException(
-                "Ship execution returned an unexpected non-record payload during promotion."
-            )
-        final_record = build_executed_promotion_record(
-            request=resolved_request,
-            record_id=record_id,
-            deployment_record_id=deployment_record.record_id,
-            deployment_id=deployment_record.deploy.deployment_id,
-            deployment_status=deployment_record.deploy.status,
-        )
-    except (subprocess.CalledProcessError, click.ClickException, json.JSONDecodeError):
-        final_record = build_executed_promotion_record(
-            request=resolved_request,
-            record_id=record_id,
-            deployment_id="control-plane-dokploy",
-            deployment_status="fail",
-        )
-        record_store.write_promotion_record(final_record)
-        raise
-
-    record_store.write_promotion_record(final_record)
-    if deployment_record.wait_for_completion and deployment_record.deploy.status == "pass":
-        _write_environment_inventory(
-            record_store=record_store,
-            deployment_record=deployment_record,
-            promotion_record_id=final_record.record_id,
-            promoted_from_instance=final_record.from_instance,
-        )
-        _write_promoted_release_tuple(
-            record_store=record_store,
-            source_tuple=source_release_tuple,
-            deployment_record=deployment_record,
-            promotion_record=final_record,
-        )
-    click.echo(record_path)
-
-
-@main.group()
-def ship() -> None:
-    """Ship workflow commands."""
-
-
-@ship.command("plan")
-@click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
-def ship_plan(input_file: Path) -> None:
-    request = ShipRequest.model_validate(_load_json_file(input_file))
-    click.echo(json.dumps(request.model_dump(mode="json"), indent=2, sort_keys=True))
-
-
-@ship.command("resolve")
-@click.option("--context", "context_name", required=True)
-@click.option("--instance", "instance_name", required=True)
-@click.option("--artifact-id", required=True)
-@click.option("--source-ref", "source_git_ref", default="")
-@click.option("--wait/--no-wait", default=True, show_default=True)
-@click.option("--timeout", "timeout_override_seconds", type=int, default=None)
-@click.option("--verify-health/--no-verify-health", default=True)
-@click.option("--health-timeout", "health_timeout_override_seconds", type=int, default=None)
-@click.option("--dry-run", is_flag=True, default=False)
-@click.option("--no-cache", is_flag=True, default=False)
-@click.option("--allow-dirty", is_flag=True, default=False)
-def ship_resolve(
-    context_name: str,
-    instance_name: str,
-    artifact_id: str,
-    source_git_ref: str,
-    wait: bool,
-    timeout_override_seconds: int | None,
-    verify_health: bool,
-    health_timeout_override_seconds: int | None,
-    dry_run: bool,
-    no_cache: bool,
-    allow_dirty: bool,
-) -> None:
-    request = _resolve_native_ship_request(
-        context_name=context_name,
-        instance_name=instance_name,
-        artifact_id=artifact_id,
-        source_git_ref=source_git_ref,
-        wait=wait,
-        timeout_override_seconds=timeout_override_seconds,
-        verify_health=verify_health,
-        health_timeout_override_seconds=health_timeout_override_seconds,
-        dry_run=dry_run,
-        no_cache=no_cache,
-        allow_dirty=allow_dirty,
-    )
-    click.echo(json.dumps(request.model_dump(mode="json"), indent=2, sort_keys=True))
-
-
-@ship.command("execute")
-@click.option(
-    "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
-)
-@click.option("--database-url", default="", show_default=False)
-@click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
-@click.option("--env-file", type=click.Path(exists=True, path_type=Path), default=None)
-def ship_execute(
-    state_dir: Path,
-    database_url: str,
-    input_file: Path,
-    env_file: Path | None,
-) -> None:
-    request = ShipRequest.model_validate(_load_json_file(input_file))
-    record_path, _record = _execute_ship(
-        state_dir=state_dir,
-        database_url=database_url,
-        env_file=env_file,
-        request=request,
-    )
-    if record_path is not None:
-        click.echo(record_path)

--- a/control_plane/cli_promotion_ship.py
+++ b/control_plane/cli_promotion_ship.py
@@ -1,0 +1,387 @@
+import json
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import click
+
+from control_plane.contracts.deployment_record import DeploymentRecord
+from control_plane.contracts.promotion_record import PromotionRequest
+from control_plane.contracts.ship_request import ShipRequest
+from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.workflows.promote import (
+    build_executed_promotion_record,
+    build_promotion_record,
+    generate_promotion_record_id,
+)
+
+
+@dataclass(frozen=True)
+class PromotionShipCliCallbacks:
+    store_factory: Callable[..., FilesystemRecordStore | PostgresRecordStore]
+    load_json_file: Callable[[Path], dict[str, object]]
+    normalize_dokploy_target_type: Callable[[str], Literal["compose", "application"]]
+    resolve_native_promotion_request: Callable[..., PromotionRequest]
+    require_artifact_id: Callable[..., str]
+    resolve_backup_gate_for_promotion: Callable[..., tuple[PromotionRequest, object | None]]
+    read_artifact_manifest: Callable[..., object]
+    read_source_release_tuple_for_promotion: Callable[..., object]
+    resolve_ship_request_for_promotion: Callable[..., ShipRequest]
+    execute_ship: Callable[..., tuple[Path | None, DeploymentRecord | ShipRequest]]
+    write_environment_inventory: Callable[..., Path | None]
+    write_promoted_release_tuple: Callable[..., Path | None]
+    resolve_native_ship_request: Callable[..., ShipRequest]
+
+
+_callbacks: PromotionShipCliCallbacks | None = None
+
+
+def register_promotion_ship_commands(
+    main: click.Group, *, callbacks: PromotionShipCliCallbacks
+) -> None:
+    global _callbacks
+    _callbacks = callbacks
+    main.add_command(promote)
+    main.add_command(ship)
+
+
+def _promotion_ship_callbacks() -> PromotionShipCliCallbacks:
+    if _callbacks is None:
+        raise click.ClickException("Launchplane promotion/ship CLI callbacks are not configured.")
+    return _callbacks
+
+
+def _store(
+    state_dir: Path, *, database_url: str | None = None
+) -> FilesystemRecordStore | PostgresRecordStore:
+    return _promotion_ship_callbacks().store_factory(state_dir, database_url=database_url)
+
+
+def _load_json_file(input_file: Path) -> dict[str, object]:
+    return _promotion_ship_callbacks().load_json_file(input_file)
+
+
+def _normalize_dokploy_target_type(target_type: str) -> Literal["compose", "application"]:
+    return _promotion_ship_callbacks().normalize_dokploy_target_type(target_type)
+
+
+def _resolve_native_promotion_request(**kwargs: object) -> PromotionRequest:
+    return _promotion_ship_callbacks().resolve_native_promotion_request(**kwargs)
+
+
+def _require_artifact_id(**kwargs: object) -> str:
+    return _promotion_ship_callbacks().require_artifact_id(**kwargs)
+
+
+def _resolve_backup_gate_for_promotion(**kwargs: object) -> tuple[PromotionRequest, object | None]:
+    return _promotion_ship_callbacks().resolve_backup_gate_for_promotion(**kwargs)
+
+
+def _read_artifact_manifest(**kwargs: object) -> object:
+    return _promotion_ship_callbacks().read_artifact_manifest(**kwargs)
+
+
+def _read_source_release_tuple_for_promotion(**kwargs: object) -> object:
+    return _promotion_ship_callbacks().read_source_release_tuple_for_promotion(**kwargs)
+
+
+def _resolve_ship_request_for_promotion(**kwargs: object) -> ShipRequest:
+    return _promotion_ship_callbacks().resolve_ship_request_for_promotion(**kwargs)
+
+
+def _execute_ship(**kwargs: object) -> tuple[Path | None, DeploymentRecord | ShipRequest]:
+    return _promotion_ship_callbacks().execute_ship(**kwargs)
+
+
+def _write_environment_inventory(**kwargs: object) -> Path | None:
+    return _promotion_ship_callbacks().write_environment_inventory(**kwargs)
+
+
+def _write_promoted_release_tuple(**kwargs: object) -> Path | None:
+    return _promotion_ship_callbacks().write_promoted_release_tuple(**kwargs)
+
+
+def _resolve_native_ship_request(**kwargs: object) -> ShipRequest:
+    return _promotion_ship_callbacks().resolve_native_ship_request(**kwargs)
+
+
+@click.group()
+def promote() -> None:
+    """Promotion workflow commands."""
+
+
+@promote.command("record")
+@click.option(
+    "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
+)
+@click.option("--database-url", default="", show_default=False)
+@click.option("--record-id", required=True)
+@click.option("--artifact-id", required=True)
+@click.option("--backup-record-id", default="", show_default=False)
+@click.option("--context", "context_name", required=True)
+@click.option("--from-instance", "from_instance_name", required=True)
+@click.option("--to-instance", "to_instance_name", required=True)
+@click.option("--target-name", required=True)
+@click.option("--target-type", type=click.Choice(["compose", "application"]), required=True)
+@click.option("--deploy-mode", required=True)
+@click.option("--deployment-id", default="", show_default=False)
+def promote_record(
+    state_dir: Path,
+    database_url: str,
+    record_id: str,
+    artifact_id: str,
+    backup_record_id: str,
+    context_name: str,
+    from_instance_name: str,
+    to_instance_name: str,
+    target_name: str,
+    target_type: str,
+    deploy_mode: str,
+    deployment_id: str,
+) -> None:
+    record = build_promotion_record(
+        record_id=record_id,
+        artifact_id=artifact_id,
+        backup_record_id=backup_record_id,
+        context_name=context_name,
+        from_instance_name=from_instance_name,
+        to_instance_name=to_instance_name,
+        target_name=target_name,
+        target_type=_normalize_dokploy_target_type(target_type),
+        deploy_mode=deploy_mode,
+        deployment_id=deployment_id,
+    )
+    record_path = _store(state_dir, database_url=database_url).write_promotion_record(record)
+    click.echo(record_path)
+
+
+@promote.command("resolve")
+@click.option("--context", "context_name", required=True)
+@click.option("--from-instance", "from_instance_name", required=True)
+@click.option("--to-instance", "to_instance_name", required=True)
+@click.option("--artifact-id", required=True)
+@click.option("--backup-record-id", required=True)
+@click.option("--source-ref", "source_git_ref", default="")
+@click.option("--wait/--no-wait", default=True, show_default=True)
+@click.option("--timeout", "timeout_override_seconds", type=int, default=None)
+@click.option("--verify-health/--no-verify-health", default=True)
+@click.option("--health-timeout", "health_timeout_override_seconds", type=int, default=None)
+@click.option("--dry-run", is_flag=True, default=False)
+@click.option("--no-cache", is_flag=True, default=False)
+@click.option("--allow-dirty", is_flag=True, default=False)
+def promote_resolve(
+    context_name: str,
+    from_instance_name: str,
+    to_instance_name: str,
+    artifact_id: str,
+    backup_record_id: str,
+    source_git_ref: str,
+    wait: bool,
+    timeout_override_seconds: int | None,
+    verify_health: bool,
+    health_timeout_override_seconds: int | None,
+    dry_run: bool,
+    no_cache: bool,
+    allow_dirty: bool,
+) -> None:
+    request = _resolve_native_promotion_request(
+        context_name=context_name,
+        from_instance_name=from_instance_name,
+        to_instance_name=to_instance_name,
+        artifact_id=artifact_id,
+        backup_record_id=backup_record_id,
+        source_git_ref=source_git_ref,
+        wait=wait,
+        timeout_override_seconds=timeout_override_seconds,
+        verify_health=verify_health,
+        health_timeout_override_seconds=health_timeout_override_seconds,
+        dry_run=dry_run,
+        no_cache=no_cache,
+        allow_dirty=allow_dirty,
+    )
+    click.echo(json.dumps(request.model_dump(mode="json"), indent=2, sort_keys=True))
+
+
+@promote.command("execute")
+@click.option(
+    "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
+)
+@click.option("--database-url", default="", show_default=False)
+@click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
+@click.option("--env-file", type=click.Path(exists=True, path_type=Path), default=None)
+def promote_execute(
+    state_dir: Path,
+    database_url: str,
+    input_file: Path,
+    env_file: Path | None,
+) -> None:
+    request = PromotionRequest.model_validate(_load_json_file(input_file))
+    record_store = _store(state_dir, database_url=database_url)
+    resolved_artifact_id = _require_artifact_id(requested_artifact_id=request.artifact_id)
+    _read_artifact_manifest(
+        record_store=record_store,
+        artifact_id=resolved_artifact_id,
+    )
+    normalized_request = request.model_copy(update={"artifact_id": resolved_artifact_id})
+    resolved_request, _backup_gate_record = _resolve_backup_gate_for_promotion(
+        request=normalized_request,
+        record_store=record_store,
+    )
+    source_release_tuple = _read_source_release_tuple_for_promotion(
+        record_store=record_store,
+        request=resolved_request,
+    )
+    record_id = generate_promotion_record_id(
+        context_name=resolved_request.context,
+        from_instance_name=resolved_request.from_instance,
+        to_instance_name=resolved_request.to_instance,
+    )
+    if resolved_request.dry_run:
+        _resolve_ship_request_for_promotion(request=resolved_request)
+        click.echo(
+            json.dumps(
+                build_executed_promotion_record(
+                    request=resolved_request,
+                    record_id=record_id,
+                    deployment_id="",
+                    deployment_status="pending",
+                ).model_dump(mode="json"),
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return
+
+    pending_record = build_executed_promotion_record(
+        request=resolved_request,
+        record_id=record_id,
+        deployment_id="",
+        deployment_status="pending",
+    )
+    record_path = record_store.write_promotion_record(pending_record)
+
+    try:
+        ship_request = _resolve_ship_request_for_promotion(request=resolved_request)
+        _record_path, deployment_record = _execute_ship(
+            state_dir=state_dir,
+            database_url=database_url,
+            env_file=env_file,
+            request=ship_request,
+            mint_release_tuple=False,
+        )
+        if not isinstance(deployment_record, DeploymentRecord):
+            raise click.ClickException(
+                "Ship execution returned an unexpected non-record payload during promotion."
+            )
+        final_record = build_executed_promotion_record(
+            request=resolved_request,
+            record_id=record_id,
+            deployment_record_id=deployment_record.record_id,
+            deployment_id=deployment_record.deploy.deployment_id,
+            deployment_status=deployment_record.deploy.status,
+        )
+    except (subprocess.CalledProcessError, click.ClickException, json.JSONDecodeError):
+        final_record = build_executed_promotion_record(
+            request=resolved_request,
+            record_id=record_id,
+            deployment_id="control-plane-dokploy",
+            deployment_status="fail",
+        )
+        record_store.write_promotion_record(final_record)
+        raise
+
+    record_store.write_promotion_record(final_record)
+    if deployment_record.wait_for_completion and deployment_record.deploy.status == "pass":
+        _write_environment_inventory(
+            record_store=record_store,
+            deployment_record=deployment_record,
+            promotion_record_id=final_record.record_id,
+            promoted_from_instance=final_record.from_instance,
+        )
+        _write_promoted_release_tuple(
+            record_store=record_store,
+            source_tuple=source_release_tuple,
+            deployment_record=deployment_record,
+            promotion_record=final_record,
+        )
+    click.echo(record_path)
+
+
+@click.group()
+def ship() -> None:
+    """Ship workflow commands."""
+
+
+@ship.command("plan")
+@click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
+def ship_plan(input_file: Path) -> None:
+    request = ShipRequest.model_validate(_load_json_file(input_file))
+    click.echo(json.dumps(request.model_dump(mode="json"), indent=2, sort_keys=True))
+
+
+@ship.command("resolve")
+@click.option("--context", "context_name", required=True)
+@click.option("--instance", "instance_name", required=True)
+@click.option("--artifact-id", required=True)
+@click.option("--source-ref", "source_git_ref", default="")
+@click.option("--wait/--no-wait", default=True, show_default=True)
+@click.option("--timeout", "timeout_override_seconds", type=int, default=None)
+@click.option("--verify-health/--no-verify-health", default=True)
+@click.option("--health-timeout", "health_timeout_override_seconds", type=int, default=None)
+@click.option("--dry-run", is_flag=True, default=False)
+@click.option("--no-cache", is_flag=True, default=False)
+@click.option("--allow-dirty", is_flag=True, default=False)
+def ship_resolve(
+    context_name: str,
+    instance_name: str,
+    artifact_id: str,
+    source_git_ref: str,
+    wait: bool,
+    timeout_override_seconds: int | None,
+    verify_health: bool,
+    health_timeout_override_seconds: int | None,
+    dry_run: bool,
+    no_cache: bool,
+    allow_dirty: bool,
+) -> None:
+    request = _resolve_native_ship_request(
+        context_name=context_name,
+        instance_name=instance_name,
+        artifact_id=artifact_id,
+        source_git_ref=source_git_ref,
+        wait=wait,
+        timeout_override_seconds=timeout_override_seconds,
+        verify_health=verify_health,
+        health_timeout_override_seconds=health_timeout_override_seconds,
+        dry_run=dry_run,
+        no_cache=no_cache,
+        allow_dirty=allow_dirty,
+    )
+    click.echo(json.dumps(request.model_dump(mode="json"), indent=2, sort_keys=True))
+
+
+@ship.command("execute")
+@click.option(
+    "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
+)
+@click.option("--database-url", default="", show_default=False)
+@click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
+@click.option("--env-file", type=click.Path(exists=True, path_type=Path), default=None)
+def ship_execute(
+    state_dir: Path,
+    database_url: str,
+    input_file: Path,
+    env_file: Path | None,
+) -> None:
+    request = ShipRequest.model_validate(_load_json_file(input_file))
+    record_path, _record = _execute_ship(
+        state_dir=state_dir,
+        database_url=database_url,
+        env_file=env_file,
+        request=request,
+    )
+    if record_path is not None:
+        click.echo(record_path)


### PR DESCRIPTION
## Summary
- Extract promote and ship command groups into control_plane.cli_promotion_ship
- Keep workflow-heavy resolution/execution helpers owned by the existing root CLI via callbacks
- Preserve promote/ship command names, options, JSON output, and monkeypatch-compatible behavior

## Validation
- uv run --extra dev ruff format --check control_plane/cli.py control_plane/cli_promotion_ship.py
- uv run --extra dev ruff check control_plane/cli.py control_plane/cli_promotion_ship.py
- uv run --extra dev mypy control_plane/cli.py control_plane/cli_promotion_ship.py
- uv run launchplane promote --help
- uv run launchplane promote record --help
- uv run launchplane promote resolve --help
- uv run launchplane promote execute --help
- uv run launchplane ship --help
- uv run launchplane ship plan --help
- uv run launchplane ship resolve --help
- uv run launchplane ship execute --help
- uv run python -m unittest tests.test_promote

Refs #804
Refs #421