### PR TITLE
Require database storage for hosted service startup

### DIFF
--- a/control_plane/cli_service.py
+++ b/control_plane/cli_service.py
@@ -216,6 +216,12 @@ def service_serve(
     audience: str,
     database_url: str | None,
 ) -> None:
+    normalized_host = host.strip().lower()
+    if database_url is None and normalized_host not in {"127.0.0.1", "localhost", "::1"}:
+        raise click.ClickException(
+            "Launchplane service refuses hosted startup without --database-url or "
+            "LAUNCHPLANE_DATABASE_URL. Filesystem state is local-only."
+        )
     serve_launchplane_service(
         state_dir=state_dir,
         policy_file=policy_file,

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -68,8 +68,10 @@ records.
   validate record contract parity and service behavior without requiring a live
   Postgres database.
 - `launchplane service serve --state-dir ...` may stay as a local-only fallback
-  for development when `--database-url` is omitted. Hosted/shared service runs
-  should use `LAUNCHPLANE_DATABASE_URL`.
+  for development when `--database-url` is omitted and the service binds only to
+  `127.0.0.1`, `localhost`, or `::1`. Hosted/shared service runs must provide
+  `--database-url` or `LAUNCHPLANE_DATABASE_URL`; startup fails closed instead
+  of treating local JSON files as shared authority.
 - Every Code local worker commands may keep `--state-dir` for daemon pid/log
   files and local worktree/session state. Work-request authority should use
   `--service-url` mode for the deployed Launchplane service.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -76,12 +76,15 @@ The first implemented service command is:
 ```bash
 uv run launchplane service serve \
   --state-dir ./state \
+  --database-url "$LAUNCHPLANE_DATABASE_URL" \
   --policy-file ./bootstrap-policy.toml
 ```
 
 The service needs an explicit minimal bootstrap policy input, but the repo no
 longer tracks the live policy. Product and workflow grants should be represented
-as DB-backed authz policy records.
+as DB-backed authz policy records. Omitting `--database-url` is supported only
+for loopback local development; hosted/shared service startup fails closed rather
+than using file-backed JSON state as authority.
 
 Current implementation scope:
 

--- a/scripts/start-launchplane-service.sh
+++ b/scripts/start-launchplane-service.sh
@@ -34,6 +34,7 @@ launchplane_policy_file="${LAUNCHPLANE_POLICY_FILE:-}"
 launchplane_service_host="${LAUNCHPLANE_SERVICE_HOST:-0.0.0.0}"
 launchplane_service_port="${LAUNCHPLANE_SERVICE_PORT:-8080}"
 launchplane_service_audience="${LAUNCHPLANE_SERVICE_AUDIENCE:-localhost}"
+launchplane_database_url="${LAUNCHPLANE_DATABASE_URL:-}"
 policy_file=""
 
 mkdir -p "$state_dir"
@@ -65,6 +66,28 @@ esac
 if [ ! -f "$policy_file" ]; then
   echo "Launchplane policy file does not exist: $policy_file" >&2
   exit 1
+fi
+
+case "$launchplane_service_host" in
+  127.0.0.1|localhost|::1)
+    ;;
+  *)
+    if [ -z "$launchplane_database_url" ]; then
+      echo "Launchplane service refuses hosted startup without LAUNCHPLANE_DATABASE_URL." >&2
+      echo "Filesystem state is local-only; hosted/shared service runs must use Postgres-backed Launchplane storage." >&2
+      exit 1
+    fi
+    ;;
+esac
+
+if [ -n "$launchplane_database_url" ]; then
+  exec uv run launchplane service serve \
+    --host "$launchplane_service_host" \
+    --port "$launchplane_service_port" \
+    --state-dir "$state_dir" \
+    --database-url "$launchplane_database_url" \
+    --policy-file "$policy_file" \
+    --audience "$launchplane_service_audience"
 fi
 
 exec uv run launchplane service serve \

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3351,7 +3351,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
             with (
                 patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient),
-                patch("control_plane.service.GitHubMergeTrainSnapshotReader", _FailingSnapshotReader),
+                patch(
+                    "control_plane.service.GitHubMergeTrainSnapshotReader", _FailingSnapshotReader
+                ),
             ):
                 status, payload = _invoke_app(
                     app,
@@ -9435,7 +9437,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                                         "state": "closed",
                                         "project_status": "closed",
                                         "present_in_project": True,
-                                    }
+                                    },
                                 ],
                             }
                         ],
@@ -9954,6 +9956,29 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(status_code, 200)
             self.assertEqual(payload["status"], "ok")
             self.assertEqual(payload["storage_backend"], "filesystem")
+
+    def test_service_serve_rejects_hosted_filesystem_startup(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            policy_file = Path(temporary_directory_name) / "policy.toml"
+            policy_file.write_text("schema_version = 1\n", encoding="utf-8")
+
+            result = runner.invoke(
+                CLI_MAIN,
+                [
+                    "service",
+                    "serve",
+                    "--host",
+                    "0.0.0.0",
+                    "--state-dir",
+                    str(Path(temporary_directory_name) / "state"),
+                    "--policy-file",
+                    str(policy_file),
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 1, msg=result.output)
+        self.assertIn("refuses hosted startup without --database-url", result.output)
 
     def test_service_runtime_endpoint_reports_current_image_reference(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_start_launchplane_service.py
+++ b/tests/test_start_launchplane_service.py
@@ -90,6 +90,7 @@ class StartLaunchplaneServiceScriptTests(unittest.TestCase):
                         "UV_CAPTURE_FILE": str(capture_file),
                         "LAUNCHPLANE_APP_ROOT": str(app_root),
                         "LAUNCHPLANE_STATE_DIR": str(temporary_directory / "state"),
+                        "LAUNCHPLANE_SERVICE_HOST": "127.0.0.1",
                         "LAUNCHPLANE_POLICY_B64": base64.b64encode(b"schema_version = 1\n").decode(
                             "ascii"
                         ),
@@ -103,6 +104,69 @@ class StartLaunchplaneServiceScriptTests(unittest.TestCase):
             self.assertIn("--policy-file", captured_args)
             self.assertIn(str(policy_path), captured_args)
             self.assertEqual(policy_path.read_text(encoding="utf-8"), "schema_version = 1\n")
+        finally:
+            policy_path.unlink(missing_ok=True)
+
+    def test_rejects_hosted_filesystem_startup_without_database_url(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            app_root = temporary_directory / "app"
+            app_root.mkdir()
+
+            result = subprocess.run(
+                [str(self.script_path)],
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "LAUNCHPLANE_APP_ROOT": str(app_root),
+                    "LAUNCHPLANE_STATE_DIR": str(temporary_directory / "state"),
+                    "LAUNCHPLANE_POLICY_TOML": "schema_version = 1\n",
+                    "LAUNCHPLANE_SERVICE_HOST": "0.0.0.0",
+                    "LAUNCHPLANE_DATABASE_URL": "",
+                },
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 1, msg=result.stderr)
+        self.assertIn("refuses hosted startup without LAUNCHPLANE_DATABASE_URL", result.stderr)
+
+    def test_forwards_database_url_for_hosted_startup(self) -> None:
+        policy_path = Path("/tmp/launchplane-authz.toml")
+        policy_path.unlink(missing_ok=True)
+
+        try:
+            with TemporaryDirectory() as temporary_directory_name:
+                temporary_directory = Path(temporary_directory_name)
+                app_root = temporary_directory / "app"
+                bin_dir = temporary_directory / "bin"
+                capture_file = temporary_directory / "uv-args.txt"
+                app_root.mkdir()
+                bin_dir.mkdir()
+                self._write_fake_uv(bin_dir)
+
+                result = subprocess.run(
+                    [str(self.script_path)],
+                    capture_output=True,
+                    text=True,
+                    env={
+                        **os.environ,
+                        "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+                        "UV_CAPTURE_FILE": str(capture_file),
+                        "LAUNCHPLANE_APP_ROOT": str(app_root),
+                        "LAUNCHPLANE_STATE_DIR": str(temporary_directory / "state"),
+                        "LAUNCHPLANE_POLICY_TOML": "schema_version = 1\n",
+                        "LAUNCHPLANE_SERVICE_HOST": "0.0.0.0",
+                        "LAUNCHPLANE_DATABASE_URL": "postgresql+psycopg://launchplane:test@db/launchplane",
+                    },
+                    check=False,
+                )
+
+                captured_args = capture_file.read_text(encoding="utf-8").splitlines()
+
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            self.assertIn("--database-url", captured_args)
+            self.assertIn("postgresql+psycopg://launchplane:test@db/launchplane", captured_args)
         finally:
             policy_path.unlink(missing_ok=True)
 


### PR DESCRIPTION
Refs #163.\n\n## Summary\n- fail closed when hosted `launchplane service serve` would otherwise use filesystem storage\n- make the container startup script require and forward `LAUNCHPLANE_DATABASE_URL` for non-loopback service binds\n- update compatibility/operations docs and focused tests for the local-only filesystem boundary\n\n## Validation\n- `uv run python -m unittest tests.test_start_launchplane_service tests.test_service.LaunchplaneServiceTests.test_service_serve_rejects_hosted_filesystem_startup tests.test_service.LaunchplaneServiceTests.test_health_endpoint_reports_storage_backend`\n- `uv run --extra dev ruff format --check control_plane/cli_service.py tests/test_start_launchplane_service.py tests/test_service.py`\n- `uv run --extra dev ruff check control_plane/cli_service.py tests/test_start_launchplane_service.py tests/test_service.py`\n- `uv run --extra dev mypy control_plane tests`\n- `sh -n scripts/start-launchplane-service.sh && shellcheck scripts/start-launchplane-service.sh`\n- JetBrains changed-file inspection: clean