### PR TITLE
Label rendered state recipes as local rehearsal

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -979,7 +979,7 @@ def _build_launchplane_promotion_action_payload(
                 backup_record_id=backup_record_id,
             )
             execute_recipe = _build_launchplane_promotion_execute_recipe_script(
-                state_dir="/path/to/state"
+                state_dir="/path/to/local-state"
             )
         else:
             promotion_status = "blocked"

--- a/control_plane/launchplane_rendering.py
+++ b/control_plane/launchplane_rendering.py
@@ -92,7 +92,7 @@ def render_launchplane_action_recipe(
         <button class=\"copy-button\" type=\"button\" data-copy-target=\"{escape(recipe_id)}\">Copy recipe</button>
       </div>
       <details class=\"action-details\">
-        <summary>Show shell recipe</summary>
+        <summary>Show local rehearsal recipe</summary>
         <pre id=\"{escape(recipe_id)}\" class=\"action-pre\">{escape(script)}</pre>
       </details>
       {footer_html}
@@ -106,7 +106,11 @@ def build_launchplane_action_script(
     file_payloads: tuple[tuple[str, str, dict[str, object]], ...],
     command_args: tuple[str, ...],
 ) -> str:
-    lines = ['STATE_DIR="/path/to/state"']
+    lines = [
+        "# Local rehearsal only. Shared/live mutations must use the deployed "
+        "Launchplane service API or DB-backed operator flows.",
+        'STATE_DIR="/path/to/local-state"',
+    ]
     for variable_name, file_path, payload in file_payloads:
         lines.append(f'{variable_name}="{file_path}"')
         lines.append(f"cat >\"${variable_name}\" <<'JSON'")
@@ -333,7 +337,9 @@ def build_launchplane_backup_gate_write_recipe_script(
         "evidence": evidence or {"snapshot": "s3://path/to/prod-backup"},
     }
     lines = [
-        'STATE_DIR="/path/to/state"',
+        "# Local rehearsal only. Shared/live mutations must use the deployed "
+        "Launchplane service API or DB-backed operator flows.",
+        'STATE_DIR="/path/to/local-state"',
         'BACKUP_GATE_FILE="/tmp/launchplane-backup-gate.json"',
         "cat >\"$BACKUP_GATE_FILE\" <<'JSON'",
         json.dumps(payload, indent=2, sort_keys=True),
@@ -346,7 +352,9 @@ def build_launchplane_backup_gate_write_recipe_script(
 def build_launchplane_promotion_execute_recipe_script(*, state_dir: str) -> str:
     return "\n".join(
         (
-            f'STATE_DIR="{state_dir or "/path/to/state"}"',
+            "# Local rehearsal only. Shared/live mutations must use the deployed "
+            "Launchplane service API or DB-backed operator flows.",
+            f'STATE_DIR="{state_dir or "/path/to/local-state"}"',
             'PROMOTION_REQUEST_FILE="/tmp/launchplane-promotion-request.json"',
             'uv run launchplane promote execute --state-dir "$STATE_DIR" --input-file "$PROMOTION_REQUEST_FILE"',
         )
@@ -363,7 +371,9 @@ def build_launchplane_environment_ship_recipe_script(
     request_file = f"/tmp/launchplane-{context_name}-{instance_name}-ship-request.json"
     return "\n".join(
         (
-            'STATE_DIR="/path/to/state"',
+            "# Local rehearsal only. Shared/live mutations must use the deployed "
+            "Launchplane service API or DB-backed operator flows.",
+            'STATE_DIR="/path/to/local-state"',
             f'SHIP_REQUEST_FILE="{request_file}"',
             f'uv run launchplane ship resolve --context "{context_name}" --instance "{instance_name}" --artifact-id "{artifact_id}" --source-ref "{source_git_ref}" >"$SHIP_REQUEST_FILE"',
             'cat "$SHIP_REQUEST_FILE"',
@@ -3986,7 +3996,7 @@ def render_launchplane_preview_status_page_html(
     <section class=\"preview-detail-section\" id=\"operator-actions\">
       <div class=\"section-label\">Operator actions</div>
       <h2>Write-side Launchplane recipes</h2>
-      <p>Launchplane still renders as a static operator surface here, so each action is shown as the exact shell recipe for this preview identity.</p>
+      <p>Launchplane still renders as a static operator surface here, so each action is shown as a local rehearsal recipe for this preview identity. Shared and production mutations should use the deployed service API or DB-backed operator flows.</p>
       <div class=\"action-stack\">{operator_actions_html}</div>
     </section>
     """

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -96,6 +96,10 @@ records.
 - Any public doc that shows a product/tenant operator mutating live state through
   local JSON files should be rewritten to use service ingress, DB-backed
   operator commands, or a clearly labeled local-only rehearsal.
+- Static operator pages may still render shell recipes for local rehearsal and
+  incident inspection, but those snippets must label `--state-dir` paths as
+  local-only and must not present file-backed writes as shared-service mutation
+  authority.
 
 ### Delete Later
 


### PR DESCRIPTION
Refs #163.\n\n## Summary\n- label rendered shell recipes as local rehearsal instead of generic operator recipes\n- replace placeholder `/path/to/state` with `/path/to/local-state` in static recipes\n- document that static operator pages may render `--state-dir` snippets only as local rehearsal/inspection aids\n\n## Validation\n- `uv run python -m unittest tests.test_launchplane_previews.LaunchplanePreviewReadModelTests.test_launchplane_previews_render_site_release_tuple_records_resolve_enablement_recipe tests.test_launchplane_previews.LaunchplanePreviewReadModelTests.test_launchplane_previews_render_index_page_surfaces_backup_gate_recipe_when_promotion_blocked tests.test_launchplane_previews.LaunchplanePreviewReadModelTests.test_launchplane_previews_show_tenant_uses_companion_sha_snapshot_for_enablement_recipe`\n- `uv run --extra dev ruff format --check control_plane/cli.py control_plane/launchplane_rendering.py tests/test_launchplane_previews.py`\n- `uv run --extra dev ruff check control_plane/cli.py control_plane/launchplane_rendering.py tests/test_launchplane_previews.py`\n- `uv run --extra dev mypy control_plane tests`\n- JetBrains changed-file inspection completed but reported pre-existing/stale weak warnings in unrelated files, with no finding on this three-file diff.