### PR TITLE
Loosen VeriReel workflow store coupling

### DIFF
--- a/control_plane/workflows/verireel_prod_backup_gate.py
+++ b/control_plane/workflows/verireel_prod_backup_gate.py
@@ -6,13 +6,13 @@ from pathlib import Path
 import shlex
 import subprocess
 import threading
+from typing import Protocol
 
 import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane.contracts.backup_gate_record import BackupGateRecord
-from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.ship import utc_now_timestamp
 from control_plane.workflows.worker_runtime_key_safety import enforce_worker_runtime_key_safety
 
@@ -38,6 +38,12 @@ WORKER_RUNTIME_ENV_KEYS = (
     "VERIREEL_TESTING_BASE_URL",
     "VERIREEL_PROD_OPERATOR_BASE_URL",
 )
+
+
+class VeriReelProdBackupGateStore(Protocol):
+    def read_backup_gate_record(self, record_id: str) -> BackupGateRecord: ...
+
+    def write_backup_gate_record(self, record: BackupGateRecord) -> Path | None: ...
 
 
 class VeriReelProdBackupGateRequest(BaseModel):
@@ -272,7 +278,7 @@ def _result_from_backup_gate_record(
 
 def _read_existing_backup_gate_record(
     *,
-    record_store: FilesystemRecordStore,
+    record_store: VeriReelProdBackupGateStore,
     record_id: str,
 ) -> BackupGateRecord | None:
     try:
@@ -284,7 +290,7 @@ def _read_existing_backup_gate_record(
 def _run_backup_gate_worker_and_store(
     *,
     control_plane_root: Path,
-    record_store: FilesystemRecordStore,
+    record_store: VeriReelProdBackupGateStore,
     request: VeriReelProdBackupGateRequest,
 ) -> None:
     try:
@@ -314,7 +320,7 @@ def _run_backup_gate_worker_and_store(
 def _ensure_async_backup_gate_worker(
     *,
     control_plane_root: Path,
-    record_store: FilesystemRecordStore,
+    record_store: VeriReelProdBackupGateStore,
     request: VeriReelProdBackupGateRequest,
 ) -> None:
     with _ACTIVE_BACKUP_GATES_LOCK:
@@ -337,7 +343,7 @@ def _ensure_async_backup_gate_worker(
 def execute_verireel_prod_backup_gate(
     *,
     control_plane_root: Path,
-    record_store: FilesystemRecordStore,
+    record_store: VeriReelProdBackupGateStore,
     request: VeriReelProdBackupGateRequest,
     run_async: bool = False,
 ) -> VeriReelProdBackupGateResult:

--- a/control_plane/workflows/verireel_prod_promotion.py
+++ b/control_plane/workflows/verireel_prod_promotion.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import time
+from typing import Protocol
 
 import click
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -19,7 +20,6 @@ from control_plane.contracts.promotion_record import (
     PromotionRecord,
     ReleaseStatus,
 )
-from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.verireel_stable_deploy import (
     VeriReelStableDeployRequest,
     execute_verireel_stable_deploy,
@@ -31,6 +31,16 @@ from control_plane.workflows.verireel_rollout import (
     resolve_verireel_rollout_base_urls,
     verify_verireel_rollout,
 )
+
+
+class VeriReelProdPromotionStore(Protocol):
+    def read_backup_gate_record(self, record_id: str) -> BackupGateRecord: ...
+
+    def read_deployment_record(self, record_id: str) -> DeploymentRecord: ...
+
+    def write_deployment_record(self, record: DeploymentRecord) -> Path | None: ...
+
+    def write_promotion_record(self, record: PromotionRecord) -> Path | None: ...
 
 
 class VeriReelProdPromotionRequest(BaseModel):
@@ -128,7 +138,7 @@ def _default_migration_schedule_name() -> str:
 
 def _read_backup_gate_record(
     *,
-    record_store: FilesystemRecordStore,
+    record_store: VeriReelProdPromotionStore,
     record_id: str,
 ) -> BackupGateRecord:
     try:
@@ -141,7 +151,7 @@ def _read_backup_gate_record(
 
 def _resolve_backup_gate_record(
     *,
-    record_store: FilesystemRecordStore,
+    record_store: VeriReelProdPromotionStore,
     request: VeriReelProdPromotionRequest,
 ) -> BackupGateRecord:
     backup_gate_record = _read_backup_gate_record(
@@ -269,7 +279,7 @@ def _build_destination_health(
 
 def _write_failed_promotion_record(
     *,
-    record_store: FilesystemRecordStore,
+    record_store: VeriReelProdPromotionStore,
     request: VeriReelProdPromotionRequest,
     backup_gate_record: BackupGateRecord | None,
     error_message: str,
@@ -537,7 +547,7 @@ def _run_prisma_migrations(
 def execute_verireel_prod_promotion(
     *,
     control_plane_root: Path,
-    record_store: FilesystemRecordStore,
+    record_store: VeriReelProdPromotionStore,
     request: VeriReelProdPromotionRequest,
 ) -> VeriReelProdPromotionResult:
     try:

--- a/control_plane/workflows/verireel_stable_deploy.py
+++ b/control_plane/workflows/verireel_stable_deploy.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Protocol
 
 import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -9,11 +9,11 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane.contracts.deployment_record import ResolvedTargetEvidence
+from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetType
 from control_plane.contracts.promotion_record import HealthcheckEvidence, ReleaseStatus
 from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.contracts.ship_request import ShipRequest
-from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.dokploy_deploy import execute_dokploy_artifact_deploy
 from control_plane.workflows.ship import (
     build_deployment_record,
@@ -31,6 +31,10 @@ from control_plane.workflows.verireel_rollout import (
 
 
 StableInstanceName = Literal["testing", "prod"]
+
+
+class VeriReelStableDeployStore(Protocol):
+    def write_deployment_record(self, record: DeploymentRecord) -> Path | None: ...
 
 
 class VeriReelStableDeployRequest(BaseModel):
@@ -241,7 +245,7 @@ def _verify_rollout(
 def execute_verireel_stable_deploy(
     *,
     control_plane_root: Path,
-    record_store: FilesystemRecordStore,
+    record_store: VeriReelStableDeployStore,
     request: VeriReelStableDeployRequest,
 ) -> VeriReelStableDeployResult:
     record_id = generate_deployment_record_id(


### PR DESCRIPTION
Refs #163

## Summary
- replace direct `FilesystemRecordStore` annotations in VeriReel stable deploy, prod backup gate, and prod promotion workflows with minimal store protocols
- keep local filesystem and Postgres-backed stores compatible by accepting write returns of `Path | None`
- leave the Odoo promotion workflow concrete for now because its helper boundary still depends on the existing concrete store union

## Validation
- `uv run --extra dev ruff format --check control_plane/workflows/verireel_stable_deploy.py control_plane/workflows/verireel_prod_backup_gate.py control_plane/workflows/verireel_prod_promotion.py`
- `uv run --extra dev ruff check control_plane/workflows/verireel_stable_deploy.py control_plane/workflows/verireel_prod_backup_gate.py control_plane/workflows/verireel_prod_promotion.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest tests.test_verireel_testing_deploy tests.test_verireel_prod_backup_gate tests.test_verireel_prod_promotion tests.test_verireel_prod_rollback`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files`
