### PR TITLE
Loosen Odoo promotion store coupling

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -6,7 +6,7 @@ import os
 import time
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Literal, TypeVar, cast, overload
+from typing import Literal, Protocol, TypeVar, cast, overload
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit
 from urllib.request import Request, urlopen
@@ -147,6 +147,38 @@ _LAUNCHPLANE_SERVICE_POLICY_ENV_KEYS = (
 )
 _SECRET_SHAPED_RUNTIME_ENV_KEY_PARTS = {"PASSWORD", "TOKEN", "SECRET", "KEY"}
 _SUCCESSFUL_DOKPLOY_STATUSES = {"success", "succeeded", "done", "completed", "healthy", "finished"}
+
+
+class ArtifactManifestReadStore(Protocol):
+    def read_artifact_manifest(self, artifact_id: str) -> ArtifactIdentityManifest: ...
+
+
+class BackupGateReadStore(Protocol):
+    def read_backup_gate_record(self, record_id: str) -> BackupGateRecord: ...
+
+
+class EnvironmentInventoryWriteStore(Protocol):
+    def write_environment_inventory(self, record: EnvironmentInventory) -> Path | None: ...
+
+
+class DeploymentRecordReadStore(Protocol):
+    def read_deployment_record(self, record_id: str) -> DeploymentRecord: ...
+
+
+class ReleaseTupleReadStore(Protocol):
+    def read_release_tuple_record(
+        self, *, context_name: str, channel_name: str
+    ) -> ReleaseTupleRecord: ...
+
+
+class ReleaseTupleWriteStore(Protocol):
+    def write_release_tuple_record(self, record: ReleaseTupleRecord) -> Path | None: ...
+
+
+class EnvironmentInventoryRefreshStore(
+    DeploymentRecordReadStore, EnvironmentInventoryWriteStore, Protocol
+):
+    pass
 
 
 @overload
@@ -2820,7 +2852,7 @@ def _require_artifact_id(*, requested_artifact_id: str) -> str:
 
 def _read_artifact_manifest(
     *,
-    record_store: FilesystemRecordStore | PostgresRecordStore,
+    record_store: ArtifactManifestReadStore,
     artifact_id: str,
 ) -> ArtifactIdentityManifest:
     try:
@@ -2833,7 +2865,7 @@ def _read_artifact_manifest(
 
 def _read_backup_gate_record(
     *,
-    record_store: FilesystemRecordStore | PostgresRecordStore,
+    record_store: BackupGateReadStore,
     record_id: str,
 ) -> BackupGateRecord:
     try:
@@ -2847,7 +2879,7 @@ def _read_backup_gate_record(
 def _resolve_backup_gate_for_promotion(
     *,
     request: PromotionRequest,
-    record_store: FilesystemRecordStore | PostgresRecordStore,
+    record_store: BackupGateReadStore,
 ) -> tuple[PromotionRequest, BackupGateRecord | None]:
     if not request.backup_gate.required:
         resolved_request = request.model_copy(
@@ -3340,7 +3372,7 @@ def _build_runtime_environment_sync_evidence(
 
 def _write_environment_inventory(
     *,
-    record_store: FilesystemRecordStore | PostgresRecordStore,
+    record_store: EnvironmentInventoryWriteStore,
     deployment_record: DeploymentRecord,
     promotion_record_id: str = "",
     promoted_from_instance: str = "",
@@ -3356,7 +3388,7 @@ def _write_environment_inventory(
 
 def _write_environment_inventory_from_promotion(
     *,
-    record_store: FilesystemRecordStore | PostgresRecordStore,
+    record_store: EnvironmentInventoryRefreshStore,
     promotion_record: PromotionRecord,
 ) -> Path | None:
     deployment_record_id = promotion_record.deployment_record_id.strip()
@@ -3397,7 +3429,7 @@ def _write_environment_inventory_from_promotion(
 
 def _write_release_tuple_from_deployment(
     *,
-    record_store: FilesystemRecordStore | PostgresRecordStore,
+    record_store: ReleaseTupleWriteStore,
     deployment_record: DeploymentRecord,
     artifact_manifest: ArtifactIdentityManifest,
 ) -> Path | None:
@@ -3417,7 +3449,7 @@ def _write_release_tuple_from_deployment(
 
 def _read_source_release_tuple_for_promotion(
     *,
-    record_store: FilesystemRecordStore | PostgresRecordStore,
+    record_store: ReleaseTupleReadStore,
     request: PromotionRequest,
 ) -> ReleaseTupleRecord | None:
     if not control_plane_release_tuples.should_mint_release_tuple_for_channel(
@@ -3444,7 +3476,7 @@ def _read_source_release_tuple_for_promotion(
 
 def _read_source_release_tuple_for_promotion_record(
     *,
-    record_store: FilesystemRecordStore | PostgresRecordStore,
+    record_store: ReleaseTupleReadStore,
     promotion_record: PromotionRecord,
 ) -> ReleaseTupleRecord:
     artifact_id = _artifact_id_or_empty(promotion_record.artifact_identity)
@@ -3472,7 +3504,7 @@ def _read_source_release_tuple_for_promotion_record(
 
 def _write_promoted_release_tuple(
     *,
-    record_store: FilesystemRecordStore | PostgresRecordStore,
+    record_store: ReleaseTupleWriteStore,
     source_tuple: ReleaseTupleRecord | None,
     deployment_record: DeploymentRecord,
     promotion_record: PromotionRecord,

--- a/control_plane/workflows/odoo_prod_promotion.py
+++ b/control_plane/workflows/odoo_prod_promotion.py
@@ -3,14 +3,33 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Protocol
 
 import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
+from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
+from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.promotion_record import PromotionRecord
-from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+
+
+class OdooProdPromotionStore(Protocol):
+    def read_artifact_manifest(self, artifact_id: str) -> ArtifactIdentityManifest: ...
+
+    def read_backup_gate_record(self, record_id: str) -> BackupGateRecord: ...
+
+    def read_release_tuple_record(
+        self, *, context_name: str, channel_name: str
+    ) -> ReleaseTupleRecord: ...
+
+    def write_environment_inventory(self, record: EnvironmentInventory) -> Path | None: ...
+
+    def write_promotion_record(self, record: PromotionRecord) -> Path | None: ...
+
+    def write_release_tuple_record(self, record: ReleaseTupleRecord) -> Path | None: ...
 
 
 class OdooProdPromotionRequest(BaseModel):
@@ -73,7 +92,7 @@ def execute_odoo_prod_promotion(
     control_plane_root: Path,
     state_dir: Path,
     database_url: str | None,
-    record_store: FilesystemRecordStore,
+    record_store: OdooProdPromotionStore,
     request: OdooProdPromotionRequest,
 ) -> OdooProdPromotionResult:
     del control_plane_root


### PR DESCRIPTION
Refs #163

## Summary
- replace Odoo prod promotion's direct `FilesystemRecordStore` annotation with a narrow workflow-local store protocol
- relax the shared promotion/ship helper signatures in `control_plane.cli` from concrete filesystem/Postgres unions to structural read/write protocols
- keep runtime behavior unchanged while allowing the Odoo promotion workflow to work against either local filesystem or database-backed stores by capability

## Validation
- `uv run --extra dev ruff format --check control_plane/cli.py control_plane/workflows/odoo_prod_promotion.py`
- `uv run --extra dev ruff check control_plane/cli.py control_plane/workflows/odoo_prod_promotion.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest tests.test_odoo_prod_promotion`
- `uv run python -m unittest tests.test_promote`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files` (reported stale preview-workflow findings outside this diff)
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope files --file control_plane/cli.py --file control_plane/workflows/odoo_prod_promotion.py` (reported pre-existing private CLI helper access in `odoo_prod_promotion.py`)
