### PR TITLE
Require DB authority for ship execution

### DIFF
--- a/control_plane/cli_promotion_ship.py
+++ b/control_plane/cli_promotion_ship.py
@@ -1,4 +1,5 @@
 import json
+import os
 import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -17,6 +18,9 @@ from control_plane.workflows.promote import (
     build_promotion_record,
     generate_promotion_record_id,
 )
+
+
+_DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
 
 
 @dataclass(frozen=True)
@@ -58,6 +62,25 @@ def _store(
     state_dir: Path, *, database_url: str | None = None
 ) -> FilesystemRecordStore | PostgresRecordStore:
     return _promotion_ship_callbacks().store_factory(state_dir, database_url=database_url)
+
+
+def _resolve_execution_database_url(*, database_url: str, local_rehearsal: bool) -> str | None:
+    if local_rehearsal:
+        return None
+    normalized_database_url = database_url.strip()
+    if not normalized_database_url:
+        for environment_key in _DATABASE_URL_ENV_KEYS:
+            environment_value = os.environ.get(environment_key, "").strip()
+            if environment_value:
+                normalized_database_url = environment_value
+                break
+    if not normalized_database_url:
+        raise click.ClickException(
+            "Promotion and ship execution require --database-url or "
+            "LAUNCHPLANE_DATABASE_URL. Use --local-rehearsal for explicit "
+            "local filesystem rehearsal."
+        )
+    return normalized_database_url
 
 
 def _load_json_file(input_file: Path) -> dict[str, object]:
@@ -210,16 +233,22 @@ def promote_resolve(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
 @click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
 @click.option("--env-file", type=click.Path(exists=True, path_type=Path), default=None)
 def promote_execute(
     state_dir: Path,
     database_url: str,
+    local_rehearsal: bool,
     input_file: Path,
     env_file: Path | None,
 ) -> None:
+    execution_database_url = _resolve_execution_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+    )
     request = PromotionRequest.model_validate(_load_json_file(input_file))
-    record_store = _store(state_dir, database_url=database_url)
+    record_store = _store(state_dir, database_url=execution_database_url)
     resolved_artifact_id = _require_artifact_id(requested_artifact_id=request.artifact_id)
     _read_artifact_manifest(
         record_store=record_store,
@@ -267,7 +296,7 @@ def promote_execute(
         ship_request = _resolve_ship_request_for_promotion(request=resolved_request)
         _record_path, deployment_record = _execute_ship(
             state_dir=state_dir,
-            database_url=database_url,
+            database_url=execution_database_url,
             env_file=env_file,
             request=ship_request,
             mint_release_tuple=False,
@@ -368,18 +397,24 @@ def ship_resolve(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
 @click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
 @click.option("--env-file", type=click.Path(exists=True, path_type=Path), default=None)
 def ship_execute(
     state_dir: Path,
     database_url: str,
+    local_rehearsal: bool,
     input_file: Path,
     env_file: Path | None,
 ) -> None:
+    execution_database_url = _resolve_execution_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+    )
     request = ShipRequest.model_validate(_load_json_file(input_file))
     record_path, _record = _execute_ship(
         state_dir=state_dir,
-        database_url=database_url,
+        database_url=execution_database_url,
         env_file=env_file,
         request=request,
     )

--- a/control_plane/launchplane_rendering.py
+++ b/control_plane/launchplane_rendering.py
@@ -352,11 +352,11 @@ def build_launchplane_backup_gate_write_recipe_script(
 def build_launchplane_promotion_execute_recipe_script(*, state_dir: str) -> str:
     return "\n".join(
         (
-            "# Local rehearsal only. Shared/live mutations must use the deployed "
-            "Launchplane service API or DB-backed operator flows.",
-            f'STATE_DIR="{state_dir or "/path/to/local-state"}"',
+            "# DB-backed execution authority. For offline rehearsal only, replace --database-url with --local-rehearsal.",
+            'LAUNCHPLANE_DATABASE_URL="postgresql+psycopg://..."',
+            f'STATE_DIR="{state_dir or "/path/to/runtime"}"',
             'PROMOTION_REQUEST_FILE="/tmp/launchplane-promotion-request.json"',
-            'uv run launchplane promote execute --state-dir "$STATE_DIR" --input-file "$PROMOTION_REQUEST_FILE"',
+            'uv run launchplane promote execute --database-url "$LAUNCHPLANE_DATABASE_URL" --state-dir "$STATE_DIR" --input-file "$PROMOTION_REQUEST_FILE"',
         )
     )
 
@@ -371,13 +371,13 @@ def build_launchplane_environment_ship_recipe_script(
     request_file = f"/tmp/launchplane-{context_name}-{instance_name}-ship-request.json"
     return "\n".join(
         (
-            "# Local rehearsal only. Shared/live mutations must use the deployed "
-            "Launchplane service API or DB-backed operator flows.",
-            'STATE_DIR="/path/to/local-state"',
+            "# DB-backed execution authority. For offline rehearsal only, replace --database-url with --local-rehearsal.",
+            'LAUNCHPLANE_DATABASE_URL="postgresql+psycopg://..."',
+            'STATE_DIR="/path/to/runtime"',
             f'SHIP_REQUEST_FILE="{request_file}"',
             f'uv run launchplane ship resolve --context "{context_name}" --instance "{instance_name}" --artifact-id "{artifact_id}" --source-ref "{source_git_ref}" >"$SHIP_REQUEST_FILE"',
             'cat "$SHIP_REQUEST_FILE"',
-            'uv run launchplane ship execute --state-dir "$STATE_DIR" --input-file "$SHIP_REQUEST_FILE"',
+            'uv run launchplane ship execute --database-url "$LAUNCHPLANE_DATABASE_URL" --state-dir "$STATE_DIR" --input-file "$SHIP_REQUEST_FILE"',
         )
     )
 

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -78,6 +78,9 @@ fallback.
   `--service-url` mode for the deployed Launchplane service.
 - `storage import-core-records --state-dir ... --database-url ...` stays as the
   explicit backfill bridge from local JSON records into Postgres-backed records.
+- `promote execute` and `ship execute` require `--database-url` or
+  `LAUNCHPLANE_DATABASE_URL`; explicit offline filesystem execution must opt in
+  with `--local-rehearsal`.
 
 ### Migrate Or Demote
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -400,6 +400,9 @@ Current derived-state behavior:
 - `promote execute` requires the source lane's current release tuple to match
   the requested artifact, then promotes that exact tuple to the destination
   lane after the deploy passes.
+- `promote execute` and `ship execute` require `--database-url` or
+  `LAUNCHPLANE_DATABASE_URL`; explicit offline filesystem execution must opt in
+  with `--local-rehearsal`.
 - Current environment inventory is refreshed from successful waited `ship` and
   `promote` executions.
 - Externally produced promotion evidence can also refresh current inventory

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -876,6 +876,7 @@ target_id = "compose-123"
                         "execute",
                         "--state-dir",
                         str(state_dir),
+                        "--local-rehearsal",
                         "--input-file",
                         str(input_file),
                     ],
@@ -891,6 +892,72 @@ target_id = "compose-123"
 
 
 class PromoteCliTests(unittest.TestCase):
+    def test_promote_execute_requires_database_url(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            repo_root = Path(temporary_directory_name)
+            input_file = repo_root / "promotion-request.json"
+            input_file.write_text(
+                PromotionRequest(
+                    artifact_id="artifact-sha256-image456",
+                    backup_record_id="backup-opw-prod-20260410T182231Z",
+                    source_git_ref="abc123",
+                    context="opw",
+                    from_instance="testing",
+                    to_instance="prod",
+                    target_name="opw-prod",
+                    target_type="compose",
+                    deploy_mode="dokploy-compose-api",
+                ).model_dump_json(indent=2),
+                encoding="utf-8",
+            )
+
+            result = runner.invoke(
+                main,
+                [
+                    "promote",
+                    "execute",
+                    "--input-file",
+                    str(input_file),
+                ],
+                env={"LAUNCHPLANE_DATABASE_URL": ""},
+            )
+
+            self.assertNotEqual(result.exit_code, 0)
+            self.assertIn("require --database-url", result.output)
+
+    def test_ship_execute_requires_database_url(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            repo_root = Path(temporary_directory_name)
+            input_file = repo_root / "ship-request.json"
+            input_file.write_text(
+                ShipRequest(
+                    artifact_id="artifact-sha256-image456",
+                    context="opw",
+                    instance="prod",
+                    source_git_ref="abc123",
+                    target_name="opw-prod",
+                    target_type="compose",
+                    deploy_mode="dokploy-compose-api",
+                ).model_dump_json(indent=2),
+                encoding="utf-8",
+            )
+
+            result = runner.invoke(
+                main,
+                [
+                    "ship",
+                    "execute",
+                    "--input-file",
+                    str(input_file),
+                ],
+                env={"LAUNCHPLANE_DATABASE_URL": ""},
+            )
+
+            self.assertNotEqual(result.exit_code, 0)
+            self.assertIn("require --database-url", result.output)
+
     def test_promote_execute_persists_record_and_executes_control_plane_ship(self) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
@@ -962,6 +1029,7 @@ class PromoteCliTests(unittest.TestCase):
                         "execute",
                         "--state-dir",
                         str(state_dir),
+                        "--local-rehearsal",
                         "--input-file",
                         str(input_file),
                     ],
@@ -1517,6 +1585,7 @@ DOKPLOY_SHIP_MODE = "auto"
                         "execute",
                         "--state-dir",
                         str(state_dir),
+                        "--local-rehearsal",
                         "--input-file",
                         str(input_file),
                     ],
@@ -2142,6 +2211,7 @@ DOKPLOY_SHIP_MODE = "auto"
                     "execute",
                     "--state-dir",
                     str(state_dir),
+                    "--local-rehearsal",
                     "--input-file",
                     str(input_file),
                 ],
@@ -2182,6 +2252,7 @@ DOKPLOY_SHIP_MODE = "auto"
                     "execute",
                     "--state-dir",
                     str(state_dir),
+                    "--local-rehearsal",
                     "--input-file",
                     str(input_file),
                 ],
@@ -2221,6 +2292,7 @@ DOKPLOY_SHIP_MODE = "auto"
                     "execute",
                     "--state-dir",
                     str(state_dir),
+                    "--local-rehearsal",
                     "--input-file",
                     str(input_file),
                 ],
@@ -2260,6 +2332,7 @@ DOKPLOY_SHIP_MODE = "auto"
                     "execute",
                     "--state-dir",
                     str(state_dir),
+                    "--local-rehearsal",
                     "--input-file",
                     str(input_file),
                 ],
@@ -2323,6 +2396,7 @@ DOKPLOY_SHIP_MODE = "auto"
                         "execute",
                         "--state-dir",
                         str(state_dir),
+                        "--local-rehearsal",
                         "--input-file",
                         str(input_file),
                     ],
@@ -2415,6 +2489,7 @@ DOKPLOY_SHIP_MODE = "auto"
                         "execute",
                         "--state-dir",
                         str(state_dir),
+                        "--local-rehearsal",
                         "--input-file",
                         str(input_file),
                     ],
@@ -2510,6 +2585,7 @@ DOKPLOY_SHIP_MODE = "auto"
                     "execute",
                     "--state-dir",
                     str(state_dir),
+                    "--local-rehearsal",
                     "--input-file",
                     str(input_file),
                 ],
@@ -2581,6 +2657,7 @@ target_id = "compose-123"
                         "execute",
                         "--state-dir",
                         str(state_dir),
+                        "--local-rehearsal",
                         "--input-file",
                         str(input_file),
                     ],
@@ -2678,6 +2755,7 @@ target_id = "compose-123"
                         "execute",
                         "--state-dir",
                         str(state_dir),
+                        "--local-rehearsal",
                         "--input-file",
                         str(input_file),
                     ],
@@ -2764,6 +2842,7 @@ target_id = "compose-123"
                         "execute",
                         "--state-dir",
                         str(state_dir),
+                        "--local-rehearsal",
                         "--input-file",
                         str(input_file),
                     ],
@@ -2828,6 +2907,7 @@ target_id = "compose-123"
                         "execute",
                         "--state-dir",
                         str(state_dir),
+                        "--local-rehearsal",
                         "--input-file",
                         str(input_file),
                     ],
@@ -2913,6 +2993,7 @@ target_id = "compose-123"
                         "execute",
                         "--state-dir",
                         str(state_dir),
+                        "--local-rehearsal",
                         "--input-file",
                         str(input_file),
                     ],
@@ -2991,6 +3072,7 @@ target_id = "compose-123"
                         "execute",
                         "--state-dir",
                         str(state_dir),
+                        "--local-rehearsal",
                         "--input-file",
                         str(input_file),
                     ],
@@ -3057,6 +3139,7 @@ target_id = "compose-123"
                         "execute",
                         "--state-dir",
                         str(state_dir),
+                        "--local-rehearsal",
                         "--input-file",
                         str(input_file),
                     ],
@@ -3121,6 +3204,7 @@ target_id = "compose-123"
                         "execute",
                         "--state-dir",
                         str(state_dir),
+                        "--local-rehearsal",
                         "--input-file",
                         str(input_file),
                     ],
@@ -3158,6 +3242,7 @@ target_id = "compose-123"
                     "execute",
                     "--state-dir",
                     str(state_dir),
+                    "--local-rehearsal",
                     "--input-file",
                     str(input_file),
                 ],
@@ -3221,6 +3306,7 @@ target_id = "compose-123"
                         "execute",
                         "--state-dir",
                         str(state_dir),
+                        "--local-rehearsal",
                         "--input-file",
                         str(input_file),
                     ],
@@ -3287,6 +3373,7 @@ target_id = "compose-123"
                         "execute",
                         "--state-dir",
                         str(state_dir),
+                        "--local-rehearsal",
                         "--input-file",
                         str(input_file),
                     ],
@@ -3354,6 +3441,7 @@ target_id = "compose-123"
                         "execute",
                         "--state-dir",
                         str(state_dir),
+                        "--local-rehearsal",
                         "--input-file",
                         str(input_file),
                     ],
@@ -3398,6 +3486,7 @@ target_id = "compose-123"
                         "execute",
                         "--state-dir",
                         str(state_dir),
+                        "--local-rehearsal",
                         "--input-file",
                         str(input_file),
                     ],
@@ -3769,6 +3858,7 @@ DOKPLOY_SHIP_MODE = "auto"
                         "execute",
                         "--state-dir",
                         str(state_dir),
+                        "--local-rehearsal",
                         "--input-file",
                         str(input_file),
                     ],
@@ -3842,6 +3932,7 @@ DOKPLOY_SHIP_MODE = "auto"
                         "execute",
                         "--state-dir",
                         str(state_dir),
+                        "--local-rehearsal",
                         "--input-file",
                         str(input_file),
                     ],


### PR DESCRIPTION
## Summary
- require `promote execute` and `ship execute` to resolve DB authority unless callers opt into explicit `--local-rehearsal`
- update rendered execution recipes and docs so DB-backed execution is the default authority path
- mark existing filesystem-backed execution tests as explicit local rehearsals and add fail-closed coverage for missing DB config

## Verification
- `uv run python -m unittest tests.test_promote`
- `uv run --extra dev ruff format --check control_plane/cli_promotion_ship.py control_plane/launchplane_rendering.py tests/test_promote.py`
- `uv run --extra dev ruff check control_plane/cli_promotion_ship.py control_plane/launchplane_rendering.py tests/test_promote.py`
- `uv run --extra dev mypy control_plane tests`
- JetBrains changed-files inspection: not clean; reported preexisting broad service/doc warnings outside this patch, including `control_plane/service.py` preview payload typing warnings and `docs/config-boundary.md` table formatting warnings.

Refs #834
