### PR TITLE
Require DB authority for record mutations

### DIFF
--- a/control_plane/cli_records.py
+++ b/control_plane/cli_records.py
@@ -1,4 +1,5 @@
 import json
+import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -14,6 +15,9 @@ from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
+
+
+_DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
 
 
 @dataclass(frozen=True)
@@ -58,6 +62,26 @@ def _store(
     return _records_callbacks().store_factory(state_dir, database_url=database_url)
 
 
+def _resolve_record_mutation_database_url(
+    *, database_url: str, local_rehearsal: bool, command_label: str
+) -> str | None:
+    if local_rehearsal:
+        return None
+    normalized_database_url = database_url.strip()
+    if not normalized_database_url:
+        for environment_key in _DATABASE_URL_ENV_KEYS:
+            environment_value = os.environ.get(environment_key, "").strip()
+            if environment_value:
+                normalized_database_url = environment_value
+                break
+    if not normalized_database_url:
+        raise click.ClickException(
+            f"{command_label} requires --database-url or LAUNCHPLANE_DATABASE_URL. "
+            "Use --local-rehearsal for explicit local filesystem rehearsal."
+        )
+    return normalized_database_url
+
+
 def _load_json_file(input_file: Path) -> dict[str, object]:
     return _records_callbacks().load_json_file(input_file)
 
@@ -72,10 +96,20 @@ def artifacts() -> None:
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
 @click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
-def artifacts_write(state_dir: Path, database_url: str, input_file: Path) -> None:
+def artifacts_write(
+    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+) -> None:
+    execution_database_url = _resolve_record_mutation_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label="artifacts write",
+    )
     manifest = ArtifactIdentityManifest.model_validate(_load_json_file(input_file))
-    record_path = _store(state_dir, database_url=database_url).write_artifact_manifest(manifest)
+    record_path = _store(state_dir, database_url=execution_database_url).write_artifact_manifest(
+        manifest
+    )
     click.echo(record_path)
 
 
@@ -95,10 +129,20 @@ def artifacts_show(state_dir: Path, database_url: str, artifact_id: str) -> None
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
 @click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
-def artifacts_ingest(state_dir: Path, database_url: str, input_file: Path) -> None:
+def artifacts_ingest(
+    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+) -> None:
+    execution_database_url = _resolve_record_mutation_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label="artifacts ingest",
+    )
     manifest = ArtifactIdentityManifest.model_validate(_load_json_file(input_file))
-    record_path = _store(state_dir, database_url=database_url).write_artifact_manifest(manifest)
+    record_path = _store(state_dir, database_url=execution_database_url).write_artifact_manifest(
+        manifest
+    )
     click.echo(record_path)
 
 
@@ -162,9 +206,17 @@ def release_tuples_export_catalog(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
 @click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--record-id", required=True)
-def release_tuples_write_from_promotion(state_dir: Path, database_url: str, record_id: str) -> None:
-    record_store = _store(state_dir, database_url=database_url)
+def release_tuples_write_from_promotion(
+    state_dir: Path, database_url: str, local_rehearsal: bool, record_id: str
+) -> None:
+    execution_database_url = _resolve_record_mutation_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label="release-tuples write-from-promotion",
+    )
+    record_store = _store(state_dir, database_url=execution_database_url)
     promotion_record = record_store.read_promotion_record(record_id)
     if not control_plane_release_tuples.should_mint_release_tuple_for_channel(
         promotion_record.from_instance
@@ -209,10 +261,20 @@ def backup_gates() -> None:
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
 @click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
-def backup_gates_write(state_dir: Path, database_url: str, input_file: Path) -> None:
+def backup_gates_write(
+    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+) -> None:
+    execution_database_url = _resolve_record_mutation_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label="backup-gates write",
+    )
     record = BackupGateRecord.model_validate(_load_json_file(input_file))
-    record_path = _store(state_dir, database_url=database_url).write_backup_gate_record(record)
+    record_path = _store(state_dir, database_url=execution_database_url).write_backup_gate_record(
+        record
+    )
     click.echo(record_path)
 
 
@@ -262,10 +324,20 @@ def promotions() -> None:
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
 @click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
-def promotions_write(state_dir: Path, database_url: str, input_file: Path) -> None:
+def promotions_write(
+    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+) -> None:
+    execution_database_url = _resolve_record_mutation_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label="promotions write",
+    )
     record = PromotionRecord.model_validate(_load_json_file(input_file))
-    record_path = _store(state_dir, database_url=database_url).write_promotion_record(record)
+    record_path = _store(state_dir, database_url=execution_database_url).write_promotion_record(
+        record
+    )
     click.echo(record_path)
 
 
@@ -322,10 +394,20 @@ def deployments() -> None:
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
 @click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
-def deployments_write(state_dir: Path, database_url: str, input_file: Path) -> None:
+def deployments_write(
+    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+) -> None:
+    execution_database_url = _resolve_record_mutation_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label="deployments write",
+    )
     record = DeploymentRecord.model_validate(_load_json_file(input_file))
-    record_path = _store(state_dir, database_url=database_url).write_deployment_record(record)
+    record_path = _store(state_dir, database_url=execution_database_url).write_deployment_record(
+        record
+    )
     click.echo(record_path)
 
 
@@ -375,9 +457,17 @@ def inventory() -> None:
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
 @click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--record-id", required=True)
-def inventory_write_from_deployment(state_dir: Path, database_url: str, record_id: str) -> None:
-    record_store = _store(state_dir, database_url=database_url)
+def inventory_write_from_deployment(
+    state_dir: Path, database_url: str, local_rehearsal: bool, record_id: str
+) -> None:
+    execution_database_url = _resolve_record_mutation_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label="inventory write-from-deployment",
+    )
+    record_store = _store(state_dir, database_url=execution_database_url)
     deployment_record = record_store.read_deployment_record(record_id)
     inventory_path = _records_callbacks().write_environment_inventory(
         record_store=record_store,
@@ -391,9 +481,17 @@ def inventory_write_from_deployment(state_dir: Path, database_url: str, record_i
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
 @click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--record-id", required=True)
-def inventory_write_from_promotion(state_dir: Path, database_url: str, record_id: str) -> None:
-    record_store = _store(state_dir, database_url=database_url)
+def inventory_write_from_promotion(
+    state_dir: Path, database_url: str, local_rehearsal: bool, record_id: str
+) -> None:
+    execution_database_url = _resolve_record_mutation_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label="inventory write-from-promotion",
+    )
+    record_store = _store(state_dir, database_url=execution_database_url)
     promotion_record = record_store.read_promotion_record(record_id)
     inventory_path = _records_callbacks().write_environment_inventory_from_promotion(
         record_store=record_store,

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -81,13 +81,19 @@ fallback.
 - `promote execute` and `ship execute` require `--database-url` or
   `LAUNCHPLANE_DATABASE_URL`; explicit offline filesystem execution must opt in
   with `--local-rehearsal`.
+- Generic record mutation commands such as `artifacts write`,
+  `backup-gates write`, `promotions write`, `deployments write`,
+  `inventory write-from-*`, and `release-tuples write-from-promotion` require
+  `--database-url` or `LAUNCHPLANE_DATABASE_URL`; explicit offline filesystem
+  writes must opt in with `--local-rehearsal`.
 
 ### Migrate Or Demote
 
-- Generic record CLI groups such as `artifacts`, `backup-gates`, `deployments`,
-  `promotions`, `inventory`, `release-tuples`, and `launchplane-previews`
-  should be treated as local inspection/backfill tools unless they are run with
-  `--database-url`. Do not document them as live shared-service mutation paths.
+- Generic record CLI read/export groups such as `artifacts`, `backup-gates`,
+  `deployments`, `promotions`, `inventory`, and `release-tuples` may read local
+  `--state-dir` data for inspection. Mutation commands require DB authority or
+  an explicit `--local-rehearsal` flag. Do not document local record writes as
+  live shared-service mutation paths.
 - Service routes and product driver workflows should accept generic record-store
   protocols instead of concrete file-backed stores. The first compatibility
   retirement pass migrated Launchplane preview, Odoo promotion, VeriReel deploy,

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -303,7 +303,9 @@ class FilesystemRecordStoreTests(unittest.TestCase):
             [record.feedback_id for record in listed_records],
             [newer_record.feedback_id, older_record.feedback_id],
         )
-        self.assertEqual([record.feedback_id for record in limited_records], [other_record.feedback_id])
+        self.assertEqual(
+            [record.feedback_id for record in limited_records], [other_record.feedback_id]
+        )
 
     def test_write_and_list_every_code_preview_gate_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -1057,6 +1059,7 @@ class FilesystemRecordStoreTests(unittest.TestCase):
                     "ingest",
                     "--state-dir",
                     str(state_dir),
+                    "--local-rehearsal",
                     "--input-file",
                     str(input_file),
                 ],
@@ -1095,6 +1098,7 @@ class FilesystemRecordStoreTests(unittest.TestCase):
                     "write",
                     "--state-dir",
                     str(state_dir),
+                    "--local-rehearsal",
                     "--input-file",
                     str(input_file),
                 ],

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -1846,6 +1846,7 @@ DOKPLOY_SHIP_MODE = "auto"
                     "write",
                     "--state-dir",
                     str(state_dir),
+                    "--local-rehearsal",
                     "--input-file",
                     str(input_file),
                 ],
@@ -1860,6 +1861,43 @@ DOKPLOY_SHIP_MODE = "auto"
                 ),
                 record,
             )
+
+    def test_deployments_write_requires_database_url_without_local_rehearsal(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            repo_root = Path(temporary_directory_name)
+            input_file = repo_root / "deployment-record.json"
+            record = DeploymentRecord(
+                record_id="deployment-20260411T182231Z-opw-prod",
+                artifact_identity=_artifact_identity_reference("artifact-2"),
+                context="opw",
+                instance="prod",
+                source_git_ref="def456",
+                deploy=DeploymentEvidence(
+                    target_name="opw-prod",
+                    target_type="compose",
+                    deploy_mode="dokploy-compose-api",
+                    deployment_id="control-plane-dokploy",
+                    status="pass",
+                    started_at="2026-04-11T18:22:31Z",
+                    finished_at="2026-04-11T18:22:31Z",
+                ),
+            )
+            input_file.write_text(record.model_dump_json(indent=2), encoding="utf-8")
+
+            result = runner.invoke(
+                main,
+                [
+                    "deployments",
+                    "write",
+                    "--input-file",
+                    str(input_file),
+                ],
+                env={"LAUNCHPLANE_DATABASE_URL": ""},
+            )
+
+            self.assertNotEqual(result.exit_code, 0)
+            self.assertIn("deployments write requires --database-url", result.output)
 
     def test_promotions_write_persists_record(self) -> None:
         runner = CliRunner()
@@ -1888,6 +1926,7 @@ DOKPLOY_SHIP_MODE = "auto"
                     "write",
                     "--state-dir",
                     str(state_dir),
+                    "--local-rehearsal",
                     "--input-file",
                     str(input_file),
                 ],
@@ -1945,6 +1984,7 @@ DOKPLOY_SHIP_MODE = "auto"
                     "write-from-deployment",
                     "--state-dir",
                     str(state_dir),
+                    "--local-rehearsal",
                     "--record-id",
                     record.record_id,
                 ],
@@ -2018,6 +2058,7 @@ DOKPLOY_SHIP_MODE = "auto"
                     "write-from-promotion",
                     "--state-dir",
                     str(state_dir),
+                    "--local-rehearsal",
                     "--record-id",
                     promotion_record.record_id,
                 ],
@@ -2061,6 +2102,7 @@ DOKPLOY_SHIP_MODE = "auto"
                     "write-from-promotion",
                     "--state-dir",
                     str(state_dir),
+                    "--local-rehearsal",
                     "--record-id",
                     promotion_record.record_id,
                 ],
@@ -2127,6 +2169,7 @@ DOKPLOY_SHIP_MODE = "auto"
                     "write-from-promotion",
                     "--state-dir",
                     str(state_dir),
+                    "--local-rehearsal",
                     "--record-id",
                     promotion_record.record_id,
                 ],
@@ -2173,6 +2216,7 @@ DOKPLOY_SHIP_MODE = "auto"
                     "write-from-promotion",
                     "--state-dir",
                     str(state_dir),
+                    "--local-rehearsal",
                     "--record-id",
                     promotion_record.record_id,
                 ],


### PR DESCRIPTION
## Summary
- require generic record mutation commands to resolve DB authority unless callers opt into explicit `--local-rehearsal`
- keep read/list/export record commands usable for local inspection
- update compatibility docs and tests to make filesystem-backed record writes explicit rehearsal behavior

## Verification
- `uv run python -m unittest tests.test_promote`
- `uv run --extra dev ruff format --check control_plane/cli_records.py tests/test_promote.py`
- `uv run --extra dev ruff check control_plane/cli_records.py tests/test_promote.py`
- `uv run --extra dev mypy control_plane tests`
- JetBrains changed-files inspection: not clean; reported known click-test typing/duplicate-decorator warnings, not a targeted correctness failure for this patch.

Refs #834
