### PR TITLE
Require DB authority for preview CLI mutations

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -114,6 +114,7 @@ from control_plane.workflows.launchplane import (
     launchplane_anchor_repo_context,
     launchplane_preview_label_enabled,
     LAUNCHPLANE_PREVIEW_ENABLE_LABEL,
+    ProductProfileListStore,
     resolve_pull_request_event_manifest,
 )
 from control_plane.workflows.inventory import build_environment_inventory
@@ -411,7 +412,7 @@ def _require_launchplane_preview_status_payload(
 
 
 def _launchplane_preview_profile_rows(
-    record_store: FilesystemRecordStore,
+    record_store: ProductProfileListStore,
 ) -> tuple[tuple[str, str], ...]:
     rows: list[tuple[str, str]] = []
     for profile in record_store.list_product_profile_records():

--- a/control_plane/cli_launchplane_previews.py
+++ b/control_plane/cli_launchplane_previews.py
@@ -1,4 +1,5 @@
 import json
+import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from json import JSONDecodeError
@@ -26,6 +27,8 @@ from control_plane.launchplane_mutations import (
     upsert_launchplane_preview_from_request as shared_upsert_launchplane_preview_from_request,
 )
 from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.workflows.launchplane import ProductProfileListStore
 from control_plane.workflows.launchplane import (
     adapt_github_webhook_pull_request_event,
     apply_generation_failed_transition,
@@ -45,9 +48,13 @@ from control_plane.workflows.launchplane import (
 )
 
 
+_DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
+LaunchplanePreviewRecordStore = FilesystemRecordStore | PostgresRecordStore
+
+
 @dataclass(frozen=True)
 class LaunchplanePreviewCliCallbacks:
-    store_factory: Callable[..., FilesystemRecordStore]
+    store_factory: Callable[..., LaunchplanePreviewRecordStore]
     control_plane_root: Callable[[], Path]
     load_json_file: Callable[[Path], dict[str, object]]
     require_preview_status_payload: Callable[..., dict[str, object]]
@@ -56,7 +63,7 @@ class LaunchplanePreviewCliCallbacks:
     render_policy_page_html: Callable[..., str]
     write_site_bundle: Callable[..., None]
     render_status_page_html: Callable[[dict[str, object]], str]
-    preview_profile_rows: Callable[[FilesystemRecordStore], tuple[tuple[str, str], ...]]
+    preview_profile_rows: Callable[[ProductProfileListStore], tuple[tuple[str, str], ...]]
     build_preview_enablement_record: Callable[..., PreviewEnablementRecord | None]
     load_github_webhook_json_bytes: Callable[..., dict[str, object]]
     json_object: Callable[[object], dict[str, object] | None]
@@ -79,8 +86,28 @@ def _preview_callbacks() -> LaunchplanePreviewCliCallbacks:
     return _callbacks
 
 
-def _store(state_dir: Path) -> FilesystemRecordStore:
-    return _preview_callbacks().store_factory(state_dir)
+def _store(state_dir: Path, *, database_url: str | None = None) -> LaunchplanePreviewRecordStore:
+    return _preview_callbacks().store_factory(state_dir, database_url=database_url)
+
+
+def _resolve_preview_mutation_database_url(
+    *, database_url: str, local_rehearsal: bool, command_label: str
+) -> str | None:
+    if local_rehearsal:
+        return None
+    normalized_database_url = database_url.strip()
+    if not normalized_database_url:
+        for environment_key in _DATABASE_URL_ENV_KEYS:
+            environment_value = os.environ.get(environment_key, "").strip()
+            if environment_value:
+                normalized_database_url = environment_value
+                break
+    if not normalized_database_url:
+        raise click.ClickException(
+            f"{command_label} requires --database-url or LAUNCHPLANE_DATABASE_URL. "
+            "Use --local-rehearsal for explicit local filesystem rehearsal."
+        )
+    return normalized_database_url
 
 
 def _control_plane_root() -> Path:
@@ -105,7 +132,7 @@ def _require_launchplane_preview_status_payload(
 def _build_launchplane_tenant_payload(
     *,
     control_plane_root: Path,
-    record_store: FilesystemRecordStore,
+    record_store: LaunchplanePreviewRecordStore,
     context_name: str,
     anchor_repo: str = "",
 ) -> dict[str, object] | None:
@@ -142,7 +169,7 @@ def _render_launchplane_preview_status_page_html(payload: dict[str, object]) -> 
 
 
 def _launchplane_preview_profile_rows(
-    record_store: FilesystemRecordStore,
+    record_store: LaunchplanePreviewRecordStore,
 ) -> tuple[tuple[str, str], ...]:
     return _preview_callbacks().preview_profile_rows(record_store)
 
@@ -174,6 +201,28 @@ def _json_object(value: object) -> dict[str, object] | None:
     return _preview_callbacks().json_object(value)
 
 
+def _record_locator(value: object, fallback: str) -> str:
+    if value is None:
+        return fallback
+    normalized_value = str(value).strip()
+    return normalized_value or fallback
+
+
+def _generation_transition_payload(
+    *,
+    generation: PreviewGenerationRecord,
+    preview: PreviewRecord,
+    generation_locator: object,
+    preview_locator: object,
+) -> dict[str, str]:
+    return {
+        "generation_id": generation.generation_id,
+        "generation_path": _record_locator(generation_locator, generation.generation_id),
+        "preview_id": preview.preview_id,
+        "preview_path": _record_locator(preview_locator, preview.preview_id),
+    }
+
+
 @click.group("launchplane-previews")
 def launchplane_previews() -> None:
     """Launchplane preview record and read-model commands."""
@@ -183,42 +232,72 @@ def launchplane_previews() -> None:
 @click.option(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
+@click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
-def launchplane_previews_write_preview(state_dir: Path, input_file: Path) -> None:
+def launchplane_previews_write_preview(
+    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+) -> None:
+    execution_database_url = _resolve_preview_mutation_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label="launchplane-previews write-preview",
+    )
+    record_store = _store(state_dir, database_url=execution_database_url)
     request = PreviewMutationRequest.model_validate(_load_json_file(input_file))
     record = build_preview_record_from_request(
         control_plane_root=_control_plane_root(),
-        record_store=_store(state_dir),
+        record_store=record_store,
         request=request,
     )
-    record_path = _store(state_dir).write_preview_record(record)
-    click.echo(record_path)
+    record_path = record_store.write_preview_record(record)
+    click.echo(_record_locator(record_path, record.preview_id))
 
 
 @launchplane_previews.command("write-generation")
 @click.option(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
+@click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
-def launchplane_previews_write_generation(state_dir: Path, input_file: Path) -> None:
+def launchplane_previews_write_generation(
+    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+) -> None:
+    execution_database_url = _resolve_preview_mutation_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label="launchplane-previews write-generation",
+    )
+    record_store = _store(state_dir, database_url=execution_database_url)
     request = PreviewGenerationMutationRequest.model_validate(_load_json_file(input_file))
     record = build_preview_generation_record_from_request(
-        record_store=_store(state_dir),
+        record_store=record_store,
         request=request,
     )
-    record_path = _store(state_dir).write_preview_generation_record(record)
-    click.echo(record_path)
+    record_path = record_store.write_preview_generation_record(record)
+    click.echo(_record_locator(record_path, record.generation_id))
 
 
 @launchplane_previews.command("write-enablement")
 @click.option(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
+@click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
-def launchplane_previews_write_enablement(state_dir: Path, input_file: Path) -> None:
+def launchplane_previews_write_enablement(
+    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+) -> None:
+    execution_database_url = _resolve_preview_mutation_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label="launchplane-previews write-enablement",
+    )
+    record_store = _store(state_dir, database_url=execution_database_url)
     record = PreviewEnablementRecord.model_validate(_load_json_file(input_file))
-    record_path = _store(state_dir).write_preview_enablement_record(record)
-    click.echo(record_path)
+    record_path = record_store.write_preview_enablement_record(record)
+    click.echo(_record_locator(record_path, record.record_id))
 
 
 @launchplane_previews.command("request-generation")
@@ -229,12 +308,21 @@ def launchplane_previews_write_enablement(state_dir: Path, input_file: Path) -> 
 @click.option(
     "--generation-input-file", type=click.Path(exists=True, path_type=Path), required=True
 )
+@click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 def launchplane_previews_request_generation(
     state_dir: Path,
     preview_input_file: Path,
     generation_input_file: Path,
+    database_url: str,
+    local_rehearsal: bool,
 ) -> None:
-    record_store = _store(state_dir)
+    execution_database_url = _resolve_preview_mutation_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label="launchplane-previews request-generation",
+    )
+    record_store = _store(state_dir, database_url=execution_database_url)
     preview_request = PreviewMutationRequest.model_validate(_load_json_file(preview_input_file))
     generation_request = PreviewGenerationMutationRequest.model_validate(
         _load_json_file(generation_input_file)
@@ -256,12 +344,21 @@ def launchplane_previews_request_generation(
 @click.option(
     "--generation-input-file", type=click.Path(exists=True, path_type=Path), required=True
 )
+@click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 def launchplane_previews_write_from_generation(
     state_dir: Path,
     preview_input_file: Path,
     generation_input_file: Path,
+    database_url: str,
+    local_rehearsal: bool,
 ) -> None:
-    record_store = _store(state_dir)
+    execution_database_url = _resolve_preview_mutation_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label="launchplane-previews write-from-generation",
+    )
+    record_store = _store(state_dir, database_url=execution_database_url)
     preview_request = PreviewMutationRequest.model_validate(_load_json_file(preview_input_file))
     generation_request = PreviewGenerationMutationRequest.model_validate(
         _load_json_file(generation_input_file)
@@ -279,9 +376,18 @@ def launchplane_previews_write_from_generation(
 @click.option(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
+@click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
-def launchplane_previews_write_destroyed(state_dir: Path, input_file: Path) -> None:
-    record_store = _store(state_dir)
+def launchplane_previews_write_destroyed(
+    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+) -> None:
+    execution_database_url = _resolve_preview_mutation_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label="launchplane-previews write-destroyed",
+    )
+    record_store = _store(state_dir, database_url=execution_database_url)
     request = PreviewDestroyMutationRequest.model_validate(_load_json_file(input_file))
     result_payload = _apply_launchplane_destroy_preview(
         record_store=record_store,
@@ -294,9 +400,18 @@ def launchplane_previews_write_destroyed(state_dir: Path, input_file: Path) -> N
 @click.option(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
+@click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
-def launchplane_previews_mark_generation_ready(state_dir: Path, input_file: Path) -> None:
-    record_store = _store(state_dir)
+def launchplane_previews_mark_generation_ready(
+    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+) -> None:
+    execution_database_url = _resolve_preview_mutation_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label="launchplane-previews mark-generation-ready",
+    )
+    record_store = _store(state_dir, database_url=execution_database_url)
     request = PreviewGenerationMutationRequest.model_validate(_load_json_file(input_file))
     if not request.generation_id.strip():
         raise click.ClickException("Ready-generation transition requires generation_id.")
@@ -323,12 +438,12 @@ def launchplane_previews_mark_generation_ready(state_dir: Path, input_file: Path
     preview_path = record_store.write_preview_record(transitioned_preview)
     click.echo(
         json.dumps(
-            {
-                "generation_id": generation_record.generation_id,
-                "generation_path": str(generation_path),
-                "preview_id": transitioned_preview.preview_id,
-                "preview_path": str(preview_path),
-            },
+            _generation_transition_payload(
+                generation=generation_record,
+                preview=transitioned_preview,
+                generation_locator=generation_path,
+                preview_locator=preview_path,
+            ),
             indent=2,
             sort_keys=True,
         )
@@ -339,9 +454,18 @@ def launchplane_previews_mark_generation_ready(state_dir: Path, input_file: Path
 @click.option(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
+@click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
-def launchplane_previews_mark_generation_failed(state_dir: Path, input_file: Path) -> None:
-    record_store = _store(state_dir)
+def launchplane_previews_mark_generation_failed(
+    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+) -> None:
+    execution_database_url = _resolve_preview_mutation_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label="launchplane-previews mark-generation-failed",
+    )
+    record_store = _store(state_dir, database_url=execution_database_url)
     request = PreviewGenerationMutationRequest.model_validate(_load_json_file(input_file))
     if not request.generation_id.strip():
         raise click.ClickException("Failed-generation transition requires generation_id.")
@@ -368,12 +492,12 @@ def launchplane_previews_mark_generation_failed(state_dir: Path, input_file: Pat
     preview_path = record_store.write_preview_record(transitioned_preview)
     click.echo(
         json.dumps(
-            {
-                "generation_id": generation_record.generation_id,
-                "generation_path": str(generation_path),
-                "preview_id": transitioned_preview.preview_id,
-                "preview_path": str(preview_path),
-            },
+            _generation_transition_payload(
+                generation=generation_record,
+                preview=transitioned_preview,
+                generation_locator=generation_path,
+                preview_locator=preview_path,
+            ),
             indent=2,
             sort_keys=True,
         )
@@ -384,9 +508,18 @@ def launchplane_previews_mark_generation_failed(state_dir: Path, input_file: Pat
 @click.option(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
+@click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
-def launchplane_previews_destroy_preview(state_dir: Path, input_file: Path) -> None:
-    record_store = _store(state_dir)
+def launchplane_previews_destroy_preview(
+    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+) -> None:
+    execution_database_url = _resolve_preview_mutation_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label="launchplane-previews destroy-preview",
+    )
+    record_store = _store(state_dir, database_url=execution_database_url)
     request = PreviewDestroyMutationRequest.model_validate(_load_json_file(input_file))
     result_payload = _apply_launchplane_destroy_preview(
         record_store=record_store,
@@ -399,15 +532,28 @@ def launchplane_previews_destroy_preview(state_dir: Path, input_file: Path) -> N
 @click.option(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
+@click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
 @click.option("--apply", "apply_intent", is_flag=True)
 @click.option("--deliver-feedback", is_flag=True)
 def launchplane_previews_ingest_pr_event(
-    state_dir: Path, input_file: Path, apply_intent: bool, deliver_feedback: bool
+    state_dir: Path,
+    database_url: str,
+    local_rehearsal: bool,
+    input_file: Path,
+    apply_intent: bool,
+    deliver_feedback: bool,
 ) -> None:
+    execution_database_url = _resolve_preview_mutation_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label="launchplane-previews ingest-pr-event",
+    )
     event = GitHubPullRequestEvent.model_validate(_load_json_file(input_file))
     payload = _ingest_launchplane_pr_event_payload(
         state_dir=state_dir,
+        database_url=execution_database_url,
         event=event,
         apply_intent=apply_intent,
         deliver_feedback=deliver_feedback,
@@ -419,6 +565,8 @@ def launchplane_previews_ingest_pr_event(
 @click.option(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
+@click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
 @click.option("--event-name", default="pull_request", show_default=True)
 @click.option("--delivery-id", default="", help="Optional GitHub delivery id for traceability.")
@@ -432,6 +580,8 @@ def launchplane_previews_ingest_pr_event(
 @click.option("--deliver-feedback", is_flag=True)
 def launchplane_previews_ingest_github_webhook(
     state_dir: Path,
+    database_url: str,
+    local_rehearsal: bool,
     input_file: Path,
     event_name: str,
     delivery_id: str,
@@ -440,9 +590,15 @@ def launchplane_previews_ingest_github_webhook(
     apply_intent: bool,
     deliver_feedback: bool,
 ) -> None:
+    execution_database_url = _resolve_preview_mutation_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label="launchplane-previews ingest-github-webhook",
+    )
     raw_payload_bytes, webhook_payload = _load_github_webhook_json_file(input_file)
     payload = _ingest_launchplane_github_webhook_payload(
         state_dir=state_dir,
+        database_url=execution_database_url,
         event_name=event_name,
         raw_payload_bytes=raw_payload_bytes,
         webhook_payload=webhook_payload,
@@ -795,15 +951,24 @@ def launchplane_previews_build_github_webhook_replay_envelope(
 @click.option(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
+@click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
 @click.option("--apply", "apply_intent", is_flag=True)
 @click.option("--deliver-feedback", is_flag=True)
 def launchplane_previews_replay_github_webhook(
     state_dir: Path,
+    database_url: str,
+    local_rehearsal: bool,
     input_file: Path,
     apply_intent: bool,
     deliver_feedback: bool,
 ) -> None:
+    execution_database_url = _resolve_preview_mutation_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label="launchplane-previews replay-github-webhook",
+    )
     try:
         envelope = GitHubWebhookReplayEnvelope.model_validate(_load_json_file(input_file))
     except ValidationError as exc:
@@ -814,6 +979,7 @@ def launchplane_previews_replay_github_webhook(
     raw_payload_bytes, webhook_payload = _load_github_webhook_replay_envelope(envelope)
     payload = _ingest_launchplane_github_webhook_payload(
         state_dir=state_dir,
+        database_url=execution_database_url,
         event_name=resolved_event_name,
         raw_payload_bytes=raw_payload_bytes,
         webhook_payload=webhook_payload,
@@ -840,12 +1006,13 @@ def launchplane_previews_replay_github_webhook(
 def _ingest_launchplane_pr_event_payload(
     *,
     state_dir: Path,
+    database_url: str | None,
     event: GitHubPullRequestEvent,
     apply_intent: bool,
     deliver_feedback: bool,
 ) -> dict[str, object]:
     control_plane_root = _control_plane_root()
-    record_store = _store(state_dir)
+    record_store = _store(state_dir, database_url=database_url)
     payload = build_pull_request_event_action_payload(
         control_plane_root=control_plane_root,
         record_store=record_store,
@@ -929,6 +1096,7 @@ def _ingest_launchplane_pr_event_payload(
 def _ingest_launchplane_github_webhook_payload(
     *,
     state_dir: Path,
+    database_url: str | None,
     event_name: str,
     raw_payload_bytes: bytes,
     webhook_payload: dict[str, object],
@@ -956,6 +1124,7 @@ def _ingest_launchplane_github_webhook_payload(
     )
     payload = _ingest_launchplane_pr_event_payload(
         state_dir=state_dir,
+        database_url=database_url,
         event=event,
         apply_intent=apply_intent,
         deliver_feedback=deliver_feedback,
@@ -1004,7 +1173,7 @@ def _load_github_webhook_replay_envelope(
 
 def _verify_launchplane_github_webhook_signature(
     *,
-    record_store: FilesystemRecordStore,
+    record_store: LaunchplanePreviewRecordStore,
     control_plane_root: Path,
     event_name: str,
     webhook_payload: dict[str, object],
@@ -1049,7 +1218,10 @@ def _verify_launchplane_github_webhook_signature(
 
 
 def _resolve_launchplane_github_webhook_context(
-    *, record_store: FilesystemRecordStore, event_name: str, webhook_payload: dict[str, object]
+    *,
+    record_store: LaunchplanePreviewRecordStore,
+    event_name: str,
+    webhook_payload: dict[str, object],
 ) -> str:
     if event_name.strip() != "pull_request":
         return ""
@@ -1251,7 +1423,7 @@ def launchplane_previews_history(
 
 def _read_launchplane_preview_or_fail(
     *,
-    record_store: FilesystemRecordStore,
+    record_store: LaunchplanePreviewRecordStore,
     context_name: str,
     anchor_repo: str,
     anchor_pr_number: int,
@@ -1271,7 +1443,7 @@ def _read_launchplane_preview_or_fail(
 
 def _read_launchplane_generation_or_fail(
     *,
-    record_store: FilesystemRecordStore,
+    record_store: LaunchplanePreviewRecordStore,
     preview_id: str,
     generation_id: str,
 ) -> PreviewGenerationRecord:
@@ -1287,7 +1459,7 @@ def _read_launchplane_generation_or_fail(
 def _apply_launchplane_request_generation(
     *,
     control_plane_root: Path,
-    record_store: FilesystemRecordStore,
+    record_store: LaunchplanePreviewRecordStore,
     preview_request: PreviewMutationRequest,
     generation_request: PreviewGenerationMutationRequest,
 ) -> dict[str, object]:
@@ -1308,16 +1480,16 @@ def _apply_launchplane_request_generation(
     preview_path = record_store.write_preview_record(transitioned_preview)
     return {
         "generation_id": generation_record.generation_id,
-        "generation_path": str(generation_path),
+        "generation_path": _record_locator(generation_path, generation_record.generation_id),
         "preview_id": transitioned_preview.preview_id,
-        "preview_path": str(preview_path),
+        "preview_path": _record_locator(preview_path, transitioned_preview.preview_id),
     }
 
 
 def _upsert_launchplane_preview_from_request(
     *,
     control_plane_root: Path,
-    record_store: FilesystemRecordStore,
+    record_store: LaunchplanePreviewRecordStore,
     request: PreviewMutationRequest,
 ) -> PreviewRecord:
     return shared_upsert_launchplane_preview_from_request(
@@ -1330,7 +1502,7 @@ def _upsert_launchplane_preview_from_request(
 def _apply_launchplane_generation_evidence(
     *,
     control_plane_root: Path,
-    record_store: FilesystemRecordStore,
+    record_store: LaunchplanePreviewRecordStore,
     preview_request: PreviewMutationRequest,
     generation_request: PreviewGenerationMutationRequest,
 ) -> dict[str, object]:
@@ -1344,7 +1516,7 @@ def _apply_launchplane_generation_evidence(
 
 def _apply_launchplane_destroy_preview(
     *,
-    record_store: FilesystemRecordStore,
+    record_store: LaunchplanePreviewRecordStore,
     request: PreviewDestroyMutationRequest,
 ) -> dict[str, object]:
     return shared_apply_launchplane_destroy_preview(
@@ -1356,7 +1528,7 @@ def _apply_launchplane_destroy_preview(
 def _apply_launchplane_pr_event_intent(
     *,
     control_plane_root: Path,
-    record_store: FilesystemRecordStore,
+    record_store: LaunchplanePreviewRecordStore,
     payload: dict[str, object],
 ) -> dict[str, object]:
     mutation_payload = payload.get("mutation")

--- a/control_plane/launchplane_mutations.py
+++ b/control_plane/launchplane_mutations.py
@@ -22,6 +22,13 @@ from control_plane.workflows.launchplane import (
 )
 
 
+def _record_locator(value: object, fallback: str) -> str:
+    if value is None:
+        return fallback
+    normalized_value = str(value).strip()
+    return normalized_value or fallback
+
+
 class LaunchplaneMutationStore(PreviewMutationRecordStore, Protocol):
     def write_preview_record(self, record: PreviewRecord) -> object: ...
 
@@ -108,9 +115,9 @@ def apply_launchplane_generation_evidence(
     preview_path = record_store.write_preview_record(transitioned_preview)
     return {
         "generation_id": generation_record.generation_id,
-        "generation_path": str(generation_path),
+        "generation_path": _record_locator(generation_path, generation_record.generation_id),
         "preview_id": transitioned_preview.preview_id,
-        "preview_path": str(preview_path),
+        "preview_path": _record_locator(preview_path, transitioned_preview.preview_id),
         "transition": generation_record.state,
     }
 
@@ -138,6 +145,6 @@ def apply_launchplane_destroy_preview(
     preview_path = record_store.write_preview_record(transitioned_preview)
     return {
         "preview_id": transitioned_preview.preview_id,
-        "preview_path": str(preview_path),
+        "preview_path": _record_locator(preview_path, transitioned_preview.preview_id),
         "transition": "destroyed",
     }

--- a/control_plane/launchplane_rendering.py
+++ b/control_plane/launchplane_rendering.py
@@ -122,6 +122,7 @@ def build_launchplane_action_script(
         "launchplane",
         "launchplane-previews",
         command_name,
+        "--local-rehearsal",
         "--state-dir",
         '"$STATE_DIR"',
     ]
@@ -344,7 +345,7 @@ def build_launchplane_backup_gate_write_recipe_script(
         "cat >\"$BACKUP_GATE_FILE\" <<'JSON'",
         json.dumps(payload, indent=2, sort_keys=True),
         "JSON",
-        'uv run launchplane backup-gates write --state-dir "$STATE_DIR" --input-file "$BACKUP_GATE_FILE"',
+        'uv run launchplane backup-gates write --local-rehearsal --state-dir "$STATE_DIR" --input-file "$BACKUP_GATE_FILE"',
     ]
     return "\n".join(lines)
 

--- a/control_plane/storage/migrations/versions/b1c3d5e7f9a1_add_preview_enablement.py
+++ b/control_plane/storage/migrations/versions/b1c3d5e7f9a1_add_preview_enablement.py
@@ -1,0 +1,59 @@
+"""add preview enablement records
+
+Revision ID: b1c3d5e7f9a1
+Revises: f7d8e9a0b1c2
+Create Date: 2026-05-22 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "b1c3d5e7f9a1"
+down_revision: str | None = "f7d8e9a0b1c2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "launchplane_preview_enablement",
+        sa.Column("record_id", sa.String(), nullable=False),
+        sa.Column("context", sa.String(), nullable=False),
+        sa.Column("anchor_repo", sa.String(), nullable=False),
+        sa.Column("anchor_pr_number", sa.Integer(), nullable=False),
+        sa.Column("pr_state", sa.String(), nullable=False),
+        sa.Column("updated_at", sa.String(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("record_id"),
+    )
+    op.create_index(
+        "launchplane_preview_enablement_context_idx",
+        "launchplane_preview_enablement",
+        ["context", sa.text("updated_at DESC")],
+    )
+    op.create_index(
+        "launchplane_preview_enablement_anchor_idx",
+        "launchplane_preview_enablement",
+        ["anchor_repo", "anchor_pr_number", sa.text("updated_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "launchplane_preview_enablement_anchor_idx",
+        table_name="launchplane_preview_enablement",
+    )
+    op.drop_index(
+        "launchplane_preview_enablement_context_idx",
+        table_name="launchplane_preview_enablement",
+    )
+    op.drop_table("launchplane_preview_enablement")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -7,7 +7,6 @@ from typing import Any, Literal, Protocol, TypeVar, cast
 from pydantic import BaseModel
 from sqlalchemy import (
     JSON,
-    ColumnExpressionArgument,
     Index,
     Integer,
     String,
@@ -59,6 +58,7 @@ from control_plane.contracts.odoo_stable_target_replacement_operation import (
     OdooStableTargetReplacementOperationRecord,
 )
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
+from control_plane.contracts.preview_enablement_record import PreviewEnablementRecord
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
 from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
 from control_plane.contracts.preview_lifecycle_cleanup_record import PreviewLifecycleCleanupRecord
@@ -90,8 +90,6 @@ PayloadDict = dict[str, Any]
 PayloadJsonType = JSON().with_variant(JSONB(), "postgresql")
 RuntimeEnvironmentDeleteStatus = Literal["deleted", "missing", "changed"]
 CurrentAuthorityDeleteStatus = Literal["deleted", "missing", "changed"]
-_SqlFilter = ColumnExpressionArgument[bool]
-_SqlOrderBy = ColumnExpressionArgument[Any]
 
 
 class _PayloadRow(Protocol):
@@ -252,6 +250,31 @@ class LaunchplanePreviewGenerationRow(Base):
     requested_at: Mapped[str] = mapped_column(String, nullable=False)
     finished_at: Mapped[str] = mapped_column(String, nullable=False)
     artifact_id: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplanePreviewEnablementRow(Base):
+    __tablename__ = "launchplane_preview_enablement"
+    __table_args__ = (
+        Index(
+            "launchplane_preview_enablement_context_idx",
+            "context",
+            desc("updated_at"),
+        ),
+        Index(
+            "launchplane_preview_enablement_anchor_idx",
+            "anchor_repo",
+            "anchor_pr_number",
+            desc("updated_at"),
+        ),
+    )
+
+    record_id: Mapped[str] = mapped_column(String, primary_key=True)
+    context: Mapped[str] = mapped_column(String, nullable=False)
+    anchor_repo: Mapped[str] = mapped_column(String, nullable=False)
+    anchor_pr_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    pr_state: Mapped[str] = mapped_column(String, nullable=False)
+    updated_at: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -1057,7 +1080,7 @@ class PostgresRecordStore(HumanSessionStore):
         orm_model: type[Base],
         filters: Sequence[object],
     ) -> RecordModel:
-        statement = select(orm_model).where(*cast(Sequence[_SqlFilter], filters)).limit(1)
+        statement = select(orm_model).where(*cast(Any, filters)).limit(1)
         with self._session_factory() as session:
             row = session.scalar(statement)
             if row is None:
@@ -1094,8 +1117,8 @@ class PostgresRecordStore(HumanSessionStore):
     ) -> tuple[RecordModel, ...]:
         statement = select(orm_model)
         if filters:
-            statement = statement.where(*cast(Sequence[_SqlFilter], filters))
-        statement = statement.order_by(*cast(Sequence[_SqlOrderBy], order_by))
+            statement = statement.where(*cast(Any, filters))
+        statement = statement.order_by(*cast(Any, order_by))
         if offset > 0:
             statement = statement.offset(offset)
         if limit is not None:
@@ -1683,6 +1706,52 @@ class PostgresRecordStore(HumanSessionStore):
             limit=limit,
         )
 
+    def write_preview_enablement_record(self, record: PreviewEnablementRecord) -> None:
+        self._write_row(
+            LaunchplanePreviewEnablementRow(
+                record_id=record.record_id,
+                context=record.context,
+                anchor_repo=record.anchor_repo,
+                anchor_pr_number=record.anchor_pr_number,
+                pr_state=record.pr_state,
+                updated_at=record.updated_at,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def read_preview_enablement_record(self, record_id: str) -> PreviewEnablementRecord:
+        return self._read_model(
+            model_type=PreviewEnablementRecord,
+            orm_model=LaunchplanePreviewEnablementRow,
+            filters=(LaunchplanePreviewEnablementRow.record_id == record_id,),
+        )
+
+    def list_preview_enablement_records(
+        self,
+        *,
+        context_name: str = "",
+        anchor_repo: str = "",
+        pr_state: str = "",
+        limit: int | None = None,
+    ) -> tuple[PreviewEnablementRecord, ...]:
+        filters: list[object] = []
+        if context_name:
+            filters.append(LaunchplanePreviewEnablementRow.context == context_name)
+        if anchor_repo:
+            filters.append(LaunchplanePreviewEnablementRow.anchor_repo == anchor_repo)
+        if pr_state:
+            filters.append(LaunchplanePreviewEnablementRow.pr_state == pr_state)
+        return self._list_models(
+            model_type=PreviewEnablementRecord,
+            orm_model=LaunchplanePreviewEnablementRow,
+            filters=filters,
+            order_by=(
+                LaunchplanePreviewEnablementRow.updated_at.desc(),
+                LaunchplanePreviewEnablementRow.record_id.desc(),
+            ),
+            limit=limit,
+        )
+
     def write_preview_inventory_scan_record(self, record: PreviewInventoryScanRecord) -> None:
         self._write_row(
             LaunchplanePreviewInventoryScanRow(
@@ -1805,7 +1874,7 @@ class PostgresRecordStore(HumanSessionStore):
         limit: int | None = None,
         offset: int = 0,
     ) -> tuple[EveryCodeWorkRequestRecord, ...]:
-        filters: list[_SqlFilter] = []
+        filters: list[Any] = []
         if state:
             filters.append(LaunchplaneEveryCodeWorkRequestRow.state == state)
         if repository:
@@ -1952,9 +2021,7 @@ class PostgresRecordStore(HumanSessionStore):
             )
         )
 
-    def write_merge_train_pr_feedback_record(
-        self, record: MergeTrainPrFeedbackRecord
-    ) -> None:
+    def write_merge_train_pr_feedback_record(self, record: MergeTrainPrFeedbackRecord) -> None:
         self._write_row(
             LaunchplaneMergeTrainPrFeedbackRow(
                 feedback_id=record.feedback_id,
@@ -3105,6 +3172,7 @@ class PostgresRecordStore(HumanSessionStore):
             "odoo_instance_overrides": 0,
             "product_profiles": 0,
             "preview_records": 0,
+            "preview_enablement": 0,
             "preview_generations": 0,
             "preview_desired_states": 0,
             "preview_inventory_scans": 0,
@@ -3154,6 +3222,10 @@ class PostgresRecordStore(HumanSessionStore):
         for preview_record in filesystem_store.list_preview_records():
             self.write_preview_record(preview_record)
             counts["preview_records"] += 1
+        if hasattr(filesystem_store, "list_preview_enablement_records"):
+            for enablement_record in filesystem_store.list_preview_enablement_records():
+                self.write_preview_enablement_record(enablement_record)
+                counts["preview_enablement"] += 1
         for generation_record in filesystem_store.list_preview_generation_records():
             self.write_preview_generation_record(generation_record)
             counts["preview_generations"] += 1

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -86,6 +86,10 @@ fallback.
   `inventory write-from-*`, and `release-tuples write-from-promotion` require
   `--database-url` or `LAUNCHPLANE_DATABASE_URL`; explicit offline filesystem
   writes must opt in with `--local-rehearsal`.
+- `launchplane-previews` mutation, ingest, replay, and lifecycle transition
+  commands require `--database-url` or `LAUNCHPLANE_DATABASE_URL`; explicit
+  offline filesystem writes must opt in with `--local-rehearsal`. Read and
+  render commands may keep `--state-dir` as local inspection surfaces.
 
 ### Migrate Or Demote
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -688,6 +688,11 @@ baseline tuples from Launchplane's DB-backed release-tuple records. Cockpit and
 local renders should run with `LAUNCHPLANE_DATABASE_URL` pointed at the same
 shared store that owns the current stable-lane tuple state.
 
+Preview mutation, ingest, replay, and lifecycle transition commands require
+`--database-url` or `LAUNCHPLANE_DATABASE_URL`. Offline JSON writes are local
+rehearsals only and must opt in with `--local-rehearsal`; read and render
+commands may still inspect a local `--state-dir`.
+
 Any exported release-tuple catalog is seed/reference material now, not live
 runtime authority. Pull requests flow through Launchplane preview records
 instead of a tracked long-lived `dev` tuple lane.
@@ -867,8 +872,8 @@ to pin the payload shape while the Launchplane service ingress continues to
 absorb the reusable lifecycle behavior.
 
 For a successful or failed preview refresh, emit two JSON payloads and hand
-them to Launchplane's preview-generation evidence ingress. The current local adapter
-is `launchplane-previews write-from-generation`:
+them to Launchplane's preview-generation evidence ingress. The current local
+rehearsal adapter is `launchplane-previews write-from-generation`:
 
 ```json
 {
@@ -914,7 +919,7 @@ That evidence maps directly from the VeriReel workflow outputs:
 
 For cleanup, emit the destroy payload and hand it to
 Launchplane's preview-destroyed evidence ingress once the preview teardown has
-actually completed. The current local adapter is
+actually completed. The current local rehearsal adapter is
 `launchplane-previews write-destroyed`:
 
 ```json

--- a/tests/test_launchplane_previews.py
+++ b/tests/test_launchplane_previews.py
@@ -1262,6 +1262,7 @@ ODOO_DB_PASSWORD = "local-secret"
             self.assertIn("Write-side Launchplane recipes", rendered_html)
             self.assertIn("request-generation", rendered_html)
             self.assertIn("destroy-preview", rendered_html)
+            self.assertIn("--local-rehearsal", rendered_html)
             self.assertIn('id="operator-actions"', rendered_html)
             self.assertIn(
                 "This preview is live at the stable Launchplane route and serving the latest requested generation.",
@@ -1478,6 +1479,7 @@ ODOO_DB_PASSWORD = "local-secret"
                 [
                     "launchplane-previews",
                     "ingest-pr-event",
+                    "--local-rehearsal",
                     "--state-dir",
                     str(state_dir),
                     "--input-file",
@@ -1523,6 +1525,7 @@ ODOO_DB_PASSWORD = "local-secret"
                 [
                     "launchplane-previews",
                     "write-enablement",
+                    "--local-rehearsal",
                     "--state-dir",
                     str(state_dir),
                     "--input-file",
@@ -1578,6 +1581,7 @@ ODOO_DB_PASSWORD = "local-secret"
                 [
                     "launchplane-previews",
                     "ingest-pr-event",
+                    "--local-rehearsal",
                     "--state-dir",
                     str(state_dir),
                     "--input-file",
@@ -1855,6 +1859,7 @@ ODOO_DB_PASSWORD = "local-secret"
                 rendered_html,
             )
             self.assertIn("backup-gates write", rendered_html)
+            self.assertIn("--local-rehearsal", rendered_html)
             self.assertNotIn("promote resolve", rendered_html)
 
     def test_launchplane_previews_render_index_page_leads_with_enablement_when_no_lane_evidence_exists(
@@ -3000,6 +3005,7 @@ ODOO_DB_PASSWORD = "local-secret"
             self.assertIn("latest / active", rendered_html)
             self.assertIn("mark-generation-ready", rendered_html)
             self.assertIn("mark-generation-failed", rendered_html)
+            self.assertIn("--local-rehearsal", rendered_html)
             self.assertNotIn(
                 "Latest replacement failed. Launchplane is still serving the older preview.",
                 rendered_html,
@@ -3261,6 +3267,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "write-preview",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -3327,6 +3334,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "write-preview",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -3377,6 +3385,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "write-preview",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -3417,6 +3426,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "write-preview",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -3471,6 +3481,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                 [
                     "launchplane-previews",
                     "write-generation",
+                    "--local-rehearsal",
                     "--state-dir",
                     str(state_dir),
                     "--input-file",
@@ -3512,6 +3523,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                 [
                     "launchplane-previews",
                     "write-generation",
+                    "--local-rehearsal",
                     "--state-dir",
                     str(state_dir),
                     "--input-file",
@@ -3598,6 +3610,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "request-generation",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--preview-input-file",
@@ -3668,6 +3681,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "write-from-generation",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--preview-input-file",
@@ -3758,6 +3772,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                 [
                     "launchplane-previews",
                     "mark-generation-ready",
+                    "--local-rehearsal",
                     "--state-dir",
                     str(state_dir),
                     "--input-file",
@@ -3837,6 +3852,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                 [
                     "launchplane-previews",
                     "mark-generation-failed",
+                    "--local-rehearsal",
                     "--state-dir",
                     str(state_dir),
                     "--input-file",
@@ -3884,6 +3900,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                 [
                     "launchplane-previews",
                     "destroy-preview",
+                    "--local-rehearsal",
                     "--state-dir",
                     str(state_dir),
                     "--input-file",
@@ -3937,6 +3954,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                 [
                     "launchplane-previews",
                     "write-destroyed",
+                    "--local-rehearsal",
                     "--state-dir",
                     str(state_dir),
                     "--input-file",
@@ -3997,6 +4015,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "ingest-pr-event",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -4086,6 +4105,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "ingest-pr-event",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -4162,6 +4182,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "ingest-pr-event",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -4233,6 +4254,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "ingest-pr-event",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -4418,6 +4440,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "ingest-pr-event",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -4504,6 +4527,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "ingest-pr-event",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -4559,6 +4583,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "ingest-pr-event",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -4609,6 +4634,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "ingest-pr-event",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -4674,6 +4700,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "ingest-pr-event",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -4744,6 +4771,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "ingest-pr-event",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -4793,6 +4821,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "ingest-pr-event",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -4825,6 +4854,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "ingest-github-webhook",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -4875,6 +4905,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "ingest-github-webhook",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -4913,6 +4944,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                 [
                     "launchplane-previews",
                     "ingest-github-webhook",
+                    "--local-rehearsal",
                     "--input-file",
                     str(input_file),
                     "--event-name",
@@ -4939,6 +4971,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                 [
                     "launchplane-previews",
                     "ingest-github-webhook",
+                    "--local-rehearsal",
                     "--input-file",
                     str(input_file),
                     "--allow-unsigned",
@@ -4965,6 +4998,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "ingest-github-webhook",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -4997,6 +5031,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "ingest-github-webhook",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -5038,6 +5073,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "replay-github-webhook",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -5162,6 +5198,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "replay-github-webhook",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -5379,6 +5416,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "replay-github-webhook",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -5614,6 +5652,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "replay-github-webhook",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -6515,6 +6554,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "replay-github-webhook",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",
@@ -6572,6 +6612,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                 [
                     "launchplane-previews",
                     "replay-github-webhook",
+                    "--local-rehearsal",
                     "--input-file",
                     str(input_file),
                 ],
@@ -6601,6 +6642,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                 [
                     "launchplane-previews",
                     "replay-github-webhook",
+                    "--local-rehearsal",
                     "--input-file",
                     str(input_file),
                 ],
@@ -6648,6 +6690,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                     [
                         "launchplane-previews",
                         "ingest-pr-event",
+                        "--local-rehearsal",
                         "--state-dir",
                         str(state_dir),
                         "--input-file",

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -75,6 +75,7 @@ from control_plane.contracts.odoo_stable_target_replacement_operation import (
     OdooStableTargetReplacementOperationRecord,
 )
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
+from control_plane.contracts.preview_enablement_record import PreviewEnablementRecord
 from control_plane.contracts.preview_generation_record import (
     PreviewGenerationRecord,
     PreviewPullRequestSummary,
@@ -407,6 +408,26 @@ def _preview_generation_record(*, generation_id: str, preview_id: str) -> Previe
         deploy_status="pass",
         verify_status="pass",
         overall_health_status="pass",
+    )
+
+
+def _preview_enablement_record(
+    *, record_id: str, updated_at: str, pr_number: int
+) -> PreviewEnablementRecord:
+    return PreviewEnablementRecord(
+        record_id=record_id,
+        context="verireel-testing",
+        anchor_repo="verireel",
+        anchor_pr_number=pr_number,
+        anchor_pr_url=f"https://github.com/every/verireel/pull/{pr_number}",
+        anchor_head_sha="6b3c9d7e8f901234567890abcdef1234567890ab",
+        action="labeled",
+        pr_state="open",
+        updated_at=updated_at,
+        label_enabled=True,
+        action_label="preview",
+        request_metadata_status="valid",
+        request_metadata_baseline_channel="testing",
     )
 
 
@@ -1161,6 +1182,49 @@ class PostgresRecordStoreTests(unittest.TestCase):
                 "preview-verireel-testing-verireel-pr-102",
                 "preview-verireel-testing-verireel-pr-103",
             ],
+        )
+
+    def test_write_read_and_list_preview_enablement_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+
+            older_record = _preview_enablement_record(
+                record_id="verireel-testing-verireel-pr-101",
+                updated_at="2026-04-20T10:01:00Z",
+                pr_number=101,
+            )
+            newer_record = _preview_enablement_record(
+                record_id="verireel-testing-verireel-pr-102",
+                updated_at="2026-04-20T10:03:00Z",
+                pr_number=102,
+            )
+            closed_record = _preview_enablement_record(
+                record_id="verireel-testing-verireel-pr-103",
+                updated_at="2026-04-20T10:02:00Z",
+                pr_number=103,
+            ).model_copy(update={"pr_state": "closed"})
+
+            store.write_preview_enablement_record(older_record)
+            store.write_preview_enablement_record(newer_record)
+            store.write_preview_enablement_record(closed_record)
+            read_record = store.read_preview_enablement_record(newer_record.record_id)
+            listed_records = store.list_preview_enablement_records(
+                context_name="verireel-testing",
+                anchor_repo="verireel",
+                pr_state="open",
+                limit=2,
+            )
+            store.close()
+
+        self.assertEqual(read_record.anchor_pr_number, 102)
+        self.assertEqual(
+            [record.record_id for record in listed_records],
+            ["verireel-testing-verireel-pr-102", "verireel-testing-verireel-pr-101"],
         )
 
     def test_preview_summaries_include_latest_generation(self) -> None:
@@ -2284,6 +2348,13 @@ env_var = "GH_TOKEN"
                     pr_number=123,
                 )
             )
+            filesystem_store.write_preview_enablement_record(
+                _preview_enablement_record(
+                    record_id="verireel-testing-verireel-pr-123",
+                    updated_at="2026-04-20T10:05:30Z",
+                    pr_number=123,
+                )
+            )
             filesystem_store.write_preview_generation_record(
                 _preview_generation_record(
                     generation_id="preview-verireel-testing-verireel-pr-123-generation-0001",
@@ -2456,6 +2527,7 @@ env_var = "GH_TOKEN"
                     "odoo_instance_overrides": 1,
                     "product_profiles": 1,
                     "preview_records": 1,
+                    "preview_enablement": 1,
                     "preview_generations": 1,
                     "preview_desired_states": 1,
                     "preview_inventory_scans": 1,
@@ -2487,6 +2559,12 @@ env_var = "GH_TOKEN"
                     "preview-verireel-testing-verireel-pr-123-generation-0001"
                 ).state,
                 "ready",
+            )
+            self.assertEqual(
+                store.read_preview_enablement_record(
+                    "verireel-testing-verireel-pr-123"
+                ).request_metadata_baseline_channel,
+                "testing",
             )
             self.assertEqual(
                 store.list_preview_inventory_scan_records(


### PR DESCRIPTION
## Summary

- require `launchplane-previews` mutation, ingest, replay, and lifecycle commands to use `--database-url`/`LAUNCHPLANE_DATABASE_URL` unless `--local-rehearsal` is explicitly set
- add Postgres persistence and migration support for `PreviewEnablementRecord`, including filesystem import coverage
- update local rehearsal recipes/docs so rendered preview actions and operational guidance no longer imply silent file-backed authority

## Verification

- `uv run --extra dev ruff format --check control_plane/cli_launchplane_previews.py control_plane/launchplane_mutations.py control_plane/launchplane_rendering.py control_plane/storage/postgres.py tests/test_launchplane_previews.py tests/test_postgres_store.py control_plane/storage/migrations/versions/b1c3d5e7f9a1_add_preview_enablement.py`
- `uv run --extra dev ruff check control_plane/cli_launchplane_previews.py control_plane/launchplane_mutations.py control_plane/launchplane_rendering.py control_plane/storage/postgres.py tests/test_launchplane_previews.py tests/test_postgres_store.py control_plane/storage/migrations/versions/b1c3d5e7f9a1_add_preview_enablement.py`
- `uv run --extra dev mypy control_plane/cli_launchplane_previews.py control_plane/launchplane_mutations.py control_plane/launchplane_rendering.py control_plane/storage/postgres.py tests/test_launchplane_previews.py tests/test_postgres_store.py`
- `uv run python -m unittest tests.test_postgres_store tests.test_launchplane_previews`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files` (non-blocking existing weak/test-harness warnings remain; no ruff/mypy/test failures)

Part of #834.
