### PR TITLE
Require DB authority for data freshness inspection

### DIFF
--- a/control_plane/cli_service.py
+++ b/control_plane/cli_service.py
@@ -526,14 +526,29 @@ def service_inspect_config_boundary(control_plane_root: Path | None) -> None:
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
 @click.option("--database-url", envvar=_DATABASE_URL_ENV_KEYS, default="", show_default=False)
+@click.option("--local-inspection", is_flag=True, default=False)
 @click.option("--context", "context_name", default="verireel", show_default=True)
 @click.option(
     "--preview-context", "preview_context_name", default="verireel-testing", show_default=True
 )
 def service_inspect_data_freshness(
-    state_dir: Path, database_url: str, context_name: str, preview_context_name: str
+    state_dir: Path,
+    database_url: str,
+    local_inspection: bool,
+    context_name: str,
+    preview_context_name: str,
 ) -> None:
-    record_store = _store(state_dir=state_dir, database_url=database_url)
+    resolved_database_url = database_url.strip()
+    if not resolved_database_url and not local_inspection:
+        raise click.ClickException(
+            "service inspect-data-freshness requires --database-url or "
+            "LAUNCHPLANE_DATABASE_URL. Use --local-inspection for explicit local "
+            "filesystem inspection."
+        )
+    record_store = _store(
+        state_dir=state_dir,
+        database_url=resolved_database_url if resolved_database_url else None,
+    )
     try:
         payload = _build_data_freshness_report(
             record_store=record_store,

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -90,6 +90,9 @@ fallback.
   commands require `--database-url` or `LAUNCHPLANE_DATABASE_URL`; explicit
   offline filesystem writes must opt in with `--local-rehearsal`. Read and
   render commands may keep `--state-dir` as local inspection surfaces.
+- `service inspect-data-freshness` requires `--database-url` or
+  `LAUNCHPLANE_DATABASE_URL`; explicit local JSON inspection must opt in with
+  `--local-inspection`.
 
 ### Migrate Or Demote
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -17135,6 +17135,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 [
                     "service",
                     "inspect-data-freshness",
+                    "--local-inspection",
                     "--state-dir",
                     str(state_dir),
                 ],
@@ -17153,6 +17154,24 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 "verireel-testing/preview-verireel-testing-verireel-pr-123",
             },
         )
+
+    def test_data_freshness_report_requires_database_or_local_inspection(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            result = runner.invoke(
+                CLI_MAIN,
+                [
+                    "service",
+                    "inspect-data-freshness",
+                    "--state-dir",
+                    str(state_dir),
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 1, msg=result.output)
+        self.assertIn("requires --database-url or LAUNCHPLANE_DATABASE_URL", result.output)
+        self.assertIn("--local-inspection", result.output)
 
     def test_data_freshness_report_uses_empty_preview_inventory_scan(self) -> None:
         runner = CliRunner()
@@ -17176,6 +17195,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 [
                     "service",
                     "inspect-data-freshness",
+                    "--local-inspection",
                     "--state-dir",
                     str(state_dir),
                 ],


### PR DESCRIPTION
## Summary
- require `service inspect-data-freshness` to use `--database-url`/`LAUNCHPLANE_DATABASE_URL` unless `--local-inspection` is explicitly set
- update local filesystem tests to opt into local inspection
- document the data freshness inspection authority boundary

## Verification
- `uv run --extra dev ruff format --check control_plane/cli_service.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/cli_service.py tests/test_service.py`
- `uv run --extra dev mypy control_plane/cli_service.py tests/test_service.py`
- `uv run python -m unittest tests.test_service`

Part of #834.
