### PR TITLE
Use DB authority for preview webhook context

### DIFF
--- a/control_plane/cli_launchplane_previews.py
+++ b/control_plane/cli_launchplane_previews.py
@@ -1108,7 +1108,7 @@ def _ingest_launchplane_github_webhook_payload(
     deliver_feedback: bool,
 ) -> dict[str, object]:
     control_plane_root = _control_plane_root()
-    record_store = _store(state_dir)
+    record_store = _store(state_dir, database_url=database_url)
     signature_verification = _verify_launchplane_github_webhook_signature(
         record_store=record_store,
         control_plane_root=control_plane_root,

--- a/tests/test_launchplane_previews.py
+++ b/tests/test_launchplane_previews.py
@@ -4879,6 +4879,53 @@ ENV_OVERRIDE_DISABLE_CRON = true
             self.assertEqual(payload["webhook"]["delivery"]["delivery_id"], "gh-delivery-123")
             self.assertEqual(payload["webhook"]["delivery"]["delivery_source"], "github-webhook")
 
+    def test_launchplane_previews_ingest_github_webhook_uses_database_for_signature_context(
+        self,
+    ) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            _write_release_tuples_file(control_plane_root)
+            _write_runtime_environments_file(control_plane_root)
+            database_url = _runtime_environments_database_url(control_plane_root)
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                store.write_product_profile_record(
+                    _preview_product_profile(
+                        product="tenant-opw",
+                        repository="every/tenant-opw",
+                        preview_context="opw",
+                    )
+                )
+            finally:
+                store.close()
+            input_file = control_plane_root / "github-webhook.json"
+            webhook_payload = _github_pull_request_webhook_payload()
+            input_file.write_text(json.dumps(webhook_payload), encoding="utf-8")
+
+            with patch("control_plane.cli._control_plane_root", return_value=control_plane_root):
+                result = runner.invoke(
+                    CLI_MAIN,
+                    [
+                        "launchplane-previews",
+                        "ingest-github-webhook",
+                        "--database-url",
+                        database_url,
+                        "--state-dir",
+                        str(control_plane_root / "empty-state"),
+                        "--input-file",
+                        str(input_file),
+                        "--signature-256",
+                        _github_webhook_signature(webhook_payload),
+                    ],
+                    env={"LAUNCHPLANE_DATABASE_URL": database_url},
+                )
+
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+            payload = json.loads(result.output)
+            self.assertEqual(payload["webhook"]["signature_verification"]["context"], "opw")
+            self.assertTrue(payload["webhook"]["signature_verification"]["verified"])
+
     def test_launchplane_previews_ingest_github_webhook_adapts_closed_pull_request_destroy_intent(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- route Launchplane preview webhook signature/context lookup through the resolved preview store instead of always opening filesystem state
- add a regression that seeds product profile authority in SQLite while pointing `--state-dir` at an empty directory

## Verification
- `uv run --extra dev ruff format --check control_plane/cli_launchplane_previews.py tests/test_launchplane_previews.py`
- `uv run --extra dev ruff check control_plane/cli_launchplane_previews.py tests/test_launchplane_previews.py`
- `uv run --extra dev mypy control_plane/cli_launchplane_previews.py tests/test_launchplane_previews.py`
- `uv run python -m unittest tests.test_launchplane_previews`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files` (non-blocking broad weak warnings in previously touched files remain)

Part of #834.
