### PR TITLE
Require DB authority for worker runtime key safety

### DIFF
--- a/control_plane/workflows/worker_runtime_key_safety.py
+++ b/control_plane/workflows/worker_runtime_key_safety.py
@@ -22,7 +22,9 @@ def enforce_worker_runtime_key_safety(
 ) -> None:
     database_url = resolve_database_url(None)
     if database_url is None:
-        return
+        raise click.ClickException(
+            f"Runtime key-safety gate requires LAUNCHPLANE_DATABASE_URL for {operation_name}."
+        )
 
     record_store = PostgresRecordStore(database_url=database_url)
     record_store.ensure_schema()

--- a/tests/test_verireel_prod_backup_gate.py
+++ b/tests/test_verireel_prod_backup_gate.py
@@ -199,6 +199,25 @@ class VeriReelProdBackupGateWorkflowTests(unittest.TestCase):
 
         run.assert_not_called()
 
+    def test_run_delegated_worker_requires_database_for_runtime_key_safety(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            with (
+                patch.dict("os.environ", {}, clear=True),
+                patch("control_plane.workflows.verireel_prod_backup_gate.subprocess.run") as run,
+            ):
+                with self.assertRaisesRegex(click.ClickException, "LAUNCHPLANE_DATABASE_URL"):
+                    _run_delegated_worker(
+                        control_plane_root=root,
+                        request=VeriReelProdBackupGateWorkerRequest(
+                            context="verireel",
+                            instance="prod",
+                            backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                        ),
+                    )
+
+        run.assert_not_called()
+
     def test_prod_backup_gate_default_timeout_allows_longer_vzdump_backup(self) -> None:
         self.assertEqual(DEFAULT_TIMEOUT_SECONDS, 1800)
 

--- a/tests/test_verireel_prod_rollback.py
+++ b/tests/test_verireel_prod_rollback.py
@@ -237,6 +237,27 @@ class VeriReelProdRollbackWorkflowTests(unittest.TestCase):
 
         run.assert_not_called()
 
+    def test_run_delegated_worker_requires_database_for_runtime_key_safety(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            with (
+                patch.dict("os.environ", {}, clear=True),
+                patch("control_plane.workflows.verireel_prod_rollback.subprocess.run") as run,
+            ):
+                with self.assertRaisesRegex(click.ClickException, "LAUNCHPLANE_DATABASE_URL"):
+                    _run_delegated_worker(
+                        control_plane_root=root,
+                        request=VeriReelProdRollbackWorkerRequest(
+                            context="verireel",
+                            instance="prod",
+                            promotion_record_id="promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                            backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                            snapshot_name="ver-predeploy-20260421-180000",
+                        ),
+                    )
+
+        run.assert_not_called()
+
     def test_rollout_base_url_resolution_accepts_rollback_request_shape(self) -> None:
         request = VeriReelProdRollbackRequest(
             promotion_record_id="promotion-verireel-testing-to-prod-run-12345-attempt-1",
@@ -391,9 +412,7 @@ class VeriReelProdRollbackWorkflowTests(unittest.TestCase):
                 clear=True,
             ),
         ):
-            with self.assertRaisesRegex(
-                Exception, "Missing LAUNCHPLANE_VERIREEL_PROD_ROLLBACK_WORKER_COMMAND"
-            ):
+            with self.assertRaisesRegex(click.ClickException, "LAUNCHPLANE_DATABASE_URL"):
                 _run_delegated_worker(
                     control_plane_root=Path(temporary_directory_name),
                     request=VeriReelProdRollbackWorkerRequest(


### PR DESCRIPTION
## Summary
- make worker runtime key-safety enforcement fail closed when `LAUNCHPLANE_DATABASE_URL` is absent
- add backup gate and rollback delegated-worker regression coverage to prove subprocess workers are not launched without DB-backed policy authority
- update the rollback process-env worker config test to expect the stricter DB-authority failure first

## Verification
- `uv run --extra dev ruff format --check control_plane/workflows/worker_runtime_key_safety.py tests/test_verireel_prod_backup_gate.py tests/test_verireel_prod_rollback.py`
- `uv run --extra dev ruff check control_plane/workflows/worker_runtime_key_safety.py tests/test_verireel_prod_backup_gate.py tests/test_verireel_prod_rollback.py`
- `uv run --extra dev mypy control_plane/workflows/worker_runtime_key_safety.py tests/test_verireel_prod_backup_gate.py tests/test_verireel_prod_rollback.py`
- `uv run python -m unittest tests.test_verireel_prod_backup_gate tests.test_verireel_prod_rollback`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files` (tool returned `STATUS: error` without diagnostics)

Part of #834.
