### PR TITLE
Require DB authority for Odoo post-deploy overrides

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -2687,6 +2687,12 @@ def _run_compose_post_deploy_update(
     request: ShipRequest,
 ) -> None:
     control_plane_root = _control_plane_root()
+    database_url = resolve_database_url(None)
+    if database_url is None:
+        raise click.ClickException(
+            "Compose post-deploy update requires LAUNCHPLANE_DATABASE_URL for "
+            "DB-backed Odoo override authority."
+        )
     host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
     source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
         control_plane_root=control_plane_root,
@@ -2706,6 +2712,7 @@ def _run_compose_post_deploy_update(
             f"Configured={target_definition.target_type}."
         )
     odoo_override_record = _read_odoo_instance_override_record_for_post_deploy(
+        database_url=database_url,
         context_name=request.context,
         instance_name=request.instance,
     )
@@ -2728,6 +2735,7 @@ def _run_compose_post_deploy_update(
             )
         except click.ClickException as error:
             _write_odoo_instance_override_apply_result(
+                database_url=database_url,
                 record=odoo_override_record,
                 status="fail",
                 detail=str(error),
@@ -2746,6 +2754,7 @@ def _run_compose_post_deploy_update(
     except click.ClickException as error:
         if odoo_override_record is not None:
             _write_odoo_instance_override_apply_result(
+                database_url=database_url,
                 record=odoo_override_record,
                 status="fail",
                 detail=str(error),
@@ -2753,6 +2762,7 @@ def _run_compose_post_deploy_update(
         raise
     if odoo_override_record is not None:
         _write_odoo_instance_override_apply_result(
+            database_url=database_url,
             record=odoo_override_record,
             status="pass"
             if workflow_environment_overrides or required_workflow_environment_keys
@@ -2767,12 +2777,10 @@ def _run_compose_post_deploy_update(
 
 def _read_odoo_instance_override_record_for_post_deploy(
     *,
+    database_url: str,
     context_name: str,
     instance_name: str,
 ) -> OdooInstanceOverrideRecord | None:
-    database_url = resolve_database_url(None)
-    if database_url is None:
-        return None
     postgres_store = PostgresRecordStore(database_url=database_url)
     try:
         return postgres_store.read_odoo_instance_override_record(
@@ -2787,13 +2795,11 @@ def _read_odoo_instance_override_record_for_post_deploy(
 
 def _write_odoo_instance_override_apply_result(
     *,
+    database_url: str,
     record: OdooInstanceOverrideRecord,
     status: Literal["skipped", "pending", "pass", "fail"],
     detail: str,
 ) -> None:
-    database_url = resolve_database_url(None)
-    if database_url is None:
-        return
     postgres_store = PostgresRecordStore(database_url=database_url)
     postgres_store.ensure_schema()
     try:

--- a/tests/test_odoo_instance_overrides.py
+++ b/tests/test_odoo_instance_overrides.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
+import click
 from control_plane.odoo_instance_overrides import ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY
 from click.testing import CliRunner
 from pydantic import ValidationError
@@ -680,6 +681,37 @@ class OdooInstanceOverrideTests(unittest.TestCase):
             ["ODOO_OVERRIDE_SECRET__ADDON__SHOPIFY__API_TOKEN"],
         )
         self.assertEqual(stored_record.last_apply.status, "pass")
+
+    def test_post_deploy_update_requires_database_for_override_authority(self) -> None:
+        source_of_truth = DokploySourceOfTruth(
+            schema_version=1,
+            targets=(
+                DokployTargetDefinition(
+                    context="opw",
+                    instance="prod",
+                    target_type="compose",
+                    target_name="opw-prod",
+                    target_id="compose-123",
+                ),
+            ),
+        )
+
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch(
+                "control_plane.dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example.com", "token-123"),
+            ),
+            patch(
+                "control_plane.dokploy.read_control_plane_dokploy_source_of_truth",
+                return_value=source_of_truth,
+            ),
+            patch("control_plane.dokploy.run_compose_post_deploy_update") as runner,
+        ):
+            with self.assertRaisesRegex(click.ClickException, "LAUNCHPLANE_DATABASE_URL"):
+                _run_compose_post_deploy_update(env_file=None, request=_ship_request())
+
+        runner.assert_not_called()
 
     def test_cli_migrate_secret_transport_relabels_secret_bindings_without_plaintext(
         self,


### PR DESCRIPTION
## Summary
- require `LAUNCHPLANE_DATABASE_URL` before compose post-deploy can read/write Odoo override apply state
- pass the resolved DB authority explicitly into post-deploy override read/write helpers instead of letting them silently no-op
- add a regression test that missing DB authority stops before live post-deploy execution

## Verification
- `uv run --extra dev ruff format control_plane/cli.py tests/test_odoo_instance_overrides.py`
- `uv run python -m unittest tests.test_odoo_instance_overrides`
- `uv run --extra dev ruff check control_plane/cli.py tests/test_odoo_instance_overrides.py`
- `uv run --extra dev mypy control_plane/cli.py tests/test_odoo_instance_overrides.py`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files` (non-blocking PSI churn in unrelated `tests/test_promote.py`)

Part of #834.
