### PR TITLE
Require DB authority for live target runtime apply

### DIFF
--- a/control_plane/live_target_runtime.py
+++ b/control_plane/live_target_runtime.py
@@ -224,20 +224,25 @@ def apply_live_target_runtime_environment(
         "reason": "dry_run" if not apply_changes else "no_runtime_env_changes",
     }
 
-    if not apply_changes or changed_key_count or deploy:
-        database_url = resolve_database_url(None)
-        if database_url is not None:
-            postgres_store = PostgresRecordStore(database_url=database_url)
-            postgres_store.ensure_schema()
-            try:
-                runtime_key_safety = evaluate_runtime_key_safety_for_live_target_sync(
-                    record_store=postgres_store,
-                    context_name=context_name,
-                    instance_name=instance_name,
-                    require_policy=apply_changes,
-                )
-            finally:
-                postgres_store.close()
+    database_url = resolve_database_url(None)
+    if apply_changes and database_url is None:
+        raise LiveTargetRuntimeError(
+            "Live target runtime apply requires LAUNCHPLANE_DATABASE_URL for DB-backed "
+            "runtime key-safety evaluation.",
+            code="runtime_key_safety_unavailable",
+        )
+    if database_url is not None and (not apply_changes or changed_key_count or deploy):
+        postgres_store = PostgresRecordStore(database_url=database_url)
+        postgres_store.ensure_schema()
+        try:
+            runtime_key_safety = evaluate_runtime_key_safety_for_live_target_sync(
+                record_store=postgres_store,
+                context_name=context_name,
+                instance_name=instance_name,
+                require_policy=apply_changes,
+            )
+        finally:
+            postgres_store.close()
 
     if apply_changes and changed_key_count:
         try:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -19,6 +19,7 @@ from click import ClickException, Command
 from click.testing import CliRunner
 
 from control_plane.cli import main
+from control_plane import live_target_runtime as control_plane_live_target_runtime
 from control_plane import secrets as control_plane_secrets
 from control_plane import service as control_plane_service
 from control_plane.contracts.backup_gate_record import BackupGateRecord
@@ -30,6 +31,7 @@ from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
+from control_plane.dokploy import DokploySourceOfTruth, DokployTargetDefinition
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.merge_train_policy import MergeTrainPolicy
@@ -18640,6 +18642,130 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(result["mode"], "apply")
         self.assertTrue(result["apply"]["env_updated"])
         self.assertEqual(result["apply"]["verification"]["status"], "pass")
+
+    def test_live_target_runtime_apply_requires_database_for_key_safety(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"
+                    },
+                    clear=True,
+                ),
+                patch(
+                    "control_plane.dokploy.read_control_plane_dokploy_source_of_truth",
+                    return_value=DokploySourceOfTruth(
+                        schema_version=1,
+                        targets=(
+                            DokployTargetDefinition(
+                                context="sellyouroutboard",
+                                instance="prod",
+                                target_type="application",
+                                target_name="syo-prod-app",
+                                target_id="application-syo-prod",
+                            ),
+                        ),
+                    ),
+                ),
+                patch(
+                    "control_plane.runtime_environments.resolve_runtime_environment_values",
+                    return_value={"GOOGLE_ANALYTICS_MEASUREMENT_ID": "G-9KRMER45KG"},
+                ),
+                patch(
+                    "control_plane.dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "dokploy-token"),
+                ),
+                patch(
+                    "control_plane.dokploy.fetch_dokploy_target_payload",
+                    return_value={
+                        "applicationId": "application-syo-prod",
+                        "name": "syo-prod-app",
+                        "env": "CONTACT_EMAIL_MODE=resend\n",
+                    },
+                ),
+                patch("control_plane.dokploy.update_dokploy_target_env") as update_env,
+            ):
+                with self.assertRaisesRegex(
+                    control_plane_live_target_runtime.LiveTargetRuntimeError,
+                    "LAUNCHPLANE_DATABASE_URL",
+                ) as context:
+                    control_plane_live_target_runtime.apply_live_target_runtime_environment(
+                        control_plane_root=root,
+                        context_name="sellyouroutboard",
+                        instance_name="prod",
+                        apply_changes=True,
+                        deploy=False,
+                        no_cache=False,
+                        deploy_timeout_seconds=None,
+                        deploy_trigger=(
+                            control_plane_live_target_runtime.trigger_and_wait_for_dokploy_target_deploy
+                        ),
+                    )
+
+        self.assertEqual(context.exception.code, "runtime_key_safety_unavailable")
+        update_env.assert_not_called()
+
+    def test_live_target_runtime_api_maps_runtime_key_safety_database_error(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/live-target-runtime.yml@refs/heads/main"
+                            ],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard"],
+                            "actions": ["live_target_runtime.apply"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/live-target-runtime.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            with patch(
+                "control_plane.service.control_plane_live_target_runtime.apply_live_target_runtime_environment",
+                side_effect=control_plane_live_target_runtime.LiveTargetRuntimeError(
+                    "Live target runtime apply requires LAUNCHPLANE_DATABASE_URL for DB-backed runtime key-safety evaluation.",
+                    code="runtime_key_safety_unavailable",
+                ),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/live-target-runtime/apply",
+                    payload={
+                        "schema_version": 1,
+                        "mode": "apply",
+                        "product": "sellyouroutboard",
+                        "context": "sellyouroutboard",
+                        "instance": "prod",
+                    },
+                    headers={"Idempotency-Key": "live-target-runtime:missing-db"},
+                )
+
+        self.assertEqual(status_code, 503)
+        self.assertEqual(payload["error"]["code"], "runtime_key_safety_unavailable")
+        self.assertIn("LAUNCHPLANE_DATABASE_URL", payload["error"]["message"])
 
     def test_live_target_runtime_api_apply_requires_apply_authorization(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- require `LAUNCHPLANE_DATABASE_URL` before live target runtime `--apply` can update env or trigger deploy
- keep dry-run planning available while using DB-backed runtime key-safety when DB authority is present
- add direct runtime and service route regressions for the missing-DB key-safety error

## Verification
- `uv run --extra dev ruff format control_plane/live_target_runtime.py tests/test_service.py`
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_apply_requires_database_for_key_safety tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_api_maps_runtime_key_safety_database_error`
- `uv run --extra dev ruff check control_plane/live_target_runtime.py tests/test_service.py`
- `uv run --extra dev mypy control_plane/live_target_runtime.py tests/test_service.py`
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_api_dry_run_returns_redacted_delta tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_api_apply_updates_env_and_verifies tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_apply_requires_database_for_key_safety tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_api_maps_runtime_key_safety_database_error`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files`

Part of #834.
