### PR TITLE
Extract GitHub payload helpers

### DIFF
--- a/control_plane/github_payload.py
+++ b/control_plane/github_payload.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+
+def json_object(
+    value: object,
+    label: str,
+    *,
+    error_type: Callable[[str], Exception],
+) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise error_type(f"{label} must be a JSON object.")
+    return value
+
+
+def required_stripped_text(
+    value: object,
+    message: str,
+    *,
+    error_type: Callable[[str], Exception],
+) -> str:
+    normalized_value = str(value or "").strip()
+    if not normalized_value:
+        raise error_type(message)
+    return normalized_value
+
+
+def required_string_text(
+    value: object,
+    message: str,
+    *,
+    error_type: Callable[[str], Exception],
+) -> str:
+    if not isinstance(value, str):
+        raise error_type(message)
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise error_type(message)
+    return normalized_value
+
+
+def required_int(
+    value: object,
+    message: str,
+    *,
+    error_type: Callable[[str], Exception],
+) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise error_type(message)
+    return value
+
+
+def required_positive_int(
+    value: object,
+    message: str,
+    *,
+    error_type: Callable[[str], Exception],
+) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise error_type(message)
+    return value

--- a/control_plane/merge_train_github.py
+++ b/control_plane/merge_train_github.py
@@ -10,6 +10,9 @@ from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidate
 from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlan
 from control_plane.contracts.merge_train_stack_collapse import MergeTrainStackCollapseBranchClient
 from control_plane.contracts.merge_train_policy import MergeTrainMergeMethod
+from control_plane.github_payload import json_object
+from control_plane.github_payload import required_positive_int
+from control_plane.github_payload import required_string_text
 from control_plane.merge_train import MergeTrainCheckStatus
 from control_plane.merge_train import MergeTrainDryRunSnapshot
 from control_plane.merge_train import MergeTrainMergeableState
@@ -547,9 +550,7 @@ def _reference_path(reference: str) -> str:
 
 
 def _json_object(value: object, label: str) -> dict[str, object]:
-    if not isinstance(value, dict):
-        raise MergeTrainGitHubError(f"{label} must be a JSON object.")
-    return value
+    return json_object(value, label, error_type=MergeTrainGitHubError)
 
 
 def _repository_full_name(value: object, label: str) -> str:
@@ -609,18 +610,11 @@ def _base_rooted_pull_requests(
 
 
 def _required_int(value: object, message: str) -> int:
-    if not isinstance(value, int) or value <= 0:
-        raise MergeTrainGitHubError(message)
-    return value
+    return required_positive_int(value, message, error_type=MergeTrainGitHubError)
 
 
 def _required_text(value: object, message: str) -> str:
-    if not isinstance(value, str):
-        raise MergeTrainGitHubError(message)
-    normalized = value.strip()
-    if not normalized:
-        raise MergeTrainGitHubError(message)
-    return normalized
+    return required_string_text(value, message, error_type=MergeTrainGitHubError)
 
 
 def _pull_request_state(value: str) -> MergeTrainPullRequestState:

--- a/control_plane/runner_lane_github.py
+++ b/control_plane/runner_lane_github.py
@@ -7,6 +7,9 @@ from urllib.parse import urlencode
 from control_plane.contracts.runner_lane_inventory import RunnerLaneInventory
 from control_plane.contracts.runner_lane_inventory import RunnerLaneRecord
 from control_plane.contracts.runner_lane_inventory import build_runner_lane_inventory
+from control_plane.github_payload import json_object
+from control_plane.github_payload import required_int
+from control_plane.github_payload import required_stripped_text
 from control_plane.merge_train_github import MergeTrainGitHubError
 from control_plane.merge_train_github import MergeTrainGitHubTransport
 
@@ -117,22 +120,15 @@ def _repository_path(repository: str) -> str:
 
 
 def _json_object(value: object, label: str) -> dict[str, object]:
-    if not isinstance(value, dict):
-        raise MergeTrainGitHubError(f"{label} must be a JSON object.")
-    return value
+    return json_object(value, label, error_type=MergeTrainGitHubError)
 
 
 def _required_text(value: object, message: str) -> str:
-    normalized_value = str(value or "").strip()
-    if not normalized_value:
-        raise MergeTrainGitHubError(message)
-    return normalized_value
+    return required_stripped_text(value, message, error_type=MergeTrainGitHubError)
 
 
 def _required_int(value: object, message: str) -> int:
-    if not isinstance(value, int) or isinstance(value, bool):
-        raise MergeTrainGitHubError(message)
-    return value
+    return required_int(value, message, error_type=MergeTrainGitHubError)
 
 
 def _required_bool(value: object, message: str) -> bool:

--- a/control_plane/runner_queue_wait_github.py
+++ b/control_plane/runner_queue_wait_github.py
@@ -8,6 +8,9 @@ from control_plane.contracts.runner_queue_wait import RunnerQueueWaitJob
 from control_plane.contracts.runner_queue_wait import RunnerQueueWaitSummary
 from control_plane.contracts.runner_queue_wait import build_runner_queue_wait_job
 from control_plane.contracts.runner_queue_wait import build_runner_queue_wait_summary
+from control_plane.github_payload import json_object
+from control_plane.github_payload import required_int
+from control_plane.github_payload import required_stripped_text
 from control_plane.merge_train_github import MergeTrainGitHubError
 from control_plane.merge_train_github import MergeTrainGitHubTransport
 
@@ -157,16 +160,11 @@ def _repository_path(repository: str) -> str:
 
 
 def _json_object(value: object, label: str) -> dict[str, object]:
-    if not isinstance(value, dict):
-        raise MergeTrainGitHubError(f"{label} must be a JSON object.")
-    return value
+    return json_object(value, label, error_type=MergeTrainGitHubError)
 
 
 def _required_text(value: object, message: str) -> str:
-    normalized_value = str(value or "").strip()
-    if not normalized_value:
-        raise MergeTrainGitHubError(message)
-    return normalized_value
+    return required_stripped_text(value, message, error_type=MergeTrainGitHubError)
 
 
 def _optional_text(value: object) -> str:
@@ -174,6 +172,4 @@ def _optional_text(value: object) -> str:
 
 
 def _required_int(value: object, message: str) -> int:
-    if not isinstance(value, int) or isinstance(value, bool):
-        raise MergeTrainGitHubError(message)
-    return value
+    return required_int(value, message, error_type=MergeTrainGitHubError)


### PR DESCRIPTION
## Summary
- add shared GitHub payload validation helpers
- route merge-train, runner lane, and runner queue readers through the shared helper module
- preserve the stricter merge-train positive-int/string validation separately from the runner readers' stripped-value behavior

Refs #79

## Verification
- `uv run python -m unittest tests.test_merge_train_github tests.test_runner_lane_inventory tests.test_runner_queue_wait`
- `uv run --extra dev ruff check --diff control_plane/github_payload.py control_plane/merge_train_github.py control_plane/runner_lane_github.py control_plane/runner_queue_wait_github.py`
- `uv run --extra dev ruff check control_plane/github_payload.py control_plane/merge_train_github.py control_plane/runner_lane_github.py control_plane/runner_queue_wait_github.py`
- `uv run --extra dev mypy control_plane/github_payload.py control_plane/merge_train_github.py control_plane/runner_lane_github.py control_plane/runner_queue_wait_github.py`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files` (existing weak warnings outside this patch; no findings in touched files)
