### PR TITLE
Clarify local state authority docs

### DIFF
--- a/control_plane/github_payload.py
+++ b/control_plane/github_payload.py
@@ -46,7 +46,7 @@ def required_int(
     *,
     error_type: Callable[[str], Exception],
 ) -> int:
-    if not isinstance(value, int) or isinstance(value, bool):
+    if isinstance(value, bool) or not isinstance(value, int):
         raise error_type(message)
     return value
 
@@ -57,6 +57,6 @@ def required_positive_int(
     *,
     error_type: Callable[[str], Exception],
 ) -> int:
-    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
         raise error_type(message)
     return value

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -4,9 +4,11 @@ title: Compatibility Retirement
 
 ## Purpose
 
-Launchplane keeps local CLI helpers and file-backed stores for development,
-tests, and emergency operator inspection. They are not production authority once
-the matching service route, DB-backed records, and product workflow calls exist.
+Launchplane keeps local CLI helpers and file-backed stores only for local
+development, tests, explicit import/backfill, local rehearsal, and emergency
+operator inspection. They are not production authority, and production-capable
+service or CLI mutation paths must fail closed unless they have DB-backed
+authority.
 
 Use this page as the review checklist before keeping or deleting compatibility
 surfaces.
@@ -54,10 +56,10 @@ Keep a compatibility surface only when it is one of these:
 ## File-Backed State Inventory
 
 `state/`, `FilesystemRecordStore`, `--state-dir`, and `LAUNCHPLANE_STATE_DIR`
-remain compatibility surfaces. They are allowed only for local development,
-tests, import/backfill, and emergency inspection. Shared and production live
-mutations must use the deployed Launchplane service API or DB-backed operator
-records. Service startup requires `--database-url` or
+remain local-only surfaces. They are allowed only for local development, tests,
+import/backfill, explicitly flagged local rehearsal, and emergency inspection.
+Shared and production live mutations must use the deployed Launchplane service
+API or DB-backed operator records. Service startup requires `--database-url` or
 `LAUNCHPLANE_DATABASE_URL`; filesystem state is never a service persistence
 fallback.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -7,14 +7,13 @@ title: Operations
 Use `uv run launchplane --help` for the complete CLI surface. The current
 top-level groups are:
 
-Today this CLI is the local Launchplane operator surface around the service API.
-It owns stable-lane deploy and promotion records for `testing` and `prod`, plus
-Launchplane preview records and read models for PR review flows. It should not
-be treated as the final cross-product ingress boundary for Launchplane. Shared
-or production mutations must prefer the deployed service API with GitHub OIDC or
-the operator UI that calls it. If a live mutation still exists only as a local
-CLI command, stop and add or use a service API path instead of running the local
-command from an arbitrary checkout.
+Today this CLI is the local Launchplane operator/client surface around the
+service API. DB-backed commands may create stable-lane deploy and promotion
+records for `testing` and `prod`, plus Launchplane preview records and read
+models for PR review flows. Shared or production mutations must prefer the
+deployed service API with GitHub OIDC or the operator UI that calls it. If a live
+mutation still exists only as a local CLI command, stop and add or use a service
+API path instead of running the local command from an arbitrary checkout.
 
 - `artifacts`: write, ingest, and inspect artifact manifests.
 - `backup-gates`: write and inspect backup-gate records.
@@ -39,10 +38,10 @@ are the current small evidence-ingest surfaces that let Launchplane accept
 externally-produced deployment and promotion facts without claiming it
 executed that product's runtime action itself.
 
-Those commands are current implementation scaffolding. The target Launchplane
-boundary is a long-running service with authenticated HTTP ingress, where the
-CLI becomes a client of Launchplane's stable API contract instead of defining that
-contract itself.
+Those commands are current implementation scaffolding. The Launchplane boundary
+is a long-running service with authenticated HTTP ingress. The CLI should remain
+a client of Launchplane's stable API contract or an explicit DB-backed operator
+tool, not a separate live-state authority.
 
 ## Target Launchplane Ingress
 
@@ -54,8 +53,9 @@ The target communication model is:
 - GitHub Actions OIDC is the default machine-to-machine trust boundary.
 - Launchplane authorizes requests from GitHub-issued identity claims such as repo,
   workflow, ref, environment, and event context.
-- Typed evidence payloads are the stable contract; CLI commands are temporary
-  adapters while the service boundary is being built.
+- Typed evidence payloads are the stable contract; CLI commands are service
+  clients, DB-backed operator tools, or explicit local-only rehearsal and
+  inspection helpers.
 
 Launchplane should eventually expose API ingress for at least:
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -15,9 +15,10 @@ It exists to keep new cross-product work aligned with Launchplane's target form:
 - Launchplane-owned drivers
 - thin repo extensions
 
-The current repo-local CLI and file-backed state directory are implementation
-scaffolding. This document defines the boundary those adapters should converge
-on.
+The repo-local CLI is an operator/client surface around this boundary. Local
+file-backed state is allowed only for development, tests, import/backfill,
+explicit local rehearsal, and emergency inspection; it is not a production
+persistence fallback.
 
 Agent-facing context and scoped write-intent rules are summarized in
 [agent-context-boundary.md](agent-context-boundary.md). Keep that page aligned


### PR DESCRIPTION
## Summary
- tighten compatibility-retirement, operations, and service-boundary docs so file-backed state is local-only and never a service persistence fallback
- clarify that CLI commands are service clients, DB-backed operator tools, or explicit local-only rehearsal/inspection helpers
- reorder GitHub payload integer checks so IDE type narrowing sees the returned value as `int`

Refs #79

## Verification
- `uv run python -m unittest tests.test_merge_train_github tests.test_runner_lane_inventory tests.test_runner_queue_wait`
- `uv run --extra dev ruff check --diff control_plane/github_payload.py docs/compatibility-retirement.md docs/operations.md docs/service-boundary.md`
- `uv run --extra dev ruff check control_plane/github_payload.py docs/compatibility-retirement.md docs/operations.md docs/service-boundary.md`
- `uv run --extra dev mypy control_plane/github_payload.py`
- PyCharm changed-files inspection attempted twice; both attempts returned `capture_incomplete` with zero captured problems

## Note
`HANDOFF.md` has the stale local handoff wording fixed in the checkout, but it is git-excluded by `.git/info/exclude` and is not part of this PR.
