### PR TITLE
Deduplicate runner GitHub repository parsing

### DIFF
--- a/control_plane/github_payload.py
+++ b/control_plane/github_payload.py
@@ -60,3 +60,13 @@ def required_positive_int(
     if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
         raise error_type(message)
     return value
+
+
+def repository_full_name(repository: str) -> str:
+    normalized_repository = "/".join(part.strip() for part in repository.strip().split("/"))
+    if normalized_repository.count("/") != 1:
+        raise ValueError("GitHub repository must be formatted as owner/name.")
+    owner, repo = normalized_repository.split("/", 1)
+    if not owner or not repo:
+        raise ValueError("GitHub repository must be formatted as owner/name.")
+    return normalized_repository

--- a/control_plane/runner_lane_github.py
+++ b/control_plane/runner_lane_github.py
@@ -8,6 +8,7 @@ from control_plane.contracts.runner_lane_inventory import RunnerLaneInventory
 from control_plane.contracts.runner_lane_inventory import RunnerLaneRecord
 from control_plane.contracts.runner_lane_inventory import build_runner_lane_inventory
 from control_plane.github_payload import json_object
+from control_plane.github_payload import repository_full_name
 from control_plane.github_payload import required_int
 from control_plane.github_payload import required_stripped_text
 from control_plane.merge_train_github import MergeTrainGitHubError
@@ -110,13 +111,7 @@ def _host_hint_from_name(name: str) -> str:
 
 
 def _repository_path(repository: str) -> str:
-    normalized_repository = "/".join(part.strip() for part in repository.strip().split("/"))
-    if normalized_repository.count("/") != 1:
-        raise ValueError("GitHub repository must be formatted as owner/name.")
-    owner, repo = normalized_repository.split("/", 1)
-    if not owner or not repo:
-        raise ValueError("GitHub repository must be formatted as owner/name.")
-    return normalized_repository
+    return repository_full_name(repository)
 
 
 def _json_object(value: object, label: str) -> dict[str, object]:

--- a/control_plane/runner_queue_wait_github.py
+++ b/control_plane/runner_queue_wait_github.py
@@ -9,6 +9,7 @@ from control_plane.contracts.runner_queue_wait import RunnerQueueWaitSummary
 from control_plane.contracts.runner_queue_wait import build_runner_queue_wait_job
 from control_plane.contracts.runner_queue_wait import build_runner_queue_wait_summary
 from control_plane.github_payload import json_object
+from control_plane.github_payload import repository_full_name
 from control_plane.github_payload import required_int
 from control_plane.github_payload import required_stripped_text
 from control_plane.merge_train_github import MergeTrainGitHubError
@@ -150,13 +151,7 @@ def _job_labels(value: object) -> tuple[str, ...]:
 
 
 def _repository_path(repository: str) -> str:
-    normalized_repository = "/".join(part.strip() for part in repository.strip().split("/"))
-    if normalized_repository.count("/") != 1:
-        raise ValueError("GitHub repository must be formatted as owner/name.")
-    owner, repo = normalized_repository.split("/", 1)
-    if not owner or not repo:
-        raise ValueError("GitHub repository must be formatted as owner/name.")
-    return normalized_repository
+    return repository_full_name(repository)
 
 
 def _json_object(value: object, label: str) -> dict[str, object]:


### PR DESCRIPTION
## Summary
- add a shared GitHub repository full-name normalizer beside the payload helpers
- route runner lane and runner queue readers through the shared normalizer
- leave merge-train repository path handling separate because it URL-encodes path segments for API paths

Refs #79

## Verification
- `uv run python -m unittest tests.test_merge_train_github tests.test_runner_lane_inventory tests.test_runner_queue_wait`
- `uv run --extra dev ruff check --diff control_plane/github_payload.py control_plane/runner_lane_github.py control_plane/runner_queue_wait_github.py`
- `uv run --extra dev ruff check control_plane/github_payload.py control_plane/runner_lane_github.py control_plane/runner_queue_wait_github.py`
- `uv run --extra dev mypy control_plane/github_payload.py control_plane/runner_lane_github.py control_plane/runner_queue_wait_github.py`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files` (fresh results still include broad existing project warnings; runner repository-path duplicate warning is gone)
