### PR TITLE
Deduplicate artifact record command body

### DIFF
--- a/control_plane/cli_records.py
+++ b/control_plane/cli_records.py
@@ -101,16 +101,13 @@ def artifacts() -> None:
 def artifacts_write(
     state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
 ) -> None:
-    execution_database_url = _resolve_record_mutation_database_url(
+    _write_artifact_manifest_command(
+        state_dir=state_dir,
         database_url=database_url,
         local_rehearsal=local_rehearsal,
+        input_file=input_file,
         command_label="artifacts write",
     )
-    manifest = ArtifactIdentityManifest.model_validate(_load_json_file(input_file))
-    record_path = _store(state_dir, database_url=execution_database_url).write_artifact_manifest(
-        manifest
-    )
-    click.echo(record_path)
 
 
 @artifacts.command("show")
@@ -134,10 +131,27 @@ def artifacts_show(state_dir: Path, database_url: str, artifact_id: str) -> None
 def artifacts_ingest(
     state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
 ) -> None:
+    _write_artifact_manifest_command(
+        state_dir=state_dir,
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        input_file=input_file,
+        command_label="artifacts ingest",
+    )
+
+
+def _write_artifact_manifest_command(
+    *,
+    state_dir: Path,
+    database_url: str,
+    local_rehearsal: bool,
+    input_file: Path,
+    command_label: str,
+) -> None:
     execution_database_url = _resolve_record_mutation_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
-        command_label="artifacts ingest",
+        command_label=command_label,
     )
     manifest = ArtifactIdentityManifest.model_validate(_load_json_file(input_file))
     record_path = _store(state_dir, database_url=execution_database_url).write_artifact_manifest(


### PR DESCRIPTION
## Summary
- extract the shared artifact manifest write/ingest command body in `cli_records`
- preserve the separate `artifacts write` and `artifacts ingest` command labels for fail-closed DB/local-rehearsal errors
- keep command names, options, validation, record writes, and output behavior unchanged

Refs #79

## Verification
- `uv run python -m unittest tests.test_filesystem_store tests.test_postgres_store tests.test_promote`
- `uv run --extra dev ruff check --diff control_plane/cli_records.py`
- `uv run --extra dev ruff check control_plane/cli_records.py`
- `uv run --extra dev mypy control_plane/cli_records.py`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files` (reports existing broad project findings outside `control_plane/cli_records.py`)
