### PR TITLE
Add product environments read endpoint

### DIFF
--- a/control_plane/product_read_service.py
+++ b/control_plane/product_read_service.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from control_plane.contracts.product_environment_read_model import (
     ActionAllowed,
     ProductReadModelStore,
+    ProductSiteOverview,
     build_product_activity_read_model,
     build_product_environment_config_status,
     build_product_environment_detail,
@@ -23,7 +24,10 @@ class ProductEnvironmentReadServiceResult:
 
 
 def is_product_environment_detail_request(params: Mapping[str, str]) -> bool:
-    return any(key in params for key in ("activity", "config_status", "environment", "product"))
+    return any(
+        key in params
+        for key in ("activity", "config_status", "environment", "environments", "product")
+    )
 
 
 def build_product_profile_list_service_payload(
@@ -81,6 +85,19 @@ def build_product_environment_read_service_result(
             denial_message="Workflow cannot read the requested product environment.",
         )
 
+    if params.get("environments") == "true":
+        overview = build_product_site_overview(
+            record_store=record_store,
+            product=params["product"],
+            action_allowed=action_allowed,
+        )
+        return ProductEnvironmentReadServiceResult(
+            payload=_product_environments_payload(overview),
+            authorization_product=overview.product,
+            authorization_context="launchplane",
+            denial_message="Workflow cannot list the requested product environments.",
+        )
+
     if "product" in params:
         overview = build_product_site_overview(
             record_store=record_store,
@@ -109,4 +126,19 @@ def build_product_environment_list_service_payload(
     )
     return {
         "products": [overview.model_dump(mode="json") for overview in overviews],
+    }
+
+
+def _product_environments_payload(overview: ProductSiteOverview) -> dict[str, object]:
+    return {
+        "product": overview.product,
+        "display_name": overview.display_name,
+        "repository": overview.repository,
+        "driver_id": overview.driver_id,
+        "base_driver_id": overview.base_driver_id,
+        "environments": [
+            environment.model_dump(mode="json") for environment in overview.environments
+        ],
+        "trust_state": overview.trust_state,
+        "provenance": overview.provenance.model_dump(mode="json"),
     }

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2618,6 +2618,8 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "product_environment.read", {"product": segments[2], "activity": "true"}
     if len(segments) == 3 and segments[:2] == ["v1", "products"]:
         return "product_environment.read", {"product": segments[2]}
+    if len(segments) == 4 and segments[:2] == ["v1", "products"] and segments[3] == "environments":
+        return "product_environment.read", {"product": segments[2], "environments": "true"}
     if len(segments) == 5 and segments[:2] == ["v1", "products"] and segments[3] == "environments":
         return "product_environment.read", {"product": segments[2], "environment": segments[4]}
     if (

--- a/docs/operator-experience.md
+++ b/docs/operator-experience.md
@@ -63,6 +63,7 @@ The first product/site read endpoints are:
 - `GET /v1/products`
 - `GET /v1/products/{product}`
 - `GET /v1/products/{product}/activity`
+- `GET /v1/products/{product}/environments`
 - `GET /v1/products/{product}/environments/{environment}`
 - `GET /v1/products/{product}/environments/{environment}/config-status`
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -877,6 +877,7 @@ only after a passing plan and a matching stored preview record are present.
 - `GET /v1/products`
 - `GET /v1/products/{product}`
 - `GET /v1/products/{product}/activity`
+- `GET /v1/products/{product}/environments`
 - `GET /v1/products/{product}/environments/{environment}`
 - `GET /v1/previews/{preview_id}`
 - `GET /v1/previews/{preview_id}/history`
@@ -903,6 +904,14 @@ metadata, action availability, and trust state. Raw context names and provider
 target identifiers remain evidence metadata; runtime values, secret plaintext,
 secret ciphertext, and product-specific driver payloads are not exposed as
 shared top-level fields.
+
+`GET /v1/products/{product}/environments` returns the product's stable
+environment summaries from DB-backed Launchplane records. It is the collection
+form of the per-product read model and is intended for operator and UI
+navigation before loading a single environment detail page. It uses the same
+redaction rules as the product overview: environment summaries include context,
+URLs, action availability, trust state, and provenance, but not runtime values or
+secret material.
 
 `GET /v1/products/{product}/environments/{environment}/config-status` is a
 redacted product/site read under the same action. It compares product-profile

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -10728,6 +10728,81 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["activity"]["events"][0]["event_type"], "authz_policy")
         self.assertEqual(payload["activity"]["events"][0]["action_id"], "authz_policy.update")
 
+    def test_product_environments_endpoint_lists_db_backed_environment_summaries(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
+            )
+            store.write_runtime_environment_record(
+                RuntimeEnvironmentRecord(
+                    scope="instance",
+                    context="example-site",
+                    instance="prod",
+                    env={"INTERNAL_CALLBACK_URL": "https://internal.example-site.invalid"},
+                    updated_at="2026-05-02T22:32:00Z",
+                    source_label="test",
+                )
+            )
+            store.write_dokploy_target_record(
+                DokployTargetRecord(
+                    context="example-site",
+                    instance="prod",
+                    target_type="application",
+                    target_name="example-site-prod",
+                    updated_at="2026-05-02T22:33:00Z",
+                    source_label="test",
+                )
+            )
+            store.close()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["example-site"],
+                            "contexts": ["launchplane"],
+                            "actions": ["product_environment.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/products/example-site/environments",
+            )
+
+        response_text = json.dumps(payload)
+        self.assertEqual(status_code, 200)
+        self.assertEqual(payload["product"], "example-site")
+        self.assertEqual(
+            [environment["environment"] for environment in payload["environments"]],
+            ["testing", "prod"],
+        )
+        prod_environment = payload["environments"][1]
+        self.assertEqual(prod_environment["context"], "example-site")
+        self.assertEqual(prod_environment["trust_state"], "missing")
+        self.assertEqual(payload["trust_state"], "missing")
+        self.assertNotIn("https://internal.example-site.invalid", response_text)
+
     def test_product_environment_detail_redacts_runtime_and_secret_values(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add `GET /v1/products/{product}/environments` as the collection route for product environment summaries
- reuse the existing product overview builder so the route stays DB-backed and redacted
- document the collection endpoint in the service boundary and operator-experience API list

Refs #849

## Verification
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_product_environments_endpoint_lists_db_backed_environment_summaries tests.test_service.LaunchplaneServiceTests.test_product_overview_endpoint_is_generic_web_profile_driven tests.test_service.LaunchplaneServiceTests.test_product_environment_detail_redacts_runtime_and_secret_values`
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests`
- `uv run --extra dev ruff check --diff control_plane/product_read_service.py control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/product_read_service.py control_plane/service.py tests/test_service.py`
- `uv run --extra dev mypy control_plane/product_read_service.py`
- `uv run --extra dev mypy control_plane/service.py`
- `uv run --extra dev mypy tests/test_service.py`
- `uv run --extra dev markdownlint-cli2 docs/service-boundary.md docs/operator-experience.md`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files` reports existing broad findings in `service.py` and `tests/test_service.py`; no new finding is tied to `product_read_service.py`.
