### PR TITLE
Cover product read authorization targets

### DIFF
--- a/tests/test_product_read_service.py
+++ b/tests/test_product_read_service.py
@@ -156,6 +156,64 @@ class ProductReadServiceTests(unittest.TestCase):
         )
         self.assertIn("environment", result.payload)
 
+    def test_product_environment_results_identify_branch_authorization_targets(
+        self,
+    ) -> None:
+        cases = (
+            (
+                {"product": "example-site"},
+                "product",
+                "example-site",
+                "launchplane",
+                "Workflow cannot read the requested product overview.",
+            ),
+            (
+                {"product": "example-site", "activity": "true"},
+                "activity",
+                "example-site",
+                "launchplane",
+                "Workflow cannot read the requested product activity.",
+            ),
+            (
+                {"product": "example-site", "environments": "true"},
+                "environments",
+                "example-site",
+                "launchplane",
+                "Workflow cannot list the requested product environments.",
+            ),
+            (
+                {"product": "example-site", "environment": "prod"},
+                "environment",
+                "example-site",
+                "example-site-prod",
+                "Workflow cannot read the requested product environment.",
+            ),
+            (
+                {
+                    "product": "example-site",
+                    "environment": "prod",
+                    "config_status": "true",
+                },
+                "config_status",
+                "example-site",
+                "example-site-prod",
+                "Workflow cannot read the requested product environment config status.",
+            ),
+        )
+
+        for params, payload_key, product, context, denial_message in cases:
+            with self.subTest(payload_key=payload_key):
+                result = build_product_environment_read_service_result(
+                    record_store=self.store,
+                    params=params,
+                    action_allowed=lambda _action, _product, _context: True,
+                )
+
+                self.assertEqual(result.authorization_product, product)
+                self.assertEqual(result.authorization_context, context)
+                self.assertEqual(result.denial_message, denial_message)
+                self.assertIn(payload_key, result.payload)
+
     def test_product_environment_list_payload_serializes_overviews(self) -> None:
         payload = build_product_environment_list_service_payload(
             record_store=self.store,


### PR DESCRIPTION
## Summary
- add direct coverage for each product read-model branch's authorization product/context target
- include overview, activity, environment collection, environment detail, and config-status payload branches
- lock denial messages to the branch-specific service contract

Refs #849

## Verification
- `uv run python -m unittest tests.test_product_read_service`
- `uv run --extra dev ruff check --diff tests/test_product_read_service.py`
- `uv run --extra dev ruff check tests/test_product_read_service.py`
- `uv run --extra dev mypy tests/test_product_read_service.py`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files` reports existing unrelated weak warnings in `tests/test_service.py`; no finding in the touched file.
