### PR TITLE
Require DB-backed product read-model store

### DIFF
--- a/control_plane/contracts/product_environment_read_model.py
+++ b/control_plane/contracts/product_environment_read_model.py
@@ -49,6 +49,22 @@ class ProductReadModelStore(Protocol):
     def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord: ...
 
 
+class ProductEnvironmentReadModelStore(ProductReadModelStore, Protocol):
+    def read_lane_summary(
+        self, *, context_name: str, instance_name: str
+    ) -> LaunchplaneLaneSummary: ...
+
+    def list_preview_summaries(
+        self,
+        *,
+        context_name: str = "",
+        anchor_repo: str = "",
+        anchor_pr_number: int | None = None,
+        preview_limit: int | None = None,
+        generation_limit: int | None = 1,
+    ) -> tuple[LaunchplanePreviewSummary, ...]: ...
+
+
 def _build_action_authz_by_route() -> dict[str, str]:
     return {
         action.route_path: action.authz_action

--- a/control_plane/product_read_service.py
+++ b/control_plane/product_read_service.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import cast
 
 from control_plane.contracts.product_environment_read_model import (
     ActionAllowed,
+    ProductEnvironmentReadModelStore,
     ProductReadModelStore,
     ProductSiteOverview,
     build_product_activity_read_model,
@@ -21,6 +23,35 @@ class ProductEnvironmentReadServiceResult:
     authorization_product: str
     authorization_context: str
     denial_message: str
+
+
+class ProductReadModelStoreCapabilityError(RuntimeError):
+    pass
+
+
+_PRODUCT_ENVIRONMENT_READ_MODEL_STORE_METHODS = (
+    "list_product_profile_records",
+    "read_product_profile_record",
+    "read_lane_summary",
+    "list_preview_summaries",
+)
+
+
+def require_product_environment_read_model_store(
+    record_store: object,
+) -> ProductEnvironmentReadModelStore:
+    missing_methods = tuple(
+        method_name
+        for method_name in _PRODUCT_ENVIRONMENT_READ_MODEL_STORE_METHODS
+        if not callable(getattr(record_store, method_name, None))
+    )
+    if missing_methods:
+        missing = ", ".join(missing_methods)
+        raise ProductReadModelStoreCapabilityError(
+            "Product environment reads require DB-backed Launchplane storage; "
+            f"missing store method(s): {missing}."
+        )
+    return cast(ProductEnvironmentReadModelStore, record_store)
 
 
 def is_product_environment_detail_request(params: Mapping[str, str]) -> bool:
@@ -42,7 +73,7 @@ def build_product_profile_list_service_payload(
 
 def build_product_environment_read_service_result(
     *,
-    record_store: ProductReadModelStore,
+    record_store: ProductEnvironmentReadModelStore,
     params: Mapping[str, str],
     action_allowed: ActionAllowed,
 ) -> ProductEnvironmentReadServiceResult:
@@ -116,7 +147,7 @@ def build_product_environment_read_service_result(
 
 def build_product_environment_list_service_payload(
     *,
-    record_store: ProductReadModelStore,
+    record_store: ProductEnvironmentReadModelStore,
     action_allowed: ActionAllowed,
 ) -> dict[str, object]:
 

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -8615,11 +8615,26 @@ def create_launchplane_service_app(
                             start_response=start_response,
                         )
 
-                    if control_plane_product_read_service.is_product_environment_detail_request(
-                        params
-                    ):
+                    if control_plane_product_read_service.is_product_environment_detail_request(params):
+                        try:
+                            product_read_store = control_plane_product_read_service.require_product_environment_read_model_store(
+                                record_store
+                            )
+                        except control_plane_product_read_service.ProductReadModelStoreCapabilityError as error:
+                            return _json_response(
+                                start_response=start_response,
+                                status_code=503,
+                                payload={
+                                    "status": "rejected",
+                                    "trace_id": request_trace_id,
+                                    "error": {
+                                        "code": "database_storage_required",
+                                        "message": str(error),
+                                    },
+                                },
+                            )
                         product_read_result = control_plane_product_read_service.build_product_environment_read_service_result(
-                            record_store=record_store,
+                            record_store=product_read_store,
                             params=params,
                             action_allowed=product_action_allowed,
                         )
@@ -8666,8 +8681,25 @@ def create_launchplane_service_app(
                                 },
                             },
                         )
+                    try:
+                        product_read_store = control_plane_product_read_service.require_product_environment_read_model_store(
+                            record_store
+                        )
+                    except control_plane_product_read_service.ProductReadModelStoreCapabilityError as error:
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=503,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "database_storage_required",
+                                    "message": str(error),
+                                },
+                            },
+                        )
                     product_list_payload = control_plane_product_read_service.build_product_environment_list_service_payload(
-                        record_store=record_store,
+                        record_store=product_read_store,
                         action_allowed=product_action_allowed,
                     )
                     return _json_response(

--- a/tests/test_product_read_service.py
+++ b/tests/test_product_read_service.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 import unittest
 from typing import cast
 
+from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
+from control_plane.contracts.preview_summary import LaunchplanePreviewSummary
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.product_read_service import (
+    ProductReadModelStoreCapabilityError,
     build_product_environment_list_service_payload,
     build_product_environment_read_service_result,
     build_product_profile_list_service_payload,
+    require_product_environment_read_model_store,
 )
 
 
@@ -64,6 +68,31 @@ class _ProductReadStore:
         if product != self.profile.product:
             raise FileNotFoundError(product)
         return self.profile
+
+    def read_lane_summary(
+        self, *, context_name: str, instance_name: str
+    ) -> LaunchplaneLaneSummary:
+        _ = self
+        return LaunchplaneLaneSummary(context=context_name, instance=instance_name)
+
+    def list_preview_summaries(
+        self,
+        *,
+        context_name: str = "",
+        anchor_repo: str = "",
+        anchor_pr_number: int | None = None,
+        preview_limit: int | None = None,
+        generation_limit: int | None = 1,
+    ) -> tuple[LaunchplanePreviewSummary, ...]:
+        _ = (
+            self,
+            context_name,
+            anchor_repo,
+            anchor_pr_number,
+            preview_limit,
+            generation_limit,
+        )
+        return ()
 
     def list_preview_records(
         self,
@@ -140,6 +169,24 @@ class ProductReadServiceTests(unittest.TestCase):
         self.assertEqual(payload["driver_id"], "generic-web")
         profiles = cast(list[dict[str, object]], payload["profiles"])
         self.assertEqual(len(profiles), 1)
+
+    def test_product_read_model_store_requires_db_summary_capabilities(self) -> None:
+        class PartialStore:
+            def list_product_profile_records(
+                self, *, driver_id: str = ""
+            ) -> tuple[LaunchplaneProductProfileRecord, ...]:
+                return ()
+
+            def read_product_profile_record(
+                self, product: str
+            ) -> LaunchplaneProductProfileRecord:
+                raise FileNotFoundError(product)
+
+        with self.assertRaisesRegex(
+            ProductReadModelStoreCapabilityError,
+            "read_lane_summary, list_preview_summaries",
+        ):
+            require_product_environment_read_model_store(PartialStore())
 
     def test_product_environment_result_identifies_authorization_target(self) -> None:
         result = build_product_environment_read_service_result(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -10743,6 +10743,48 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ["testing", "prod"],
         )
 
+    def test_products_endpoint_requires_database_backed_read_model_store(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["launchplane", "example-site"],
+                            "contexts": ["launchplane", "example-site"],
+                            "actions": ["product_environment.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/products",
+            )
+
+        self.assertEqual(status_code, 503)
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+        self.assertIn("DB-backed Launchplane storage", payload["error"]["message"])
+
     def test_product_activity_endpoint_returns_product_timeline(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -11051,11 +11093,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
     ) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
             store.write_product_profile_record(
                 LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
             )
+            store.close()
             policy = LaunchplaneAuthzPolicy.model_validate(
                 {
                     "github_actions": [
@@ -11073,10 +11117,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 }
             )
             app = create_launchplane_service_app(
-                state_dir=state_dir,
+                state_dir=root / "state",
                 verifier=_StubVerifier(_identity()),
                 authz_policy=policy,
                 control_plane_root_path=root,
+                database_url=database_url,
             )
 
             status_code, payload = _invoke_app(


### PR DESCRIPTION
## Summary
- add an explicit product-environment read-model store contract for profile, lane-summary, and preview-summary capabilities
- return `database_storage_required` for product/environment read endpoints when the service is not backed by the DB read model
- cover the capability guard and convert the config-status service path to DB-backed setup

Refs #849

## Verification
- `uv run python -m unittest tests.test_product_read_service`
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_product_profile_endpoints_round_trip_authorized_record tests.test_service.LaunchplaneServiceTests.test_product_overview_endpoint_is_generic_web_profile_driven tests.test_service.LaunchplaneServiceTests.test_products_endpoint_lists_db_backed_product_overviews tests.test_service.LaunchplaneServiceTests.test_products_endpoint_requires_database_backed_read_model_store tests.test_service.LaunchplaneServiceTests.test_product_activity_endpoint_returns_product_timeline tests.test_service.LaunchplaneServiceTests.test_product_environments_endpoint_lists_db_backed_environment_summaries tests.test_service.LaunchplaneServiceTests.test_product_environment_detail_redacts_runtime_and_secret_values tests.test_service.LaunchplaneServiceTests.test_product_environment_config_status_endpoint_redacts_expected_config_status tests.test_service.LaunchplaneServiceTests.test_product_environment_config_status_endpoint_uses_lane_authorization`
- `uv run --extra dev ruff check --diff control_plane/product_read_service.py control_plane/contracts/product_environment_read_model.py control_plane/service.py tests/test_product_read_service.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/product_read_service.py control_plane/contracts/product_environment_read_model.py control_plane/service.py tests/test_product_read_service.py tests/test_service.py`
- `uv run --extra dev mypy control_plane/product_read_service.py control_plane/contracts/product_environment_read_model.py control_plane/service.py tests/test_product_read_service.py tests/test_service.py`
- `uv run python -m unittest`

## Inspection
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files` reports residual pre-existing warnings in touched contract/service modules; no Ruff/mypy/test failures.
