### PR TITLE
Tighten product read activity store contract

### DIFF
--- a/control_plane/contracts/product_environment_read_model.py
+++ b/control_plane/contracts/product_environment_read_model.py
@@ -6,9 +6,15 @@ from typing import Literal, Protocol
 from pydantic import BaseModel, ConfigDict, Field
 
 from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
+from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRecord
+from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.data_provenance import DataProvenance, FreshnessStatus
+from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.driver_descriptor import DriverActionDescriptor, DriverDescriptor
 from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
+from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
+from control_plane.contracts.preview_lifecycle_cleanup_record import PreviewLifecycleCleanupRecord
+from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedbackRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.preview_summary import LaunchplanePreviewSummary
 from control_plane.contracts.product_profile_record import (
@@ -17,6 +23,7 @@ from control_plane.contracts.product_profile_record import (
     ProductRuntimeConfigRequirement,
     ProductSecretConfigRequirement,
 )
+from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.contracts.runtime_identity import RuntimeIdentity, RuntimeIdentityStatus
 from control_plane.contracts.secret_record import SecretBinding
@@ -54,6 +61,32 @@ class ProductEnvironmentReadModelStore(ProductReadModelStore, Protocol):
         self, *, context_name: str, instance_name: str
     ) -> LaunchplaneLaneSummary: ...
 
+    def list_deployment_records(
+        self, *, context_name: str = "", instance_name: str = "", limit: int | None = None
+    ) -> tuple[DeploymentRecord, ...]: ...
+
+    def list_promotion_records(
+        self,
+        *,
+        context_name: str = "",
+        from_instance_name: str = "",
+        to_instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[PromotionRecord, ...]: ...
+
+    def list_backup_gate_records(
+        self, *, context_name: str = "", instance_name: str = "", limit: int | None = None
+    ) -> tuple[BackupGateRecord, ...]: ...
+
+    def list_preview_records(
+        self,
+        *,
+        context_name: str = "",
+        anchor_repo: str = "",
+        anchor_pr_number: int | None = None,
+        limit: int | None = None,
+    ) -> tuple[PreviewRecord, ...]: ...
+
     def list_preview_summaries(
         self,
         *,
@@ -63,6 +96,22 @@ class ProductEnvironmentReadModelStore(ProductReadModelStore, Protocol):
         preview_limit: int | None = None,
         generation_limit: int | None = 1,
     ) -> tuple[LaunchplanePreviewSummary, ...]: ...
+
+    def list_preview_desired_state_records(
+        self, *, context_name: str = "", limit: int | None = None
+    ) -> tuple[PreviewDesiredStateRecord, ...]: ...
+
+    def list_preview_lifecycle_cleanup_records(
+        self, *, context_name: str = "", limit: int | None = None
+    ) -> tuple[PreviewLifecycleCleanupRecord, ...]: ...
+
+    def list_preview_pr_feedback_records(
+        self, *, context_name: str = "", limit: int | None = None
+    ) -> tuple[PreviewPrFeedbackRecord, ...]: ...
+
+    def list_authz_policy_records(
+        self, *, status: str = "", limit: int | None = None
+    ) -> tuple[LaunchplaneAuthzPolicyRecord, ...]: ...
 
 
 def _build_action_authz_by_route() -> dict[str, str]:

--- a/control_plane/product_read_service.py
+++ b/control_plane/product_read_service.py
@@ -33,7 +33,15 @@ _PRODUCT_ENVIRONMENT_READ_MODEL_STORE_METHODS = (
     "list_product_profile_records",
     "read_product_profile_record",
     "read_lane_summary",
+    "list_deployment_records",
+    "list_promotion_records",
+    "list_backup_gate_records",
+    "list_preview_records",
     "list_preview_summaries",
+    "list_preview_desired_state_records",
+    "list_preview_lifecycle_cleanup_records",
+    "list_preview_pr_feedback_records",
+    "list_authz_policy_records",
 )
 
 

--- a/tests/test_product_read_service.py
+++ b/tests/test_product_read_service.py
@@ -3,9 +3,17 @@ from __future__ import annotations
 import unittest
 from typing import cast
 
+from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRecord
+from control_plane.contracts.backup_gate_record import BackupGateRecord
+from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
+from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
+from control_plane.contracts.preview_lifecycle_cleanup_record import PreviewLifecycleCleanupRecord
+from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedbackRecord
+from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.preview_summary import LaunchplanePreviewSummary
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.product_read_service import (
     ProductReadModelStoreCapabilityError,
     build_product_environment_list_service_payload,
@@ -101,12 +109,14 @@ class _ProductReadStore:
         anchor_repo: str = "",
         anchor_pr_number: int | None = None,
         limit: int | None = None,
-    ) -> tuple[object, ...]:
+    ) -> tuple[PreviewRecord, ...]:
+        _ = (self, context_name, anchor_repo, anchor_pr_number, limit)
         return ()
 
     def list_deployment_records(
         self, *, context_name: str = "", instance_name: str = "", limit: int | None = None
-    ) -> tuple[object, ...]:
+    ) -> tuple[DeploymentRecord, ...]:
+        _ = (self, context_name, instance_name, limit)
         return ()
 
     def list_promotion_records(
@@ -116,32 +126,38 @@ class _ProductReadStore:
         from_instance_name: str = "",
         to_instance_name: str = "",
         limit: int | None = None,
-    ) -> tuple[object, ...]:
+    ) -> tuple[PromotionRecord, ...]:
+        _ = (self, context_name, from_instance_name, to_instance_name, limit)
         return ()
 
     def list_backup_gate_records(
         self, *, context_name: str = "", instance_name: str = "", limit: int | None = None
-    ) -> tuple[object, ...]:
+    ) -> tuple[BackupGateRecord, ...]:
+        _ = (self, context_name, instance_name, limit)
         return ()
 
     def list_preview_desired_state_records(
         self, *, context_name: str = "", limit: int | None = None
-    ) -> tuple[object, ...]:
+    ) -> tuple[PreviewDesiredStateRecord, ...]:
+        _ = (self, context_name, limit)
         return ()
 
     def list_preview_lifecycle_cleanup_records(
         self, *, context_name: str = "", limit: int | None = None
-    ) -> tuple[object, ...]:
+    ) -> tuple[PreviewLifecycleCleanupRecord, ...]:
+        _ = (self, context_name, limit)
         return ()
 
     def list_preview_pr_feedback_records(
         self, *, context_name: str = "", limit: int | None = None
-    ) -> tuple[object, ...]:
+    ) -> tuple[PreviewPrFeedbackRecord, ...]:
+        _ = (self, context_name, limit)
         return ()
 
     def list_authz_policy_records(
         self, *, status: str = "", limit: int | None = None
-    ) -> tuple[object, ...]:
+    ) -> tuple[LaunchplaneAuthzPolicyRecord, ...]:
+        _ = (self, status, limit)
         return ()
 
     def list_runtime_environment_records(
@@ -184,7 +200,7 @@ class ProductReadServiceTests(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ProductReadModelStoreCapabilityError,
-            "read_lane_summary, list_preview_summaries",
+            "read_lane_summary, list_deployment_records, list_promotion_records",
         ):
             require_product_environment_read_model_store(PartialStore())
 


### PR DESCRIPTION
## Summary
- extend the product environment read-model store protocol to include the activity/feed record readers product views use
- require those activity reader methods before serving product environment read-model requests
- type the product-read service fake against the concrete records so partial stores cannot silently satisfy tests

## Verification
- `uv run python -m unittest tests.test_product_read_service tests.test_service.LaunchplaneServiceTests.test_products_endpoint_requires_database_backed_read_model_store tests.test_service.LaunchplaneServiceTests.test_product_environments_endpoint_lists_db_backed_environment_summaries tests.test_service.LaunchplaneServiceTests.test_products_endpoint_lists_db_backed_product_overviews`
- `uv run --extra dev ruff check control_plane/contracts/product_environment_read_model.py control_plane/product_read_service.py tests/test_product_read_service.py --no-cache`

Refs #849
