### PR TITLE
Verify shared DB schema on startup

### DIFF
--- a/control_plane/storage/factory.py
+++ b/control_plane/storage/factory.py
@@ -24,7 +24,7 @@ def build_shared_record_store(*, database_url: str | None = None) -> PostgresRec
             "LAUNCHPLANE_DATABASE_URL. Filesystem state is local-only."
         )
     store = PostgresRecordStore(database_url=resolved_database_url)
-    store.ensure_schema()
+    store.verify_schema()
     return store
 
 

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     create_engine,
     delete,
     desc,
+    inspect,
     text,
     select,
 )
@@ -1052,6 +1053,23 @@ class PostgresRecordStore(HumanSessionStore):
 
     def ensure_schema(self) -> None:
         Base.metadata.create_all(self._engine)
+
+    def verify_schema(self) -> None:
+        inspector = inspect(self._engine)
+        existing_tables = set(inspector.get_table_names())
+        missing_tables = tuple(
+            sorted(
+                table_name
+                for table_name in Base.metadata.tables
+                if table_name not in existing_tables
+            )
+        )
+        if missing_tables:
+            missing = ", ".join(missing_tables)
+            raise RuntimeError(
+                "Launchplane shared storage schema is missing required table(s): "
+                f"{missing}. Run Alembic migrations before starting the hosted service."
+            )
 
     def close(self) -> None:
         self._engine.dispose()

--- a/docs/records.md
+++ b/docs/records.md
@@ -21,8 +21,10 @@ title: Records
 ## Schema Migrations
 
 Launchplane uses SQLAlchemy ORM models as the persistence boundary and Alembic as
-the versioned migration mechanism for shared-service Postgres databases. Runtime
-code can still call `ensure_schema()` for compatibility and ephemeral test/local
+the versioned migration mechanism for shared-service Postgres databases. Hosted
+service startup verifies that the shared database schema is already present; it
+does not create or migrate tables as a startup side effect. Runtime code can
+still call `ensure_schema()` for compatibility and ephemeral test/local
 databases, but new production schema changes should land as Alembic revisions.
 
 For a fresh database, apply the current schema with:

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, patch
 from alembic import command as alembic_command
 from alembic.config import Config as AlembicConfig
 from click.testing import CliRunner
+from sqlalchemy import inspect
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.sql.schema import Index
 
@@ -127,6 +128,7 @@ from control_plane.service_auth import (
 )
 from control_plane.service_human_auth import LaunchplaneHumanSession
 from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.storage.factory import build_shared_record_store
 from control_plane.storage.postgres import Base, PostgresRecordStore
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy_with_codex_skills
@@ -789,6 +791,37 @@ class PostgresRecordStoreTests(unittest.TestCase):
 
         self.assertEqual(loaded.artifact_id, manifest.artifact_id)
         self.assertEqual(loaded.image.digest, "sha256:image123")
+
+    def test_verify_schema_rejects_empty_database_without_creating_tables(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            store = PostgresRecordStore(database_url=database_url)
+
+            with self.assertRaisesRegex(RuntimeError, "missing required table"):
+                store.verify_schema()
+
+            self.assertEqual(inspect(store._engine).get_table_names(), [])
+            store.close()
+
+    def test_shared_record_store_verifies_existing_schema_without_creating_it(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "Run Alembic migrations"):
+                build_shared_record_store(database_url=database_url)
+
+            alembic_command.upgrade(_alembic_config(database_url), "head")
+            store = build_shared_record_store(database_url=database_url)
+            manifest = _artifact_manifest()
+            store.write_artifact_manifest(manifest)
+            loaded = store.read_artifact_manifest(manifest.artifact_id)
+            store.close()
+
+        self.assertEqual(loaded.artifact_id, manifest.artifact_id)
 
     def test_alembic_baseline_downgrades_to_empty_schema(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -939,6 +939,11 @@ def create_launchplane_service_app(
         if not isinstance(state_dir, Path):
             raise AssertionError("service tests must pass a pathlib state_dir")
         kwargs["local_record_store_for_tests"] = FilesystemRecordStore(state_dir=state_dir)
+    database_url = kwargs.get("database_url")
+    if isinstance(database_url, str) and database_url.startswith("sqlite"):
+        store = PostgresRecordStore(database_url=database_url)
+        store.ensure_schema()
+        store.close()
     factory = cast(Any, _create_launchplane_service_app)
     return cast(
         Callable[[dict[str, object], Callable[[str, list[tuple[str, str]]], None]], list[bytes]],


### PR DESCRIPTION
## Summary
- add `PostgresRecordStore.verify_schema()` for fail-closed shared DB startup checks
- make shared record-store construction verify schema instead of creating it
- document hosted startup as verify-only and add focused tests proving empty DB startup does not create tables

## Verification
- `uv run python -m unittest tests.test_postgres_store.PostgresRecordStoreTests.test_verify_schema_rejects_empty_database_without_creating_tables tests.test_postgres_store.PostgresRecordStoreTests.test_shared_record_store_verifies_existing_schema_without_creating_it tests.test_postgres_store.PostgresRecordStoreTests.test_alembic_baseline_creates_schema_used_by_record_store`
- `uv run --extra dev ruff check control_plane/storage/postgres.py control_plane/storage/factory.py tests/test_postgres_store.py docs/records.md --no-cache`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files` reported only an unrelated weak warning in `control_plane/runner_lane_github.py`

Refs #855
