### PR TITLE
Handle product read missing targets

### DIFF
--- a/control_plane/product_read_service.py
+++ b/control_plane/product_read_service.py
@@ -85,10 +85,18 @@ def build_product_environment_read_service_result(
     params: Mapping[str, str],
     action_allowed: ActionAllowed,
 ) -> ProductEnvironmentReadServiceResult:
+    product = params.get("product", "").strip()
+    if not product:
+        raise ValueError("Product environment read result requires product parameters.")
+    try:
+        record_store.read_product_profile_record(product)
+    except FileNotFoundError as error:
+        raise FileNotFoundError(f"Product '{product}' was not found.") from error
+
     if params.get("activity") == "true":
         activity = build_product_activity_read_model(
             record_store=record_store,
-            product=params["product"],
+            product=product,
         )
         return ProductEnvironmentReadServiceResult(
             payload={"activity": activity.model_dump(mode="json")},
@@ -98,11 +106,17 @@ def build_product_environment_read_service_result(
         )
 
     if params.get("config_status") == "true":
-        config_status = build_product_environment_config_status(
-            record_store=record_store,
-            product=params["product"],
-            environment=params["environment"],
-        )
+        environment = params["environment"]
+        try:
+            config_status = build_product_environment_config_status(
+                record_store=record_store,
+                product=product,
+                environment=environment,
+            )
+        except FileNotFoundError as error:
+            raise FileNotFoundError(
+                f"Product '{product}' has no environment '{environment}'."
+            ) from error
         return ProductEnvironmentReadServiceResult(
             payload={"config_status": config_status.model_dump(mode="json")},
             authorization_product=config_status.product,
@@ -111,12 +125,18 @@ def build_product_environment_read_service_result(
         )
 
     if "environment" in params:
-        detail = build_product_environment_detail(
-            record_store=record_store,
-            product=params["product"],
-            environment=params["environment"],
-            action_allowed=action_allowed,
-        )
+        environment = params["environment"]
+        try:
+            detail = build_product_environment_detail(
+                record_store=record_store,
+                product=product,
+                environment=environment,
+                action_allowed=action_allowed,
+            )
+        except FileNotFoundError as error:
+            raise FileNotFoundError(
+                f"Product '{product}' has no environment '{environment}'."
+            ) from error
         return ProductEnvironmentReadServiceResult(
             payload={"environment": detail.model_dump(mode="json")},
             authorization_product=detail.product,
@@ -127,7 +147,7 @@ def build_product_environment_read_service_result(
     if params.get("environments") == "true":
         overview = build_product_site_overview(
             record_store=record_store,
-            product=params["product"],
+            product=product,
             action_allowed=action_allowed,
         )
         return ProductEnvironmentReadServiceResult(
@@ -140,7 +160,7 @@ def build_product_environment_read_service_result(
     if "product" in params:
         overview = build_product_site_overview(
             record_store=record_store,
-            product=params["product"],
+            product=product,
             action_allowed=action_allowed,
         )
         return ProductEnvironmentReadServiceResult(

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -8633,11 +8633,38 @@ def create_launchplane_service_app(
                                     },
                                 },
                             )
-                        product_read_result = control_plane_product_read_service.build_product_environment_read_service_result(
-                            record_store=product_read_store,
-                            params=params,
-                            action_allowed=product_action_allowed,
-                        )
+                        try:
+                            product_read_result = control_plane_product_read_service.build_product_environment_read_service_result(
+                                record_store=product_read_store,
+                                params=params,
+                                action_allowed=product_action_allowed,
+                            )
+                        except FileNotFoundError as error:
+                            return _json_response(
+                                start_response=start_response,
+                                status_code=404,
+                                payload={
+                                    "status": "rejected",
+                                    "trace_id": request_trace_id,
+                                    "error": {
+                                        "code": "not_found",
+                                        "message": str(error),
+                                    },
+                                },
+                            )
+                        except ValueError as error:
+                            return _json_response(
+                                start_response=start_response,
+                                status_code=400,
+                                payload={
+                                    "status": "rejected",
+                                    "trace_id": request_trace_id,
+                                    "error": {
+                                        "code": "invalid_request",
+                                        "message": str(error),
+                                    },
+                                },
+                            )
                         if not product_action_allowed(
                             "product_environment.read",
                             product_read_result.authorization_product,

--- a/tests/test_product_environment_read_model.py
+++ b/tests/test_product_environment_read_model.py
@@ -444,6 +444,29 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
         self.assertNotIn("testing_verification", actions)
         self.assertNotIn("preview_verification", actions)
 
+    def test_product_site_overview_raises_for_unknown_product(self) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(_site_profile_payload())
+        store = _PreviewRecordStore(profile, ())
+
+        with self.assertRaisesRegex(FileNotFoundError, "unknown-site"):
+            build_product_site_overview(
+                record_store=store,
+                product="unknown-site",
+                action_allowed=lambda _action, _product, _context: True,
+            )
+
+    def test_product_environment_detail_raises_for_unknown_environment(self) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(_site_profile_payload())
+        store = _PreviewRecordStore(profile, ())
+
+        with self.assertRaisesRegex(FileNotFoundError, "staging"):
+            build_product_environment_detail(
+                record_store=store,
+                product="example-site",
+                environment="staging",
+                action_allowed=lambda _action, _product, _context: True,
+            )
+
     def test_product_site_overview_filters_preview_summaries_by_repository_and_state(self) -> None:
         profile = LaunchplaneProductProfileRecord.model_validate(_site_profile_payload())
         store = _PreviewRecordStore(

--- a/tests/test_product_read_service.py
+++ b/tests/test_product_read_service.py
@@ -219,6 +219,14 @@ class ProductReadServiceTests(unittest.TestCase):
         )
         self.assertIn("environment", result.payload)
 
+    def test_product_environment_result_requires_product_params(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires product parameters"):
+            build_product_environment_read_service_result(
+                record_store=self.store,
+                params={},
+                action_allowed=lambda _action, _product, _context: True,
+            )
+
     def test_product_environment_results_identify_branch_authorization_targets(
         self,
     ) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -11005,6 +11005,100 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertNotIn("https://internal.example-site.invalid", response_text)
         self.assertNotIn("super-secret-password", response_text)
 
+    def test_product_environment_detail_returns_not_found_for_unknown_product(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.close()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["missing-site"],
+                            "contexts": ["missing-site"],
+                            "actions": ["product_environment.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/products/missing-site/environments/prod",
+            )
+
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "not_found")
+        self.assertEqual(payload["error"]["message"], "Product 'missing-site' was not found.")
+
+    def test_product_environment_detail_returns_not_found_for_unknown_environment(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
+            )
+            store.close()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["example-site"],
+                            "contexts": ["example-site"],
+                            "actions": ["product_environment.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/products/example-site/environments/staging",
+            )
+
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "not_found")
+        self.assertEqual(
+            payload["error"]["message"],
+            "Product 'example-site' has no environment 'staging'.",
+        )
+
     def test_product_environment_config_status_endpoint_redacts_expected_config_status(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- normalize missing product and missing product-environment read model errors before they reach HTTP responses
- return structured `404 not_found` and `400 invalid_request` payloads from the product read route instead of unhandled exceptions
- add direct read-model, read-service, and HTTP endpoint unhappy-path coverage

Refs #857

## Verification
- `uv run python -m unittest tests.test_product_read_service tests.test_service.LaunchplaneServiceTests.test_product_environment_detail_returns_not_found_for_unknown_product tests.test_service.LaunchplaneServiceTests.test_product_environment_detail_returns_not_found_for_unknown_environment tests.test_service.LaunchplaneServiceTests.test_product_environment_detail_redacts_runtime_and_secret_values tests.test_service.LaunchplaneServiceTests.test_product_activity_endpoint_returns_product_timeline tests.test_service.LaunchplaneServiceTests.test_product_environments_endpoint_lists_db_backed_environment_summaries tests.test_service.LaunchplaneServiceTests.test_product_environment_config_status_endpoint_redacts_expected_config_status`
- `uv run --extra dev ruff check --diff control_plane/product_read_service.py control_plane/service.py tests/test_product_read_service.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/product_read_service.py control_plane/service.py tests/test_product_read_service.py tests/test_service.py`
- `uv run --extra dev mypy control_plane/product_read_service.py control_plane/service.py tests/test_product_read_service.py tests/test_service.py`
- `uv run python -m unittest`

## Inspection
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files` reports residual pre-existing warnings in `tests/test_postgres_store.py`; no product-read inspection findings were introduced.
