### PR TITLE
Detect missing DB schema columns

### DIFF
--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -1070,6 +1070,18 @@ class PostgresRecordStore(HumanSessionStore):
                 "Launchplane shared storage schema is missing required table(s): "
                 f"{missing}. Run Alembic migrations before starting the hosted service."
             )
+        missing_columns: list[str] = []
+        for table_name, table in sorted(Base.metadata.tables.items()):
+            existing_columns = {column["name"] for column in inspector.get_columns(table_name)}
+            for column_name in sorted(table.columns.keys()):
+                if column_name not in existing_columns:
+                    missing_columns.append(f"{table_name}.{column_name}")
+        if missing_columns:
+            missing = ", ".join(missing_columns)
+            raise RuntimeError(
+                "Launchplane shared storage schema is missing required column(s): "
+                f"{missing}. Run Alembic migrations before starting the hosted service."
+            )
 
     def close(self) -> None:
         self._engine.dispose()

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, patch
 from alembic import command as alembic_command
 from alembic.config import Config as AlembicConfig
 from click.testing import CliRunner
-from sqlalchemy import inspect
+from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.sql.schema import Index
 
@@ -803,6 +803,33 @@ class PostgresRecordStoreTests(unittest.TestCase):
                 store.verify_schema()
 
             self.assertEqual(inspect(store._engine).get_table_names(), [])
+            store.close()
+
+    def test_verify_schema_rejects_missing_columns_without_creating_them(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            alembic_command.upgrade(_alembic_config(database_url), "head")
+            engine = create_engine(database_url)
+            with engine.begin() as connection:
+                connection.execute(text("ALTER TABLE launchplane_artifact_manifests DROP COLUMN payload"))
+            engine.dispose()
+            store = PostgresRecordStore(database_url=database_url)
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "missing required column.*launchplane_artifact_manifests.payload",
+            ):
+                store.verify_schema()
+
+            artifact_columns = {
+                column["name"]
+                for column in inspect(store._engine).get_columns(
+                    "launchplane_artifact_manifests"
+                )
+            }
+            self.assertNotIn("payload", artifact_columns)
             store.close()
 
     def test_shared_record_store_verifies_existing_schema_without_creating_it(self) -> None:


### PR DESCRIPTION
## Summary
- extend shared DB schema verification to reject missing mapped columns, not only missing tables
- add a partial-schema regression test that drops a required column after migrations
- prove verification remains non-mutating when a column is absent

## Verification
- `uv run python -m unittest tests.test_postgres_store.PostgresRecordStoreTests.test_verify_schema_rejects_empty_database_without_creating_tables tests.test_postgres_store.PostgresRecordStoreTests.test_verify_schema_rejects_missing_columns_without_creating_them tests.test_postgres_store.PostgresRecordStoreTests.test_shared_record_store_verifies_existing_schema_without_creating_it`
- `uv run python -m unittest`
- `uv run --extra dev ruff check control_plane/storage/postgres.py tests/test_postgres_store.py --no-cache`

Refs #859
