### PR TITLE
Run migrations before Launchplane self deploy

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -82,6 +82,7 @@ jobs:
       LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_LOGINS: ${{ vars.LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_LOGINS }}
       LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_PRODUCTS: ${{ vars.LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_PRODUCTS }}
       LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_CONTEXTS: ${{ vars.LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_CONTEXTS }}
+      LAUNCHPLANE_DATABASE_URL: ${{ secrets.LAUNCHPLANE_DATABASE_URL }}
       ODOO_CM_TESTING_DOKPLOY_TARGET_ID: ${{ vars.ODOO_CM_TESTING_DOKPLOY_TARGET_ID }}
       ODOO_CM_PROD_DOKPLOY_TARGET_ID: ${{ vars.ODOO_CM_PROD_DOKPLOY_TARGET_ID }}
       ODOO_OPW_TESTING_DOKPLOY_TARGET_ID: ${{ vars.ODOO_OPW_TESTING_DOKPLOY_TARGET_ID }}
@@ -214,6 +215,14 @@ jobs:
             image_reference="${{ steps.prep.outputs.image_repository }}@${{ steps.build.outputs.digest }}"
           fi
           echo "image_reference=$image_reference" >> "$GITHUB_OUTPUT"
+
+      - name: Apply Launchplane database migrations
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${LAUNCHPLANE_DATABASE_URL:?Missing LAUNCHPLANE_DATABASE_URL secret}"
+
+          uv run alembic upgrade head
 
       - name: Request Launchplane self deploy
         id: self_deploy

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -320,6 +320,12 @@ than Launchplane CLI validations:
 - The Postgres service referenced by `LAUNCHPLANE_DATABASE_URL` must already be
   deployed and reachable on the Dokploy network before Launchplane is redeployed.
 
+The Launchplane self-deploy workflow applies `uv run alembic upgrade head` to
+the workflow-provided `LAUNCHPLANE_DATABASE_URL` before requesting a Dokploy
+image swap. This keeps hosted service startup fail-closed on schema drift while
+ensuring new images that require new columns are deployed only after the shared
+database has been migrated.
+
 Current derived-state behavior:
 
 - accepted deployment evidence also refreshes current environment inventory for
@@ -415,9 +421,8 @@ Current derived-state behavior:
   preview generations instead of adding another long-lived route.
 - Operator read models compose inventory, deployment, promotion, and
   backup-gate records instead of requiring operators to inspect raw JSON first.
-- Until Launchplane has a formal schema migration system, DB-backed schema changes
-  must stay additive and backward-compatible so image rollback remains a valid
-  recovery path.
+- DB-backed schema changes must land as Alembic revisions. Keep revisions
+  additive and rollback-aware so image rollback remains a valid recovery path.
 - Local CLI/file-backed compatibility paths must pass the review checkpoints in
   [compatibility-retirement.md](compatibility-retirement.md). Product workflows
   should use service routes once matching OIDC-authenticated routes exist.


### PR DESCRIPTION
## Summary
- run `uv run alembic upgrade head` in the Launchplane deploy workflow before requesting the self-deploy image swap
- require the workflow-scoped `LAUNCHPLANE_DATABASE_URL` secret for deploy migrations
- document the migration-before-swap ordering in operations docs

## Verification
- `prettier --check .github/workflows/deploy-launchplane.yml docs/operations.md`
- `actionlint .github/workflows/deploy-launchplane.yml`
- `git diff --check`
- `LAUNCHPLANE_DATABASE_URL=sqlite:///... uv run alembic upgrade head`
- JetBrains changed-files inspection run; reported existing noisy findings in `tests/test_postgres_store.py` and `control_plane/storage/postgres.py`, not in this workflow/docs slice

Refs #859
