### PR TITLE
Resolve deploy database URL from target env

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -216,6 +216,48 @@ jobs:
           fi
           echo "image_reference=$image_reference" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve Launchplane database URL
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -n "${LAUNCHPLANE_DATABASE_URL:-}" ]; then
+            echo "::add-mask::${LAUNCHPLANE_DATABASE_URL}"
+            exit 0
+          fi
+          if [ -z "${LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST:-}" ] || [ -z "${LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN:-}" ]; then
+            echo "Launchplane deploy migrations require LAUNCHPLANE_DATABASE_URL or emergency Dokploy read credentials." >&2
+            exit 1
+          fi
+
+          uv run python - <<'PY'
+          import os
+
+          from control_plane import dokploy as control_plane_dokploy
+
+          host = os.environ["LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST"].strip()
+          token = os.environ["LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN"].strip()
+          target_type = os.environ["LAUNCHPLANE_DOKPLOY_TARGET_TYPE"].strip()
+          target_id = os.environ["LAUNCHPLANE_DOKPLOY_TARGET_ID"].strip()
+
+          target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
+              host=host,
+              token=token,
+              target_type=target_type,
+              target_id=target_id,
+          )
+          env_map = control_plane_dokploy.parse_dokploy_env_text(
+              str(target_payload.get("env") or "")
+          )
+          database_url = env_map.get("LAUNCHPLANE_DATABASE_URL", "").strip()
+          if not database_url:
+              raise SystemExit(
+                  "Launchplane target env is missing LAUNCHPLANE_DATABASE_URL."
+              )
+          print(f"::add-mask::{database_url}")
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as handle:
+              handle.write(f"LAUNCHPLANE_DATABASE_URL={database_url}\n")
+          PY
+
       - name: Apply Launchplane database migrations
         shell: bash
         run: |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -324,7 +324,9 @@ The Launchplane self-deploy workflow applies `uv run alembic upgrade head` to
 the workflow-provided `LAUNCHPLANE_DATABASE_URL` before requesting a Dokploy
 image swap. This keeps hosted service startup fail-closed on schema drift while
 ensuring new images that require new columns are deployed only after the shared
-database has been migrated.
+database has been migrated. If the GitHub secret is not configured, the workflow
+can read the current Launchplane target env through the emergency Dokploy read
+credentials and masks the resolved database URL before running migrations.
 
 Current derived-state behavior:
 


### PR DESCRIPTION
## Summary
- resolve the Launchplane migration database URL from the current Dokploy target env when the GitHub secret is absent
- mask the resolved database URL before exporting it to later workflow steps
- document the emergency Dokploy read fallback used by the deploy migration step

## Verification
- `prettier --check .github/workflows/deploy-launchplane.yml docs/operations.md`
- `actionlint .github/workflows/deploy-launchplane.yml`
- `git diff --check`

Refs #859
