### PR TITLE
Run migrations in Launchplane entrypoint

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -82,7 +82,6 @@ jobs:
       LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_LOGINS: ${{ vars.LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_LOGINS }}
       LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_PRODUCTS: ${{ vars.LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_PRODUCTS }}
       LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_CONTEXTS: ${{ vars.LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_CONTEXTS }}
-      LAUNCHPLANE_DATABASE_URL: ${{ secrets.LAUNCHPLANE_DATABASE_URL }}
       ODOO_CM_TESTING_DOKPLOY_TARGET_ID: ${{ vars.ODOO_CM_TESTING_DOKPLOY_TARGET_ID }}
       ODOO_CM_PROD_DOKPLOY_TARGET_ID: ${{ vars.ODOO_CM_PROD_DOKPLOY_TARGET_ID }}
       ODOO_OPW_TESTING_DOKPLOY_TARGET_ID: ${{ vars.ODOO_OPW_TESTING_DOKPLOY_TARGET_ID }}
@@ -215,56 +214,6 @@ jobs:
             image_reference="${{ steps.prep.outputs.image_repository }}@${{ steps.build.outputs.digest }}"
           fi
           echo "image_reference=$image_reference" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve Launchplane database URL
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ -n "${LAUNCHPLANE_DATABASE_URL:-}" ]; then
-            echo "::add-mask::${LAUNCHPLANE_DATABASE_URL}"
-            exit 0
-          fi
-          if [ -z "${LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST:-}" ] || [ -z "${LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN:-}" ]; then
-            echo "Launchplane deploy migrations require LAUNCHPLANE_DATABASE_URL or emergency Dokploy read credentials." >&2
-            exit 1
-          fi
-
-          uv run python - <<'PY'
-          import os
-
-          from control_plane import dokploy as control_plane_dokploy
-
-          host = os.environ["LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST"].strip()
-          token = os.environ["LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN"].strip()
-          target_type = os.environ["LAUNCHPLANE_DOKPLOY_TARGET_TYPE"].strip()
-          target_id = os.environ["LAUNCHPLANE_DOKPLOY_TARGET_ID"].strip()
-
-          target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
-              host=host,
-              token=token,
-              target_type=target_type,
-              target_id=target_id,
-          )
-          env_map = control_plane_dokploy.parse_dokploy_env_text(
-              str(target_payload.get("env") or "")
-          )
-          database_url = env_map.get("LAUNCHPLANE_DATABASE_URL", "").strip()
-          if not database_url:
-              raise SystemExit(
-                  "Launchplane target env is missing LAUNCHPLANE_DATABASE_URL."
-              )
-          print(f"::add-mask::{database_url}")
-          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as handle:
-              handle.write(f"LAUNCHPLANE_DATABASE_URL={database_url}\n")
-          PY
-
-      - name: Apply Launchplane database migrations
-        shell: bash
-        run: |
-          set -euo pipefail
-          : "${LAUNCHPLANE_DATABASE_URL:?Missing LAUNCHPLANE_DATABASE_URL secret}"
-
-          uv run alembic upgrade head
 
       - name: Request Launchplane self deploy
         id: self_deploy

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -320,13 +320,13 @@ than Launchplane CLI validations:
 - The Postgres service referenced by `LAUNCHPLANE_DATABASE_URL` must already be
   deployed and reachable on the Dokploy network before Launchplane is redeployed.
 
-The Launchplane self-deploy workflow applies `uv run alembic upgrade head` to
-the workflow-provided `LAUNCHPLANE_DATABASE_URL` before requesting a Dokploy
-image swap. This keeps hosted service startup fail-closed on schema drift while
-ensuring new images that require new columns are deployed only after the shared
-database has been migrated. If the GitHub secret is not configured, the workflow
-can read the current Launchplane target env through the emergency Dokploy read
-credentials and masks the resolved database URL before running migrations.
+The Launchplane service entrypoint applies `uv run alembic upgrade head` with
+the container's `LAUNCHPLANE_DATABASE_URL` before starting HTTP service. This
+keeps hosted service startup fail-closed on schema drift while running
+migrations from inside the Dokploy network that can resolve the shared Postgres
+service hostname. The self-deploy workflow should not run shared database
+migrations from the GitHub runner; keep Launchplane migrations additive and
+rollback-aware so a failed health check can still return to the previous image.
 
 Current derived-state behavior:
 

--- a/scripts/start-launchplane-service.sh
+++ b/scripts/start-launchplane-service.sh
@@ -74,6 +74,9 @@ if [ -z "$launchplane_database_url" ]; then
 	exit 1
 fi
 
+echo "Applying Launchplane database migrations before service startup."
+LAUNCHPLANE_DATABASE_URL="$launchplane_database_url" uv run alembic upgrade head
+
 exec uv run launchplane service serve \
 	--host "$launchplane_service_host" \
 	--port "$launchplane_service_port" \


### PR DESCRIPTION
## Summary
- run Alembic migrations inside the Launchplane service entrypoint before starting HTTP service
- remove runner-side deploy migration attempts that cannot reach Dokploy-internal Postgres hostnames
- update operations docs to describe container-side migration ordering

## Verification
- `prettier --check .github/workflows/deploy-launchplane.yml docs/operations.md`
- `actionlint .github/workflows/deploy-launchplane.yml`
- `sh -n scripts/start-launchplane-service.sh && shellcheck scripts/start-launchplane-service.sh`
- `git diff --check`
- `LAUNCHPLANE_DATABASE_URL=sqlite:///... uv run alembic upgrade head`

Refs #859
