### PR TITLE
Stamp legacy Launchplane schemas before migrations

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -327,6 +327,10 @@ migrations from inside the Dokploy network that can resolve the shared Postgres
 service hostname. The self-deploy workflow should not run shared database
 migrations from the GitHub runner; keep Launchplane migrations additive and
 rollback-aware so a failed health check can still return to the previous image.
+If a shared database already has Launchplane tables but no `alembic_version`
+table from the pre-migration `create_all` era, the entrypoint stamps the
+baseline revision before applying later migrations. Empty databases still run
+the full migration chain from the first revision.
 
 Current derived-state behavior:
 

--- a/scripts/start-launchplane-service.sh
+++ b/scripts/start-launchplane-service.sh
@@ -26,6 +26,35 @@ with open(path, "wb") as handle:
 PY
 }
 
+schema_has_alembic_version() {
+	database_url="$1"
+	LAUNCHPLANE_DATABASE_URL="$database_url" uv run python - <<'PY'
+from control_plane.storage.postgres import _build_engine
+from control_plane.storage.postgres import Base
+from sqlalchemy import inspect
+import os
+import sys
+
+database_url = os.environ["LAUNCHPLANE_DATABASE_URL"]
+engine = _build_engine(database_url)
+try:
+    inspector = inspect(engine)
+    existing_tables = set(inspector.get_table_names())
+    if "alembic_version" in existing_tables:
+        raise SystemExit(0)
+    if not existing_tables.intersection(Base.metadata.tables):
+        raise SystemExit(0)
+    raise SystemExit(1)
+except SystemExit:
+    raise
+except Exception as error:
+    print(f"Could not inspect Launchplane database schema version: {error}", file=sys.stderr)
+    raise SystemExit(2)
+finally:
+    engine.dispose()
+PY
+}
+
 launchplane_app_root="${LAUNCHPLANE_APP_ROOT:-/app}"
 state_dir="${LAUNCHPLANE_STATE_DIR:-$launchplane_app_root/runtime}"
 launchplane_policy_toml="${LAUNCHPLANE_POLICY_TOML:-}"
@@ -75,6 +104,19 @@ if [ -z "$launchplane_database_url" ]; then
 fi
 
 echo "Applying Launchplane database migrations before service startup."
+schema_version_status=0
+schema_has_alembic_version "$launchplane_database_url" || schema_version_status="$?"
+case "$schema_version_status" in
+0) ;;
+1)
+	echo "Existing Launchplane schema is unversioned; stamping Alembic baseline before upgrade."
+	LAUNCHPLANE_DATABASE_URL="$launchplane_database_url" uv run alembic stamp fe94a0486977
+	;;
+*)
+	echo "Launchplane database schema verification failed before migrations." >&2
+	exit 1
+	;;
+esac
 LAUNCHPLANE_DATABASE_URL="$launchplane_database_url" uv run alembic upgrade head
 
 exec uv run launchplane service serve \

--- a/tests/test_start_launchplane_service.py
+++ b/tests/test_start_launchplane_service.py
@@ -16,7 +16,15 @@ class StartLaunchplaneServiceScriptTests(unittest.TestCase):
     def _write_fake_uv(self, bin_dir: Path) -> None:
         uv_path = bin_dir / "uv"
         uv_path.write_text(
-            '#!/bin/sh\nprintf \'%s\\n\' "$@" >"$UV_CAPTURE_FILE"\n',
+            """#!/bin/sh
+if [ "$1" = "run" ] && [ "$2" = "python" ]; then
+  if [ "${UV_SCHEMA_STATUS:-0}" = "2" ]; then
+    exit 2
+  fi
+  exit "${UV_SCHEMA_STATUS:-0}"
+fi
+printf '%s\n' "$@" >>"$UV_CAPTURE_FILE"
+""",
             encoding="utf-8",
         )
         uv_path.chmod(uv_path.stat().st_mode | stat.S_IXUSR)
@@ -195,6 +203,80 @@ class StartLaunchplaneServiceScriptTests(unittest.TestCase):
             self.assertIn("postgresql+psycopg://launchplane:test@db/launchplane", captured_args)
         finally:
             policy_path.unlink(missing_ok=True)
+
+    def test_stamps_unversioned_schema_before_upgrade(self) -> None:
+        policy_path = Path("/tmp/launchplane-authz.toml")
+        policy_path.unlink(missing_ok=True)
+
+        try:
+            with TemporaryDirectory() as temporary_directory_name:
+                temporary_directory = Path(temporary_directory_name)
+                app_root = temporary_directory / "app"
+                bin_dir = temporary_directory / "bin"
+                capture_file = temporary_directory / "uv-args.txt"
+                app_root.mkdir()
+                bin_dir.mkdir()
+                self._write_fake_uv(bin_dir)
+
+                result = subprocess.run(
+                    [str(self.script_path)],
+                    capture_output=True,
+                    text=True,
+                    env={
+                        **os.environ,
+                        "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+                        "UV_CAPTURE_FILE": str(capture_file),
+                        "UV_SCHEMA_STATUS": "1",
+                        "LAUNCHPLANE_APP_ROOT": str(app_root),
+                        "LAUNCHPLANE_STATE_DIR": str(temporary_directory / "state"),
+                        "LAUNCHPLANE_POLICY_TOML": "schema_version = 1\n",
+                        "LAUNCHPLANE_SERVICE_HOST": "0.0.0.0",
+                        "LAUNCHPLANE_DATABASE_URL": "postgresql+psycopg://launchplane:test@db/launchplane",
+                    },
+                    check=False,
+                )
+
+                captured_lines = capture_file.read_text(encoding="utf-8").splitlines()
+
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            self.assertIn("alembic", captured_lines)
+            self.assertIn("stamp", captured_lines)
+            self.assertIn("fe94a0486977", captured_lines)
+            self.assertIn("upgrade", captured_lines)
+            self.assertIn("head", captured_lines)
+        finally:
+            policy_path.unlink(missing_ok=True)
+
+    def test_fails_when_schema_probe_errors(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            app_root = temporary_directory / "app"
+            bin_dir = temporary_directory / "bin"
+            capture_file = temporary_directory / "uv-args.txt"
+            app_root.mkdir()
+            bin_dir.mkdir()
+            self._write_fake_uv(bin_dir)
+
+            result = subprocess.run(
+                [str(self.script_path)],
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+                    "UV_CAPTURE_FILE": str(capture_file),
+                    "UV_SCHEMA_STATUS": "2",
+                    "LAUNCHPLANE_APP_ROOT": str(app_root),
+                    "LAUNCHPLANE_STATE_DIR": str(temporary_directory / "state"),
+                    "LAUNCHPLANE_POLICY_TOML": "schema_version = 1\n",
+                    "LAUNCHPLANE_SERVICE_HOST": "0.0.0.0",
+                    "LAUNCHPLANE_DATABASE_URL": "postgresql+psycopg://launchplane:test@db/launchplane",
+                },
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 1, msg=result.stdout)
+        self.assertIn("schema verification failed before migrations", result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- detect existing Launchplane schemas that predate Alembic version tracking
- stamp the baseline revision before applying later migrations for legacy `create_all` databases
- document the baseline-stamp path and cover entrypoint branching tests

## Verification
- `uv run python -m unittest tests.test_start_launchplane_service`
- `prettier --check docs/operations.md`
- `sh -n scripts/start-launchplane-service.sh && shellcheck scripts/start-launchplane-service.sh`
- `git diff --check`
- PyCharm changed-file inspection
- local Docker image startup through entrypoint migrations and `/v1/health`

Refs #859
