### PR TITLE
Stamp current legacy schemas before migrations

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -328,9 +328,10 @@ service hostname. The self-deploy workflow should not run shared database
 migrations from the GitHub runner; keep Launchplane migrations additive and
 rollback-aware so a failed health check can still return to the previous image.
 If a shared database already has Launchplane tables but no `alembic_version`
-table from the pre-migration `create_all` era, the entrypoint stamps the
-baseline revision before applying later migrations. Empty databases still run
-the full migration chain from the first revision.
+table from the pre-migration `create_all` era, the entrypoint stamps the newest
+revision that matches the detected legacy table set before applying later
+migrations. Empty databases still run the full migration chain from the first
+revision.
 
 Current derived-state behavior:
 

--- a/scripts/start-launchplane-service.sh
+++ b/scripts/start-launchplane-service.sh
@@ -26,12 +26,13 @@ with open(path, "wb") as handle:
 PY
 }
 
-schema_has_alembic_version() {
+schema_stamp_revision() {
 	database_url="$1"
 	LAUNCHPLANE_DATABASE_URL="$database_url" uv run python - <<'PY'
 from control_plane.storage.postgres import _build_engine
 from control_plane.storage.postgres import Base
 from sqlalchemy import inspect
+from sqlalchemy import text
 import os
 import sys
 
@@ -40,34 +41,16 @@ engine = _build_engine(database_url)
 try:
     inspector = inspect(engine)
     existing_tables = set(inspector.get_table_names())
+    has_latest_table = "launchplane_preview_enablement" in existing_tables
     if "alembic_version" in existing_tables:
+        with engine.connect() as connection:
+            version_rows = connection.execute(text("select version_num from alembic_version")).fetchall()
+        version_numbers = {str(row[0]).strip() for row in version_rows if str(row[0]).strip()}
+        if version_numbers == {"fe94a0486977"} and has_latest_table:
+            print("b1c3d5e7f9a1")
         raise SystemExit(0)
     if not existing_tables.intersection(Base.metadata.tables):
         raise SystemExit(0)
-    raise SystemExit(1)
-except SystemExit:
-    raise
-except Exception as error:
-    print(f"Could not inspect Launchplane database schema version: {error}", file=sys.stderr)
-    raise SystemExit(2)
-finally:
-    engine.dispose()
-PY
-}
-
-legacy_schema_revision() {
-	database_url="$1"
-	LAUNCHPLANE_DATABASE_URL="$database_url" uv run python - <<'PY'
-from control_plane.storage.postgres import _build_engine
-from sqlalchemy import inspect
-import os
-import sys
-
-database_url = os.environ["LAUNCHPLANE_DATABASE_URL"]
-engine = _build_engine(database_url)
-try:
-    inspector = inspect(engine)
-    existing_tables = set(inspector.get_table_names())
     if "launchplane_preview_enablement" in existing_tables:
         print("b1c3d5e7f9a1")
         raise SystemExit(0)
@@ -129,20 +112,14 @@ if [ -z "$launchplane_database_url" ]; then
 fi
 
 echo "Applying Launchplane database migrations before service startup."
-schema_version_status=0
-schema_has_alembic_version "$launchplane_database_url" || schema_version_status="$?"
-case "$schema_version_status" in
-0) ;;
-1)
-	legacy_revision="$(legacy_schema_revision "$launchplane_database_url")"
-	echo "Existing Launchplane schema is unversioned; stamping Alembic revision ${legacy_revision} before upgrade."
-	LAUNCHPLANE_DATABASE_URL="$launchplane_database_url" uv run alembic stamp "$legacy_revision"
-	;;
-*)
+stamp_revision="$(schema_stamp_revision "$launchplane_database_url")" || {
 	echo "Launchplane database schema verification failed before migrations." >&2
 	exit 1
-	;;
-esac
+}
+if [ -n "$stamp_revision" ]; then
+	echo "Stamping Launchplane database at Alembic revision ${stamp_revision} before upgrade."
+	LAUNCHPLANE_DATABASE_URL="$launchplane_database_url" uv run alembic stamp "$stamp_revision"
+fi
 LAUNCHPLANE_DATABASE_URL="$launchplane_database_url" uv run alembic upgrade head
 
 exec uv run launchplane service serve \

--- a/scripts/start-launchplane-service.sh
+++ b/scripts/start-launchplane-service.sh
@@ -55,6 +55,31 @@ finally:
 PY
 }
 
+legacy_schema_revision() {
+	database_url="$1"
+	LAUNCHPLANE_DATABASE_URL="$database_url" uv run python - <<'PY'
+from control_plane.storage.postgres import _build_engine
+from sqlalchemy import inspect
+import os
+import sys
+
+database_url = os.environ["LAUNCHPLANE_DATABASE_URL"]
+engine = _build_engine(database_url)
+try:
+    inspector = inspect(engine)
+    existing_tables = set(inspector.get_table_names())
+    if "launchplane_preview_enablement" in existing_tables:
+        print("b1c3d5e7f9a1")
+        raise SystemExit(0)
+    print("fe94a0486977")
+except Exception as error:
+    print(f"Could not classify legacy Launchplane database schema: {error}", file=sys.stderr)
+    raise SystemExit(1)
+finally:
+    engine.dispose()
+PY
+}
+
 launchplane_app_root="${LAUNCHPLANE_APP_ROOT:-/app}"
 state_dir="${LAUNCHPLANE_STATE_DIR:-$launchplane_app_root/runtime}"
 launchplane_policy_toml="${LAUNCHPLANE_POLICY_TOML:-}"
@@ -109,8 +134,9 @@ schema_has_alembic_version "$launchplane_database_url" || schema_version_status=
 case "$schema_version_status" in
 0) ;;
 1)
-	echo "Existing Launchplane schema is unversioned; stamping Alembic baseline before upgrade."
-	LAUNCHPLANE_DATABASE_URL="$launchplane_database_url" uv run alembic stamp fe94a0486977
+	legacy_revision="$(legacy_schema_revision "$launchplane_database_url")"
+	echo "Existing Launchplane schema is unversioned; stamping Alembic revision ${legacy_revision} before upgrade."
+	LAUNCHPLANE_DATABASE_URL="$launchplane_database_url" uv run alembic stamp "$legacy_revision"
 	;;
 *)
 	echo "Launchplane database schema verification failed before migrations." >&2

--- a/tests/test_start_launchplane_service.py
+++ b/tests/test_start_launchplane_service.py
@@ -18,10 +18,20 @@ class StartLaunchplaneServiceScriptTests(unittest.TestCase):
         uv_path.write_text(
             """#!/bin/sh
 if [ "$1" = "run" ] && [ "$2" = "python" ]; then
-  if [ "${UV_SCHEMA_STATUS:-0}" = "2" ]; then
-    exit 2
+  count_file="${UV_PYTHON_COUNT_FILE:-$UV_CAPTURE_FILE.python-count}"
+  call_count="$(cat "$count_file" 2>/dev/null || printf '0')"
+  call_count="$((call_count + 1))"
+  printf '%s\n' "$call_count" >"$count_file"
+  if [ "$call_count" = "1" ]; then
+    if [ "${UV_SCHEMA_STATUS:-0}" = "2" ]; then
+      exit 2
+    fi
+    exit "${UV_SCHEMA_STATUS:-0}"
   fi
-  exit "${UV_SCHEMA_STATUS:-0}"
+  if [ -n "${UV_LEGACY_REVISION:-}" ]; then
+    printf '%s\n' "$UV_LEGACY_REVISION"
+  fi
+  exit 0
 fi
 printf '%s\n' "$@" >>"$UV_CAPTURE_FILE"
 """,
@@ -204,7 +214,7 @@ printf '%s\n' "$@" >>"$UV_CAPTURE_FILE"
         finally:
             policy_path.unlink(missing_ok=True)
 
-    def test_stamps_unversioned_schema_before_upgrade(self) -> None:
+    def test_stamps_legacy_head_for_unversioned_current_schema(self) -> None:
         policy_path = Path("/tmp/launchplane-authz.toml")
         policy_path.unlink(missing_ok=True)
 
@@ -227,6 +237,52 @@ printf '%s\n' "$@" >>"$UV_CAPTURE_FILE"
                         "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
                         "UV_CAPTURE_FILE": str(capture_file),
                         "UV_SCHEMA_STATUS": "1",
+                        "UV_LEGACY_REVISION": "b1c3d5e7f9a1",
+                        "LAUNCHPLANE_APP_ROOT": str(app_root),
+                        "LAUNCHPLANE_STATE_DIR": str(temporary_directory / "state"),
+                        "LAUNCHPLANE_POLICY_TOML": "schema_version = 1\n",
+                        "LAUNCHPLANE_SERVICE_HOST": "0.0.0.0",
+                        "LAUNCHPLANE_DATABASE_URL": "postgresql+psycopg://launchplane:test@db/launchplane",
+                    },
+                    check=False,
+                )
+
+                captured_lines = capture_file.read_text(encoding="utf-8").splitlines()
+
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            self.assertIn("alembic", captured_lines)
+            self.assertIn("stamp", captured_lines)
+            self.assertIn("b1c3d5e7f9a1", captured_lines)
+            self.assertNotIn("fe94a0486977", captured_lines)
+            self.assertIn("upgrade", captured_lines)
+            self.assertIn("head", captured_lines)
+        finally:
+            policy_path.unlink(missing_ok=True)
+
+    def test_stamps_baseline_for_unversioned_baseline_schema(self) -> None:
+        policy_path = Path("/tmp/launchplane-authz.toml")
+        policy_path.unlink(missing_ok=True)
+
+        try:
+            with TemporaryDirectory() as temporary_directory_name:
+                temporary_directory = Path(temporary_directory_name)
+                app_root = temporary_directory / "app"
+                bin_dir = temporary_directory / "bin"
+                capture_file = temporary_directory / "uv-args.txt"
+                app_root.mkdir()
+                bin_dir.mkdir()
+                self._write_fake_uv(bin_dir)
+
+                result = subprocess.run(
+                    [str(self.script_path)],
+                    capture_output=True,
+                    text=True,
+                    env={
+                        **os.environ,
+                        "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+                        "UV_CAPTURE_FILE": str(capture_file),
+                        "UV_SCHEMA_STATUS": "1",
+                        "UV_LEGACY_REVISION": "fe94a0486977",
                         "LAUNCHPLANE_APP_ROOT": str(app_root),
                         "LAUNCHPLANE_STATE_DIR": str(temporary_directory / "state"),
                         "LAUNCHPLANE_POLICY_TOML": "schema_version = 1\n",

--- a/tests/test_start_launchplane_service.py
+++ b/tests/test_start_launchplane_service.py
@@ -18,15 +18,8 @@ class StartLaunchplaneServiceScriptTests(unittest.TestCase):
         uv_path.write_text(
             """#!/bin/sh
 if [ "$1" = "run" ] && [ "$2" = "python" ]; then
-  count_file="${UV_PYTHON_COUNT_FILE:-$UV_CAPTURE_FILE.python-count}"
-  call_count="$(cat "$count_file" 2>/dev/null || printf '0')"
-  call_count="$((call_count + 1))"
-  printf '%s\n' "$call_count" >"$count_file"
-  if [ "$call_count" = "1" ]; then
-    if [ "${UV_SCHEMA_STATUS:-0}" = "2" ]; then
-      exit 2
-    fi
-    exit "${UV_SCHEMA_STATUS:-0}"
+  if [ "${UV_SCHEMA_STATUS:-0}" = "2" ]; then
+    exit 2
   fi
   if [ -n "${UV_LEGACY_REVISION:-}" ]; then
     printf '%s\n' "$UV_LEGACY_REVISION"
@@ -254,6 +247,50 @@ printf '%s\n' "$@" >>"$UV_CAPTURE_FILE"
             self.assertIn("stamp", captured_lines)
             self.assertIn("b1c3d5e7f9a1", captured_lines)
             self.assertNotIn("fe94a0486977", captured_lines)
+            self.assertIn("upgrade", captured_lines)
+            self.assertIn("head", captured_lines)
+        finally:
+            policy_path.unlink(missing_ok=True)
+
+    def test_stamps_legacy_head_for_baseline_stamped_current_schema(self) -> None:
+        policy_path = Path("/tmp/launchplane-authz.toml")
+        policy_path.unlink(missing_ok=True)
+
+        try:
+            with TemporaryDirectory() as temporary_directory_name:
+                temporary_directory = Path(temporary_directory_name)
+                app_root = temporary_directory / "app"
+                bin_dir = temporary_directory / "bin"
+                capture_file = temporary_directory / "uv-args.txt"
+                app_root.mkdir()
+                bin_dir.mkdir()
+                self._write_fake_uv(bin_dir)
+
+                result = subprocess.run(
+                    [str(self.script_path)],
+                    capture_output=True,
+                    text=True,
+                    env={
+                        **os.environ,
+                        "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+                        "UV_CAPTURE_FILE": str(capture_file),
+                        "UV_SCHEMA_STATUS": "0",
+                        "UV_LEGACY_REVISION": "b1c3d5e7f9a1",
+                        "LAUNCHPLANE_APP_ROOT": str(app_root),
+                        "LAUNCHPLANE_STATE_DIR": str(temporary_directory / "state"),
+                        "LAUNCHPLANE_POLICY_TOML": "schema_version = 1\n",
+                        "LAUNCHPLANE_SERVICE_HOST": "0.0.0.0",
+                        "LAUNCHPLANE_DATABASE_URL": "postgresql+psycopg://launchplane:test@db/launchplane",
+                    },
+                    check=False,
+                )
+
+                captured_lines = capture_file.read_text(encoding="utf-8").splitlines()
+
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            self.assertIn("alembic", captured_lines)
+            self.assertIn("stamp", captured_lines)
+            self.assertIn("b1c3d5e7f9a1", captured_lines)
             self.assertIn("upgrade", captured_lines)
             self.assertIn("head", captured_lines)
         finally:


### PR DESCRIPTION
## Summary
- classify unversioned legacy Launchplane schemas before entrypoint migrations
- stamp the current matching Alembic revision when the pre-Alembic database already has the latest table set
- keep baseline stamping for older unversioned schemas and update entrypoint tests/docs

## Verification
- `uv run python -m unittest tests.test_start_launchplane_service`
- `prettier --check docs/operations.md`
- `sh -n scripts/start-launchplane-service.sh && shellcheck scripts/start-launchplane-service.sh`
- `git diff --check`
- PyCharm changed-file inspection
- public rollback `/v1/health` returned 200 during deploy recovery

Refs #859
