### PR TITLE
Repair stamped Odoo replacement schema

### DIFF
--- a/control_plane/storage/migrations/versions/c2d4e6f8a0b2_repair_odoo_target_replacement_scope.py
+++ b/control_plane/storage/migrations/versions/c2d4e6f8a0b2_repair_odoo_target_replacement_scope.py
@@ -1,0 +1,69 @@
+"""repair Odoo target replacement operation scope column
+
+Revision ID: c2d4e6f8a0b2
+Revises: b1c3d5e7f9a1
+Create Date: 2026-05-23 01:15:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "c2d4e6f8a0b2"
+down_revision: str | None = "b1c3d5e7f9a1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "launchplane_odoo_stable_target_replacement_operations"
+_ACTIVE_LANE_INDEX = "launchplane_odoo_replacement_active_lane_uidx"
+_IDEMPOTENCY_INDEX = "launchplane_odoo_replacement_operation_idempotency_idx"
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return column_name in {str(column["name"]) for column in inspector.get_columns(table_name)}
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return index_name in {str(index["name"]) for index in inspector.get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    if not _column_exists(_TABLE, "idempotency_scope"):
+        op.add_column(
+            _TABLE,
+            sa.Column(
+                "idempotency_scope",
+                sa.String(),
+                nullable=False,
+                server_default="",
+            ),
+        )
+
+    if _index_exists(_TABLE, _IDEMPOTENCY_INDEX):
+        op.drop_index(_IDEMPOTENCY_INDEX, table_name=_TABLE)
+    op.create_index(
+        _IDEMPOTENCY_INDEX,
+        _TABLE,
+        ["idempotency_scope", "idempotency_key", sa.text("updated_at DESC")],
+    )
+
+    if not _index_exists(_TABLE, _ACTIVE_LANE_INDEX):
+        op.create_index(
+            _ACTIVE_LANE_INDEX,
+            _TABLE,
+            ["product", "context", "instance"],
+            unique=True,
+            postgresql_where=sa.text("status IN ('pending', 'running')"),
+            sqlite_where=sa.text("status IN ('pending', 'running')"),
+        )
+
+
+def downgrade() -> None:
+    return None

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -813,7 +813,9 @@ class PostgresRecordStoreTests(unittest.TestCase):
             alembic_command.upgrade(_alembic_config(database_url), "head")
             engine = create_engine(database_url)
             with engine.begin() as connection:
-                connection.execute(text("ALTER TABLE launchplane_artifact_manifests DROP COLUMN payload"))
+                connection.execute(
+                    text("ALTER TABLE launchplane_artifact_manifests DROP COLUMN payload")
+                )
             engine.dispose()
             store = PostgresRecordStore(database_url=database_url)
 
@@ -825,9 +827,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
 
             artifact_columns = {
                 column["name"]
-                for column in inspect(store._engine).get_columns(
-                    "launchplane_artifact_manifests"
-                )
+                for column in inspect(store._engine).get_columns("launchplane_artifact_manifests")
             }
             self.assertNotIn("payload", artifact_columns)
             store.close()
@@ -849,6 +849,48 @@ class PostgresRecordStoreTests(unittest.TestCase):
             store.close()
 
         self.assertEqual(loaded.artifact_id, manifest.artifact_id)
+
+    def test_alembic_head_repairs_stamped_schema_missing_odoo_replacement_scope(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            config = _alembic_config(database_url)
+            alembic_command.upgrade(config, "head")
+            engine = create_engine(database_url)
+            with engine.begin() as connection:
+                connection.execute(
+                    text("DROP INDEX launchplane_odoo_replacement_operation_idempotency_idx")
+                )
+                connection.execute(
+                    text(
+                        "ALTER TABLE "
+                        "launchplane_odoo_stable_target_replacement_operations "
+                        "DROP COLUMN idempotency_scope"
+                    )
+                )
+                connection.execute(text("DELETE FROM alembic_version"))
+                connection.execute(
+                    text("INSERT INTO alembic_version (version_num) VALUES (:version_num)"),
+                    {"version_num": "b1c3d5e7f9a1"},
+                )
+            engine.dispose()
+
+            alembic_command.upgrade(config, "head")
+            store = PostgresRecordStore(database_url=database_url)
+            store.verify_schema()
+
+            repaired_columns = {
+                column["name"]
+                for column in inspect(store._engine).get_columns(
+                    "launchplane_odoo_stable_target_replacement_operations"
+                )
+            }
+            store.close()
+
+        self.assertIn("idempotency_scope", repaired_columns)
 
     def test_alembic_baseline_downgrades_to_empty_schema(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- Add a forward Alembic repair migration after the current head for databases already stamped at `b1c3d5e7f9a1` but missing the Odoo target replacement `idempotency_scope` column
- Rebuild the idempotency and active-lane indexes idempotently so normal fresh databases and repaired legacy databases both converge on the mapped schema
- Add a regression test that simulates the live failure state reported by the deploy diagnostics

## Verification
- `uv run python -m unittest tests.test_postgres_store.PostgresRecordStoreTests.test_alembic_baseline_creates_schema_used_by_record_store tests.test_postgres_store.PostgresRecordStoreTests.test_alembic_head_repairs_stamped_schema_missing_odoo_replacement_scope tests.test_postgres_store.PostgresRecordStoreTests.test_alembic_baseline_downgrades_to_empty_schema tests.test_start_launchplane_service`
- `sh -n scripts/start-launchplane-service.sh`
- `uv run alembic heads`
- `uv run --extra dev ruff check control_plane/storage/migrations/versions/c2d4e6f8a0b2_repair_odoo_target_replacement_scope.py tests/test_postgres_store.py`
- `uv run --extra dev ruff format --check control_plane/storage/migrations/versions/c2d4e6f8a0b2_repair_odoo_target_replacement_scope.py tests/test_postgres_store.py`
- `git diff --check`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files` returned existing weak warnings in `tests/test_start_launchplane_service.py`; no actionable findings in the repair migration.

Refs #859
