### PR TITLE
Add runner host hygiene reporting

### DIFF
--- a/control_plane/cli_runner_lanes.py
+++ b/control_plane/cli_runner_lanes.py
@@ -15,6 +15,9 @@ from control_plane.contracts.runner_lane_control import RunnerLaneControlPolicy
 from control_plane.contracts.runner_lane_control import RunnerLaneControlRequest
 from control_plane.contracts.runner_lane_control import plan_runner_lane_control
 from control_plane.contracts.runner_lane_inventory import RunnerLaneInventory
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneObservation
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygienePolicy
+from control_plane.contracts.runner_host_hygiene import evaluate_runner_host_hygiene
 from control_plane.merge_train_github import MergeTrainGitHubError
 from control_plane.merge_train_github import UrllibMergeTrainGitHubTransport
 from control_plane.runner_lane_github import GitHubRunnerLaneInventoryReader
@@ -27,6 +30,7 @@ def register_runner_lane_commands(work_graph: click.Group) -> None:
     work_graph.add_command(runner_queue_wait, name="runner-queue-wait")
     work_graph.add_command(runner_baseline_observe, name="runner-baseline-observe")
     work_graph.add_command(runner_control_plan, name="runner-control-plan")
+    work_graph.add_command(runner_host_hygiene_report, name="runner-host-hygiene-report")
 
 
 @click.command("runner-inventory")
@@ -56,9 +60,9 @@ def runner_inventory(repository: str, github_token_env: str, github_api_base_url
         if not token:
             raise click.ClickException(f"Missing GitHub token in environment variable {token_env}.")
         transport = UrllibMergeTrainGitHubTransport(token=token, api_base_url=github_api_base_url)
-        inventory = GitHubRunnerLaneInventoryReader(
-            transport=transport
-        ).read_runner_lane_inventory(repository=repository)
+        inventory = GitHubRunnerLaneInventoryReader(transport=transport).read_runner_lane_inventory(
+            repository=repository
+        )
     except MergeTrainGitHubError as error:
         detail = str(error)
         if error.status_code is not None:
@@ -366,6 +370,86 @@ def runner_control_plan(
     )
 
 
+@click.command("runner-host-hygiene-report")
+@click.option(
+    "--observation-file",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False),
+    required=True,
+    help="RunnerHostHygieneObservation JSON collected by an approved read-only probe.",
+)
+@click.option(
+    "--policy-file",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False),
+    help="Optional RunnerHostHygienePolicy JSON. CLI policy flags are ignored when set.",
+)
+@click.option(
+    "--minimum-free-disk-bytes",
+    default=0,
+    show_default=True,
+    type=click.IntRange(min=0),
+    help="Minimum acceptable free disk bytes for report-only evaluation.",
+)
+@click.option(
+    "--maximum-docker-reclaimable-bytes",
+    type=click.IntRange(min=0),
+    help="Maximum acceptable Docker reclaimable bytes before the host needs attention.",
+)
+@click.option(
+    "--maximum-runner-workdir-bytes",
+    type=click.IntRange(min=0),
+    help="Maximum acceptable runner work-directory bytes before the host needs attention.",
+)
+@click.option(
+    "--required-warm-builder",
+    "required_warm_builders",
+    multiple=True,
+    help="Builder name that must remain warm. Repeat for each required builder.",
+)
+@click.option(
+    "--allow-orphan-buildkit/--forbid-orphan-buildkit",
+    default=False,
+    show_default=True,
+    help="Whether orphan BuildKit containers or volumes are acceptable in the report.",
+)
+def runner_host_hygiene_report(
+    observation_file: Path,
+    policy_file: Path | None,
+    minimum_free_disk_bytes: int,
+    maximum_docker_reclaimable_bytes: int | None,
+    maximum_runner_workdir_bytes: int | None,
+    required_warm_builders: tuple[str, ...],
+    allow_orphan_buildkit: bool,
+) -> None:
+    try:
+        observation = _load_runner_host_hygiene_observation(observation_file)
+        policy = (
+            _load_runner_host_hygiene_policy(policy_file)
+            if policy_file is not None
+            else RunnerHostHygienePolicy(
+                minimum_free_disk_bytes=minimum_free_disk_bytes,
+                maximum_docker_reclaimable_bytes=maximum_docker_reclaimable_bytes,
+                maximum_runner_workdir_bytes=maximum_runner_workdir_bytes,
+                required_warm_builders=required_warm_builders,
+                allow_orphan_buildkit=allow_orphan_buildkit,
+            )
+        )
+        report = evaluate_runner_host_hygiene(policy=policy, observation=observation)
+    except (OSError, JSONDecodeError, ValidationError, ValueError) as error:
+        raise click.ClickException(str(error)) from error
+    click.echo(
+        json.dumps(
+            {
+                "mode": "report-only",
+                "observation": observation.model_dump(mode="json"),
+                "policy": policy.model_dump(mode="json"),
+                "report": report.model_dump(mode="json"),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
 def _load_runner_lane_inventory(inventory_file: Path) -> RunnerLaneInventory:
     return RunnerLaneInventory.model_validate(
         json.loads(inventory_file.read_text(encoding="utf-8"))
@@ -379,6 +463,20 @@ def _load_runner_lane_baseline_readiness(
     if isinstance(payload, dict) and isinstance(payload.get("readiness"), dict):
         payload = payload["readiness"]
     return RunnerLaneBaselineReadiness.model_validate(payload)
+
+
+def _load_runner_host_hygiene_observation(
+    observation_file: Path,
+) -> RunnerHostHygieneObservation:
+    return RunnerHostHygieneObservation.model_validate(
+        json.loads(observation_file.read_text(encoding="utf-8"))
+    )
+
+
+def _load_runner_host_hygiene_policy(policy_file: Path) -> RunnerHostHygienePolicy:
+    return RunnerHostHygienePolicy.model_validate(
+        json.loads(policy_file.read_text(encoding="utf-8"))
+    )
 
 
 def _runner_baseline_runner_name(value: str) -> str:

--- a/control_plane/contracts/runner_host_hygiene.py
+++ b/control_plane/contracts/runner_host_hygiene.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+RunnerHostHygieneStatus = Literal["healthy", "attention"]
+RunnerHostHygieneFindingCode = Literal[
+    "docker_reclaimable_above_limit",
+    "free_disk_below_minimum",
+    "orphan_buildkit_present",
+    "required_warm_builder_missing",
+    "runner_workdir_above_limit",
+]
+
+
+class RunnerHostHygienePolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    minimum_free_disk_bytes: int = Field(default=0, ge=0)
+    maximum_docker_reclaimable_bytes: int | None = Field(default=None, ge=0)
+    maximum_runner_workdir_bytes: int | None = Field(default=None, ge=0)
+    required_warm_builders: tuple[str, ...] = ()
+    allow_orphan_buildkit: bool = False
+
+    @model_validator(mode="after")
+    def _normalize_policy(self) -> "RunnerHostHygienePolicy":
+        self.required_warm_builders = _normalized_tokens(self.required_warm_builders)
+        return self
+
+
+class RunnerHostHygieneObservation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    host_name: str
+    observed_at: str
+    free_disk_bytes: int = Field(ge=0)
+    docker_reclaimable_bytes: int = Field(default=0, ge=0)
+    runner_workdir_bytes: int = Field(default=0, ge=0)
+    warm_builders: tuple[str, ...] = ()
+    orphan_buildkit_containers: int = Field(default=0, ge=0)
+    orphan_buildkit_volumes: int = Field(default=0, ge=0)
+    notes: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def _normalize_observation(self) -> "RunnerHostHygieneObservation":
+        self.host_name = _required_text(
+            self.host_name, "runner host hygiene observation requires host_name"
+        )
+        self.observed_at = _required_text(
+            self.observed_at, "runner host hygiene observation requires observed_at"
+        )
+        self.warm_builders = _normalized_tokens(self.warm_builders)
+        self.notes = tuple(note.strip() for note in self.notes if note.strip())
+        return self
+
+
+class RunnerHostHygieneFinding(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: RunnerHostHygieneFindingCode
+    message: str
+
+    @model_validator(mode="after")
+    def _normalize_finding(self) -> "RunnerHostHygieneFinding":
+        self.message = _required_text(self.message, "runner host hygiene finding requires message")
+        return self
+
+
+class RunnerHostHygieneReport(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    status: RunnerHostHygieneStatus
+    host_name: str
+    findings: tuple[RunnerHostHygieneFinding, ...] = ()
+    summary: str
+    next_steps: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def _normalize_report(self) -> "RunnerHostHygieneReport":
+        self.host_name = _required_text(
+            self.host_name, "runner host hygiene report requires host_name"
+        )
+        self.findings = tuple(sorted(self.findings, key=lambda finding: finding.code))
+        self.summary = _required_text(self.summary, "runner host hygiene report requires summary")
+        self.next_steps = tuple(step.strip() for step in self.next_steps if step.strip())
+        if self.status == "healthy" and self.findings:
+            raise ValueError("healthy runner host hygiene report cannot include findings")
+        if self.status == "attention" and not self.findings:
+            raise ValueError("attention runner host hygiene report requires findings")
+        return self
+
+
+def evaluate_runner_host_hygiene(
+    *,
+    policy: RunnerHostHygienePolicy,
+    observation: RunnerHostHygieneObservation,
+) -> RunnerHostHygieneReport:
+    findings: list[RunnerHostHygieneFinding] = []
+    if observation.free_disk_bytes < policy.minimum_free_disk_bytes:
+        findings.append(
+            _finding(
+                "free_disk_below_minimum",
+                (
+                    "runner host free disk is below the configured minimum: "
+                    f"{observation.free_disk_bytes} < {policy.minimum_free_disk_bytes}"
+                ),
+            )
+        )
+    if (
+        policy.maximum_docker_reclaimable_bytes is not None
+        and observation.docker_reclaimable_bytes > policy.maximum_docker_reclaimable_bytes
+    ):
+        findings.append(
+            _finding(
+                "docker_reclaimable_above_limit",
+                (
+                    "runner host Docker reclaimable bytes exceed the configured limit: "
+                    f"{observation.docker_reclaimable_bytes} > "
+                    f"{policy.maximum_docker_reclaimable_bytes}"
+                ),
+            )
+        )
+    if (
+        policy.maximum_runner_workdir_bytes is not None
+        and observation.runner_workdir_bytes > policy.maximum_runner_workdir_bytes
+    ):
+        findings.append(
+            _finding(
+                "runner_workdir_above_limit",
+                (
+                    "runner host work directory bytes exceed the configured limit: "
+                    f"{observation.runner_workdir_bytes} > "
+                    f"{policy.maximum_runner_workdir_bytes}"
+                ),
+            )
+        )
+    missing_builders = tuple(
+        builder
+        for builder in policy.required_warm_builders
+        if builder not in observation.warm_builders
+    )
+    if missing_builders:
+        findings.append(
+            _finding(
+                "required_warm_builder_missing",
+                "runner host is missing required warm builders: " + ", ".join(missing_builders),
+            )
+        )
+    if not policy.allow_orphan_buildkit and (
+        observation.orphan_buildkit_containers > 0 or observation.orphan_buildkit_volumes > 0
+    ):
+        findings.append(
+            _finding(
+                "orphan_buildkit_present",
+                (
+                    "runner host has orphan BuildKit artifacts: "
+                    f"{observation.orphan_buildkit_containers} containers, "
+                    f"{observation.orphan_buildkit_volumes} volumes"
+                ),
+            )
+        )
+
+    status: RunnerHostHygieneStatus = "attention" if findings else "healthy"
+    return RunnerHostHygieneReport(
+        status=status,
+        host_name=observation.host_name,
+        findings=tuple(findings),
+        summary=(
+            "runner host hygiene satisfies report-only policy"
+            if status == "healthy"
+            else "runner host hygiene needs operator attention"
+        ),
+        next_steps=_next_steps(status),
+    )
+
+
+def _next_steps(status: RunnerHostHygieneStatus) -> tuple[str, ...]:
+    if status == "healthy":
+        return ("keep collecting read-only host hygiene evidence before enabling apply",)
+    return (
+        "review findings before scheduling any host cleanup",
+        "use a Launchplane-owned apply workflow before mutating runner hosts",
+    )
+
+
+def _finding(code: RunnerHostHygieneFindingCode, message: str) -> RunnerHostHygieneFinding:
+    return RunnerHostHygieneFinding(code=code, message=message)
+
+
+def _normalized_tokens(values: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(
+        sorted({normalized for value in values if (normalized := _normalized_token(value))})
+    )
+
+
+def _normalized_token(value: str) -> str:
+    return value.strip().lower()
+
+
+def _required_text(value: str, message: str) -> str:
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise ValueError(message)
+    return normalized_value

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,8 @@ Use these docs as the source of truth for `launchplane`.
   train policy contract, enqueue authority, and smoke-target policy.
 - [runner-lane-baseline.md](runner-lane-baseline.md) — self-hosted runner lane
   baseline, Docker credential isolation, and readiness contract.
+- [runner-host-hygiene.md](runner-host-hygiene.md) — report-only shared runner
+  host hygiene evidence, budgets, and future apply boundary.
 - [agent-context-boundary.md](agent-context-boundary.md) — public-safe agent
   context, caller profiles, scoped intent, redaction, and provenance boundary.
 - [operations.md](operations.md) — operator workflows and runtime boundary rules.

--- a/docs/runner-host-hygiene.md
+++ b/docs/runner-host-hygiene.md
@@ -1,0 +1,77 @@
+---
+title: Runner Host Hygiene
+---
+
+Launchplane owns shared self-hosted runner host hygiene. Product repositories
+must not grow one-off Docker pruning, builder reset, or host cleanup workflows as
+a workaround for shared runner pressure.
+
+## Boundary
+
+Runner host hygiene has two separate phases:
+
+- Report-only evidence: collect host facts and evaluate them against a typed
+  policy. This phase is safe for normal development because it does not mutate
+  Docker, runner services, GitHub runner registrations, or product state.
+- Apply workflow: clean Docker state, restart services, or change runner lanes
+  through an approved Launchplane-owned host adapter. This phase is not active
+  until a disposable host or explicit operator target exists.
+
+The current Launchplane surface implements only the report-only phase.
+
+## Report Contract
+
+The typed contract in `control_plane.contracts.runner_host_hygiene` separates
+policy from observation:
+
+- `RunnerHostHygienePolicy` records minimum free disk, optional Docker
+  reclaimable and runner work-directory budgets, required warm builders, and
+  whether orphan BuildKit artifacts are tolerated.
+- `RunnerHostHygieneObservation` records facts collected by an approved
+  read-only probe, including host name, free disk, Docker reclaimable bytes,
+  runner work-directory bytes, warm builders, and orphan BuildKit counts.
+- `evaluate_runner_host_hygiene(...)` returns a structured report with
+  `healthy` or `attention` status, findings, and non-mutating next steps.
+
+The report is intentionally conservative. Missing required warm builders, low
+free disk, Docker reclaimable bytes over budget, runner work-directory bytes over
+budget, and orphan BuildKit artifacts all produce `attention` unless policy
+explicitly permits that condition.
+
+## CLI
+
+Evaluate a saved observation without touching the host:
+
+```bash
+uv run launchplane work-graph runner-host-hygiene-report \
+  --observation-file runner-host-observation.json \
+  --minimum-free-disk-bytes 10737418240 \
+  --maximum-docker-reclaimable-bytes 21474836480 \
+  --required-warm-builder odoo-docker-chris-testing \
+  --required-warm-builder odoo-enterprise-chris-testing
+```
+
+The command prints `mode: report-only` with the normalized observation, policy,
+and report. It does not call Docker, inspect live services, contact GitHub, prune
+images, or restart runners.
+
+Operators can provide a policy JSON instead of CLI flags:
+
+```bash
+uv run launchplane work-graph runner-host-hygiene-report \
+  --observation-file runner-host-observation.json \
+  --policy-file runner-host-policy.json
+```
+
+## Future Apply Requirements
+
+Before Launchplane grows a host mutation path, the apply design must name:
+
+- the disposable or explicitly approved host target
+- the runner lane and repository scope the host adapter is allowed to affect
+- the evidence snapshot captured before and after cleanup
+- the warm builder retention budget
+- the rollback or stop condition when cleanup cannot be completed safely
+- the audit record written back to Launchplane-owned storage
+
+Until those are present, host hygiene work remains report-only.

--- a/docs/runner-lane-baseline.md
+++ b/docs/runner-lane-baseline.md
@@ -6,6 +6,9 @@ Launchplane owns the safety contract for self-hosted GitHub Actions runner lanes
 used by product publish, preview, and promotion workflows. Product repositories
 may request work, but runner host readiness and Docker credential hygiene belong
 to Launchplane rather than repo-by-repo workflow workarounds.
+Shared host hygiene reporting lives in
+[runner-host-hygiene.md](runner-host-hygiene.md); lane readiness and lane control
+planning stay here.
 
 ## Baseline Policy
 

--- a/tests/test_runner_host_hygiene.py
+++ b/tests/test_runner_host_hygiene.py
@@ -1,0 +1,177 @@
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import cast
+import unittest
+
+from click import Command
+from click.testing import CliRunner
+
+from control_plane.cli import main
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneObservation
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygienePolicy
+from control_plane.contracts.runner_host_hygiene import evaluate_runner_host_hygiene
+
+
+CLI_MAIN = cast(Command, main)
+
+
+class RunnerHostHygieneTests(unittest.TestCase):
+    def test_report_is_healthy_when_observation_satisfies_policy(self) -> None:
+        report = evaluate_runner_host_hygiene(
+            policy=RunnerHostHygienePolicy(
+                minimum_free_disk_bytes=100,
+                maximum_docker_reclaimable_bytes=50,
+                maximum_runner_workdir_bytes=75,
+                required_warm_builders=("odoo-docker-chris-testing",),
+            ),
+            observation=RunnerHostHygieneObservation(
+                host_name="chris-testing",
+                observed_at="2026-05-23T13:00:00Z",
+                free_disk_bytes=200,
+                docker_reclaimable_bytes=25,
+                runner_workdir_bytes=50,
+                warm_builders=(" Odoo-Docker-Chris-Testing ",),
+            ),
+        )
+
+        self.assertEqual(report.status, "healthy")
+        self.assertEqual(report.host_name, "chris-testing")
+        self.assertEqual(report.findings, ())
+        self.assertIn("report-only", report.summary)
+
+    def test_report_finds_missing_builder_and_low_free_disk(self) -> None:
+        report = evaluate_runner_host_hygiene(
+            policy=RunnerHostHygienePolicy(
+                minimum_free_disk_bytes=500,
+                required_warm_builders=("odoo-docker-chris-testing",),
+            ),
+            observation=RunnerHostHygieneObservation(
+                host_name="chris-testing",
+                observed_at="2026-05-23T13:00:00Z",
+                free_disk_bytes=100,
+                warm_builders=(),
+            ),
+        )
+
+        self.assertEqual(report.status, "attention")
+        self.assertEqual(
+            [finding.code for finding in report.findings],
+            ["free_disk_below_minimum", "required_warm_builder_missing"],
+        )
+
+    def test_report_flags_orphan_buildkit_by_default(self) -> None:
+        report = evaluate_runner_host_hygiene(
+            policy=RunnerHostHygienePolicy(),
+            observation=RunnerHostHygieneObservation(
+                host_name="chris-testing",
+                observed_at="2026-05-23T13:00:00Z",
+                free_disk_bytes=100,
+                orphan_buildkit_containers=1,
+                orphan_buildkit_volumes=2,
+            ),
+        )
+
+        self.assertEqual(report.status, "attention")
+        self.assertEqual(
+            [finding.code for finding in report.findings],
+            ["orphan_buildkit_present"],
+        )
+
+    def test_report_can_allow_orphan_buildkit_for_observation_only(self) -> None:
+        report = evaluate_runner_host_hygiene(
+            policy=RunnerHostHygienePolicy(allow_orphan_buildkit=True),
+            observation=RunnerHostHygieneObservation(
+                host_name="chris-testing",
+                observed_at="2026-05-23T13:00:00Z",
+                free_disk_bytes=100,
+                orphan_buildkit_containers=1,
+            ),
+        )
+
+        self.assertEqual(report.status, "healthy")
+
+
+class RunnerHostHygieneCliTests(unittest.TestCase):
+    def test_cli_builds_report_from_observation_and_flags(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            observation_file = Path(temp_dir) / "observation.json"
+            observation_file.write_text(
+                json.dumps(
+                    RunnerHostHygieneObservation(
+                        host_name="chris-testing",
+                        observed_at="2026-05-23T13:00:00Z",
+                        free_disk_bytes=100,
+                        docker_reclaimable_bytes=80,
+                    ).model_dump(mode="json")
+                ),
+                encoding="utf-8",
+            )
+
+            result = CliRunner().invoke(
+                CLI_MAIN,
+                [
+                    "work-graph",
+                    "runner-host-hygiene-report",
+                    "--observation-file",
+                    observation_file.as_posix(),
+                    "--minimum-free-disk-bytes",
+                    "200",
+                    "--maximum-docker-reclaimable-bytes",
+                    "50",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["mode"], "report-only")
+        self.assertEqual(payload["report"]["status"], "attention")
+        self.assertEqual(
+            [finding["code"] for finding in payload["report"]["findings"]],
+            ["docker_reclaimable_above_limit", "free_disk_below_minimum"],
+        )
+
+    def test_cli_accepts_policy_file(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            observation_file = root / "observation.json"
+            policy_file = root / "policy.json"
+            observation_file.write_text(
+                json.dumps(
+                    RunnerHostHygieneObservation(
+                        host_name="chris-testing",
+                        observed_at="2026-05-23T13:00:00Z",
+                        free_disk_bytes=500,
+                        warm_builders=("odoo-enterprise-chris-testing",),
+                    ).model_dump(mode="json")
+                ),
+                encoding="utf-8",
+            )
+            policy_file.write_text(
+                json.dumps(
+                    RunnerHostHygienePolicy(
+                        required_warm_builders=("odoo-enterprise-chris-testing",)
+                    ).model_dump(mode="json")
+                ),
+                encoding="utf-8",
+            )
+
+            result = CliRunner().invoke(
+                CLI_MAIN,
+                [
+                    "work-graph",
+                    "runner-host-hygiene-report",
+                    "--observation-file",
+                    observation_file.as_posix(),
+                    "--policy-file",
+                    policy_file.as_posix(),
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["report"]["status"], "healthy")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a typed report-only runner host hygiene contract for disk, Docker reclaimable, workdir, warm-builder, and orphan BuildKit findings
- wire `work-graph runner-host-hygiene-report` as JSON-in/JSON-out evidence evaluation with no host/GitHub mutation
- document the report-only boundary and future apply requirements for Launchplane-owned runner host hygiene

Refs #474.

## Verification
- `uv run python -m unittest tests.test_runner_host_hygiene tests.test_runner_lane_baseline tests.test_runner_lane_control`
- `uv run --extra dev ruff check control_plane/contracts/runner_host_hygiene.py control_plane/cli_runner_lanes.py tests/test_runner_host_hygiene.py`
- `uv run --extra dev ruff format --check control_plane/contracts/runner_host_hygiene.py control_plane/cli_runner_lanes.py tests/test_runner_host_hygiene.py`
- `npx prettier --check docs/README.md docs/runner-lane-baseline.md docs/runner-host-hygiene.md`
- `git diff --check`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files`
- `uv run python -m unittest`
