### PR TITLE
Add runner host hygiene apply planning

### DIFF
--- a/control_plane/cli_runner_lanes.py
+++ b/control_plane/cli_runner_lanes.py
@@ -16,8 +16,14 @@ from control_plane.contracts.runner_lane_control import RunnerLaneControlRequest
 from control_plane.contracts.runner_lane_control import plan_runner_lane_control
 from control_plane.contracts.runner_lane_inventory import RunnerLaneInventory
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneObservation
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAction
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyPolicy
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyRequest
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygienePolicy
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneReport
 from control_plane.contracts.runner_host_hygiene import evaluate_runner_host_hygiene
+from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene_apply
 from control_plane.merge_train_github import MergeTrainGitHubError
 from control_plane.merge_train_github import UrllibMergeTrainGitHubTransport
 from control_plane.runner_lane_github import GitHubRunnerLaneInventoryReader
@@ -31,6 +37,7 @@ def register_runner_lane_commands(work_graph: click.Group) -> None:
     work_graph.add_command(runner_baseline_observe, name="runner-baseline-observe")
     work_graph.add_command(runner_control_plan, name="runner-control-plan")
     work_graph.add_command(runner_host_hygiene_report, name="runner-host-hygiene-report")
+    work_graph.add_command(runner_host_hygiene_apply_plan, name="runner-host-hygiene-apply-plan")
 
 
 @click.command("runner-inventory")
@@ -450,6 +457,144 @@ def runner_host_hygiene_report(
     )
 
 
+@click.command("runner-host-hygiene-apply-plan")
+@click.option(
+    "--action",
+    "apply_action",
+    required=True,
+    type=click.Choice(("prune_docker_cache", "prune_runner_workdir", "restart_runner_service")),
+    help="Runner host hygiene apply action to plan. The command never mutates hosts.",
+)
+@click.option("--host-name", required=True, help="Runner host name to plan against.")
+@click.option(
+    "--mutate/--dry-run",
+    default=False,
+    show_default=True,
+    help="Record explicit mutate intent. This command still emits only a dry-run plan.",
+)
+@click.option(
+    "--audit-record-key",
+    default="",
+    help="Launchplane-owned audit record key the future apply adapter must write.",
+)
+@click.option(
+    "--approved-host",
+    "approved_hosts",
+    multiple=True,
+    help="Host approved for this apply boundary. Repeat for each approved host.",
+)
+@click.option(
+    "--retained-warm-builder",
+    "retained_warm_builders",
+    multiple=True,
+    help="Warm builder the request promises to retain. Repeat for each retained builder.",
+)
+@click.option(
+    "--required-retained-warm-builder",
+    "required_retained_warm_builders",
+    multiple=True,
+    help="Warm builder policy requires the apply request to retain. Repeat for each builder.",
+)
+@click.option(
+    "--allow-docker-cache-prune/--disallow-docker-cache-prune",
+    default=False,
+    show_default=True,
+    help="Enable Docker cache prune planning in the local policy.",
+)
+@click.option(
+    "--allow-runner-workdir-prune/--disallow-runner-workdir-prune",
+    default=False,
+    show_default=True,
+    help="Enable runner work-directory prune planning in the local policy.",
+)
+@click.option(
+    "--allow-runner-service-restart/--disallow-runner-service-restart",
+    default=False,
+    show_default=True,
+    help="Enable runner service restart planning in the local policy.",
+)
+@click.option(
+    "--require-healthy-report/--allow-attention-report",
+    default=True,
+    show_default=True,
+    help="Require a healthy pre-apply hygiene report before planning can become ready.",
+)
+@click.option(
+    "--require-audit-record/--allow-missing-audit-record",
+    default=True,
+    show_default=True,
+    help="Require an audit record key before planning can become ready.",
+)
+@click.option(
+    "--report-file",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False),
+    required=True,
+    help="RunnerHostHygieneReport JSON or runner-host-hygiene-report output.",
+)
+def runner_host_hygiene_apply_plan(
+    apply_action: RunnerHostHygieneApplyAction,
+    host_name: str,
+    mutate: bool,
+    audit_record_key: str,
+    approved_hosts: tuple[str, ...],
+    retained_warm_builders: tuple[str, ...],
+    required_retained_warm_builders: tuple[str, ...],
+    allow_docker_cache_prune: bool,
+    allow_runner_workdir_prune: bool,
+    allow_runner_service_restart: bool,
+    require_healthy_report: bool,
+    require_audit_record: bool,
+    report_file: Path,
+) -> None:
+    try:
+        report = _load_runner_host_hygiene_report(report_file)
+        policy = RunnerHostHygieneApplyPolicy(
+            approved_hosts=approved_hosts,
+            required_retained_warm_builders=required_retained_warm_builders,
+            require_healthy_report=require_healthy_report,
+            require_audit_record=require_audit_record,
+            allow_docker_cache_prune=allow_docker_cache_prune,
+            allow_runner_workdir_prune=allow_runner_workdir_prune,
+            allow_runner_service_restart=allow_runner_service_restart,
+        )
+        request = RunnerHostHygieneApplyRequest(
+            action=apply_action,
+            host_name=host_name,
+            mutate=mutate,
+            retained_warm_builders=retained_warm_builders,
+            audit_record_key=audit_record_key,
+        )
+        plan = plan_runner_host_hygiene_apply(
+            policy=policy,
+            request=request,
+            report=report,
+        )
+        audit_record = (
+            RunnerHostHygieneApplyAuditRecord(
+                audit_record_key=request.audit_record_key,
+                status="planned",
+                request=request,
+                plan=plan,
+                pre_apply_report=report,
+                message="planned runner host hygiene apply; no host mutation was executed",
+            )
+            if request.audit_record_key
+            else None
+        )
+    except (OSError, JSONDecodeError, ValidationError, ValueError) as error:
+        raise click.ClickException(str(error)) from error
+    payload: dict[str, object] = {
+        "mode": "dry-run",
+        "policy": policy.model_dump(mode="json"),
+        "request": request.model_dump(mode="json"),
+        "report": report.model_dump(mode="json"),
+        "plan": plan.model_dump(mode="json"),
+    }
+    if audit_record is not None:
+        payload["audit_record"] = audit_record.model_dump(mode="json")
+    click.echo(json.dumps(payload, indent=2, sort_keys=True))
+
+
 def _load_runner_lane_inventory(inventory_file: Path) -> RunnerLaneInventory:
     return RunnerLaneInventory.model_validate(
         json.loads(inventory_file.read_text(encoding="utf-8"))
@@ -477,6 +622,13 @@ def _load_runner_host_hygiene_policy(policy_file: Path) -> RunnerHostHygienePoli
     return RunnerHostHygienePolicy.model_validate(
         json.loads(policy_file.read_text(encoding="utf-8"))
     )
+
+
+def _load_runner_host_hygiene_report(report_file: Path) -> RunnerHostHygieneReport:
+    payload = json.loads(report_file.read_text(encoding="utf-8"))
+    if isinstance(payload, dict) and isinstance(payload.get("report"), dict):
+        payload = payload["report"]
+    return RunnerHostHygieneReport.model_validate(payload)
 
 
 def _runner_baseline_runner_name(value: str) -> str:

--- a/control_plane/contracts/runner_host_hygiene.py
+++ b/control_plane/contracts/runner_host_hygiene.py
@@ -6,6 +6,21 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 RunnerHostHygieneStatus = Literal["healthy", "attention"]
+RunnerHostHygieneApplyAction = Literal[
+    "prune_docker_cache",
+    "prune_runner_workdir",
+    "restart_runner_service",
+]
+RunnerHostHygieneApplyPlanStatus = Literal["ready", "blocked"]
+RunnerHostHygieneApplyAuditStatus = Literal["planned", "completed", "failed"]
+RunnerHostHygieneApplyBlockerCode = Literal[
+    "action_not_enabled",
+    "approved_host_mismatch",
+    "audit_record_required",
+    "host_needs_attention",
+    "mutate_not_requested",
+    "warm_builder_not_retained",
+]
 RunnerHostHygieneFindingCode = Literal[
     "docker_reclaimable_above_limit",
     "free_disk_below_minimum",
@@ -94,6 +109,117 @@ class RunnerHostHygieneReport(BaseModel):
         return self
 
 
+class RunnerHostHygieneApplyPolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    approved_hosts: tuple[str, ...] = ()
+    required_retained_warm_builders: tuple[str, ...] = ()
+    require_healthy_report: bool = True
+    require_audit_record: bool = True
+    allow_docker_cache_prune: bool = False
+    allow_runner_workdir_prune: bool = False
+    allow_runner_service_restart: bool = False
+
+    @model_validator(mode="after")
+    def _normalize_policy(self) -> "RunnerHostHygieneApplyPolicy":
+        self.approved_hosts = _normalized_host_names(self.approved_hosts)
+        self.required_retained_warm_builders = _normalized_tokens(
+            self.required_retained_warm_builders
+        )
+        return self
+
+
+class RunnerHostHygieneApplyRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    action: RunnerHostHygieneApplyAction
+    host_name: str
+    mutate: bool = False
+    retained_warm_builders: tuple[str, ...] = ()
+    audit_record_key: str = ""
+
+    @model_validator(mode="after")
+    def _normalize_request(self) -> "RunnerHostHygieneApplyRequest":
+        self.host_name = _normalized_host_name(self.host_name)
+        if not self.host_name:
+            raise ValueError("runner host hygiene apply requires host_name")
+        self.retained_warm_builders = _normalized_tokens(self.retained_warm_builders)
+        self.audit_record_key = self.audit_record_key.strip()
+        return self
+
+
+class RunnerHostHygieneApplyBlocker(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: RunnerHostHygieneApplyBlockerCode
+    message: str
+
+    @model_validator(mode="after")
+    def _normalize_blocker(self) -> "RunnerHostHygieneApplyBlocker":
+        self.message = _required_text(
+            self.message, "runner host hygiene apply blocker requires message"
+        )
+        return self
+
+
+class RunnerHostHygieneApplyPlan(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    status: RunnerHostHygieneApplyPlanStatus
+    action: RunnerHostHygieneApplyAction
+    host_name: str
+    mutate: bool
+    audit_record_key: str = ""
+    blockers: tuple[RunnerHostHygieneApplyBlocker, ...] = ()
+    next_steps: tuple[str, ...] = ()
+    summary: str
+
+    @model_validator(mode="after")
+    def _normalize_plan(self) -> "RunnerHostHygieneApplyPlan":
+        self.host_name = _required_text(
+            self.host_name, "runner host hygiene apply plan requires host_name"
+        )
+        self.audit_record_key = self.audit_record_key.strip()
+        self.blockers = tuple(sorted(self.blockers, key=lambda blocker: blocker.code))
+        self.next_steps = tuple(step.strip() for step in self.next_steps if step.strip())
+        self.summary = _required_text(
+            self.summary, "runner host hygiene apply plan requires summary"
+        )
+        if self.status == "ready" and self.blockers:
+            raise ValueError("ready runner host hygiene apply plan cannot include blockers")
+        if self.status == "blocked" and not self.blockers:
+            raise ValueError("blocked runner host hygiene apply plan requires blockers")
+        return self
+
+
+class RunnerHostHygieneApplyAuditRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    audit_record_key: str
+    status: RunnerHostHygieneApplyAuditStatus
+    request: RunnerHostHygieneApplyRequest
+    plan: RunnerHostHygieneApplyPlan
+    pre_apply_report: RunnerHostHygieneReport
+    post_apply_report: RunnerHostHygieneReport | None = None
+    message: str = ""
+
+    @model_validator(mode="after")
+    def _normalize_record(self) -> "RunnerHostHygieneApplyAuditRecord":
+        self.audit_record_key = _required_text(
+            self.audit_record_key, "runner host hygiene apply audit record requires key"
+        )
+        self.message = self.message.strip()
+        if self.audit_record_key != self.request.audit_record_key:
+            raise ValueError("runner host hygiene audit record key must match request")
+        if self.status == "planned" and self.post_apply_report is not None:
+            raise ValueError("planned runner host hygiene audit record cannot include post report")
+        return self
+
+
 def evaluate_runner_host_hygiene(
     *,
     policy: RunnerHostHygienePolicy,
@@ -178,6 +304,115 @@ def evaluate_runner_host_hygiene(
     )
 
 
+def plan_runner_host_hygiene_apply(
+    *,
+    policy: RunnerHostHygieneApplyPolicy,
+    request: RunnerHostHygieneApplyRequest,
+    report: RunnerHostHygieneReport,
+) -> RunnerHostHygieneApplyPlan:
+    blockers: list[RunnerHostHygieneApplyBlocker] = []
+    if not policy.approved_hosts or request.host_name not in policy.approved_hosts:
+        blockers.append(
+            _apply_blocker(
+                "approved_host_mismatch",
+                f"runner host is not approved for hygiene apply: {request.host_name}",
+            )
+        )
+    if not _apply_action_allowed(policy=policy, action=request.action):
+        blockers.append(
+            _apply_blocker(
+                "action_not_enabled",
+                f"runner host hygiene apply action is not enabled: {request.action}",
+            )
+        )
+    if not request.mutate:
+        blockers.append(
+            _apply_blocker(
+                "mutate_not_requested",
+                "runner host hygiene apply is dry-run only until mutate is explicitly requested",
+            )
+        )
+    if policy.require_audit_record and not request.audit_record_key:
+        blockers.append(
+            _apply_blocker(
+                "audit_record_required",
+                "runner host hygiene apply requires an audit record key",
+            )
+        )
+    if policy.require_healthy_report and report.status != "healthy":
+        blockers.append(
+            _apply_blocker(
+                "host_needs_attention",
+                f"runner host hygiene report is not healthy: {report.summary}",
+            )
+        )
+    missing_retained_builders = tuple(
+        builder
+        for builder in policy.required_retained_warm_builders
+        if builder not in request.retained_warm_builders
+    )
+    if missing_retained_builders:
+        blockers.append(
+            _apply_blocker(
+                "warm_builder_not_retained",
+                (
+                    "runner host hygiene apply request does not retain required warm builders: "
+                    + ", ".join(missing_retained_builders)
+                ),
+            )
+        )
+
+    status: RunnerHostHygieneApplyPlanStatus = "blocked" if blockers else "ready"
+    return RunnerHostHygieneApplyPlan(
+        status=status,
+        action=request.action,
+        host_name=request.host_name,
+        mutate=request.mutate,
+        audit_record_key=request.audit_record_key,
+        blockers=tuple(blockers),
+        next_steps=_apply_next_steps(action=request.action, status=status),
+        summary=(
+            "runner host hygiene apply plan is ready"
+            if status == "ready"
+            else "runner host hygiene apply plan is blocked"
+        ),
+    )
+
+
+def _apply_action_allowed(
+    *, policy: RunnerHostHygieneApplyPolicy, action: RunnerHostHygieneApplyAction
+) -> bool:
+    if action == "prune_docker_cache":
+        return policy.allow_docker_cache_prune
+    if action == "prune_runner_workdir":
+        return policy.allow_runner_workdir_prune
+    return policy.allow_runner_service_restart
+
+
+def _apply_next_steps(
+    *, action: RunnerHostHygieneApplyAction, status: RunnerHostHygieneApplyPlanStatus
+) -> tuple[str, ...]:
+    if status == "blocked":
+        return ("resolve blockers before invoking any host adapter",)
+    if action == "restart_runner_service":
+        return (
+            "capture pre-apply host hygiene evidence",
+            "restart only the approved runner service through the host adapter",
+            "capture post-apply host hygiene evidence and write the audit record",
+        )
+    if action == "prune_runner_workdir":
+        return (
+            "capture pre-apply host hygiene evidence",
+            "prune only approved runner work directories through the host adapter",
+            "capture post-apply host hygiene evidence and write the audit record",
+        )
+    return (
+        "capture pre-apply host hygiene evidence",
+        "prune Docker cache without removing retained warm builders",
+        "capture post-apply host hygiene evidence and write the audit record",
+    )
+
+
 def _next_steps(status: RunnerHostHygieneStatus) -> tuple[str, ...]:
     if status == "healthy":
         return ("keep collecting read-only host hygiene evidence before enabling apply",)
@@ -189,6 +424,22 @@ def _next_steps(status: RunnerHostHygieneStatus) -> tuple[str, ...]:
 
 def _finding(code: RunnerHostHygieneFindingCode, message: str) -> RunnerHostHygieneFinding:
     return RunnerHostHygieneFinding(code=code, message=message)
+
+
+def _apply_blocker(
+    code: RunnerHostHygieneApplyBlockerCode, message: str
+) -> RunnerHostHygieneApplyBlocker:
+    return RunnerHostHygieneApplyBlocker(code=code, message=message)
+
+
+def _normalized_host_names(values: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(
+        sorted({normalized for value in values if (normalized := _normalized_host_name(value))})
+    )
+
+
+def _normalized_host_name(value: str) -> str:
+    return value.strip().lower()
 
 
 def _normalized_tokens(values: tuple[str, ...]) -> tuple[str, ...]:

--- a/docs/runner-host-hygiene.md
+++ b/docs/runner-host-hygiene.md
@@ -17,7 +17,8 @@ Runner host hygiene has two separate phases:
   through an approved Launchplane-owned host adapter. This phase is not active
   until a disposable host or explicit operator target exists.
 
-The current Launchplane surface implements only the report-only phase.
+The current Launchplane surface implements report-only evidence and local
+apply-boundary planning. It still does not execute host mutations.
 
 ## Report Contract
 
@@ -63,9 +64,38 @@ uv run launchplane work-graph runner-host-hygiene-report \
   --policy-file runner-host-policy.json
 ```
 
+## Apply Planning
+
+Apply planning records the safety boundary a future host adapter must satisfy,
+but it still does not execute cleanup:
+
+```bash
+uv run launchplane work-graph runner-host-hygiene-apply-plan \
+  --action prune_docker_cache \
+  --host-name chris-testing \
+  --mutate \
+  --audit-record-key runner-host-hygiene/2026-05-23/chris-testing \
+  --approved-host chris-testing \
+  --allow-docker-cache-prune \
+  --required-retained-warm-builder odoo-docker-chris-testing \
+  --retained-warm-builder odoo-docker-chris-testing \
+  --report-file runner-host-report.json
+```
+
+The planner fails closed unless the host is approved, the action is enabled, the
+request carries explicit mutate intent, the pre-apply report is healthy, required
+warm builders are retained, and an audit record key is present. Passing
+`--mutate` records operator intent in the request so the boundary can be tested;
+this CLI still prints a dry-run JSON plan and does not invoke Docker, systemd,
+SSH, GitHub, or a host adapter.
+
+When an audit key is provided, the CLI also emits a planned audit-record payload.
+That record is a contract for a future Launchplane-owned storage write, not a
+write performed by this local command.
+
 ## Future Apply Requirements
 
-Before Launchplane grows a host mutation path, the apply design must name:
+Before Launchplane grows a host mutation adapter, the apply design must name:
 
 - the disposable or explicitly approved host target
 - the runner lane and repository scope the host adapter is allowed to affect
@@ -74,4 +104,5 @@ Before Launchplane grows a host mutation path, the apply design must name:
 - the rollback or stop condition when cleanup cannot be completed safely
 - the audit record written back to Launchplane-owned storage
 
-Until those are present, host hygiene work remains report-only.
+Until those are present, host hygiene work remains report-only or dry-run
+planning only.

--- a/tests/test_runner_host_hygiene.py
+++ b/tests/test_runner_host_hygiene.py
@@ -9,8 +9,13 @@ from click.testing import CliRunner
 
 from control_plane.cli import main
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneObservation
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyPolicy
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyRequest
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygienePolicy
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneReport
 from control_plane.contracts.runner_host_hygiene import evaluate_runner_host_hygiene
+from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene_apply
 
 
 CLI_MAIN = cast(Command, main)
@@ -171,6 +176,165 @@ class RunnerHostHygieneCliTests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         payload = json.loads(result.output)
         self.assertEqual(payload["report"]["status"], "healthy")
+
+
+class RunnerHostHygieneApplyPlanTests(unittest.TestCase):
+    def test_apply_plan_requires_mutate_audit_healthy_report_and_retained_builders(
+        self,
+    ) -> None:
+        plan = plan_runner_host_hygiene_apply(
+            policy=RunnerHostHygieneApplyPolicy(
+                approved_hosts=("chris-testing",),
+                required_retained_warm_builders=("odoo-docker-chris-testing",),
+                allow_docker_cache_prune=True,
+            ),
+            request=RunnerHostHygieneApplyRequest(
+                action="prune_docker_cache",
+                host_name="chris-testing",
+            ),
+            report=_attention_report(),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(
+            [blocker.code for blocker in plan.blockers],
+            [
+                "audit_record_required",
+                "host_needs_attention",
+                "mutate_not_requested",
+                "warm_builder_not_retained",
+            ],
+        )
+
+    def test_apply_plan_requires_approved_host_and_enabled_action(self) -> None:
+        plan = plan_runner_host_hygiene_apply(
+            policy=RunnerHostHygieneApplyPolicy(approved_hosts=("other-host",)),
+            request=RunnerHostHygieneApplyRequest(
+                action="restart_runner_service",
+                host_name="chris-testing",
+                mutate=True,
+                audit_record_key="runner-host-hygiene/2026-05-23/chris-testing",
+            ),
+            report=_healthy_report(),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(
+            [blocker.code for blocker in plan.blockers],
+            ["action_not_enabled", "approved_host_mismatch"],
+        )
+
+    def test_apply_plan_can_be_ready_without_executing_host_mutation(self) -> None:
+        plan = plan_runner_host_hygiene_apply(
+            policy=RunnerHostHygieneApplyPolicy(
+                approved_hosts=("Chris-Testing",),
+                required_retained_warm_builders=("odoo-docker-chris-testing",),
+                allow_docker_cache_prune=True,
+            ),
+            request=RunnerHostHygieneApplyRequest(
+                action="prune_docker_cache",
+                host_name=" chris-testing ",
+                mutate=True,
+                retained_warm_builders=("Odoo-Docker-Chris-Testing",),
+                audit_record_key="runner-host-hygiene/2026-05-23/chris-testing",
+            ),
+            report=_healthy_report(),
+        )
+
+        self.assertEqual(plan.status, "ready")
+        self.assertEqual(plan.blockers, ())
+        self.assertIn("pre-apply", plan.next_steps[0])
+
+    def test_apply_audit_record_requires_matching_key(self) -> None:
+        request = RunnerHostHygieneApplyRequest(
+            action="prune_docker_cache",
+            host_name="chris-testing",
+            mutate=True,
+            audit_record_key="runner-host-hygiene/2026-05-23/chris-testing",
+        )
+        plan = plan_runner_host_hygiene_apply(
+            policy=RunnerHostHygieneApplyPolicy(
+                approved_hosts=("chris-testing",), allow_docker_cache_prune=True
+            ),
+            request=request,
+            report=_healthy_report(),
+        )
+
+        with self.assertRaisesRegex(ValueError, "key must match request"):
+            RunnerHostHygieneApplyAuditRecord(
+                audit_record_key="runner-host-hygiene/other",
+                status="planned",
+                request=request,
+                plan=plan,
+                pre_apply_report=_healthy_report(),
+            )
+
+
+class RunnerHostHygieneApplyPlanCliTests(unittest.TestCase):
+    def test_cli_builds_apply_plan_from_report_file(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            report_file = Path(temp_dir) / "report.json"
+            report_file.write_text(
+                json.dumps({"report": _healthy_report().model_dump(mode="json")}),
+                encoding="utf-8",
+            )
+
+            result = CliRunner().invoke(
+                CLI_MAIN,
+                [
+                    "work-graph",
+                    "runner-host-hygiene-apply-plan",
+                    "--action",
+                    "prune_docker_cache",
+                    "--host-name",
+                    "chris-testing",
+                    "--mutate",
+                    "--audit-record-key",
+                    "runner-host-hygiene/2026-05-23/chris-testing",
+                    "--approved-host",
+                    "chris-testing",
+                    "--allow-docker-cache-prune",
+                    "--required-retained-warm-builder",
+                    "odoo-docker-chris-testing",
+                    "--retained-warm-builder",
+                    "odoo-docker-chris-testing",
+                    "--report-file",
+                    report_file.as_posix(),
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["mode"], "dry-run")
+        self.assertEqual(payload["plan"]["status"], "ready")
+        self.assertEqual(payload["audit_record"]["status"], "planned")
+        self.assertEqual(
+            payload["audit_record"]["message"],
+            "planned runner host hygiene apply; no host mutation was executed",
+        )
+
+
+def _healthy_report() -> RunnerHostHygieneReport:
+    return evaluate_runner_host_hygiene(
+        policy=RunnerHostHygienePolicy(required_warm_builders=("odoo-docker-chris-testing",)),
+        observation=RunnerHostHygieneObservation(
+            host_name="chris-testing",
+            observed_at="2026-05-23T13:00:00Z",
+            free_disk_bytes=500,
+            warm_builders=("odoo-docker-chris-testing",),
+        ),
+    )
+
+
+def _attention_report() -> RunnerHostHygieneReport:
+    return evaluate_runner_host_hygiene(
+        policy=RunnerHostHygienePolicy(minimum_free_disk_bytes=500),
+        observation=RunnerHostHygieneObservation(
+            host_name="chris-testing",
+            observed_at="2026-05-23T13:00:00Z",
+            free_disk_bytes=100,
+        ),
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add dry-run runner-host hygiene apply policy/request/plan/audit contracts
- wire `work-graph runner-host-hygiene-apply-plan` so operators can validate the future host-adapter boundary without executing cleanup
- document the apply planner gates and reinforce that Docker, services, GitHub, and host adapters are not invoked

Refs #474.

## Verification
- `uv run python -m unittest tests.test_runner_host_hygiene`
- `uv run python -m unittest tests.test_runner_host_hygiene tests.test_runner_lane_baseline tests.test_runner_lane_control`
- `uv run --extra dev ruff check control_plane/contracts/runner_host_hygiene.py control_plane/cli_runner_lanes.py tests/test_runner_host_hygiene.py`
- `uv run --extra dev ruff format --check control_plane/contracts/runner_host_hygiene.py control_plane/cli_runner_lanes.py tests/test_runner_host_hygiene.py`
- `npx prettier --check docs/runner-host-hygiene.md docs/README.md docs/runner-lane-baseline.md`
- `git diff --check`
- `uv run python -m unittest`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files`
