### PR TITLE
Validate runner host hygiene audit consistency

### DIFF
--- a/control_plane/contracts/runner_host_hygiene.py
+++ b/control_plane/contracts/runner_host_hygiene.py
@@ -19,6 +19,7 @@ RunnerHostHygieneApplyBlockerCode = Literal[
     "audit_record_required",
     "host_needs_attention",
     "mutate_not_requested",
+    "report_host_mismatch",
     "warm_builder_not_retained",
 ]
 RunnerHostHygieneFindingCode = Literal[
@@ -215,8 +216,36 @@ class RunnerHostHygieneApplyAuditRecord(BaseModel):
         self.message = self.message.strip()
         if self.audit_record_key != self.request.audit_record_key:
             raise ValueError("runner host hygiene audit record key must match request")
+        if self.plan.audit_record_key != self.request.audit_record_key:
+            raise ValueError("runner host hygiene audit record plan key must match request")
+        if _normalized_host_name(self.request.host_name) != _normalized_host_name(
+            self.plan.host_name
+        ):
+            raise ValueError("runner host hygiene audit record plan must match request host")
+        if self.plan.action != self.request.action:
+            raise ValueError("runner host hygiene audit record plan must match request action")
+        if self.plan.mutate != self.request.mutate:
+            raise ValueError(
+                "runner host hygiene audit record plan must match request mutate intent"
+            )
+        if _normalized_host_name(self.request.host_name) != _normalized_host_name(
+            self.pre_apply_report.host_name
+        ):
+            raise ValueError(
+                "runner host hygiene audit record pre-apply report must match request host"
+            )
+        if self.post_apply_report is not None and _normalized_host_name(
+            self.request.host_name
+        ) != _normalized_host_name(self.post_apply_report.host_name):
+            raise ValueError(
+                "runner host hygiene audit record post-apply report must match request host"
+            )
         if self.status == "planned" and self.post_apply_report is not None:
             raise ValueError("planned runner host hygiene audit record cannot include post report")
+        if self.status in {"completed", "failed"} and self.post_apply_report is None:
+            raise ValueError("terminal runner host hygiene audit record requires post-apply report")
+        if self.status in {"completed", "failed"} and self.plan.status != "ready":
+            raise ValueError("terminal runner host hygiene audit record requires a ready plan")
         return self
 
 
@@ -344,6 +373,16 @@ def plan_runner_host_hygiene_apply(
             _apply_blocker(
                 "host_needs_attention",
                 f"runner host hygiene report is not healthy: {report.summary}",
+            )
+        )
+    if _normalized_host_name(report.host_name) != request.host_name:
+        blockers.append(
+            _apply_blocker(
+                "report_host_mismatch",
+                (
+                    "runner host hygiene report host does not match requested host: "
+                    f"{report.host_name} != {request.host_name}"
+                ),
             )
         )
     missing_retained_builders = tuple(

--- a/tests/test_runner_host_hygiene.py
+++ b/tests/test_runner_host_hygiene.py
@@ -245,6 +245,28 @@ class RunnerHostHygieneApplyPlanTests(unittest.TestCase):
         self.assertEqual(plan.blockers, ())
         self.assertIn("pre-apply", plan.next_steps[0])
 
+    def test_apply_plan_rejects_report_for_different_host(self) -> None:
+        plan = plan_runner_host_hygiene_apply(
+            policy=RunnerHostHygieneApplyPolicy(
+                approved_hosts=("chris-testing",),
+                allow_docker_cache_prune=True,
+            ),
+            request=RunnerHostHygieneApplyRequest(
+                action="prune_docker_cache",
+                host_name="chris-testing",
+                mutate=True,
+                audit_record_key="runner-host-hygiene/2026-05-23/chris-testing",
+            ),
+            report=RunnerHostHygieneReport(
+                status="healthy",
+                host_name="other-host",
+                summary="runner host hygiene satisfies report-only policy",
+            ),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertIn("report_host_mismatch", [blocker.code for blocker in plan.blockers])
+
     def test_apply_audit_record_requires_matching_key(self) -> None:
         request = RunnerHostHygieneApplyRequest(
             action="prune_docker_cache",
@@ -267,6 +289,166 @@ class RunnerHostHygieneApplyPlanTests(unittest.TestCase):
                 request=request,
                 plan=plan,
                 pre_apply_report=_healthy_report(),
+            )
+
+    def test_apply_audit_record_requires_matching_plan_audit_key(self) -> None:
+        request = RunnerHostHygieneApplyRequest(
+            action="prune_docker_cache",
+            host_name="chris-testing",
+            mutate=True,
+            audit_record_key="runner-host-hygiene/2026-05-23/chris-testing",
+        )
+        plan = plan_runner_host_hygiene_apply(
+            policy=RunnerHostHygieneApplyPolicy(
+                approved_hosts=("chris-testing",), allow_docker_cache_prune=True
+            ),
+            request=RunnerHostHygieneApplyRequest(
+                action="prune_docker_cache",
+                host_name="chris-testing",
+                mutate=True,
+                audit_record_key="runner-host-hygiene/other",
+            ),
+            report=_healthy_report(),
+        )
+
+        with self.assertRaisesRegex(ValueError, "plan key must match request"):
+            RunnerHostHygieneApplyAuditRecord(
+                audit_record_key=request.audit_record_key,
+                status="planned",
+                request=request,
+                plan=plan,
+                pre_apply_report=_healthy_report(),
+            )
+
+    def test_apply_audit_record_requires_plan_action_and_mutate_to_match_request(
+        self,
+    ) -> None:
+        request = RunnerHostHygieneApplyRequest(
+            action="prune_docker_cache",
+            host_name="chris-testing",
+            mutate=True,
+            audit_record_key="runner-host-hygiene/2026-05-23/chris-testing",
+        )
+        healthy_report = _healthy_report()
+
+        with self.assertRaisesRegex(ValueError, "plan must match request action"):
+            RunnerHostHygieneApplyAuditRecord(
+                audit_record_key=request.audit_record_key,
+                status="planned",
+                request=request,
+                plan=plan_runner_host_hygiene_apply(
+                    policy=RunnerHostHygieneApplyPolicy(
+                        approved_hosts=("chris-testing",), allow_runner_service_restart=True
+                    ),
+                    request=RunnerHostHygieneApplyRequest(
+                        action="restart_runner_service",
+                        host_name="chris-testing",
+                        mutate=True,
+                        audit_record_key=request.audit_record_key,
+                    ),
+                    report=healthy_report,
+                ),
+                pre_apply_report=healthy_report,
+            )
+
+        with self.assertRaisesRegex(ValueError, "plan must match request mutate intent"):
+            RunnerHostHygieneApplyAuditRecord(
+                audit_record_key=request.audit_record_key,
+                status="planned",
+                request=request,
+                plan=plan_runner_host_hygiene_apply(
+                    policy=RunnerHostHygieneApplyPolicy(
+                        approved_hosts=("chris-testing",), allow_docker_cache_prune=True
+                    ),
+                    request=RunnerHostHygieneApplyRequest(
+                        action="prune_docker_cache",
+                        host_name="chris-testing",
+                        mutate=False,
+                        audit_record_key=request.audit_record_key,
+                    ),
+                    report=healthy_report,
+                ),
+                pre_apply_report=healthy_report,
+            )
+
+    def test_apply_audit_record_requires_matching_host_for_reports(self) -> None:
+        request = RunnerHostHygieneApplyRequest(
+            action="prune_docker_cache",
+            host_name="chris-testing",
+            mutate=True,
+            audit_record_key="runner-host-hygiene/2026-05-23/chris-testing",
+        )
+        plan = plan_runner_host_hygiene_apply(
+            policy=RunnerHostHygieneApplyPolicy(
+                approved_hosts=("chris-testing",), allow_docker_cache_prune=True
+            ),
+            request=request,
+            report=_healthy_report(),
+        )
+
+        with self.assertRaisesRegex(ValueError, "pre-apply report must match request host"):
+            RunnerHostHygieneApplyAuditRecord(
+                audit_record_key=request.audit_record_key,
+                status="planned",
+                request=request,
+                plan=plan,
+                pre_apply_report=RunnerHostHygieneReport(
+                    status="healthy",
+                    host_name="other-host",
+                    summary="runner host hygiene satisfies report-only policy",
+                ),
+            )
+
+    def test_apply_audit_record_requires_terminal_post_apply_report(self) -> None:
+        request = RunnerHostHygieneApplyRequest(
+            action="prune_docker_cache",
+            host_name="chris-testing",
+            mutate=True,
+            audit_record_key="runner-host-hygiene/2026-05-23/chris-testing",
+        )
+        plan = plan_runner_host_hygiene_apply(
+            policy=RunnerHostHygieneApplyPolicy(
+                approved_hosts=("chris-testing",), allow_docker_cache_prune=True
+            ),
+            request=request,
+            report=_healthy_report(),
+        )
+
+        with self.assertRaisesRegex(ValueError, "requires post-apply report"):
+            RunnerHostHygieneApplyAuditRecord(
+                audit_record_key=request.audit_record_key,
+                status="completed",
+                request=request,
+                plan=plan,
+                pre_apply_report=_healthy_report(),
+            )
+
+    def test_apply_audit_record_requires_terminal_ready_plan(self) -> None:
+        request = RunnerHostHygieneApplyRequest(
+            action="prune_docker_cache",
+            host_name="chris-testing",
+            mutate=True,
+            audit_record_key="runner-host-hygiene/2026-05-23/chris-testing",
+        )
+        healthy_report = _healthy_report()
+
+        with self.assertRaisesRegex(ValueError, "requires a ready plan"):
+            RunnerHostHygieneApplyAuditRecord(
+                audit_record_key=request.audit_record_key,
+                status="completed",
+                request=request,
+                plan=plan_runner_host_hygiene_apply(
+                    policy=RunnerHostHygieneApplyPolicy(approved_hosts=("chris-testing",)),
+                    request=RunnerHostHygieneApplyRequest(
+                        action="prune_docker_cache",
+                        host_name="chris-testing",
+                        mutate=True,
+                        audit_record_key=request.audit_record_key,
+                    ),
+                    report=_attention_report(),
+                ),
+                pre_apply_report=healthy_report,
+                post_apply_report=healthy_report,
             )
 
 


### PR DESCRIPTION
## Summary
- reject runner-host hygiene apply audit records whose nested plan key, host, action, mutate intent, or report host no longer match the request
- block apply plans when the supplied hygiene report is for a different host
- add regression tests for the late auto-review integrity gap and terminal audit-record consistency

Refs #474.

## Verification
- `uv run python -m unittest tests.test_runner_host_hygiene`
- `uv run --extra dev ruff check control_plane/contracts/runner_host_hygiene.py tests/test_runner_host_hygiene.py`
- `uv run --extra dev ruff format --check control_plane/contracts/runner_host_hygiene.py tests/test_runner_host_hygiene.py`
- `git diff --check`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files`
