### PR TITLE
Require retained builder evidence for hygiene apply

### DIFF
--- a/control_plane/contracts/runner_host_hygiene.py
+++ b/control_plane/contracts/runner_host_hygiene.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -20,6 +21,7 @@ RunnerHostHygieneApplyBlockerCode = Literal[
     "host_needs_attention",
     "mutate_not_requested",
     "report_host_mismatch",
+    "retained_warm_builder_missing_from_report",
     "warm_builder_not_retained",
 ]
 RunnerHostHygieneFindingCode = Literal[
@@ -91,6 +93,7 @@ class RunnerHostHygieneReport(BaseModel):
     schema_version: int = Field(default=1, ge=1)
     status: RunnerHostHygieneStatus
     host_name: str
+    warm_builders: tuple[str, ...] = ()
     findings: tuple[RunnerHostHygieneFinding, ...] = ()
     summary: str
     next_steps: tuple[str, ...] = ()
@@ -100,6 +103,7 @@ class RunnerHostHygieneReport(BaseModel):
         self.host_name = _required_text(
             self.host_name, "runner host hygiene report requires host_name"
         )
+        self.warm_builders = _normalized_tokens(self.warm_builders)
         self.findings = tuple(sorted(self.findings, key=lambda finding: finding.code))
         self.summary = _required_text(self.summary, "runner host hygiene report requires summary")
         self.next_steps = tuple(step.strip() for step in self.next_steps if step.strip())
@@ -323,6 +327,7 @@ def evaluate_runner_host_hygiene(
     return RunnerHostHygieneReport(
         status=status,
         host_name=observation.host_name,
+        warm_builders=observation.warm_builders,
         findings=tuple(findings),
         summary=(
             "runner host hygiene satisfies report-only policy"
@@ -400,6 +405,21 @@ def plan_runner_host_hygiene_apply(
                 ),
             )
         )
+    missing_observed_retained_builders = tuple(
+        builder
+        for builder in policy.required_retained_warm_builders
+        if builder not in report.warm_builders
+    )
+    if missing_observed_retained_builders:
+        blockers.append(
+            _apply_blocker(
+                "retained_warm_builder_missing_from_report",
+                (
+                    "runner host hygiene report did not observe required retained warm builders: "
+                    + ", ".join(missing_observed_retained_builders)
+                ),
+            )
+        )
 
     status: RunnerHostHygieneApplyPlanStatus = "blocked" if blockers else "ready"
     return RunnerHostHygieneApplyPlan(
@@ -472,9 +492,7 @@ def _apply_blocker(
 
 
 def _normalized_host_names(values: tuple[str, ...]) -> tuple[str, ...]:
-    return tuple(
-        sorted({normalized for value in values if (normalized := _normalized_host_name(value))})
-    )
+    return _normalized_values(values, _normalized_host_name)
 
 
 def _normalized_host_name(value: str) -> str:
@@ -482,9 +500,11 @@ def _normalized_host_name(value: str) -> str:
 
 
 def _normalized_tokens(values: tuple[str, ...]) -> tuple[str, ...]:
-    return tuple(
-        sorted({normalized for value in values if (normalized := _normalized_token(value))})
-    )
+    return _normalized_values(values, _normalized_token)
+
+
+def _normalized_values(values: tuple[str, ...], normalize: Callable[[str], str]) -> tuple[str, ...]:
+    return tuple(sorted({normalized for value in values if (normalized := normalize(value))}))
 
 
 def _normalized_token(value: str) -> str:

--- a/tests/test_runner_host_hygiene.py
+++ b/tests/test_runner_host_hygiene.py
@@ -42,6 +42,7 @@ class RunnerHostHygieneTests(unittest.TestCase):
 
         self.assertEqual(report.status, "healthy")
         self.assertEqual(report.host_name, "chris-testing")
+        self.assertEqual(report.warm_builders, ("odoo-docker-chris-testing",))
         self.assertEqual(report.findings, ())
         self.assertIn("report-only", report.summary)
 
@@ -202,6 +203,7 @@ class RunnerHostHygieneApplyPlanTests(unittest.TestCase):
                 "audit_record_required",
                 "host_needs_attention",
                 "mutate_not_requested",
+                "retained_warm_builder_missing_from_report",
                 "warm_builder_not_retained",
             ],
         )
@@ -266,6 +268,33 @@ class RunnerHostHygieneApplyPlanTests(unittest.TestCase):
 
         self.assertEqual(plan.status, "blocked")
         self.assertIn("report_host_mismatch", [blocker.code for blocker in plan.blockers])
+
+    def test_apply_plan_requires_report_to_observe_retained_warm_builders(self) -> None:
+        plan = plan_runner_host_hygiene_apply(
+            policy=RunnerHostHygieneApplyPolicy(
+                approved_hosts=("chris-testing",),
+                required_retained_warm_builders=("odoo-docker-chris-testing",),
+                allow_docker_cache_prune=True,
+            ),
+            request=RunnerHostHygieneApplyRequest(
+                action="prune_docker_cache",
+                host_name="chris-testing",
+                mutate=True,
+                retained_warm_builders=("odoo-docker-chris-testing",),
+                audit_record_key="runner-host-hygiene/2026-05-23/chris-testing",
+            ),
+            report=RunnerHostHygieneReport(
+                status="healthy",
+                host_name="chris-testing",
+                summary="runner host hygiene satisfies report-only policy",
+            ),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertIn(
+            "retained_warm_builder_missing_from_report",
+            [blocker.code for blocker in plan.blockers],
+        )
 
     def test_apply_audit_record_requires_matching_key(self) -> None:
         request = RunnerHostHygieneApplyRequest(
@@ -363,7 +392,6 @@ class RunnerHostHygieneApplyPlanTests(unittest.TestCase):
                     request=RunnerHostHygieneApplyRequest(
                         action="prune_docker_cache",
                         host_name="chris-testing",
-                        mutate=False,
                         audit_record_key=request.audit_record_key,
                     ),
                     report=healthy_report,


### PR DESCRIPTION
## Summary
- carry observed warm builders on runner-host hygiene reports
- block hygiene apply plans when required retained builders are absent from the pre-apply report evidence
- add regression coverage for the late auto-review safety finding

Refs #474.

## Verification
- `uv run python -m unittest tests.test_runner_host_hygiene`
- `uv run --extra dev ruff check control_plane/contracts/runner_host_hygiene.py tests/test_runner_host_hygiene.py`
- `uv run --extra dev ruff format --check control_plane/contracts/runner_host_hygiene.py tests/test_runner_host_hygiene.py`
- `git diff --check`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files`
