### PR TITLE
Validate request retained builder evidence

### DIFF
--- a/control_plane/contracts/runner_host_hygiene.py
+++ b/control_plane/contracts/runner_host_hygiene.py
@@ -406,16 +406,14 @@ def plan_runner_host_hygiene_apply(
             )
         )
     missing_observed_retained_builders = tuple(
-        builder
-        for builder in policy.required_retained_warm_builders
-        if builder not in report.warm_builders
+        builder for builder in request.retained_warm_builders if builder not in report.warm_builders
     )
     if missing_observed_retained_builders:
         blockers.append(
             _apply_blocker(
                 "retained_warm_builder_missing_from_report",
                 (
-                    "runner host hygiene report did not observe required retained warm builders: "
+                    "runner host hygiene report did not observe requested retained warm builders: "
                     + ", ".join(missing_observed_retained_builders)
                 ),
             )

--- a/tests/test_runner_host_hygiene.py
+++ b/tests/test_runner_host_hygiene.py
@@ -203,7 +203,6 @@ class RunnerHostHygieneApplyPlanTests(unittest.TestCase):
                 "audit_record_required",
                 "host_needs_attention",
                 "mutate_not_requested",
-                "retained_warm_builder_missing_from_report",
                 "warm_builder_not_retained",
             ],
         )
@@ -288,6 +287,34 @@ class RunnerHostHygieneApplyPlanTests(unittest.TestCase):
                 host_name="chris-testing",
                 summary="runner host hygiene satisfies report-only policy",
             ),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertIn(
+            "retained_warm_builder_missing_from_report",
+            [blocker.code for blocker in plan.blockers],
+        )
+
+    def test_apply_plan_requires_report_to_observe_each_request_retained_builder(
+        self,
+    ) -> None:
+        plan = plan_runner_host_hygiene_apply(
+            policy=RunnerHostHygieneApplyPolicy(
+                approved_hosts=("chris-testing",),
+                required_retained_warm_builders=("odoo-docker-chris-testing",),
+                allow_docker_cache_prune=True,
+            ),
+            request=RunnerHostHygieneApplyRequest(
+                action="prune_docker_cache",
+                host_name="chris-testing",
+                mutate=True,
+                retained_warm_builders=(
+                    "odoo-docker-chris-testing",
+                    "odoo-enterprise-chris-testing",
+                ),
+                audit_record_key="runner-host-hygiene/2026-05-23/chris-testing",
+            ),
+            report=_healthy_report(),
         )
 
         self.assertEqual(plan.status, "blocked")


### PR DESCRIPTION
## Summary
- validate every request-declared retained warm builder against the pre-apply report evidence
- keep policy-required retention separate from report-evidence validation
- add regression coverage for the late auto-review finding

Refs #474.

## Verification
- `uv run python -m unittest tests.test_runner_host_hygiene`
- `uv run --extra dev ruff check control_plane/contracts/runner_host_hygiene.py tests/test_runner_host_hygiene.py`
- `uv run --extra dev ruff format --check control_plane/contracts/runner_host_hygiene.py tests/test_runner_host_hygiene.py`
- `git diff --check`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files`
