### PR TITLE
Add runner host adapter boundary planning

### DIFF
--- a/control_plane/cli_runner_lanes.py
+++ b/control_plane/cli_runner_lanes.py
@@ -19,11 +19,17 @@ from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneObserva
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAction
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyPolicy
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyPlan
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyRequest
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneAdapterPolicy
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneAdapterProposal
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneAdapterType
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygienePolicy
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygienePrivilegedScope
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneReport
 from control_plane.contracts.runner_host_hygiene import evaluate_runner_host_hygiene
 from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene_apply
+from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene_adapter_boundary
 from control_plane.merge_train_github import MergeTrainGitHubError
 from control_plane.merge_train_github import UrllibMergeTrainGitHubTransport
 from control_plane.runner_lane_github import GitHubRunnerLaneInventoryReader
@@ -38,6 +44,10 @@ def register_runner_lane_commands(work_graph: click.Group) -> None:
     work_graph.add_command(runner_control_plan, name="runner-control-plan")
     work_graph.add_command(runner_host_hygiene_report, name="runner-host-hygiene-report")
     work_graph.add_command(runner_host_hygiene_apply_plan, name="runner-host-hygiene-apply-plan")
+    work_graph.add_command(
+        runner_host_hygiene_adapter_boundary_plan,
+        name="runner-host-hygiene-adapter-boundary-plan",
+    )
 
 
 @click.command("runner-inventory")
@@ -595,6 +605,194 @@ def runner_host_hygiene_apply_plan(
     click.echo(json.dumps(payload, indent=2, sort_keys=True))
 
 
+@click.command("runner-host-hygiene-adapter-boundary-plan")
+@click.option(
+    "--adapter-type",
+    required=True,
+    type=click.Choice(("github_actions_runner", "launchplane_worker", "remote_host_executor")),
+    help="Proposed host adapter type. The command never mutates hosts.",
+)
+@click.option("--host-name", required=True, help="Runner host name to plan against.")
+@click.option(
+    "--execution-lane",
+    required=True,
+    help="Dedicated execution lane proposed for privileged host work.",
+)
+@click.option("--service-user", required=True, help="Host service user for the proposed adapter.")
+@click.option(
+    "--repository-scope",
+    "repository_scopes",
+    multiple=True,
+    help="Repository scope the adapter is allowed to affect. Repeat for each repository.",
+)
+@click.option(
+    "--privileged-scope",
+    "privileged_scopes",
+    multiple=True,
+    type=click.Choice(("docker_cache", "runner_service", "runner_workdir")),
+    help="Privileged host capability requested by the adapter. Repeat for each scope.",
+)
+@click.option(
+    "--audit-record-key",
+    required=True,
+    help="Launchplane-owned audit record key the future adapter must write.",
+)
+@click.option(
+    "--rollback-plan",
+    default="",
+    help="Rollback or stop condition required before implementing host mutation.",
+)
+@click.option(
+    "--pre-apply-evidence",
+    "pre_apply_evidence",
+    multiple=True,
+    help="Pre-apply evidence the adapter proposal will capture. Repeat for each item.",
+)
+@click.option(
+    "--post-apply-evidence",
+    "post_apply_evidence",
+    multiple=True,
+    help="Post-apply evidence the adapter proposal will capture. Repeat for each item.",
+)
+@click.option(
+    "--approved-host",
+    "approved_hosts",
+    multiple=True,
+    help="Host approved for adapter execution. Repeat for each approved host.",
+)
+@click.option(
+    "--allowed-adapter-type",
+    "allowed_adapter_types",
+    multiple=True,
+    type=click.Choice(("github_actions_runner", "launchplane_worker", "remote_host_executor")),
+    help="Adapter type allowed by local policy. Repeat for each type.",
+)
+@click.option(
+    "--allowed-execution-lane",
+    "allowed_execution_lanes",
+    multiple=True,
+    help="Execution lane allowed by local policy. Repeat for each lane.",
+)
+@click.option(
+    "--allowed-service-user",
+    "allowed_service_users",
+    multiple=True,
+    help="Service user allowed by local policy. Repeat for each user.",
+)
+@click.option(
+    "--allowed-repository-scope",
+    "allowed_repository_scopes",
+    multiple=True,
+    help="Repository scope allowed by local policy. Repeat for each repository.",
+)
+@click.option(
+    "--allowed-privileged-scope",
+    "allowed_privileged_scopes",
+    multiple=True,
+    type=click.Choice(("docker_cache", "runner_service", "runner_workdir")),
+    help="Privileged host scope allowed by local policy. Repeat for each scope.",
+)
+@click.option(
+    "--required-pre-apply-evidence",
+    "required_pre_apply_evidence",
+    multiple=True,
+    help="Pre-apply evidence required by local policy. Repeat for each item.",
+)
+@click.option(
+    "--required-post-apply-evidence",
+    "required_post_apply_evidence",
+    multiple=True,
+    help="Post-apply evidence required by local policy. Repeat for each item.",
+)
+@click.option(
+    "--audit-record-key-prefix",
+    default="runner-host-hygiene/",
+    show_default=True,
+    help="Required audit record key prefix.",
+)
+@click.option(
+    "--require-rollback-plan/--allow-missing-rollback-plan",
+    default=True,
+    show_default=True,
+    help="Require a rollback or stop condition before the adapter boundary can be ready.",
+)
+@click.option(
+    "--apply-plan-file",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False),
+    required=True,
+    help="RunnerHostHygieneApplyPlan JSON or runner-host-hygiene-apply-plan output.",
+)
+def runner_host_hygiene_adapter_boundary_plan(
+    adapter_type: RunnerHostHygieneAdapterType,
+    host_name: str,
+    execution_lane: str,
+    service_user: str,
+    repository_scopes: tuple[str, ...],
+    privileged_scopes: tuple[RunnerHostHygienePrivilegedScope, ...],
+    audit_record_key: str,
+    rollback_plan: str,
+    pre_apply_evidence: tuple[str, ...],
+    post_apply_evidence: tuple[str, ...],
+    approved_hosts: tuple[str, ...],
+    allowed_adapter_types: tuple[RunnerHostHygieneAdapterType, ...],
+    allowed_execution_lanes: tuple[str, ...],
+    allowed_service_users: tuple[str, ...],
+    allowed_repository_scopes: tuple[str, ...],
+    allowed_privileged_scopes: tuple[RunnerHostHygienePrivilegedScope, ...],
+    required_pre_apply_evidence: tuple[str, ...],
+    required_post_apply_evidence: tuple[str, ...],
+    audit_record_key_prefix: str,
+    require_rollback_plan: bool,
+    apply_plan_file: Path,
+) -> None:
+    try:
+        apply_plan = _load_runner_host_hygiene_apply_plan(apply_plan_file)
+        policy = RunnerHostHygieneAdapterPolicy(
+            approved_hosts=approved_hosts,
+            allowed_adapter_types=allowed_adapter_types,
+            allowed_execution_lanes=allowed_execution_lanes,
+            allowed_service_users=allowed_service_users,
+            allowed_repository_scopes=allowed_repository_scopes,
+            allowed_privileged_scopes=allowed_privileged_scopes,
+            required_pre_apply_evidence=required_pre_apply_evidence,
+            required_post_apply_evidence=required_post_apply_evidence,
+            audit_record_key_prefix=audit_record_key_prefix,
+            require_rollback_plan=require_rollback_plan,
+        )
+        proposal = RunnerHostHygieneAdapterProposal(
+            adapter_type=adapter_type,
+            host_name=host_name,
+            execution_lane=execution_lane,
+            service_user=service_user,
+            repository_scopes=repository_scopes,
+            privileged_scopes=privileged_scopes,
+            audit_record_key=audit_record_key,
+            rollback_plan=rollback_plan,
+            pre_apply_evidence=pre_apply_evidence,
+            post_apply_evidence=post_apply_evidence,
+        )
+        boundary = plan_runner_host_hygiene_adapter_boundary(
+            policy=policy,
+            proposal=proposal,
+            apply_plan=apply_plan,
+        )
+    except (OSError, JSONDecodeError, ValidationError, ValueError) as error:
+        raise click.ClickException(str(error)) from error
+    click.echo(
+        json.dumps(
+            {
+                "mode": "adapter-boundary-plan",
+                "policy": policy.model_dump(mode="json"),
+                "proposal": proposal.model_dump(mode="json"),
+                "apply_plan": apply_plan.model_dump(mode="json"),
+                "boundary": boundary.model_dump(mode="json"),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
 def _load_runner_lane_inventory(inventory_file: Path) -> RunnerLaneInventory:
     return RunnerLaneInventory.model_validate(
         json.loads(inventory_file.read_text(encoding="utf-8"))
@@ -629,6 +827,13 @@ def _load_runner_host_hygiene_report(report_file: Path) -> RunnerHostHygieneRepo
     if isinstance(payload, dict) and isinstance(payload.get("report"), dict):
         payload = payload["report"]
     return RunnerHostHygieneReport.model_validate(payload)
+
+
+def _load_runner_host_hygiene_apply_plan(apply_plan_file: Path) -> RunnerHostHygieneApplyPlan:
+    payload = json.loads(apply_plan_file.read_text(encoding="utf-8"))
+    if isinstance(payload, dict) and isinstance(payload.get("plan"), dict):
+        payload = payload["plan"]
+    return RunnerHostHygieneApplyPlan.model_validate(payload)
 
 
 def _runner_baseline_runner_name(value: str) -> str:

--- a/control_plane/contracts/runner_host_hygiene.py
+++ b/control_plane/contracts/runner_host_hygiene.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Literal
+from typing import Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -14,6 +14,12 @@ RunnerHostHygieneApplyAction = Literal[
 ]
 RunnerHostHygieneApplyPlanStatus = Literal["ready", "blocked"]
 RunnerHostHygieneApplyAuditStatus = Literal["planned", "completed", "failed"]
+RunnerHostHygieneAdapterType = Literal[
+    "github_actions_runner",
+    "launchplane_worker",
+    "remote_host_executor",
+]
+RunnerHostHygieneAdapterBoundaryStatus = Literal["ready", "blocked"]
 RunnerHostHygieneApplyBlockerCode = Literal[
     "action_not_enabled",
     "approved_host_mismatch",
@@ -30,6 +36,29 @@ RunnerHostHygieneFindingCode = Literal[
     "orphan_buildkit_present",
     "required_warm_builder_missing",
     "runner_workdir_above_limit",
+]
+RunnerHostHygienePrivilegedScope = Literal[
+    "docker_cache",
+    "runner_service",
+    "runner_workdir",
+]
+RunnerHostHygieneAdapterBoundaryBlockerCode = Literal[
+    "adapter_type_not_allowed",
+    "apply_plan_not_ready",
+    "audit_record_key_mismatch",
+    "audit_record_key_prefix_missing",
+    "execution_lane_not_allowed",
+    "host_not_approved",
+    "host_plan_mismatch",
+    "post_apply_evidence_missing",
+    "pre_apply_evidence_missing",
+    "privileged_scope_forbidden",
+    "privileged_scope_missing",
+    "privileged_scope_overbroad",
+    "repository_scope_not_allowed",
+    "repository_scope_required",
+    "rollback_plan_required",
+    "service_user_not_allowed",
 ]
 
 
@@ -253,6 +282,137 @@ class RunnerHostHygieneApplyAuditRecord(BaseModel):
         return self
 
 
+class RunnerHostHygieneAdapterPolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    approved_hosts: tuple[str, ...] = ()
+    allowed_adapter_types: tuple[RunnerHostHygieneAdapterType, ...] = ()
+    allowed_execution_lanes: tuple[str, ...] = ()
+    allowed_service_users: tuple[str, ...] = ()
+    allowed_repository_scopes: tuple[str, ...] = ()
+    allowed_privileged_scopes: tuple[RunnerHostHygienePrivilegedScope, ...] = ()
+    required_pre_apply_evidence: tuple[str, ...] = ()
+    required_post_apply_evidence: tuple[str, ...] = ()
+    audit_record_key_prefix: str = "runner-host-hygiene/"
+    require_rollback_plan: bool = True
+
+    @model_validator(mode="after")
+    def _normalize_policy(self) -> "RunnerHostHygieneAdapterPolicy":
+        self.approved_hosts = _normalized_host_names(self.approved_hosts)
+        self.allowed_execution_lanes = _normalized_tokens(self.allowed_execution_lanes)
+        self.allowed_service_users = _normalized_tokens(self.allowed_service_users)
+        self.allowed_repository_scopes = _normalized_repositories(self.allowed_repository_scopes)
+        self.allowed_privileged_scopes = cast(
+            tuple[RunnerHostHygienePrivilegedScope, ...],
+            _normalized_values(self.allowed_privileged_scopes, _normalized_token),
+        )
+        self.required_pre_apply_evidence = _normalized_tokens(self.required_pre_apply_evidence)
+        self.required_post_apply_evidence = _normalized_tokens(self.required_post_apply_evidence)
+        self.audit_record_key_prefix = _required_text(
+            self.audit_record_key_prefix,
+            "runner host hygiene adapter policy requires audit record key prefix",
+        )
+        return self
+
+
+class RunnerHostHygieneAdapterProposal(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    adapter_type: RunnerHostHygieneAdapterType
+    host_name: str
+    execution_lane: str
+    service_user: str
+    repository_scopes: tuple[str, ...] = ()
+    privileged_scopes: tuple[RunnerHostHygienePrivilegedScope, ...] = ()
+    audit_record_key: str
+    rollback_plan: str = ""
+    pre_apply_evidence: tuple[str, ...] = ()
+    post_apply_evidence: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def _normalize_proposal(self) -> "RunnerHostHygieneAdapterProposal":
+        self.host_name = _normalized_host_name(self.host_name)
+        if not self.host_name:
+            raise ValueError("runner host hygiene adapter proposal requires host_name")
+        self.execution_lane = _normalized_token(self.execution_lane)
+        if not self.execution_lane:
+            raise ValueError("runner host hygiene adapter proposal requires execution_lane")
+        self.service_user = _normalized_token(self.service_user)
+        if not self.service_user:
+            raise ValueError("runner host hygiene adapter proposal requires service_user")
+        self.repository_scopes = _normalized_repositories(self.repository_scopes)
+        self.privileged_scopes = cast(
+            tuple[RunnerHostHygienePrivilegedScope, ...],
+            _normalized_values(self.privileged_scopes, _normalized_token),
+        )
+        self.audit_record_key = _required_text(
+            self.audit_record_key, "runner host hygiene adapter proposal requires audit_record_key"
+        )
+        self.rollback_plan = self.rollback_plan.strip()
+        self.pre_apply_evidence = _normalized_tokens(self.pre_apply_evidence)
+        self.post_apply_evidence = _normalized_tokens(self.post_apply_evidence)
+        return self
+
+
+class RunnerHostHygieneAdapterBoundaryBlocker(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: RunnerHostHygieneAdapterBoundaryBlockerCode
+    message: str
+
+    @model_validator(mode="after")
+    def _normalize_blocker(self) -> "RunnerHostHygieneAdapterBoundaryBlocker":
+        self.message = _required_text(
+            self.message, "runner host hygiene adapter boundary blocker requires message"
+        )
+        return self
+
+
+class RunnerHostHygieneAdapterBoundaryPlan(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    status: RunnerHostHygieneAdapterBoundaryStatus
+    adapter_type: RunnerHostHygieneAdapterType
+    host_name: str
+    execution_lane: str
+    service_user: str
+    audit_record_key: str
+    blockers: tuple[RunnerHostHygieneAdapterBoundaryBlocker, ...] = ()
+    next_steps: tuple[str, ...] = ()
+    summary: str
+
+    @model_validator(mode="after")
+    def _normalize_plan(self) -> "RunnerHostHygieneAdapterBoundaryPlan":
+        self.host_name = _required_text(
+            self.host_name, "runner host hygiene adapter boundary plan requires host_name"
+        )
+        self.execution_lane = _required_text(
+            self.execution_lane,
+            "runner host hygiene adapter boundary plan requires execution_lane",
+        )
+        self.service_user = _required_text(
+            self.service_user,
+            "runner host hygiene adapter boundary plan requires service_user",
+        )
+        self.audit_record_key = _required_text(
+            self.audit_record_key,
+            "runner host hygiene adapter boundary plan requires audit_record_key",
+        )
+        self.blockers = tuple(sorted(self.blockers, key=lambda blocker: blocker.code))
+        self.next_steps = tuple(step.strip() for step in self.next_steps if step.strip())
+        self.summary = _required_text(
+            self.summary, "runner host hygiene adapter boundary plan requires summary"
+        )
+        if self.status == "ready" and self.blockers:
+            raise ValueError("ready runner host hygiene adapter boundary cannot include blockers")
+        if self.status == "blocked" and not self.blockers:
+            raise ValueError("blocked runner host hygiene adapter boundary requires blockers")
+        return self
+
+
 def evaluate_runner_host_hygiene(
     *,
     policy: RunnerHostHygienePolicy,
@@ -436,6 +596,186 @@ def plan_runner_host_hygiene_apply(
     )
 
 
+def plan_runner_host_hygiene_adapter_boundary(
+    *,
+    policy: RunnerHostHygieneAdapterPolicy,
+    proposal: RunnerHostHygieneAdapterProposal,
+    apply_plan: RunnerHostHygieneApplyPlan,
+) -> RunnerHostHygieneAdapterBoundaryPlan:
+    blockers: list[RunnerHostHygieneAdapterBoundaryBlocker] = []
+    required_scope = _required_privileged_scope(apply_plan.action)
+    if apply_plan.status != "ready":
+        blockers.append(
+            _adapter_blocker(
+                "apply_plan_not_ready",
+                f"runner host adapter boundary requires a ready apply plan: {apply_plan.summary}",
+            )
+        )
+    if not policy.approved_hosts or proposal.host_name not in policy.approved_hosts:
+        blockers.append(
+            _adapter_blocker(
+                "host_not_approved",
+                f"runner host is not approved for adapter execution: {proposal.host_name}",
+            )
+        )
+    if proposal.host_name != _normalized_host_name(apply_plan.host_name):
+        blockers.append(
+            _adapter_blocker(
+                "host_plan_mismatch",
+                (
+                    "runner host adapter proposal does not match apply plan host: "
+                    f"{proposal.host_name} != {apply_plan.host_name}"
+                ),
+            )
+        )
+    if proposal.audit_record_key != apply_plan.audit_record_key:
+        blockers.append(
+            _adapter_blocker(
+                "audit_record_key_mismatch",
+                "runner host adapter proposal audit key must match the apply plan",
+            )
+        )
+    if not proposal.audit_record_key.startswith(policy.audit_record_key_prefix):
+        blockers.append(
+            _adapter_blocker(
+                "audit_record_key_prefix_missing",
+                (
+                    "runner host adapter audit key must use prefix: "
+                    f"{policy.audit_record_key_prefix}"
+                ),
+            )
+        )
+    if (
+        not policy.allowed_adapter_types
+        or proposal.adapter_type not in policy.allowed_adapter_types
+    ):
+        blockers.append(
+            _adapter_blocker(
+                "adapter_type_not_allowed",
+                f"runner host adapter type is not allowed: {proposal.adapter_type}",
+            )
+        )
+    if (
+        not policy.allowed_execution_lanes
+        or proposal.execution_lane not in policy.allowed_execution_lanes
+    ):
+        blockers.append(
+            _adapter_blocker(
+                "execution_lane_not_allowed",
+                f"runner host execution lane is not allowed: {proposal.execution_lane}",
+            )
+        )
+    if (
+        not policy.allowed_service_users
+        or proposal.service_user not in policy.allowed_service_users
+    ):
+        blockers.append(
+            _adapter_blocker(
+                "service_user_not_allowed",
+                f"runner host service user is not allowed: {proposal.service_user}",
+            )
+        )
+    if not proposal.repository_scopes:
+        blockers.append(
+            _adapter_blocker(
+                "repository_scope_required",
+                "runner host adapter proposal requires explicit repository scope",
+            )
+        )
+    forbidden_repositories = tuple(
+        repository
+        for repository in proposal.repository_scopes
+        if repository not in policy.allowed_repository_scopes
+    )
+    if forbidden_repositories:
+        blockers.append(
+            _adapter_blocker(
+                "repository_scope_not_allowed",
+                "runner host adapter repository scope is not allowed: "
+                + ", ".join(forbidden_repositories),
+            )
+        )
+    if required_scope not in proposal.privileged_scopes:
+        blockers.append(
+            _adapter_blocker(
+                "privileged_scope_missing",
+                f"runner host adapter proposal is missing required scope: {required_scope}",
+            )
+        )
+    forbidden_scopes = tuple(
+        scope
+        for scope in proposal.privileged_scopes
+        if scope not in policy.allowed_privileged_scopes
+    )
+    if forbidden_scopes:
+        blockers.append(
+            _adapter_blocker(
+                "privileged_scope_forbidden",
+                "runner host adapter privileged scope is not allowed: "
+                + ", ".join(forbidden_scopes),
+            )
+        )
+    extra_scopes = tuple(scope for scope in proposal.privileged_scopes if scope != required_scope)
+    if extra_scopes:
+        blockers.append(
+            _adapter_blocker(
+                "privileged_scope_overbroad",
+                "runner host adapter privileged scope is broader than the apply action: "
+                + ", ".join(extra_scopes),
+            )
+        )
+    missing_pre_apply_evidence = tuple(
+        evidence
+        for evidence in policy.required_pre_apply_evidence
+        if evidence not in proposal.pre_apply_evidence
+    )
+    if missing_pre_apply_evidence:
+        blockers.append(
+            _adapter_blocker(
+                "pre_apply_evidence_missing",
+                "runner host adapter proposal is missing pre-apply evidence: "
+                + ", ".join(missing_pre_apply_evidence),
+            )
+        )
+    missing_post_apply_evidence = tuple(
+        evidence
+        for evidence in policy.required_post_apply_evidence
+        if evidence not in proposal.post_apply_evidence
+    )
+    if missing_post_apply_evidence:
+        blockers.append(
+            _adapter_blocker(
+                "post_apply_evidence_missing",
+                "runner host adapter proposal is missing post-apply evidence: "
+                + ", ".join(missing_post_apply_evidence),
+            )
+        )
+    if policy.require_rollback_plan and not proposal.rollback_plan:
+        blockers.append(
+            _adapter_blocker(
+                "rollback_plan_required",
+                "runner host adapter proposal requires a rollback or stop condition",
+            )
+        )
+
+    status: RunnerHostHygieneAdapterBoundaryStatus = "blocked" if blockers else "ready"
+    return RunnerHostHygieneAdapterBoundaryPlan(
+        status=status,
+        adapter_type=proposal.adapter_type,
+        host_name=proposal.host_name,
+        execution_lane=proposal.execution_lane,
+        service_user=proposal.service_user,
+        audit_record_key=proposal.audit_record_key,
+        blockers=tuple(blockers),
+        next_steps=_adapter_next_steps(status=status),
+        summary=(
+            "runner host hygiene adapter boundary is ready"
+            if status == "ready"
+            else "runner host hygiene adapter boundary is blocked"
+        ),
+    )
+
+
 def _apply_action_allowed(
     *, policy: RunnerHostHygieneApplyPolicy, action: RunnerHostHygieneApplyAction
 ) -> bool:
@@ -489,6 +829,32 @@ def _apply_blocker(
     return RunnerHostHygieneApplyBlocker(code=code, message=message)
 
 
+def _adapter_blocker(
+    code: RunnerHostHygieneAdapterBoundaryBlockerCode, message: str
+) -> RunnerHostHygieneAdapterBoundaryBlocker:
+    return RunnerHostHygieneAdapterBoundaryBlocker(code=code, message=message)
+
+
+def _required_privileged_scope(
+    action: RunnerHostHygieneApplyAction,
+) -> RunnerHostHygienePrivilegedScope:
+    if action == "prune_docker_cache":
+        return "docker_cache"
+    if action == "prune_runner_workdir":
+        return "runner_workdir"
+    return "runner_service"
+
+
+def _adapter_next_steps(*, status: RunnerHostHygieneAdapterBoundaryStatus) -> tuple[str, ...]:
+    if status == "blocked":
+        return ("resolve adapter boundary blockers before wiring a host mutation path",)
+    return (
+        "review the adapter proposal with operators before implementation",
+        "implement the narrow host adapter behind the approved execution lane",
+        "write planned, completed, or failed audit records to Launchplane-owned storage",
+    )
+
+
 def _normalized_host_names(values: tuple[str, ...]) -> tuple[str, ...]:
     return _normalized_values(values, _normalized_host_name)
 
@@ -501,12 +867,29 @@ def _normalized_tokens(values: tuple[str, ...]) -> tuple[str, ...]:
     return _normalized_values(values, _normalized_token)
 
 
+def _normalized_repositories(values: tuple[str, ...]) -> tuple[str, ...]:
+    return _normalized_values(values, _normalized_repository)
+
+
 def _normalized_values(values: tuple[str, ...], normalize: Callable[[str], str]) -> tuple[str, ...]:
     return tuple(sorted({normalized for value in values if (normalized := normalize(value))}))
 
 
 def _normalized_token(value: str) -> str:
     return value.strip().lower()
+
+
+def _normalized_repository(value: str) -> str:
+    normalized_value = value.strip().lower()
+    if not normalized_value:
+        return ""
+    normalized_repository = "/".join(part.strip() for part in normalized_value.split("/"))
+    if normalized_repository.count("/") != 1:
+        raise ValueError("runner host hygiene adapter requires repository formatted as owner/name")
+    owner, name = normalized_repository.split("/", 1)
+    if not owner or not name:
+        raise ValueError("runner host hygiene adapter requires repository formatted as owner/name")
+    return normalized_repository
 
 
 def _required_text(value: str, message: str) -> str:

--- a/docs/runner-host-hygiene.md
+++ b/docs/runner-host-hygiene.md
@@ -93,6 +93,58 @@ When an audit key is provided, the CLI also emits a planned audit-record payload
 That record is a contract for a future Launchplane-owned storage write, not a
 write performed by this local command.
 
+## Adapter Boundary Planning
+
+Before a real host mutation adapter is implemented, operators can review the
+privileged execution boundary against a ready apply plan:
+
+```bash
+uv run launchplane work-graph runner-host-hygiene-adapter-boundary-plan \
+  --adapter-type github_actions_runner \
+  --host-name chris-testing \
+  --execution-lane chris-testing-ops-gate \
+  --service-user gha \
+  --repository-scope cbusillo/launchplane \
+  --privileged-scope docker_cache \
+  --audit-record-key runner-host-hygiene/2026-05-23/chris-testing \
+  --rollback-plan "Stop before mutation if retained builders are absent." \
+  --pre-apply-evidence df \
+  --pre-apply-evidence docker_summary \
+  --pre-apply-evidence warm_builders \
+  --post-apply-evidence df \
+  --post-apply-evidence docker_summary \
+  --post-apply-evidence warm_builders \
+  --approved-host chris-testing \
+  --allowed-adapter-type github_actions_runner \
+  --allowed-execution-lane chris-testing-ops-gate \
+  --allowed-service-user gha \
+  --allowed-repository-scope cbusillo/launchplane \
+  --allowed-privileged-scope docker_cache \
+  --required-pre-apply-evidence df \
+  --required-pre-apply-evidence docker_summary \
+  --required-pre-apply-evidence warm_builders \
+  --required-post-apply-evidence df \
+  --required-post-apply-evidence docker_summary \
+  --required-post-apply-evidence warm_builders \
+  --apply-plan-file runner-host-apply-plan.json
+```
+
+This command is still a planning surface. It fails closed unless the apply plan
+is ready, the host is approved, the proposal names an allowed adapter type,
+execution lane, service user, repository scope, narrow privileged scope, audit
+record key prefix, pre/post evidence set, and rollback or stop condition. It
+does not call Docker, systemd, SSH, GitHub runner registration APIs, or a host
+executor.
+
+The privileged scope must match the planned action exactly:
+
+- `prune_docker_cache` requires `docker_cache`.
+- `prune_runner_workdir` requires `runner_workdir`.
+- `restart_runner_service` requires `runner_service`.
+
+Extra privileged scopes block the boundary plan so a Docker-cache prune cannot
+quietly grow service-restart or work-directory powers.
+
 ## Future Apply Requirements
 
 Before Launchplane grows a host mutation adapter, the apply design must name:

--- a/tests/test_runner_host_hygiene.py
+++ b/tests/test_runner_host_hygiene.py
@@ -11,11 +11,15 @@ from control_plane.cli import main
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneObservation
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyPolicy
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyPlan
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyRequest
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneAdapterPolicy
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneAdapterProposal
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygienePolicy
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneReport
 from control_plane.contracts.runner_host_hygiene import evaluate_runner_host_hygiene
 from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene_apply
+from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene_adapter_boundary
 
 
 CLI_MAIN = cast(Command, main)
@@ -507,6 +511,106 @@ class RunnerHostHygieneApplyPlanTests(unittest.TestCase):
             )
 
 
+class RunnerHostHygieneAdapterBoundaryTests(unittest.TestCase):
+    def test_adapter_boundary_can_be_ready_for_narrow_docker_prune(self) -> None:
+        apply_plan = _ready_apply_plan()
+
+        boundary = plan_runner_host_hygiene_adapter_boundary(
+            policy=_adapter_policy(),
+            proposal=RunnerHostHygieneAdapterProposal(
+                adapter_type="github_actions_runner",
+                host_name="Chris-Testing",
+                execution_lane="chris-testing-ops-gate",
+                service_user="gha",
+                repository_scopes=("Cbusillo/Launchplane",),
+                privileged_scopes=("docker_cache",),
+                audit_record_key=apply_plan.audit_record_key,
+                rollback_plan="Stop if retained builders are missing after pre-apply evidence.",
+                pre_apply_evidence=("df", "docker_summary", "warm_builders"),
+                post_apply_evidence=("df", "docker_summary", "warm_builders"),
+            ),
+            apply_plan=apply_plan,
+        )
+
+        self.assertEqual(boundary.status, "ready")
+        self.assertEqual(boundary.blockers, ())
+        self.assertEqual(boundary.execution_lane, "chris-testing-ops-gate")
+        self.assertIn("approved execution lane", boundary.next_steps[1])
+
+    def test_adapter_boundary_blocks_until_apply_plan_is_ready(self) -> None:
+        blocked_apply_plan = plan_runner_host_hygiene_apply(
+            policy=RunnerHostHygieneApplyPolicy(approved_hosts=("chris-testing",)),
+            request=RunnerHostHygieneApplyRequest(
+                action="prune_docker_cache",
+                host_name="chris-testing",
+                mutate=True,
+                audit_record_key="runner-host-hygiene/2026-05-23/chris-testing",
+            ),
+            report=_healthy_report(),
+        )
+
+        boundary = plan_runner_host_hygiene_adapter_boundary(
+            policy=_adapter_policy(),
+            proposal=_adapter_proposal(blocked_apply_plan),
+            apply_plan=blocked_apply_plan,
+        )
+
+        self.assertEqual(boundary.status, "blocked")
+        self.assertIn("apply_plan_not_ready", [blocker.code for blocker in boundary.blockers])
+
+    def test_adapter_boundary_rejects_overbroad_privileged_scope(self) -> None:
+        apply_plan = _ready_apply_plan()
+
+        boundary = plan_runner_host_hygiene_adapter_boundary(
+            policy=_adapter_policy(),
+            proposal=RunnerHostHygieneAdapterProposal(
+                adapter_type="github_actions_runner",
+                host_name="chris-testing",
+                execution_lane="chris-testing-ops-gate",
+                service_user="gha",
+                repository_scopes=("cbusillo/launchplane",),
+                privileged_scopes=("docker_cache", "runner_service"),
+                audit_record_key=apply_plan.audit_record_key,
+                rollback_plan="Stop if post-apply evidence cannot be collected.",
+                pre_apply_evidence=("df", "docker_summary", "warm_builders"),
+                post_apply_evidence=("df", "docker_summary", "warm_builders"),
+            ),
+            apply_plan=apply_plan,
+        )
+
+        self.assertEqual(boundary.status, "blocked")
+        self.assertIn("privileged_scope_overbroad", [blocker.code for blocker in boundary.blockers])
+
+    def test_adapter_boundary_requires_repository_scope_evidence_and_rollback(self) -> None:
+        apply_plan = _ready_apply_plan()
+
+        boundary = plan_runner_host_hygiene_adapter_boundary(
+            policy=_adapter_policy(),
+            proposal=RunnerHostHygieneAdapterProposal(
+                adapter_type="github_actions_runner",
+                host_name="chris-testing",
+                execution_lane="chris-testing-ops-gate",
+                service_user="gha",
+                privileged_scopes=("docker_cache",),
+                audit_record_key=apply_plan.audit_record_key,
+                pre_apply_evidence=("df",),
+                post_apply_evidence=("df",),
+            ),
+            apply_plan=apply_plan,
+        )
+
+        self.assertEqual(boundary.status, "blocked")
+        self.assertEqual(
+            [blocker.code for blocker in boundary.blockers],
+            [
+                "post_apply_evidence_missing",
+                "pre_apply_evidence_missing",
+                "repository_scope_required",
+                "rollback_plan_required",
+            ],
+        )
+
+
 class RunnerHostHygieneApplyPlanCliTests(unittest.TestCase):
     def test_cli_builds_apply_plan_from_report_file(self) -> None:
         with TemporaryDirectory() as temp_dir:
@@ -550,6 +654,83 @@ class RunnerHostHygieneApplyPlanCliTests(unittest.TestCase):
             "planned runner host hygiene apply; no host mutation was executed",
         )
 
+    def test_cli_builds_adapter_boundary_from_apply_plan_file(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            apply_plan = _ready_apply_plan()
+            apply_plan_file = Path(temp_dir) / "apply-plan.json"
+            apply_plan_file.write_text(
+                json.dumps({"plan": apply_plan.model_dump(mode="json")}),
+                encoding="utf-8",
+            )
+
+            result = CliRunner().invoke(
+                CLI_MAIN,
+                [
+                    "work-graph",
+                    "runner-host-hygiene-adapter-boundary-plan",
+                    "--adapter-type",
+                    "github_actions_runner",
+                    "--host-name",
+                    "chris-testing",
+                    "--execution-lane",
+                    "chris-testing-ops-gate",
+                    "--service-user",
+                    "gha",
+                    "--repository-scope",
+                    "cbusillo/launchplane",
+                    "--privileged-scope",
+                    "docker_cache",
+                    "--audit-record-key",
+                    apply_plan.audit_record_key,
+                    "--rollback-plan",
+                    "Stop before mutation if retained builders are absent.",
+                    "--pre-apply-evidence",
+                    "df",
+                    "--pre-apply-evidence",
+                    "docker_summary",
+                    "--pre-apply-evidence",
+                    "warm_builders",
+                    "--post-apply-evidence",
+                    "df",
+                    "--post-apply-evidence",
+                    "docker_summary",
+                    "--post-apply-evidence",
+                    "warm_builders",
+                    "--approved-host",
+                    "chris-testing",
+                    "--allowed-adapter-type",
+                    "github_actions_runner",
+                    "--allowed-execution-lane",
+                    "chris-testing-ops-gate",
+                    "--allowed-service-user",
+                    "gha",
+                    "--allowed-repository-scope",
+                    "cbusillo/launchplane",
+                    "--allowed-privileged-scope",
+                    "docker_cache",
+                    "--required-pre-apply-evidence",
+                    "df",
+                    "--required-pre-apply-evidence",
+                    "docker_summary",
+                    "--required-pre-apply-evidence",
+                    "warm_builders",
+                    "--required-post-apply-evidence",
+                    "df",
+                    "--required-post-apply-evidence",
+                    "docker_summary",
+                    "--required-post-apply-evidence",
+                    "warm_builders",
+                    "--apply-plan-file",
+                    apply_plan_file.as_posix(),
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["mode"], "adapter-boundary-plan")
+        self.assertEqual(payload["boundary"]["status"], "ready")
+        self.assertEqual(payload["proposal"]["privileged_scopes"], ["docker_cache"])
+
 
 def _healthy_report() -> RunnerHostHygieneReport:
     return evaluate_runner_host_hygiene(
@@ -571,6 +752,52 @@ def _attention_report() -> RunnerHostHygieneReport:
             observed_at="2026-05-23T13:00:00Z",
             free_disk_bytes=100,
         ),
+    )
+
+
+def _ready_apply_plan() -> RunnerHostHygieneApplyPlan:
+    return plan_runner_host_hygiene_apply(
+        policy=RunnerHostHygieneApplyPolicy(
+            approved_hosts=("chris-testing",),
+            required_retained_warm_builders=("odoo-docker-chris-testing",),
+            allow_docker_cache_prune=True,
+        ),
+        request=RunnerHostHygieneApplyRequest(
+            action="prune_docker_cache",
+            host_name="chris-testing",
+            mutate=True,
+            retained_warm_builders=("odoo-docker-chris-testing",),
+            audit_record_key="runner-host-hygiene/2026-05-23/chris-testing",
+        ),
+        report=_healthy_report(),
+    )
+
+
+def _adapter_policy() -> RunnerHostHygieneAdapterPolicy:
+    return RunnerHostHygieneAdapterPolicy(
+        approved_hosts=("chris-testing",),
+        allowed_adapter_types=("github_actions_runner",),
+        allowed_execution_lanes=("chris-testing-ops-gate",),
+        allowed_service_users=("gha",),
+        allowed_repository_scopes=("cbusillo/launchplane",),
+        allowed_privileged_scopes=("docker_cache",),
+        required_pre_apply_evidence=("df", "docker_summary", "warm_builders"),
+        required_post_apply_evidence=("df", "docker_summary", "warm_builders"),
+    )
+
+
+def _adapter_proposal(apply_plan: RunnerHostHygieneApplyPlan) -> RunnerHostHygieneAdapterProposal:
+    return RunnerHostHygieneAdapterProposal(
+        adapter_type="github_actions_runner",
+        host_name="chris-testing",
+        execution_lane="chris-testing-ops-gate",
+        service_user="gha",
+        repository_scopes=("cbusillo/launchplane",),
+        privileged_scopes=("docker_cache",),
+        audit_record_key=apply_plan.audit_record_key,
+        rollback_plan="Stop if retained builders are missing after pre-apply evidence.",
+        pre_apply_evidence=("df", "docker_summary", "warm_builders"),
+        post_apply_evidence=("df", "docker_summary", "warm_builders"),
     )
 
 


### PR DESCRIPTION
## Summary
- add a typed runner-host hygiene adapter boundary plan before real host mutation exists
- expose a dry-run CLI command for reviewing adapter type, execution lane, service user, repository scope, privileged scope, evidence, rollback, and audit-key requirements
- document the operator workflow and cover ready/blocked boundary cases in tests

## Validation
- `uv run python -m unittest tests.test_runner_host_hygiene`
- `uv run python -m unittest`
- `uv run --extra dev ruff check control_plane/contracts/runner_host_hygiene.py control_plane/cli_runner_lanes.py tests/test_runner_host_hygiene.py`
- `uv run --extra dev ruff format --check control_plane/contracts/runner_host_hygiene.py control_plane/cli_runner_lanes.py tests/test_runner_host_hygiene.py`
- `uv run --extra dev mypy control_plane/contracts/runner_host_hygiene.py control_plane/cli_runner_lanes.py tests/test_runner_host_hygiene.py`
- `git diff --check`
- JetBrains inspection, changed files: clean

Refs #474
