### PR TITLE
Persist runner host hygiene audits

### DIFF
--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -51,6 +51,7 @@ from control_plane.contracts.product_profile_record import LaunchplaneProductPro
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
 from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyPolicyRecord
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
 
 RecordModel = TypeVar("RecordModel", bound=BaseModel)
 
@@ -143,6 +144,15 @@ class FilesystemRecordStore:
             "launchplane_runtime_key_safety_policies", record.record_id, record
         )
 
+    def write_runner_host_hygiene_audit_record(
+        self, record: RunnerHostHygieneApplyAuditRecord
+    ) -> Path:
+        return self._write_model(
+            "launchplane_runner_host_hygiene_audits",
+            _runner_host_hygiene_audit_record_id(record.audit_record_key),
+            record,
+        )
+
     def write_agent_write_intent_record(self, record: AgentWriteIntentRecord) -> Path:
         return self._write_model("launchplane_agent_write_intents", record.record_id, record)
 
@@ -187,12 +197,8 @@ class FilesystemRecordStore:
     def write_merge_train_policy_record(self, record: MergeTrainPolicyRecord) -> Path:
         return self._write_model("launchplane_merge_train_policies", record.record_id, record)
 
-    def write_merge_train_pr_feedback_record(
-        self, record: MergeTrainPrFeedbackRecord
-    ) -> Path:
-        return self._write_model(
-            "launchplane_merge_train_pr_feedback", record.feedback_id, record
-        )
+    def write_merge_train_pr_feedback_record(self, record: MergeTrainPrFeedbackRecord) -> Path:
+        return self._write_model("launchplane_merge_train_pr_feedback", record.feedback_id, record)
 
     def list_merge_train_pr_feedback_records(
         self,
@@ -388,6 +394,28 @@ class FilesystemRecordStore:
             if not status or record.status == status
         ]
         records.sort(key=lambda record: (record.updated_at, record.record_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def list_runner_host_hygiene_audit_records(
+        self,
+        *,
+        host_name: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[RunnerHostHygieneApplyAuditRecord, ...]:
+        normalized_host_name = host_name.strip().lower()
+        records = [
+            record
+            for record in self._list_models(
+                RunnerHostHygieneApplyAuditRecord,
+                "launchplane_runner_host_hygiene_audits",
+            )
+            if (not normalized_host_name or record.request.host_name == normalized_host_name)
+            and (not status or record.status == status)
+        ]
+        records.sort(key=lambda record: record.audit_record_key, reverse=True)
         if limit is not None:
             records = records[:limit]
         return tuple(records)
@@ -1112,3 +1140,8 @@ def _odoo_target_replacement_lane_reservation_id(
     lane_key = "|".join((record.product, record.context, record.instance))
     digest = hashlib.sha256(lane_key.encode()).hexdigest()[:16]
     return f"{record.product}-{record.context}-{record.instance}".replace("/", "-") + f"-{digest}"
+
+
+def _runner_host_hygiene_audit_record_id(audit_record_key: str) -> str:
+    digest = hashlib.sha256(audit_record_key.encode()).hexdigest()[:16]
+    return audit_record_key.strip().replace("/", "-") + f"-{digest}"

--- a/control_plane/storage/migrations/versions/c3e5f7a9b1d2_add_runner_host_hygiene_audits.py
+++ b/control_plane/storage/migrations/versions/c3e5f7a9b1d2_add_runner_host_hygiene_audits.py
@@ -1,0 +1,71 @@
+"""add runner host hygiene audits
+
+Revision ID: c3e5f7a9b1d2
+Revises: c2d4e6f8a0b2
+Create Date: 2026-05-23 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "c3e5f7a9b1d2"
+down_revision: str | None = "c2d4e6f8a0b2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "launchplane_runner_host_hygiene_audits"
+_HOST_INDEX = "launchplane_runner_host_hygiene_audits_host_idx"
+_STATUS_INDEX = "launchplane_runner_host_hygiene_audits_status_idx"
+
+
+def _table_exists(table_name: str) -> bool:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return table_name in set(inspector.get_table_names())
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return index_name in {str(index["name"]) for index in inspector.get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    if not _table_exists(_TABLE):
+        op.create_table(
+            _TABLE,
+            sa.Column("audit_record_key", sa.String(), nullable=False),
+            sa.Column("host_name", sa.String(), nullable=False),
+            sa.Column("action", sa.String(), nullable=False),
+            sa.Column("status", sa.String(), nullable=False),
+            sa.Column("mutate", sa.Integer(), nullable=False),
+            sa.Column(
+                "payload",
+                sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+                nullable=False,
+            ),
+            sa.PrimaryKeyConstraint("audit_record_key"),
+        )
+    if not _index_exists(_TABLE, _HOST_INDEX):
+        op.create_index(
+            _HOST_INDEX,
+            _TABLE,
+            ["host_name", sa.text("audit_record_key DESC")],
+        )
+    if not _index_exists(_TABLE, _STATUS_INDEX):
+        op.create_index(
+            _STATUS_INDEX,
+            _TABLE,
+            ["status", sa.text("audit_record_key DESC")],
+        )
+
+
+def downgrade() -> None:
+    op.drop_index(_STATUS_INDEX, table_name=_TABLE)
+    op.drop_index(_HOST_INDEX, table_name=_TABLE)
+    op.drop_table(_TABLE)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -75,6 +75,7 @@ from control_plane.contracts.runtime_environment_record import (
     RuntimeEnvironmentRecord,
 )
 from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyPolicyRecord
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
 from control_plane.contracts.secret_record import (
     SecretAuditEvent,
     SecretBinding,
@@ -386,6 +387,29 @@ class LaunchplanePreviewPrFeedbackRow(Base):
     requested_at: Mapped[str] = mapped_column(String, nullable=False)
     status: Mapped[str] = mapped_column(String, nullable=False)
     delivery_status: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneRunnerHostHygieneAuditRow(Base):
+    __tablename__ = "launchplane_runner_host_hygiene_audits"
+    __table_args__ = (
+        Index(
+            "launchplane_runner_host_hygiene_audits_host_idx",
+            "host_name",
+            desc("audit_record_key"),
+        ),
+        Index(
+            "launchplane_runner_host_hygiene_audits_status_idx",
+            "status",
+            desc("audit_record_key"),
+        ),
+    )
+
+    audit_record_key: Mapped[str] = mapped_column(String, primary_key=True)
+    host_name: Mapped[str] = mapped_column(String, nullable=False)
+    action: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    mutate: Mapped[int] = mapped_column(Integer, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -2469,6 +2493,41 @@ class PostgresRecordStore(HumanSessionStore):
             limit=limit,
         )
 
+    def write_runner_host_hygiene_audit_record(
+        self, record: RunnerHostHygieneApplyAuditRecord
+    ) -> None:
+        self._write_row(
+            LaunchplaneRunnerHostHygieneAuditRow(
+                audit_record_key=record.audit_record_key,
+                host_name=record.request.host_name,
+                action=record.request.action,
+                status=record.status,
+                mutate=int(record.request.mutate),
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def list_runner_host_hygiene_audit_records(
+        self,
+        *,
+        host_name: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[RunnerHostHygieneApplyAuditRecord, ...]:
+        filters: list[object] = []
+        normalized_host_name = host_name.strip().lower()
+        if normalized_host_name:
+            filters.append(LaunchplaneRunnerHostHygieneAuditRow.host_name == normalized_host_name)
+        if status:
+            filters.append(LaunchplaneRunnerHostHygieneAuditRow.status == status)
+        return self._list_models(
+            model_type=RunnerHostHygieneApplyAuditRecord,
+            orm_model=LaunchplaneRunnerHostHygieneAuditRow,
+            filters=filters,
+            order_by=(LaunchplaneRunnerHostHygieneAuditRow.audit_record_key.desc(),),
+            limit=limit,
+        )
+
     def read_preview_summary(
         self,
         *,
@@ -3209,6 +3268,7 @@ class PostgresRecordStore(HumanSessionStore):
             "preview_lifecycle_cleanups": 0,
             "preview_lifecycle_plans": 0,
             "preview_pr_feedback": 0,
+            "runner_host_hygiene_audits": 0,
             "every_code_preview_gates": 0,
             "agent_write_intents": 0,
             "merge_train_pr_feedback": 0,
@@ -3279,6 +3339,10 @@ class PostgresRecordStore(HumanSessionStore):
             for pr_feedback_record in filesystem_store.list_preview_pr_feedback_records():
                 self.write_preview_pr_feedback_record(pr_feedback_record)
                 counts["preview_pr_feedback"] += 1
+        if hasattr(filesystem_store, "list_runner_host_hygiene_audit_records"):
+            for audit_record in filesystem_store.list_runner_host_hygiene_audit_records():
+                self.write_runner_host_hygiene_audit_record(audit_record)
+                counts["runner_host_hygiene_audits"] += 1
         if hasattr(filesystem_store, "list_every_code_preview_gate_records"):
             for gate_record in filesystem_store.list_every_code_preview_gate_records():
                 self.write_every_code_preview_gate_record(gate_record)

--- a/docs/records.md
+++ b/docs/records.md
@@ -138,6 +138,11 @@ an ORM column/table or remains only in the evidence payload.
 - Secret audit event: modeled fields are `event_id`, `secret_id`, `event_type`,
   and `recorded_at`. Actor, detail, and metadata stay payload-only until audit
   filtering needs more columns.
+- Runner host hygiene audit: modeled fields are `audit_record_key`,
+  `host_name`, `action`, `status`, and `mutate`. The payload carries the typed
+  request, plan, pre/post hygiene reports, retained warm-builder evidence, and
+  operator message. Host-command output, Docker summaries, and rollout notes stay
+  payload-only until they need queryable operational views.
 
 Promote a payload field into ORM structure when Launchplane needs to filter,
 order, join, authorize, constrain, display it regularly, or drive an action from

--- a/docs/runner-host-hygiene.md
+++ b/docs/runner-host-hygiene.md
@@ -93,6 +93,14 @@ When an audit key is provided, the CLI also emits a planned audit-record payload
 That record is a contract for a future Launchplane-owned storage write, not a
 write performed by this local command.
 
+Launchplane storage supports durable runner-host hygiene audit records keyed by
+`audit_record_key`. Shared-service storage promotes the key, host, action,
+status, and mutate intent into columns, while the full typed request, plan,
+pre/post reports, retained warm-builder evidence, and operator message remain in
+the JSON payload. The current CLI still only prints the planned record; a future
+approved executor or service route must write planned, completed, or failed
+records through Launchplane-owned storage.
+
 ## Adapter Boundary Planning
 
 Before a real host mutation adapter is implemented, operators can review the

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -67,6 +67,14 @@ from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeKeySafetyPolicyRecord,
     RuntimeSecretSafetyRule,
 )
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditStatus
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyPolicy
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyRequest
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneObservation
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygienePolicy
+from control_plane.contracts.runner_host_hygiene import evaluate_runner_host_hygiene
+from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene_apply
 from control_plane.storage.filesystem import FilesystemRecordStore
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy_with_codex_skills
 
@@ -158,6 +166,48 @@ def _merge_train_batch_candidate_record(
     )
 
 
+def _runner_host_hygiene_audit_record(
+    *,
+    audit_record_key: str,
+    status: RunnerHostHygieneApplyAuditStatus = "planned",
+    message: str = "planned runner host hygiene apply; no host mutation was executed",
+) -> RunnerHostHygieneApplyAuditRecord:
+    report = evaluate_runner_host_hygiene(
+        policy=RunnerHostHygienePolicy(required_warm_builders=("odoo-docker-chris-testing",)),
+        observation=RunnerHostHygieneObservation(
+            host_name="chris-testing",
+            observed_at="2026-05-23T13:00:00Z",
+            free_disk_bytes=500,
+            warm_builders=("odoo-docker-chris-testing",),
+        ),
+    )
+    request = RunnerHostHygieneApplyRequest(
+        action="prune_docker_cache",
+        host_name="chris-testing",
+        mutate=True,
+        retained_warm_builders=("odoo-docker-chris-testing",),
+        audit_record_key=audit_record_key,
+    )
+    plan = plan_runner_host_hygiene_apply(
+        policy=RunnerHostHygieneApplyPolicy(
+            approved_hosts=("chris-testing",),
+            required_retained_warm_builders=("odoo-docker-chris-testing",),
+            allow_docker_cache_prune=True,
+        ),
+        request=request,
+        report=report,
+    )
+    return RunnerHostHygieneApplyAuditRecord(
+        audit_record_key=audit_record_key,
+        status=status,
+        request=request,
+        plan=plan,
+        pre_apply_report=report,
+        post_apply_report=report if status != "planned" else None,
+        message=message,
+    )
+
+
 def _merge_train_batch_landing_plan_record(
     *,
     record_id: str = "merge-train-batch-landing-plan-20260514T010500Z-active",
@@ -241,6 +291,45 @@ def _merge_train_stack_collapse_plan_record(
 
 
 class FilesystemRecordStoreTests(unittest.TestCase):
+    def test_write_and_list_runner_host_hygiene_audit_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            older_record = _runner_host_hygiene_audit_record(
+                audit_record_key="runner-host-hygiene/2026-05-23/chris-testing"
+            )
+            newer_record = _runner_host_hygiene_audit_record(
+                audit_record_key="runner-host-hygiene/2026-05-24/chris-testing"
+            )
+            failed_record = _runner_host_hygiene_audit_record(
+                audit_record_key="runner-host-hygiene/2026-05-25/chris-testing",
+                status="failed",
+                message="post-apply evidence reported low disk",
+            )
+
+            written_path = store.write_runner_host_hygiene_audit_record(older_record)
+            store.write_runner_host_hygiene_audit_record(newer_record)
+            store.write_runner_host_hygiene_audit_record(failed_record)
+            planned_records = store.list_runner_host_hygiene_audit_records(
+                host_name="Chris-Testing",
+                status="planned",
+            )
+            limited_records = store.list_runner_host_hygiene_audit_records(limit=1)
+
+        self.assertEqual(
+            written_path.parent.relative_to(state_dir).as_posix(),
+            "launchplane_runner_host_hygiene_audits",
+        )
+        self.assertTrue(written_path.name.startswith("runner-host-hygiene-2026-05-23-"))
+        self.assertEqual(
+            [record.audit_record_key for record in planned_records],
+            [newer_record.audit_record_key, older_record.audit_record_key],
+        )
+        self.assertEqual(
+            [record.audit_record_key for record in limited_records],
+            [failed_record.audit_record_key],
+        )
+
     def test_write_and_list_merge_train_pr_feedback_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name)

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -114,6 +114,14 @@ from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeKeySafetyPolicyRecord,
     RuntimeSecretSafetyRule,
 )
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditStatus
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyPolicy
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyRequest
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneObservation
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygienePolicy
+from control_plane.contracts.runner_host_hygiene import evaluate_runner_host_hygiene
+from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene_apply
 from control_plane.contracts.secret_record import (
     SecretAuditEvent,
     SecretBinding,
@@ -223,6 +231,48 @@ def _generic_web_rollback_plan_record(
         target_health=HealthcheckEvidence(status="pass"),
         created_at=created_at,
         summary="generic web rollback plan is ready",
+    )
+
+
+def _runner_host_hygiene_audit_record(
+    *,
+    audit_record_key: str,
+    status: RunnerHostHygieneApplyAuditStatus = "planned",
+    message: str = "planned runner host hygiene apply; no host mutation was executed",
+) -> RunnerHostHygieneApplyAuditRecord:
+    report = evaluate_runner_host_hygiene(
+        policy=RunnerHostHygienePolicy(required_warm_builders=("odoo-docker-chris-testing",)),
+        observation=RunnerHostHygieneObservation(
+            host_name="chris-testing",
+            observed_at="2026-05-23T13:00:00Z",
+            free_disk_bytes=500,
+            warm_builders=("odoo-docker-chris-testing",),
+        ),
+    )
+    request = RunnerHostHygieneApplyRequest(
+        action="prune_docker_cache",
+        host_name="chris-testing",
+        mutate=True,
+        retained_warm_builders=("odoo-docker-chris-testing",),
+        audit_record_key=audit_record_key,
+    )
+    plan = plan_runner_host_hygiene_apply(
+        policy=RunnerHostHygieneApplyPolicy(
+            approved_hosts=("chris-testing",),
+            required_retained_warm_builders=("odoo-docker-chris-testing",),
+            allow_docker_cache_prune=True,
+        ),
+        request=request,
+        report=report,
+    )
+    return RunnerHostHygieneApplyAuditRecord(
+        audit_record_key=audit_record_key,
+        status=status,
+        request=request,
+        plan=plan,
+        pre_apply_report=report,
+        post_apply_report=report if status != "planned" else None,
+        message=message,
     )
 
 
@@ -1889,6 +1939,46 @@ env_var = "GH_TOKEN"
         self.assertEqual(listed_records[0].destroyed_slugs, ("pr-122",))
         self.assertEqual(listed_records[0].results[0].application_id, "app-122")
 
+    def test_runner_host_hygiene_audit_records_round_trip(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            older_record = _runner_host_hygiene_audit_record(
+                audit_record_key="runner-host-hygiene/2026-05-23/chris-testing"
+            )
+            newer_record = _runner_host_hygiene_audit_record(
+                audit_record_key="runner-host-hygiene/2026-05-24/chris-testing"
+            )
+            failed_record = _runner_host_hygiene_audit_record(
+                audit_record_key="runner-host-hygiene/2026-05-25/chris-testing",
+                status="failed",
+                message="post-apply evidence reported low disk",
+            )
+
+            store.write_runner_host_hygiene_audit_record(older_record)
+            store.write_runner_host_hygiene_audit_record(newer_record)
+            store.write_runner_host_hygiene_audit_record(failed_record)
+            planned_records = store.list_runner_host_hygiene_audit_records(
+                host_name="Chris-Testing",
+                status="planned",
+            )
+            limited_records = store.list_runner_host_hygiene_audit_records(limit=1)
+            store.close()
+
+        self.assertEqual(
+            [record.audit_record_key for record in planned_records],
+            [newer_record.audit_record_key, older_record.audit_record_key],
+        )
+        self.assertEqual(
+            [record.audit_record_key for record in limited_records],
+            [failed_record.audit_record_key],
+        )
+        self.assertEqual(limited_records[0].message, "post-apply evidence reported low disk")
+
     def test_preview_pr_feedback_records_round_trip(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(
@@ -2535,6 +2625,11 @@ env_var = "GH_TOKEN"
                     error_message="Launchplane runtime records do not expose GITHUB_TOKEN for this context",
                 )
             )
+            filesystem_store.write_runner_host_hygiene_audit_record(
+                _runner_host_hygiene_audit_record(
+                    audit_record_key="runner-host-hygiene/2026-05-23/chris-testing"
+                )
+            )
             filesystem_store.write_release_tuple_record(_release_tuple_record())
             filesystem_store.write_product_profile_record(_product_profile_record())
             filesystem_store.write_runtime_key_safety_policy_record(
@@ -2636,6 +2731,7 @@ env_var = "GH_TOKEN"
                     "preview_lifecycle_cleanups": 1,
                     "preview_lifecycle_plans": 1,
                     "preview_pr_feedback": 1,
+                    "runner_host_hygiene_audits": 1,
                     "every_code_preview_gates": 0,
                     "agent_write_intents": 0,
                     "merge_train_pr_feedback": 0,
@@ -2720,6 +2816,13 @@ env_var = "GH_TOKEN"
                     limit=1,
                 )[0].feedback_id,
                 "preview-pr-feedback-verireel-testing-pr-123-20260420T100800Z",
+            )
+            self.assertEqual(
+                store.list_runner_host_hygiene_audit_records(
+                    host_name="chris-testing",
+                    limit=1,
+                )[0].audit_record_key,
+                "runner-host-hygiene/2026-05-23/chris-testing",
             )
             self.assertEqual(
                 store.list_runtime_key_safety_policy_records(status="active", limit=1)[0]


### PR DESCRIPTION
## Summary
- add Launchplane-owned filesystem and Postgres storage for runner-host hygiene audit records
- add an Alembic migration for `launchplane_runner_host_hygiene_audits`, including idempotent upgrade behavior for stamped schemas that already have the ORM-created table
- document the audit record family and cover storage/import round trips

## Validation
- `uv run python -m unittest tests.test_filesystem_store tests.test_postgres_store`
- `uv run --extra dev ruff check control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/c3e5f7a9b1d2_add_runner_host_hygiene_audits.py tests/test_filesystem_store.py tests/test_postgres_store.py`
- `uv run --extra dev ruff format --check control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/c3e5f7a9b1d2_add_runner_host_hygiene_audits.py tests/test_filesystem_store.py tests/test_postgres_store.py`
- `uv run --extra dev mypy control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/c3e5f7a9b1d2_add_runner_host_hygiene_audits.py tests/test_filesystem_store.py tests/test_postgres_store.py`
- `git diff --check`
- JetBrains inspection, changed files: clean

Refs #474
