### PR TITLE
Add runner host hygiene audit evidence route

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -167,6 +167,7 @@ from control_plane.contracts.promotion_record import (
     ReleaseStatus,
 )
 from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyTarget
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
 from control_plane.runtime_key_safety import (
     evaluate_runtime_key_safety_from_store,
     latest_active_runtime_key_safety_policy,
@@ -796,6 +797,21 @@ class DeploymentEvidenceEnvelope(BaseModel):
     def _validate_alignment(self) -> "DeploymentEvidenceEnvelope":
         if not self.product.strip():
             raise ValueError("deployment evidence requires product")
+        return self
+
+
+class RunnerHostHygieneAuditEvidenceEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    audit: RunnerHostHygieneApplyAuditRecord
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "RunnerHostHygieneAuditEvidenceEnvelope":
+        if self.product.strip() != "launchplane":
+            raise ValueError("runner host hygiene audit evidence requires product 'launchplane'")
+        self.product = "launchplane"
         return self
 
 
@@ -2695,6 +2711,7 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/work-graph/rank",
         "/v1/evidence/deployments",
         "/v1/evidence/backup-gates",
+        "/v1/evidence/runner-host-hygiene/audits",
         "/v1/evidence/previews/generations",
         "/v1/evidence/previews/destroyed",
         "/v1/authz-policies/github-actions/grants",
@@ -4692,6 +4709,7 @@ def _accepted_payload(
         "merge_train_run_id",
         "odoo_stable_bootstrap_operation_id",
         "odoo_stable_target_replacement_operation_id",
+        "runner_host_hygiene_audit_record_key",
     }
     records: dict[str, object] = {}
     for key, value in result.items():
@@ -8615,12 +8633,16 @@ def create_launchplane_service_app(
                             start_response=start_response,
                         )
 
-                    if control_plane_product_read_service.is_product_environment_detail_request(params):
+                    if control_plane_product_read_service.is_product_environment_detail_request(
+                        params
+                    ):
                         try:
                             product_read_store = control_plane_product_read_service.require_product_environment_read_model_store(
                                 record_store
                             )
-                        except control_plane_product_read_service.ProductReadModelStoreCapabilityError as error:
+                        except (
+                            control_plane_product_read_service.ProductReadModelStoreCapabilityError
+                        ) as error:
                             return _json_response(
                                 start_response=start_response,
                                 status_code=503,
@@ -8712,7 +8734,9 @@ def create_launchplane_service_app(
                         product_read_store = control_plane_product_read_service.require_product_environment_read_model_store(
                             record_store
                         )
-                    except control_plane_product_read_service.ProductReadModelStoreCapabilityError as error:
+                    except (
+                        control_plane_product_read_service.ProductReadModelStoreCapabilityError
+                    ) as error:
                         return _json_response(
                             start_response=start_response,
                             status_code=503,
@@ -10415,6 +10439,51 @@ def create_launchplane_service_app(
                     return idempotent_response
                 record_store.write_backup_gate_record(backup_gate_request.backup_gate)
                 result = {"backup_gate_record_id": backup_gate_request.backup_gate.record_id}
+            elif path == "/v1/evidence/runner-host-hygiene/audits":
+                runner_host_hygiene_request = RunnerHostHygieneAuditEvidenceEnvelope.model_validate(
+                    payload
+                )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="runner_host_hygiene_audit.write",
+                    product=runner_host_hygiene_request.product,
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot write runner host hygiene audit evidence."
+                                ),
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                record_store.write_runner_host_hygiene_audit_record(
+                    runner_host_hygiene_request.audit
+                )
+                result = {
+                    "runner_host_hygiene_audit_record_key": runner_host_hygiene_request.audit.audit_record_key,
+                    "host_name": runner_host_hygiene_request.audit.request.host_name,
+                    "audit_status": runner_host_hygiene_request.audit.status,
+                    "mutate": str(runner_host_hygiene_request.audit.request.mutate).lower(),
+                }
+                driver_result = {"audit": runner_host_hygiene_request.audit.model_dump(mode="json")}
             elif path == "/v1/product-config/apply":
                 product_config_request, product_config_response = (
                     validate_product_config_apply_request(

--- a/docs/runner-host-hygiene.md
+++ b/docs/runner-host-hygiene.md
@@ -97,9 +97,11 @@ Launchplane storage supports durable runner-host hygiene audit records keyed by
 `audit_record_key`. Shared-service storage promotes the key, host, action,
 status, and mutate intent into columns, while the full typed request, plan,
 pre/post reports, retained warm-builder evidence, and operator message remain in
-the JSON payload. The current CLI still only prints the planned record; a future
-approved executor or service route must write planned, completed, or failed
-records through Launchplane-owned storage.
+the JSON payload. `POST /v1/evidence/runner-host-hygiene/audits` accepts planned,
+completed, and failed audit records for product/context `launchplane/launchplane`
+under `runner_host_hygiene_audit.write`. The current CLI still only prints the
+planned record; a future approved executor must call the service route after it
+captures the required pre/post host evidence.
 
 ## Adapter Boundary Planning
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -43,6 +43,7 @@ VeriReel product paths:
   - `POST /v1/evidence/promotions`
   - `POST /v1/evidence/previews/generations`
   - `POST /v1/evidence/previews/destroyed`
+  - `POST /v1/evidence/runner-host-hygiene/audits`
 - product profile routes:
   - `GET /v1/product-profiles`
   - `GET /v1/product-profiles/{product}`
@@ -1292,6 +1293,35 @@ evidence ingestion only; it does not mutate provider state.
 
 The deployment and promotion endpoints should follow the same pattern: stable
 typed record payloads inside a Launchplane-owned API envelope.
+
+### Runner host hygiene audit evidence
+
+`POST /v1/evidence/runner-host-hygiene/audits`
+
+Request payload:
+
+```json
+{
+  "schema_version": 1,
+  "product": "launchplane",
+  "audit": {
+    "schema_version": 1,
+    "audit_record_key": "runner-host-hygiene/2026-05-23/chris-testing",
+    "status": "planned",
+    "request": "RunnerHostHygieneApplyRequest",
+    "plan": "RunnerHostHygieneApplyPlan",
+    "pre_apply_report": "RunnerHostHygieneReport",
+    "post_apply_report": null,
+    "message": "planned runner host hygiene apply; no host mutation was executed"
+  }
+}
+```
+
+The route requires `runner_host_hygiene_audit.write` for product/context
+`launchplane/launchplane`, writes the typed audit record to Launchplane-owned
+storage, and returns the `runner_host_hygiene_audit_record_key`. It is evidence
+ingress only: it records planned, completed, or failed audit facts supplied by a
+future approved executor, but it does not mutate runner hosts itself.
 
 For VeriReel's first stable-lane Launchplane slice, use context `verireel` for the
 long-lived `testing` and `prod` instances. Preview evidence remains separate

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -84,6 +84,15 @@ from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeKeySafetyPolicyRecord,
     RuntimeSecretSafetyRule,
 )
+from control_plane.contracts.runner_host_hygiene import (
+    RunnerHostHygieneApplyAuditRecord,
+    RunnerHostHygieneApplyPolicy,
+    RunnerHostHygieneApplyRequest,
+    RunnerHostHygieneObservation,
+    RunnerHostHygienePolicy,
+    evaluate_runner_host_hygiene,
+    plan_runner_host_hygiene_apply,
+)
 from control_plane.contracts.secret_record import SecretBinding
 from control_plane.contracts.work_graph_read_model import WorkGraphPlanningIssueFacts
 from control_plane.work_graph_issue_inbox import GitHubIssueInboxReadModel
@@ -980,6 +989,47 @@ def _write_runtime_key_safety_policy(
         )
     finally:
         store.close()
+
+
+def _runner_host_hygiene_audit_payload(
+    *,
+    audit_record_key: str = "runner-host-hygiene/2026-05-23/chris-testing",
+    product: str = "launchplane",
+) -> dict[str, object]:
+    report = evaluate_runner_host_hygiene(
+        policy=RunnerHostHygienePolicy(required_warm_builders=("odoo-docker-chris-testing",)),
+        observation=RunnerHostHygieneObservation(
+            host_name="chris-testing",
+            observed_at="2026-05-23T13:00:00Z",
+            free_disk_bytes=500,
+            warm_builders=("odoo-docker-chris-testing",),
+        ),
+    )
+    request = RunnerHostHygieneApplyRequest(
+        action="prune_docker_cache",
+        host_name="chris-testing",
+        mutate=False,
+        retained_warm_builders=("odoo-docker-chris-testing",),
+        audit_record_key=audit_record_key,
+    )
+    plan = plan_runner_host_hygiene_apply(
+        policy=RunnerHostHygieneApplyPolicy(
+            approved_hosts=("chris-testing",),
+            required_retained_warm_builders=("odoo-docker-chris-testing",),
+            allow_docker_cache_prune=True,
+        ),
+        request=request,
+        report=report,
+    )
+    audit_record = RunnerHostHygieneApplyAuditRecord(
+        audit_record_key=audit_record_key,
+        status="planned",
+        request=request,
+        plan=plan,
+        pre_apply_report=report,
+        message="planned runner host hygiene apply; no host mutation was executed",
+    )
+    return {"schema_version": 1, "product": product, "audit": audit_record.model_dump(mode="json")}
 
 
 def _write_dokploy_managed_secrets(*, store: PostgresRecordStore) -> None:
@@ -10741,10 +10791,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         )
         self.assertEqual(payload["products"][0]["driver_id"], "generic-web")
         self.assertEqual(
-            [
-                environment["environment"]
-                for environment in payload["products"][0]["environments"]
-            ],
+            [environment["environment"] for environment in payload["products"][0]["environments"]],
             ["testing", "prod"],
         )
 
@@ -19972,6 +20019,189 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     },
                 ),
             )
+
+    def test_runner_host_hygiene_audit_endpoint_writes_record_for_authorized_workflow(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/runner-host-hygiene.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["runner_host_hygiene_audit.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/runner-host-hygiene.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/evidence/runner-host-hygiene/audits",
+                payload=_runner_host_hygiene_audit_payload(),
+            )
+
+            self.assertEqual(status_code, 202, msg=json.dumps(payload, indent=2))
+            self.assertEqual(payload["status"], "accepted")
+            self.assertEqual(
+                payload["records"],
+                {
+                    "runner_host_hygiene_audit_record_key": (
+                        "runner-host-hygiene/2026-05-23/chris-testing"
+                    ),
+                },
+            )
+            self.assertEqual(payload["result"]["audit"]["status"], "planned")
+            store = FilesystemRecordStore(state_dir=state_dir)
+            records = store.list_runner_host_hygiene_audit_records(
+                host_name="chris-testing", status="planned"
+            )
+            self.assertEqual(len(records), 1)
+            self.assertEqual(
+                records[0].audit_record_key,
+                "runner-host-hygiene/2026-05-23/chris-testing",
+            )
+            self.assertFalse(records[0].request.mutate)
+
+    def test_runner_host_hygiene_audit_endpoint_replays_idempotent_write(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/runner-host-hygiene.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["runner_host_hygiene_audit.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/runner-host-hygiene.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            request_payload = _runner_host_hygiene_audit_payload()
+
+            first_status_code, first_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/evidence/runner-host-hygiene/audits",
+                payload=request_payload,
+                headers={"Idempotency-Key": "runner-host-hygiene:chris-testing:planned"},
+            )
+            second_status_code, second_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/evidence/runner-host-hygiene/audits",
+                payload=request_payload,
+                headers={"Idempotency-Key": "runner-host-hygiene:chris-testing:planned"},
+            )
+
+            self.assertEqual(first_status_code, 202, msg=json.dumps(first_payload, indent=2))
+            self.assertEqual(second_status_code, 202, msg=json.dumps(second_payload, indent=2))
+            self.assertEqual(first_payload["records"], second_payload["records"])
+            self.assertTrue(second_payload["replayed"])
+            self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
+
+    def test_runner_host_hygiene_audit_endpoint_rejects_unauthorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/evidence/runner-host-hygiene/audits",
+                payload=_runner_host_hygiene_audit_payload(),
+            )
+
+            self.assertEqual(status_code, 403)
+            self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_runner_host_hygiene_audit_endpoint_rejects_non_launchplane_product(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": ["*"],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["runner_host_hygiene_audit.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/evidence/runner-host-hygiene/audits",
+                payload=_runner_host_hygiene_audit_payload(product="odoo"),
+            )
+
+            self.assertEqual(status_code, 400)
+            self.assertEqual(payload["error"]["code"], "invalid_request")
 
     def test_preview_destroyed_endpoint_writes_records_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary

- add authenticated `POST /v1/evidence/runner-host-hygiene/audits` evidence ingress
- authorize writes with `runner_host_hygiene_audit.write` for `launchplane/launchplane`
- persist typed planned/completed/failed runner-host hygiene audit records through Launchplane-owned storage
- document the service route and update runner-host hygiene storage guidance

Refs #474

## Validation

- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_runner_host_hygiene_audit_endpoint_writes_record_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_runner_host_hygiene_audit_endpoint_replays_idempotent_write tests.test_service.LaunchplaneServiceTests.test_runner_host_hygiene_audit_endpoint_rejects_unauthorized_workflow tests.test_service.LaunchplaneServiceTests.test_runner_host_hygiene_audit_endpoint_rejects_non_launchplane_product`
- `uv run --extra dev ruff check --diff control_plane/service.py tests/test_service.py docs/service-boundary.md docs/runner-host-hygiene.md`
- `uv run --extra dev ruff check control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/service.py tests/test_service.py`
- `uv run --extra dev mypy control_plane/service.py tests/test_service.py`
- `uv run python -m unittest tests.test_service tests.test_runner_host_hygiene tests.test_filesystem_store tests.test_postgres_store`
- `uv run ~/.code/skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope files --file control_plane/service.py --file tests/test_service.py --file docs/service-boundary.md --file docs/runner-host-hygiene.md`
