### PR TITLE
Expose runner host hygiene audit response summary

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -10479,11 +10479,14 @@ def create_launchplane_service_app(
                 )
                 result = {
                     "runner_host_hygiene_audit_record_key": runner_host_hygiene_request.audit.audit_record_key,
+                }
+                driver_result = {
+                    "runner_host_hygiene_audit_record_key": runner_host_hygiene_request.audit.audit_record_key,
                     "host_name": runner_host_hygiene_request.audit.request.host_name,
                     "audit_status": runner_host_hygiene_request.audit.status,
-                    "mutate": str(runner_host_hygiene_request.audit.request.mutate).lower(),
+                    "mutate": runner_host_hygiene_request.audit.request.mutate,
+                    "audit": runner_host_hygiene_request.audit.model_dump(mode="json"),
                 }
-                driver_result = {"audit": runner_host_hygiene_request.audit.model_dump(mode="json")}
             elif path == "/v1/product-config/apply":
                 product_config_request, product_config_response = (
                     validate_product_config_apply_request(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -20074,6 +20074,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ),
                 },
             )
+            self.assertEqual(
+                payload["result"]["runner_host_hygiene_audit_record_key"],
+                "runner-host-hygiene/2026-05-23/chris-testing",
+            )
+            self.assertEqual(payload["result"]["host_name"], "chris-testing")
+            self.assertEqual(payload["result"]["audit_status"], "planned")
+            self.assertFalse(payload["result"]["mutate"])
             self.assertEqual(payload["result"]["audit"]["status"], "planned")
             store = FilesystemRecordStore(state_dir=state_dir)
             records = store.list_runner_host_hygiene_audit_records(


### PR DESCRIPTION
## Summary

- surface runner-host hygiene audit response summary fields under `result`
- keep the audit record key in `records` for standard accepted-payload record discovery
- add service coverage for the visible response shape

Fixes the auto-review finding from PR #876.
Refs #474

## Validation

- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_runner_host_hygiene_audit_endpoint_writes_record_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_runner_host_hygiene_audit_endpoint_replays_idempotent_write`
- `uv run --extra dev ruff check --diff control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/service.py tests/test_service.py`
- `uv run --extra dev mypy control_plane/service.py tests/test_service.py`
- `uv run ~/.code/skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope files --file control_plane/service.py --file tests/test_service.py`
