### PR TITLE
Add runner host hygiene SSH executor

### DIFF
--- a/.github/workflows/runner-host-hygiene.yml
+++ b/.github/workflows/runner-host-hygiene.yml
@@ -1,0 +1,137 @@
+---
+name: Runner Host Hygiene
+
+"on":
+  workflow_dispatch:
+    inputs:
+      audit_record_key:
+        description: Launchplane audit record key
+        required: true
+        type: string
+      mutate:
+        description: Execute the approved Docker cache prune
+        required: true
+        default: false
+        type: boolean
+      minimum_free_disk_bytes:
+        description: Minimum free disk bytes required in pre/post evidence
+        required: false
+        default: "0"
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: runner-host-hygiene-${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_HOST }}
+  cancel-in-progress: false
+
+jobs:
+  docker-cache-prune:
+    runs-on: ubuntu-latest
+    env:
+      LAUNCHPLANE_SERVICE_URL: >-
+        ${{ vars.LAUNCHPLANE_PUBLIC_URL ||
+        'https://launchplane.shinycomputers.com' }}
+      RUNNER_HOST_NAME: ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_HOST }}
+      RUNNER_EXECUTION_LANE: >-
+        ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_EXECUTION_LANE }}
+      RUNNER_SERVICE_USER: >-
+        ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_SERVICE_USER }}
+      RUNNER_REPOSITORY_SCOPE: ${{ github.repository }}
+      RUNNER_RETAINED_WARM_BUILDERS: >-
+        ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_RETAINED_WARM_BUILDERS }}
+      LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_HOST: >-
+        ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_HOST }}
+      LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_USER: >-
+        ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_USER }}
+      LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_PRIVATE_KEY: >-
+        ${{ secrets.LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_PRIVATE_KEY }}
+      LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_KNOWN_HOSTS: >-
+        ${{ secrets.LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_KNOWN_HOSTS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Run approved runner host hygiene executor
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          require_env() {
+            local name="$1"
+            if [ -z "${!name:-}" ]; then
+              echo "Missing ${name}." >&2
+              exit 1
+            fi
+          }
+          require_env RUNNER_HOST_NAME
+          require_env RUNNER_EXECUTION_LANE
+          require_env RUNNER_SERVICE_USER
+          require_env RUNNER_RETAINED_WARM_BUILDERS
+          require_env LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_HOST
+          require_env LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_USER
+          require_env LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_PRIVATE_KEY
+          require_env LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_KNOWN_HOSTS
+
+          service_audience="$({
+            python3 - <<'PY'
+          import os
+          from urllib.parse import urlsplit
+
+          parsed = urlsplit(os.environ["LAUNCHPLANE_SERVICE_URL"].strip())
+          if not parsed.hostname:
+              raise SystemExit("service URL must include a hostname.")
+          print(parsed.hostname)
+          PY
+          })"
+          token_json="$(curl -fsSL \
+            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${service_audience}")"
+          oidc_token="$(jq -r '.value' <<<"$token_json")"
+          if [ -z "$oidc_token" ] || [ "$oidc_token" = "null" ]; then
+            echo "GitHub OIDC token response did not include a token." >&2
+            exit 1
+          fi
+          export LAUNCHPLANE_SERVICE_TOKEN="$oidc_token"
+
+          builder_args=()
+          IFS=',' read -r -a builders <<< "$RUNNER_RETAINED_WARM_BUILDERS"
+          for builder in "${builders[@]}"; do
+            trimmed="$(xargs <<< "$builder")"
+            if [ -n "$trimmed" ]; then
+              builder_args+=(--retained-warm-builder "$trimmed")
+            fi
+          done
+          if [ "${#builder_args[@]}" -eq 0 ]; then
+            echo "At least one retained warm builder is required." >&2
+            exit 1
+          fi
+
+          mutate_flag="--dry-run"
+          if [ "${{ inputs.mutate }}" = "true" ]; then
+            mutate_flag="--mutate"
+          fi
+
+          uv run launchplane work-graph runner-host-hygiene-ssh-executor \
+            --host-name "$RUNNER_HOST_NAME" \
+            --execution-lane "$RUNNER_EXECUTION_LANE" \
+            --service-user "$RUNNER_SERVICE_USER" \
+            --repository-scope "$RUNNER_REPOSITORY_SCOPE" \
+            --audit-record-key "${{ inputs.audit_record_key }}" \
+            "${builder_args[@]}" \
+            "$mutate_flag" \
+            --minimum-free-disk-bytes "${{ inputs.minimum_free_disk_bytes }}" \
+            --service-url "$LAUNCHPLANE_SERVICE_URL" \
+            | tee runner-host-hygiene-result.json
+
+      - name: Upload executor result
+        uses: actions/upload-artifact@v7
+        with:
+          name: runner-host-hygiene-result
+          path: runner-host-hygiene-result.json
+          if-no-files-found: error

--- a/control_plane/cli_runner_lanes.py
+++ b/control_plane/cli_runner_lanes.py
@@ -34,6 +34,15 @@ from control_plane.merge_train_github import MergeTrainGitHubError
 from control_plane.merge_train_github import UrllibMergeTrainGitHubTransport
 from control_plane.runner_lane_github import GitHubRunnerLaneInventoryReader
 from control_plane.runner_queue_wait_github import GitHubRunnerQueueWaitReader
+from control_plane.workflows.runner_host_hygiene_executor import (
+    RunnerHostHygieneSshExecutorRequest,
+)
+from control_plane.workflows.runner_host_hygiene_executor import build_service_audit_poster
+from control_plane.workflows.runner_host_hygiene_executor import build_ssh_remote_runner
+from control_plane.workflows.runner_host_hygiene_executor import (
+    execute_runner_host_hygiene_ssh_executor,
+)
+from control_plane.workflows.runner_host_hygiene_executor import validate_ssh_executor_environment
 from control_plane.workflows.ship import utc_now_timestamp
 
 
@@ -47,6 +56,10 @@ def register_runner_lane_commands(work_graph: click.Group) -> None:
     work_graph.add_command(
         runner_host_hygiene_adapter_boundary_plan,
         name="runner-host-hygiene-adapter-boundary-plan",
+    )
+    work_graph.add_command(
+        runner_host_hygiene_ssh_executor,
+        name="runner-host-hygiene-ssh-executor",
     )
 
 
@@ -791,6 +804,116 @@ def runner_host_hygiene_adapter_boundary_plan(
             sort_keys=True,
         )
     )
+
+
+@click.command("runner-host-hygiene-ssh-executor")
+@click.option(
+    "--host-name",
+    required=True,
+    help="Approved runner host name. Must match the configured SSH target boundary.",
+)
+@click.option(
+    "--execution-lane",
+    required=True,
+    help="Approved execution lane label for this privileged host action.",
+)
+@click.option(
+    "--service-user",
+    required=True,
+    help="Constrained SSH service user expected on the remote host.",
+)
+@click.option(
+    "--repository-scope",
+    required=True,
+    help="owner/name repository scope approved for this executor run.",
+)
+@click.option(
+    "--audit-record-key",
+    required=True,
+    help="Launchplane-owned audit record key to write through the service route.",
+)
+@click.option(
+    "--retained-warm-builder",
+    "retained_warm_builders",
+    multiple=True,
+    required=True,
+    help="Warm builder image/tag that must remain after cleanup. Repeat as needed.",
+)
+@click.option(
+    "--mutate/--dry-run",
+    default=False,
+    show_default=True,
+    help="Require explicit mutate=true before the executor runs Docker cache prune.",
+)
+@click.option(
+    "--minimum-free-disk-bytes",
+    default=0,
+    show_default=True,
+    type=click.IntRange(min=0),
+    help="Minimum post/pre free disk policy in bytes.",
+)
+@click.option(
+    "--timeout-seconds",
+    default=120,
+    show_default=True,
+    type=click.IntRange(min=1),
+    help="Timeout for each remote evidence or prune command.",
+)
+@click.option(
+    "--service-url",
+    required=True,
+    help="Launchplane service origin, for example https://launchplane.example.com.",
+)
+@click.option(
+    "--bearer-token-env",
+    default="LAUNCHPLANE_SERVICE_TOKEN",
+    show_default=True,
+    help="Environment variable containing a GitHub OIDC bearer token.",
+)
+def runner_host_hygiene_ssh_executor(
+    host_name: str,
+    execution_lane: str,
+    service_user: str,
+    repository_scope: str,
+    audit_record_key: str,
+    retained_warm_builders: tuple[str, ...],
+    mutate: bool,
+    minimum_free_disk_bytes: int,
+    timeout_seconds: int,
+    service_url: str,
+    bearer_token_env: str,
+) -> None:
+    try:
+        token_env = bearer_token_env.strip()
+        if not token_env:
+            raise click.ClickException("runner host hygiene executor requires --bearer-token-env.")
+        bearer_token = os.environ.get(token_env, "").strip()
+        if not bearer_token:
+            raise click.ClickException(f"Missing Launchplane bearer token in {token_env}.")
+        request = RunnerHostHygieneSshExecutorRequest(
+            action="prune_docker_cache",
+            host_name=host_name,
+            execution_lane=execution_lane,
+            service_user=service_user,
+            repository_scope=repository_scope,
+            audit_record_key=audit_record_key,
+            retained_warm_builders=retained_warm_builders,
+            mutate=mutate,
+            minimum_free_disk_bytes=minimum_free_disk_bytes,
+            timeout_seconds=timeout_seconds,
+        )
+        validate_ssh_executor_environment(request=request)
+        result = execute_runner_host_hygiene_ssh_executor(
+            request=request,
+            remote_runner=build_ssh_remote_runner(),
+            audit_poster=build_service_audit_poster(
+                service_url=service_url,
+                bearer_token=bearer_token,
+            ),
+        )
+    except (OSError, ValidationError, ValueError) as error:
+        raise click.ClickException(str(error)) from error
+    click.echo(json.dumps(result.model_dump(mode="json"), indent=2, sort_keys=True))
 
 
 def _load_runner_lane_inventory(inventory_file: Path) -> RunnerLaneInventory:

--- a/control_plane/workflows/runner_host_hygiene_executor.py
+++ b/control_plane/workflows/runner_host_hygiene_executor.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import subprocess
+from tempfile import TemporaryDirectory
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+import click
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAction
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditStatus
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyPolicy
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyRequest
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneObservation
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygienePolicy
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneReport
+from control_plane.contracts.runner_host_hygiene import evaluate_runner_host_hygiene
+from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene_apply
+from control_plane.workflows.ship import utc_now_timestamp
+
+
+SSH_PRIVATE_KEY_ENV_VAR = "LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_PRIVATE_KEY"
+SSH_KNOWN_HOSTS_ENV_VAR = "LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_KNOWN_HOSTS"
+SSH_HOST_ENV_VAR = "LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_HOST"
+SSH_USER_ENV_VAR = "LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_USER"
+AUDIT_ROUTE_PATH = "/v1/evidence/runner-host-hygiene/audits"
+
+
+@dataclass(frozen=True)
+class RemoteCommandResult:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+RemoteCommandRunner = Callable[[Sequence[str], int], RemoteCommandResult]
+AuditPoster = Callable[[RunnerHostHygieneApplyAuditRecord, str], dict[str, object]]
+
+
+class RunnerHostHygieneSshExecutorRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    action: RunnerHostHygieneApplyAction
+    host_name: str
+    execution_lane: str
+    service_user: str
+    repository_scope: str
+    audit_record_key: str
+    retained_warm_builders: tuple[str, ...]
+    mutate: bool = False
+    minimum_free_disk_bytes: int = Field(default=0, ge=0)
+    timeout_seconds: int = Field(default=120, ge=1)
+
+    @model_validator(mode="after")
+    def _validate_first_lane(self) -> "RunnerHostHygieneSshExecutorRequest":
+        if self.action != "prune_docker_cache":
+            raise ValueError("runner host SSH executor only supports prune_docker_cache")
+        self.host_name = self.host_name.strip()
+        self.execution_lane = self.execution_lane.strip()
+        self.service_user = self.service_user.strip()
+        self.repository_scope = self.repository_scope.strip()
+        self.audit_record_key = self.audit_record_key.strip()
+        self.retained_warm_builders = tuple(
+            token.strip().lower() for token in self.retained_warm_builders if token.strip()
+        )
+        if not self.host_name:
+            raise ValueError("runner host SSH executor requires host_name")
+        if not self.execution_lane:
+            raise ValueError("runner host SSH executor requires execution_lane")
+        if not self.service_user:
+            raise ValueError("runner host SSH executor requires service_user")
+        if "/" not in self.repository_scope:
+            raise ValueError("runner host SSH executor requires repository_scope as owner/name")
+        if not self.audit_record_key:
+            raise ValueError("runner host SSH executor requires audit_record_key")
+        if not self.retained_warm_builders:
+            raise ValueError("runner host SSH executor requires retained_warm_builders")
+        return self
+
+
+class RunnerHostHygieneSshExecutorResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: str
+    audit_record_key: str
+    planned_response: dict[str, object]
+    terminal_response: dict[str, object] | None = None
+    message: str
+
+
+def execute_runner_host_hygiene_ssh_executor(
+    *,
+    request: RunnerHostHygieneSshExecutorRequest,
+    remote_runner: RemoteCommandRunner,
+    audit_poster: AuditPoster,
+) -> RunnerHostHygieneSshExecutorResult:
+    pre_report = collect_runner_host_hygiene_report(
+        request=request,
+        remote_runner=remote_runner,
+    )
+    apply_request = RunnerHostHygieneApplyRequest(
+        action=request.action,
+        host_name=request.host_name,
+        mutate=request.mutate,
+        retained_warm_builders=request.retained_warm_builders,
+        audit_record_key=request.audit_record_key,
+    )
+    apply_plan = plan_runner_host_hygiene_apply(
+        policy=RunnerHostHygieneApplyPolicy(
+            approved_hosts=(request.host_name,),
+            required_retained_warm_builders=request.retained_warm_builders,
+            allow_docker_cache_prune=True,
+        ),
+        request=apply_request,
+        report=pre_report,
+    )
+    planned_audit = RunnerHostHygieneApplyAuditRecord(
+        audit_record_key=request.audit_record_key,
+        status="planned",
+        request=apply_request,
+        plan=apply_plan,
+        pre_apply_report=pre_report,
+        message="planned runner host hygiene apply; no host mutation was executed yet",
+    )
+    planned_response = audit_poster(
+        planned_audit,
+        f"runner-host-hygiene:{request.audit_record_key}:planned",
+    )
+    if apply_plan.status != "ready":
+        return RunnerHostHygieneSshExecutorResult(
+            status="blocked",
+            audit_record_key=request.audit_record_key,
+            planned_response=planned_response,
+            message=apply_plan.summary,
+        )
+
+    prune_result = remote_runner(
+        ("docker", "builder", "prune", "--all", "--force"), request.timeout_seconds
+    )
+    post_report = collect_runner_host_hygiene_report(
+        request=request,
+        remote_runner=remote_runner,
+    )
+    terminal_status: RunnerHostHygieneApplyAuditStatus = (
+        "completed"
+        if prune_result.returncode == 0 and post_report.status == "healthy"
+        else "failed"
+    )
+    terminal_message = _terminal_message(prune_result=prune_result, post_report=post_report)
+    terminal_audit = RunnerHostHygieneApplyAuditRecord(
+        audit_record_key=request.audit_record_key,
+        status=terminal_status,
+        request=apply_request,
+        plan=apply_plan,
+        pre_apply_report=pre_report,
+        post_apply_report=post_report,
+        message=terminal_message,
+    )
+    terminal_response = audit_poster(
+        terminal_audit,
+        f"runner-host-hygiene:{request.audit_record_key}:{terminal_status}",
+    )
+    return RunnerHostHygieneSshExecutorResult(
+        status=terminal_status,
+        audit_record_key=request.audit_record_key,
+        planned_response=planned_response,
+        terminal_response=terminal_response,
+        message=terminal_message,
+    )
+
+
+def collect_runner_host_hygiene_report(
+    *,
+    request: RunnerHostHygieneSshExecutorRequest,
+    remote_runner: RemoteCommandRunner,
+) -> RunnerHostHygieneReport:
+    df_result = _require_remote_success(
+        remote_runner(("df", "-B1", "-P", "/"), request.timeout_seconds),
+        evidence_name="df",
+    )
+    docker_summary = _require_remote_success(
+        remote_runner(("docker", "system", "df"), request.timeout_seconds),
+        evidence_name="docker_summary",
+    )
+    warm_builders = tuple(
+        builder
+        for builder in request.retained_warm_builders
+        if remote_runner(
+            ("docker", "image", "inspect", builder), request.timeout_seconds
+        ).returncode
+        == 0
+    )
+    observation = RunnerHostHygieneObservation(
+        host_name=request.host_name,
+        observed_at=utc_now_timestamp(),
+        free_disk_bytes=_parse_df_available_bytes(df_result.stdout),
+        warm_builders=warm_builders,
+        notes=(
+            f"execution_lane={request.execution_lane}",
+            f"service_user={request.service_user}",
+            f"repository_scope={request.repository_scope}",
+            f"docker_summary={_compact_evidence(docker_summary.stdout)}",
+        ),
+    )
+    return evaluate_runner_host_hygiene(
+        policy=RunnerHostHygienePolicy(
+            minimum_free_disk_bytes=request.minimum_free_disk_bytes,
+            required_warm_builders=request.retained_warm_builders,
+        ),
+        observation=observation,
+    )
+
+
+def build_ssh_remote_runner(env: Mapping[str, str] | None = None) -> RemoteCommandRunner:
+    resolved_env = env or os.environ
+
+    def run(command_args: Sequence[str], timeout_seconds: int) -> RemoteCommandResult:
+        with TemporaryDirectory(prefix="launchplane-runner-host-hygiene-") as material_dir_name:
+            identity_file, known_hosts_file = _write_ssh_material(
+                material_dir=Path(material_dir_name), env=resolved_env
+            )
+            command = _build_ssh_command(
+                command_args,
+                identity_file=identity_file,
+                known_hosts_file=known_hosts_file,
+                env=resolved_env,
+            )
+            completed = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=max(timeout_seconds, 1),
+            )
+            return RemoteCommandResult(
+                returncode=completed.returncode,
+                stdout=completed.stdout,
+                stderr=completed.stderr,
+            )
+
+    return run
+
+
+def validate_ssh_executor_environment(
+    *, request: RunnerHostHygieneSshExecutorRequest, env: Mapping[str, str] | None = None
+) -> None:
+    resolved_env = env or os.environ
+    configured_user = _required_env(resolved_env, SSH_USER_ENV_VAR)
+    if configured_user != request.service_user:
+        raise click.ClickException(
+            "Runner host hygiene SSH user must match the approved service user."
+        )
+    _required_env(resolved_env, SSH_HOST_ENV_VAR)
+    _required_env(resolved_env, SSH_PRIVATE_KEY_ENV_VAR)
+    _required_env(resolved_env, SSH_KNOWN_HOSTS_ENV_VAR)
+
+
+def build_service_audit_poster(*, service_url: str, bearer_token: str) -> AuditPoster:
+    normalized_service_url = service_url.strip().rstrip("/")
+    normalized_bearer_token = bearer_token.strip()
+    if not normalized_service_url:
+        raise click.ClickException("runner host hygiene executor requires service_url")
+    if not normalized_bearer_token:
+        raise click.ClickException("runner host hygiene executor requires bearer token")
+
+    def post(audit: RunnerHostHygieneApplyAuditRecord, idempotency_key: str) -> dict[str, object]:
+        body = json.dumps(_audit_route_payload(audit)).encode()
+        request = Request(
+            f"{normalized_service_url}{AUDIT_ROUTE_PATH}",
+            data=body,
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {normalized_bearer_token}",
+                "Content-Type": "application/json",
+                "Idempotency-Key": idempotency_key,
+            },
+            method="POST",
+        )
+        try:
+            with urlopen(request, timeout=30) as response:
+                response_payload = json.loads(response.read().decode("utf-8"))
+        except HTTPError as error:
+            response_text = error.read().decode(errors="replace")
+            raise click.ClickException(
+                response_text.strip() or f"Launchplane service returned HTTP {error.code}."
+            ) from error
+        if not isinstance(response_payload, dict):
+            raise click.ClickException("Launchplane service returned a non-object response.")
+        return response_payload
+
+    return post
+
+
+def _audit_route_payload(audit: RunnerHostHygieneApplyAuditRecord) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "product": "launchplane",
+        "audit": audit.model_dump(mode="json"),
+    }
+
+
+def _write_ssh_material(*, material_dir: Path, env: Mapping[str, str]) -> tuple[str, str]:
+    private_key = _required_env(env, SSH_PRIVATE_KEY_ENV_VAR)
+    known_hosts = _required_env(env, SSH_KNOWN_HOSTS_ENV_VAR)
+    identity_file = material_dir / "runner-host-hygiene-key"
+    known_hosts_file = material_dir / "known_hosts"
+    _write_secret_file(path=identity_file, value=private_key)
+    _write_secret_file(path=known_hosts_file, value=known_hosts)
+    return str(identity_file), str(known_hosts_file)
+
+
+def _write_secret_file(*, path: Path, value: str) -> None:
+    path.write_text(f"{value.rstrip()}\n", encoding="utf-8")
+    path.chmod(0o600)
+
+
+def _build_ssh_command(
+    command_args: Sequence[str],
+    *,
+    identity_file: str,
+    known_hosts_file: str,
+    env: Mapping[str, str],
+) -> list[str]:
+    ssh_host = _required_env(env, SSH_HOST_ENV_VAR)
+    ssh_user = _required_env(env, SSH_USER_ENV_VAR)
+    return [
+        "ssh",
+        "-F",
+        "/dev/null",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "IdentitiesOnly=yes",
+        "-o",
+        "StrictHostKeyChecking=yes",
+        "-o",
+        f"UserKnownHostsFile={known_hosts_file}",
+        "-i",
+        identity_file,
+        f"{ssh_user}@{ssh_host}",
+        *command_args,
+    ]
+
+
+def _required_env(env: Mapping[str, str], name: str) -> str:
+    value = env.get(name, "").strip()
+    if not value:
+        raise click.ClickException(f"Missing required env var: {name}")
+    return value
+
+
+def _require_remote_success(
+    result: RemoteCommandResult, *, evidence_name: str
+) -> RemoteCommandResult:
+    if result.returncode == 0:
+        return result
+    detail = result.stderr.strip() or result.stdout.strip() or "unknown error"
+    raise click.ClickException(f"runner host hygiene {evidence_name} evidence failed: {detail}")
+
+
+def _parse_df_available_bytes(output: str) -> int:
+    lines = [line.split() for line in output.splitlines() if line.strip()]
+    if len(lines) < 2 or len(lines[1]) < 4:
+        raise click.ClickException(
+            "runner host hygiene df evidence did not include available bytes"
+        )
+    available = lines[1][3]
+    if not available.isdigit():
+        raise click.ClickException("runner host hygiene df available bytes was not numeric")
+    return int(available)
+
+
+def _compact_evidence(output: str) -> str:
+    compact = " | ".join(line.strip() for line in output.splitlines() if line.strip())
+    return compact[:500]
+
+
+def _terminal_message(
+    *, prune_result: RemoteCommandResult, post_report: RunnerHostHygieneReport
+) -> str:
+    if prune_result.returncode != 0:
+        detail = prune_result.stderr.strip() or prune_result.stdout.strip() or "unknown error"
+        return f"runner host Docker cache prune failed: {detail}"
+    if post_report.status != "healthy":
+        return f"runner host Docker cache prune completed but post evidence is not healthy: {post_report.summary}"
+    return "runner host Docker cache prune completed and post evidence is healthy"

--- a/docs/runner-host-hygiene.md
+++ b/docs/runner-host-hygiene.md
@@ -14,11 +14,13 @@ Runner host hygiene has two separate phases:
   policy. This phase is safe for normal development because it does not mutate
   Docker, runner services, GitHub runner registrations, or product state.
 - Apply workflow: clean Docker state, restart services, or change runner lanes
-  through an approved Launchplane-owned host adapter. This phase is not active
-  until a disposable host or explicit operator target exists.
+  through an approved Launchplane-owned host adapter. The first approved lane is
+  limited to remote Docker cache pruning and keeps runner work-directory pruning
+  and runner service restarts disabled.
 
-The current Launchplane surface implements report-only evidence and local
-apply-boundary planning. It still does not execute host mutations.
+The current Launchplane surface implements report-only evidence, local
+apply-boundary planning, durable audit evidence, and a constrained SSH executor
+for the approved first lane.
 
 ## Report Contract
 
@@ -99,9 +101,42 @@ status, and mutate intent into columns, while the full typed request, plan,
 pre/post reports, retained warm-builder evidence, and operator message remain in
 the JSON payload. `POST /v1/evidence/runner-host-hygiene/audits` accepts planned,
 completed, and failed audit records for product/context `launchplane/launchplane`
-under `runner_host_hygiene_audit.write`. The current CLI still only prints the
-planned record; a future approved executor must call the service route after it
-captures the required pre/post host evidence.
+under `runner_host_hygiene_audit.write`. The local planner only prints the
+planned record; the approved executor calls the service route after it captures
+the required pre/post host evidence.
+
+## Approved SSH Executor
+
+The first live executor is `.github/workflows/runner-host-hygiene.yml`. It runs
+on GitHub-hosted infrastructure, authenticates back to Launchplane with GitHub
+Actions OIDC, and reaches the approved runner host over SSH as a constrained
+service user. It supports only `prune_docker_cache`, implemented as:
+
+```bash
+docker builder prune --all --force
+```
+
+The workflow requires these repository variables:
+
+- `LAUNCHPLANE_RUNNER_HOST_HYGIENE_HOST`
+- `LAUNCHPLANE_RUNNER_HOST_HYGIENE_EXECUTION_LANE`
+- `LAUNCHPLANE_RUNNER_HOST_HYGIENE_SERVICE_USER`
+- `LAUNCHPLANE_RUNNER_HOST_HYGIENE_RETAINED_WARM_BUILDERS`
+- `LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_HOST`
+- `LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_USER`
+
+It requires these repository secrets:
+
+- `LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_PRIVATE_KEY`
+- `LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_KNOWN_HOSTS`
+
+The executor fails closed unless the configured SSH user matches the requested
+service user, retained warm builders are present in pre-apply evidence, the
+apply plan is ready, and `mutate=true` is explicitly supplied to the workflow.
+It writes a `planned` audit before mutation, then writes `completed` only when
+the prune command succeeds and post-apply evidence is healthy. If the prune
+command fails or post evidence reports a missing warm builder, it writes
+`failed`. It does not attempt runner service restart or automatic rollback.
 
 ## Adapter Boundary Planning
 
@@ -110,10 +145,10 @@ privileged execution boundary against a ready apply plan:
 
 ```bash
 uv run launchplane work-graph runner-host-hygiene-adapter-boundary-plan \
-  --adapter-type github_actions_runner \
+  --adapter-type remote_host_executor \
   --host-name chris-testing \
   --execution-lane chris-testing-ops-gate \
-  --service-user gha \
+  --service-user launchplane-runner-hygiene \
   --repository-scope cbusillo/launchplane \
   --privileged-scope docker_cache \
   --audit-record-key runner-host-hygiene/2026-05-23/chris-testing \
@@ -125,9 +160,9 @@ uv run launchplane work-graph runner-host-hygiene-adapter-boundary-plan \
   --post-apply-evidence docker_summary \
   --post-apply-evidence warm_builders \
   --approved-host chris-testing \
-  --allowed-adapter-type github_actions_runner \
+  --allowed-adapter-type remote_host_executor \
   --allowed-execution-lane chris-testing-ops-gate \
-  --allowed-service-user gha \
+  --allowed-service-user launchplane-runner-hygiene \
   --allowed-repository-scope cbusillo/launchplane \
   --allowed-privileged-scope docker_cache \
   --required-pre-apply-evidence df \
@@ -144,7 +179,7 @@ is ready, the host is approved, the proposal names an allowed adapter type,
 execution lane, service user, repository scope, narrow privileged scope, audit
 record key prefix, pre/post evidence set, and rollback or stop condition. It
 does not call Docker, systemd, SSH, GitHub runner registration APIs, or a host
-executor.
+executor; the dedicated SSH executor is the separate apply surface.
 
 The privileged scope must match the planned action exactly:
 
@@ -157,7 +192,8 @@ quietly grow service-restart or work-directory powers.
 
 ## Future Apply Requirements
 
-Before Launchplane grows a host mutation adapter, the apply design must name:
+Before Launchplane grows additional host mutation powers, each apply design must
+name:
 
 - the disposable or explicitly approved host target
 - the runner lane and repository scope the host adapter is allowed to affect
@@ -166,5 +202,5 @@ Before Launchplane grows a host mutation adapter, the apply design must name:
 - the rollback or stop condition when cleanup cannot be completed safely
 - the audit record written back to Launchplane-owned storage
 
-Until those are present, host hygiene work remains report-only or dry-run
-planning only.
+Until those are present for another action, that action remains report-only or
+dry-run planning only.

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -962,6 +962,14 @@ post_launchplane_grant \
   product-legacy-context-cleanup
 post_grant \
   "$GITHUB_REPOSITORY" \
+  runner-host-hygiene.yml \
+  launchplane \
+  launchplane \
+  runner_host_hygiene_audit.write \
+  deploy:runner-host-hygiene-audit-grant \
+  runner-host-hygiene-audit
+post_grant \
+  "$GITHUB_REPOSITORY" \
   work-graph-snapshot-validate.yml \
   launchplane \
   launchplane \

--- a/tests/test_runner_host_hygiene_executor.py
+++ b/tests/test_runner_host_hygiene_executor.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import unittest
+
+from collections.abc import Sequence
+
+from control_plane.workflows.runner_host_hygiene_executor import RemoteCommandResult
+from control_plane.workflows.runner_host_hygiene_executor import RunnerHostHygieneSshExecutorRequest
+from control_plane.workflows.runner_host_hygiene_executor import (
+    execute_runner_host_hygiene_ssh_executor,
+)
+from control_plane.workflows.runner_host_hygiene_executor import validate_ssh_executor_environment
+
+
+class _RemoteRunner:
+    def __init__(self, *, prune_returncode: int = 0, image_present_after: bool = True) -> None:
+        self.commands: list[tuple[str, ...]] = []
+        self._prune_returncode = prune_returncode
+        self._image_present_after = image_present_after
+        self._pruned = False
+
+    def __call__(self, command: Sequence[str], _timeout_seconds: int) -> RemoteCommandResult:
+        command_tuple = tuple(command)
+        self.commands.append(command_tuple)
+        if command_tuple == ("df", "-B1", "-P", "/"):
+            return RemoteCommandResult(
+                returncode=0,
+                stdout="Filesystem 1B-blocks Used Available Use% Mounted on\n/dev/disk 1000 100 900 10% /\n",
+            )
+        if command_tuple == ("docker", "system", "df"):
+            return RemoteCommandResult(returncode=0, stdout="TYPE TOTAL ACTIVE SIZE RECLAIMABLE\n")
+        if command_tuple[:3] == ("docker", "image", "inspect"):
+            if not self._pruned or self._image_present_after:
+                return RemoteCommandResult(returncode=0, stdout="[]\n")
+            return RemoteCommandResult(returncode=1, stderr="image missing")
+        if command_tuple == ("docker", "builder", "prune", "--all", "--force"):
+            self._pruned = True
+            return RemoteCommandResult(returncode=self._prune_returncode, stderr="prune failed")
+        return RemoteCommandResult(returncode=127, stderr="unexpected command")
+
+
+class _AuditPoster:
+    def __init__(self) -> None:
+        self.records: list[tuple[str, str]] = []
+
+    def __call__(self, audit: object, idempotency_key: str) -> dict[str, object]:
+        status = getattr(audit, "status")
+        audit_record_key = getattr(audit, "audit_record_key")
+        self.records.append((str(status), idempotency_key))
+        return {
+            "status": "accepted",
+            "records": {"runner_host_hygiene_audit_record_key": audit_record_key},
+        }
+
+
+class RunnerHostHygieneExecutorTests(unittest.TestCase):
+    def test_executor_posts_planned_and_completed_audits(self) -> None:
+        remote_runner = _RemoteRunner()
+        audit_poster = _AuditPoster()
+
+        result = execute_runner_host_hygiene_ssh_executor(
+            request=_request(mutate=True),
+            remote_runner=remote_runner,
+            audit_poster=audit_poster,
+        )
+
+        self.assertEqual(result.status, "completed")
+        self.assertIn(
+            ("planned", "runner-host-hygiene:runner-host-hygiene/2026-05-23/chris-testing:planned"),
+            audit_poster.records,
+        )
+        self.assertIn(
+            (
+                "completed",
+                "runner-host-hygiene:runner-host-hygiene/2026-05-23/chris-testing:completed",
+            ),
+            audit_poster.records,
+        )
+        self.assertIn(("docker", "builder", "prune", "--all", "--force"), remote_runner.commands)
+
+    def test_executor_blocks_before_prune_without_mutate_intent(self) -> None:
+        remote_runner = _RemoteRunner()
+        audit_poster = _AuditPoster()
+
+        result = execute_runner_host_hygiene_ssh_executor(
+            request=_request(mutate=False),
+            remote_runner=remote_runner,
+            audit_poster=audit_poster,
+        )
+
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual([record[0] for record in audit_poster.records], ["planned"])
+        self.assertNotIn(("docker", "builder", "prune", "--all", "--force"), remote_runner.commands)
+
+    def test_executor_posts_failed_when_warm_builder_missing_after_prune(self) -> None:
+        remote_runner = _RemoteRunner(image_present_after=False)
+        audit_poster = _AuditPoster()
+
+        result = execute_runner_host_hygiene_ssh_executor(
+            request=_request(mutate=True),
+            remote_runner=remote_runner,
+            audit_poster=audit_poster,
+        )
+
+        self.assertEqual(result.status, "failed")
+        self.assertIn(
+            ("failed", "runner-host-hygiene:runner-host-hygiene/2026-05-23/chris-testing:failed"),
+            audit_poster.records,
+        )
+        self.assertIn("post evidence is not healthy", result.message)
+
+    def test_executor_environment_requires_configured_ssh_user_to_match_service_user(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(Exception, "must match the approved service user"):
+            validate_ssh_executor_environment(
+                request=_request(mutate=True),
+                env={
+                    "LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_HOST": "runner.example.com",
+                    "LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_USER": "root",
+                    "LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_PRIVATE_KEY": "private-key",
+                    "LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_KNOWN_HOSTS": "known-hosts",
+                },
+            )
+
+
+def _request(*, mutate: bool) -> RunnerHostHygieneSshExecutorRequest:
+    return RunnerHostHygieneSshExecutorRequest(
+        action="prune_docker_cache",
+        host_name="chris-testing",
+        execution_lane="chris-testing-ops-gate",
+        service_user="launchplane-runner-hygiene",
+        repository_scope="cbusillo/launchplane",
+        audit_record_key="runner-host-hygiene/2026-05-23/chris-testing",
+        retained_warm_builders=("odoo-docker-chris-testing",),
+        mutate=mutate,
+    )


### PR DESCRIPTION
## Summary

- add a constrained runner-host hygiene SSH executor for the approved first lane
- wire `runner-host-hygiene-ssh-executor` CLI and a manual GitHub-hosted workflow
- post planned and terminal audit records through Launchplane service evidence ingress
- add deploy-time authz grant for the new workflow and document required variables/secrets

Refs #474

## Validation

- `uv run python -m unittest tests.test_runner_host_hygiene_executor tests.test_runner_host_hygiene`
- `uv run --extra dev ruff check --diff control_plane/workflows/runner_host_hygiene_executor.py control_plane/cli_runner_lanes.py tests/test_runner_host_hygiene_executor.py tests/test_runner_host_hygiene.py .github/workflows/runner-host-hygiene.yml scripts/deploy/ensure-authz-grants.sh docs/runner-host-hygiene.md`
- `uv run --extra dev ruff check control_plane/workflows/runner_host_hygiene_executor.py control_plane/cli_runner_lanes.py tests/test_runner_host_hygiene_executor.py tests/test_runner_host_hygiene.py`
- `uv run --extra dev ruff format --check control_plane/workflows/runner_host_hygiene_executor.py control_plane/cli_runner_lanes.py tests/test_runner_host_hygiene_executor.py tests/test_runner_host_hygiene.py`
- `uv run --extra dev mypy control_plane/workflows/runner_host_hygiene_executor.py control_plane/cli_runner_lanes.py tests/test_runner_host_hygiene_executor.py tests/test_runner_host_hygiene.py`
- `actionlint .github/workflows/runner-host-hygiene.yml`
- `shellcheck scripts/deploy/ensure-authz-grants.sh`
- `bash -n scripts/deploy/ensure-authz-grants.sh`
- `uv run ~/.code/skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope files --file control_plane/workflows/runner_host_hygiene_executor.py --file control_plane/cli_runner_lanes.py --file tests/test_runner_host_hygiene_executor.py --file tests/test_runner_host_hygiene.py --file .github/workflows/runner-host-hygiene.yml --file scripts/deploy/ensure-authz-grants.sh --file docs/runner-host-hygiene.md`
