### PR TITLE
Join tailnet for runner host hygiene SSH

### DIFF
--- a/.github/workflows/runner-host-hygiene.yml
+++ b/.github/workflows/runner-host-hygiene.yml
@@ -50,6 +50,14 @@ jobs:
         ${{ secrets.LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_PRIVATE_KEY }}
       LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_KNOWN_HOSTS: >-
         ${{ secrets.LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_KNOWN_HOSTS }}
+      LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_OAUTH_CLIENT_ID: >-
+        ${{ secrets.LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_OAUTH_CLIENT_ID }}
+      LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_OAUTH_SECRET: >-
+        ${{ secrets.LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_OAUTH_SECRET }}
+      LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_AUDIENCE: >-
+        ${{ secrets.LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_AUDIENCE }}
+      LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_TAGS: >-
+        ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_TAGS }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -57,7 +65,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v7
 
-      - name: Run approved runner host hygiene executor
+      - name: Validate workflow configuration
         shell: bash
         run: |
           set -euo pipefail
@@ -77,6 +85,42 @@ jobs:
           require_env LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_USER
           require_env LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_PRIVATE_KEY
           require_env LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_KNOWN_HOSTS
+          require_env LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_OAUTH_CLIENT_ID
+          require_env LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_TAGS
+
+          ts_audience="${LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_AUDIENCE:-}"
+          ts_secret="${LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_OAUTH_SECRET:-}"
+          if [ -z "$ts_audience" ] && [ -z "$ts_secret" ]; then
+            echo "Missing Tailscale auth secret or audience." >&2
+            exit 1
+          fi
+
+      - name: Tailscale using workload identity
+        if: ${{ env.LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_AUDIENCE != '' }}
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: >-
+            ${{ secrets.LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_OAUTH_CLIENT_ID }}
+          audience: >-
+            ${{ secrets.LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_AUDIENCE }}
+          tags: ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_TAGS }}
+          ping: ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_HOST }}
+
+      - name: Tailscale using OAuth secret
+        if: ${{ env.LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_AUDIENCE == '' }}
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: >-
+            ${{ secrets.LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_OAUTH_CLIENT_ID }}
+          oauth-secret: >-
+            ${{ secrets.LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_OAUTH_SECRET }}
+          tags: ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_TAGS }}
+          ping: ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_HOST }}
+
+      - name: Run approved runner host hygiene executor
+        shell: bash
+        run: |
+          set -euo pipefail
 
           service_audience="$({
             python3 - <<'PY'

--- a/docs/runner-host-hygiene.md
+++ b/docs/runner-host-hygiene.md
@@ -108,9 +108,10 @@ the required pre/post host evidence.
 ## Approved SSH Executor
 
 The first live executor is `.github/workflows/runner-host-hygiene.yml`. It runs
-on GitHub-hosted infrastructure, authenticates back to Launchplane with GitHub
-Actions OIDC, and reaches the approved runner host over SSH as a constrained
-service user. It supports only `prune_docker_cache`, implemented as:
+on GitHub-hosted infrastructure, joins the private tailnet through the official
+Tailscale GitHub Action, authenticates back to Launchplane with GitHub Actions
+OIDC, and reaches the approved runner host over SSH as a constrained service
+user. It supports only `prune_docker_cache`, implemented as:
 
 ```bash
 docker builder prune --all --force
@@ -124,11 +125,18 @@ The workflow requires these repository variables:
 - `LAUNCHPLANE_RUNNER_HOST_HYGIENE_RETAINED_WARM_BUILDERS`
 - `LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_HOST`
 - `LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_USER`
+- `LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_TAGS`
 
 It requires these repository secrets:
 
 - `LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_PRIVATE_KEY`
 - `LAUNCHPLANE_RUNNER_HOST_HYGIENE_SSH_KNOWN_HOSTS`
+- `LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_OAUTH_CLIENT_ID`
+
+For Tailscale authentication, set either
+`LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_AUDIENCE` for workload identity or
+`LAUNCHPLANE_RUNNER_HOST_HYGIENE_TS_OAUTH_SECRET` for an OAuth secret. The
+workflow fails closed if neither authentication mode is configured.
 
 The executor fails closed unless the configured SSH user matches the requested
 service user, retained warm builders are present in pre-apply evidence, the


### PR DESCRIPTION
## Summary
- join Tailscale before the runner-host hygiene SSH executor runs
- accept either workload-identity audience or OAuth secret authentication for the Tailscale action
- document the new tailnet variables/secrets for the approved SSH executor

## Verification
- `git diff --check`
- `actionlint .github/workflows/runner-host-hygiene.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/runner-host-hygiene.yml"); puts "yaml ok"'`
- `uv run --extra dev ruff check --diff .github/workflows/runner-host-hygiene.yml docs/runner-host-hygiene.md`
- `uv run ~/.code/skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope files --file .github/workflows/runner-host-hygiene.yml --file docs/runner-host-hygiene.md` (JetBrains reported unknown `tailscale/github-action@v4` inputs; verified false positive against upstream `action.yml` for v4)

Refs #474
