### PR TITLE
Guard runner host hygiene audit downgrade

### DIFF
--- a/control_plane/storage/migrations/versions/c3e5f7a9b1d2_add_runner_host_hygiene_audits.py
+++ b/control_plane/storage/migrations/versions/c3e5f7a9b1d2_add_runner_host_hygiene_audits.py
@@ -66,6 +66,10 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_index(_STATUS_INDEX, table_name=_TABLE)
-    op.drop_index(_HOST_INDEX, table_name=_TABLE)
+    if not _table_exists(_TABLE):
+        return
+    if _index_exists(_TABLE, _STATUS_INDEX):
+        op.drop_index(_STATUS_INDEX, table_name=_TABLE)
+    if _index_exists(_TABLE, _HOST_INDEX):
+        op.drop_index(_HOST_INDEX, table_name=_TABLE)
     op.drop_table(_TABLE)

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -942,6 +942,25 @@ class PostgresRecordStoreTests(unittest.TestCase):
 
         self.assertIn("idempotency_scope", repaired_columns)
 
+    def test_runner_host_hygiene_audit_downgrade_tolerates_missing_table(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            config = _alembic_config(database_url)
+            alembic_command.upgrade(config, "c2d4e6f8a0b2")
+            alembic_command.stamp(config, "c3e5f7a9b1d2")
+
+            alembic_command.downgrade(config, "c2d4e6f8a0b2")
+
+            engine = create_engine(database_url)
+            table_names = set(inspect(engine).get_table_names())
+            engine.dispose()
+
+        self.assertNotIn("launchplane_runner_host_hygiene_audits", table_names)
+
     def test_alembic_baseline_downgrades_to_empty_schema(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             database_path = Path(temporary_directory_name) / "launchplane.sqlite3"


### PR DESCRIPTION
## Summary
- guard the runner-host hygiene audit migration downgrade when the table is absent
- only drop audit indexes when they actually exist
- add an Alembic regression test for a stamped/partial schema rollback

## Verification
- `uv run python -m unittest tests.test_postgres_store.PostgresRecordStoreTests.test_runner_host_hygiene_audit_downgrade_tolerates_missing_table tests.test_postgres_store.PostgresRecordStoreTests.test_alembic_baseline_downgrades_to_empty_schema tests.test_postgres_store.PostgresRecordStoreTests.test_alembic_baseline_creates_schema_used_by_record_store`
- `uv run --extra dev ruff check --diff control_plane/storage/migrations/versions/c3e5f7a9b1d2_add_runner_host_hygiene_audits.py tests/test_postgres_store.py`
- `uv run --extra dev ruff check control_plane/storage/migrations/versions/c3e5f7a9b1d2_add_runner_host_hygiene_audits.py tests/test_postgres_store.py`
- `uv run --extra dev ruff format --check control_plane/storage/migrations/versions/c3e5f7a9b1d2_add_runner_host_hygiene_audits.py tests/test_postgres_store.py`
- `uv run --extra dev mypy control_plane/storage/migrations/versions/c3e5f7a9b1d2_add_runner_host_hygiene_audits.py tests/test_postgres_store.py`
- `git diff --check`
- `uv run ~/.code/skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope files --file control_plane/storage/migrations/versions/c3e5f7a9b1d2_add_runner_host_hygiene_audits.py --file tests/test_postgres_store.py` (reports pre-existing Click command typing/default-argument warnings in `tests/test_postgres_store.py`, not introduced by this patch)

Refs #474
