### PR TITLE
Stabilize runner host hygiene dry-run evidence

### DIFF
--- a/.github/workflows/runner-host-hygiene.yml
+++ b/.github/workflows/runner-host-hygiene.yml
@@ -23,6 +23,11 @@ name: Runner Host Hygiene
         required: false
         default: 168h
         type: string
+      timeout_seconds:
+        description: Timeout for each local host evidence or prune command
+        required: false
+        default: "300"
+        type: string
 
 permissions:
   contents: read
@@ -132,6 +137,7 @@ jobs:
             "$mutate_flag" \
             --minimum-free-disk-bytes "${{ inputs.minimum_free_disk_bytes }}" \
             --prune-until "${{ inputs.prune_until }}" \
+            --timeout-seconds "${{ inputs.timeout_seconds }}" \
             --service-url "$LAUNCHPLANE_SERVICE_URL" \
             | tee runner-host-hygiene-result.json
 

--- a/control_plane/workflows/runner_host_hygiene_executor.py
+++ b/control_plane/workflows/runner_host_hygiene_executor.py
@@ -222,7 +222,16 @@ def collect_runner_host_hygiene_report(
         evidence_name="df",
     )
     docker_summary = _require_remote_success(
-        remote_runner(("docker", "system", "df"), request.timeout_seconds),
+        remote_runner(
+            (
+                "docker",
+                "system",
+                "df",
+                "--format",
+                "{{.Type}} {{.TotalCount}} {{.Size}} {{.Reclaimable}}",
+            ),
+            request.timeout_seconds,
+        ),
         evidence_name="docker_summary",
     )
     warm_builders = tuple(
@@ -375,7 +384,7 @@ def _check_host_idle(
             (
                 "bash",
                 "-lc",
-                "pgrep -af 'Runner.Worker|docker buildx|docker build|buildctl' || true",
+                "pgrep -af 'docker buildx|docker build|buildctl' || true",
             ),
             request.timeout_seconds,
         ),

--- a/tests/test_runner_host_hygiene_executor.py
+++ b/tests/test_runner_host_hygiene_executor.py
@@ -36,6 +36,14 @@ class _CommandRunner:
             )
         if command_tuple == ("docker", "system", "df"):
             return RemoteCommandResult(returncode=0, stdout="TYPE TOTAL ACTIVE SIZE RECLAIMABLE\n")
+        if command_tuple == (
+            "docker",
+            "system",
+            "df",
+            "--format",
+            "{{.Type}} {{.TotalCount}} {{.Size}} {{.Reclaimable}}",
+        ):
+            return RemoteCommandResult(returncode=0, stdout="Images 1 1GB 500MB\n")
         if command_tuple[:3] == ("docker", "image", "inspect"):
             if not self._pruned or self._image_present_after:
                 return RemoteCommandResult(returncode=0, stdout="[]\n")
@@ -43,7 +51,7 @@ class _CommandRunner:
         if command_tuple == (
             "bash",
             "-lc",
-            "pgrep -af 'Runner.Worker|docker buildx|docker build|buildctl' || true",
+            "pgrep -af 'docker buildx|docker build|buildctl' || true",
         ):
             return RemoteCommandResult(returncode=0, stdout=self._active_build_processes)
         if command_tuple == (


### PR DESCRIPTION
## Summary
- add workflow input for executor command timeout and default it to 300s for slow host Docker evidence
- make Docker summary evidence use formatted output
- make active-build preflight ignore the current Actions worker and check only build client processes

## Verification
- `ssh chris-testing 'time sudo -u launchplane-runner-hygiene docker system df --format "{{.Type}} {{.TotalCount}} {{.Size}} {{.Reclaimable}}" | head -20'` (observed ~130s runtime)
- `uv run python -m unittest tests.test_runner_host_hygiene_executor tests.test_runner_host_hygiene`
- `uv run --extra dev ruff check --diff control_plane/workflows/runner_host_hygiene_executor.py tests/test_runner_host_hygiene_executor.py .github/workflows/runner-host-hygiene.yml`
- `uv run --extra dev ruff check control_plane/workflows/runner_host_hygiene_executor.py tests/test_runner_host_hygiene_executor.py`
- `uv run --extra dev ruff format --check control_plane/workflows/runner_host_hygiene_executor.py tests/test_runner_host_hygiene_executor.py`
- `uv run --extra dev mypy control_plane/workflows/runner_host_hygiene_executor.py tests/test_runner_host_hygiene_executor.py`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/runner-host-hygiene.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/runner-host-hygiene.yml"); puts "yaml ok"'`
- `git diff --check`

Refs #474
