### PR TITLE
Surface VeriReel preview refresh config failures

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -426,6 +426,7 @@ from control_plane.workflows.verireel_prod_rollback import (
 from control_plane.workflows.verireel_preview_driver import (
     VeriReelPreviewDestroyRequest,
     VeriReelPreviewDestroyResult,
+    VeriReelPreviewRefreshConfigError,
     VeriReelPreviewInventoryRequest,
     VeriReelPreviewRefreshRequest,
     VeriReelPreviewRefreshResult,
@@ -7289,9 +7290,11 @@ def _apply_verireel_preview_refresh_records(
         driver_result.refresh_started_at.strip() or driver_result.refresh_finished_at.strip()
     )
     finished_at = driver_result.refresh_finished_at.strip() or requested_at
-    preview_url = driver_result.preview_url.strip() or request.preview_url.strip()
     refresh_passed = driver_result.refresh_status == "pass"
     failure_summary = driver_result.error_message.strip() or "Preview provisioning failed."
+    preview_url = driver_result.preview_url.strip() or request.preview_url.strip()
+    if not preview_url and not refresh_passed:
+        preview_url = _verireel_preview_url_for_failed_records(request=request)
     preview_request = PreviewMutationRequest(
         context=request.context,
         anchor_repo=request.anchor_repo,
@@ -7329,6 +7332,10 @@ def _apply_verireel_preview_refresh_records(
         preview_request=preview_request,
         generation_request=generation_request,
     )
+
+
+def _verireel_preview_url_for_failed_records(*, request: VeriReelPreviewRefreshRequest) -> str:
+    return f"https://{request.preview_slug}.preview-config-missing.launchplane.invalid"
 
 
 def _apply_verireel_preview_destroy_records(
@@ -13133,13 +13140,29 @@ def create_launchplane_service_app(
                 )
                 if idempotent_response is not None:
                     return idempotent_response
-                driver_result = execute_verireel_preview_refresh(
-                    control_plane_root=resolved_root,
-                    record_store=record_store
-                    if isinstance(record_store, PostgresRecordStore)
-                    else None,
-                    request=verireel_preview_refresh_request.refresh,
-                )
+                try:
+                    driver_result = execute_verireel_preview_refresh(
+                        control_plane_root=resolved_root,
+                        record_store=record_store
+                        if isinstance(record_store, PostgresRecordStore)
+                        else None,
+                        request=verireel_preview_refresh_request.refresh,
+                    )
+                except VeriReelPreviewRefreshConfigError as error:
+                    now = _utc_now_timestamp()
+                    error_message = (
+                        str(error).strip()
+                        or "VeriReel preview refresh configuration is incomplete."
+                    )
+                    driver_result = VeriReelPreviewRefreshResult(
+                        refresh_status="fail",
+                        refresh_started_at=now,
+                        refresh_finished_at=now,
+                        application_name="",
+                        application_id="",
+                        preview_url=verireel_preview_refresh_request.refresh.preview_url,
+                        error_message=error_message,
+                    )
                 result = _apply_verireel_preview_refresh_records(
                     control_plane_root_path=resolved_root,
                     record_store=record_store,

--- a/control_plane/workflows/verireel_preview_driver.py
+++ b/control_plane/workflows/verireel_preview_driver.py
@@ -141,6 +141,10 @@ class VeriReelPreviewRefreshResult(BaseModel):
     error_message: str = ""
 
 
+class VeriReelPreviewRefreshConfigError(click.ClickException):
+    """Public-safe preflight/configuration failure for preview refresh."""
+
+
 class VeriReelPreviewDestroyResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -225,11 +229,13 @@ def _preview_url_host(preview_url: str) -> str:
 def _preview_url_from_base_url(*, preview_slug: str, preview_base_url: str) -> str:
     parsed = urlparse(str(preview_base_url).strip())
     if parsed.scheme not in {"http", "https"}:
-        raise click.ClickException(f"{PREVIEW_BASE_URL_ENV_KEY} must use http or https.")
+        raise VeriReelPreviewRefreshConfigError(
+            f"{PREVIEW_BASE_URL_ENV_KEY} must use http or https."
+        )
     if not parsed.hostname:
-        raise click.ClickException(f"{PREVIEW_BASE_URL_ENV_KEY} requires a hostname.")
+        raise VeriReelPreviewRefreshConfigError(f"{PREVIEW_BASE_URL_ENV_KEY} requires a hostname.")
     if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
-        raise click.ClickException(
+        raise VeriReelPreviewRefreshConfigError(
             f"{PREVIEW_BASE_URL_ENV_KEY} must be a root URL without path, query, or fragment."
         )
     return parsed._replace(
@@ -248,7 +254,7 @@ def _resolve_preview_base_url(*, control_plane_root: Path, context_name: str) ->
     )
     preview_base_url = str(resolved_values.get(PREVIEW_BASE_URL_ENV_KEY) or "").strip()
     if not preview_base_url:
-        raise click.ClickException(
+        raise VeriReelPreviewRefreshConfigError(
             f"Missing {PREVIEW_BASE_URL_ENV_KEY} in Launchplane runtime-environment records for {context_name}."
         )
     return preview_base_url
@@ -290,16 +296,24 @@ def _preview_domain_from_url(preview_url: str) -> str:
 def _parse_database_url(database_url: str) -> _DatabaseParts:
     parsed = urlparse(database_url.strip())
     if not parsed.scheme:
-        raise click.ClickException("Preview template DATABASE_URL must include a scheme.")
+        raise VeriReelPreviewRefreshConfigError(
+            "Preview template DATABASE_URL must include a scheme."
+        )
     if not parsed.hostname:
-        raise click.ClickException("Preview template DATABASE_URL must include a hostname.")
+        raise VeriReelPreviewRefreshConfigError(
+            "Preview template DATABASE_URL must include a hostname."
+        )
     database_name = parsed.path.lstrip("/").strip()
     if not database_name:
-        raise click.ClickException("Preview template DATABASE_URL must include a database name.")
+        raise VeriReelPreviewRefreshConfigError(
+            "Preview template DATABASE_URL must include a database name."
+        )
     username = unquote(parsed.username or "").strip()
     password = unquote(parsed.password or "")
     if not username:
-        raise click.ClickException("Preview template DATABASE_URL must include a username.")
+        raise VeriReelPreviewRefreshConfigError(
+            "Preview template DATABASE_URL must include a username."
+        )
     return _DatabaseParts(
         host=parsed.hostname,
         port=parsed.port or 5432,
@@ -342,13 +356,13 @@ def _enforce_verireel_preview_runtime_key_safety(
     if not required_binding_keys:
         return
     if record_store is None:
-        raise click.ClickException(
+        raise VeriReelPreviewRefreshConfigError(
             "VeriReel preview refresh copied runtime secrets require Launchplane database storage."
         )
     try:
         policy_record = latest_active_runtime_key_safety_policy(record_store)
     except ValueError as exc:
-        raise click.ClickException(
+        raise VeriReelPreviewRefreshConfigError(
             "VeriReel preview refresh copied runtime secrets require an active runtime "
             "key-safety policy."
         ) from exc
@@ -371,7 +385,7 @@ def _enforce_verireel_preview_runtime_key_safety(
         return
     finding_codes = ", ".join(finding.code for finding in evaluation.findings)
     checked_keys = ", ".join(evaluation.checked_binding_keys)
-    raise click.ClickException(
+    raise VeriReelPreviewRefreshConfigError(
         f"VeriReel preview runtime key-safety gate failed for {checked_keys}: {finding_codes}."
     )
 
@@ -405,30 +419,38 @@ def _random_password(length: int = 32) -> str:
 def _template_application_payload(
     *, control_plane_root: Path, host: str, token: str
 ) -> tuple[control_plane_dokploy.DokployTargetDefinition, JsonObject]:
-    source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
-        control_plane_root=control_plane_root,
-    )
+    try:
+        source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
+            control_plane_root=control_plane_root,
+        )
+    except click.ClickException as exc:
+        raise VeriReelPreviewRefreshConfigError(str(exc)) from exc
     target_definition = control_plane_dokploy.find_dokploy_target_definition(
         source_of_truth,
         context_name="verireel",
         instance_name="testing",
     )
     if target_definition is None:
-        raise click.ClickException("No Dokploy target definition found for verireel/testing.")
+        raise VeriReelPreviewRefreshConfigError(
+            "No Dokploy target definition found for verireel/testing."
+        )
     if target_definition.target_type != "application":
-        raise click.ClickException(
+        raise VeriReelPreviewRefreshConfigError(
             "VeriReel preview driver requires the testing target to be a Dokploy application."
         )
     if not target_definition.target_id.strip():
-        raise click.ClickException(
+        raise VeriReelPreviewRefreshConfigError(
             "VeriReel testing target requires a Dokploy target_id before preview execution."
         )
-    payload = control_plane_dokploy.fetch_dokploy_target_payload(
-        host=host,
-        token=token,
-        target_type="application",
-        target_id=target_definition.target_id,
-    )
+    try:
+        payload = control_plane_dokploy.fetch_dokploy_target_payload(
+            host=host,
+            token=token,
+            target_type="application",
+            target_id=target_definition.target_id,
+        )
+    except click.ClickException as exc:
+        raise VeriReelPreviewRefreshConfigError(str(exc)) from exc
     return target_definition, payload
 
 
@@ -1102,7 +1124,12 @@ def execute_verireel_preview_refresh(
     request: VeriReelPreviewRefreshRequest,
     record_store: RuntimeKeySafetyPolicyReadStore | None = None,
 ) -> VeriReelPreviewRefreshResult:
-    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
+    try:
+        host, token = control_plane_dokploy.read_dokploy_config(
+            control_plane_root=control_plane_root
+        )
+    except click.ClickException as exc:
+        raise VeriReelPreviewRefreshConfigError(str(exc)) from exc
     template_target, template_application = _template_application_payload(
         control_plane_root=control_plane_root,
         host=host,
@@ -1113,7 +1140,9 @@ def execute_verireel_preview_refresh(
     )
     template_database_url = str(template_env_map.get("DATABASE_URL") or "").strip()
     if not template_database_url:
-        raise click.ClickException("VeriReel testing template application is missing DATABASE_URL.")
+        raise VeriReelPreviewRefreshConfigError(
+            "VeriReel testing template application is missing DATABASE_URL."
+        )
     _enforce_verireel_preview_runtime_key_safety(
         record_store=record_store,
         template_target=template_target,

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1037,6 +1037,14 @@ build/publish, browser verification, and the follow-up preview evidence write.
 Browser verification uses the preview URL returned by the driver plus
 allow-listed app maintenance actions keyed by preview slug when it needs remote
 owner-admin setup/cleanup.
+When a VeriReel preview-refresh request is syntactically valid but Launchplane
+cannot complete preflight because preview URL, runtime key-safety, managed
+secret, Dokploy target, or template `DATABASE_URL` configuration is incomplete,
+the route returns an accepted driver result with `refresh_status="fail"` and a
+public-safe `error_message`. The same response writes failed preview generation
+evidence so product workflows and PR feedback can surface the actionable reason
+instead of a generic `invalid_request` rejection. Malformed request payloads and
+unauthorized calls still fail closed before provider mutation.
 
 VeriReel app maintenance accepts an optional `intent` alongside the allow-listed
 action. Smoke/E2E helpers should set the narrow intent, such as

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -128,6 +128,7 @@ from control_plane.workflows.verireel_preview_driver import (
     VeriReelPreviewDestroyResult,
     VeriReelPreviewInventoryItem,
     VeriReelPreviewInventoryResult,
+    VeriReelPreviewRefreshConfigError,
     VeriReelPreviewRefreshResult,
 )
 
@@ -27562,6 +27563,140 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(generation.verify_status, "skipped")
             self.assertEqual(generation.failure_stage, "provision")
             self.assertEqual(generation.failure_summary, "Dokploy update failed.")
+
+    def test_verireel_preview_refresh_config_error_is_recorded_as_failed_generation(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel-testing"],
+                            "actions": ["verireel_preview_refresh.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_verireel_preview_refresh",
+                side_effect=VeriReelPreviewRefreshConfigError(
+                    "Missing LAUNCHPLANE_PREVIEW_BASE_URL in Launchplane runtime-environment records for verireel-testing."
+                ),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/preview-refresh",
+                    payload={
+                        "schema_version": 1,
+                        "product": "verireel",
+                        "refresh": {
+                            "schema_version": 1,
+                            "context": "verireel-testing",
+                            "anchor_repo": "verireel",
+                            "anchor_pr_number": 189,
+                            "anchor_pr_url": "https://github.com/every/verireel/pull/189",
+                            "anchor_head_sha": "bd6ef6afb3c6c9cc3359cf98ac613eca414ac4fe",
+                            "preview_slug": "pr-189",
+                            "image_reference": "ghcr.io/every/verireel-app:pr-189-sha-bd6ef6a",
+                        },
+                    },
+                    headers={
+                        "Idempotency-Key": "verireel-preview-refresh:verireel:verireel-testing:verireel:189:bd6ef6a"
+                    },
+                )
+
+            self.assertEqual(status_code, 202)
+            self.assertEqual(payload["status"], "accepted")
+            self.assertEqual(payload["records"]["transition"], "failed")
+            self.assertEqual(payload["result"]["refresh_status"], "fail")
+            self.assertEqual(
+                payload["result"]["error_message"],
+                "Missing LAUNCHPLANE_PREVIEW_BASE_URL in Launchplane runtime-environment records for verireel-testing.",
+            )
+            store = FilesystemRecordStore(state_dir=state_dir)
+            preview = store.read_preview_record("preview-verireel-testing-verireel-pr-189")
+            generation = store.read_preview_generation_record(
+                "preview-verireel-testing-verireel-pr-189-generation-0001"
+            )
+            self.assertEqual(preview.state, "failed")
+            self.assertEqual(generation.state, "failed")
+            self.assertEqual(generation.deploy_status, "fail")
+            self.assertEqual(generation.verify_status, "skipped")
+            self.assertEqual(generation.failure_stage, "provision")
+            self.assertEqual(
+                generation.failure_summary,
+                "Missing LAUNCHPLANE_PREVIEW_BASE_URL in Launchplane runtime-environment records for verireel-testing.",
+            )
+
+    def test_verireel_preview_refresh_payload_validation_still_rejects_bad_slug(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel-testing"],
+                            "actions": ["verireel_preview_refresh.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/verireel/preview-refresh",
+                payload={
+                    "schema_version": 1,
+                    "product": "verireel",
+                    "refresh": {
+                        "schema_version": 1,
+                        "context": "verireel-testing",
+                        "anchor_repo": "verireel",
+                        "anchor_pr_number": 189,
+                        "anchor_pr_url": "https://github.com/every/verireel/pull/189",
+                        "anchor_head_sha": "bd6ef6afb3c6c9cc3359cf98ac613eca414ac4fe",
+                        "preview_slug": "pr-190",
+                        "image_reference": "ghcr.io/every/verireel-app:pr-189-sha-bd6ef6a",
+                    },
+                },
+            )
+
+            self.assertEqual(status_code, 400)
+            self.assertEqual(payload["status"], "rejected")
+            self.assertEqual(payload["error"]["code"], "invalid_request")
+            self.assertEqual(payload["error"]["message"], "Request payload failed validation.")
 
     def test_verireel_preview_verification_driver_marks_latest_generation_ready(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- convert public-safe VeriReel preview-refresh preflight/config failures into structured `refresh_status: fail` driver results
- persist failed preview/generation evidence for valid requests instead of returning generic `invalid_request`
- document the route behavior and add regression coverage for config failure vs malformed payload validation

Fixes #943

## Verification
- `uv run python -m unittest tests.test_verireel_preview_driver tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_config_error_is_recorded_as_failed_generation tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_payload_validation_still_rejects_bad_slug tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_driver_writes_failed_generation_record`
- `uv run --extra dev ruff format --check control_plane/service.py control_plane/workflows/verireel_preview_driver.py tests/test_service.py`
- `uv run --extra dev mypy control_plane/service.py control_plane/workflows/verireel_preview_driver.py tests/test_service.py`
- `uv run --extra dev ruff check --diff control_plane/service.py control_plane/workflows/verireel_preview_driver.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/service.py control_plane/workflows/verireel_preview_driver.py tests/test_service.py docs/service-boundary.md`

## Inspection
JetBrains closeout ran on changed files via PyCharm and closed the helper-opened project. It reported existing weak warnings in the touched files: duplicate-code warnings in `control_plane/workflows/verireel_preview_driver.py` and static-method suggestions in shared test fixtures in `tests/test_service.py`. No new error-level IDE finding was surfaced for this change.
