### PR TITLE
Generate VeriReel preview runtime secrets

### DIFF
--- a/control_plane/workflows/verireel_preview_driver.py
+++ b/control_plane/workflows/verireel_preview_driver.py
@@ -6,7 +6,7 @@ import secrets
 import shlex
 import time
 from pathlib import Path
-from typing import Literal
+from typing import Callable, Literal
 from urllib.error import HTTPError, URLError
 from urllib.parse import parse_qsl, quote, unquote, urlparse
 from urllib.request import Request, urlopen
@@ -36,6 +36,14 @@ PREVIEW_APP_PREFIX = "ver-preview"
 PREVIEW_DATABASE_PREFIX = "verireel_preview_"
 PREVIEW_BASE_URL_ENV_KEY = "LAUNCHPLANE_PREVIEW_BASE_URL"
 _SECRET_SHAPED_RUNTIME_ENV_KEY_PARTS = {"PASSWORD", "TOKEN", "SECRET", "KEY"}
+_PREVIEW_REFRESH_GENERATED_ENV_KEYS = frozenset(
+    {
+        "BETTER_AUTH_SECRET",
+        "DATABASE_URL",
+        "VERIREEL_CRON_SECRET",
+        "VERIREEL_SECRETS_MASTER_KEY",
+    }
+)
 
 
 def _expected_preview_slug(anchor_pr_number: int) -> str:
@@ -338,9 +346,9 @@ def _verireel_template_runtime_secret_keys(
         normalized_key = key.strip()
         if not normalized_key or not str(value).strip():
             continue
-        if normalized_key == "DATABASE_URL" or _runtime_environment_key_requires_secret_store(
-            normalized_key
-        ):
+        if normalized_key in _PREVIEW_REFRESH_GENERATED_ENV_KEYS:
+            continue
+        if _runtime_environment_key_requires_secret_store(normalized_key):
             required_keys.append(normalized_key)
     return tuple(dict.fromkeys(required_keys))
 
@@ -414,6 +422,23 @@ def _build_preview_database_url(
 
 def _random_password(length: int = 32) -> str:
     return secrets.token_hex(length)[:length]
+
+
+def _random_base64_secret(byte_count: int = 32) -> str:
+    return base64.b64encode(secrets.token_bytes(byte_count)).decode("ascii")
+
+
+def _random_urlsafe_secret(byte_count: int = 32) -> str:
+    return secrets.token_urlsafe(byte_count)
+
+
+def _resolve_preview_secret(
+    *, existing_env_map: dict[str, str], key: str, generate: Callable[[], str]
+) -> str:
+    existing_value = existing_env_map.get(key, "").strip()
+    if existing_value:
+        return existing_value
+    return generate()
 
 
 def _template_application_payload(
@@ -1167,6 +1192,9 @@ def execute_verireel_preview_refresh(
             host=host, token=token, application_id=application_id
         )
     existing_database = _resolve_existing_preview_database(existing_snapshot)
+    existing_env_map = control_plane_dokploy.parse_dokploy_env_text(
+        str((existing_snapshot or {}).get("env") or "")
+    )
     database_name, role_name = _preview_database_identifiers(request.preview_slug)
     database_parts = existing_database or _DatabaseParts(
         host=template_database.host,
@@ -1210,6 +1238,21 @@ def execute_verireel_preview_refresh(
                     database_name=database_parts.database,
                     role_name=database_parts.username,
                     password=database_parts.password,
+                ),
+                "BETTER_AUTH_SECRET": _resolve_preview_secret(
+                    existing_env_map=existing_env_map,
+                    key="BETTER_AUTH_SECRET",
+                    generate=_random_urlsafe_secret,
+                ),
+                "VERIREEL_SECRETS_MASTER_KEY": _resolve_preview_secret(
+                    existing_env_map=existing_env_map,
+                    key="VERIREEL_SECRETS_MASTER_KEY",
+                    generate=_random_base64_secret,
+                ),
+                "VERIREEL_CRON_SECRET": _resolve_preview_secret(
+                    existing_env_map=existing_env_map,
+                    key="VERIREEL_CRON_SECRET",
+                    generate=_random_urlsafe_secret,
                 ),
                 **runtime_identity_env(_build_preview_runtime_identity(request=request)),
             },

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -92,9 +92,12 @@ title: Secrets
 - Product-specific preview drivers that derive runtime secrets from a template,
   such as VeriReel's preview database bootstrap, must run the same metadata-only
   gate before creating databases, rendering preview env, or starting preview
-  instances. Template secret-shaped keys and semantic secret keys such as
-  `DATABASE_URL` must resolve to managed template-lane bindings, and the active
-  policy must allow those bindings for the preview target.
+  instances. Template secret-shaped keys copied into the preview must resolve to
+  managed template-lane bindings, and the active policy must allow those
+  bindings for the preview target. Template values that the driver rewrites for
+  each preview, such as VeriReel's generated `DATABASE_URL`,
+  `BETTER_AUTH_SECRET`, `VERIREEL_SECRETS_MASTER_KEY`, and
+  `VERIREEL_CRON_SECRET`, are not copied template secrets.
 - Delegated worker workflows that overlay managed runtime secrets into
   subprocess environments, such as VeriReel prod backup and rollback workers,
   must evaluate the managed bindings for the worker target before the worker

--- a/tests/test_verireel_preview_driver.py
+++ b/tests/test_verireel_preview_driver.py
@@ -1,3 +1,4 @@
+import base64
 import subprocess
 import unittest
 from pathlib import Path
@@ -6,6 +7,7 @@ from unittest.mock import patch
 
 import click
 
+from control_plane import dokploy as control_plane_dokploy
 from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeKeySafetyPolicyRecord,
     RuntimeSecretClass,
@@ -22,6 +24,7 @@ from control_plane.workflows.verireel_preview_driver import (
 from control_plane.workflows.verireel_preview_driver import _preview_database_admin_module_source
 from control_plane.workflows.verireel_preview_driver import _resolve_preview_url
 from control_plane.workflows.verireel_preview_driver import _run_application_command_with_retries
+from control_plane.workflows.verireel_preview_driver import _verireel_template_runtime_secret_keys
 from control_plane.workflows.verireel_preview_driver import execute_verireel_preview_refresh
 
 
@@ -211,9 +214,47 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
             _enforce_verireel_preview_runtime_key_safety(
                 record_store=None,
                 template_target=_template_target(),
-                template_env_map={
+                template_env_map={"EXTERNAL_API_TOKEN": "api-token"},
+                request=_refresh_request(),
+            )
+
+    def test_verireel_template_runtime_secret_keys_skip_rewritten_database_url(self) -> None:
+        self.assertEqual(
+            _verireel_template_runtime_secret_keys(
+                {
                     "DATABASE_URL": "postgresql://user:pass@db.example/verireel_testing",
-                },
+                    "BETTER_AUTH_SECRET": "auth-secret",
+                    "VERIREEL_SECRETS_MASTER_KEY": "master-key",
+                    "VERIREEL_CRON_SECRET": "cron-secret",
+                    "NEXT_PUBLIC_SITE_URL": "https://testing.example",
+                }
+            ),
+            (),
+        )
+
+    def test_verireel_preview_runtime_key_safety_ignores_generated_preview_secrets(
+        self,
+    ) -> None:
+        _enforce_verireel_preview_runtime_key_safety(
+            record_store=None,
+            template_target=_template_target(),
+            template_env_map={
+                "DATABASE_URL": "postgresql://user:pass@db.example/verireel_testing",
+                "BETTER_AUTH_SECRET": "auth-secret",
+                "VERIREEL_SECRETS_MASTER_KEY": "master-key",
+                "VERIREEL_CRON_SECRET": "cron-secret",
+            },
+            request=_refresh_request(),
+        )
+
+    def test_verireel_preview_runtime_key_safety_requires_bindings_for_other_copied_secrets(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(click.ClickException, "binding_missing"):
+            _enforce_verireel_preview_runtime_key_safety(
+                record_store=_RuntimeKeySafetyStore(policies=(_runtime_policy(),)),
+                template_target=_template_target(),
+                template_env_map={"EXTERNAL_API_TOKEN": "api-token"},
                 request=_refresh_request(),
             )
 
@@ -221,17 +262,29 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
         self,
     ) -> None:
         store = _RuntimeKeySafetyStore(
-            policies=(_runtime_policy(secret_class="prod_only"),),
-            bindings=(_runtime_binding("DATABASE_URL"),),
+            policies=(
+                RuntimeKeySafetyPolicyRecord(
+                    record_id="runtime-key-safety-policy-prod-only-test",
+                    status="active",
+                    source="test",
+                    updated_at="2026-05-05T22:15:00Z",
+                    rules=(
+                        RuntimeSecretSafetyRule(
+                            binding_key="EXTERNAL_API_TOKEN",
+                            secret_class="prod_only",
+                            allowed_contexts=("verireel-testing",),
+                        ),
+                    ),
+                ),
+            ),
+            bindings=(_runtime_binding("EXTERNAL_API_TOKEN"),),
         )
 
         with self.assertRaisesRegex(click.ClickException, "secret_class_not_allowed"):
             _enforce_verireel_preview_runtime_key_safety(
                 record_store=store,
                 template_target=_template_target(),
-                template_env_map={
-                    "DATABASE_URL": "postgresql://user:pass@db.example/verireel_testing",
-                },
+                template_env_map={"EXTERNAL_API_TOKEN": "api-token"},
                 request=_refresh_request(),
             )
 
@@ -271,7 +324,7 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
                     _template_target(),
                     {
                         "applicationId": "app-template",
-                        "env": "DATABASE_URL=postgresql://user:pass@db.example/verireel_testing\n",
+                        "env": "DATABASE_URL=postgresql://user:pass@db.example/verireel_testing\nEXTERNAL_API_TOKEN=api-token\n",
                     },
                 ),
             ),
@@ -287,6 +340,166 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
                 )
 
         run_command.assert_not_called()
+
+    def test_preview_refresh_generates_preview_local_runtime_secrets(self) -> None:
+        captured_env: dict[str, str] = {}
+
+        def capture_environment(**kwargs: object) -> None:
+            captured_env.update(
+                control_plane_dokploy.parse_dokploy_env_text(str(kwargs["env_text"]))
+            )
+
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch(
+                "control_plane.workflows.verireel_preview_driver.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver._template_application_payload",
+                return_value=(
+                    _template_target(),
+                    {
+                        "applicationId": "app-template",
+                        "env": (
+                            "DATABASE_URL=postgresql://template:template-pass@db.example/verireel_testing\n"
+                            "BETTER_AUTH_SECRET=template-auth-secret\n"
+                            "VERIREEL_SECRETS_MASTER_KEY=dGVtcGxhdGUtbWFzdGVyLWtleQ==\n"
+                            "VERIREEL_CRON_SECRET=template-cron-secret\n"
+                        ),
+                    },
+                ),
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver._find_application_by_name",
+                return_value=None,
+            ),
+            patch("control_plane.workflows.verireel_preview_driver._run_application_command"),
+            patch(
+                "control_plane.workflows.verireel_preview_driver._ensure_application",
+                return_value={"applicationId": "app-preview"},
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver._configure_application",
+                side_effect=capture_environment,
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver._ensure_domain",
+                return_value=("domain-preview", ()),
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver.control_plane_dokploy.latest_deployment_for_target",
+                return_value=None,
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver.control_plane_dokploy.trigger_deployment"
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver.control_plane_dokploy.wait_for_target_deployment"
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver._run_application_command_with_retries"
+            ),
+            patch("control_plane.workflows.verireel_preview_driver._wait_for_preview_health"),
+        ):
+            result = execute_verireel_preview_refresh(
+                control_plane_root=Path(temporary_directory_name),
+                request=_refresh_request(),
+                record_store=None,
+            )
+
+        self.assertEqual(result.refresh_status, "pass")
+        self.assertNotEqual(captured_env["BETTER_AUTH_SECRET"], "template-auth-secret")
+        self.assertNotEqual(captured_env["VERIREEL_CRON_SECRET"], "template-cron-secret")
+        self.assertNotEqual(
+            captured_env["VERIREEL_SECRETS_MASTER_KEY"],
+            "dGVtcGxhdGUtbWFzdGVyLWtleQ==",
+        )
+        self.assertEqual(len(base64.b64decode(captured_env["VERIREEL_SECRETS_MASTER_KEY"])), 32)
+        self.assertIn("/verireel_preview_pr_71?", captured_env["DATABASE_URL"])
+
+    def test_preview_refresh_reuses_existing_preview_runtime_secrets(self) -> None:
+        captured_env: dict[str, str] = {}
+
+        def capture_environment(**kwargs: object) -> None:
+            captured_env.update(
+                control_plane_dokploy.parse_dokploy_env_text(str(kwargs["env_text"]))
+            )
+
+        existing_env = (
+            "DATABASE_URL=postgresql://existing:existing-pass@db.example/verireel_preview_pr_71?schema=public\n"
+            "BETTER_AUTH_SECRET=existing-auth-secret\n"
+            "VERIREEL_SECRETS_MASTER_KEY="
+            + base64.b64encode(bytes(range(32))).decode("ascii")
+            + "\n"
+            "VERIREEL_CRON_SECRET=existing-cron-secret\n"
+        )
+
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch(
+                "control_plane.workflows.verireel_preview_driver.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver._template_application_payload",
+                return_value=(
+                    _template_target(),
+                    {
+                        "applicationId": "app-template",
+                        "env": "DATABASE_URL=postgresql://template:template-pass@db.example/verireel_testing\n",
+                    },
+                ),
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver._find_application_by_name",
+                return_value={"applicationId": "app-preview"},
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver._fetch_application",
+                return_value={"applicationId": "app-preview", "env": existing_env},
+            ),
+            patch("control_plane.workflows.verireel_preview_driver._run_application_command"),
+            patch(
+                "control_plane.workflows.verireel_preview_driver._ensure_application",
+                return_value={"applicationId": "app-preview"},
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver._configure_application",
+                side_effect=capture_environment,
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver._ensure_domain",
+                return_value=("", ()),
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver.control_plane_dokploy.latest_deployment_for_target",
+                return_value=None,
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver.control_plane_dokploy.trigger_deployment"
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver.control_plane_dokploy.wait_for_target_deployment"
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver._run_application_command_with_retries"
+            ),
+            patch("control_plane.workflows.verireel_preview_driver._wait_for_preview_health"),
+        ):
+            result = execute_verireel_preview_refresh(
+                control_plane_root=Path(temporary_directory_name),
+                request=_refresh_request(),
+                record_store=None,
+            )
+
+        self.assertEqual(result.refresh_status, "pass")
+        self.assertEqual(captured_env["BETTER_AUTH_SECRET"], "existing-auth-secret")
+        self.assertEqual(captured_env["VERIREEL_CRON_SECRET"], "existing-cron-secret")
+        self.assertEqual(
+            captured_env["VERIREEL_SECRETS_MASTER_KEY"],
+            base64.b64encode(bytes(range(32))).decode("ascii"),
+        )
 
     def test_preview_destroy_request_requires_pr_scoped_preview_slug(self) -> None:
         with self.assertRaisesRegex(ValueError, "preview_slug to match anchor_pr_number"):

--- a/tests/test_verireel_preview_driver.py
+++ b/tests/test_verireel_preview_driver.py
@@ -343,6 +343,7 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
 
     def test_preview_refresh_generates_preview_local_runtime_secrets(self) -> None:
         captured_env: dict[str, str] = {}
+        template_master_key = base64.b64encode(b"template-master-key").decode("ascii")
 
         def capture_environment(**kwargs: object) -> None:
             captured_env.update(
@@ -364,7 +365,7 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
                         "env": (
                             "DATABASE_URL=postgresql://template:template-pass@db.example/verireel_testing\n"
                             "BETTER_AUTH_SECRET=template-auth-secret\n"
-                            "VERIREEL_SECRETS_MASTER_KEY=dGVtcGxhdGUtbWFzdGVyLWtleQ==\n"
+                            f"VERIREEL_SECRETS_MASTER_KEY={template_master_key}\n"
                             "VERIREEL_CRON_SECRET=template-cron-secret\n"
                         ),
                     },
@@ -413,7 +414,7 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
         self.assertNotEqual(captured_env["VERIREEL_CRON_SECRET"], "template-cron-secret")
         self.assertNotEqual(
             captured_env["VERIREEL_SECRETS_MASTER_KEY"],
-            "dGVtcGxhdGUtbWFzdGVyLWtleQ==",
+            template_master_key,
         )
         self.assertEqual(len(base64.b64decode(captured_env["VERIREEL_SECRETS_MASTER_KEY"])), 32)
         self.assertIn("/verireel_preview_pr_71?", captured_env["DATABASE_URL"])


### PR DESCRIPTION
## Summary
- generate preview-local VeriReel runtime secrets instead of copying template app secrets
- preserve existing preview secrets across refreshes so reruns do not rotate runtime identity unexpectedly
- keep runtime key-safety checks for any other secret-shaped template keys that would still be copied

## Verification
- `uv run python -m unittest tests.test_verireel_preview_driver tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_driver_writes_failed_generation_record tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_config_error_is_recorded_as_failed_generation tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_payload_validation_still_rejects_bad_slug`
- `uv run --extra dev ruff format --check control_plane/workflows/verireel_preview_driver.py tests/test_verireel_preview_driver.py`
- `uv run --extra dev ruff check control_plane/workflows/verireel_preview_driver.py tests/test_verireel_preview_driver.py`
- `uv run --extra dev mypy control_plane/workflows/verireel_preview_driver.py tests/test_verireel_preview_driver.py`
- `uv run --extra dev markdownlint-cli2 docs/secrets.md`

Fixes #943 follow-up preview runtime secret blocker.
