### PR TITLE
Classify VeriReel preview backend failures

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -430,6 +430,7 @@ from control_plane.workflows.verireel_preview_driver import (
     VeriReelPreviewInventoryRequest,
     VeriReelPreviewRefreshRequest,
     VeriReelPreviewRefreshResult,
+    VeriReelPreviewRefreshTransportError,
     execute_verireel_preview_destroy,
     execute_verireel_preview_inventory,
     execute_verireel_preview_refresh,
@@ -13148,6 +13149,22 @@ def create_launchplane_service_app(
                         else None,
                         request=verireel_preview_refresh_request.refresh,
                     )
+                except VeriReelPreviewRefreshTransportError as error:
+                    error_message = (
+                        str(error).strip() or "VeriReel preview refresh backend request failed."
+                    )
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=502,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "preview_refresh_backend_unavailable",
+                                "message": error_message,
+                            },
+                        },
+                    )
                 except VeriReelPreviewRefreshConfigError as error:
                     now = _utc_now_timestamp()
                     error_message = (
@@ -13160,7 +13177,9 @@ def create_launchplane_service_app(
                         refresh_finished_at=now,
                         application_name="",
                         application_id="",
-                        preview_url=verireel_preview_refresh_request.refresh.preview_url,
+                        preview_url=_verireel_preview_url_for_failed_records(
+                            request=verireel_preview_refresh_request.refresh
+                        ),
                         error_message=error_message,
                     )
                 result = _apply_verireel_preview_refresh_records(

--- a/control_plane/workflows/verireel_preview_driver.py
+++ b/control_plane/workflows/verireel_preview_driver.py
@@ -153,6 +153,10 @@ class VeriReelPreviewRefreshConfigError(click.ClickException):
     """Public-safe preflight/configuration failure for preview refresh."""
 
 
+class VeriReelPreviewRefreshTransportError(click.ClickException):
+    """Public-safe backend/provider failure for preview refresh."""
+
+
 class VeriReelPreviewDestroyResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -449,6 +453,8 @@ def _template_application_payload(
             control_plane_root=control_plane_root,
         )
     except click.ClickException as exc:
+        if _is_source_of_truth_backend_failure(exc):
+            raise VeriReelPreviewRefreshTransportError(str(exc)) from exc
         raise VeriReelPreviewRefreshConfigError(str(exc)) from exc
     target_definition = control_plane_dokploy.find_dokploy_target_definition(
         source_of_truth,
@@ -475,8 +481,27 @@ def _template_application_payload(
             target_id=target_definition.target_id,
         )
     except click.ClickException as exc:
+        if _is_dokploy_provider_failure(exc):
+            raise VeriReelPreviewRefreshTransportError(str(exc)) from exc
         raise VeriReelPreviewRefreshConfigError(str(exc)) from exc
     return target_definition, payload
+
+
+def _is_source_of_truth_backend_failure(error: click.ClickException) -> bool:
+    message = str(error).strip()
+    return message.startswith(
+        "Could not load tracked Dokploy targets from Launchplane Postgres storage:"
+    )
+
+
+def _is_dokploy_provider_failure(error: click.ClickException) -> bool:
+    cause = error.__cause__
+    if isinstance(cause, (HTTPError, URLError, TimeoutError)):
+        return True
+    message = str(error).strip()
+    return message.startswith("Dokploy API ") or message.endswith(
+        "returned an invalid response payload."
+    )
 
 
 def _find_application_by_name(*, host: str, token: str, application_name: str) -> JsonObject | None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -130,6 +130,7 @@ from control_plane.workflows.verireel_preview_driver import (
     VeriReelPreviewInventoryResult,
     VeriReelPreviewRefreshConfigError,
     VeriReelPreviewRefreshResult,
+    VeriReelPreviewRefreshTransportError,
 )
 
 from control_plane.workflows.verireel_app_maintenance import VeriReelAppMaintenanceResult
@@ -27630,12 +27631,20 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 payload["result"]["error_message"],
                 "Missing LAUNCHPLANE_PREVIEW_BASE_URL in Launchplane runtime-environment records for verireel-testing.",
             )
+            self.assertEqual(
+                payload["result"]["preview_url"],
+                "https://pr-189.preview-config-missing.launchplane.invalid",
+            )
             store = FilesystemRecordStore(state_dir=state_dir)
             preview = store.read_preview_record("preview-verireel-testing-verireel-pr-189")
             generation = store.read_preview_generation_record(
                 "preview-verireel-testing-verireel-pr-189-generation-0001"
             )
             self.assertEqual(preview.state, "failed")
+            self.assertEqual(
+                preview.canonical_url,
+                "https://pr-189.preview-config-missing.launchplane.invalid",
+            )
             self.assertEqual(generation.state, "failed")
             self.assertEqual(generation.deploy_status, "fail")
             self.assertEqual(generation.verify_status, "skipped")
@@ -27644,6 +27653,71 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 generation.failure_summary,
                 "Missing LAUNCHPLANE_PREVIEW_BASE_URL in Launchplane runtime-environment records for verireel-testing.",
             )
+
+    def test_verireel_preview_refresh_transport_error_rejects_without_records(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel-testing"],
+                            "actions": ["verireel_preview_refresh.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_verireel_preview_refresh",
+                side_effect=VeriReelPreviewRefreshTransportError(
+                    "Dokploy API GET /api/application.one request failed: timed out"
+                ),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/preview-refresh",
+                    payload={
+                        "schema_version": 1,
+                        "product": "verireel",
+                        "refresh": {
+                            "schema_version": 1,
+                            "context": "verireel-testing",
+                            "anchor_repo": "verireel",
+                            "anchor_pr_number": 189,
+                            "anchor_pr_url": "https://github.com/every/verireel/pull/189",
+                            "anchor_head_sha": "bd6ef6afb3c6c9cc3359cf98ac613eca414ac4fe",
+                            "preview_slug": "pr-189",
+                            "image_reference": "ghcr.io/every/verireel-app:pr-189-sha-bd6ef6a",
+                        },
+                    },
+                    headers={
+                        "Idempotency-Key": "verireel-preview-refresh:verireel:verireel-testing:verireel:189:bd6ef6a"
+                    },
+                )
+
+            self.assertEqual(status_code, 502)
+            self.assertEqual(payload["status"], "rejected")
+            self.assertEqual(payload["error"]["code"], "preview_refresh_backend_unavailable")
+            store = FilesystemRecordStore(state_dir=state_dir)
+            with self.assertRaises(FileNotFoundError):
+                store.read_preview_record("preview-verireel-testing-verireel-pr-189")
 
     def test_verireel_preview_refresh_payload_validation_still_rejects_bad_slug(
         self,

--- a/tests/test_verireel_preview_driver.py
+++ b/tests/test_verireel_preview_driver.py
@@ -17,6 +17,7 @@ from control_plane.contracts.secret_record import SecretBinding
 from control_plane.dokploy import DokployTargetDefinition
 from control_plane.workflows.verireel_preview_driver import VeriReelPreviewDestroyRequest
 from control_plane.workflows.verireel_preview_driver import VeriReelPreviewRefreshRequest
+from control_plane.workflows.verireel_preview_driver import VeriReelPreviewRefreshTransportError
 from control_plane.workflows.verireel_preview_driver import _build_preview_database_command
 from control_plane.workflows.verireel_preview_driver import (
     _enforce_verireel_preview_runtime_key_safety,
@@ -340,6 +341,63 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
                 )
 
         run_command.assert_not_called()
+
+    def test_preview_refresh_maps_source_of_truth_backend_failure_to_transport(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch(
+                "control_plane.workflows.verireel_preview_driver.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                side_effect=click.ClickException(
+                    "Could not load tracked Dokploy targets from Launchplane Postgres storage: connection failed"
+                ),
+            ),
+        ):
+            with self.assertRaises(VeriReelPreviewRefreshTransportError):
+                execute_verireel_preview_refresh(
+                    control_plane_root=Path(temporary_directory_name),
+                    request=_refresh_request(),
+                    record_store=None,
+                )
+
+    def test_preview_refresh_maps_template_payload_fetch_failure_to_transport(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch(
+                "control_plane.workflows.verireel_preview_driver.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                return_value=control_plane_dokploy.DokploySourceOfTruth(
+                    schema_version=1,
+                    targets=(
+                        control_plane_dokploy.DokployTargetDefinition(
+                            context="verireel",
+                            instance="testing",
+                            target_type="application",
+                            target_id="app-template",
+                            target_name="verireel-testing",
+                        ),
+                    ),
+                ),
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver.control_plane_dokploy.fetch_dokploy_target_payload",
+                side_effect=click.ClickException(
+                    "Dokploy API GET /api/application.one request failed: timed out"
+                ),
+            ),
+        ):
+            with self.assertRaises(VeriReelPreviewRefreshTransportError):
+                execute_verireel_preview_refresh(
+                    control_plane_root=Path(temporary_directory_name),
+                    request=_refresh_request(),
+                    record_store=None,
+                )
 
     def test_preview_refresh_generates_preview_local_runtime_secrets(self) -> None:
         captured_env: dict[str, str] = {}


### PR DESCRIPTION
## Summary
- return a synthesized `.invalid` preview URL in accepted VeriReel config-failure responses
- distinguish Launchplane/Postgres source-of-truth and Dokploy provider failures from operator-fixable config failures
- reject backend/provider failures with 502 instead of writing failed preview records

## Verification
- `uv run python -m unittest tests.test_verireel_preview_driver tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_driver_writes_failed_generation_record tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_config_error_is_recorded_as_failed_generation tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_transport_error_rejects_without_records tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_payload_validation_still_rejects_bad_slug`
- `uv run --extra dev ruff format --check control_plane/service.py control_plane/workflows/verireel_preview_driver.py tests/test_service.py tests/test_verireel_preview_driver.py`
- `uv run --extra dev ruff check control_plane/service.py control_plane/workflows/verireel_preview_driver.py tests/test_service.py tests/test_verireel_preview_driver.py`
- `uv run --extra dev mypy control_plane/service.py control_plane/workflows/verireel_preview_driver.py tests/test_service.py tests/test_verireel_preview_driver.py`
- JetBrains changed-files inspection: capture incomplete, zero problems shown

Follow-up to auto-review findings on #945.
