### PR TITLE
Classify existing VeriReel preview fetch outages

### DIFF
--- a/control_plane/workflows/verireel_preview_driver.py
+++ b/control_plane/workflows/verireel_preview_driver.py
@@ -1213,9 +1213,14 @@ def execute_verireel_preview_refresh(
     existing_snapshot = None
     if existing_application is not None:
         application_id = str(existing_application.get("applicationId") or "").strip()
-        existing_snapshot = _fetch_application(
-            host=host, token=token, application_id=application_id
-        )
+        try:
+            existing_snapshot = _fetch_application(
+                host=host, token=token, application_id=application_id
+            )
+        except click.ClickException as exc:
+            if _is_dokploy_provider_failure(exc):
+                raise VeriReelPreviewRefreshTransportError(str(exc)) from exc
+            raise VeriReelPreviewRefreshConfigError(str(exc)) from exc
     existing_database = _resolve_existing_preview_database(existing_snapshot)
     existing_env_map = control_plane_dokploy.parse_dokploy_env_text(
         str((existing_snapshot or {}).get("env") or "")

--- a/tests/test_verireel_preview_driver.py
+++ b/tests/test_verireel_preview_driver.py
@@ -399,6 +399,48 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
                     record_store=None,
                 )
 
+    def test_preview_refresh_maps_existing_preview_fetch_failure_to_transport(
+        self,
+    ) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch(
+                "control_plane.workflows.verireel_preview_driver.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver._template_application_payload",
+                return_value=(
+                    _template_target(),
+                    {
+                        "applicationId": "app-template",
+                        "env": "DATABASE_URL=postgresql://template:template-pass@db.example/verireel_testing\n",
+                    },
+                ),
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver._find_application_by_name",
+                return_value={"applicationId": "app-preview"},
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver._fetch_application",
+                side_effect=click.ClickException(
+                    "Dokploy API GET /api/application.one request failed: timed out"
+                ),
+            ),
+            patch(
+                "control_plane.workflows.verireel_preview_driver._run_application_command"
+            ) as run_command,
+        ):
+            with self.assertRaises(VeriReelPreviewRefreshTransportError):
+                execute_verireel_preview_refresh(
+                    control_plane_root=Path(temporary_directory_name),
+                    request=_refresh_request(),
+                    record_store=None,
+                )
+
+        run_command.assert_not_called()
+
     def test_preview_refresh_generates_preview_local_runtime_secrets(self) -> None:
         captured_env: dict[str, str] = {}
         template_master_key = base64.b64encode(b"template-master-key").decode("ascii")


### PR DESCRIPTION
## Summary
- classify existing VeriReel preview application snapshot fetch failures as transport/backend failures
- prevent Dokploy outages during existing preview refresh setup from being recorded as config-failure preview records
- add a regression test that stops before database bootstrap when the existing preview fetch is unavailable

## Verification
- `uv run python -m unittest tests.test_verireel_preview_driver.VeriReelPreviewDriverTests.test_preview_refresh_maps_existing_preview_fetch_failure_to_transport tests.test_verireel_preview_driver.VeriReelPreviewDriverTests.test_preview_refresh_maps_template_payload_fetch_failure_to_transport tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_transport_error_rejects_without_records`
- `uv run python -m unittest tests.test_verireel_preview_driver tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_driver_writes_failed_generation_record tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_config_error_is_recorded_as_failed_generation tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_transport_error_rejects_without_records tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_payload_validation_still_rejects_bad_slug`
- `uv run --extra dev ruff format --check --diff control_plane/workflows/verireel_preview_driver.py tests/test_verireel_preview_driver.py`
- `uv run --extra dev ruff check --diff control_plane/workflows/verireel_preview_driver.py tests/test_verireel_preview_driver.py`
- `uv run --extra dev ruff format control_plane/workflows/verireel_preview_driver.py tests/test_verireel_preview_driver.py`
- `uv run --extra dev ruff check control_plane/workflows/verireel_preview_driver.py tests/test_verireel_preview_driver.py`
- `uv run --extra dev mypy control_plane/workflows/verireel_preview_driver.py tests/test_verireel_preview_driver.py`

JetBrains changed-file closeout reported zero problems but did not reach a settled capture state before its deadline on two attempts (`capture_incomplete`).
