### PR TITLE
Fix merge train landing retry idempotency

### DIFF
--- a/control_plane/merge_train_github.py
+++ b/control_plane/merge_train_github.py
@@ -7,6 +7,7 @@ from urllib.request import Request, urlopen
 from pydantic import BaseModel, ConfigDict, model_validator
 
 from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidate
+from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingEntry
 from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlan
 from control_plane.contracts.merge_train_stack_collapse import MergeTrainStackCollapseBranchClient
 from control_plane.contracts.merge_train_policy import MergeTrainMergeMethod
@@ -139,15 +140,30 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
         expected_base_sha = landing_plan.entries[0].expected_base_sha
         merged_entries = []
         for entry in landing_plan.entries:
+            if entry.status == "merged":
+                merged_entries.append(entry)
+                expected_base_sha = _required_value(
+                    entry.merge_commit_sha,
+                    "Merged batch landing entry requires merge_commit_sha.",
+                )
+                continue
             current_base_sha = _base_branch_sha(
                 transport=self.transport,
                 repository_path=repository_path,
                 base_branch=landing_plan.base_branch,
             )
             if current_base_sha != expected_base_sha:
-                raise MergeTrainGitHubStaleHeadError(
-                    "Base branch moved outside the batch landing plan.", status_code=409
+                already_merged_entry = self._already_merged_landing_entry(
+                    repository_path=repository_path,
+                    entry=entry,
                 )
+                if already_merged_entry is None:
+                    raise MergeTrainGitHubStaleHeadError(
+                        "Base branch moved outside the batch landing plan.", status_code=409
+                    )
+                merged_entries.append(already_merged_entry)
+                expected_base_sha = already_merged_entry.merge_commit_sha
+                continue
             merge_commit_sha = self.merge_pull_request(
                 repository=landing_plan.repository,
                 pull_request_number=entry.pull_request_number,
@@ -161,6 +177,33 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
             )
             expected_base_sha = merge_commit_sha
         return landing_plan.model_copy(update={"entries": tuple(merged_entries)})
+
+    def _already_merged_landing_entry(
+        self, *, repository_path: str, entry: MergeTrainBatchLandingEntry
+    ) -> MergeTrainBatchLandingEntry | None:
+        pull_request = _json_object(
+            self.transport.request(
+                method="GET",
+                path=f"/repos/{repository_path}/pulls/{entry.pull_request_number}",
+            ),
+            "GitHub pull request detail response",
+        )
+        if _pull_request_state(str(pull_request.get("state") or "")) != "closed":
+            return None
+        if pull_request.get("merged") is not True:
+            return None
+        head = _json_object(pull_request.get("head"), "GitHub pull request head")
+        head_sha = _required_text(head.get("sha"), "GitHub pull request head requires sha.")
+        if head_sha != entry.expected_head_sha:
+            raise MergeTrainGitHubStaleHeadError(
+                "Pull request was merged with a different head SHA than the batch landing plan.",
+                status_code=409,
+            )
+        merge_commit_sha = _required_text(
+            pull_request.get("merge_commit_sha"),
+            "Merged GitHub pull request requires merge_commit_sha.",
+        )
+        return entry.model_copy(update={"status": "merged", "merge_commit_sha": merge_commit_sha})
 
     def add_pull_request_label(
         self, *, repository: str, pull_request_number: int, label: str

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -487,7 +487,10 @@ writes a `launchplane_merge_train_batch_landing_plans` record, or `mode: land`
 with a landing-plan record id and merges the original pull requests in recorded
 queue order. Landing fails closed if the base branch head has moved from the
 candidate base SHA, and each PR merge uses the recorded head SHA guard so a
-changed PR head cannot be merged under stale validation.
+changed PR head cannot be merged under stale validation. Retried landing is
+idempotent across already-merged entries when GitHub shows the pull request was
+merged with the exact recorded head SHA; unrelated base movement or mismatched
+head evidence still stops the landing attempt.
 
 Scheduler admission is a deterministic decision over the latest stored
 `launchplane_merge_train_runs` record for the repository/base branch. Dry-run

--- a/tests/test_merge_train_github.py
+++ b/tests/test_merge_train_github.py
@@ -405,6 +405,107 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
             ],
         )
 
+    def test_land_batch_candidate_skips_persisted_merged_entries_on_retry(self) -> None:
+        first_entry = _landing_plan().entries[0].model_copy(
+            update={"status": "merged", "merge_commit_sha": "merge-sha-1"}
+        )
+        landing_plan = _landing_plan().model_copy(
+            update={"entries": (first_entry, _landing_plan().entries[1])}
+        )
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                _github_branch(sha="merge-sha-1"),
+                {"sha": "merge-sha-2"},
+            )
+        )
+
+        landed_plan = GitHubMergeTrainClient(transport=transport).land_batch_candidate(
+            landing_plan=landing_plan
+        )
+
+        self.assertEqual(
+            [entry.merge_commit_sha for entry in landed_plan.entries],
+            ["merge-sha-1", "merge-sha-2"],
+        )
+        self.assertEqual(
+            [(request.method, request.path, request.body) for request in transport.requests],
+            [
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
+                (
+                    "PUT",
+                    "/repos/example/merge-train-repo/pulls/2/merge",
+                    {"sha": "head-2", "merge_method": "merge"},
+                ),
+            ],
+        )
+
+    def test_land_batch_candidate_recovers_already_merged_pr_after_partial_landing(
+        self,
+    ) -> None:
+        landing_plan = _landing_plan()
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                _github_branch(sha="merge-sha-1"),
+                _github_pull_request(
+                    1,
+                    state="closed",
+                    merged=True,
+                    merge_commit_sha="merge-sha-1",
+                ),
+                _github_branch(sha="merge-sha-1"),
+                {"sha": "merge-sha-2"},
+            )
+        )
+
+        landed_plan = GitHubMergeTrainClient(transport=transport).land_batch_candidate(
+            landing_plan=landing_plan
+        )
+
+        self.assertEqual(
+            [entry.status for entry in landed_plan.entries], ["merged", "merged"]
+        )
+        self.assertEqual(
+            [entry.merge_commit_sha for entry in landed_plan.entries],
+            ["merge-sha-1", "merge-sha-2"],
+        )
+        self.assertEqual(
+            [(request.method, request.path, request.body) for request in transport.requests],
+            [
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
+                ("GET", "/repos/example/merge-train-repo/pulls/1", None),
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
+                (
+                    "PUT",
+                    "/repos/example/merge-train-repo/pulls/2/merge",
+                    {"sha": "head-2", "merge_method": "merge"},
+                ),
+            ],
+        )
+
+    def test_land_batch_candidate_rejects_already_merged_pr_with_different_head(
+        self,
+    ) -> None:
+        landing_plan = _landing_plan()
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                _github_branch(sha="merge-sha-1"),
+                _github_pull_request(
+                    1,
+                    state="closed",
+                    merged=True,
+                    head_sha="unexpected-head",
+                    merge_commit_sha="merge-sha-1",
+                ),
+            )
+        )
+
+        with self.assertRaisesRegex(MergeTrainGitHubStaleHeadError, "different head SHA"):
+            GitHubMergeTrainClient(transport=transport).land_batch_candidate(
+                landing_plan=landing_plan
+            )
+
+        self.assertEqual([request.method for request in transport.requests], ["GET", "GET"])
+
     def test_land_batch_candidate_rejects_base_movement_between_prs(self) -> None:
         landing_plan = _landing_plan()
         transport = RecordingMergeTrainGitHubTransport(
@@ -412,6 +513,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 _github_branch(sha="base-main"),
                 {"sha": "merge-sha-1"},
                 _github_branch(sha="unexpected-base"),
+                _github_pull_request(2),
             )
         )
 
@@ -421,13 +523,13 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
             )
 
         self.assertEqual(
-            [request.method for request in transport.requests], ["GET", "PUT", "GET"]
+            [request.method for request in transport.requests], ["GET", "PUT", "GET", "GET"]
         )
 
     def test_land_batch_candidate_rejects_moved_base_branch(self) -> None:
         landing_plan = _landing_plan()
         transport = RecordingMergeTrainGitHubTransport(
-            responses=(_github_branch(sha="new-base-main"),)
+            responses=(_github_branch(sha="new-base-main"), _github_pull_request(1))
         )
 
         with self.assertRaisesRegex(MergeTrainGitHubStaleHeadError, "outside"):
@@ -435,7 +537,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 landing_plan=landing_plan
             )
 
-        self.assertEqual(len(transport.requests), 1)
+        self.assertEqual(len(transport.requests), 2)
 
     def test_repository_must_be_owner_name(self) -> None:
         client = GitHubMergeTrainClient(transport=RecordingMergeTrainGitHubTransport())
@@ -670,9 +772,13 @@ class GitHubMergeTrainSnapshotReaderTests(unittest.TestCase):
 def _github_pull_request(
     number: int,
     *,
+    state: str = "open",
+    merged: bool = False,
+    merge_commit_sha: str | None = None,
     mergeable: bool | None = True,
     mergeable_state: str = "clean",
     author_association: str = "COLLABORATOR",
+    head_sha: str | None = None,
     head_ref: str | None = None,
     base_ref: str = "main",
     repository: str = "cbusillo/sellyouroutboard",
@@ -685,14 +791,16 @@ def _github_pull_request(
         "number": number,
         "html_url": f"https://github.com/cbusillo/sellyouroutboard/pull/{number}",
         "title": f"Pull request {number}",
-        "state": "open",
+        "state": state,
+        "merged": merged,
+        "merge_commit_sha": merge_commit_sha,
         "draft": False,
         "created_at": f"2026-05-08T10:{number % 60:02d}:00Z",
         "labels": [{"name": "ready-to-merge"}],
         "user": {"login": "cbusillo"},
         "author_association": author_association,
         "head": {
-            "sha": f"head-{number}",
+            "sha": head_sha or f"head-{number}",
             "ref": head_ref or f"feature-{number}",
             "repo": {"full_name": normalized_head_repository},
         },


### PR DESCRIPTION
## Summary
- make batch landing retries resume across already-merged entries that match the recorded head SHA
- preserve fail-closed behavior for unrelated base movement or mismatched merged PR heads
- document retry idempotency for PR-native batch landing

Fixes #952.

## Verification
- `uv run python -m unittest tests.test_merge_train_github`
- `uv run python -m unittest tests.test_merge_train_batch tests.test_merge_train_controller tests.test_merge_train_admission tests.test_merge_train_controller_feedback tests.test_service`
- `uv run --extra dev ruff check --diff control_plane/merge_train_github.py tests/test_merge_train_github.py`
- `uv run --extra dev ruff check control_plane/merge_train_github.py tests/test_merge_train_github.py`
- `uv run python -m unittest`
- `uv run --extra dev mypy control_plane tests`

## Inspection
- JetBrains closeout routed to PyCharm 2026.1.2 for the exact worktree and extracted `total_problems=0`, but ended `capture_incomplete` because the inspection view was still updating at the helper deadline. Cleanup closed the helper-opened project.
