### PR TITLE
Reconcile completed merge train landing retries

### DIFF
--- a/control_plane/merge_train_github.py
+++ b/control_plane/merge_train_github.py
@@ -138,20 +138,40 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
     def land_batch_candidate(self, *, landing_plan: MergeTrainBatchLandingPlan) -> MergeTrainBatchLandingPlan:
         repository_path = _repository_path(landing_plan.repository)
         expected_base_sha = landing_plan.entries[0].expected_base_sha
+        recorded_landing_shas = _recorded_landing_shas(landing_plan)
         merged_entries = []
         for entry in landing_plan.entries:
-            if entry.status == "merged":
-                merged_entries.append(entry)
-                expected_base_sha = _required_value(
-                    entry.merge_commit_sha,
-                    "Merged batch landing entry requires merge_commit_sha.",
-                )
-                continue
             current_base_sha = _base_branch_sha(
                 transport=self.transport,
                 repository_path=repository_path,
                 base_branch=landing_plan.base_branch,
             )
+            if entry.status == "merged":
+                merge_commit_sha = _required_value(
+                    entry.merge_commit_sha,
+                    "Merged batch landing entry requires merge_commit_sha.",
+                )
+                if current_base_sha not in {expected_base_sha, merge_commit_sha}:
+                    if current_base_sha not in recorded_landing_shas:
+                        raise MergeTrainGitHubStaleHeadError(
+                            "Base branch moved outside the batch landing plan.", status_code=409
+                        )
+                    already_merged_entry = self._already_merged_landing_entry(
+                        repository_path=repository_path,
+                        entry=entry,
+                    )
+                    if already_merged_entry is None:
+                        raise MergeTrainGitHubStaleHeadError(
+                            "Base branch moved outside the batch landing plan.", status_code=409
+                        )
+                    if already_merged_entry.merge_commit_sha != merge_commit_sha:
+                        raise MergeTrainGitHubStaleHeadError(
+                            "Pull request merge commit does not match the batch landing plan.",
+                            status_code=409,
+                        )
+                merged_entries.append(entry)
+                expected_base_sha = merge_commit_sha
+                continue
             if current_base_sha != expected_base_sha:
                 already_merged_entry = self._already_merged_landing_entry(
                     repository_path=repository_path,
@@ -176,6 +196,15 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
                 )
             )
             expected_base_sha = merge_commit_sha
+        current_base_sha = _base_branch_sha(
+            transport=self.transport,
+            repository_path=repository_path,
+            base_branch=landing_plan.base_branch,
+        )
+        if current_base_sha != expected_base_sha:
+            raise MergeTrainGitHubStaleHeadError(
+                "Base branch moved outside the batch landing plan.", status_code=409
+            )
         return landing_plan.model_copy(update={"entries": tuple(merged_entries)})
 
     def _already_merged_landing_entry(
@@ -574,6 +603,19 @@ def _repository_path(repository: str) -> str:
     if len(parts) != 2 or not all(part.strip() for part in parts):
         raise ValueError("GitHub repository must be formatted as owner/name.")
     return "/".join(quote(part.strip(), safe="") for part in parts)
+
+
+def _recorded_landing_shas(landing_plan: MergeTrainBatchLandingPlan) -> set[str]:
+    shas = {_required_value(landing_plan.entries[0].expected_base_sha, "Landing plan base SHA is required.")}
+    for entry in landing_plan.entries:
+        if entry.status == "merged":
+            shas.add(
+                _required_value(
+                    entry.merge_commit_sha,
+                    "Merged batch landing entry requires merge_commit_sha.",
+                )
+            )
+    return shas
 
 
 def _branch_name_from_ref(reference: str) -> str:

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -490,7 +490,10 @@ candidate base SHA, and each PR merge uses the recorded head SHA guard so a
 changed PR head cannot be merged under stale validation. Retried landing is
 idempotent across already-merged entries when GitHub shows the pull request was
 merged with the exact recorded head SHA; unrelated base movement or mismatched
-head evidence still stops the landing attempt.
+head evidence still stops the landing attempt. When every landing-plan entry is
+already merged with its recorded head SHA and the live base branch is at the
+recorded final merge commit, the retry writes terminal landing evidence instead
+of continuing to advertise the stale `land_batch` action.
 
 Scheduler admission is a deterministic decision over the latest stored
 `launchplane_merge_train_runs` record for the repository/base branch. Dry-run

--- a/tests/test_merge_train_github.py
+++ b/tests/test_merge_train_github.py
@@ -373,6 +373,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 {"sha": "merge-sha-1"},
                 _github_branch(sha="merge-sha-1"),
                 {"sha": "merge-sha-2"},
+                _github_branch(sha="merge-sha-2"),
             )
         )
 
@@ -402,6 +403,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                     "/repos/example/merge-train-repo/pulls/2/merge",
                     {"sha": "head-2", "merge_method": "merge"},
                 ),
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
             ],
         )
 
@@ -415,7 +417,9 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
         transport = RecordingMergeTrainGitHubTransport(
             responses=(
                 _github_branch(sha="merge-sha-1"),
+                _github_branch(sha="merge-sha-1"),
                 {"sha": "merge-sha-2"},
+                _github_branch(sha="merge-sha-2"),
             )
         )
 
@@ -431,13 +435,75 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
             [(request.method, request.path, request.body) for request in transport.requests],
             [
                 ("GET", "/repos/example/merge-train-repo/branches/main", None),
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
                 (
                     "PUT",
                     "/repos/example/merge-train-repo/pulls/2/merge",
                     {"sha": "head-2", "merge_method": "merge"},
                 ),
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
             ],
         )
+
+    def test_land_batch_candidate_reconciles_all_already_merged_entries(self) -> None:
+        first_entry = _landing_plan().entries[0].model_copy(
+            update={"status": "merged", "merge_commit_sha": "merge-sha-1"}
+        )
+        second_entry = _landing_plan().entries[1].model_copy(
+            update={"status": "merged", "merge_commit_sha": "merge-sha-2"}
+        )
+        landing_plan = _landing_plan().model_copy(
+            update={"entries": (first_entry, second_entry)}
+        )
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                _github_branch(sha="merge-sha-2"),
+                _github_pull_request(
+                    1,
+                    state="closed",
+                    merged=True,
+                    merge_commit_sha="merge-sha-1",
+                ),
+                _github_branch(sha="merge-sha-2"),
+                _github_branch(sha="merge-sha-2"),
+            )
+        )
+
+        landed_plan = GitHubMergeTrainClient(transport=transport).land_batch_candidate(
+            landing_plan=landing_plan
+        )
+
+        self.assertEqual(
+            [entry.merge_commit_sha for entry in landed_plan.entries],
+            ["merge-sha-1", "merge-sha-2"],
+        )
+        self.assertEqual(
+            [(request.method, request.path, request.body) for request in transport.requests],
+            [
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
+                ("GET", "/repos/example/merge-train-repo/pulls/1", None),
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
+            ],
+        )
+
+    def test_land_batch_candidate_revalidates_persisted_merged_entry_base(self) -> None:
+        first_entry = _landing_plan().entries[0].model_copy(
+            update={"status": "merged", "merge_commit_sha": "merge-sha-1"}
+        )
+        landing_plan = _landing_plan().model_copy(
+            update={"entries": (first_entry, _landing_plan().entries[1])}
+        )
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(_github_branch(sha="unexpected-base"),)
+        )
+
+        with self.assertRaisesRegex(MergeTrainGitHubStaleHeadError, "outside"):
+            GitHubMergeTrainClient(transport=transport).land_batch_candidate(
+                landing_plan=landing_plan
+            )
+
+        self.assertEqual(len(transport.requests), 1)
 
     def test_land_batch_candidate_recovers_already_merged_pr_after_partial_landing(
         self,
@@ -454,6 +520,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 ),
                 _github_branch(sha="merge-sha-1"),
                 {"sha": "merge-sha-2"},
+                _github_branch(sha="merge-sha-2"),
             )
         )
 
@@ -479,6 +546,53 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                     "/repos/example/merge-train-repo/pulls/2/merge",
                     {"sha": "head-2", "merge_method": "merge"},
                 ),
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
+            ],
+        )
+
+    def test_land_batch_candidate_reconciles_all_planned_entries_already_merged(
+        self,
+    ) -> None:
+        landing_plan = _landing_plan()
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                _github_branch(sha="merge-sha-2"),
+                _github_pull_request(
+                    1,
+                    state="closed",
+                    merged=True,
+                    merge_commit_sha="merge-sha-1",
+                ),
+                _github_branch(sha="merge-sha-2"),
+                _github_pull_request(
+                    2,
+                    state="closed",
+                    merged=True,
+                    merge_commit_sha="merge-sha-2",
+                ),
+                _github_branch(sha="merge-sha-2"),
+            )
+        )
+
+        landed_plan = GitHubMergeTrainClient(transport=transport).land_batch_candidate(
+            landing_plan=landing_plan
+        )
+
+        self.assertEqual(
+            [entry.status for entry in landed_plan.entries], ["merged", "merged"]
+        )
+        self.assertEqual(
+            [entry.merge_commit_sha for entry in landed_plan.entries],
+            ["merge-sha-1", "merge-sha-2"],
+        )
+        self.assertEqual(
+            [(request.method, request.path, request.body) for request in transport.requests],
+            [
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
+                ("GET", "/repos/example/merge-train-repo/pulls/1", None),
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
+                ("GET", "/repos/example/merge-train-repo/pulls/2", None),
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
             ],
         )
 


### PR DESCRIPTION
## Summary

- Reconcile batch landing retries when every planned PR has already merged and the live base branch is at the recorded final merge commit.
- Revalidate persisted `merged` landing entries against the live base branch before skipping them, so unrelated base movement still fails closed.
- Document terminal landing retry behavior in the merge train policy.

Fixes #956.

## Verification

- `git diff --check`
- `uv run --extra dev ruff check control_plane/merge_train_github.py tests/test_merge_train_github.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest tests.test_merge_train_github tests.test_service tests.test_merge_train_controller tests.test_merge_train_admission`
- `uv run python -m unittest`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py closeout --repo "$PWD" --scope changed_files`
