### PR TITLE
Reconcile mixed merge train landing retry state

### DIFF
--- a/control_plane/merge_train_github.py
+++ b/control_plane/merge_train_github.py
@@ -138,7 +138,6 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
     def land_batch_candidate(self, *, landing_plan: MergeTrainBatchLandingPlan) -> MergeTrainBatchLandingPlan:
         repository_path = _repository_path(landing_plan.repository)
         expected_base_sha = landing_plan.entries[0].expected_base_sha
-        recorded_landing_shas = _recorded_landing_shas(landing_plan)
         merged_entries = []
         for entry in landing_plan.entries:
             current_base_sha = _base_branch_sha(
@@ -152,10 +151,6 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
                     "Merged batch landing entry requires merge_commit_sha.",
                 )
                 if current_base_sha not in {expected_base_sha, merge_commit_sha}:
-                    if current_base_sha not in recorded_landing_shas:
-                        raise MergeTrainGitHubStaleHeadError(
-                            "Base branch moved outside the batch landing plan.", status_code=409
-                        )
                     already_merged_entry = self._already_merged_landing_entry(
                         repository_path=repository_path,
                         entry=entry,
@@ -603,19 +598,6 @@ def _repository_path(repository: str) -> str:
     if len(parts) != 2 or not all(part.strip() for part in parts):
         raise ValueError("GitHub repository must be formatted as owner/name.")
     return "/".join(quote(part.strip(), safe="") for part in parts)
-
-
-def _recorded_landing_shas(landing_plan: MergeTrainBatchLandingPlan) -> set[str]:
-    shas = {_required_value(landing_plan.entries[0].expected_base_sha, "Landing plan base SHA is required.")}
-    for entry in landing_plan.entries:
-        if entry.status == "merged":
-            shas.add(
-                _required_value(
-                    entry.merge_commit_sha,
-                    "Merged batch landing entry requires merge_commit_sha.",
-                )
-            )
-    return shas
 
 
 def _branch_name_from_ref(reference: str) -> str:

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -263,6 +263,7 @@ from control_plane.merge_train_github import (
     GitHubMergeTrainClient,
     GitHubMergeTrainSnapshotReader,
     MergeTrainGitHubError,
+    MergeTrainGitHubStaleHeadError,
     MergeTrainGitHubTransport,
     UrllibMergeTrainGitHubTransport,
 )
@@ -14230,7 +14231,25 @@ def create_launchplane_service_app(
                     },
                 },
             )
-        except MergeTrainGitHubError:
+        except MergeTrainGitHubStaleHeadError as error:
+            message = str(error).strip() or "Merge train landing evidence no longer matches GitHub."
+            return _json_response(
+                start_response=start_response,
+                status_code=409,
+                payload={
+                    "status": "rejected",
+                    "trace_id": request_trace_id,
+                    "error": {
+                        "code": "merge_train_github_stale_state",
+                        "message": message,
+                    },
+                    "details": {
+                        "github_status_code": error.status_code,
+                    },
+                },
+            )
+        except MergeTrainGitHubError as error:
+            message = str(error).strip() or "GitHub merge train request failed."
             return _json_response(
                 start_response=start_response,
                 status_code=502,
@@ -14240,6 +14259,10 @@ def create_launchplane_service_app(
                     "error": {
                         "code": "github_request_failed",
                         "message": "GitHub merge train request failed; retry after upstream recovers.",
+                    },
+                    "details": {
+                        "github_status_code": error.status_code,
+                        "message": message,
                     },
                 },
             )

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -489,11 +489,16 @@ queue order. Landing fails closed if the base branch head has moved from the
 candidate base SHA, and each PR merge uses the recorded head SHA guard so a
 changed PR head cannot be merged under stale validation. Retried landing is
 idempotent across already-merged entries when GitHub shows the pull request was
-merged with the exact recorded head SHA; unrelated base movement or mismatched
-head evidence still stops the landing attempt. When every landing-plan entry is
-already merged with its recorded head SHA and the live base branch is at the
-recorded final merge commit, the retry writes terminal landing evidence instead
-of continuing to advertise the stale `land_batch` action.
+merged with the exact recorded head SHA. If the live base is already ahead of a
+persisted merged entry, Launchplane revalidates that entry's PR evidence and
+continues through later planned entries before deciding whether the landing plan
+is stale. Unrelated base movement or mismatched head evidence still stops the
+landing attempt. Stale landing evidence is reported as a merge-train stale-state
+conflict, while real GitHub transport/API failures include upstream status
+details for debugging. When every landing-plan entry is already merged with its
+recorded head SHA and the live base branch is at the recorded final merge
+commit, the retry writes terminal landing evidence instead of continuing to
+advertise the stale `land_batch` action.
 
 Scheduler admission is a deterministic decision over the latest stored
 `launchplane_merge_train_runs` record for the repository/base branch. Dry-run

--- a/tests/test_merge_train_github.py
+++ b/tests/test_merge_train_github.py
@@ -495,7 +495,17 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
             update={"entries": (first_entry, _landing_plan().entries[1])}
         )
         transport = RecordingMergeTrainGitHubTransport(
-            responses=(_github_branch(sha="unexpected-base"),)
+            responses=(
+                _github_branch(sha="unexpected-base"),
+                _github_pull_request(
+                    1,
+                    state="closed",
+                    merged=True,
+                    merge_commit_sha="merge-sha-1",
+                ),
+                _github_branch(sha="unexpected-base"),
+                _github_pull_request(2, state="open", merged=False),
+            )
         )
 
         with self.assertRaisesRegex(MergeTrainGitHubStaleHeadError, "outside"):
@@ -503,7 +513,66 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 landing_plan=landing_plan
             )
 
-        self.assertEqual(len(transport.requests), 1)
+        self.assertEqual(
+            [(request.method, request.path, request.body) for request in transport.requests],
+            [
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
+                ("GET", "/repos/example/merge-train-repo/pulls/1", None),
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
+                ("GET", "/repos/example/merge-train-repo/pulls/2", None),
+            ],
+        )
+
+    def test_land_batch_candidate_reconciles_partially_persisted_plan_at_final_base(
+        self,
+    ) -> None:
+        first_entry = _landing_plan().entries[0].model_copy(
+            update={"status": "merged", "merge_commit_sha": "merge-sha-1"}
+        )
+        landing_plan = _landing_plan().model_copy(
+            update={"entries": (first_entry, _landing_plan().entries[1])}
+        )
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                _github_branch(sha="merge-sha-2"),
+                _github_pull_request(
+                    1,
+                    state="closed",
+                    merged=True,
+                    merge_commit_sha="merge-sha-1",
+                ),
+                _github_branch(sha="merge-sha-2"),
+                _github_pull_request(
+                    2,
+                    state="closed",
+                    merged=True,
+                    merge_commit_sha="merge-sha-2",
+                ),
+                _github_branch(sha="merge-sha-2"),
+            )
+        )
+
+        landed_plan = GitHubMergeTrainClient(transport=transport).land_batch_candidate(
+            landing_plan=landing_plan
+        )
+
+        self.assertEqual(
+            [entry.status for entry in landed_plan.entries], ["merged", "merged"]
+        )
+        self.assertEqual(
+            [entry.merge_commit_sha for entry in landed_plan.entries],
+            ["merge-sha-1", "merge-sha-2"],
+        )
+        self.assertEqual(
+            [(request.method, request.path, request.body) for request in transport.requests],
+            [
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
+                ("GET", "/repos/example/merge-train-repo/pulls/1", None),
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
+                ("GET", "/repos/example/merge-train-repo/pulls/2", None),
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
+            ],
+        )
 
     def test_land_batch_candidate_recovers_already_merged_pr_after_partial_landing(
         self,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -43,6 +43,8 @@ from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidateRe
 from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlan
 from control_plane.contracts.merge_train_batch import build_merge_train_batch_candidate
 from control_plane.contracts.merge_train_batch import build_merge_train_batch_candidate_record
+from control_plane.merge_train_github import MergeTrainGitHubError
+from control_plane.merge_train_github import MergeTrainGitHubStaleHeadError
 from control_plane.contracts.merge_train_stack_collapse import (
     build_merge_train_stack_collapse_plan,
     build_merge_train_stack_collapse_plan_record,
@@ -319,6 +321,20 @@ class _FakeFailingMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
         self, *, candidate: MergeTrainBatchCandidate
     ) -> MergeTrainBatchCandidate:
         return candidate.model_copy(update={"required_checks_status": "fail", "status": "failed"})
+
+
+class _StaleLandingMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
+    def land_batch_candidate(
+        self, *, landing_plan: MergeTrainBatchLandingPlan
+    ) -> MergeTrainBatchLandingPlan:
+        raise MergeTrainGitHubStaleHeadError("Base branch moved outside the batch landing plan.", status_code=409)
+
+
+class _UnavailableLandingMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
+    def land_batch_candidate(
+        self, *, landing_plan: MergeTrainBatchLandingPlan
+    ) -> MergeTrainBatchLandingPlan:
+        raise MergeTrainGitHubError("GitHub API request failed for /repos/example/repo", status_code=503)
 
 
 class _FailingChildDispositionMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
@@ -2780,6 +2796,112 @@ class LaunchplaneServiceTests(unittest.TestCase):
             next_observe_payload["result"]["landing_plan"]["batch_id"],
             superseding_candidate.batch_id,
         )
+
+    def test_merge_train_controller_reports_stale_landing_state(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with (
+                patch(
+                    "control_plane.service.GitHubMergeTrainSnapshotReader",
+                    _FakeMergeTrainSnapshotReader,
+                ),
+                patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient),
+            ):
+                for _ in range(4):
+                    _invoke_app(
+                        app,
+                        method="POST",
+                        path="/v1/work-graph/merge-train/controller/run-once",
+                        payload={
+                            "schema_version": 1,
+                            "repository": "cbusillo/sellyouroutboard",
+                            "base_branch": "main",
+                            "mutate": True,
+                        },
+                    )
+            with patch(
+                "control_plane.service.GitHubMergeTrainClient",
+                _StaleLandingMergeTrainGitHubClient,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+
+        self.assertEqual(status_code, 409)
+        self.assertEqual(payload["error"]["code"], "merge_train_github_stale_state")
+        self.assertIn("outside", payload["error"]["message"])
+        self.assertEqual(payload["details"]["github_status_code"], 409)
+
+    def test_merge_train_controller_reports_github_failure_details(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with (
+                patch(
+                    "control_plane.service.GitHubMergeTrainSnapshotReader",
+                    _FakeMergeTrainSnapshotReader,
+                ),
+                patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient),
+            ):
+                for _ in range(4):
+                    _invoke_app(
+                        app,
+                        method="POST",
+                        path="/v1/work-graph/merge-train/controller/run-once",
+                        payload={
+                            "schema_version": 1,
+                            "repository": "cbusillo/sellyouroutboard",
+                            "base_branch": "main",
+                            "mutate": True,
+                        },
+                    )
+            with patch(
+                "control_plane.service.GitHubMergeTrainClient",
+                _UnavailableLandingMergeTrainGitHubClient,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+
+        self.assertEqual(status_code, 502)
+        self.assertEqual(payload["error"]["code"], "github_request_failed")
+        self.assertEqual(payload["details"]["github_status_code"], 503)
+        self.assertIn("GitHub API request failed", payload["details"]["message"])
 
     def test_merge_train_controller_ignores_stale_stack_record_when_landing_batch(
         self,


### PR DESCRIPTION
## Summary

- Let landing retries continue past persisted `merged` entries when the live base is already at a later batch merge commit, using PR detail evidence instead of a premature recorded-SHA guard.
- Keep the final live-base check so unrelated base movement still fails closed after the full plan is reconciled.
- Return explicit `merge_train_github_stale_state` conflicts for stale landing evidence and include upstream status/message details on real GitHub request failures.
- Document the retry and debugging behavior in the merge train policy.

Fixes #956.

## Verification

- `uv run --extra dev ruff check --diff control_plane/merge_train_github.py control_plane/service.py tests/test_merge_train_github.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/merge_train_github.py control_plane/service.py tests/test_merge_train_github.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest tests.test_merge_train_github tests.test_service`
- `uv run python -m unittest tests.test_merge_train_github tests.test_service tests.test_merge_train_controller tests.test_merge_train_admission`
- `git diff --check`
- `uv run python -m unittest`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py closeout --repo "$PWD" --scope changed_files`
