### PR TITLE
Retire stale merge train landing plans

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -3713,9 +3713,24 @@ def _latest_completed_merge_train_batch_landing_plan_record(
         return None
     if not latest_record.landing_plan.entries:
         return None
-    if any(entry.status != "merged" for entry in latest_record.landing_plan.entries):
+    if any(entry.status not in {"merged", "stale"} for entry in latest_record.landing_plan.entries):
         return None
     return latest_record
+
+
+def _stale_merge_train_landing_plan(
+    landing_plan: MergeTrainBatchLandingPlan,
+) -> MergeTrainBatchLandingPlan:
+    return landing_plan.model_copy(
+        update={
+            "entries": tuple(
+                entry.model_copy(update={"status": "stale"})
+                if entry.status in {"planned", "merging"}
+                else entry
+                for entry in landing_plan.entries
+            )
+        }
+    )
 
 
 def _latest_merge_train_stack_collapse_plan_record(
@@ -10071,61 +10086,97 @@ def create_launchplane_service_app(
                             )
                         driver_result = result
                     else:
-                        landed_plan = github_client.land_batch_candidate(
-                            landing_plan=active_landing_record.landing_plan
-                        )
-                        landed_record = build_merge_train_batch_landing_plan_record(
-                            landing_plan=landed_plan,
-                            source=f"service:controller:land:{request_trace_id}",
-                            updated_at=recorded_at,
-                        )
-                        landing_store.write_merge_train_batch_landing_plan_record(landed_record)
-                        result = {
-                            "merge_train_batch_landing_plan_record_id": landed_record.record_id,
-                            "repository": landed_plan.repository,
-                            "base_branch": landed_plan.base_branch,
-                            "mode": "land",
-                            "controller_action": "land_batch",
-                            "landing_plan": landed_plan.model_dump(mode="json"),
-                        }
-                        if collapse_record is not None:
-                            root_entry = next(
-                                (
-                                    entry
-                                    for entry in landed_plan.entries
-                                    if entry.pull_request_number
-                                    == collapse_record.plan.root_pull_request_number
-                                ),
-                                None,
+                        try:
+                            landed_plan = github_client.land_batch_candidate(
+                                landing_plan=active_landing_record.landing_plan
                             )
-                            if root_entry is None or root_entry.status != "merged":
-                                raise ValueError(
-                                    "merge train stack child disposition requires merged root PR"
-                                )
-                            reconciled_collapse_plan = (
-                                reconcile_merge_train_stack_children_after_root_landing(
-                                    plan=collapse_record.plan,
-                                    disposition_client=github_client,
-                                    root_merge_commit_sha=root_entry.merge_commit_sha,
-                                    label=repository_policy.stack_child_disposition_label,
-                                    updated_at=recorded_at,
-                                )
+                        except MergeTrainGitHubStaleHeadError as error:
+                            stale_plan = _stale_merge_train_landing_plan(
+                                active_landing_record.landing_plan
                             )
-                            reconciled_record = build_merge_train_stack_collapse_plan_record(
-                                plan=reconciled_collapse_plan,
-                                source=f"service:controller:child-disposition:{request_trace_id}",
+                            stale_record = build_merge_train_batch_landing_plan_record(
+                                landing_plan=stale_plan,
+                                source=f"service:controller:stale-landing:{request_trace_id}",
                                 updated_at=recorded_at,
                             )
-                            collapse_store.write_merge_train_stack_collapse_plan_record(
-                                reconciled_record
+                            landing_store.write_merge_train_batch_landing_plan_record(
+                                stale_record
                             )
-                            result["merge_train_stack_collapse_plan_record_id"] = (
-                                reconciled_record.record_id
+                            message = (
+                                str(error).strip()
+                                or "Merge train landing evidence no longer matches GitHub."
                             )
-                            result["stack_collapse_plan"] = reconciled_collapse_plan.model_dump(
-                                mode="json"
+                            result = {
+                                "merge_train_batch_landing_plan_record_id": stale_record.record_id,
+                                "repository": stale_plan.repository,
+                                "base_branch": stale_plan.base_branch,
+                                "mode": "stale_landing",
+                                "controller_action": "land_batch",
+                                "landing_plan": stale_plan.model_dump(mode="json"),
+                                "error": {
+                                    "code": "merge_train_github_stale_state",
+                                    "message": message,
+                                },
+                                "details": {
+                                    "github_status_code": error.status_code,
+                                },
+                            }
+                            driver_result = result
+                        else:
+                            landed_record = build_merge_train_batch_landing_plan_record(
+                                landing_plan=landed_plan,
+                                source=f"service:controller:land:{request_trace_id}",
+                                updated_at=recorded_at,
                             )
-                        driver_result = result
+                            landing_store.write_merge_train_batch_landing_plan_record(
+                                landed_record
+                            )
+                            result = {
+                                "merge_train_batch_landing_plan_record_id": landed_record.record_id,
+                                "repository": landed_plan.repository,
+                                "base_branch": landed_plan.base_branch,
+                                "mode": "land",
+                                "controller_action": "land_batch",
+                                "landing_plan": landed_plan.model_dump(mode="json"),
+                            }
+                            if collapse_record is not None:
+                                root_entry = next(
+                                    (
+                                        entry
+                                        for entry in landed_plan.entries
+                                        if entry.pull_request_number
+                                        == collapse_record.plan.root_pull_request_number
+                                    ),
+                                    None,
+                                )
+                                if root_entry is None or root_entry.status != "merged":
+                                    raise ValueError(
+                                        "merge train stack child disposition requires merged root PR"
+                                    )
+                                reconciled_collapse_plan = (
+                                    reconcile_merge_train_stack_children_after_root_landing(
+                                        plan=collapse_record.plan,
+                                        disposition_client=github_client,
+                                        root_merge_commit_sha=root_entry.merge_commit_sha,
+                                        label=repository_policy.stack_child_disposition_label,
+                                        updated_at=recorded_at,
+                                    )
+                                )
+                                reconciled_record = build_merge_train_stack_collapse_plan_record(
+                                    plan=reconciled_collapse_plan,
+                                    source=f"service:controller:child-disposition:{request_trace_id}",
+                                    updated_at=recorded_at,
+                                )
+                                collapse_store.write_merge_train_stack_collapse_plan_record(
+                                    reconciled_record
+                                )
+                                result["merge_train_stack_collapse_plan_record_id"] = (
+                                    reconciled_record.record_id
+                                )
+                                result["stack_collapse_plan"] = (
+                                    reconciled_collapse_plan.model_dump(mode="json")
+                                )
+                            driver_result = result
                 else:
                     active_candidate_record = _latest_merge_train_batch_candidate_record(
                         record_store=candidate_store,

--- a/control_plane/workflows/merge_train_controller.py
+++ b/control_plane/workflows/merge_train_controller.py
@@ -177,7 +177,7 @@ def latest_completed_merge_train_batch_landing_plan_record(
         return None
     if not latest_record.landing_plan.entries:
         return None
-    if any(entry.status != "merged" for entry in latest_record.landing_plan.entries):
+    if any(entry.status not in {"merged", "stale"} for entry in latest_record.landing_plan.entries):
         return None
     return latest_record
 

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -498,7 +498,11 @@ conflict, while real GitHub transport/API failures include upstream status
 details for debugging. When every landing-plan entry is already merged with its
 recorded head SHA and the live base branch is at the recorded final merge
 commit, the retry writes terminal landing evidence instead of continuing to
-advertise the stale `land_batch` action.
+advertise the stale `land_batch` action. If GitHub proves a pull request merged
+with a different head SHA than the landing plan recorded, Launchplane writes
+terminal stale landing evidence for the plan. That stale evidence does not count
+as a successful Launchplane landing, but it does retire the stale plan so a fresh
+controller pass can read current GitHub state and admit later eligible work.
 
 Scheduler admission is a deterministic decision over the latest stored
 `launchplane_merge_train_runs` record for the repository/base branch. Dry-run

--- a/scripts/merge_train_controller_feedback.py
+++ b/scripts/merge_train_controller_feedback.py
@@ -126,6 +126,8 @@ def _feedback_event(*, controller_action: str, result: dict[str, Any]) -> str:
 
     if controller_action in {"idle", "candidate_stopped"} and candidate_status == "stale":
         return "stale_policy"
+    if _landing_plan_stale(landing_plan):
+        return "stale_policy"
     if controller_action == "batch_landed" or _landing_plan_complete(landing_plan):
         return "completed"
     if candidate_status in {"blocked", "failed", "stale"}:
@@ -151,7 +153,7 @@ def _feedback_message(
     if event == "completed":
         return "Launchplane finished the merge-train step for this pull request."
     if event == "stale_policy":
-        return "Launchplane stopped using this train record because policy changed."
+        return "Launchplane stopped using this train record because its stored evidence is stale."
     if event == "blocked":
         detail = _blocking_detail(result)
         if detail:
@@ -211,6 +213,14 @@ def _landing_plan_complete(landing_plan: dict[str, Any]) -> bool:
     return bool(entries) and all(
         _string(_as_dict(entry).get("status")) == "merged" for entry in entries
     )
+
+
+def _landing_plan_stale(landing_plan: dict[str, Any]) -> bool:
+    entries = _as_list(landing_plan.get("entries"))
+    return bool(entries) and all(
+        _string(_as_dict(entry).get("status")) in {"merged", "stale"}
+        for entry in entries
+    ) and any(_string(_as_dict(entry).get("status")) == "stale" for entry in entries)
 
 
 def _required_string(value: object, field_name: str) -> str:

--- a/tests/test_merge_train_admission.py
+++ b/tests/test_merge_train_admission.py
@@ -306,6 +306,28 @@ class MergeTrainAdmissionTests(unittest.TestCase):
         self.assertEqual(decision.controller_landing_plan_record_id, "")
         self.assertEqual(decision.controller_stack_collapse_plan_record_id, "")
 
+    def test_ignores_stale_landing_plan_for_admission(self) -> None:
+        candidate_record = _candidate_record(status="passed")
+        landing_plan_record = _landing_plan_record(candidate_record, entry_status="stale")
+        store = _RunHistoryStore(
+            None,
+            candidate_records=(candidate_record,),
+            landing_plan_records=(landing_plan_record,),
+        )
+
+        decision = evaluate_merge_train_admission_from_store(
+            store=store,
+            repository="cbusillo/sellyouroutboard",
+            base_branch="main",
+            requested_at="2026-05-09T02:10:00Z",
+            current_policy_key=candidate_record.candidate.policy_key,
+            current_policy_sha256=candidate_record.candidate.policy_sha256,
+        )
+
+        self.assertTrue(decision.admitted)
+        self.assertEqual(decision.controller_action, "idle")
+        self.assertEqual(decision.controller_landing_plan_record_id, "")
+
     def test_latest_idle_run_supersedes_older_controller_records_for_admission(self) -> None:
         candidate_record = _candidate_record(status="passed")
         landing_plan_record = _landing_plan_record(candidate_record)

--- a/tests/test_merge_train_controller.py
+++ b/tests/test_merge_train_controller.py
@@ -161,6 +161,24 @@ class MergeTrainControllerDecisionTests(unittest.TestCase):
         self.assertEqual(decision.action, "idle")
         self.assertEqual(decision.landing_plan_record_id, "")
 
+    def test_decision_treats_stale_landing_plan_as_terminal_for_candidate(self) -> None:
+        passed_record = _candidate_record(status="passed", candidate_sha="candidate-sha")
+        stale_landing_record = _landing_plan_record(
+            candidate=passed_record.candidate,
+            record_id="landing-stale",
+            entry_status="stale",
+            updated_at="2026-05-18T01:02:00Z",
+        )
+
+        decision = decide_merge_train_controller_record_action(
+            candidate_records=(passed_record,),
+            landing_plan_records=(stale_landing_record,),
+            stack_collapse_plan_records=(),
+        )
+
+        self.assertEqual(decision.action, "idle")
+        self.assertEqual(decision.landing_plan_record_id, "")
+
     def test_decision_supports_stack_collapse_records(self) -> None:
         planned_record = _stack_collapse_record(status="planned")
         waiting_record = _stack_collapse_record(

--- a/tests/test_merge_train_controller_feedback.py
+++ b/tests/test_merge_train_controller_feedback.py
@@ -94,6 +94,28 @@ class MergeTrainControllerFeedbackTests(TestCase):
         self.assertEqual([7, 8], [payload["pull_request_number"] for payload in payloads])
         self.assertEqual({"completed"}, {payload["event"] for payload in payloads})
 
+    def test_build_feedback_payloads_marks_stale_landing_plan_terminal(self) -> None:
+        response: dict[str, Any] = {
+            "result": {
+                "repository": "cbusillo/example",
+                "base_branch": "main",
+                "controller_action": "land_batch",
+                "landing_plan": {
+                    "entries": [
+                        {"pull_request_number": 7, "status": "merged"},
+                        {"pull_request_number": 8, "status": "stale"},
+                    ],
+                },
+            },
+            "records": {"merge_train_batch_landing_plan_record_id": "landing-plan-123"},
+        }
+
+        payloads = feedback.build_feedback_payloads(response=response)
+
+        self.assertEqual([7, 8], [payload["pull_request_number"] for payload in payloads])
+        self.assertEqual({"stale_policy"}, {payload["event"] for payload in payloads})
+        self.assertIn("stale", payloads[0]["message"])
+
     def test_build_feedback_payloads_skips_actions_without_pr_numbers(self) -> None:
         response: dict[str, Any] = {
             "result": {

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2797,7 +2797,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             superseding_candidate.batch_id,
         )
 
-    def test_merge_train_controller_reports_stale_landing_state(self) -> None:
+    def test_merge_train_controller_terminalizes_stale_landing_state(self) -> None:
         with (
             TemporaryDirectory() as temporary_directory_name,
             patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
@@ -2844,11 +2844,50 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "mutate": True,
                     },
                 )
+            landing_records = FilesystemRecordStore(
+                state_dir
+            ).list_merge_train_batch_landing_plan_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+            with (
+                patch(
+                    "control_plane.service.GitHubMergeTrainSnapshotReader",
+                    _FakeMergeTrainSnapshotReader,
+                ),
+                patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient),
+            ):
+                next_status_code, next_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": False,
+                    },
+                )
 
-        self.assertEqual(status_code, 409)
-        self.assertEqual(payload["error"]["code"], "merge_train_github_stale_state")
-        self.assertIn("outside", payload["error"]["message"])
-        self.assertEqual(payload["details"]["github_status_code"], 409)
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "stale_landing")
+        self.assertEqual(payload["result"]["error"]["code"], "merge_train_github_stale_state")
+        self.assertIn("outside", payload["result"]["error"]["message"])
+        self.assertEqual(payload["result"]["details"]["github_status_code"], 409)
+        self.assertTrue(
+            all(
+                entry["status"] == "stale"
+                for entry in payload["result"]["landing_plan"]["entries"]
+            )
+        )
+        stale_record = next(
+            record
+            for record in landing_records
+            if record.record_id
+            == payload["records"]["merge_train_batch_landing_plan_record_id"]
+        )
+        self.assertEqual(stale_record.landing_plan.entries[0].status, "stale")
+        self.assertEqual(next_status_code, 202)
+        self.assertNotEqual(next_payload["result"]["controller_action"], "land_batch")
 
     def test_merge_train_controller_reports_github_failure_details(self) -> None:
         with (


### PR DESCRIPTION
## Summary

- Write terminal stale landing evidence when GitHub proves an already-merged PR used a different head than the stored landing plan.
- Treat stale landing evidence as terminal for the old passed candidate so the controller stops advertising the stale `land_batch` and can reread current GitHub state.
- Update merge-train PR feedback so terminal stale landing records report stale evidence instead of ongoing build progress.
- Document the stale-evidence retirement behavior.

Fixes #956.

## Verification

- `uv run --extra dev ruff check --diff control_plane/service.py control_plane/workflows/merge_train_controller.py scripts/merge_train_controller_feedback.py tests/test_service.py tests/test_merge_train_controller.py tests/test_merge_train_admission.py tests/test_merge_train_controller_feedback.py`
- `uv run --extra dev ruff check control_plane/service.py control_plane/workflows/merge_train_controller.py scripts/merge_train_controller_feedback.py tests/test_service.py tests/test_merge_train_controller.py tests/test_merge_train_admission.py tests/test_merge_train_controller_feedback.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest tests.test_service tests.test_merge_train_controller tests.test_merge_train_admission tests.test_merge_train_controller_feedback`
- `git diff --check`
- `uv run python -m unittest`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py closeout --repo "$PWD" --scope changed_files`
