### PR TITLE
Fail Odoo prod promotion workflow on status failures

### DIFF
--- a/.github/workflows/reusable-odoo-prod-promotion.yml
+++ b/.github/workflows/reusable-odoo-prod-promotion.yml
@@ -37,9 +37,14 @@ jobs:
             run.context=${{ inputs.context }}
             run.request_id=${{ github.run_id }}-${{ github.run_attempt }}
           idempotency-key: >-
-            opp:${{ inputs.context }}:${{ github.run_id }}:${{ github.run_attempt }}
+            opp:${{ inputs.context }}:${{ github.run_id }}:${{
+              github.run_attempt
+            }}
           timeout-ms: ${{ inputs['timeout-ms'] }}
-          fail-result-paths: result.run_status,result.destination_health_status
+          fail-result-paths: >-
+            result.run_status,result.promotion_status,
+            result.deployment_status,result.post_deploy_status,
+            result.destination_health_status
           output-paths: >-
             trace_id=trace_id,
             backup_record_id=result.backup_record_id,

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -170,6 +170,22 @@ class ProductOnboardingTests(unittest.TestCase):
             )
             self.assertIn(f"deploy:odoo-{context_name}-prod-rollback-grant", script_text)
 
+    def test_reusable_odoo_prod_promotion_fails_on_each_result_status(self) -> None:
+        workflow_text = Path(
+            ".github/workflows/reusable-odoo-prod-promotion.yml"
+        ).read_text(encoding="utf-8")
+
+        for result_path in (
+            "result.run_status",
+            "result.promotion_status",
+            "result.deployment_status",
+            "result.post_deploy_status",
+            "result.destination_health_status",
+        ):
+            self.assertIn(result_path, workflow_text)
+
+        self.assertIn("fail-result-paths", workflow_text)
+
     def test_deploy_authz_grants_include_opw_manual_preview_workflow(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- include promotion, deployment, and post-deploy statuses in the reusable Odoo prod promotion fail-result paths
- keep run/destination health failures covered
- add a regression assertion for the workflow's fail status coverage

## Validation
- actionlint -config-file .github/actionlint.yaml .github/workflows/reusable-odoo-prod-promotion.yml
- yamllint .github/workflows/reusable-odoo-prod-promotion.yml
- uv run python -m unittest tests.test_product_onboarding tests.test_launchplane_request_action tests.test_odoo_prod_promotion_run tests.test_service.LaunchplaneServiceTests.test_odoo_prod_promotion_run_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_prod_promotion_run_allows_reusable_launchplane_workflow
- uv run --extra dev ruff check --diff tests/test_product_onboarding.py