### PR TITLE
Add reusable Odoo artifact publish workflow

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -73,6 +73,7 @@
     "Odoo Config Parameter Override",
     "Odoo Website Bootstrap Override",
     "Odoo Stable Bootstrap",
+    "Reusable Odoo Artifact Publish",
     "Reusable Odoo Post Deploy",
     "Reusable Odoo Prod Promotion",
     "Reusable Odoo Prod Rollback",

--- a/.github/workflows/reusable-odoo-artifact-publish.yml
+++ b/.github/workflows/reusable-odoo-artifact-publish.yml
@@ -1,0 +1,198 @@
+---
+name: Reusable Odoo Artifact Publish
+
+"on":
+  workflow_call:
+    inputs:
+      context:
+        description: Launchplane Odoo context.
+        required: true
+        type: string
+      instance:
+        description: Odoo instance whose artifact should be published.
+        required: true
+        type: string
+      timeout-ms:
+        description: Launchplane request timeout in milliseconds.
+        required: false
+        default: "600000"
+        type: string
+    secrets:
+      ODOO_GHCR_PUBLISH_TOKEN:
+        description: Token allowed to publish the tenant image to GHCR.
+        required: true
+      ODOO_SOURCE_GITHUB_TOKEN:
+        description: Token allowed to fetch private Odoo source inputs.
+        required: true
+    outputs:
+      artifact_id:
+        description: Launchplane artifact ID recorded for the published image.
+        value: ${{ jobs.artifact-publish.outputs.artifact_id }}
+      image_digest:
+        description: Immutable image digest recorded by Launchplane.
+        value: ${{ jobs.artifact-publish.outputs.image_digest }}
+      source_commit:
+        description: Source commit recorded in the artifact manifest.
+        value: ${{ jobs.artifact-publish.outputs.source_commit }}
+
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
+jobs:
+  artifact-publish:
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    outputs:
+      artifact_id: ${{ steps.launchplane.outputs.artifact_id }}
+      image_digest: ${{ steps.launchplane.outputs.image_digest }}
+      source_commit: ${{ steps.launchplane.outputs.source_commit }}
+    steps:
+      - name: Checkout tenant repo
+        uses: actions/checkout@v6
+        with:
+          path: tenant
+          persist-credentials: false
+
+      - name: Checkout devkit repo
+        uses: actions/checkout@v6
+        with:
+          repository: cbusillo/odoo-devkit
+          path: odoo-devkit
+          persist-credentials: false
+
+      - name: Checkout shared addons repo
+        uses: actions/checkout@v6
+        with:
+          repository: cbusillo/odoo-shared-addons
+          path: odoo-shared-addons
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.ODOO_GHCR_PUBLISH_TOKEN }}
+
+      - name: Resolve Launchplane publish inputs
+        id: publish_inputs
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: https://launchplane.shinycomputers.com
+          audience: launchplane.shinycomputers.com
+          route-path: /v1/drivers/odoo/artifact-publish-inputs
+          payload: >-
+            {"schema_version":1,"product":"odoo","inputs":{"schema_version":1}}
+          payload-fields: |-
+            inputs.context=${{ inputs.context }}
+            inputs.instance=${{ inputs.instance }}
+          idempotency-key: >-
+            odoo-artifact-publish-inputs:odoo:${{ inputs.context }}:${{
+              inputs.instance
+            }}:run-${{ github.run_id }}-attempt-${{ github.run_attempt }}
+          timeout-ms: ${{ inputs['timeout-ms'] }}
+          fail-result-paths: result.input_status
+          response-output-file: >-
+            ${{ runner.temp }}/${{ inputs.context }}-publish-inputs.json
+          response-output-path: result
+          output-paths: >-
+            image_repository=result.image_repository,
+            image_tag=result.image_tag,
+            preview_slug=result.preview_slug
+
+      - name: Locate publish inputs file
+        id: publish_inputs_file
+        env:
+          CONTEXT_NAME: ${{ inputs.context }}
+        run: |
+          inputs_file="$RUNNER_TEMP/${CONTEXT_NAME}-publish-inputs.json"
+          echo "inputs_file=$inputs_file" >>"$GITHUB_OUTPUT"
+
+      - name: Publish Odoo artifact image
+        id: publish
+        working-directory: tenant
+        env:
+          INSTANCE: ${{ inputs.instance }}
+          IMAGE_REPOSITORY: ghcr.io/${{ github.repository }}
+          GHCR_USERNAME: ${{ github.repository_owner }}
+          GHCR_TOKEN: ${{ secrets.ODOO_GHCR_PUBLISH_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+          ODOO_SOURCE_GITHUB_TOKEN: ${{ secrets.ODOO_SOURCE_GITHUB_TOKEN }}
+          PUBLISH_INPUTS_FILE: >-
+            ${{ steps.publish_inputs_file.outputs.inputs_file }}
+        run: |
+          # shellcheck disable=SC2016
+          node -e '
+            const fs = require("node:fs");
+            const path = process.env.PUBLISH_INPUTS_FILE;
+            const payload = JSON.parse(fs.readFileSync(path, "utf8"));
+            payload.environment = payload.environment || {};
+            payload.environment.GITHUB_TOKEN =
+              process.env.ODOO_SOURCE_GITHUB_TOKEN;
+            fs.writeFileSync(path, `${JSON.stringify(payload)}\n`, "utf8");
+          '
+          export ODOO_DEVKIT_RUNTIME_ENVIRONMENT_JSON
+          ODOO_DEVKIT_RUNTIME_ENVIRONMENT_JSON="$(cat "$PUBLISH_INPUTS_FILE")"
+          short_sha="${GITHUB_SHA::8}"
+          image_tag="${{ inputs.context }}-${short_sha}-amd64"
+          output_file="$RUNNER_TEMP/${{ inputs.context }}-artifact.json"
+          manifest_path="$PWD/workspace.toml"
+          uv --directory ../odoo-devkit run platform runtime publish \
+            --manifest "$manifest_path" \
+            --instance "$INSTANCE" \
+            --image-repository "$IMAGE_REPOSITORY" \
+            --image-tag "$image_tag" \
+            --platform linux/amd64 \
+            --output-file "$output_file"
+          echo "manifest_file=$output_file" >>"$GITHUB_OUTPUT"
+
+      - name: Record artifact in Launchplane
+        id: launchplane
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: https://launchplane.shinycomputers.com
+          audience: launchplane.shinycomputers.com
+          route-path: /v1/drivers/odoo/artifact-publish
+          payload: >-
+            {"schema_version":1,"product":"odoo","publish":{"schema_version":1}}
+          payload-fields: |-
+            publish.context=${{ inputs.context }}
+            publish.instance=${{ inputs.instance }}
+          payload-json-files: |-
+            publish.manifest=${{ steps.publish.outputs.manifest_file }}
+          idempotency-key: >-
+            odoo-artifact-publish:odoo:${{ inputs.context }}:${{ inputs.instance
+            }}:run-${{ github.run_id }}-attempt-${{ github.run_attempt }}
+          timeout-ms: ${{ inputs['timeout-ms'] }}
+          fail-result-paths: result.status,result.publish_status
+          output-paths: >-
+            publish_status=result.status,
+            artifact_id=result.artifact_id,
+            image_repository=result.image_repository,
+            image_digest=result.image_digest,
+            source_commit=result.source_commit,
+            error_message=result.error_message
+
+      - name: Report result
+        env:
+          ARTIFACT_ID: ${{ steps.launchplane.outputs.artifact_id }}
+          IMAGE_DIGEST: ${{ steps.launchplane.outputs.image_digest }}
+          SOURCE_COMMIT: ${{ steps.launchplane.outputs.source_commit }}
+        run: |
+          echo "artifact_id=$ARTIFACT_ID"
+          echo "image_digest=$IMAGE_DIGEST"
+          echo "source_commit=$SOURCE_COMMIT"

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -179,6 +179,13 @@ For an existing repo, classify each workflow and script before deleting code:
   keep only dispatch inputs, confirmation text, and product-owned build or test
   facts locally.
 
+Odoo artifact publication now follows the reusable workflow shape: tenant repos
+own the manual dispatch confirmation and the source workspace, while
+`reusable-odoo-artifact-publish.yml` owns the Launchplane publish-input request,
+artifact-record request, idempotency keys, and response mapping. The tenant
+workflow should not duplicate `/v1/drivers/odoo/artifact-publish-inputs` or
+`/v1/drivers/odoo/artifact-publish` wiring once it uses that workflow.
+
 Start with low-risk deletions and documentation, then replace active workflow
 behavior in small slices. Do not remove active backup, promotion, rollback,
 runtime health, or cleanup safety gates until Launchplane owns the equivalent

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -1280,6 +1280,22 @@ post_odoo_cm_preview_grant \
 post_odoo_stable_grant \
   cbusillo/odoo-tenant-cm \
   cm \
+  odoo-artifact-publish.yml \
+  odoo_artifact_publish_inputs.read \
+  deploy:odoo-cm-artifact-publish-inputs-grant \
+  odoo-cm-artifact-publish-inputs \
+  reusable-odoo-artifact-publish.yml
+post_odoo_stable_grant \
+  cbusillo/odoo-tenant-cm \
+  cm \
+  odoo-artifact-publish.yml \
+  odoo_artifact_publish.write \
+  deploy:odoo-cm-artifact-publish-grant \
+  odoo-cm-artifact-publish \
+  reusable-odoo-artifact-publish.yml
+post_odoo_stable_grant \
+  cbusillo/odoo-tenant-cm \
+  cm \
   odoo-post-deploy.yml \
   odoo_post_deploy.execute \
   deploy:odoo-cm-post-deploy-grant \
@@ -1362,6 +1378,22 @@ post_odoo_opw_preview_grant \
   deploy:odoo-opw-preview-apply-manual-grant \
   odoo-opw-preview-apply-manual \
   workflow_dispatch
+post_odoo_stable_grant \
+  cbusillo/odoo-tenant-opw \
+  opw \
+  odoo-artifact-publish.yml \
+  odoo_artifact_publish_inputs.read \
+  deploy:odoo-opw-artifact-publish-inputs-grant \
+  odoo-opw-artifact-publish-inputs \
+  reusable-odoo-artifact-publish.yml
+post_odoo_stable_grant \
+  cbusillo/odoo-tenant-opw \
+  opw \
+  odoo-artifact-publish.yml \
+  odoo_artifact_publish.write \
+  deploy:odoo-opw-artifact-publish-grant \
+  odoo-opw-artifact-publish \
+  reusable-odoo-artifact-publish.yml
 post_odoo_stable_grant \
   cbusillo/odoo-tenant-opw \
   opw \

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -157,6 +157,7 @@ class ProductOnboardingTests(unittest.TestCase):
         )
 
         expected_workflows = (
+            "reusable-odoo-artifact-publish.yml",
             "reusable-odoo-post-deploy.yml",
             "reusable-odoo-prod-promotion.yml",
             "reusable-odoo-prod-rollback.yml",
@@ -164,11 +165,30 @@ class ProductOnboardingTests(unittest.TestCase):
         for workflow_file in expected_workflows:
             self.assertIn(workflow_file, script_text)
         for context_name in ("cm", "opw"):
+            self.assertIn(
+                f"deploy:odoo-{context_name}-artifact-publish-inputs-grant",
+                script_text,
+            )
+            self.assertIn(f"deploy:odoo-{context_name}-artifact-publish-grant", script_text)
             self.assertIn(f"deploy:odoo-{context_name}-post-deploy-grant", script_text)
             self.assertIn(
                 f"deploy:odoo-{context_name}-prod-promotion-run-grant", script_text
             )
             self.assertIn(f"deploy:odoo-{context_name}-prod-rollback-grant", script_text)
+
+    def test_reusable_odoo_artifact_publish_standardizes_request_shape(self) -> None:
+        workflow_text = Path(
+            ".github/workflows/reusable-odoo-artifact-publish.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("workflow_call", workflow_text)
+        self.assertIn("/v1/drivers/odoo/artifact-publish-inputs", workflow_text)
+        self.assertIn("/v1/drivers/odoo/artifact-publish", workflow_text)
+        self.assertIn("odoo-artifact-publish-inputs:odoo:", workflow_text)
+        self.assertIn("odoo-artifact-publish:odoo:", workflow_text)
+        self.assertIn("fail-result-paths: result.input_status", workflow_text)
+        self.assertIn("fail-result-paths: result.status,result.publish_status", workflow_text)
+        self.assertIn("publish.manifest=${{ steps.publish.outputs.manifest_file }}", workflow_text)
 
     def test_reusable_odoo_prod_promotion_fails_on_each_result_status(self) -> None:
         workflow_text = Path(


### PR DESCRIPTION
## Summary
- add a reusable Odoo artifact publish workflow that owns Launchplane publish-input and artifact-record requests
- grant the reusable workflow OIDC authorization for CM and OPW artifact publish routes
- document the artifact publish wrapper and test the standardized request shape

## Tests
- actionlint .github/workflows/reusable-odoo-artifact-publish.yml
- bash -n scripts/deploy/ensure-authz-grants.sh
- uv run launchplane odoo-ownership check --workspace-root .. --format json
- uv run python -m unittest tests.test_product_onboarding tests.test_odoo_ownership_checks
- uv run python -m unittest