### PR TITLE
Clean up terminal Every Code worktrees

### DIFF
--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -302,9 +302,7 @@ class EveryCodeWorkerApiStore:
             raise EveryCodeWorkerApiError("Launchplane preview gate list response is invalid")
         return tuple(EveryCodePreviewGateRecord.model_validate(item) for item in gates)
 
-    def write_every_code_preview_gate_record(
-        self, record: EveryCodePreviewGateRecord
-    ) -> object:
+    def write_every_code_preview_gate_record(self, record: EveryCodePreviewGateRecord) -> object:
         payload = self._request(
             "POST",
             "/v1/every-code/preview-gates",
@@ -691,8 +689,11 @@ def default_every_code_command(record: EveryCodeWorkRequestRecord) -> str:
         f"include `Closes #{record.issue_number}` or `Fixes #{record.issue_number}` "
         "in the PR body so GitHub closes the issue when the PR merges. Use "
         "`Refs` only when the PR is partial or still needs reporter validation. "
-        "When the PR is open and your checks are complete, let the session exit "
-        "so Launchplane can mark this request finished."
+        "Before the PR can be merged or the issue can close, run closeout hygiene "
+        "for this worktree: update the PR/issue status, record checks, clean safe "
+        "artifacts, and perform the Love Gate. When closeout is complete and your "
+        "checks are complete, let the session exit so Launchplane can mark this "
+        "request finished."
     )
     return "code " + shlex.quote(prompt)
 
@@ -717,6 +718,7 @@ def every_code_pr_feedback_prompt(feedback: EveryCodePrFeedbackRecord) -> str:
             "",
             "Read the PR context and existing discussion before changing files. "
             "Apply the requested correction on the same branch/worktree, update the PR, "
+            "run closeout hygiene including the Love Gate before merge or issue closure, "
             "and then let the session exit when checks are complete.",
         )
     )
@@ -1323,11 +1325,15 @@ def close_terminal_every_code_sessions(
             session_name=session_name,
             runner=run,
         )
-        worktree_processes_closed = _terminate_every_code_worktree_processes(
-            session_state=session_state,
-            runner=run,
-        ) > 0
+        worktree_processes_closed = (
+            _terminate_every_code_worktree_processes(
+                session_state=session_state,
+                runner=run,
+            )
+            > 0
+        )
         if existing_session is False:
+            _cleanup_every_code_worktree(session_state=session_state, runner=run)
             path.unlink(missing_ok=True)
             closed += 1 if worktree_processes_closed else 0
             continue
@@ -1339,6 +1345,7 @@ def close_terminal_every_code_sessions(
             session_name=session_name,
             runner=run,
         ):
+            _cleanup_every_code_worktree(session_state=session_state, runner=run)
             path.unlink(missing_ok=True)
             closed += 1
             continue
@@ -1418,6 +1425,85 @@ def _terminate_every_code_worktree_processes(
     return closed
 
 
+def _cleanup_every_code_worktree(
+    *,
+    session_state: Mapping[str, object],
+    runner: Runner,
+) -> bool:
+    source_checkout_root_value = session_state.get("source_checkout_root")
+    launch_root_value = session_state.get("launch_root")
+    worktree_branch_value = session_state.get("worktree_branch")
+    if (
+        not isinstance(source_checkout_root_value, str)
+        or not source_checkout_root_value.strip()
+        or not isinstance(launch_root_value, str)
+        or not launch_root_value.strip()
+        or not isinstance(worktree_branch_value, str)
+        or not worktree_branch_value.strip()
+    ):
+        return False
+
+    worktree_branch = worktree_branch_value.strip()
+    if not worktree_branch.startswith("every-code/"):
+        return False
+
+    source_checkout_root = Path(source_checkout_root_value).expanduser().resolve()
+    launch_root = Path(launch_root_value).expanduser().resolve()
+    if source_checkout_root == launch_root:
+        return False
+    if not source_checkout_root.is_dir() or not launch_root.is_dir():
+        return False
+    if not _is_git_checkout(source_checkout_root) or not _is_git_checkout(launch_root):
+        return False
+
+    try:
+        inside_source = launch_root.is_relative_to(source_checkout_root)
+    except ValueError:
+        inside_source = False
+    if inside_source:
+        return False
+
+    if _git_worktree_dirty(launch_root, runner=runner):
+        return False
+
+    try:
+        _git_checked(
+            (
+                "git",
+                "-C",
+                str(source_checkout_root),
+                "worktree",
+                "remove",
+                str(launch_root),
+            ),
+            runner=runner,
+            detail="remove Every Code worktree",
+        )
+        _git_checked(
+            (
+                "git",
+                "-C",
+                str(source_checkout_root),
+                "branch",
+                "-d",
+                worktree_branch,
+            ),
+            runner=runner,
+            detail="delete Every Code worktree branch",
+        )
+    except RuntimeError:
+        return False
+    return True
+
+
+def _git_worktree_dirty(path: Path, *, runner: Runner) -> bool:
+    try:
+        result = runner(("git", "-C", str(path), "status", "--porcelain"))
+    except OSError:
+        return True
+    return result.returncode != 0 or bool(result.stdout.strip())
+
+
 def _apply_every_code_pr_feedback_record(
     *,
     record_store: EveryCodeWorkerStore,
@@ -1435,9 +1521,7 @@ def _apply_every_code_pr_feedback_record(
         record = record_store.read_every_code_work_request_record(feedback.request_id)
     except Exception:
         _mark_every_code_pr_feedback(record_store, feedback=feedback, status="ignored")
-        _acknowledge_every_code_pr_feedback(
-            feedback=feedback, reaction="confused", runner=runner
-        )
+        _acknowledge_every_code_pr_feedback(feedback=feedback, reaction="confused", runner=runner)
         return EveryCodePrFeedbackApplyResult(
             status="ignored",
             detail="Every Code work request for PR feedback was not found.",
@@ -1453,9 +1537,7 @@ def _apply_every_code_pr_feedback_record(
         )
     if _terminal_every_code_request_closed_by_linked_pr(record):
         _mark_every_code_pr_feedback(record_store, feedback=feedback, status="ignored")
-        _acknowledge_every_code_pr_feedback(
-            feedback=feedback, reaction="confused", runner=runner
-        )
+        _acknowledge_every_code_pr_feedback(feedback=feedback, reaction="confused", runner=runner)
         return EveryCodePrFeedbackApplyResult(
             status="ignored",
             detail="Every Code PR feedback belongs to a closed linked pull request.",
@@ -1466,9 +1548,7 @@ def _apply_every_code_pr_feedback_record(
     session_state = read_every_code_session_state(state_path)
     if session_state is None:
         _mark_every_code_pr_feedback(record_store, feedback=feedback, status="ignored")
-        _acknowledge_every_code_pr_feedback(
-            feedback=feedback, reaction="confused", runner=runner
-        )
+        _acknowledge_every_code_pr_feedback(feedback=feedback, reaction="confused", runner=runner)
         return EveryCodePrFeedbackApplyResult(
             status="ignored",
             detail="Every Code PR feedback has no local session state on this host.",
@@ -1526,9 +1606,7 @@ def _apply_every_code_pr_feedback_record(
     launch_root = Path(session_state.get("launch_root", "")).expanduser()
     if not launch_root.is_dir():
         _mark_every_code_pr_feedback(record_store, feedback=feedback, status="ignored")
-        _acknowledge_every_code_pr_feedback(
-            feedback=feedback, reaction="confused", runner=runner
-        )
+        _acknowledge_every_code_pr_feedback(feedback=feedback, reaction="confused", runner=runner)
         state_path.unlink(missing_ok=True)
         return EveryCodePrFeedbackApplyResult(
             status="ignored",
@@ -1567,9 +1645,7 @@ def _apply_every_code_pr_feedback_record(
             )
         )
     except OSError:
-        _acknowledge_every_code_pr_feedback(
-            feedback=feedback, reaction="confused", runner=runner
-        )
+        _acknowledge_every_code_pr_feedback(feedback=feedback, reaction="confused", runner=runner)
         return EveryCodePrFeedbackApplyResult(
             status="blocked",
             detail=f"Could not relaunch tmux session {session_name!r} for PR feedback.",
@@ -1578,9 +1654,7 @@ def _apply_every_code_pr_feedback_record(
             session_name=session_name,
         )
     if launch_result.returncode != 0:
-        _acknowledge_every_code_pr_feedback(
-            feedback=feedback, reaction="confused", runner=runner
-        )
+        _acknowledge_every_code_pr_feedback(feedback=feedback, reaction="confused", runner=runner)
         return EveryCodePrFeedbackApplyResult(
             status="blocked",
             detail=f"tmux relaunch failed: {launch_result.stderr.strip()}",
@@ -1836,9 +1910,7 @@ def finish_every_code_work_request(
     )
     if succeeded and not resolved_pr_url:
         succeeded = False
-        summary = (
-            "Every Code session exited successfully but did not open a pull request."
-        )
+        summary = "Every Code session exited successfully but did not open a pull request."
     updated_record = apply_every_code_work_request_status(
         record,
         EveryCodeWorkRequestStatusUpdate(
@@ -2429,9 +2501,7 @@ def route_every_code_pr_check_failures(
             )
             continue
         app_failures = [
-            item
-            for item in failed_checks
-            if _every_code_pr_failure_kind(item) == "app"
+            item for item in failed_checks if _every_code_pr_failure_kind(item) == "app"
         ]
         if app_failures:
             feedback = _build_every_code_check_failure_feedback(

--- a/docs/records.md
+++ b/docs/records.md
@@ -688,6 +688,11 @@ preflights.
   `uv run launchplane every-code stop`. The supervisor writes a pid file and log
   under `state/every-code-worker/` by default while the worker-created tmux
   sessions remain visible and independently attachable.
+- Worker prompts require closeout hygiene, including the Love Gate, before a PR
+  can be merged or an issue can close. After a terminal session is gone, worker
+  maintenance removes clean Every Code worktrees and their local `every-code/*`
+  branches from the source checkout. Dirty or suspicious worktrees are left in
+  place for operator inspection.
 - For a remote Launchplane database, run the Mac worker through the service API
   instead of sharing DB credentials with the local host. Configure the service
   and worker with the same `LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN`, then start the

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -288,7 +288,9 @@ class _Process:
 
 
 class _MaintenanceFailingStore(FilesystemRecordStore):
-    def list_every_code_pr_feedback_records(self, **kwargs: object) -> tuple[EveryCodePrFeedbackRecord, ...]:
+    def list_every_code_pr_feedback_records(
+        self, **kwargs: object
+    ) -> tuple[EveryCodePrFeedbackRecord, ...]:
         if kwargs.get("status") == "pending":
             raise EveryCodeWorkerApiError("Launchplane API request failed with HTTP 401")
         return super().list_every_code_pr_feedback_records(**kwargs)  # type: ignore[arg-type]
@@ -743,6 +745,8 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertIn("isolated Every Code worktree", command)
         self.assertIn("Closes #123", command)
         self.assertIn("Use `Refs` only", command)
+        self.assertIn("run closeout hygiene", command)
+        self.assertIn("Love Gate", command)
         self.assertIn("let the session exit", command)
 
     def test_claim_comment_body_marks_issue_as_in_progress(self) -> None:
@@ -887,9 +891,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
                     repository="cbusillo/sellyouroutboard",
                     result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/86",
                 ).model_copy(
-                    update={
-                        "issue_url": "https://github.com/cbusillo/sellyouroutboard/issues/123"
-                    }
+                    update={"issue_url": "https://github.com/cbusillo/sellyouroutboard/issues/123"}
                 )
             )
             runner = _Runner(
@@ -1300,9 +1302,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
                     "started_at": "2026-05-05T22:02:00Z",
                 }
             )
-            store.write_every_code_work_request_record(
-                running_record
-            )
+            store.write_every_code_work_request_record(running_record)
             runner = _Runner(
                 pr_list_payload=[{"url": "https://github.com/cbusillo/sellyouroutboard/pull/86"}],
                 pr_view_payload={
@@ -1452,7 +1452,9 @@ class EveryCodeWorkerTests(unittest.TestCase):
             runner.calls,
         )
 
-    def test_check_failure_route_marks_previous_pending_failure_ignored_after_recovery(self) -> None:
+    def test_check_failure_route_marks_previous_pending_failure_ignored_after_recovery(
+        self,
+    ) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
             store.write_every_code_work_request_record(
@@ -1671,9 +1673,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(send_calls[0][-1], send_calls[0][4])
         self.assertEqual(send_calls[1][-1], "C-m")
         reaction_calls = [
-            call
-            for call in runner.calls
-            if call[:4] == ("gh", "api", "--method", "POST")
+            call for call in runner.calls if call[:4] == ("gh", "api", "--method", "POST")
         ]
         self.assertEqual(
             [call[-1] for call in reaction_calls],
@@ -1709,9 +1709,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(result.status, "blocked")
         self.assertEqual(feedback.status, "pending")
         reaction_calls = [
-            call
-            for call in runner.calls
-            if call[:4] == ("gh", "api", "--method", "POST")
+            call for call in runner.calls if call[:4] == ("gh", "api", "--method", "POST")
         ]
         self.assertEqual(
             [call[-1] for call in reaction_calls],
@@ -1854,6 +1852,96 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(runner.calls[1][0], "lsof")
         self.assertEqual(runner.calls[2][1], "display-message")
         self.assertEqual(runner.calls[3][1], "kill-session")
+
+    def test_terminal_request_removes_clean_worktree_after_session_close(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "state",
+                runner=_Runner(),
+            )
+            record = store.read_every_code_work_request_record(
+                "every-code-cbusillo-code-123-test"
+            ).model_copy(
+                update={
+                    "state": "done",
+                    "finished_at": "2026-05-06T00:02:00Z",
+                    "updated_at": "2026-05-06T00:02:00Z",
+                    "result_summary": "Linked pull request merged.",
+                }
+            )
+            store.write_every_code_work_request_record(record)
+            state_path = every_code_session_state_path(
+                state_dir=temporary_root / "state",
+                request_id="every-code-cbusillo-code-123-test",
+            )
+            runner = _ExistingSessionRunner()
+
+            with patch("control_plane.every_code_worker.os.killpg"):
+                close_terminal_every_code_sessions(
+                    record_store=store,
+                    host="Chris-Studio",
+                    state_dir=temporary_root / "state",
+                    runner=runner,
+                )
+
+        self.assertFalse(state_path.exists())
+        self.assertTrue(any(call[3:5] == ("worktree", "remove") for call in runner.calls))
+        self.assertTrue(any(call[3:5] == ("branch", "-d") for call in runner.calls))
+
+    def test_terminal_request_preserves_dirty_worktree(self) -> None:
+        class _DirtyWorktreeRunner(_ExistingSessionRunner):
+            def __call__(self, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+                if args[0] == "git" and args[3:5] == ("status", "--porcelain"):
+                    self.calls.append(tuple(args))
+                    return subprocess.CompletedProcess(args, 0, " M README.md\n", "")
+                return super().__call__(args)
+
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "state",
+                runner=_Runner(),
+            )
+            record = store.read_every_code_work_request_record(
+                "every-code-cbusillo-code-123-test"
+            ).model_copy(
+                update={
+                    "state": "done",
+                    "finished_at": "2026-05-06T00:02:00Z",
+                    "updated_at": "2026-05-06T00:02:00Z",
+                    "result_summary": "Linked pull request merged.",
+                }
+            )
+            store.write_every_code_work_request_record(record)
+            runner = _DirtyWorktreeRunner()
+
+            with patch("control_plane.every_code_worker.os.killpg"):
+                close_terminal_every_code_sessions(
+                    record_store=store,
+                    host="Chris-Studio",
+                    state_dir=temporary_root / "state",
+                    runner=runner,
+                )
+
+        self.assertFalse(any(call[3:5] == ("worktree", "remove") for call in runner.calls))
+        self.assertFalse(any(call[3:5] == ("branch", "-d") for call in runner.calls))
 
     def test_terminal_request_kills_worktree_processes_when_tmux_is_gone(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -2073,9 +2161,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
                 state_dir=temporary_root / "state",
                 runner=_Runner(),
             )
-            runner = _Runner(
-                pr_list_payload=[{"url": "https://github.com/cbusillo/code/pull/99"}]
-            )
+            runner = _Runner(pr_list_payload=[{"url": "https://github.com/cbusillo/code/pull/99"}])
 
             result = finish_every_code_work_request(
                 record_store=store,
@@ -2342,9 +2428,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
                 runner=_Runner(),
                 sleeper=lambda _seconds: None,
             )
-            record = store.read_every_code_work_request_record(
-                "every-code-cbusillo-code-123-test"
-            )
+            record = store.read_every_code_work_request_record("every-code-cbusillo-code-123-test")
 
         self.assertEqual(result.handed_off, 1)
         self.assertEqual(result.blocked, 0)
@@ -2401,9 +2485,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
                     repository="cbusillo/sellyouroutboard",
                     result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/86",
                 ).model_copy(
-                    update={
-                        "issue_url": "https://github.com/cbusillo/sellyouroutboard/issues/123"
-                    }
+                    update={"issue_url": "https://github.com/cbusillo/sellyouroutboard/issues/123"}
                 )
             )
             runner = _Runner(


### PR DESCRIPTION
## Summary
- require Every Code sessions to run closeout hygiene, including the Love Gate, before merge or issue closure
- clean up terminal Every Code worktrees and local `every-code/*` branches from worker maintenance when the worktree is clean and safe
- document the terminal-session cleanup behavior and cover clean/dirty worktree cases in tests

## Validation
- `uv run python -m unittest tests.test_every_code_worker`
- `uv run --extra dev ruff check --no-fix control_plane/every_code_worker.py tests/test_every_code_worker.py`
- `uv run --extra dev ruff format --check control_plane/every_code_worker.py tests/test_every_code_worker.py`
- `uv run --extra dev mypy control_plane/every_code_worker.py tests/test_every_code_worker.py`
- `npx markdownlint-cli2 docs/records.md`
- JetBrains inspection closeout: PyCharm changed files, clean
