### PR TITLE
Fix Odoo artifact publish wrapper inputs

### DIFF
--- a/.github/workflows/reusable-odoo-artifact-publish.yml
+++ b/.github/workflows/reusable-odoo-artifact-publish.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           repository: cbusillo/odoo-devkit
           path: odoo-devkit
+          token: ${{ secrets.ODOO_SOURCE_GITHUB_TOKEN }}
           persist-credentials: false
 
       - name: Checkout shared addons repo
@@ -68,6 +69,7 @@ jobs:
         with:
           repository: cbusillo/odoo-shared-addons
           path: odoo-shared-addons
+          token: ${{ secrets.ODOO_SOURCE_GITHUB_TOKEN }}
           persist-credentials: false
 
       - name: Install uv
@@ -100,6 +102,7 @@ jobs:
           payload-fields: |-
             inputs.context=${{ inputs.context }}
             inputs.instance=${{ inputs.instance }}
+            inputs.source_git_ref=${{ github.sha }}
           idempotency-key: >-
             odoo-artifact-publish-inputs:odoo:${{ inputs.context }}:${{
               inputs.instance
@@ -127,7 +130,9 @@ jobs:
         working-directory: tenant
         env:
           INSTANCE: ${{ inputs.instance }}
-          IMAGE_REPOSITORY: ghcr.io/${{ github.repository }}
+          RESOLVED_IMAGE_REPOSITORY: >-
+            ${{ steps.publish_inputs.outputs.image_repository }}
+          RESOLVED_IMAGE_TAG: ${{ steps.publish_inputs.outputs.image_tag }}
           GHCR_USERNAME: ${{ github.repository_owner }}
           GHCR_TOKEN: ${{ secrets.ODOO_GHCR_PUBLISH_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}
@@ -147,15 +152,21 @@ jobs:
           '
           export ODOO_DEVKIT_RUNTIME_ENVIRONMENT_JSON
           ODOO_DEVKIT_RUNTIME_ENVIRONMENT_JSON="$(cat "$PUBLISH_INPUTS_FILE")"
-          short_sha="${GITHUB_SHA::8}"
-          image_tag="${{ inputs.context }}-${short_sha}-amd64"
+          if [ -z "$RESOLVED_IMAGE_REPOSITORY" ]; then
+            echo "Launchplane publish inputs missing image_repository." >&2
+            exit 1
+          fi
+          if [ -z "$RESOLVED_IMAGE_TAG" ]; then
+            echo "Launchplane publish inputs did not return image_tag." >&2
+            exit 1
+          fi
           output_file="$RUNNER_TEMP/${{ inputs.context }}-artifact.json"
           manifest_path="$PWD/workspace.toml"
           uv --directory ../odoo-devkit run platform runtime publish \
             --manifest "$manifest_path" \
             --instance "$INSTANCE" \
-            --image-repository "$IMAGE_REPOSITORY" \
-            --image-tag "$image_tag" \
+            --image-repository "$RESOLVED_IMAGE_REPOSITORY" \
+            --image-tag "$RESOLVED_IMAGE_TAG" \
             --platform linux/amd64 \
             --output-file "$output_file"
           echo "manifest_file=$output_file" >>"$GITHUB_OUTPUT"

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -188,7 +188,20 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("odoo-artifact-publish:odoo:", workflow_text)
         self.assertIn("fail-result-paths: result.input_status", workflow_text)
         self.assertIn("fail-result-paths: result.status,result.publish_status", workflow_text)
+        self.assertIn("token: ${{ secrets.ODOO_SOURCE_GITHUB_TOKEN }}", workflow_text)
+        self.assertIn("inputs.source_git_ref=${{ github.sha }}", workflow_text)
+        self.assertIn(
+            "RESOLVED_IMAGE_REPOSITORY: >-\n"
+            "            ${{ steps.publish_inputs.outputs.image_repository }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "RESOLVED_IMAGE_TAG: ${{ steps.publish_inputs.outputs.image_tag }}",
+            workflow_text,
+        )
         self.assertIn("publish.manifest=${{ steps.publish.outputs.manifest_file }}", workflow_text)
+        self.assertNotIn("short_sha=", workflow_text)
+        self.assertNotIn("IMAGE_REPOSITORY: ghcr.io/${{ github.repository }}", workflow_text)
 
     def test_reusable_odoo_prod_promotion_fails_on_each_result_status(self) -> None:
         workflow_text = Path(


### PR DESCRIPTION
## Summary
- pass the Odoo source token to private sibling-repo checkouts in the reusable artifact publish workflow
- request Launchplane publish inputs with the source Git ref and use Launchplane's resolved image repository/tag
- fail closed if Launchplane does not return the required publish identity

## Tests
- `actionlint .github/workflows/reusable-odoo-artifact-publish.yml`
- `uv run launchplane odoo-ownership check --workspace-root .. --format json`
- `uv run python -m unittest tests.test_product_onboarding`
- `uv run python -m unittest`
