### PR TITLE
Make Every Code cleanup retryable

### DIFF
--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -1333,8 +1333,8 @@ def close_terminal_every_code_sessions(
             > 0
         )
         if existing_session is False:
-            _cleanup_every_code_worktree(session_state=session_state, runner=run)
-            path.unlink(missing_ok=True)
+            if _cleanup_every_code_worktree(session_state=session_state, runner=run):
+                path.unlink(missing_ok=True)
             closed += 1 if worktree_processes_closed else 0
             continue
         if existing_session is None:
@@ -1345,8 +1345,8 @@ def close_terminal_every_code_sessions(
             session_name=session_name,
             runner=run,
         ):
-            _cleanup_every_code_worktree(session_state=session_state, runner=run)
-            path.unlink(missing_ok=True)
+            if _cleanup_every_code_worktree(session_state=session_state, runner=run):
+                path.unlink(missing_ok=True)
             closed += 1
             continue
         if worktree_processes_closed:
@@ -1451,46 +1451,52 @@ def _cleanup_every_code_worktree(
     launch_root = Path(launch_root_value).expanduser().resolve()
     if source_checkout_root == launch_root:
         return False
-    if not source_checkout_root.is_dir() or not launch_root.is_dir():
+    if not source_checkout_root.is_dir():
         return False
-    if not _is_git_checkout(source_checkout_root) or not _is_git_checkout(launch_root):
-        return False
-
-    try:
-        inside_source = launch_root.is_relative_to(source_checkout_root)
-    except ValueError:
-        inside_source = False
-    if inside_source:
-        return False
-
-    if _git_worktree_dirty(launch_root, runner=runner):
+    if not _is_git_checkout(source_checkout_root):
         return False
 
     try:
-        _git_checked(
-            (
-                "git",
-                "-C",
-                str(source_checkout_root),
-                "worktree",
-                "remove",
-                str(launch_root),
-            ),
+        if launch_root.exists():
+            if not launch_root.is_dir() or not _is_git_checkout(launch_root):
+                return False
+            try:
+                inside_source = launch_root.is_relative_to(source_checkout_root)
+            except ValueError:
+                inside_source = False
+            if inside_source:
+                return False
+            if _git_worktree_dirty(launch_root, runner=runner):
+                return False
+            _git_checked(
+                (
+                    "git",
+                    "-C",
+                    str(source_checkout_root),
+                    "worktree",
+                    "remove",
+                    str(launch_root),
+                ),
+                runner=runner,
+                detail="remove Every Code worktree",
+            )
+        if _git_branch_exists(
+            source_checkout_root,
+            branch=worktree_branch,
             runner=runner,
-            detail="remove Every Code worktree",
-        )
-        _git_checked(
-            (
-                "git",
-                "-C",
-                str(source_checkout_root),
-                "branch",
-                "-d",
-                worktree_branch,
-            ),
-            runner=runner,
-            detail="delete Every Code worktree branch",
-        )
+        ):
+            _git_checked(
+                (
+                    "git",
+                    "-C",
+                    str(source_checkout_root),
+                    "branch",
+                    "-d",
+                    worktree_branch,
+                ),
+                runner=runner,
+                detail="delete Every Code worktree branch",
+            )
     except RuntimeError:
         return False
     return True

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -5,6 +5,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 from pathlib import Path
 import signal
+import shutil
 import threading
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
@@ -1836,7 +1837,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
                 }
             )
             store.write_every_code_work_request_record(record)
-            runner = _ExistingSessionRunner()
+            runner = _ExistingSessionRunner(existing_branch=True)
 
             with patch("control_plane.every_code_worker.os.killpg") as killpg:
                 closed = close_terminal_every_code_sessions(
@@ -1942,6 +1943,114 @@ class EveryCodeWorkerTests(unittest.TestCase):
 
         self.assertFalse(any(call[3:5] == ("worktree", "remove") for call in runner.calls))
         self.assertFalse(any(call[3:5] == ("branch", "-d") for call in runner.calls))
+
+    def test_terminal_request_preserves_session_state_when_worktree_cleanup_fails(
+        self,
+    ) -> None:
+        class _BranchDeleteFailsRunner(_ExistingSessionRunner):
+            def __init__(self) -> None:
+                super().__init__(existing_branch=True)
+
+            def __call__(self, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+                self.calls.append(tuple(args))
+                if args[0] == "git" and args[3:5] == ("branch", "-d"):
+                    return subprocess.CompletedProcess(args, 1, "", "not merged")
+                if args[0] == "git":
+                    self.calls.pop()
+                    return _Runner.__call__(self, args)
+                self.calls.pop()
+                return super().__call__(args)
+
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "state",
+                runner=_Runner(),
+            )
+            record = store.read_every_code_work_request_record(
+                "every-code-cbusillo-code-123-test"
+            ).model_copy(
+                update={
+                    "state": "done",
+                    "finished_at": "2026-05-06T00:02:00Z",
+                    "updated_at": "2026-05-06T00:02:00Z",
+                    "result_summary": "Linked pull request merged.",
+                }
+            )
+            store.write_every_code_work_request_record(record)
+            state_path = every_code_session_state_path(
+                state_dir=temporary_root / "state",
+                request_id="every-code-cbusillo-code-123-test",
+            )
+            runner = _BranchDeleteFailsRunner()
+
+            with patch("control_plane.every_code_worker.os.killpg"):
+                close_terminal_every_code_sessions(
+                    record_store=store,
+                    host="Chris-Studio",
+                    state_dir=temporary_root / "state",
+                    runner=runner,
+                )
+
+            self.assertTrue(state_path.exists())
+        self.assertTrue(any(call[3:5] == ("worktree", "remove") for call in runner.calls))
+        self.assertTrue(any(call[3:5] == ("branch", "-d") for call in runner.calls))
+
+    def test_terminal_request_deletes_branch_when_worktree_path_is_gone(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "state",
+                runner=_Runner(),
+            )
+            record = store.read_every_code_work_request_record(
+                "every-code-cbusillo-code-123-test"
+            ).model_copy(
+                update={
+                    "state": "done",
+                    "finished_at": "2026-05-06T00:02:00Z",
+                    "updated_at": "2026-05-06T00:02:00Z",
+                    "result_summary": "Linked pull request merged.",
+                }
+            )
+            store.write_every_code_work_request_record(record)
+            worktree_root = every_code_worktree_root(
+                _queued_record(), state_dir=temporary_root / "state"
+            )
+            shutil.rmtree(worktree_root)
+            state_path = every_code_session_state_path(
+                state_dir=temporary_root / "state",
+                request_id="every-code-cbusillo-code-123-test",
+            )
+            runner = _Runner(existing_branch=True)
+
+            with patch("control_plane.every_code_worker.os.killpg"):
+                close_terminal_every_code_sessions(
+                    record_store=store,
+                    host="Chris-Studio",
+                    state_dir=temporary_root / "state",
+                    runner=runner,
+                )
+
+        self.assertFalse(state_path.exists())
+        self.assertFalse(any(call[3:5] == ("worktree", "remove") for call in runner.calls))
+        self.assertTrue(any(call[3:5] == ("branch", "-d") for call in runner.calls))
 
     def test_terminal_request_kills_worktree_processes_when_tmux_is_gone(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- keep Every Code terminal session state when worktree cleanup fails so the worker can retry
- still delete leftover every-code branches when the saved worktree path is already gone
- add regressions for cleanup failure and missing worktree-path branch cleanup

## Checks
- `uv run python -m unittest tests.test_every_code_worker`
- `uv run python -m unittest`
- `uv run ruff check --diff control_plane/every_code_worker.py tests/test_every_code_worker.py`
- `uv run ruff check control_plane/every_code_worker.py tests/test_every_code_worker.py`
- `uv run ruff format --check control_plane/every_code_worker.py tests/test_every_code_worker.py`
- `uv run pyright control_plane/every_code_worker.py tests/test_every_code_worker.py`
- JetBrains changed-files inspection: clean
