### PR TITLE
Add public ingress synthetic monitoring

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -80,6 +80,7 @@
     "Odoo Target Replacement Plan",
     "Odoo Target Replacement Apply",
     "Preview Lifecycle",
+    "Public Ingress Monitor",
     "Product Context Cutover Audit",
     "Product Context Cutover",
     "Product Legacy Context Cleanup",

--- a/.github/workflows/public-ingress-monitor.yml
+++ b/.github/workflows/public-ingress-monitor.yml
@@ -1,0 +1,61 @@
+---
+name: Public Ingress Monitor
+
+"on":
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+    inputs:
+      timeout_seconds:
+        description: Timeout per public ingress request
+        required: false
+        default: "10"
+        type: string
+      notify:
+        description: Send transition notifications
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: launchplane-public-ingress-monitor
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    env:
+      LAUNCHPLANE_URL: >-
+        ${{ vars.LAUNCHPLANE_PUBLIC_URL ||
+        'https://launchplane.shinycomputers.com' }}
+      TIMEOUT_SECONDS: ${{ inputs.timeout_seconds || '10' }}
+      NOTIFY: >-
+        ${{ github.event_name == 'schedule' && 'true' ||
+        inputs.notify && 'true' || 'false' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run public ingress monitor
+        uses: ./.github/actions/launchplane-request
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          route-path: /v1/products/public-ingress-monitor/run-once
+          payload: >-
+            {
+              "schema_version": 1,
+              "product": "launchplane"
+            }
+          payload-fields: |-
+            timeout_seconds=${{ env.TIMEOUT_SECONDS }}
+            notify=${{ env.NOTIFY }}
+          idempotency-key: >-
+            public-ingress-monitor:${{ github.run_id }}:${{
+            github.run_attempt }}
+          timeout-ms: "180000"

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -59,6 +59,7 @@ from control_plane.cli_odoo import (
     _normalize_odoo_prod_rollback_source_channel as _normalize_odoo_prod_rollback_source_channel,
 )
 from control_plane.cli_preview_workflow import register_preview_workflow_commands
+from control_plane.cli_public_ingress_monitor import register_public_ingress_monitor_commands
 from control_plane.cli_policy_profiles import (
     PolicyProfileCliCallbacks,
     register_policy_profile_commands,
@@ -3760,6 +3761,10 @@ register_runner_lane_commands(cast(click.Group, work_graph))  # type: ignore[red
 register_preview_workflow_commands(cast(click.Group, work_graph))  # type: ignore[redundant-cast]
 register_work_graph_core_commands(cast(click.Group, work_graph))  # type: ignore[redundant-cast]
 register_every_code_commands(cast(click.Group, main), store_factory=_store)  # type: ignore[redundant-cast]
+register_public_ingress_monitor_commands(
+    cast(click.Group, main),  # type: ignore[redundant-cast]
+    store_factory=_store,
+)
 register_storage_secret_commands(cast(click.Group, main))  # type: ignore[redundant-cast]
 register_product_config_commands(
     cast(click.Group, main),  # type: ignore[redundant-cast]

--- a/control_plane/cli_public_ingress_monitor.py
+++ b/control_plane/cli_public_ingress_monitor.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+
+import click
+
+from control_plane.workflows.public_ingress_monitor import (
+    build_github_issue_notifier,
+    run_public_ingress_monitor_once,
+)
+
+
+def register_public_ingress_monitor_commands(
+    main: click.Group,
+    *,
+    store_factory: object,
+) -> None:
+    @main.group("public-ingress-monitor")
+    def public_ingress_monitor() -> None:
+        """Run public ingress synthetic checks."""
+
+    @public_ingress_monitor.command("run-once")
+    @click.option("--state-dir", type=click.Path(path_type=Path), default=Path("state"))
+    @click.option("--database-url", default="", help="Launchplane database URL.")
+    @click.option("--timeout-seconds", default=10, type=click.IntRange(min=1, max=120))
+    @click.option("--notify/--no-notify", default=True, show_default=True)
+    def run_once(
+        state_dir: Path,
+        database_url: str,
+        timeout_seconds: int,
+        notify: bool,
+    ) -> None:
+        factory = store_factory
+        if not callable(factory):
+            raise click.ClickException("public ingress monitor requires a store factory.")
+        record_store = factory(state_dir, database_url=database_url)
+        notifier = build_github_issue_notifier() if notify else None
+        result = run_public_ingress_monitor_once(
+            record_store=record_store,
+            timeout_seconds=timeout_seconds,
+            notify=notify,
+            notifier=notifier,
+        )
+        click.echo(json.dumps(result.model_dump(mode="json"), indent=2, sort_keys=True))

--- a/control_plane/contracts/product_environment_read_model.py
+++ b/control_plane/contracts/product_environment_read_model.py
@@ -23,6 +23,7 @@ from control_plane.contracts.product_profile_record import (
     ProductRuntimeConfigRequirement,
     ProductSecretConfigRequirement,
 )
+from control_plane.contracts.public_ingress_monitoring import PublicIngressObservationRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.contracts.runtime_identity import RuntimeIdentity, RuntimeIdentityStatus
@@ -113,6 +114,15 @@ class ProductEnvironmentReadModelStore(ProductReadModelStore, Protocol):
     def list_authz_policy_records(
         self, *, status: str = "", limit: int | None = None
     ) -> tuple[LaunchplaneAuthzPolicyRecord, ...]: ...
+
+    def list_public_ingress_observation_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressObservationRecord, ...]: ...
 
 
 def _build_action_authz_by_route() -> dict[str, str]:
@@ -205,6 +215,23 @@ class ProductTargetSummary(BaseModel):
     trust_state: FreshnessStatus = "missing"
 
 
+class ProductPublicIngressSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: str = "missing"
+    failure_code: str = ""
+    observed_at: str = ""
+    record_id: str = ""
+    summary: str = ""
+    notification_sent: bool = False
+    trust_state: FreshnessStatus = "missing"
+    provenance: DataProvenance = DataProvenance(
+        source_kind="record",
+        freshness_status="missing",
+        detail="Launchplane has not recorded public ingress observations for this lane.",
+    )
+
+
 class ProductEnvironmentSummary(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -221,6 +248,7 @@ class ProductEnvironmentSummary(BaseModel):
     odoo_requires_backup_before_destroy: bool = True
     odoo_requires_restore_proof: bool = True
     odoo_requires_runtime_identity: bool = True
+    public_ingress: ProductPublicIngressSummary = Field(default_factory=ProductPublicIngressSummary)
     trust_state: FreshnessStatus
     provenance: DataProvenance
     warnings: tuple[str, ...] = ()
@@ -283,6 +311,7 @@ class ProductEnvironmentDetail(BaseModel):
     odoo_requires_restore_proof: bool = True
     odoo_requires_runtime_identity: bool = True
     target: ProductTargetSummary
+    public_ingress: ProductPublicIngressSummary = Field(default_factory=ProductPublicIngressSummary)
     runtime_settings: tuple[ProductRuntimeSettingSummary, ...] = ()
     managed_secrets: tuple[ProductSecretBindingSummary, ...] = ()
     available_actions: tuple[ProductActionAvailability, ...] = ()
@@ -468,6 +497,11 @@ def build_product_environment_detail(
         odoo_requires_restore_proof=lane.odoo_data_policy.requires_restore_proof,
         odoo_requires_runtime_identity=lane.odoo_data_policy.requires_runtime_identity,
         target=_target_summary(lane_summary),
+        public_ingress=_public_ingress_summary(
+            record_store=record_store,
+            profile=profile,
+            lane=lane,
+        ),
         runtime_settings=_runtime_setting_summaries(lane_summary),
         managed_secrets=_secret_binding_summaries(lane_summary),
         available_actions=_action_availability(
@@ -1132,6 +1166,11 @@ def _build_environment_summary(
         odoo_requires_backup_before_destroy=lane.odoo_data_policy.requires_backup_before_destroy,
         odoo_requires_restore_proof=lane.odoo_data_policy.requires_restore_proof,
         odoo_requires_runtime_identity=lane.odoo_data_policy.requires_runtime_identity,
+        public_ingress=_public_ingress_summary(
+            record_store=record_store,
+            profile=profile,
+            lane=lane,
+        ),
         trust_state=provenance.freshness_status,
         provenance=provenance,
         available_actions=_action_availability(
@@ -1240,6 +1279,53 @@ def _build_preview_summary(
         trust_state=provenance.freshness_status,
         provenance=provenance,
     )
+
+
+def _public_ingress_summary(
+    *,
+    record_store: object,
+    profile: LaunchplaneProductProfileRecord,
+    lane: ProductLaneProfile,
+) -> ProductPublicIngressSummary:
+    records = _optional_records(
+        record_store,
+        "list_public_ingress_observation_records",
+        product=profile.product,
+        context_name=lane.context,
+        instance_name=lane.instance,
+        limit=1,
+    )
+    latest = next(iter(records), None)
+    if latest is None or not isinstance(latest, PublicIngressObservationRecord):
+        return ProductPublicIngressSummary()
+    provenance = DataProvenance(
+        source_kind="record",
+        source_record_id=latest.record_id,
+        recorded_at=latest.observed_at,
+        refreshed_at=latest.observed_at,
+        freshness_status=_public_ingress_freshness(latest.status),
+        detail="Launchplane public ingress synthetic observation.",
+    )
+    return ProductPublicIngressSummary(
+        status=latest.status,
+        failure_code=latest.failure_code or "",
+        observed_at=latest.observed_at,
+        record_id=latest.record_id,
+        summary=latest.summary,
+        notification_sent=latest.notification_sent,
+        trust_state=provenance.freshness_status,
+        provenance=provenance,
+    )
+
+
+def _public_ingress_freshness(status: str) -> FreshnessStatus:
+    if status == "pass":
+        return "verified"
+    if status == "fail":
+        return "stale"
+    if status == "skipped":
+        return "unsupported"
+    return "missing"
 
 
 def _action_availability(

--- a/control_plane/contracts/product_onboarding_manifest.py
+++ b/control_plane/contracts/product_onboarding_manifest.py
@@ -10,6 +10,7 @@ from control_plane.contracts.product_profile_record import (
     ProductOdooStableBootstrapPolicy,
     ProductExpectedConfigProfile,
     ProductPreviewProfile,
+    ProductPublicIngressMonitoringPolicy,
     ProductPromotionWorkflowProfile,
 )
 from control_plane.contracts.runtime_environment_record import ScalarValue
@@ -29,8 +30,9 @@ class ProductOnboardingLaneManifest(BaseModel):
     odoo_prelaunch_rebuild: ProductOdooPrelaunchRebuildPolicy = Field(
         default_factory=ProductOdooPrelaunchRebuildPolicy
     )
-    odoo_data_policy: ProductOdooLaneDataPolicy = Field(
-        default_factory=ProductOdooLaneDataPolicy
+    odoo_data_policy: ProductOdooLaneDataPolicy = Field(default_factory=ProductOdooLaneDataPolicy)
+    public_ingress_monitoring: ProductPublicIngressMonitoringPolicy = Field(
+        default_factory=ProductPublicIngressMonitoringPolicy
     )
 
     @model_validator(mode="after")
@@ -267,9 +269,7 @@ class ProductOnboardingManifest(BaseModel):
         if context.strip() not in allowed_contexts:
             raise ValueError(f"{label} context is not owned by the product profile: {context}")
         if instance.strip() and (context.strip(), instance.strip()) not in lane_routes:
-            raise ValueError(
-                f"instance {label} must match a stable lane: {context}/{instance}"
-            )
+            raise ValueError(f"instance {label} must match a stable lane: {context}/{instance}")
 
     def product_expected_config_profile(self) -> ProductExpectedConfigProfile:
         return ProductExpectedConfigProfile.model_validate(

--- a/control_plane/contracts/product_profile_record.py
+++ b/control_plane/contracts/product_profile_record.py
@@ -56,9 +56,7 @@ class ProductOdooStableBootstrapPolicy(BaseModel):
         self.expected_domains = tuple(normalized_domains)
         if self.enabled:
             if not self.approval_issue_url:
-                raise ValueError(
-                    "enabled Odoo stable bootstrap policy requires approval_issue_url"
-                )
+                raise ValueError("enabled Odoo stable bootstrap policy requires approval_issue_url")
             if not self.confirmation:
                 raise ValueError("enabled Odoo stable bootstrap policy requires confirmation")
             if not self.expected_target_name:
@@ -113,9 +111,7 @@ class ProductOdooPrelaunchRebuildPolicy(BaseModel):
                     "enabled Odoo prelaunch rebuild policy requires expected_target_name"
                 )
             if not self.expected_domains:
-                raise ValueError(
-                    "enabled Odoo prelaunch rebuild policy requires expected_domains"
-                )
+                raise ValueError("enabled Odoo prelaunch rebuild policy requires expected_domains")
         return self
 
 
@@ -138,23 +134,30 @@ class ProductOdooLaneDataPolicy(BaseModel):
         self.allowed_rebuild_sources = tuple(normalized_sources)
         self.upstream_source = self.upstream_source.strip()
         if self.data_authority == "unknown" and self.allowed_rebuild_sources:
-            raise ValueError(
-                "unknown Odoo data authority cannot allow rebuild sources"
-            )
+            raise ValueError("unknown Odoo data authority cannot allow rebuild sources")
         if "upstream_restore" in self.allowed_rebuild_sources and not self.upstream_source:
-            raise ValueError(
-                "Odoo data policy allowing upstream_restore requires upstream_source"
-            )
+            raise ValueError("Odoo data policy allowing upstream_restore requires upstream_source")
         if self.data_authority == "authoritative" and not self.requires_backup_before_destroy:
-            raise ValueError(
-                "authoritative Odoo data policy requires backup before destroy"
-            )
+            raise ValueError("authoritative Odoo data policy requires backup before destroy")
         if self.data_authority == "authoritative" and not self.requires_restore_proof:
             raise ValueError("authoritative Odoo data policy requires restore proof")
         return self
 
     def allows_rebuild_source(self, source: str) -> bool:
         return source in self.allowed_rebuild_sources
+
+
+class ProductPublicIngressMonitoringPolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    require_runtime_identity: bool = True
+    alert_issue_url: str = ""
+
+    @model_validator(mode="after")
+    def _validate_policy(self) -> "ProductPublicIngressMonitoringPolicy":
+        self.alert_issue_url = self.alert_issue_url.strip()
+        return self
 
 
 class ProductLaneProfile(BaseModel):
@@ -170,8 +173,9 @@ class ProductLaneProfile(BaseModel):
     odoo_prelaunch_rebuild: ProductOdooPrelaunchRebuildPolicy = Field(
         default_factory=ProductOdooPrelaunchRebuildPolicy
     )
-    odoo_data_policy: ProductOdooLaneDataPolicy = Field(
-        default_factory=ProductOdooLaneDataPolicy
+    odoo_data_policy: ProductOdooLaneDataPolicy = Field(default_factory=ProductOdooLaneDataPolicy)
+    public_ingress_monitoring: ProductPublicIngressMonitoringPolicy = Field(
+        default_factory=ProductPublicIngressMonitoringPolicy
     )
 
     @model_validator(mode="after")

--- a/control_plane/contracts/public_ingress_monitoring.py
+++ b/control_plane/contracts/public_ingress_monitoring.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.runtime_identity import RuntimeIdentity, RuntimeIdentityStatus
+
+
+PublicIngressObservationStatus = Literal["pass", "fail", "skipped"]
+PublicIngressTargetKind = Literal["base_url", "health_url"]
+PublicIngressFailureCode = Literal[
+    "connection_timeout",
+    "dns_failure",
+    "health_status_error",
+    "http_error",
+    "invalid_url",
+    "private_url",
+    "redirect_loop",
+    "self_redirect",
+    "tls_failure",
+    "wrong_runtime_identity",
+    "unknown_error",
+]
+
+
+class PublicIngressTargetObservation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    target: PublicIngressTargetKind
+    url: str
+    status: PublicIngressObservationStatus
+    failure_code: PublicIngressFailureCode | None = None
+    http_status: int | None = Field(default=None, ge=100, le=599)
+    final_url: str = ""
+    redirect_count: int = Field(default=0, ge=0)
+    runtime_identity_status: RuntimeIdentityStatus = "unchecked"
+    runtime_identity_detail: str = ""
+    observed_runtime_identity: RuntimeIdentity | None = None
+    summary: str
+
+    @model_validator(mode="after")
+    def _validate_observation(self) -> "PublicIngressTargetObservation":
+        self.url = _required_text(self.url, "public ingress target observation requires url")
+        self.final_url = self.final_url.strip()
+        self.summary = _required_text(
+            self.summary, "public ingress target observation requires summary"
+        )
+        if self.status == "pass" and self.failure_code is not None:
+            raise ValueError("passing public ingress target cannot include failure_code")
+        if self.status == "fail" and self.failure_code is None:
+            raise ValueError("failing public ingress target requires failure_code")
+        if self.status == "skipped" and self.failure_code not in {None, "private_url"}:
+            raise ValueError("skipped public ingress target can only use private_url failure_code")
+        return self
+
+
+class PublicIngressObservationRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    record_id: str
+    product: str
+    repository: str = ""
+    driver_id: str = ""
+    context: str
+    instance: str
+    observed_at: str
+    status: PublicIngressObservationStatus
+    failure_code: PublicIngressFailureCode | None = None
+    base_url: str = ""
+    health_url: str = ""
+    expected_runtime_identity: RuntimeIdentity | None = None
+    targets: tuple[PublicIngressTargetObservation, ...] = ()
+    notification_key: str = ""
+    notification_sent: bool = False
+    summary: str
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "PublicIngressObservationRecord":
+        self.record_id = _required_text(
+            self.record_id, "public ingress observation requires record_id"
+        )
+        self.product = _required_text(self.product, "public ingress observation requires product")
+        self.context = _required_text(self.context, "public ingress observation requires context")
+        self.instance = _required_text(
+            self.instance, "public ingress observation requires instance"
+        )
+        self.observed_at = _required_text(
+            self.observed_at, "public ingress observation requires observed_at"
+        )
+        self.repository = self.repository.strip()
+        self.driver_id = self.driver_id.strip()
+        self.base_url = self.base_url.strip()
+        self.health_url = self.health_url.strip()
+        self.notification_key = self.notification_key.strip()
+        self.summary = _required_text(self.summary, "public ingress observation requires summary")
+        if self.status == "pass" and self.failure_code is not None:
+            raise ValueError("passing public ingress observation cannot include failure_code")
+        if self.status == "fail" and self.failure_code is None:
+            raise ValueError("failing public ingress observation requires failure_code")
+        if self.status == "skipped" and self.failure_code not in {None, "private_url"}:
+            raise ValueError(
+                "skipped public ingress observation can only use private_url failure_code"
+            )
+        if not self.targets:
+            raise ValueError("public ingress observation requires at least one target")
+        if self.status == "pass" and any(target.status != "pass" for target in self.targets):
+            raise ValueError("passing public ingress observation requires all targets to pass")
+        if self.status == "fail" and not any(target.status == "fail" for target in self.targets):
+            raise ValueError("failing public ingress observation requires a failing target")
+        return self
+
+
+def build_public_ingress_observation_id(
+    *, product: str, context: str, instance: str, observed_at: str
+) -> str:
+    return "-".join(
+        _record_token(value)
+        for value in ("public-ingress", product, context, instance, observed_at)
+        if _record_token(value)
+    )
+
+
+def _record_token(value: str) -> str:
+    return "".join(
+        character if character.isalnum() else "-" for character in value.strip().lower()
+    ).strip("-")
+
+
+def _required_text(value: str, message: str) -> str:
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise ValueError(message)
+    return normalized_value

--- a/control_plane/product_read_service.py
+++ b/control_plane/product_read_service.py
@@ -41,6 +41,7 @@ _PRODUCT_ENVIRONMENT_READ_MODEL_STORE_METHODS = (
     "list_preview_desired_state_records",
     "list_preview_lifecycle_cleanup_records",
     "list_preview_pr_feedback_records",
+    "list_public_ingress_observation_records",
     "list_authz_policy_records",
 )
 

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -321,6 +321,10 @@ from control_plane.workflows.odoo_preview_runtime import (
     execute_odoo_preview_dokploy_apply,
 )
 from control_plane.workflows.product_onboarding import apply_product_onboarding_manifest
+from control_plane.workflows.public_ingress_monitor import (
+    build_github_issue_notifier,
+    run_public_ingress_monitor_once,
+)
 from control_plane.workflows.preview_desired_state import discover_github_preview_desired_state
 from control_plane.workflows.preview_lifecycle import build_preview_lifecycle_plan
 from control_plane.workflows.preview_lifecycle_cleanup import (
@@ -839,6 +843,22 @@ class RunnerHostHygieneAuditEvidenceEnvelope(BaseModel):
     def _validate_alignment(self) -> "RunnerHostHygieneAuditEvidenceEnvelope":
         if self.product.strip() != "launchplane":
             raise ValueError("runner host hygiene audit evidence requires product 'launchplane'")
+        self.product = "launchplane"
+        return self
+
+
+class PublicIngressMonitorRunOnceEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str = "launchplane"
+    timeout_seconds: int = Field(default=10, ge=1, le=120)
+    notify: bool = True
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "PublicIngressMonitorRunOnceEnvelope":
+        if self.product.strip() != "launchplane":
+            raise ValueError("public ingress monitor run requires product 'launchplane'")
         self.product = "launchplane"
         return self
 
@@ -2940,6 +2960,13 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "product_profile.read", {"product": segments[2]}
     if len(segments) == 2 and segments == ["v1", "products"]:
         return "product_environment.read", {}
+    if len(segments) == 4 and segments == [
+        "v1",
+        "products",
+        "public-ingress-monitor",
+        "run-once",
+    ]:
+        return "public_ingress_monitor.run_once", {}
     if len(segments) == 4 and segments[:2] == ["v1", "products"] and segments[3] == "activity":
         return "product_environment.read", {"product": segments[2], "activity": "true"}
     if len(segments) == 3 and segments[:2] == ["v1", "products"]:
@@ -3036,6 +3063,7 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/every-code/preview-gates",
         "/v1/work-graph/github/issues/reconcile",
         "/v1/work-graph/rank",
+        "/v1/products/public-ingress-monitor/run-once",
         "/v1/evidence/deployments",
         "/v1/evidence/backup-gates",
         "/v1/evidence/runner-host-hygiene/audits",
@@ -10055,9 +10083,7 @@ def create_launchplane_service_app(
                                 source=f"service:controller:stale-landing:{request_trace_id}",
                                 updated_at=recorded_at,
                             )
-                            landing_store.write_merge_train_batch_landing_plan_record(
-                                stale_record
-                            )
+                            landing_store.write_merge_train_batch_landing_plan_record(stale_record)
                             message = (
                                 str(error).strip()
                                 or "Merge train landing evidence no longer matches GitHub."
@@ -10084,9 +10110,7 @@ def create_launchplane_service_app(
                                 source=f"service:controller:land:{request_trace_id}",
                                 updated_at=recorded_at,
                             )
-                            landing_store.write_merge_train_batch_landing_plan_record(
-                                landed_record
-                            )
+                            landing_store.write_merge_train_batch_landing_plan_record(landed_record)
                             result = {
                                 "merge_train_batch_landing_plan_record_id": landed_record.record_id,
                                 "repository": landed_plan.repository,
@@ -10129,8 +10153,8 @@ def create_launchplane_service_app(
                                 result["merge_train_stack_collapse_plan_record_id"] = (
                                     reconciled_record.record_id
                                 )
-                                result["stack_collapse_plan"] = (
-                                    reconciled_collapse_plan.model_dump(mode="json")
+                                result["stack_collapse_plan"] = reconciled_collapse_plan.model_dump(
+                                    mode="json"
                                 )
                             driver_result = result
                 else:
@@ -10648,6 +10672,48 @@ def create_launchplane_service_app(
                         "recorded_at": intent_record.recorded_at,
                     },
                 }
+                driver_result = result
+            elif path == "/v1/products/public-ingress-monitor/run-once":
+                monitor_request = PublicIngressMonitorRunOnceEnvelope.model_validate(payload)
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="public_ingress_monitor.run_once",
+                    product=monitor_request.product,
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot run public ingress monitoring.",
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                recorded_at = _utc_now_timestamp()
+                notifier = build_github_issue_notifier() if monitor_request.notify else None
+                monitor_result = run_public_ingress_monitor_once(
+                    record_store=record_store,
+                    checked_at=recorded_at,
+                    timeout_seconds=monitor_request.timeout_seconds,
+                    notify=monitor_request.notify,
+                    notifier=notifier,
+                )
+                result = monitor_result.model_dump(mode="json")
                 driver_result = result
             elif path == "/v1/every-code/work-requests/claim":
                 if not authz_policy.allows(

--- a/control_plane/service_auth.py
+++ b/control_plane/service_auth.py
@@ -77,6 +77,7 @@ AgentAuthzDecision = Literal["allowed", "denied"]
 LOCAL_OPERATOR_ALLOWED_ACTIONS = frozenset(
     {
         "merge_train.policy_targets",
+        "public_ingress_monitor.run_once",
         "product_config.plan",
         "product_config.apply",
         "work_graph.issue_inbox.reconcile",

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -48,6 +48,7 @@ from control_plane.contracts.preview_lifecycle_plan_record import PreviewLifecyc
 from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedbackRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.public_ingress_monitoring import PublicIngressObservationRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
 from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyPolicyRecord
@@ -546,6 +547,36 @@ class FilesystemRecordStore:
 
     def write_product_profile_record(self, record: LaunchplaneProductProfileRecord) -> Path:
         return self._write_model("launchplane_product_profiles", record.product, record)
+
+    def write_public_ingress_observation_record(
+        self, record: PublicIngressObservationRecord
+    ) -> Path:
+        return self._write_model(
+            "launchplane_public_ingress_observations", record.record_id, record
+        )
+
+    def list_public_ingress_observation_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressObservationRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                PublicIngressObservationRecord,
+                "launchplane_public_ingress_observations",
+            )
+            if (not product or record.product == product)
+            and (not context_name or record.context == context_name)
+            and (not instance_name or record.instance == instance_name)
+        ]
+        records.sort(key=lambda record: (record.observed_at, record.record_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
 
     def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
         return LaunchplaneProductProfileRecord.model_validate(

--- a/control_plane/storage/migrations/versions/d4e6f8a0b2c4_add_public_ingress_observations.py
+++ b/control_plane/storage/migrations/versions/d4e6f8a0b2c4_add_public_ingress_observations.py
@@ -1,0 +1,76 @@
+"""add public ingress observations
+
+Revision ID: d4e6f8a0b2c4
+Revises: c3e5f7a9b1d2
+Create Date: 2026-05-29 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "d4e6f8a0b2c4"
+down_revision: str | None = "c3e5f7a9b1d2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "launchplane_public_ingress_observations"
+_LOOKUP_INDEX = "launchplane_public_ingress_observations_lookup_idx"
+_STATUS_INDEX = "launchplane_public_ingress_observations_status_idx"
+
+
+def _table_exists(table_name: str) -> bool:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return table_name in set(inspector.get_table_names())
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return index_name in {str(index["name"]) for index in inspector.get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    if not _table_exists(_TABLE):
+        op.create_table(
+            _TABLE,
+            sa.Column("record_id", sa.String(), nullable=False),
+            sa.Column("product", sa.String(), nullable=False),
+            sa.Column("context", sa.String(), nullable=False),
+            sa.Column("instance", sa.String(), nullable=False),
+            sa.Column("status", sa.String(), nullable=False),
+            sa.Column("observed_at", sa.String(), nullable=False),
+            sa.Column(
+                "payload",
+                sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+                nullable=False,
+            ),
+            sa.PrimaryKeyConstraint("record_id"),
+        )
+    if not _index_exists(_TABLE, _LOOKUP_INDEX):
+        op.create_index(
+            _LOOKUP_INDEX,
+            _TABLE,
+            ["product", "context", "instance", sa.text("observed_at DESC")],
+        )
+    if not _index_exists(_TABLE, _STATUS_INDEX):
+        op.create_index(
+            _STATUS_INDEX,
+            _TABLE,
+            ["status", sa.text("observed_at DESC")],
+        )
+
+
+def downgrade() -> None:
+    if not _table_exists(_TABLE):
+        return
+    if _index_exists(_TABLE, _STATUS_INDEX):
+        op.drop_index(_STATUS_INDEX, table_name=_TABLE)
+    if _index_exists(_TABLE, _LOOKUP_INDEX):
+        op.drop_index(_LOOKUP_INDEX, table_name=_TABLE)
+    op.drop_table(_TABLE)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -68,6 +68,7 @@ from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedback
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.preview_summary import LaunchplanePreviewSummary
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.public_ingress_monitoring import PublicIngressObservationRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
 from control_plane.contracts.runtime_environment_record import (
@@ -462,6 +463,32 @@ class LaunchplaneProductProfileRow(Base):
     repository: Mapped[str] = mapped_column(String, nullable=False)
     driver_id: Mapped[str] = mapped_column(String, nullable=False)
     updated_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplanePublicIngressObservationRow(Base):
+    __tablename__ = "launchplane_public_ingress_observations"
+    __table_args__ = (
+        Index(
+            "launchplane_public_ingress_observations_lookup_idx",
+            "product",
+            "context",
+            "instance",
+            desc("observed_at"),
+        ),
+        Index(
+            "launchplane_public_ingress_observations_status_idx",
+            "status",
+            desc("observed_at"),
+        ),
+    )
+
+    record_id: Mapped[str] = mapped_column(String, primary_key=True)
+    product: Mapped[str] = mapped_column(String, nullable=False)
+    context: Mapped[str] = mapped_column(String, nullable=False)
+    instance: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    observed_at: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -2669,6 +2696,47 @@ class PostgresRecordStore(HumanSessionStore):
             orm_model=LaunchplaneProductProfileRow,
             filters=filters,
             order_by=(LaunchplaneProductProfileRow.product.asc(),),
+        )
+
+    def write_public_ingress_observation_record(
+        self, record: PublicIngressObservationRecord
+    ) -> None:
+        self._write_row(
+            LaunchplanePublicIngressObservationRow(
+                record_id=record.record_id,
+                product=record.product,
+                context=record.context,
+                instance=record.instance,
+                status=record.status,
+                observed_at=record.observed_at,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def list_public_ingress_observation_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressObservationRecord, ...]:
+        filters: list[object] = []
+        if product:
+            filters.append(LaunchplanePublicIngressObservationRow.product == product)
+        if context_name:
+            filters.append(LaunchplanePublicIngressObservationRow.context == context_name)
+        if instance_name:
+            filters.append(LaunchplanePublicIngressObservationRow.instance == instance_name)
+        return self._list_models(
+            model_type=PublicIngressObservationRecord,
+            orm_model=LaunchplanePublicIngressObservationRow,
+            filters=filters,
+            order_by=(
+                LaunchplanePublicIngressObservationRow.observed_at.desc(),
+                LaunchplanePublicIngressObservationRow.record_id.desc(),
+            ),
+            limit=limit,
         )
 
     def write_dokploy_target_id_record(self, record: DokployTargetIdRecord) -> None:

--- a/control_plane/workflows/product_onboarding.py
+++ b/control_plane/workflows/product_onboarding.py
@@ -64,6 +64,7 @@ def build_product_profile_record(
                 odoo_stable_bootstrap=lane.odoo_stable_bootstrap,
                 odoo_prelaunch_rebuild=lane.odoo_prelaunch_rebuild,
                 odoo_data_policy=lane.odoo_data_policy,
+                public_ingress_monitoring=lane.public_ingress_monitoring,
             )
             for lane in manifest.lanes
         ),

--- a/control_plane/workflows/public_ingress_monitor.py
+++ b/control_plane/workflows/public_ingress_monitor.py
@@ -1,0 +1,587 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from http.client import HTTPMessage
+from typing import IO, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit, urlunsplit
+from urllib.request import HTTPRedirectHandler, OpenerDirector, Request, build_opener
+import ipaddress
+import json
+import socket
+import ssl
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductLaneProfile,
+)
+from control_plane.contracts.public_ingress_monitoring import (
+    PublicIngressFailureCode,
+    PublicIngressObservationRecord,
+    PublicIngressObservationStatus,
+    PublicIngressTargetKind,
+    PublicIngressTargetObservation,
+    build_public_ingress_observation_id,
+)
+from control_plane.contracts.runtime_identity import (
+    RuntimeIdentity,
+    RuntimeIdentityStatus,
+    health_payload_runtime_identity_status,
+)
+from control_plane.drivers.registry import read_driver_descriptor
+from control_plane.workflows.ship import utc_now_timestamp
+
+
+MAX_REDIRECTS = 10
+USER_AGENT = "Launchplane public-ingress-monitor/1.0"
+
+
+class PublicIngressMonitorStore(Protocol):
+    def list_product_profile_records(
+        self, *, driver_id: str = ""
+    ) -> tuple[LaunchplaneProductProfileRecord, ...]: ...
+
+    def list_public_ingress_observation_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressObservationRecord, ...]: ...
+
+    def write_public_ingress_observation_record(
+        self, record: PublicIngressObservationRecord
+    ) -> object: ...
+
+
+@dataclass(frozen=True)
+class PublicIngressMonitorTarget:
+    product: str
+    repository: str
+    driver_id: str
+    context: str
+    instance: str
+    base_url: str
+    health_url: str
+    expected_runtime_identity: RuntimeIdentity | None
+    require_runtime_identity: bool
+    alert_issue_url: str
+
+
+@dataclass(frozen=True)
+class HttpObservation:
+    status_code: int
+    final_url: str
+    redirect_count: int
+    payload: object = None
+
+
+class PublicIngressMonitorResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    checked_at: str
+    target_count: int = Field(ge=0)
+    pass_count: int = Field(default=0, ge=0)
+    fail_count: int = Field(default=0, ge=0)
+    skipped_count: int = Field(default=0, ge=0)
+    notification_count: int = Field(default=0, ge=0)
+    records: tuple[PublicIngressObservationRecord, ...] = ()
+
+
+HttpGet = Callable[[str, int], HttpObservation]
+Notifier = Callable[[PublicIngressObservationRecord, PublicIngressObservationRecord | None], bool]
+
+
+class _RedirectTrackingHandler(HTTPRedirectHandler):
+    def redirect_request(
+        self,
+        req: Request,
+        fp: IO[bytes],
+        code: int,
+        msg: str,
+        headers: HTTPMessage,
+        newurl: str,
+    ) -> Request | None:
+        old_url = req.full_url
+        if _normalized_url(old_url) == _normalized_url(newurl):
+            raise RuntimeError(f"self redirect from {old_url}")
+        request = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if request is not None:
+            redirects = int(getattr(req, "redirect_count", 0)) + 1
+            setattr(request, "redirect_count", redirects)
+            if redirects > MAX_REDIRECTS:
+                raise RuntimeError(f"redirect loop after {MAX_REDIRECTS} redirects")
+        return request
+
+
+def discover_public_ingress_monitor_targets(
+    record_store: PublicIngressMonitorStore,
+) -> tuple[PublicIngressMonitorTarget, ...]:
+    targets: list[PublicIngressMonitorTarget] = []
+    for profile in record_store.list_product_profile_records():
+        if not _profile_uses_generic_web(profile):
+            continue
+        for lane in profile.lanes:
+            if not lane.public_ingress_monitoring.enabled:
+                continue
+            base_url = lane.base_url.strip().rstrip("/")
+            health_url = (
+                lane.health_url.strip() or _health_url(base_url, profile.health_path)
+            ).strip()
+            if not (base_url or health_url):
+                continue
+            targets.append(
+                PublicIngressMonitorTarget(
+                    product=profile.product,
+                    repository=profile.repository,
+                    driver_id=profile.driver_id,
+                    context=lane.context,
+                    instance=lane.instance,
+                    base_url=base_url,
+                    health_url=health_url,
+                    expected_runtime_identity=_expected_runtime_identity(
+                        record_store=record_store,
+                        lane=lane,
+                    ),
+                    require_runtime_identity=lane.public_ingress_monitoring.require_runtime_identity,
+                    alert_issue_url=lane.public_ingress_monitoring.alert_issue_url,
+                )
+            )
+    return tuple(targets)
+
+
+def run_public_ingress_monitor_once(
+    *,
+    record_store: PublicIngressMonitorStore,
+    checked_at: str = "",
+    timeout_seconds: int = 10,
+    notify: bool = True,
+    http_get: HttpGet | None = None,
+    notifier: Notifier | None = None,
+) -> PublicIngressMonitorResult:
+    observed_at = checked_at.strip() or utc_now_timestamp()
+    get = http_get or fetch_public_ingress_url
+    records: list[PublicIngressObservationRecord] = []
+    notification_count = 0
+    for target in discover_public_ingress_monitor_targets(record_store):
+        previous_record = _latest_observation(record_store=record_store, target=target)
+        record = check_public_ingress_target(
+            target=target,
+            checked_at=observed_at,
+            timeout_seconds=timeout_seconds,
+            http_get=get,
+        )
+        if notify and notifier is not None and _should_notify(record, previous_record):
+            notification_sent = notifier(record, previous_record)
+            record = record.model_copy(update={"notification_sent": notification_sent})
+            if notification_sent:
+                notification_count += 1
+        record_store.write_public_ingress_observation_record(record)
+        records.append(record)
+    return PublicIngressMonitorResult(
+        checked_at=observed_at,
+        target_count=len(records),
+        pass_count=sum(1 for record in records if record.status == "pass"),
+        fail_count=sum(1 for record in records if record.status == "fail"),
+        skipped_count=sum(1 for record in records if record.status == "skipped"),
+        notification_count=notification_count,
+        records=tuple(records),
+    )
+
+
+def check_public_ingress_target(
+    *,
+    target: PublicIngressMonitorTarget,
+    checked_at: str,
+    timeout_seconds: int,
+    http_get: HttpGet,
+) -> PublicIngressObservationRecord:
+    target_observations: list[PublicIngressTargetObservation] = []
+    for target_kind, url in _target_urls(target):
+        target_observations.append(
+            _check_url(
+                target_kind=target_kind,
+                url=url,
+                timeout_seconds=timeout_seconds,
+                target=target,
+                http_get=http_get,
+            )
+        )
+    status, failure_code = _record_status(target_observations)
+    summary = _record_summary(target=target, status=status, observations=target_observations)
+    return PublicIngressObservationRecord(
+        record_id=build_public_ingress_observation_id(
+            product=target.product,
+            context=target.context,
+            instance=target.instance,
+            observed_at=checked_at,
+        ),
+        product=target.product,
+        repository=target.repository,
+        driver_id=target.driver_id,
+        context=target.context,
+        instance=target.instance,
+        observed_at=checked_at,
+        status=status,
+        failure_code=failure_code,
+        base_url=target.base_url,
+        health_url=target.health_url,
+        expected_runtime_identity=target.expected_runtime_identity,
+        targets=tuple(target_observations),
+        notification_key=_notification_key(target),
+        summary=summary,
+    )
+
+
+def fetch_public_ingress_url(url: str, timeout_seconds: int) -> HttpObservation:
+    opener: OpenerDirector = build_opener(_RedirectTrackingHandler)
+    request = Request(url, headers={"User-Agent": USER_AGENT}, method="GET")
+    with opener.open(request, timeout=timeout_seconds) as response:  # noqa: S310 - operator-configured product URLs.
+        body = response.read(1024 * 256)
+        payload: object = None
+        content_type = response.headers.get("content-type", "")
+        if body and "json" in content_type.lower():
+            try:
+                payload = json.loads(body.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                payload = None
+        return HttpObservation(
+            status_code=response.status,
+            final_url=response.geturl(),
+            redirect_count=int(getattr(response, "redirect_count", 0)),
+            payload=payload,
+        )
+
+
+def _check_url(
+    *,
+    target_kind: PublicIngressTargetKind,
+    url: str,
+    timeout_seconds: int,
+    target: PublicIngressMonitorTarget,
+    http_get: HttpGet,
+) -> PublicIngressTargetObservation:
+    public_url_error = _public_url_error(url)
+    if public_url_error is not None:
+        status: PublicIngressObservationStatus = (
+            "skipped" if public_url_error == "private_url" else "fail"
+        )
+        return PublicIngressTargetObservation(
+            target=target_kind,
+            url=url,
+            status=status,
+            failure_code=public_url_error,
+            summary=_failure_summary(public_url_error),
+        )
+    try:
+        observation = http_get(url, timeout_seconds)
+    except HTTPError as error:
+        return PublicIngressTargetObservation(
+            target=target_kind,
+            url=url,
+            status="fail",
+            failure_code=("health_status_error" if target_kind == "health_url" else "http_error"),
+            http_status=error.code,
+            final_url=error.url or "",
+            summary=f"HTTP {error.code}",
+        )
+    except TimeoutError:
+        return _failed_target(target_kind=target_kind, url=url, code="connection_timeout")
+    except URLError as error:
+        return _url_error_observation(target_kind=target_kind, url=url, error=error)
+    except ssl.SSLError:
+        return _failed_target(target_kind=target_kind, url=url, code="tls_failure")
+    except RuntimeError as error:
+        message = str(error).lower()
+        code: PublicIngressFailureCode = "redirect_loop"
+        if "self redirect" in message:
+            code = "self_redirect"
+        return _failed_target(
+            target_kind=target_kind,
+            url=url,
+            code=code,
+            summary=str(error),
+        )
+    except OSError as error:
+        return _failed_target(
+            target_kind=target_kind,
+            url=url,
+            code="unknown_error",
+            summary=str(error),
+        )
+    if not 200 <= observation.status_code < 300:
+        return PublicIngressTargetObservation(
+            target=target_kind,
+            url=url,
+            status="fail",
+            failure_code=("health_status_error" if target_kind == "health_url" else "http_error"),
+            http_status=observation.status_code,
+            final_url=observation.final_url,
+            redirect_count=observation.redirect_count,
+            summary=f"HTTP {observation.status_code}",
+        )
+    runtime_status: RuntimeIdentityStatus = "unchecked"
+    runtime_detail = ""
+    observed_runtime_identity: RuntimeIdentity | None = None
+    if target_kind == "health_url" and target.expected_runtime_identity is not None:
+        runtime_status, runtime_detail, observed_runtime_identity = (
+            health_payload_runtime_identity_status(
+                expected=target.expected_runtime_identity,
+                payload=observation.payload,
+                json_parse_failed=False,
+            )
+        )
+        if target.require_runtime_identity and runtime_status != "match":
+            return PublicIngressTargetObservation(
+                target=target_kind,
+                url=url,
+                status="fail",
+                failure_code="wrong_runtime_identity",
+                http_status=observation.status_code,
+                final_url=observation.final_url,
+                redirect_count=observation.redirect_count,
+                runtime_identity_status=runtime_status,
+                runtime_identity_detail=runtime_detail,
+                observed_runtime_identity=observed_runtime_identity,
+                summary=runtime_detail or "Runtime identity did not match expected deployment.",
+            )
+    return PublicIngressTargetObservation(
+        target=target_kind,
+        url=url,
+        status="pass",
+        http_status=observation.status_code,
+        final_url=observation.final_url,
+        redirect_count=observation.redirect_count,
+        runtime_identity_status=runtime_status,
+        runtime_identity_detail=runtime_detail,
+        observed_runtime_identity=observed_runtime_identity,
+        summary="Public ingress returned a successful response.",
+    )
+
+
+def _profile_uses_generic_web(profile: LaunchplaneProductProfileRecord) -> bool:
+    if profile.driver_id == "generic-web":
+        return True
+    try:
+        return read_driver_descriptor(profile.driver_id).base_driver_id == "generic-web"
+    except FileNotFoundError:
+        return False
+
+
+def _expected_runtime_identity(
+    *, record_store: object, lane: ProductLaneProfile
+) -> RuntimeIdentity | None:
+    read_lane_summary = getattr(record_store, "read_lane_summary", None)
+    if not callable(read_lane_summary):
+        return None
+    try:
+        lane_summary = read_lane_summary(
+            context_name=lane.context,
+            instance_name=lane.instance,
+        )
+    except (FileNotFoundError, KeyError):
+        return None
+    if not isinstance(lane_summary, LaunchplaneLaneSummary):
+        return None
+    if lane_summary.inventory is not None:
+        return lane_summary.inventory.runtime_identity
+    if lane_summary.latest_deployment is not None:
+        return lane_summary.latest_deployment.runtime_identity
+    return None
+
+
+def _latest_observation(
+    *, record_store: PublicIngressMonitorStore, target: PublicIngressMonitorTarget
+) -> PublicIngressObservationRecord | None:
+    records = record_store.list_public_ingress_observation_records(
+        product=target.product,
+        context_name=target.context,
+        instance_name=target.instance,
+        limit=1,
+    )
+    return next(iter(records), None)
+
+
+def _should_notify(
+    record: PublicIngressObservationRecord, previous: PublicIngressObservationRecord | None
+) -> bool:
+    if not record.notification_key:
+        return False
+    previous_status = previous.status if previous is not None else "missing"
+    if record.status == "fail" and previous_status != "fail":
+        return True
+    return record.status == "pass" and previous_status == "fail"
+
+
+def _target_urls(
+    target: PublicIngressMonitorTarget,
+) -> tuple[tuple[PublicIngressTargetKind, str], ...]:
+    urls: list[tuple[PublicIngressTargetKind, str]] = []
+    if target.base_url:
+        urls.append(("base_url", target.base_url))
+    if target.health_url and target.health_url != target.base_url:
+        urls.append(("health_url", target.health_url))
+    return tuple(urls)
+
+
+def _record_status(
+    observations: list[PublicIngressTargetObservation],
+) -> tuple[PublicIngressObservationStatus, PublicIngressFailureCode | None]:
+    failing = next(
+        (observation for observation in observations if observation.status == "fail"), None
+    )
+    if failing is not None:
+        return "fail", failing.failure_code
+    if all(observation.status == "skipped" for observation in observations):
+        return "skipped", "private_url"
+    return "pass", None
+
+
+def _record_summary(
+    *,
+    target: PublicIngressMonitorTarget,
+    status: PublicIngressObservationStatus,
+    observations: list[PublicIngressTargetObservation],
+) -> str:
+    if status == "pass":
+        return f"Public ingress is reachable for {target.product}/{target.instance}."
+    failing = next(
+        (observation for observation in observations if observation.status == "fail"), None
+    )
+    if failing is not None:
+        return f"Public ingress failed for {target.product}/{target.instance}: {failing.summary}"
+    return f"Public ingress monitoring skipped {target.product}/{target.instance}."
+
+
+def _public_url_error(url: str) -> PublicIngressFailureCode | None:
+    parsed = urlsplit(url.strip())
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return "invalid_url"
+    hostname = (parsed.hostname or "").lower()
+    if hostname in {"localhost", "127.0.0.1", "::1"}:
+        return "private_url"
+    try:
+        if ipaddress.ip_address(hostname).is_private:
+            return "private_url"
+    except ValueError:
+        pass
+    if (
+        hostname.endswith(".local")
+        or hostname.endswith(".internal")
+        or hostname.endswith(".invalid")
+    ):
+        return "private_url"
+    return None
+
+
+def _url_error_observation(
+    *, target_kind: PublicIngressTargetKind, url: str, error: URLError
+) -> PublicIngressTargetObservation:
+    reason = error.reason
+    code: PublicIngressFailureCode = "unknown_error"
+    if isinstance(reason, TimeoutError):
+        code = "connection_timeout"
+    elif isinstance(reason, ssl.SSLError):
+        code = "tls_failure"
+    elif isinstance(reason, socket.gaierror):
+        code = "dns_failure"
+    return _failed_target(target_kind=target_kind, url=url, code=code, summary=str(reason))
+
+
+def _failed_target(
+    *,
+    target_kind: PublicIngressTargetKind,
+    url: str,
+    code: PublicIngressFailureCode,
+    summary: str = "",
+) -> PublicIngressTargetObservation:
+    return PublicIngressTargetObservation(
+        target=target_kind,
+        url=url,
+        status="fail",
+        failure_code=code,
+        summary=summary.strip() or _failure_summary(code),
+    )
+
+
+def _failure_summary(code: PublicIngressFailureCode) -> str:
+    return code.replace("_", " ")
+
+
+def _health_url(base_url: str, health_path: str) -> str:
+    if not base_url.strip():
+        return ""
+    return f"{base_url.rstrip('/')}{health_path}"
+
+
+def _normalized_url(url: str) -> str:
+    parsed = urlsplit(url.strip())
+    path = parsed.path or "/"
+    return urlunsplit(
+        (
+            parsed.scheme.lower(),
+            parsed.netloc.lower(),
+            path.rstrip("/") or "/",
+            parsed.query,
+            "",
+        )
+    )
+
+
+def _notification_key(target: PublicIngressMonitorTarget) -> str:
+    return target.alert_issue_url or ""
+
+
+def public_ingress_alert_body(
+    record: PublicIngressObservationRecord,
+    previous: PublicIngressObservationRecord | None,
+) -> str:
+    state = "RECOVERED" if record.status == "pass" else "FAILED"
+    previous_status = previous.status if previous is not None else "missing"
+    lines = [
+        f"Launchplane public ingress {state}: {record.product}/{record.instance}",
+        "",
+        f"- status: {record.status}",
+        f"- previous_status: {previous_status}",
+        f"- observed_at: {record.observed_at}",
+        f"- context: {record.context}",
+    ]
+    if record.failure_code:
+        lines.append(f"- failure_code: {record.failure_code}")
+    for target in record.targets:
+        lines.append(f"- {target.target}: {target.status} {target.summary}")
+    return "\n".join(lines)
+
+
+def build_github_issue_notifier(
+    *, gh_binary: str = "gh", runner: Callable[..., object] | None = None
+) -> Notifier:
+    import subprocess
+
+    def notify(
+        record: PublicIngressObservationRecord,
+        previous: PublicIngressObservationRecord | None,
+    ) -> bool:
+        issue_url = record.notification_key.strip()
+        if not issue_url:
+            return False
+        command = [
+            gh_binary,
+            "issue",
+            "comment",
+            issue_url,
+            "--body",
+            public_ingress_alert_body(record, previous),
+        ]
+        if runner is not None:
+            result = runner(command)
+            return getattr(result, "returncode", 0) == 0
+        completed = subprocess.run(command, check=False, text=True, capture_output=True)
+        return completed.returncode == 0
+
+    return notify

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -121,6 +121,12 @@ profile preview transport keys. Product drivers that inherit `generic-web` reuse
 that setting metadata instead of redeclaring common preview routing and runtime
 transport fields.
 
+Generic web is also the default public-ingress monitoring family. Any stable
+lane on `generic-web` or a driver based on it is eligible for Launchplane's
+scheduled synthetic check when the lane has a public `base_url` or `health_url`.
+Based drivers inherit the same observation record and notification path; they do
+not need tenant-local monitor workflows.
+
 The `stable_deploy` action routes to `POST /v1/drivers/generic-web/deploy`. The
 route resolves product lane context from DB-backed product profile records and
 runtime target bindings from DB-backed Dokploy target records. Generic-web deploy

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -27,6 +27,8 @@ API path instead of running the local command from an arbitrary checkout.
 - `promotions`: write and inspect promotion records.
 - `product-config`: dry-run and apply trusted product runtime/secret config
   bundles from a live Launchplane context.
+- `public-ingress-monitor`: run shared synthetic public-ingress checks for
+  product lanes.
 - `release-tuples`: inspect state-backed tuple records and explicitly export a
   TOML catalog from minted state.
 - `service`: run the first local Launchplane HTTP ingress slice.
@@ -97,6 +99,7 @@ Current implementation scope:
 - `POST /v1/authz-policies/github-actions/grants`
 - `POST /v1/authz-policies/github-humans/grants`
 - `POST /v1/product-profiles/context-cutover/apply`
+- `POST /v1/products/public-ingress-monitor/run-once`
 - `POST /v1/previews/lifecycle-plan`
 - `POST /v1/drivers/verireel/preview-refresh`
 - `POST /v1/drivers/verireel/preview-destroy`
@@ -146,6 +149,16 @@ workflows, including product profile cutover reads/writes, production promotion,
 and generic-web preview refresh/destroy requests. The grant request returns only
 authz policy record metadata and rule counts; it does not echo workflow refs,
 human logins, or the full policy body.
+
+The `Public Ingress Monitor` workflow is a scheduled Launchplane-owned synthetic
+check for every public generic-web stable lane, including drivers that inherit
+generic-web behavior. It calls
+`POST /v1/products/public-ingress-monitor/run-once` through GitHub OIDC and is
+authorized in the Launchplane service context. Monitoring is default-on for
+lanes with public `base_url` or `health_url`; disable it per lane only for
+non-public or intentionally unreachable endpoints. When a lane policy includes
+`public_ingress_monitoring.alert_issue_url`, Launchplane comments on that issue
+when the latest observation moves from pass to fail or from fail back to pass.
 
 The manual Product Context Cutover workflow plans or applies the same
 current-authority record move through the Launchplane service. Run it first with

--- a/docs/records.md
+++ b/docs/records.md
@@ -168,6 +168,16 @@ derived from runtime-environment records, managed secret binding records, driver
 support, and trust metadata; expected config requirements do not store runtime
 values, managed secret IDs, secret plaintext, or ciphertext.
 
+Stable lanes inherit public-ingress synthetic monitoring by default when their
+product uses `generic-web` or a driver based on it. A lane with a public
+`base_url` or `health_url` is eligible unless its
+`public_ingress_monitoring.enabled` policy is set false. The monitor records
+HTTP reachability, redirect failures, private/internal URL skips, and runtime
+identity comparison when current lane inventory or deployment evidence provides
+an expected identity. Lane policy may carry an `alert_issue_url`; Launchplane
+uses that issue for fail/recover transition comments, not as runtime
+configuration authority.
+
 The product key is the durable workspace identity. For example,
 `sellyouroutboard` is the SellYourOutboard product workspace; `testing`, `prod`,
 and the preview inventory all appear under that workspace in the operator UI.
@@ -238,6 +248,20 @@ For initial seed or repair work, operators can write the same DB-backed record
 directly with `uv run launchplane product-profiles upsert --database-url ...`.
 That command is an operator tool for creating the Launchplane record; it is not
 a repo-local manifest and should not become product repo authority.
+
+## Public Ingress Observation Records
+
+Public ingress observations are append-only Launchplane records under
+`launchplane_public_ingress_observations`. Each record is keyed by product,
+context, instance, and observation time. It stores the checked base and health
+URLs, pass/fail/skipped status, failure code, redirect and HTTP evidence,
+runtime identity match detail when available, and whether Launchplane delivered
+a configured transition notification.
+
+These records are the source for the product environment read model's
+`public_ingress` summary. A passing observation is verified evidence, a failing
+observation marks the lane stale/unhealthy, and a skipped private URL is treated
+as unsupported rather than silently healthy.
 
 Odoo stable bootstrap eligibility is lane-owned product-profile data. A lane's
 `odoo_stable_bootstrap` policy defaults to disabled and must explicitly carry

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -743,6 +743,7 @@ post_launchplane_grant() {
   local action_name="$2"
   local source_label="$3"
   local idempotency_suffix="$4"
+  local event_name="${5:-workflow_dispatch}"
   post_grant \
     "$GITHUB_REPOSITORY" \
     "$workflow_file" \
@@ -750,7 +751,8 @@ post_launchplane_grant() {
     launchplane \
     "$action_name" \
     "$source_label" \
-    "$idempotency_suffix"
+    "$idempotency_suffix" \
+    "$event_name"
 }
 
 post_syo_grant() {
@@ -962,6 +964,18 @@ apply_product_onboarding \
 apply_verireel_onboarding
 apply_odoo_cm_onboarding
 apply_odoo_opw_onboarding
+post_launchplane_grant \
+  public-ingress-monitor.yml \
+  public_ingress_monitor.run_once \
+  deploy:public-ingress-monitor-grant \
+  public-ingress-monitor \
+  schedule
+post_launchplane_grant \
+  public-ingress-monitor.yml \
+  public_ingress_monitor.run_once \
+  deploy:public-ingress-monitor-manual-grant \
+  public-ingress-monitor-manual \
+  workflow_dispatch
 post_grant \
   cbusillo/discord-blue \
   main.yml \

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -54,6 +54,8 @@ from control_plane.contracts.product_profile_record import (
     ProductLaneProfile,
     ProductPreviewProfile,
 )
+from control_plane.contracts.public_ingress_monitoring import PublicIngressObservationRecord
+from control_plane.contracts.public_ingress_monitoring import PublicIngressTargetObservation
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
     BackupGateEvidence,
@@ -519,6 +521,68 @@ class FilesystemRecordStoreTests(unittest.TestCase):
         self.assertEqual(
             [listed_record.product for listed_record in listed_records], ["sellyouroutboard"]
         )
+
+    def test_write_and_list_public_ingress_observation_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            older_record = PublicIngressObservationRecord(
+                record_id="public-ingress-example-site-prod-older",
+                product="example-site",
+                context="example-site-prod",
+                instance="prod",
+                observed_at="2026-05-29T12:00:00Z",
+                status="pass",
+                base_url="https://example.test",
+                targets=(
+                    PublicIngressTargetObservation(
+                        target="base_url",
+                        url="https://example.test",
+                        status="pass",
+                        http_status=200,
+                        summary="Public ingress returned a successful response.",
+                    ),
+                ),
+                summary="Public ingress is reachable.",
+            )
+            newer_record = older_record.model_copy(
+                update={
+                    "record_id": "public-ingress-example-site-prod-newer",
+                    "observed_at": "2026-05-29T12:05:00Z",
+                    "status": "fail",
+                    "failure_code": "http_error",
+                    "targets": (
+                        PublicIngressTargetObservation(
+                            target="base_url",
+                            url="https://example.test",
+                            status="fail",
+                            failure_code="http_error",
+                            http_status=503,
+                            summary="HTTP 503",
+                        ),
+                    ),
+                    "summary": "Public ingress failed.",
+                }
+            )
+
+            written_path = store.write_public_ingress_observation_record(older_record)
+            store.write_public_ingress_observation_record(newer_record)
+            listed_records = store.list_public_ingress_observation_records(
+                product="example-site",
+                context_name="example-site-prod",
+                instance_name="prod",
+            )
+            limited_records = store.list_public_ingress_observation_records(
+                product="example-site",
+                limit=1,
+            )
+            self.assertTrue(written_path.exists())
+
+        self.assertEqual(
+            [record.record_id for record in listed_records],
+            [newer_record.record_id, older_record.record_id],
+        )
+        self.assertEqual([record.record_id for record in limited_records], [newer_record.record_id])
 
     def test_write_and_list_runtime_key_safety_policy_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_product_environment_read_model.py
+++ b/tests/test_product_environment_read_model.py
@@ -23,6 +23,8 @@ from control_plane.contracts.product_environment_read_model import (
     build_product_site_overview,
 )
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.public_ingress_monitoring import PublicIngressObservationRecord
+from control_plane.contracts.public_ingress_monitoring import PublicIngressTargetObservation
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
     DeploymentEvidence,
@@ -221,6 +223,36 @@ class _RuntimeIdentityReadModelStore(_PreviewRecordStore):
         if artifact_id == self._artifact_manifest.artifact_id:
             return self._artifact_manifest
         raise FileNotFoundError(artifact_id)
+
+
+class _PublicIngressReadModelStore(_PreviewRecordStore):
+    def __init__(
+        self,
+        profile: LaunchplaneProductProfileRecord,
+        observations: tuple[PublicIngressObservationRecord, ...],
+    ) -> None:
+        super().__init__(profile, ())
+        self._observations = observations
+
+    def list_public_ingress_observation_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressObservationRecord, ...]:
+        records = [
+            record
+            for record in self._observations
+            if (not product or record.product == product)
+            and (not context_name or record.context == context_name)
+            and (not instance_name or record.instance == instance_name)
+        ]
+        records.sort(key=lambda record: (record.observed_at, record.record_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
 
 
 class _ActivityRecordStore(_PreviewRecordStore):
@@ -875,6 +907,53 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
         self.assertTrue(detail.odoo_requires_backup_before_destroy)
         self.assertTrue(detail.odoo_requires_restore_proof)
         self.assertTrue(detail.odoo_requires_runtime_identity)
+
+    def test_product_read_model_exposes_public_ingress_observation(self) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(
+            _site_profile_payload(preview_enabled=False)
+        )
+        observation = PublicIngressObservationRecord(
+            record_id="public-ingress-example-site-prod-20260529t120000z",
+            product="example-site",
+            context="example-site-prod",
+            instance="prod",
+            observed_at="2026-05-29T12:00:00Z",
+            status="fail",
+            failure_code="http_error",
+            base_url="https://example-site.example",
+            health_url="https://example-site.example/healthz",
+            targets=(
+                PublicIngressTargetObservation(
+                    target="base_url",
+                    url="https://example-site.example",
+                    status="fail",
+                    failure_code="http_error",
+                    http_status=503,
+                    summary="HTTP 503",
+                ),
+            ),
+            notification_sent=True,
+            summary="Public ingress failed for example-site/prod: HTTP 503",
+        )
+        store = _PublicIngressReadModelStore(profile, (observation,))
+
+        overview = build_product_site_overview(
+            record_store=store,
+            product="example-site",
+            action_allowed=lambda *_: False,
+        )
+        detail = build_product_environment_detail(
+            record_store=store,
+            product="example-site",
+            environment="prod",
+            action_allowed=lambda *_: False,
+        )
+
+        prod_summary = {summary.environment: summary for summary in overview.environments}["prod"]
+        self.assertEqual(prod_summary.public_ingress.status, "fail")
+        self.assertEqual(prod_summary.public_ingress.trust_state, "stale")
+        self.assertEqual(prod_summary.public_ingress.record_id, observation.record_id)
+        self.assertTrue(detail.public_ingress.notification_sent)
 
     def test_product_environment_detail_exposes_runtime_identity_evidence(self) -> None:
         profile = LaunchplaneProductProfileRecord.model_validate(

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -36,6 +36,9 @@ def _manifest_payload() -> dict[str, object]:
                 "instance": "testing",
                 "context": "example-site-testing",
                 "base_url": "https://testing.example.invalid",
+                "public_ingress_monitoring": {
+                    "alert_issue_url": "https://github.com/cbusillo/launchplane/issues/929"
+                },
                 "odoo_stable_bootstrap": {
                     "enabled": True,
                     "approval_issue_url": "https://github.com/cbusillo/launchplane/issues/573",
@@ -139,9 +142,7 @@ class ProductOnboardingTests(unittest.TestCase):
     def test_deploy_authz_grants_include_scheduled_merge_train_runner(
         self,
     ) -> None:
-        script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(
-            encoding="utf-8"
-        )
+        script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(encoding="utf-8")
 
         self.assertIn("deploy:merge-train-runner-manual-grant", script_text)
         self.assertIn("merge-train-runner-manual", script_text)
@@ -152,9 +153,7 @@ class ProductOnboardingTests(unittest.TestCase):
     def test_deploy_authz_grants_include_reusable_odoo_stable_workflows(
         self,
     ) -> None:
-        script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(
-            encoding="utf-8"
-        )
+        script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(encoding="utf-8")
 
         expected_workflows = (
             "reusable-odoo-artifact-publish.yml",
@@ -171,15 +170,13 @@ class ProductOnboardingTests(unittest.TestCase):
             )
             self.assertIn(f"deploy:odoo-{context_name}-artifact-publish-grant", script_text)
             self.assertIn(f"deploy:odoo-{context_name}-post-deploy-grant", script_text)
-            self.assertIn(
-                f"deploy:odoo-{context_name}-prod-promotion-run-grant", script_text
-            )
+            self.assertIn(f"deploy:odoo-{context_name}-prod-promotion-run-grant", script_text)
             self.assertIn(f"deploy:odoo-{context_name}-prod-rollback-grant", script_text)
 
     def test_reusable_odoo_artifact_publish_standardizes_request_shape(self) -> None:
-        workflow_text = Path(
-            ".github/workflows/reusable-odoo-artifact-publish.yml"
-        ).read_text(encoding="utf-8")
+        workflow_text = Path(".github/workflows/reusable-odoo-artifact-publish.yml").read_text(
+            encoding="utf-8"
+        )
 
         self.assertIn("workflow_call", workflow_text)
         self.assertIn("/v1/drivers/odoo/artifact-publish-inputs", workflow_text)
@@ -204,9 +201,9 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertNotIn("IMAGE_REPOSITORY: ghcr.io/${{ github.repository }}", workflow_text)
 
     def test_reusable_odoo_prod_promotion_fails_on_each_result_status(self) -> None:
-        workflow_text = Path(
-            ".github/workflows/reusable-odoo-prod-promotion.yml"
-        ).read_text(encoding="utf-8")
+        workflow_text = Path(".github/workflows/reusable-odoo-prod-promotion.yml").read_text(
+            encoding="utf-8"
+        )
 
         for result_path in (
             "result.run_status",
@@ -233,31 +230,30 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             captured_bin_directory.mkdir()
             (captured_bin_directory / "curl").write_text(
                 "#!/usr/bin/env bash\n"
-                "case \"$*\" in\n"
-                "  *github.invalid/oidc*) printf '{\"value\":\"oidc-token\"}' ;;\n"
+                'case "$*" in\n'
+                '  *github.invalid/oidc*) printf \'{"value":"oidc-token"}\' ;;\n'
                 "  *)\n"
                 "    output_file=''\n"
                 "    request_payload=''\n"
-                "    while [ \"$#\" -gt 0 ]; do\n"
-                "      case \"$1\" in\n"
-                "        -o) shift; output_file=\"$1\" ;;\n"
-                "        --data) shift; request_payload=\"$1\" ;;\n"
+                '    while [ "$#" -gt 0 ]; do\n'
+                '      case "$1" in\n'
+                '        -o) shift; output_file="$1" ;;\n'
+                '        --data) shift; request_payload="$1" ;;\n'
                 "      esac\n"
                 "      shift || true\n"
                 "    done\n"
                 "    if printf '%s' \"$request_payload\" | grep -q 'odoo-tenant-opw/.github/workflows/odoo-preview.yml'; then\n"
                 "      printf '%s\\n%s\\n' \"$request_payload\" '---END-GRANT---' >> \"$CAPTURED_GRANTS\"\n"
                 "    fi\n"
-                "    if [ -n \"$output_file\" ]; then\n"
-                "      printf '{\"status\":\"ok\"}' > \"$output_file\"\n"
+                '    if [ -n "$output_file" ]; then\n'
+                '      printf \'{"status":"ok"}\' > "$output_file"\n'
                 "    fi\n"
                 "    printf '200'\n"
                 "    ;;\n"
                 "esac\n"
             )
             (captured_bin_directory / "mktemp").write_text(
-                "#!/usr/bin/env bash\n"
-                "printf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
+                "#!/usr/bin/env bash\nprintf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
             )
             (captured_bin_directory / "curl").chmod(0o755)
             (captured_bin_directory / "mktemp").chmod(0o755)
@@ -364,9 +360,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
     def test_deploy_authz_grants_include_terminal_agent_product_profile_read(
         self,
     ) -> None:
-        script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(
-            encoding="utf-8"
-        )
+        script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(encoding="utf-8")
 
         self.assertIn("product_profile.read", script_text)
         self.assertIn("deploy:terminal-agent-product-profile-read-grant", script_text)
@@ -386,41 +380,40 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             captured_bin_directory.mkdir()
             (captured_bin_directory / "curl").write_text(
                 "#!/usr/bin/env bash\n"
-                "case \"$*\" in\n"
-                "  *github.invalid/oidc*) printf '{\"value\":\"oidc-token\"}' ;;\n"
+                'case "$*" in\n'
+                '  *github.invalid/oidc*) printf \'{"value":"oidc-token"}\' ;;\n'
                 "  *)\n"
                 "    idempotency_key=''\n"
                 "    output_file=''\n"
                 "    request_payload=''\n"
-                "    while [ \"$#\" -gt 0 ]; do\n"
-                "      case \"$1\" in\n"
-                "        -o) shift; output_file=\"$1\" ;;\n"
+                '    while [ "$#" -gt 0 ]; do\n'
+                '      case "$1" in\n'
+                '        -o) shift; output_file="$1" ;;\n'
                 "        -H)\n"
                 "          shift\n"
-                "          case \"$1\" in\n"
-                "            Idempotency-Key:*) idempotency_key=\"$1\" ;;\n"
+                '          case "$1" in\n'
+                '            Idempotency-Key:*) idempotency_key="$1" ;;\n'
                 "          esac\n"
                 "          ;;\n"
-                "        --data) shift; request_payload=\"$1\" ;;\n"
+                '        --data) shift; request_payload="$1" ;;\n'
                 "      esac\n"
                 "      shift || true\n"
                 "    done\n"
-                "    case \"$idempotency_key\" in\n"
+                '    case "$idempotency_key" in\n'
                 "      *launchplane-product-onboarding:verireel-preview-profile*)\n"
-                "        printf '%s' \"$request_payload\" > \"$CAPTURED_REQUEST_PAYLOAD\"\n"
-                "        printf '%s' \"${idempotency_key#Idempotency-Key: }\" > \"$CAPTURED_IDEMPOTENCY_KEY\"\n"
+                '        printf \'%s\' "$request_payload" > "$CAPTURED_REQUEST_PAYLOAD"\n'
+                '        printf \'%s\' "${idempotency_key#Idempotency-Key: }" > "$CAPTURED_IDEMPOTENCY_KEY"\n'
                 "        ;;\n"
                 "    esac\n"
-                "    if [ -n \"$output_file\" ]; then\n"
-                "      printf '{\"status\":\"ok\"}' > \"$output_file\"\n"
+                '    if [ -n "$output_file" ]; then\n'
+                '      printf \'{"status":"ok"}\' > "$output_file"\n'
                 "    fi\n"
                 "    printf '200'\n"
                 "    ;;\n"
                 "esac\n"
             )
             (captured_bin_directory / "mktemp").write_text(
-                "#!/usr/bin/env bash\n"
-                "printf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
+                "#!/usr/bin/env bash\nprintf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
             )
             (captured_bin_directory / "curl").chmod(0o755)
             (captured_bin_directory / "mktemp").chmod(0o755)
@@ -536,47 +529,46 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             captured_bin_directory.mkdir()
             (captured_bin_directory / "curl").write_text(
                 "#!/usr/bin/env bash\n"
-                "case \"$*\" in\n"
-                "  *github.invalid/oidc*) printf '{\"value\":\"oidc-token\"}' ;;\n"
+                'case "$*" in\n'
+                '  *github.invalid/oidc*) printf \'{"value":"oidc-token"}\' ;;\n'
                 "  *)\n"
                 "    idempotency_key=''\n"
                 "    output_file=''\n"
                 "    request_payload=''\n"
-                "    while [ \"$#\" -gt 0 ]; do\n"
-                "      case \"$1\" in\n"
+                '    while [ "$#" -gt 0 ]; do\n'
+                '      case "$1" in\n'
                 "        -o)\n"
                 "          shift\n"
-                "          output_file=\"$1\"\n"
+                '          output_file="$1"\n'
                 "          ;;\n"
                 "        -H)\n"
                 "          shift\n"
-                "          case \"$1\" in\n"
-                "            Idempotency-Key:*) idempotency_key=\"$1\" ;;\n"
+                '          case "$1" in\n'
+                '            Idempotency-Key:*) idempotency_key="$1" ;;\n'
                 "          esac\n"
                 "          ;;\n"
                 "        --data)\n"
                 "          shift\n"
-                "          request_payload=\"$1\"\n"
+                '          request_payload="$1"\n'
                 "          ;;\n"
                 "      esac\n"
                 "      shift || true\n"
                 "    done\n"
-                "    case \"$idempotency_key\" in\n"
+                '    case "$idempotency_key" in\n'
                 "      *launchplane-product-onboarding:odoo-cm-preview-profile*)\n"
-                "        printf '%s' \"$request_payload\" > \"$CAPTURED_REQUEST_PAYLOAD\"\n"
-                "        printf '%s' \"${idempotency_key#Idempotency-Key: }\" > \"$CAPTURED_IDEMPOTENCY_KEY\"\n"
+                '        printf \'%s\' "$request_payload" > "$CAPTURED_REQUEST_PAYLOAD"\n'
+                '        printf \'%s\' "${idempotency_key#Idempotency-Key: }" > "$CAPTURED_IDEMPOTENCY_KEY"\n'
                 "        ;;\n"
                 "    esac\n"
-                "    if [ -n \"$output_file\" ]; then\n"
-                "      printf '{\"status\":\"ok\"}' > \"$output_file\"\n"
+                '    if [ -n "$output_file" ]; then\n'
+                '      printf \'{"status":"ok"}\' > "$output_file"\n'
                 "    fi\n"
                 "    printf '200'\n"
                 "    ;;\n"
                 "esac\n"
             )
             (captured_bin_directory / "mktemp").write_text(
-                "#!/usr/bin/env bash\n"
-                "printf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
+                "#!/usr/bin/env bash\nprintf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
             )
             (captured_bin_directory / "curl").chmod(0o755)
             (captured_bin_directory / "mktemp").chmod(0o755)
@@ -667,27 +659,26 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             captured_bin_directory.mkdir()
             (captured_bin_directory / "curl").write_text(
                 "#!/usr/bin/env bash\n"
-                "case \"$*\" in\n"
-                "  *github.invalid/oidc*) printf '{\"value\":\"oidc-token\"}' ;;\n"
+                'case "$*" in\n'
+                '  *github.invalid/oidc*) printf \'{"value":"oidc-token"}\' ;;\n'
                 "  *) printf '200' ;;\n"
                 "esac\n"
                 "output_file=''\n"
-                "while [ \"$#\" -gt 0 ]; do\n"
-                "  case \"$1\" in\n"
+                'while [ "$#" -gt 0 ]; do\n'
+                '  case "$1" in\n'
                 "    -o)\n"
                 "      shift\n"
-                "      output_file=\"$1\"\n"
+                '      output_file="$1"\n'
                 "      ;;\n"
                 "  esac\n"
                 "  shift || true\n"
                 "done\n"
-                "if [ -n \"$output_file\" ]; then\n"
-                "  printf '{\"status\":\"ok\"}' > \"$output_file\"\n"
+                'if [ -n "$output_file" ]; then\n'
+                '  printf \'{"status":"ok"}\' > "$output_file"\n'
                 "fi\n"
             )
             (captured_bin_directory / "mktemp").write_text(
-                "#!/usr/bin/env bash\n"
-                "printf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
+                "#!/usr/bin/env bash\nprintf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
             )
             (captured_bin_directory / "curl").chmod(0o755)
             (captured_bin_directory / "mktemp").chmod(0o755)
@@ -732,40 +723,39 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             captured_bin_directory.mkdir()
             (captured_bin_directory / "curl").write_text(
                 "#!/usr/bin/env bash\n"
-                "case \"$*\" in\n"
-                "  *github.invalid/oidc*) printf '{\"value\":\"oidc-token\"}' ;;\n"
+                'case "$*" in\n'
+                '  *github.invalid/oidc*) printf \'{"value":"oidc-token"}\' ;;\n'
                 "  *)\n"
                 "    idempotency_key=''\n"
                 "    output_file=''\n"
                 "    request_payload=''\n"
-                "    while [ \"$#\" -gt 0 ]; do\n"
-                "      case \"$1\" in\n"
-                "        -o) shift; output_file=\"$1\" ;;\n"
+                '    while [ "$#" -gt 0 ]; do\n'
+                '      case "$1" in\n'
+                '        -o) shift; output_file="$1" ;;\n'
                 "        -H)\n"
                 "          shift\n"
-                "          case \"$1\" in\n"
-                "            Idempotency-Key:*) idempotency_key=\"$1\" ;;\n"
+                '          case "$1" in\n'
+                '            Idempotency-Key:*) idempotency_key="$1" ;;\n'
                 "          esac\n"
                 "          ;;\n"
-                "        --data) shift; request_payload=\"$1\" ;;\n"
+                '        --data) shift; request_payload="$1" ;;\n'
                 "      esac\n"
                 "      shift || true\n"
                 "    done\n"
-                "    case \"$idempotency_key\" in\n"
+                '    case "$idempotency_key" in\n'
                 "      *launchplane-product-onboarding:odoo-opw-prelaunch-profile*)\n"
-                "        printf '%s' \"$request_payload\" > \"$CAPTURED_REQUEST_PAYLOAD\"\n"
+                '        printf \'%s\' "$request_payload" > "$CAPTURED_REQUEST_PAYLOAD"\n'
                 "        ;;\n"
                 "    esac\n"
-                "    if [ -n \"$output_file\" ]; then\n"
-                "      printf '{\"status\":\"ok\"}' > \"$output_file\"\n"
+                '    if [ -n "$output_file" ]; then\n'
+                '      printf \'{"status":"ok"}\' > "$output_file"\n'
                 "    fi\n"
                 "    printf '200'\n"
                 "    ;;\n"
                 "esac\n"
             )
             (captured_bin_directory / "mktemp").write_text(
-                "#!/usr/bin/env bash\n"
-                "printf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
+                "#!/usr/bin/env bash\nprintf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
             )
             (captured_bin_directory / "curl").chmod(0o755)
             (captured_bin_directory / "mktemp").chmod(0o755)
@@ -856,6 +846,12 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertEqual(profile.driver_id, "generic-web")
         self.assertEqual(profile.lanes[0].health_url, "https://testing.example.invalid/api/health")
         self.assertTrue(profile.lanes[0].odoo_stable_bootstrap.enabled)
+        self.assertTrue(profile.lanes[0].public_ingress_monitoring.enabled)
+        self.assertTrue(profile.lanes[0].public_ingress_monitoring.require_runtime_identity)
+        self.assertEqual(
+            profile.lanes[0].public_ingress_monitoring.alert_issue_url,
+            "https://github.com/cbusillo/launchplane/issues/929",
+        )
         self.assertEqual(
             profile.lanes[0].odoo_stable_bootstrap.approval_issue_url,
             "https://github.com/cbusillo/launchplane/issues/573",
@@ -876,7 +872,9 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             ("empty",),
         )
         self.assertEqual(profile.lanes[1].odoo_data_policy.data_authority, "restorable")
-        self.assertEqual(profile.lanes[1].odoo_data_policy.upstream_source, "example-site/prod/upstream")
+        self.assertEqual(
+            profile.lanes[1].odoo_data_policy.upstream_source, "example-site/prod/upstream"
+        )
         self.assertEqual(profile.preview.enable_label, "preview-requested")
         self.assertEqual(profile.expected_config.runtime_environment_keys[0].key, "PUBLIC_BASE_URL")
         self.assertEqual(

--- a/tests/test_product_read_service.py
+++ b/tests/test_product_read_service.py
@@ -13,6 +13,7 @@ from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedback
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.preview_summary import LaunchplanePreviewSummary
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.public_ingress_monitoring import PublicIngressObservationRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.product_read_service import (
     ProductReadModelStoreCapabilityError,
@@ -77,9 +78,7 @@ class _ProductReadStore:
             raise FileNotFoundError(product)
         return self.profile
 
-    def read_lane_summary(
-        self, *, context_name: str, instance_name: str
-    ) -> LaunchplaneLaneSummary:
+    def read_lane_summary(self, *, context_name: str, instance_name: str) -> LaunchplaneLaneSummary:
         _ = self
         return LaunchplaneLaneSummary(context=context_name, instance=instance_name)
 
@@ -160,6 +159,17 @@ class _ProductReadStore:
         _ = (self, status, limit)
         return ()
 
+    def list_public_ingress_observation_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressObservationRecord, ...]:
+        _ = (self, product, context_name, instance_name, limit)
+        return ()
+
     def list_runtime_environment_records(
         self, *, context_name: str = "", scope: str = ""
     ) -> tuple[object, ...]:
@@ -193,9 +203,7 @@ class ProductReadServiceTests(unittest.TestCase):
             ) -> tuple[LaunchplaneProductProfileRecord, ...]:
                 return ()
 
-            def read_product_profile_record(
-                self, product: str
-            ) -> LaunchplaneProductProfileRecord:
+            def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
                 raise FileNotFoundError(product)
 
         with self.assertRaisesRegex(

--- a/tests/test_public_ingress_monitor.py
+++ b/tests/test_public_ingress_monitor.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import unittest
+
+from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductImageProfile,
+    ProductLaneProfile,
+    ProductPublicIngressMonitoringPolicy,
+)
+from control_plane.contracts.promotion_record import DeploymentEvidence
+from control_plane.contracts.public_ingress_monitoring import PublicIngressObservationRecord
+from control_plane.contracts.public_ingress_monitoring import PublicIngressTargetObservation
+from control_plane.contracts.runtime_identity import RuntimeIdentity
+from control_plane.workflows.public_ingress_monitor import (
+    HttpObservation,
+    build_github_issue_notifier,
+    discover_public_ingress_monitor_targets,
+    run_public_ingress_monitor_once,
+)
+
+
+class _Store:
+    def __init__(self, profiles: tuple[LaunchplaneProductProfileRecord, ...]) -> None:
+        self._profiles = profiles
+        self.records: list[PublicIngressObservationRecord] = []
+        self.lane_summaries: dict[tuple[str, str], LaunchplaneLaneSummary] = {}
+
+    def list_product_profile_records(
+        self, *, driver_id: str = ""
+    ) -> tuple[LaunchplaneProductProfileRecord, ...]:
+        if driver_id:
+            return tuple(profile for profile in self._profiles if profile.driver_id == driver_id)
+        return self._profiles
+
+    def read_lane_summary(self, *, context_name: str, instance_name: str) -> LaunchplaneLaneSummary:
+        return self.lane_summaries[(context_name, instance_name)]
+
+    def list_public_ingress_observation_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressObservationRecord, ...]:
+        records = [
+            record
+            for record in self.records
+            if (not product or record.product == product)
+            and (not context_name or record.context == context_name)
+            and (not instance_name or record.instance == instance_name)
+        ]
+        records.sort(key=lambda record: (record.observed_at, record.record_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def write_public_ingress_observation_record(
+        self, record: PublicIngressObservationRecord
+    ) -> None:
+        self.records.append(record)
+
+
+def _profile(
+    *, driver_id: str = "generic-web", lane: ProductLaneProfile | None = None
+) -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord(
+        product="example-site",
+        display_name="Example Site",
+        repository="cbusillo/example-site",
+        driver_id=driver_id,
+        image=ProductImageProfile(repository="ghcr.io/cbusillo/example-site"),
+        runtime_port=3000,
+        health_path="/healthz",
+        lanes=(
+            lane
+            or ProductLaneProfile(
+                instance="prod",
+                context="example-site",
+                base_url="https://example.test",
+                public_ingress_monitoring=ProductPublicIngressMonitoringPolicy(
+                    alert_issue_url="https://github.com/cbusillo/launchplane/issues/929"
+                ),
+            ),
+        ),
+        updated_at="2026-05-29T12:00:00Z",
+        source="test",
+    )
+
+
+def _identity() -> RuntimeIdentity:
+    return RuntimeIdentity(
+        product="example-site",
+        context="example-site",
+        instance="prod",
+        deployment_record_id="deploy-1",
+        artifact_id="ghcr.io/cbusillo/example-site@sha256:abc123",
+        source_git_ref="abc123",
+    )
+
+
+def _record_notification(
+    notifications: list[tuple[str, str]],
+    record: PublicIngressObservationRecord,
+    previous: PublicIngressObservationRecord | None,
+) -> bool:
+    notifications.append((record.status, previous.status if previous else "missing"))
+    return True
+
+
+def _capture_command(commands: list[list[str]], command: list[str]) -> object:
+    commands.append(command)
+    return object()
+
+
+def _capture_request(requested_urls: list[str], url: str) -> HttpObservation:
+    requested_urls.append(url)
+    return HttpObservation(status_code=200, final_url=url, redirect_count=0)
+
+
+class PublicIngressMonitorTests(unittest.TestCase):
+    def test_discovers_generic_web_targets_by_default_and_derives_health_url(self) -> None:
+        store = _Store((_profile(),))
+
+        targets = discover_public_ingress_monitor_targets(store)
+
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].base_url, "https://example.test")
+        self.assertEqual(targets[0].health_url, "https://example.test/healthz")
+
+    def test_discovers_inherited_generic_web_drivers(self) -> None:
+        store = _Store((_profile(driver_id="odoo"),))
+
+        targets = discover_public_ingress_monitor_targets(store)
+
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].driver_id, "odoo")
+
+    def test_disabled_lane_is_not_monitored(self) -> None:
+        lane = ProductLaneProfile(
+            instance="prod",
+            context="example-site",
+            base_url="https://example.test",
+            public_ingress_monitoring=ProductPublicIngressMonitoringPolicy(enabled=False),
+        )
+        store = _Store((_profile(lane=lane),))
+
+        self.assertEqual(discover_public_ingress_monitor_targets(store), ())
+
+    def test_private_url_records_skipped_observation_without_request(self) -> None:
+        lane = ProductLaneProfile(
+            instance="prod",
+            context="example-site",
+            base_url="https://localhost:3000",
+        )
+        store = _Store((_profile(lane=lane),))
+        requested_urls: list[str] = []
+
+        result = run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:05:00Z",
+            http_get=lambda url, _timeout: _capture_request(requested_urls, url),
+        )
+
+        self.assertEqual(result.skipped_count, 1)
+        self.assertEqual(requested_urls, [])
+        self.assertEqual(store.records[0].failure_code, "private_url")
+
+    def test_compares_runtime_identity_when_lane_evidence_exists(self) -> None:
+        identity = _identity()
+        store = _Store((_profile(),))
+        store.lane_summaries[("example-site", "prod")] = LaunchplaneLaneSummary(
+            context="example-site",
+            instance="prod",
+            inventory=EnvironmentInventory(
+                context="example-site",
+                instance="prod",
+                source_git_ref="abc123",
+                deploy=DeploymentEvidence(
+                    target_name="example-site-prod",
+                    target_type="application",
+                    deploy_mode="git",
+                    status="pass",
+                ),
+                runtime_identity=identity,
+                updated_at="2026-05-29T12:10:00Z",
+                deployment_record_id="deploy-1",
+            ),
+        )
+
+        result = run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:10:00Z",
+            http_get=lambda url, _timeout: HttpObservation(
+                status_code=200,
+                final_url=url,
+                redirect_count=0,
+                payload={"runtime_identity": identity.model_dump(mode="json")},
+            ),
+        )
+
+        self.assertEqual(result.pass_count, 1)
+        health = store.records[0].targets[-1]
+        self.assertEqual(health.runtime_identity_status, "match")
+
+    def test_notifies_on_failure_and_recovery_transitions(self) -> None:
+        store = _Store((_profile(),))
+        notifications: list[tuple[str, str]] = []
+
+        run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:15:00Z",
+            http_get=lambda url, _timeout: HttpObservation(
+                status_code=200,
+                final_url=url,
+                redirect_count=0,
+            ),
+            notifier=lambda record, previous: _record_notification(notifications, record, previous),
+        )
+        run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:20:00Z",
+            http_get=lambda url, _timeout: HttpObservation(
+                status_code=503,
+                final_url=url,
+                redirect_count=0,
+            ),
+            notifier=lambda record, previous: _record_notification(notifications, record, previous),
+        )
+        run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:25:00Z",
+            http_get=lambda url, _timeout: HttpObservation(
+                status_code=200,
+                final_url=url,
+                redirect_count=0,
+            ),
+            notifier=lambda record, previous: _record_notification(notifications, record, previous),
+        )
+
+        self.assertEqual(notifications, [("fail", "pass"), ("pass", "fail")])
+        self.assertTrue(store.records[1].notification_sent)
+        self.assertTrue(store.records[2].notification_sent)
+
+    def test_github_issue_notifier_comments_on_alert_issue(self) -> None:
+        commands: list[list[str]] = []
+        notifier = build_github_issue_notifier(
+            runner=lambda command: _capture_command(commands, command)
+        )
+        record = PublicIngressObservationRecord(
+            record_id="public-ingress-example-site-prod-20260529t122500z",
+            product="example-site",
+            context="example-site",
+            instance="prod",
+            observed_at="2026-05-29T12:25:00Z",
+            status="fail",
+            failure_code="http_error",
+            base_url="https://example.test",
+            targets=(
+                PublicIngressTargetObservation(
+                    target="base_url",
+                    url="https://example.test",
+                    status="fail",
+                    failure_code="http_error",
+                    summary="HTTP 503",
+                ),
+            ),
+            notification_key="https://github.com/cbusillo/launchplane/issues/929",
+            summary="Public ingress failed.",
+        )
+
+        self.assertTrue(notifier(record, None))
+        self.assertEqual(commands[0][:4], ["gh", "issue", "comment", record.notification_key])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -173,6 +173,7 @@ from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewRefreshResult,
 )
 from control_plane.workflows.odoo_preview_runtime import OdooPreviewDokployApplyResult
+from control_plane.workflows.public_ingress_monitor import PublicIngressMonitorResult
 
 StartResponse = Callable[[str, list[tuple[str, str]]], None]
 WsgiApp = Callable[[dict[str, object], StartResponse], Iterable[bytes]]
@@ -325,14 +326,18 @@ class _StaleLandingMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
     def land_batch_candidate(
         self, *, landing_plan: MergeTrainBatchLandingPlan
     ) -> MergeTrainBatchLandingPlan:
-        raise MergeTrainGitHubStaleHeadError("Base branch moved outside the batch landing plan.", status_code=409)
+        raise MergeTrainGitHubStaleHeadError(
+            "Base branch moved outside the batch landing plan.", status_code=409
+        )
 
 
 class _UnavailableLandingMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
     def land_batch_candidate(
         self, *, landing_plan: MergeTrainBatchLandingPlan
     ) -> MergeTrainBatchLandingPlan:
-        raise MergeTrainGitHubError("GitHub API request failed for /repos/example/repo", status_code=503)
+        raise MergeTrainGitHubError(
+            "GitHub API request failed for /repos/example/repo", status_code=503
+        )
 
 
 class _FailingChildDispositionMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
@@ -1866,6 +1871,61 @@ class GitHubHumanAuthTests(unittest.TestCase):
 
 
 class LaunchplaneServiceTests(unittest.TestCase):
+    def test_public_ingress_monitor_run_once_service_writes_observation(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/public-ingress-monitor.yml@refs/heads/main"
+                        ],
+                        "event_names": ["schedule"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["public_ingress_monitor.run_once"],
+                    }
+                ]
+            }
+        )
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/public-ingress-monitor.yml@refs/heads/main",
+            event_name="schedule",
+        )
+
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                local_record_store_for_tests=store,
+                verifier=_StubVerifier(identity),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch("control_plane.service.run_public_ingress_monitor_once") as run_monitor:
+                run_monitor.return_value = PublicIngressMonitorResult(
+                    checked_at="2026-05-29T12:00:00Z",
+                    target_count=1,
+                    pass_count=1,
+                    records=(),
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/products/public-ingress-monitor/run-once",
+                    payload={"schema_version": 1, "product": "launchplane", "notify": False},
+                    headers={"Idempotency-Key": "public-ingress-monitor-test"},
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["status"], "accepted")
+        run_monitor.assert_called_once()
+
     def test_merge_train_run_once_service_returns_dry_run_from_policy(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(
             {
@@ -2874,15 +2934,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["result"]["details"]["github_status_code"], 409)
         self.assertTrue(
             all(
-                entry["status"] == "stale"
-                for entry in payload["result"]["landing_plan"]["entries"]
+                entry["status"] == "stale" for entry in payload["result"]["landing_plan"]["entries"]
             )
         )
         stale_record = next(
             record
             for record in landing_records
-            if record.record_id
-            == payload["records"]["merge_train_batch_landing_plan_record_id"]
+            if record.record_id == payload["records"]["merge_train_batch_landing_plan_record_id"]
         )
         self.assertEqual(stale_record.landing_plan.entries[0].status, "stale")
         self.assertEqual(next_status_code, 202)


### PR DESCRIPTION
## Summary
- add Launchplane-owned public ingress observation records, storage, migration, CLI, and run-once service route
- make generic-web and inherited drivers default-on for public base/health URL monitoring, with lane opt-out and runtime identity comparison when evidence exists
- add scheduled Public Ingress Monitor workflow, authz grant reconciliation, read-model surfacing, docs, and transition issue notifications

## Validation
- actionlint .github/workflows/public-ingress-monitor.yml
- uv run --extra dev ruff check control_plane tests
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest
