### PR TITLE
Fix public ingress monitor authz scope

### DIFF
--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -755,6 +755,23 @@ post_launchplane_grant() {
     "$event_name"
 }
 
+post_launchplane_service_grant() {
+  local workflow_file="$1"
+  local action_name="$2"
+  local source_label="$3"
+  local idempotency_suffix="$4"
+  local event_name="${5:-workflow_dispatch}"
+  post_grant \
+    "$GITHUB_REPOSITORY" \
+    "$workflow_file" \
+    launchplane \
+    launchplane \
+    "$action_name" \
+    "$source_label" \
+    "$idempotency_suffix" \
+    "$event_name"
+}
+
 post_syo_grant() {
   local workflow_file="$1"
   local product_name="$2"
@@ -964,13 +981,13 @@ apply_product_onboarding \
 apply_verireel_onboarding
 apply_odoo_cm_onboarding
 apply_odoo_opw_onboarding
-post_launchplane_grant \
+post_launchplane_service_grant \
   public-ingress-monitor.yml \
   public_ingress_monitor.run_once \
   deploy:public-ingress-monitor-grant \
   public-ingress-monitor \
   schedule
-post_launchplane_grant \
+post_launchplane_service_grant \
   public-ingress-monitor.yml \
   public_ingress_monitor.run_once \
   deploy:public-ingress-monitor-manual-grant \

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -357,6 +357,99 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                 ["cbusillo/odoo-tenant-opw/.github/workflows/odoo-preview.yml@*"],
             )
 
+    def test_deploy_authz_grants_scope_public_ingress_monitor_to_launchplane(
+        self,
+    ) -> None:
+        script_path = Path("scripts/deploy/ensure-authz-grants.sh")
+        extractor = """
+set -euo pipefail
+PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
+"""
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            captured_bin_directory = temporary_directory / "bin"
+            captured_bin_directory.mkdir()
+            (captured_bin_directory / "curl").write_text(
+                "#!/usr/bin/env bash\n"
+                'case "$*" in\n'
+                '  *github.invalid/oidc*) printf \'{"value":"oidc-token"}\' ;;\n'
+                "  *)\n"
+                "    output_file=''\n"
+                "    request_payload=''\n"
+                '    while [ "$#" -gt 0 ]; do\n'
+                '      case "$1" in\n'
+                '        -o) shift; output_file="$1" ;;\n'
+                '        --data) shift; request_payload="$1" ;;\n'
+                "      esac\n"
+                "      shift || true\n"
+                "    done\n"
+                "    if printf '%s' \"$request_payload\" | grep -q 'public-ingress-monitor.yml'; then\n"
+                "      printf '%s\\n%s\\n' \"$request_payload\" '---END-GRANT---' >> \"$CAPTURED_GRANTS\"\n"
+                "    fi\n"
+                '    if [ -n "$output_file" ]; then\n'
+                '      printf \'{"status":"ok"}\' > "$output_file"\n'
+                "    fi\n"
+                "    printf '200'\n"
+                "    ;;\n"
+                "esac\n"
+            )
+            (captured_bin_directory / "mktemp").write_text(
+                "#!/usr/bin/env bash\nprintf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
+            )
+            (captured_bin_directory / "curl").chmod(0o755)
+            (captured_bin_directory / "mktemp").chmod(0o755)
+            captured_grants = temporary_directory / "grants.jsonl"
+            captured_grants.touch()
+            captured_response_file = temporary_directory / "response.json"
+            env = {
+                **os.environ,
+                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
+                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://github.invalid/oidc",
+                "GITHUB_REPOSITORY": "cbusillo/launchplane",
+                "GITHUB_SHA": "test-sha",
+                "LAUNCHPLANE_SERVICE_AUDIENCE": "launchplane-service",
+                "LAUNCHPLANE_SERVICE_URL": "https://launchplane.example.invalid",
+                "DISCORD_BLUE_DOKPLOY_TARGET_ID": "app-discord-blue",
+                "ODOO_CM_TESTING_DOKPLOY_TARGET_ID": "compose-cm-testing",
+                "ODOO_CM_PROD_DOKPLOY_TARGET_ID": "compose-cm-prod",
+                "ODOO_OPW_TESTING_DOKPLOY_TARGET_ID": "compose-opw-testing",
+                "ODOO_OPW_PROD_DOKPLOY_TARGET_ID": "compose-opw-prod",
+                "CAPTURED_GRANTS": str(captured_grants),
+                "CAPTURED_RESPONSE_FILE": str(captured_response_file),
+                "CAPTURED_BIN_DIR": str(captured_bin_directory),
+            }
+
+            result = subprocess.run(
+                ["bash", "-c", extractor],
+                check=False,
+                cwd=script_path.parent.parent.parent,
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            grants = [
+                json.loads(grant_text)["grant"]
+                for grant_text in captured_grants.read_text().split("---END-GRANT---")
+                if grant_text.strip()
+            ]
+
+        self.assertEqual(len(grants), 2)
+        grant_index = {grant["event_names"][0]: grant for grant in grants}
+        self.assertEqual(set(grant_index), {"schedule", "workflow_dispatch"})
+        for grant in grants:
+            self.assertEqual(grant["repository"], "cbusillo/launchplane")
+            self.assertEqual(
+                grant["workflow_refs"],
+                [
+                    "cbusillo/launchplane/.github/workflows/public-ingress-monitor.yml@refs/heads/main"
+                ],
+            )
+            self.assertEqual(grant["products"], ["launchplane"])
+            self.assertEqual(grant["contexts"], ["launchplane"])
+            self.assertEqual(grant["actions"], ["public_ingress_monitor.run_once"])
+
     def test_deploy_authz_grants_include_terminal_agent_product_profile_read(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- scope Public Ingress Monitor workflow grants to product/context `launchplane`
- keep existing product-scoped Launchplane helper behavior for other workflows
- add a regression test that inspects generated grant payloads for schedule/manual monitor grants

## Validation
- uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_scope_public_ingress_monitor_to_launchplane
- uv run python -m unittest tests.test_product_onboarding
- shellcheck scripts/deploy/ensure-authz-grants.sh
- bash -n scripts/deploy/ensure-authz-grants.sh
