### PR TITLE
Stagger public ingress monitor schedule

### DIFF
--- a/.github/workflows/public-ingress-monitor.yml
+++ b/.github/workflows/public-ingress-monitor.yml
@@ -3,7 +3,7 @@ name: Public Ingress Monitor
 
 "on":
   schedule:
-    - cron: "*/10 * * * *"
+    - cron: "7,17,27,37,47,57 * * * *"
   workflow_dispatch:
     inputs:
       timeout_seconds:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -150,9 +150,10 @@ and generic-web preview refresh/destroy requests. The grant request returns only
 authz policy record metadata and rule counts; it does not echo workflow refs,
 human logins, or the full policy body.
 
-The `Public Ingress Monitor` workflow is a scheduled Launchplane-owned synthetic
-check for every public generic-web stable lane, including drivers that inherit
-generic-web behavior. It calls
+The `Public Ingress Monitor` workflow is a Launchplane-owned synthetic check for
+every public generic-web stable lane, including drivers that inherit generic-web
+behavior. It runs every ten minutes on staggered minute marks to avoid GitHub's
+high-load top-of-hour scheduler window. It calls
 `POST /v1/products/public-ingress-monitor/run-once` through GitHub OIDC and is
 authorized in the Launchplane service context. Monitoring is default-on for
 lanes with public `base_url` or `health_url`; disable it per lane only for


### PR DESCRIPTION
## Summary
- move Public Ingress Monitor cron from busy ten-minute boundaries to staggered minute marks
- document the ten-minute staggered cadence

## Validation
- actionlint .github/workflows/public-ingress-monitor.yml
- git diff --check
