### PR TITLE
Run ingress monitor from scheduled merge train

### DIFF
--- a/.github/workflows/merge-train-runner.yml
+++ b/.github/workflows/merge-train-runner.yml
@@ -94,6 +94,37 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  public_ingress_monitor:
+    if: github.event_name == 'schedule'
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    env:
+      LAUNCHPLANE_URL: >-
+        ${{ vars.LAUNCHPLANE_PUBLIC_URL ||
+        'https://launchplane.shinycomputers.com' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Request public ingress monitor
+        uses: ./.github/actions/launchplane-request
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          route-path: /v1/products/public-ingress-monitor/run-once
+          payload: >-
+            {
+              "schema_version": 1,
+              "product": "launchplane"
+            }
+          payload-fields: |-
+            timeout_seconds=10
+            notify=true
+          idempotency-key: >-
+            public-ingress-monitor:${{ github.run_id }}:${{
+            github.run_attempt }}
+          timeout-ms: "180000"
+
   run:
     if: >-
       github.event_name != 'schedule' ||

--- a/.github/workflows/public-ingress-monitor.yml
+++ b/.github/workflows/public-ingress-monitor.yml
@@ -2,8 +2,6 @@
 name: Public Ingress Monitor
 
 "on":
-  schedule:
-    - cron: "7,17,27,37,47,57 * * * *"
   workflow_dispatch:
     inputs:
       timeout_seconds:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -150,11 +150,13 @@ and generic-web preview refresh/destroy requests. The grant request returns only
 authz policy record metadata and rule counts; it does not echo workflow refs,
 human logins, or the full policy body.
 
-The `Public Ingress Monitor` workflow is a Launchplane-owned synthetic check for
-every public generic-web stable lane, including drivers that inherit generic-web
-behavior. It runs every ten minutes on staggered minute marks to avoid GitHub's
-high-load top-of-hour scheduler window. It calls
-`POST /v1/products/public-ingress-monitor/run-once` through GitHub OIDC and is
+Public ingress monitoring is a Launchplane-owned synthetic check for every
+public generic-web stable lane, including drivers that inherit generic-web
+behavior. The recurring check runs from the already-scheduled `Merge Train
+Runner` workflow so it inherits the repo's proven scheduled Actions path. The
+manual `Public Ingress Monitor` workflow calls the same service route for
+operator reruns. Both paths call
+`POST /v1/products/public-ingress-monitor/run-once` through GitHub OIDC and are
 authorized in the Launchplane service context. Monitoring is default-on for
 lanes with public `base_url` or `health_url`; disable it per lane only for
 non-public or intentionally unreachable endpoints. When a lane policy includes


### PR DESCRIPTION
## Summary
- move recurring public ingress monitoring onto the already-scheduled Merge Train Runner workflow
- keep the dedicated Public Ingress Monitor workflow for manual operator reruns
- update operations docs to describe the shared scheduled path

## Validation
- actionlint -ignore 'maximum number of inputs' .github/workflows/merge-train-runner.yml .github/workflows/public-ingress-monitor.yml
- actionlint .github/workflows/public-ingress-monitor.yml
- git diff --check