### PR TITLE
Restore dedicated public ingress monitor schedule

### DIFF
--- a/.github/workflows/merge-train-runner.yml
+++ b/.github/workflows/merge-train-runner.yml
@@ -94,37 +94,6 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  public_ingress_monitor:
-    if: github.event_name == 'schedule'
-    runs-on:
-      - self-hosted
-      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
-    env:
-      LAUNCHPLANE_URL: >-
-        ${{ vars.LAUNCHPLANE_PUBLIC_URL ||
-        'https://launchplane.shinycomputers.com' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Request public ingress monitor
-        uses: ./.github/actions/launchplane-request
-        with:
-          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
-          route-path: /v1/products/public-ingress-monitor/run-once
-          payload: >-
-            {
-              "schema_version": 1,
-              "product": "launchplane"
-            }
-          payload-fields: |-
-            timeout_seconds=10
-            notify=true
-          idempotency-key: >-
-            public-ingress-monitor:${{ github.run_id }}:${{
-            github.run_attempt }}
-          timeout-ms: "180000"
-
   run:
     if: >-
       github.event_name != 'schedule' ||

--- a/.github/workflows/public-ingress-monitor.yml
+++ b/.github/workflows/public-ingress-monitor.yml
@@ -2,6 +2,8 @@
 name: Public Ingress Monitor
 
 "on":
+  schedule:
+    - cron: "17,47 * * * *"
   workflow_dispatch:
     inputs:
       timeout_seconds:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -152,10 +152,9 @@ human logins, or the full policy body.
 
 Public ingress monitoring is a Launchplane-owned synthetic check for every
 public generic-web stable lane, including drivers that inherit generic-web
-behavior. The recurring check runs from the already-scheduled `Merge Train
-Runner` workflow so it inherits the repo's proven scheduled Actions path. The
-manual `Public Ingress Monitor` workflow calls the same service route for
-operator reruns. Both paths call
+behavior. The `Public Ingress Monitor` workflow owns both the recurring schedule
+and manual operator reruns, so its GitHub OIDC identity stays scoped only to
+`public_ingress_monitor.run_once`. Both paths call
 `POST /v1/products/public-ingress-monitor/run-once` through GitHub OIDC and are
 authorized in the Launchplane service context. Monitoring is default-on for
 lanes with public `base_url` or `health_url`; disable it per lane only for


### PR DESCRIPTION
## Summary
- remove the public ingress monitor job from Merge Train Runner
- restore the dedicated Public Ingress Monitor schedule at minute 17 and 47
- document that public ingress monitoring owns its own OIDC workflow identity

## Agent review
- Antigravity recommended the dedicated schedule to preserve least-privilege workflow authz and isolate monitor failures.
- Sonnet retry agreed; the #979 403 is structural because the OIDC workflow ref changes under Merge Train Runner.

## Validation
- actionlint .github/workflows/public-ingress-monitor.yml
- actionlint -ignore 'maximum number of inputs' .github/workflows/merge-train-runner.yml
- git diff --check

Refs cbusillo/code#206