### PR TITLE
Add public ingress incident records

### DIFF
--- a/control_plane/contracts/product_environment_read_model.py
+++ b/control_plane/contracts/product_environment_read_model.py
@@ -23,6 +23,7 @@ from control_plane.contracts.product_profile_record import (
     ProductRuntimeConfigRequirement,
     ProductSecretConfigRequirement,
 )
+from control_plane.contracts.public_ingress_monitoring import PublicIngressIncidentRecord
 from control_plane.contracts.public_ingress_monitoring import PublicIngressObservationRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
@@ -124,6 +125,16 @@ class ProductEnvironmentReadModelStore(ProductReadModelStore, Protocol):
         limit: int | None = None,
     ) -> tuple[PublicIngressObservationRecord, ...]: ...
 
+    def list_public_ingress_incident_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressIncidentRecord, ...]: ...
+
 
 def _build_action_authz_by_route() -> dict[str, str]:
     return {
@@ -224,6 +235,9 @@ class ProductPublicIngressSummary(BaseModel):
     record_id: str = ""
     summary: str = ""
     notification_sent: bool = False
+    incident_status: str = ""
+    incident_id: str = ""
+    incident_opened_at: str = ""
     trust_state: FreshnessStatus = "missing"
     provenance: DataProvenance = DataProvenance(
         source_kind="record",
@@ -1298,6 +1312,19 @@ def _public_ingress_summary(
     latest = next(iter(records), None)
     if latest is None or not isinstance(latest, PublicIngressObservationRecord):
         return ProductPublicIngressSummary()
+    incidents = _optional_records(
+        record_store,
+        "list_public_ingress_incident_records",
+        product=profile.product,
+        context_name=lane.context,
+        instance_name=lane.instance,
+        status="open",
+        limit=1,
+    )
+    open_incident = next(
+        (incident for incident in incidents if isinstance(incident, PublicIngressIncidentRecord)),
+        None,
+    )
     provenance = DataProvenance(
         source_kind="record",
         source_record_id=latest.record_id,
@@ -1313,6 +1340,9 @@ def _public_ingress_summary(
         record_id=latest.record_id,
         summary=latest.summary,
         notification_sent=latest.notification_sent,
+        incident_status=open_incident.status if open_incident is not None else "",
+        incident_id=open_incident.incident_id if open_incident is not None else "",
+        incident_opened_at=open_incident.opened_at if open_incident is not None else "",
         trust_state=provenance.freshness_status,
         provenance=provenance,
     )

--- a/control_plane/contracts/public_ingress_monitoring.py
+++ b/control_plane/contracts/public_ingress_monitoring.py
@@ -8,6 +8,7 @@ from control_plane.contracts.runtime_identity import RuntimeIdentity, RuntimeIde
 
 
 PublicIngressObservationStatus = Literal["pass", "fail", "skipped"]
+PublicIngressIncidentStatus = Literal["open", "resolved"]
 PublicIngressTargetKind = Literal["base_url", "health_url"]
 PublicIngressFailureCode = Literal[
     "connection_timeout",
@@ -112,12 +113,84 @@ class PublicIngressObservationRecord(BaseModel):
         return self
 
 
+class PublicIngressIncidentRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    incident_id: str
+    product: str
+    repository: str = ""
+    driver_id: str = ""
+    context: str
+    instance: str
+    status: PublicIngressIncidentStatus
+    opened_at: str
+    opened_observation_id: str
+    latest_observation_id: str
+    latest_observed_at: str
+    failure_code: PublicIngressFailureCode
+    resolved_at: str = ""
+    resolved_observation_id: str = ""
+    summary: str
+
+    @model_validator(mode="after")
+    def _validate_incident(self) -> "PublicIngressIncidentRecord":
+        self.incident_id = _required_text(
+            self.incident_id, "public ingress incident requires incident_id"
+        )
+        self.product = _required_text(self.product, "public ingress incident requires product")
+        self.context = _required_text(self.context, "public ingress incident requires context")
+        self.instance = _required_text(
+            self.instance, "public ingress incident requires instance"
+        )
+        self.opened_at = _required_text(
+            self.opened_at, "public ingress incident requires opened_at"
+        )
+        self.opened_observation_id = _required_text(
+            self.opened_observation_id,
+            "public ingress incident requires opened_observation_id",
+        )
+        self.latest_observation_id = _required_text(
+            self.latest_observation_id,
+            "public ingress incident requires latest_observation_id",
+        )
+        self.latest_observed_at = _required_text(
+            self.latest_observed_at,
+            "public ingress incident requires latest_observed_at",
+        )
+        self.repository = self.repository.strip()
+        self.driver_id = self.driver_id.strip()
+        self.resolved_at = self.resolved_at.strip()
+        self.resolved_observation_id = self.resolved_observation_id.strip()
+        self.summary = _required_text(self.summary, "public ingress incident requires summary")
+        if self.status == "resolved":
+            if not self.resolved_at:
+                raise ValueError("resolved public ingress incident requires resolved_at")
+            if not self.resolved_observation_id:
+                raise ValueError(
+                    "resolved public ingress incident requires resolved_observation_id"
+                )
+        if self.status == "open" and (self.resolved_at or self.resolved_observation_id):
+            raise ValueError("open public ingress incident cannot include resolution fields")
+        return self
+
+
 def build_public_ingress_observation_id(
     *, product: str, context: str, instance: str, observed_at: str
 ) -> str:
     return "-".join(
         _record_token(value)
         for value in ("public-ingress", product, context, instance, observed_at)
+        if _record_token(value)
+    )
+
+
+def build_public_ingress_incident_id(
+    *, product: str, context: str, instance: str, opened_at: str
+) -> str:
+    return "-".join(
+        _record_token(value)
+        for value in ("public-ingress-incident", product, context, instance, opened_at)
         if _record_token(value)
     )
 

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -48,6 +48,7 @@ from control_plane.contracts.preview_lifecycle_plan_record import PreviewLifecyc
 from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedbackRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.public_ingress_monitoring import PublicIngressIncidentRecord
 from control_plane.contracts.public_ingress_monitoring import PublicIngressObservationRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
@@ -574,6 +575,34 @@ class FilesystemRecordStore:
             and (not instance_name or record.instance == instance_name)
         ]
         records.sort(key=lambda record: (record.observed_at, record.record_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def write_public_ingress_incident_record(self, record: PublicIngressIncidentRecord) -> Path:
+        return self._write_model("launchplane_public_ingress_incidents", record.incident_id, record)
+
+    def list_public_ingress_incident_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressIncidentRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                PublicIngressIncidentRecord,
+                "launchplane_public_ingress_incidents",
+            )
+            if (not product or record.product == product)
+            and (not context_name or record.context == context_name)
+            and (not instance_name or record.instance == instance_name)
+            and (not status or record.status == status)
+        ]
+        records.sort(key=lambda record: (record.opened_at, record.incident_id), reverse=True)
         if limit is not None:
             records = records[:limit]
         return tuple(records)

--- a/control_plane/storage/migrations/versions/e5f7a9b1c3d5_add_public_ingress_incidents.py
+++ b/control_plane/storage/migrations/versions/e5f7a9b1c3d5_add_public_ingress_incidents.py
@@ -1,0 +1,77 @@
+"""add public ingress incidents
+
+Revision ID: e5f7a9b1c3d5
+Revises: d4e6f8a0b2c4
+Create Date: 2026-05-29 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "e5f7a9b1c3d5"
+down_revision: str | None = "d4e6f8a0b2c4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "launchplane_public_ingress_incidents"
+_LOOKUP_INDEX = "launchplane_public_ingress_incidents_lookup_idx"
+_STATUS_INDEX = "launchplane_public_ingress_incidents_status_idx"
+
+
+def _table_exists(table_name: str) -> bool:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return table_name in set(inspector.get_table_names())
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return index_name in {str(index["name"]) for index in inspector.get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    if not _table_exists(_TABLE):
+        op.create_table(
+            _TABLE,
+            sa.Column("incident_id", sa.String(), nullable=False),
+            sa.Column("product", sa.String(), nullable=False),
+            sa.Column("context", sa.String(), nullable=False),
+            sa.Column("instance", sa.String(), nullable=False),
+            sa.Column("status", sa.String(), nullable=False),
+            sa.Column("opened_at", sa.String(), nullable=False),
+            sa.Column("latest_observed_at", sa.String(), nullable=False),
+            sa.Column(
+                "payload",
+                sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+                nullable=False,
+            ),
+            sa.PrimaryKeyConstraint("incident_id"),
+        )
+    if not _index_exists(_TABLE, _LOOKUP_INDEX):
+        op.create_index(
+            _LOOKUP_INDEX,
+            _TABLE,
+            ["product", "context", "instance", "status", sa.text("opened_at DESC")],
+        )
+    if not _index_exists(_TABLE, _STATUS_INDEX):
+        op.create_index(
+            _STATUS_INDEX,
+            _TABLE,
+            ["status", sa.text("opened_at DESC")],
+        )
+
+
+def downgrade() -> None:
+    if not _table_exists(_TABLE):
+        return
+    if _index_exists(_TABLE, _STATUS_INDEX):
+        op.drop_index(_STATUS_INDEX, table_name=_TABLE)
+    if _index_exists(_TABLE, _LOOKUP_INDEX):
+        op.drop_index(_LOOKUP_INDEX, table_name=_TABLE)
+    op.drop_table(_TABLE)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -68,6 +68,7 @@ from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedback
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.preview_summary import LaunchplanePreviewSummary
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.public_ingress_monitoring import PublicIngressIncidentRecord
 from control_plane.contracts.public_ingress_monitoring import PublicIngressObservationRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
@@ -489,6 +490,34 @@ class LaunchplanePublicIngressObservationRow(Base):
     instance: Mapped[str] = mapped_column(String, nullable=False)
     status: Mapped[str] = mapped_column(String, nullable=False)
     observed_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplanePublicIngressIncidentRow(Base):
+    __tablename__ = "launchplane_public_ingress_incidents"
+    __table_args__ = (
+        Index(
+            "launchplane_public_ingress_incidents_lookup_idx",
+            "product",
+            "context",
+            "instance",
+            "status",
+            desc("opened_at"),
+        ),
+        Index(
+            "launchplane_public_ingress_incidents_status_idx",
+            "status",
+            desc("opened_at"),
+        ),
+    )
+
+    incident_id: Mapped[str] = mapped_column(String, primary_key=True)
+    product: Mapped[str] = mapped_column(String, nullable=False)
+    context: Mapped[str] = mapped_column(String, nullable=False)
+    instance: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    opened_at: Mapped[str] = mapped_column(String, nullable=False)
+    latest_observed_at: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -2735,6 +2764,51 @@ class PostgresRecordStore(HumanSessionStore):
             order_by=(
                 LaunchplanePublicIngressObservationRow.observed_at.desc(),
                 LaunchplanePublicIngressObservationRow.record_id.desc(),
+            ),
+            limit=limit,
+        )
+
+    def write_public_ingress_incident_record(
+        self, record: PublicIngressIncidentRecord
+    ) -> None:
+        self._write_row(
+            LaunchplanePublicIngressIncidentRow(
+                incident_id=record.incident_id,
+                product=record.product,
+                context=record.context,
+                instance=record.instance,
+                status=record.status,
+                opened_at=record.opened_at,
+                latest_observed_at=record.latest_observed_at,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def list_public_ingress_incident_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressIncidentRecord, ...]:
+        filters: list[object] = []
+        if product:
+            filters.append(LaunchplanePublicIngressIncidentRow.product == product)
+        if context_name:
+            filters.append(LaunchplanePublicIngressIncidentRow.context == context_name)
+        if instance_name:
+            filters.append(LaunchplanePublicIngressIncidentRow.instance == instance_name)
+        if status:
+            filters.append(LaunchplanePublicIngressIncidentRow.status == status)
+        return self._list_models(
+            model_type=PublicIngressIncidentRecord,
+            orm_model=LaunchplanePublicIngressIncidentRow,
+            filters=filters,
+            order_by=(
+                LaunchplanePublicIngressIncidentRow.opened_at.desc(),
+                LaunchplanePublicIngressIncidentRow.incident_id.desc(),
             ),
             limit=limit,
         )

--- a/control_plane/workflows/public_ingress_monitor.py
+++ b/control_plane/workflows/public_ingress_monitor.py
@@ -21,10 +21,12 @@ from control_plane.contracts.product_profile_record import (
 )
 from control_plane.contracts.public_ingress_monitoring import (
     PublicIngressFailureCode,
+    PublicIngressIncidentRecord,
     PublicIngressObservationRecord,
     PublicIngressObservationStatus,
     PublicIngressTargetKind,
     PublicIngressTargetObservation,
+    build_public_ingress_incident_id,
     build_public_ingress_observation_id,
 )
 from control_plane.contracts.runtime_identity import (
@@ -56,6 +58,20 @@ class PublicIngressMonitorStore(Protocol):
 
     def write_public_ingress_observation_record(
         self, record: PublicIngressObservationRecord
+    ) -> object: ...
+
+    def list_public_ingress_incident_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressIncidentRecord, ...]: ...
+
+    def write_public_ingress_incident_record(
+        self, record: PublicIngressIncidentRecord
     ) -> object: ...
 
 
@@ -90,7 +106,10 @@ class PublicIngressMonitorResult(BaseModel):
     fail_count: int = Field(default=0, ge=0)
     skipped_count: int = Field(default=0, ge=0)
     notification_count: int = Field(default=0, ge=0)
+    open_incident_count: int = Field(default=0, ge=0)
+    resolved_incident_count: int = Field(default=0, ge=0)
     records: tuple[PublicIngressObservationRecord, ...] = ()
+    incidents: tuple[PublicIngressIncidentRecord, ...] = ()
 
 
 HttpGet = Callable[[str, int], HttpObservation]
@@ -167,6 +186,7 @@ def run_public_ingress_monitor_once(
     observed_at = checked_at.strip() or utc_now_timestamp()
     get = http_get or fetch_public_ingress_url
     records: list[PublicIngressObservationRecord] = []
+    incidents: list[PublicIngressIncidentRecord] = []
     notification_count = 0
     for target in discover_public_ingress_monitor_targets(record_store):
         previous_record = _latest_observation(record_store=record_store, target=target)
@@ -183,6 +203,13 @@ def run_public_ingress_monitor_once(
                 notification_count += 1
         record_store.write_public_ingress_observation_record(record)
         records.append(record)
+        incident = reconcile_public_ingress_incident(
+            record_store=record_store,
+            record=record,
+            previous_record=previous_record,
+        )
+        if incident is not None:
+            incidents.append(incident)
     return PublicIngressMonitorResult(
         checked_at=observed_at,
         target_count=len(records),
@@ -190,8 +217,69 @@ def run_public_ingress_monitor_once(
         fail_count=sum(1 for record in records if record.status == "fail"),
         skipped_count=sum(1 for record in records if record.status == "skipped"),
         notification_count=notification_count,
+        open_incident_count=sum(1 for incident in incidents if incident.status == "open"),
+        resolved_incident_count=sum(
+            1 for incident in incidents if incident.status == "resolved"
+        ),
         records=tuple(records),
+        incidents=tuple(incidents),
     )
+
+
+def reconcile_public_ingress_incident(
+    *,
+    record_store: PublicIngressMonitorStore,
+    record: PublicIngressObservationRecord,
+    previous_record: PublicIngressObservationRecord | None,
+) -> PublicIngressIncidentRecord | None:
+    open_incident = _open_incident(record_store=record_store, record=record)
+    if record.status == "fail":
+        if open_incident is not None:
+            incident = open_incident.model_copy(
+                update={
+                    "latest_observation_id": record.record_id,
+                    "latest_observed_at": record.observed_at,
+                    "failure_code": record.failure_code,
+                    "summary": record.summary,
+                }
+            )
+        else:
+            incident = PublicIngressIncidentRecord(
+                incident_id=build_public_ingress_incident_id(
+                    product=record.product,
+                    context=record.context,
+                    instance=record.instance,
+                    opened_at=record.observed_at,
+                ),
+                product=record.product,
+                repository=record.repository,
+                driver_id=record.driver_id,
+                context=record.context,
+                instance=record.instance,
+                status="open",
+                opened_at=record.observed_at,
+                opened_observation_id=record.record_id,
+                latest_observation_id=record.record_id,
+                latest_observed_at=record.observed_at,
+                failure_code=record.failure_code or "unknown_error",
+                summary=record.summary,
+            )
+        record_store.write_public_ingress_incident_record(incident)
+        return incident
+    if record.status == "pass" and open_incident is not None:
+        incident = open_incident.model_copy(
+            update={
+                "status": "resolved",
+                "latest_observation_id": record.record_id,
+                "latest_observed_at": record.observed_at,
+                "resolved_at": record.observed_at,
+                "resolved_observation_id": record.record_id,
+                "summary": record.summary,
+            }
+        )
+        record_store.write_public_ingress_incident_record(incident)
+        return incident
+    return None
 
 
 def check_public_ingress_target(
@@ -405,6 +493,19 @@ def _latest_observation(
         limit=1,
     )
     return next(iter(records), None)
+
+
+def _open_incident(
+    *, record_store: PublicIngressMonitorStore, record: PublicIngressObservationRecord
+) -> PublicIngressIncidentRecord | None:
+    incidents = record_store.list_public_ingress_incident_records(
+        product=record.product,
+        context_name=record.context,
+        instance_name=record.instance,
+        status="open",
+        limit=1,
+    )
+    return next(iter(incidents), None)
 
 
 def _should_notify(

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -158,9 +158,10 @@ and manual operator reruns, so its GitHub OIDC identity stays scoped only to
 `POST /v1/products/public-ingress-monitor/run-once` through GitHub OIDC and are
 authorized in the Launchplane service context. Monitoring is default-on for
 lanes with public `base_url` or `health_url`; disable it per lane only for
-non-public or intentionally unreachable endpoints. When a lane policy includes
-`public_ingress_monitoring.alert_issue_url`, Launchplane comments on that issue
-when the latest observation moves from pass to fail or from fail back to pass.
+non-public or intentionally unreachable endpoints. Observations are sensor
+evidence; public-ingress incident records are the active operator lifecycle when
+a lane fails and later recovers. Notification routing is a separate
+service-backed policy and delivery concern, not lane-owned text config.
 
 The manual Product Context Cutover workflow plans or applies the same
 current-authority record move through the Launchplane service. Run it first with

--- a/docs/records.md
+++ b/docs/records.md
@@ -263,6 +263,21 @@ These records are the source for the product environment read model's
 observation marks the lane stale/unhealthy, and a skipped private URL is treated
 as unsupported rather than silently healthy.
 
+## Public Ingress Incident Records
+
+Public ingress incidents are Launchplane-owned lifecycle records under
+`launchplane_public_ingress_incidents`. They are derived from public-ingress
+observations and keyed by product, context, instance, and incident open time. An
+open incident records the first failing observation and the latest failing
+observation for that lane. A recovery observation resolves the incident by
+recording the resolving observation and resolved timestamp.
+
+Incident records are the source of truth for whether Launchplane currently
+considers a lane to be in a public-ingress incident. Notification routing and
+delivery are separate record families: observations say what was measured,
+incidents say whether there is active operator state, and delivery records say
+where Launchplane attempted to notify operators.
+
 Odoo stable bootstrap eligibility is lane-owned product-profile data. A lane's
 `odoo_stable_bootstrap` policy defaults to disabled and must explicitly carry
 an issue-backed approval URL, the destructive confirmation phrase,

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -54,6 +54,7 @@ from control_plane.contracts.product_profile_record import (
     ProductLaneProfile,
     ProductPreviewProfile,
 )
+from control_plane.contracts.public_ingress_monitoring import PublicIngressIncidentRecord
 from control_plane.contracts.public_ingress_monitoring import PublicIngressObservationRecord
 from control_plane.contracts.public_ingress_monitoring import PublicIngressTargetObservation
 from control_plane.contracts.promotion_record import (
@@ -583,6 +584,53 @@ class FilesystemRecordStoreTests(unittest.TestCase):
             [newer_record.record_id, older_record.record_id],
         )
         self.assertEqual([record.record_id for record in limited_records], [newer_record.record_id])
+
+    def test_write_and_list_public_ingress_incident_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            open_record = PublicIngressIncidentRecord(
+                incident_id="public-ingress-incident-example-site-prod-open",
+                product="example-site",
+                context="example-site-prod",
+                instance="prod",
+                status="open",
+                opened_at="2026-05-29T12:20:00Z",
+                opened_observation_id="obs-1",
+                latest_observation_id="obs-1",
+                latest_observed_at="2026-05-29T12:20:00Z",
+                failure_code="http_error",
+                summary="Public ingress failed.",
+            )
+            resolved_record = open_record.model_copy(
+                update={
+                    "incident_id": "public-ingress-incident-example-site-prod-resolved",
+                    "status": "resolved",
+                    "latest_observation_id": "obs-2",
+                    "latest_observed_at": "2026-05-29T12:25:00Z",
+                    "resolved_at": "2026-05-29T12:25:00Z",
+                    "resolved_observation_id": "obs-2",
+                    "summary": "Public ingress recovered.",
+                }
+            )
+
+            written_path = store.write_public_ingress_incident_record(open_record)
+            store.write_public_ingress_incident_record(resolved_record)
+            listed_records = store.list_public_ingress_incident_records(
+                product="example-site",
+                context_name="example-site-prod",
+                instance_name="prod",
+            )
+            open_records = store.list_public_ingress_incident_records(status="open")
+
+            self.assertTrue(written_path.exists())
+            self.assertEqual(
+                [record.incident_id for record in listed_records],
+                [resolved_record.incident_id, open_record.incident_id],
+            )
+            self.assertEqual(
+                [record.incident_id for record in open_records], [open_record.incident_id]
+            )
 
     def test_write_and_list_runtime_key_safety_policy_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_product_environment_read_model.py
+++ b/tests/test_product_environment_read_model.py
@@ -24,6 +24,7 @@ from control_plane.contracts.product_environment_read_model import (
 )
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.public_ingress_monitoring import PublicIngressObservationRecord
+from control_plane.contracts.public_ingress_monitoring import PublicIngressIncidentRecord
 from control_plane.contracts.public_ingress_monitoring import PublicIngressTargetObservation
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
@@ -230,9 +231,11 @@ class _PublicIngressReadModelStore(_PreviewRecordStore):
         self,
         profile: LaunchplaneProductProfileRecord,
         observations: tuple[PublicIngressObservationRecord, ...],
+        incidents: tuple[PublicIngressIncidentRecord, ...] = (),
     ) -> None:
         super().__init__(profile, ())
         self._observations = observations
+        self._incidents = incidents
 
     def list_public_ingress_observation_records(
         self,
@@ -253,6 +256,28 @@ class _PublicIngressReadModelStore(_PreviewRecordStore):
         if limit is not None:
             records = records[:limit]
         return tuple(records)
+
+    def list_public_ingress_incident_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressIncidentRecord, ...]:
+        incidents = [
+            incident
+            for incident in self._incidents
+            if (not product or incident.product == product)
+            and (not context_name or incident.context == context_name)
+            and (not instance_name or incident.instance == instance_name)
+            and (not status or incident.status == status)
+        ]
+        incidents.sort(key=lambda incident: (incident.opened_at, incident.incident_id), reverse=True)
+        if limit is not None:
+            incidents = incidents[:limit]
+        return tuple(incidents)
 
 
 class _ActivityRecordStore(_PreviewRecordStore):
@@ -935,7 +960,20 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
             notification_sent=True,
             summary="Public ingress failed for example-site/prod: HTTP 503",
         )
-        store = _PublicIngressReadModelStore(profile, (observation,))
+        incident = PublicIngressIncidentRecord(
+            incident_id="public-ingress-incident-example-site-prod-20260529t120000z",
+            product="example-site",
+            context="example-site-prod",
+            instance="prod",
+            status="open",
+            opened_at="2026-05-29T12:00:00Z",
+            opened_observation_id=observation.record_id,
+            latest_observation_id=observation.record_id,
+            latest_observed_at=observation.observed_at,
+            failure_code="http_error",
+            summary="Public ingress failed for example-site/prod: HTTP 503",
+        )
+        store = _PublicIngressReadModelStore(profile, (observation,), (incident,))
 
         overview = build_product_site_overview(
             record_store=store,
@@ -953,6 +991,8 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
         self.assertEqual(prod_summary.public_ingress.status, "fail")
         self.assertEqual(prod_summary.public_ingress.trust_state, "stale")
         self.assertEqual(prod_summary.public_ingress.record_id, observation.record_id)
+        self.assertEqual(prod_summary.public_ingress.incident_status, "open")
+        self.assertEqual(prod_summary.public_ingress.incident_id, incident.incident_id)
         self.assertTrue(detail.public_ingress.notification_sent)
 
     def test_product_environment_detail_exposes_runtime_identity_evidence(self) -> None:

--- a/tests/test_product_read_service.py
+++ b/tests/test_product_read_service.py
@@ -13,6 +13,7 @@ from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedback
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.preview_summary import LaunchplanePreviewSummary
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.public_ingress_monitoring import PublicIngressIncidentRecord
 from control_plane.contracts.public_ingress_monitoring import PublicIngressObservationRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.product_read_service import (
@@ -168,6 +169,18 @@ class _ProductReadStore:
         limit: int | None = None,
     ) -> tuple[PublicIngressObservationRecord, ...]:
         _ = (self, product, context_name, instance_name, limit)
+        return ()
+
+    def list_public_ingress_incident_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressIncidentRecord, ...]:
+        _ = (self, product, context_name, instance_name, status, limit)
         return ()
 
     def list_runtime_environment_records(

--- a/tests/test_public_ingress_monitor.py
+++ b/tests/test_public_ingress_monitor.py
@@ -12,6 +12,7 @@ from control_plane.contracts.product_profile_record import (
 )
 from control_plane.contracts.promotion_record import DeploymentEvidence
 from control_plane.contracts.public_ingress_monitoring import PublicIngressObservationRecord
+from control_plane.contracts.public_ingress_monitoring import PublicIngressIncidentRecord
 from control_plane.contracts.public_ingress_monitoring import PublicIngressTargetObservation
 from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.workflows.public_ingress_monitor import (
@@ -26,6 +27,7 @@ class _Store:
     def __init__(self, profiles: tuple[LaunchplaneProductProfileRecord, ...]) -> None:
         self._profiles = profiles
         self.records: list[PublicIngressObservationRecord] = []
+        self.incidents: list[PublicIngressIncidentRecord] = []
         self.lane_summaries: dict[tuple[str, str], LaunchplaneLaneSummary] = {}
 
     def list_product_profile_records(
@@ -62,6 +64,36 @@ class _Store:
         self, record: PublicIngressObservationRecord
     ) -> None:
         self.records.append(record)
+
+    def list_public_ingress_incident_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressIncidentRecord, ...]:
+        incidents = [
+            incident
+            for incident in self.incidents
+            if (not product or incident.product == product)
+            and (not context_name or incident.context == context_name)
+            and (not instance_name or incident.instance == instance_name)
+            and (not status or incident.status == status)
+        ]
+        incidents.sort(key=lambda incident: (incident.opened_at, incident.incident_id), reverse=True)
+        if limit is not None:
+            incidents = incidents[:limit]
+        return tuple(incidents)
+
+    def write_public_ingress_incident_record(
+        self, record: PublicIngressIncidentRecord
+    ) -> None:
+        self.incidents = [
+            incident for incident in self.incidents if incident.incident_id != record.incident_id
+        ]
+        self.incidents.append(record)
 
 
 def _profile(
@@ -244,6 +276,47 @@ class PublicIngressMonitorTests(unittest.TestCase):
         self.assertEqual(notifications, [("fail", "pass"), ("pass", "fail")])
         self.assertTrue(store.records[1].notification_sent)
         self.assertTrue(store.records[2].notification_sent)
+
+    def test_opens_updates_and_resolves_public_ingress_incident(self) -> None:
+        store = _Store((_profile(),))
+
+        first_failure = run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:20:00Z",
+            http_get=lambda url, _timeout: HttpObservation(
+                status_code=503,
+                final_url=url,
+                redirect_count=0,
+            ),
+        )
+        second_failure = run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:25:00Z",
+            http_get=lambda url, _timeout: HttpObservation(
+                status_code=500,
+                final_url=url,
+                redirect_count=0,
+            ),
+        )
+        recovery = run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:30:00Z",
+            http_get=lambda url, _timeout: HttpObservation(
+                status_code=200,
+                final_url=url,
+                redirect_count=0,
+            ),
+        )
+
+        self.assertEqual(first_failure.open_incident_count, 1)
+        self.assertEqual(second_failure.open_incident_count, 1)
+        self.assertEqual(recovery.resolved_incident_count, 1)
+        self.assertEqual(len(store.incidents), 1)
+        incident = store.incidents[0]
+        self.assertEqual(incident.status, "resolved")
+        self.assertEqual(incident.opened_observation_id, store.records[0].record_id)
+        self.assertEqual(incident.latest_observation_id, store.records[2].record_id)
+        self.assertEqual(incident.resolved_observation_id, store.records[2].record_id)
 
     def test_github_issue_notifier_comments_on_alert_issue(self) -> None:
         commands: list[list[str]] = []


### PR DESCRIPTION
## Summary
- add typed public-ingress incident records and storage support
- reconcile monitor observations into open/resolved incidents
- expose open incident state in product environment public-ingress summaries
- document observations vs incidents as separate record families

## Validation
- uv run python -m unittest tests.test_public_ingress_monitor tests.test_filesystem_store tests.test_product_environment_read_model
- uv run --extra dev ruff check control_plane/contracts/public_ingress_monitoring.py control_plane/contracts/product_environment_read_model.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/e5f7a9b1c3d5_add_public_ingress_incidents.py control_plane/workflows/public_ingress_monitor.py tests/test_public_ingress_monitor.py tests/test_filesystem_store.py tests/test_product_environment_read_model.py
- uv run --extra dev mypy control_plane/contracts/public_ingress_monitoring.py control_plane/contracts/product_environment_read_model.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/workflows/public_ingress_monitor.py tests/test_public_ingress_monitor.py tests/test_filesystem_store.py tests/test_product_environment_read_model.py
- uv run alembic heads

Refs #981
Refs #929