### PR TITLE
Add public ingress notification drivers

### DIFF
--- a/control_plane/contracts/public_ingress_monitoring.py
+++ b/control_plane/contracts/public_ingress_monitoring.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import json
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -9,6 +11,10 @@ from control_plane.contracts.runtime_identity import RuntimeIdentity, RuntimeIde
 
 PublicIngressObservationStatus = Literal["pass", "fail", "skipped"]
 PublicIngressIncidentStatus = Literal["open", "resolved"]
+PublicIngressIncidentEvent = Literal["opened", "updated", "resolved"]
+PublicIngressNotificationDestinationKind = Literal["github_issue", "email", "discord"]
+PublicIngressNotificationStatus = Literal["enabled", "disabled"]
+PublicIngressNotificationDeliveryStatus = Literal["delivered", "skipped", "failed"]
 PublicIngressTargetKind = Literal["base_url", "health_url"]
 PublicIngressFailureCode = Literal[
     "connection_timeout",
@@ -140,9 +146,7 @@ class PublicIngressIncidentRecord(BaseModel):
         )
         self.product = _required_text(self.product, "public ingress incident requires product")
         self.context = _required_text(self.context, "public ingress incident requires context")
-        self.instance = _required_text(
-            self.instance, "public ingress incident requires instance"
-        )
+        self.instance = _required_text(self.instance, "public ingress incident requires instance")
         self.opened_at = _required_text(
             self.opened_at, "public ingress incident requires opened_at"
         )
@@ -175,6 +179,170 @@ class PublicIngressIncidentRecord(BaseModel):
         return self
 
 
+class PublicIngressNotificationDestination(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    destination_id: str
+    kind: PublicIngressNotificationDestinationKind
+    status: PublicIngressNotificationStatus = "enabled"
+    github_repository: str = ""
+    github_issue_number: int | None = Field(default=None, ge=1)
+    github_label: str = ""
+    email_to: tuple[str, ...] = ()
+    email_from: str = ""
+    smtp_host: str = ""
+    smtp_port: int = Field(default=587, ge=1, le=65535)
+    smtp_username_secret: str = ""
+    smtp_password_secret: str = ""
+    discord_webhook_secret: str = ""
+
+    @model_validator(mode="after")
+    def _validate_destination(self) -> "PublicIngressNotificationDestination":
+        self.destination_id = _required_text(
+            self.destination_id, "public ingress notification destination requires destination_id"
+        )
+        self.github_repository = self.github_repository.strip()
+        self.github_label = self.github_label.strip()
+        self.email_from = self.email_from.strip()
+        self.email_to = tuple(_normalize_optional_text(value) for value in self.email_to)
+        if any(not value for value in self.email_to):
+            raise ValueError("public ingress email notification recipients must be non-empty")
+        self.smtp_host = self.smtp_host.strip()
+        self.smtp_username_secret = self.smtp_username_secret.strip()
+        self.smtp_password_secret = self.smtp_password_secret.strip()
+        self.discord_webhook_secret = self.discord_webhook_secret.strip()
+        if self.kind == "github_issue":
+            if not self.github_repository or "/" not in self.github_repository:
+                raise ValueError(
+                    "public ingress GitHub notification destination requires owner/name repository"
+                )
+            if self.github_issue_number is None and not self.github_label:
+                raise ValueError(
+                    "public ingress GitHub notification destination requires issue number or label"
+                )
+        elif self.kind == "email":
+            if not self.email_to:
+                raise ValueError("public ingress email notification destination requires email_to")
+            if not self.email_from:
+                raise ValueError(
+                    "public ingress email notification destination requires email_from"
+                )
+            if not self.smtp_host:
+                raise ValueError("public ingress email notification destination requires smtp_host")
+            if not self.smtp_username_secret:
+                raise ValueError(
+                    "public ingress email notification destination requires smtp_username_secret"
+                )
+            if not self.smtp_password_secret:
+                raise ValueError(
+                    "public ingress email notification destination requires smtp_password_secret"
+                )
+        elif self.kind == "discord":
+            if not self.discord_webhook_secret:
+                raise ValueError(
+                    "public ingress Discord notification destination requires discord_webhook_secret"
+                )
+        return self
+
+
+class PublicIngressNotificationPolicyRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    policy_id: str
+    product: str = ""
+    context: str = ""
+    instance: str = ""
+    status: PublicIngressNotificationStatus = "enabled"
+    destinations: tuple[PublicIngressNotificationDestination, ...] = ()
+    created_at: str
+    updated_at: str
+    source: str = ""
+
+    @model_validator(mode="after")
+    def _validate_policy(self) -> "PublicIngressNotificationPolicyRecord":
+        self.policy_id = _required_text(
+            self.policy_id, "public ingress notification policy requires policy_id"
+        )
+        self.product = self.product.strip()
+        self.context = self.context.strip()
+        self.instance = self.instance.strip()
+        self.created_at = _required_text(
+            self.created_at, "public ingress notification policy requires created_at"
+        )
+        self.updated_at = _required_text(
+            self.updated_at, "public ingress notification policy requires updated_at"
+        )
+        self.source = self.source.strip()
+        if not self.destinations:
+            raise ValueError("public ingress notification policy requires destinations")
+        destination_ids = [destination.destination_id for destination in self.destinations]
+        if len(set(destination_ids)) != len(destination_ids):
+            raise ValueError("public ingress notification destination ids must be unique")
+        if self.instance and not self.context:
+            raise ValueError(
+                "public ingress notification policy with instance scope requires context"
+            )
+        return self
+
+    def matches(self, incident: PublicIngressIncidentRecord) -> bool:
+        return (
+            (not self.product or self.product == incident.product)
+            and (not self.context or self.context == incident.context)
+            and (not self.instance or self.instance == incident.instance)
+        )
+
+
+class PublicIngressNotificationAttemptRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    attempt_id: str
+    incident_id: str
+    event: PublicIngressIncidentEvent
+    policy_id: str
+    destination_id: str
+    destination_kind: PublicIngressNotificationDestinationKind
+    delivery_status: PublicIngressNotificationDeliveryStatus
+    attempted_at: str
+    observation_id: str
+    external_url: str = ""
+    external_id: str = ""
+    action: str = ""
+    error_message: str = ""
+
+    @model_validator(mode="after")
+    def _validate_attempt(self) -> "PublicIngressNotificationAttemptRecord":
+        self.attempt_id = _required_text(
+            self.attempt_id, "public ingress notification attempt requires attempt_id"
+        )
+        self.incident_id = _required_text(
+            self.incident_id, "public ingress notification attempt requires incident_id"
+        )
+        self.policy_id = _required_text(
+            self.policy_id, "public ingress notification attempt requires policy_id"
+        )
+        self.destination_id = _required_text(
+            self.destination_id, "public ingress notification attempt requires destination_id"
+        )
+        self.attempted_at = _required_text(
+            self.attempted_at, "public ingress notification attempt requires attempted_at"
+        )
+        self.observation_id = _required_text(
+            self.observation_id,
+            "public ingress notification attempt requires observation_id",
+        )
+        self.external_url = self.external_url.strip()
+        self.external_id = self.external_id.strip()
+        self.action = self.action.strip()
+        self.error_message = self.error_message.strip()
+        if self.delivery_status == "failed" and not self.error_message:
+            raise ValueError("failed public ingress notification attempt requires error_message")
+        if self.delivery_status == "delivered" and not self.action:
+            raise ValueError("delivered public ingress notification attempt requires action")
+        return self
+
+
 def build_public_ingress_observation_id(
     *, product: str, context: str, instance: str, observed_at: str
 ) -> str:
@@ -195,6 +363,36 @@ def build_public_ingress_incident_id(
     )
 
 
+def build_public_ingress_notification_attempt_id(
+    *, incident_id: str, event: str, policy_id: str, destination_id: str, observation_id: str
+) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            {
+                "incident_id": incident_id.strip(),
+                "event": event.strip(),
+                "policy_id": policy_id.strip(),
+                "destination_id": destination_id.strip(),
+                "observation_id": observation_id.strip(),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+    return "-".join(
+        _record_token(value)
+        for value in (
+            "public-ingress-notification",
+            incident_id,
+            event,
+            policy_id,
+            destination_id,
+            digest,
+        )
+        if _record_token(value)
+    )
+
+
 def _record_token(value: str) -> str:
     return "".join(
         character if character.isalnum() else "-" for character in value.strip().lower()
@@ -206,3 +404,7 @@ def _required_text(value: str, message: str) -> str:
     if not normalized_value:
         raise ValueError(message)
     return normalized_value
+
+
+def _normalize_optional_text(value: str) -> str:
+    return value.strip()

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -48,6 +48,12 @@ from control_plane.contracts.preview_lifecycle_plan_record import PreviewLifecyc
 from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedbackRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.public_ingress_monitoring import (
+    PublicIngressNotificationAttemptRecord,
+)
+from control_plane.contracts.public_ingress_monitoring import (
+    PublicIngressNotificationPolicyRecord,
+)
 from control_plane.contracts.public_ingress_monitoring import PublicIngressIncidentRecord
 from control_plane.contracts.public_ingress_monitoring import PublicIngressObservationRecord
 from control_plane.contracts.promotion_record import PromotionRecord
@@ -603,6 +609,68 @@ class FilesystemRecordStore:
             and (not status or record.status == status)
         ]
         records.sort(key=lambda record: (record.opened_at, record.incident_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def write_public_ingress_notification_policy_record(
+        self, record: PublicIngressNotificationPolicyRecord
+    ) -> Path:
+        return self._write_model(
+            "launchplane_public_ingress_notification_policies", record.policy_id, record
+        )
+
+    def list_public_ingress_notification_policy_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressNotificationPolicyRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                PublicIngressNotificationPolicyRecord,
+                "launchplane_public_ingress_notification_policies",
+            )
+            if (not product or record.product in {"", product})
+            and (not context_name or record.context in {"", context_name})
+            and (not instance_name or record.instance in {"", instance_name})
+            and (not status or record.status == status)
+        ]
+        records.sort(key=lambda record: (record.updated_at, record.policy_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def write_public_ingress_notification_attempt_record(
+        self, record: PublicIngressNotificationAttemptRecord
+    ) -> Path:
+        return self._write_model(
+            "launchplane_public_ingress_notification_attempts", record.attempt_id, record
+        )
+
+    def list_public_ingress_notification_attempt_records(
+        self,
+        *,
+        incident_id: str = "",
+        event: str = "",
+        destination_kind: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressNotificationAttemptRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                PublicIngressNotificationAttemptRecord,
+                "launchplane_public_ingress_notification_attempts",
+            )
+            if (not incident_id or record.incident_id == incident_id)
+            and (not event or record.event == event)
+            and (not destination_kind or record.destination_kind == destination_kind)
+        ]
+        records.sort(key=lambda record: (record.attempted_at, record.attempt_id), reverse=True)
         if limit is not None:
             records = records[:limit]
         return tuple(records)

--- a/control_plane/storage/migrations/versions/f8a0b2c3d4e5_add_public_ingress_notifications.py
+++ b/control_plane/storage/migrations/versions/f8a0b2c3d4e5_add_public_ingress_notifications.py
@@ -1,0 +1,104 @@
+"""add public ingress notifications
+
+Revision ID: f8a0b2c3d4e5
+Revises: e5f7a9b1c3d5
+Create Date: 2026-05-29 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "f8a0b2c3d4e5"
+down_revision: str | None = "e5f7a9b1c3d5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_POLICIES_TABLE = "launchplane_public_ingress_notification_policies"
+_ATTEMPTS_TABLE = "launchplane_public_ingress_notification_attempts"
+_POLICIES_SCOPE_INDEX = "launchplane_pi_notify_policies_scope_idx"
+_ATTEMPTS_INCIDENT_INDEX = "launchplane_pi_notify_attempts_incident_idx"
+_ATTEMPTS_DESTINATION_INDEX = "launchplane_pi_notify_attempts_destination_idx"
+
+
+def _table_exists(table_name: str) -> bool:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return table_name in set(inspector.get_table_names())
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return index_name in {str(index["name"]) for index in inspector.get_indexes(table_name)}
+
+
+def _payload_column() -> sa.Column[object]:
+    return sa.Column(
+        "payload",
+        sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+        nullable=False,
+    )
+
+
+def upgrade() -> None:
+    if not _table_exists(_POLICIES_TABLE):
+        op.create_table(
+            _POLICIES_TABLE,
+            sa.Column("policy_id", sa.String(), nullable=False),
+            sa.Column("product", sa.String(), nullable=False),
+            sa.Column("context", sa.String(), nullable=False),
+            sa.Column("instance", sa.String(), nullable=False),
+            sa.Column("status", sa.String(), nullable=False),
+            sa.Column("updated_at", sa.String(), nullable=False),
+            _payload_column(),
+            sa.PrimaryKeyConstraint("policy_id"),
+        )
+    if not _index_exists(_POLICIES_TABLE, _POLICIES_SCOPE_INDEX):
+        op.create_index(
+            _POLICIES_SCOPE_INDEX,
+            _POLICIES_TABLE,
+            ["product", "context", "instance", "status", sa.text("updated_at DESC")],
+        )
+
+    if not _table_exists(_ATTEMPTS_TABLE):
+        op.create_table(
+            _ATTEMPTS_TABLE,
+            sa.Column("attempt_id", sa.String(), nullable=False),
+            sa.Column("incident_id", sa.String(), nullable=False),
+            sa.Column("event", sa.String(), nullable=False),
+            sa.Column("destination_kind", sa.String(), nullable=False),
+            sa.Column("delivery_status", sa.String(), nullable=False),
+            sa.Column("attempted_at", sa.String(), nullable=False),
+            _payload_column(),
+            sa.PrimaryKeyConstraint("attempt_id"),
+        )
+    if not _index_exists(_ATTEMPTS_TABLE, _ATTEMPTS_INCIDENT_INDEX):
+        op.create_index(
+            _ATTEMPTS_INCIDENT_INDEX,
+            _ATTEMPTS_TABLE,
+            ["incident_id", "event", sa.text("attempted_at DESC")],
+        )
+    if not _index_exists(_ATTEMPTS_TABLE, _ATTEMPTS_DESTINATION_INDEX):
+        op.create_index(
+            _ATTEMPTS_DESTINATION_INDEX,
+            _ATTEMPTS_TABLE,
+            ["destination_kind", sa.text("attempted_at DESC")],
+        )
+
+
+def downgrade() -> None:
+    if _table_exists(_ATTEMPTS_TABLE):
+        if _index_exists(_ATTEMPTS_TABLE, _ATTEMPTS_DESTINATION_INDEX):
+            op.drop_index(_ATTEMPTS_DESTINATION_INDEX, table_name=_ATTEMPTS_TABLE)
+        if _index_exists(_ATTEMPTS_TABLE, _ATTEMPTS_INCIDENT_INDEX):
+            op.drop_index(_ATTEMPTS_INCIDENT_INDEX, table_name=_ATTEMPTS_TABLE)
+        op.drop_table(_ATTEMPTS_TABLE)
+    if _table_exists(_POLICIES_TABLE):
+        if _index_exists(_POLICIES_TABLE, _POLICIES_SCOPE_INDEX):
+            op.drop_index(_POLICIES_SCOPE_INDEX, table_name=_POLICIES_TABLE)
+        op.drop_table(_POLICIES_TABLE)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -68,6 +68,12 @@ from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedback
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.preview_summary import LaunchplanePreviewSummary
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.public_ingress_monitoring import (
+    PublicIngressNotificationAttemptRecord,
+)
+from control_plane.contracts.public_ingress_monitoring import (
+    PublicIngressNotificationPolicyRecord,
+)
 from control_plane.contracts.public_ingress_monitoring import PublicIngressIncidentRecord
 from control_plane.contracts.public_ingress_monitoring import PublicIngressObservationRecord
 from control_plane.contracts.promotion_record import PromotionRecord
@@ -518,6 +524,53 @@ class LaunchplanePublicIngressIncidentRow(Base):
     status: Mapped[str] = mapped_column(String, nullable=False)
     opened_at: Mapped[str] = mapped_column(String, nullable=False)
     latest_observed_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplanePublicIngressNotificationPolicyRow(Base):
+    __tablename__ = "launchplane_public_ingress_notification_policies"
+    __table_args__ = (
+        Index(
+            "launchplane_pi_notify_policies_scope_idx",
+            "product",
+            "context",
+            "instance",
+            "status",
+            desc("updated_at"),
+        ),
+    )
+
+    policy_id: Mapped[str] = mapped_column(String, primary_key=True)
+    product: Mapped[str] = mapped_column(String, nullable=False)
+    context: Mapped[str] = mapped_column(String, nullable=False)
+    instance: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    updated_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplanePublicIngressNotificationAttemptRow(Base):
+    __tablename__ = "launchplane_public_ingress_notification_attempts"
+    __table_args__ = (
+        Index(
+            "launchplane_pi_notify_attempts_incident_idx",
+            "incident_id",
+            "event",
+            desc("attempted_at"),
+        ),
+        Index(
+            "launchplane_pi_notify_attempts_destination_idx",
+            "destination_kind",
+            desc("attempted_at"),
+        ),
+    )
+
+    attempt_id: Mapped[str] = mapped_column(String, primary_key=True)
+    incident_id: Mapped[str] = mapped_column(String, nullable=False)
+    event: Mapped[str] = mapped_column(String, nullable=False)
+    destination_kind: Mapped[str] = mapped_column(String, nullable=False)
+    delivery_status: Mapped[str] = mapped_column(String, nullable=False)
+    attempted_at: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -2768,9 +2821,7 @@ class PostgresRecordStore(HumanSessionStore):
             limit=limit,
         )
 
-    def write_public_ingress_incident_record(
-        self, record: PublicIngressIncidentRecord
-    ) -> None:
+    def write_public_ingress_incident_record(self, record: PublicIngressIncidentRecord) -> None:
         self._write_row(
             LaunchplanePublicIngressIncidentRow(
                 incident_id=record.incident_id,
@@ -2809,6 +2860,99 @@ class PostgresRecordStore(HumanSessionStore):
             order_by=(
                 LaunchplanePublicIngressIncidentRow.opened_at.desc(),
                 LaunchplanePublicIngressIncidentRow.incident_id.desc(),
+            ),
+            limit=limit,
+        )
+
+    def write_public_ingress_notification_policy_record(
+        self, record: PublicIngressNotificationPolicyRecord
+    ) -> None:
+        self._write_row(
+            LaunchplanePublicIngressNotificationPolicyRow(
+                policy_id=record.policy_id,
+                product=record.product,
+                context=record.context,
+                instance=record.instance,
+                status=record.status,
+                updated_at=record.updated_at,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def list_public_ingress_notification_policy_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressNotificationPolicyRecord, ...]:
+        filters: list[object] = []
+        if product:
+            filters.append(LaunchplanePublicIngressNotificationPolicyRow.product.in_(("", product)))
+        if context_name:
+            filters.append(
+                LaunchplanePublicIngressNotificationPolicyRow.context.in_(("", context_name))
+            )
+        if instance_name:
+            filters.append(
+                LaunchplanePublicIngressNotificationPolicyRow.instance.in_(("", instance_name))
+            )
+        if status:
+            filters.append(LaunchplanePublicIngressNotificationPolicyRow.status == status)
+        return self._list_models(
+            model_type=PublicIngressNotificationPolicyRecord,
+            orm_model=LaunchplanePublicIngressNotificationPolicyRow,
+            filters=filters,
+            order_by=(
+                LaunchplanePublicIngressNotificationPolicyRow.updated_at.desc(),
+                LaunchplanePublicIngressNotificationPolicyRow.policy_id.desc(),
+            ),
+            limit=limit,
+        )
+
+    def write_public_ingress_notification_attempt_record(
+        self, record: PublicIngressNotificationAttemptRecord
+    ) -> None:
+        self._write_row(
+            LaunchplanePublicIngressNotificationAttemptRow(
+                attempt_id=record.attempt_id,
+                incident_id=record.incident_id,
+                event=record.event,
+                destination_kind=record.destination_kind,
+                delivery_status=record.delivery_status,
+                attempted_at=record.attempted_at,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def list_public_ingress_notification_attempt_records(
+        self,
+        *,
+        incident_id: str = "",
+        event: str = "",
+        destination_kind: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressNotificationAttemptRecord, ...]:
+        filters: list[object] = []
+        if incident_id:
+            filters.append(
+                LaunchplanePublicIngressNotificationAttemptRow.incident_id == incident_id
+            )
+        if event:
+            filters.append(LaunchplanePublicIngressNotificationAttemptRow.event == event)
+        if destination_kind:
+            filters.append(
+                LaunchplanePublicIngressNotificationAttemptRow.destination_kind == destination_kind
+            )
+        return self._list_models(
+            model_type=PublicIngressNotificationAttemptRecord,
+            orm_model=LaunchplanePublicIngressNotificationAttemptRow,
+            filters=filters,
+            order_by=(
+                LaunchplanePublicIngressNotificationAttemptRow.attempted_at.desc(),
+                LaunchplanePublicIngressNotificationAttemptRow.attempt_id.desc(),
             ),
             limit=limit,
         )

--- a/control_plane/workflows/public_ingress_monitor.py
+++ b/control_plane/workflows/public_ingress_monitor.py
@@ -2,15 +2,18 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from email.message import EmailMessage
 from http.client import HTTPMessage
 from typing import IO, Protocol
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit, urlunsplit
-from urllib.request import HTTPRedirectHandler, OpenerDirector, Request, build_opener
+from urllib.request import HTTPRedirectHandler, OpenerDirector, Request, build_opener, urlopen
 import ipaddress
 import json
+import smtplib
 import socket
 import ssl
+import subprocess
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -21,12 +24,18 @@ from control_plane.contracts.product_profile_record import (
 )
 from control_plane.contracts.public_ingress_monitoring import (
     PublicIngressFailureCode,
+    PublicIngressIncidentEvent,
     PublicIngressIncidentRecord,
+    PublicIngressNotificationAttemptRecord,
+    PublicIngressNotificationDeliveryStatus,
+    PublicIngressNotificationDestination,
+    PublicIngressNotificationPolicyRecord,
     PublicIngressObservationRecord,
     PublicIngressObservationStatus,
     PublicIngressTargetKind,
     PublicIngressTargetObservation,
     build_public_ingress_incident_id,
+    build_public_ingress_notification_attempt_id,
     build_public_ingress_observation_id,
 )
 from control_plane.contracts.runtime_identity import (
@@ -74,6 +83,29 @@ class PublicIngressMonitorStore(Protocol):
         self, record: PublicIngressIncidentRecord
     ) -> object: ...
 
+    def list_public_ingress_notification_policy_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressNotificationPolicyRecord, ...]: ...
+
+    def list_public_ingress_notification_attempt_records(
+        self,
+        *,
+        incident_id: str = "",
+        event: str = "",
+        destination_kind: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressNotificationAttemptRecord, ...]: ...
+
+    def write_public_ingress_notification_attempt_record(
+        self, record: PublicIngressNotificationAttemptRecord
+    ) -> object: ...
+
 
 @dataclass(frozen=True)
 class PublicIngressMonitorTarget:
@@ -97,6 +129,27 @@ class HttpObservation:
     payload: object = None
 
 
+@dataclass(frozen=True)
+class PublicIngressNotificationDelivery:
+    delivery_status: PublicIngressNotificationDeliveryStatus
+    action: str = ""
+    external_url: str = ""
+    external_id: str = ""
+    error_message: str = ""
+
+
+class PublicIngressNotificationDrivers(Protocol):
+    def send(
+        self,
+        *,
+        destination: PublicIngressNotificationDestination,
+        event: PublicIngressIncidentEvent,
+        incident: PublicIngressIncidentRecord,
+        observation: PublicIngressObservationRecord,
+        previous_attempts: tuple[PublicIngressNotificationAttemptRecord, ...] = (),
+    ) -> PublicIngressNotificationDelivery: ...
+
+
 class PublicIngressMonitorResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -108,8 +161,10 @@ class PublicIngressMonitorResult(BaseModel):
     notification_count: int = Field(default=0, ge=0)
     open_incident_count: int = Field(default=0, ge=0)
     resolved_incident_count: int = Field(default=0, ge=0)
+    delivery_attempt_count: int = Field(default=0, ge=0)
     records: tuple[PublicIngressObservationRecord, ...] = ()
     incidents: tuple[PublicIngressIncidentRecord, ...] = ()
+    delivery_attempts: tuple[PublicIngressNotificationAttemptRecord, ...] = ()
 
 
 HttpGet = Callable[[str, int], HttpObservation]
@@ -182,11 +237,13 @@ def run_public_ingress_monitor_once(
     notify: bool = True,
     http_get: HttpGet | None = None,
     notifier: Notifier | None = None,
+    notification_drivers: PublicIngressNotificationDrivers | None = None,
 ) -> PublicIngressMonitorResult:
     observed_at = checked_at.strip() or utc_now_timestamp()
     get = http_get or fetch_public_ingress_url
     records: list[PublicIngressObservationRecord] = []
     incidents: list[PublicIngressIncidentRecord] = []
+    delivery_attempts: list[PublicIngressNotificationAttemptRecord] = []
     notification_count = 0
     for target in discover_public_ingress_monitor_targets(record_store):
         previous_record = _latest_observation(record_store=record_store, target=target)
@@ -210,6 +267,16 @@ def run_public_ingress_monitor_once(
         )
         if incident is not None:
             incidents.append(incident)
+            if notify and notification_drivers is not None:
+                delivery_attempts.extend(
+                    deliver_public_ingress_incident_notifications(
+                        record_store=record_store,
+                        event=_incident_event(incident=incident, previous_record=previous_record),
+                        incident=incident,
+                        observation=record,
+                        drivers=notification_drivers,
+                    )
+                )
     return PublicIngressMonitorResult(
         checked_at=observed_at,
         target_count=len(records),
@@ -218,12 +285,76 @@ def run_public_ingress_monitor_once(
         skipped_count=sum(1 for record in records if record.status == "skipped"),
         notification_count=notification_count,
         open_incident_count=sum(1 for incident in incidents if incident.status == "open"),
-        resolved_incident_count=sum(
-            1 for incident in incidents if incident.status == "resolved"
-        ),
+        resolved_incident_count=sum(1 for incident in incidents if incident.status == "resolved"),
+        delivery_attempt_count=len(delivery_attempts),
         records=tuple(records),
         incidents=tuple(incidents),
+        delivery_attempts=tuple(delivery_attempts),
     )
+
+
+def deliver_public_ingress_incident_notifications(
+    *,
+    record_store: PublicIngressMonitorStore,
+    event: PublicIngressIncidentEvent,
+    incident: PublicIngressIncidentRecord,
+    observation: PublicIngressObservationRecord,
+    drivers: PublicIngressNotificationDrivers,
+) -> tuple[PublicIngressNotificationAttemptRecord, ...]:
+    attempts: list[PublicIngressNotificationAttemptRecord] = []
+    for policy in _matching_notification_policies(record_store=record_store, incident=incident):
+        for destination in policy.destinations:
+            attempt_id = build_public_ingress_notification_attempt_id(
+                incident_id=incident.incident_id,
+                event=event,
+                policy_id=policy.policy_id,
+                destination_id=destination.destination_id,
+                observation_id=observation.record_id,
+            )
+            existing_attempt = _notification_attempt(
+                record_store=record_store,
+                attempt_id=attempt_id,
+                incident_id=incident.incident_id,
+                event=event,
+            )
+            if existing_attempt is not None:
+                attempts.append(existing_attempt)
+                continue
+            if destination.status != "enabled":
+                delivery = PublicIngressNotificationDelivery(
+                    delivery_status="skipped",
+                    action="destination_disabled",
+                )
+            else:
+                previous_attempts = record_store.list_public_ingress_notification_attempt_records(
+                    incident_id=incident.incident_id,
+                    destination_kind=destination.kind,
+                )
+                delivery = drivers.send(
+                    destination=destination,
+                    event=event,
+                    incident=incident,
+                    observation=observation,
+                    previous_attempts=previous_attempts,
+                )
+            attempt = PublicIngressNotificationAttemptRecord(
+                attempt_id=attempt_id,
+                incident_id=incident.incident_id,
+                event=event,
+                policy_id=policy.policy_id,
+                destination_id=destination.destination_id,
+                destination_kind=destination.kind,
+                delivery_status=delivery.delivery_status,
+                attempted_at=observation.observed_at,
+                observation_id=observation.record_id,
+                external_url=delivery.external_url,
+                external_id=delivery.external_id,
+                action=delivery.action,
+                error_message=delivery.error_message,
+            )
+            record_store.write_public_ingress_notification_attempt_record(attempt)
+            attempts.append(attempt)
+    return tuple(attempts)
 
 
 def reconcile_public_ingress_incident(
@@ -280,6 +411,48 @@ def reconcile_public_ingress_incident(
         record_store.write_public_ingress_incident_record(incident)
         return incident
     return None
+
+
+def _incident_event(
+    *, incident: PublicIngressIncidentRecord, previous_record: PublicIngressObservationRecord | None
+) -> PublicIngressIncidentEvent:
+    if incident.status == "resolved":
+        return "resolved"
+    if previous_record is not None and previous_record.status == "fail":
+        return "updated"
+    return "opened"
+
+
+def _matching_notification_policies(
+    *, record_store: PublicIngressMonitorStore, incident: PublicIngressIncidentRecord
+) -> tuple[PublicIngressNotificationPolicyRecord, ...]:
+    policies = record_store.list_public_ingress_notification_policy_records(
+        product=incident.product,
+        context_name=incident.context,
+        instance_name=incident.instance,
+        status="enabled",
+    )
+    return tuple(policy for policy in policies if policy.matches(incident))
+
+
+def _notification_attempt(
+    *,
+    record_store: PublicIngressMonitorStore,
+    attempt_id: str,
+    incident_id: str,
+    event: PublicIngressIncidentEvent,
+) -> PublicIngressNotificationAttemptRecord | None:
+    return next(
+        (
+            attempt
+            for attempt in record_store.list_public_ingress_notification_attempt_records(
+                incident_id=incident_id,
+                event=event,
+            )
+            if attempt.attempt_id == attempt_id
+        ),
+        None,
+    )
 
 
 def check_public_ingress_target(
@@ -638,6 +811,315 @@ def _notification_key(target: PublicIngressMonitorTarget) -> str:
     return target.alert_issue_url or ""
 
 
+class PublicIngressNotificationDriverSet:
+    def __init__(
+        self,
+        *,
+        github_client: Callable[[str, dict[str, object]], dict[str, object]] | None = None,
+        email_sender: Callable[[PublicIngressNotificationDestination, EmailMessage], object]
+        | None = None,
+        discord_sender: Callable[[str, dict[str, object]], object] | None = None,
+        secret_resolver: Callable[[str], str] | None = None,
+    ) -> None:
+        self.github_client = github_client or _gh_issue_client
+        self.email_sender = email_sender or _send_email_message
+        self.discord_sender = discord_sender or _post_discord_webhook
+        self.secret_resolver = secret_resolver or (lambda _secret_name: "")
+
+    def send(
+        self,
+        *,
+        destination: PublicIngressNotificationDestination,
+        event: PublicIngressIncidentEvent,
+        incident: PublicIngressIncidentRecord,
+        observation: PublicIngressObservationRecord,
+        previous_attempts: tuple[PublicIngressNotificationAttemptRecord, ...] = (),
+    ) -> PublicIngressNotificationDelivery:
+        try:
+            if destination.kind == "github_issue":
+                return _deliver_github_issue_notification(
+                    destination=destination,
+                    event=event,
+                    incident=incident,
+                    observation=observation,
+                    previous_attempts=previous_attempts,
+                    github_client=self.github_client,
+                )
+            if destination.kind == "email":
+                return _deliver_email_notification(
+                    destination=destination,
+                    event=event,
+                    incident=incident,
+                    observation=observation,
+                    email_sender=self.email_sender,
+                    secret_resolver=self.secret_resolver,
+                )
+            if destination.kind == "discord":
+                return _deliver_discord_notification(
+                    destination=destination,
+                    event=event,
+                    incident=incident,
+                    observation=observation,
+                    discord_sender=self.discord_sender,
+                    secret_resolver=self.secret_resolver,
+                )
+        except Exception as error:  # noqa: BLE001 - delivery failures are recorded per destination.
+            return PublicIngressNotificationDelivery(
+                delivery_status="failed",
+                action="provider_error",
+                error_message=str(error) or error.__class__.__name__,
+            )
+        return PublicIngressNotificationDelivery(
+            delivery_status="failed",
+            action="unsupported_destination",
+            error_message=f"Unsupported public ingress notification destination: {destination.kind}",
+        )
+
+
+def _deliver_github_issue_notification(
+    *,
+    destination: PublicIngressNotificationDestination,
+    event: PublicIngressIncidentEvent,
+    incident: PublicIngressIncidentRecord,
+    observation: PublicIngressObservationRecord,
+    previous_attempts: tuple[PublicIngressNotificationAttemptRecord, ...],
+    github_client: Callable[[str, dict[str, object]], dict[str, object]],
+) -> PublicIngressNotificationDelivery:
+    issue_url = _latest_external_url(previous_attempts)
+    body = public_ingress_incident_notification_body(
+        event=event, incident=incident, observation=observation
+    )
+    if event == "opened" or not issue_url:
+        payload: dict[str, object] = {
+            "repository": destination.github_repository,
+            "title": f"Public ingress incident: {incident.product}/{incident.instance}",
+            "body": body,
+        }
+        if destination.github_label:
+            payload["labels"] = [destination.github_label]
+        if destination.github_issue_number is not None:
+            payload["issue_number"] = destination.github_issue_number
+            response = github_client("comment", payload)
+            return PublicIngressNotificationDelivery(
+                delivery_status="delivered",
+                action="commented_issue",
+                external_url=str(response.get("url", "")).strip(),
+                external_id=str(response.get("id", "")).strip(),
+            )
+        response = github_client("create", payload)
+        return PublicIngressNotificationDelivery(
+            delivery_status="delivered",
+            action="created_issue",
+            external_url=str(response.get("url", "")).strip(),
+            external_id=str(response.get("id", "")).strip(),
+        )
+    payload = {
+        "repository": destination.github_repository,
+        "issue_url": issue_url,
+        "body": body,
+    }
+    if event == "resolved":
+        response = github_client("close", payload)
+        return PublicIngressNotificationDelivery(
+            delivery_status="delivered",
+            action="closed_issue",
+            external_url=str(response.get("url", issue_url)).strip(),
+            external_id=str(response.get("id", "")).strip(),
+        )
+    response = github_client("comment", payload)
+    return PublicIngressNotificationDelivery(
+        delivery_status="delivered",
+        action="commented_issue",
+        external_url=str(response.get("url", issue_url)).strip(),
+        external_id=str(response.get("id", "")).strip(),
+    )
+
+
+def _deliver_email_notification(
+    *,
+    destination: PublicIngressNotificationDestination,
+    event: PublicIngressIncidentEvent,
+    incident: PublicIngressIncidentRecord,
+    observation: PublicIngressObservationRecord,
+    email_sender: Callable[[PublicIngressNotificationDestination, EmailMessage], object],
+    secret_resolver: Callable[[str], str],
+) -> PublicIngressNotificationDelivery:
+    smtp_username = secret_resolver(destination.smtp_username_secret).strip()
+    smtp_password = secret_resolver(destination.smtp_password_secret).strip()
+    if not smtp_username or not smtp_password:
+        return PublicIngressNotificationDelivery(
+            delivery_status="failed",
+            action="missing_smtp_secret",
+            error_message="SMTP credential secrets could not be resolved.",
+        )
+    message = EmailMessage()
+    message["From"] = destination.email_from
+    message["To"] = ", ".join(destination.email_to)
+    message["X-Launchplane-SMTP-Username"] = smtp_username
+    message["X-Launchplane-SMTP-Password"] = smtp_password
+    message["Subject"] = (
+        f"[Launchplane] Public ingress {event}: {incident.product}/{incident.instance}"
+    )
+    message.set_content(
+        public_ingress_incident_notification_body(
+            event=event, incident=incident, observation=observation
+        )
+    )
+    email_sender(destination, message)
+    return PublicIngressNotificationDelivery(delivery_status="delivered", action="sent_email")
+
+
+def _deliver_discord_notification(
+    *,
+    destination: PublicIngressNotificationDestination,
+    event: PublicIngressIncidentEvent,
+    incident: PublicIngressIncidentRecord,
+    observation: PublicIngressObservationRecord,
+    discord_sender: Callable[[str, dict[str, object]], object],
+    secret_resolver: Callable[[str], str],
+) -> PublicIngressNotificationDelivery:
+    webhook_url = secret_resolver(destination.discord_webhook_secret).strip()
+    if not webhook_url:
+        return PublicIngressNotificationDelivery(
+            delivery_status="failed",
+            action="missing_discord_webhook",
+            error_message="Discord webhook secret could not be resolved.",
+        )
+    public_url_error = _public_url_error(webhook_url)
+    if public_url_error is not None:
+        return PublicIngressNotificationDelivery(
+            delivery_status="failed",
+            action="invalid_discord_webhook",
+            error_message=f"Discord webhook URL is not public: {public_url_error}",
+        )
+    color = 0x2E7D32 if event == "resolved" else 0xC62828
+    discord_sender(
+        webhook_url,
+        {
+            "embeds": [
+                {
+                    "title": f"Public ingress {event}: {incident.product}/{incident.instance}",
+                    "description": public_ingress_incident_notification_body(
+                        event=event, incident=incident, observation=observation
+                    ),
+                    "color": color,
+                }
+            ]
+        },
+    )
+    return PublicIngressNotificationDelivery(delivery_status="delivered", action="posted_discord")
+
+
+def public_ingress_incident_notification_body(
+    *,
+    event: PublicIngressIncidentEvent,
+    incident: PublicIngressIncidentRecord,
+    observation: PublicIngressObservationRecord,
+) -> str:
+    lines = [
+        f"Launchplane public ingress incident {event}: {incident.product}/{incident.instance}",
+        "",
+        f"- status: {incident.status}",
+        f"- incident_id: {incident.incident_id}",
+        f"- context: {incident.context}",
+        f"- observed_at: {observation.observed_at}",
+        f"- observation_id: {observation.record_id}",
+        f"- failure_code: {incident.failure_code}",
+        f"- summary: {incident.summary}",
+    ]
+    for target in observation.targets:
+        lines.append(f"- {target.target}: {target.status} {target.summary}")
+    return "\n".join(lines)
+
+
+def _latest_external_url(attempts: tuple[PublicIngressNotificationAttemptRecord, ...]) -> str:
+    return next(
+        (
+            attempt.external_url
+            for attempt in attempts
+            if attempt.destination_kind == "github_issue" and attempt.external_url.strip()
+        ),
+        "",
+    )
+
+
+def _gh_issue_client(action: str, payload: dict[str, object]) -> dict[str, object]:
+    if action == "create":
+        command = [
+            "gh",
+            "issue",
+            "create",
+            "--repo",
+            str(payload["repository"]),
+            "--title",
+            str(payload["title"]),
+            "--body",
+            str(payload["body"]),
+        ]
+        labels = payload.get("labels", [])
+        if isinstance(labels, list):
+            for label in labels:
+                command.extend(["--label", str(label)])
+    elif action == "comment":
+        issue_target = str(payload.get("issue_url") or payload.get("issue_number"))
+        command = [
+            "gh",
+            "issue",
+            "comment",
+            issue_target,
+            "--repo",
+            str(payload["repository"]),
+            "--body",
+            str(payload["body"]),
+        ]
+    elif action == "close":
+        issue_target = str(payload["issue_url"])
+        command = [
+            "gh",
+            "issue",
+            "close",
+            issue_target,
+            "--repo",
+            str(payload["repository"]),
+            "--comment",
+            str(payload["body"]),
+        ]
+    else:
+        raise ValueError(f"unsupported GitHub notification action: {action}")
+    completed = subprocess.run(command, check=False, text=True, capture_output=True)
+    if completed.returncode != 0:
+        raise RuntimeError(completed.stderr.strip() or completed.stdout.strip() or "gh failed")
+    output = completed.stdout.strip()
+    return {"url": output, "id": output}
+
+
+def _send_email_message(
+    destination: PublicIngressNotificationDestination, message: EmailMessage
+) -> None:
+    with smtplib.SMTP(destination.smtp_host, destination.smtp_port, timeout=15) as smtp:
+        smtp.starttls()
+        username = message["X-Launchplane-SMTP-Username"]
+        password = message["X-Launchplane-SMTP-Password"]
+        if not username or not password:
+            raise RuntimeError("SMTP credentials were not resolved.")
+        smtp.login(str(username), str(password))
+        del message["X-Launchplane-SMTP-Username"]
+        del message["X-Launchplane-SMTP-Password"]
+        smtp.send_message(message)
+
+
+def _post_discord_webhook(webhook_url: str, payload: dict[str, object]) -> None:
+    request = Request(
+        webhook_url,
+        method="POST",
+        headers={"Content-Type": "application/json", "User-Agent": USER_AGENT},
+        data=json.dumps(payload).encode("utf-8"),
+    )
+    with urlopen(request, timeout=15) as response:  # noqa: S310 - operator-configured webhook URL with SSRF guard.
+        if not 200 <= response.status < 300:
+            raise RuntimeError(f"Discord webhook returned HTTP {response.status}")
+
+
 def public_ingress_alert_body(
     record: PublicIngressObservationRecord,
     previous: PublicIngressObservationRecord | None,
@@ -662,8 +1144,6 @@ def public_ingress_alert_body(
 def build_github_issue_notifier(
     *, gh_binary: str = "gh", runner: Callable[..., object] | None = None
 ) -> Notifier:
-    import subprocess
-
     def notify(
         record: PublicIngressObservationRecord,
         previous: PublicIngressObservationRecord | None,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -161,7 +161,9 @@ lanes with public `base_url` or `health_url`; disable it per lane only for
 non-public or intentionally unreachable endpoints. Observations are sensor
 evidence; public-ingress incident records are the active operator lifecycle when
 a lane fails and later recovers. Notification routing is a separate
-service-backed policy and delivery concern, not lane-owned text config.
+service-backed policy and delivery concern, not lane-owned text config. The
+initial notification destinations are GitHub issues, email, and Discord; each is
+selected by DB-backed policy and evidenced by delivery-attempt records.
 
 The manual Product Context Cutover workflow plans or applies the same
 current-authority record move through the Launchplane service. Run it first with

--- a/docs/records.md
+++ b/docs/records.md
@@ -278,6 +278,22 @@ delivery are separate record families: observations say what was measured,
 incidents say whether there is active operator state, and delivery records say
 where Launchplane attempted to notify operators.
 
+## Public Ingress Notification Records
+
+Public ingress notification policy records are DB-backed Launchplane records
+under `launchplane_public_ingress_notification_policies`. They select enabled
+destinations for incident events by product, context, and instance. The initial
+destination drivers are GitHub issues, email, and Discord. Policies store
+routing intent and managed secret references only; they must not store Discord
+webhook URLs, SMTP passwords, or production destination values as code defaults.
+
+Public ingress notification attempt records are append-only evidence under
+`launchplane_public_ingress_notification_attempts`. Each attempt is keyed by the
+incident, event, policy, destination, and observation. Attempts record delivered,
+skipped, or failed status plus provider-safe external ids or URLs. Delivery
+attempts are the idempotency boundary for notifications, while incident records
+remain the source of truth for active public-ingress state.
+
 Odoo stable bootstrap eligibility is lane-owned product-profile data. A lane's
 `odoo_stable_bootstrap` policy defaults to disabled and must explicitly carry
 an issue-backed approval URL, the destructive confirmation phrase,

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -55,6 +55,11 @@ from control_plane.contracts.product_profile_record import (
     ProductPreviewProfile,
 )
 from control_plane.contracts.public_ingress_monitoring import PublicIngressIncidentRecord
+from control_plane.contracts.public_ingress_monitoring import (
+    PublicIngressNotificationAttemptRecord,
+)
+from control_plane.contracts.public_ingress_monitoring import PublicIngressNotificationDestination
+from control_plane.contracts.public_ingress_monitoring import PublicIngressNotificationPolicyRecord
 from control_plane.contracts.public_ingress_monitoring import PublicIngressObservationRecord
 from control_plane.contracts.public_ingress_monitoring import PublicIngressTargetObservation
 from control_plane.contracts.promotion_record import (
@@ -631,6 +636,57 @@ class FilesystemRecordStoreTests(unittest.TestCase):
             self.assertEqual(
                 [record.incident_id for record in open_records], [open_record.incident_id]
             )
+
+    def test_write_and_list_public_ingress_notification_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            policy = PublicIngressNotificationPolicyRecord(
+                policy_id="public-ingress-notification-policy-example-site",
+                product="example-site",
+                context="example-site-prod",
+                instance="prod",
+                status="enabled",
+                destinations=(
+                    PublicIngressNotificationDestination(
+                        destination_id="discord-ops",
+                        kind="discord",
+                        discord_webhook_secret="discord-webhook",
+                    ),
+                ),
+                created_at="2026-05-29T12:00:00Z",
+                updated_at="2026-05-29T12:00:00Z",
+                source="test",
+            )
+            attempt = PublicIngressNotificationAttemptRecord(
+                attempt_id="public-ingress-notification-attempt-1",
+                incident_id="incident-1",
+                event="opened",
+                policy_id=policy.policy_id,
+                destination_id="discord-ops",
+                destination_kind="discord",
+                delivery_status="delivered",
+                attempted_at="2026-05-29T12:20:00Z",
+                observation_id="obs-1",
+                action="posted_discord",
+            )
+
+            policy_path = store.write_public_ingress_notification_policy_record(policy)
+            attempt_path = store.write_public_ingress_notification_attempt_record(attempt)
+            policies = store.list_public_ingress_notification_policy_records(
+                product="example-site",
+                context_name="example-site-prod",
+                status="enabled",
+            )
+            attempts = store.list_public_ingress_notification_attempt_records(
+                incident_id="incident-1",
+                destination_kind="discord",
+            )
+
+            self.assertTrue(policy_path.exists())
+            self.assertTrue(attempt_path.exists())
+            self.assertEqual([record.policy_id for record in policies], [policy.policy_id])
+            self.assertEqual([record.attempt_id for record in attempts], [attempt.attempt_id])
 
     def test_write_and_list_runtime_key_safety_policy_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_public_ingress_monitor.py
+++ b/tests/test_public_ingress_monitor.py
@@ -13,10 +13,16 @@ from control_plane.contracts.product_profile_record import (
 from control_plane.contracts.promotion_record import DeploymentEvidence
 from control_plane.contracts.public_ingress_monitoring import PublicIngressObservationRecord
 from control_plane.contracts.public_ingress_monitoring import PublicIngressIncidentRecord
+from control_plane.contracts.public_ingress_monitoring import (
+    PublicIngressNotificationAttemptRecord,
+)
+from control_plane.contracts.public_ingress_monitoring import PublicIngressNotificationDestination
+from control_plane.contracts.public_ingress_monitoring import PublicIngressNotificationPolicyRecord
 from control_plane.contracts.public_ingress_monitoring import PublicIngressTargetObservation
 from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.workflows.public_ingress_monitor import (
     HttpObservation,
+    PublicIngressNotificationDriverSet,
     build_github_issue_notifier,
     discover_public_ingress_monitor_targets,
     run_public_ingress_monitor_once,
@@ -28,6 +34,8 @@ class _Store:
         self._profiles = profiles
         self.records: list[PublicIngressObservationRecord] = []
         self.incidents: list[PublicIngressIncidentRecord] = []
+        self.notification_policies: list[PublicIngressNotificationPolicyRecord] = []
+        self.notification_attempts: list[PublicIngressNotificationAttemptRecord] = []
         self.lane_summaries: dict[tuple[str, str], LaunchplaneLaneSummary] = {}
 
     def list_product_profile_records(
@@ -82,18 +90,70 @@ class _Store:
             and (not instance_name or incident.instance == instance_name)
             and (not status or incident.status == status)
         ]
-        incidents.sort(key=lambda incident: (incident.opened_at, incident.incident_id), reverse=True)
+        incidents.sort(
+            key=lambda incident: (incident.opened_at, incident.incident_id), reverse=True
+        )
         if limit is not None:
             incidents = incidents[:limit]
         return tuple(incidents)
 
-    def write_public_ingress_incident_record(
-        self, record: PublicIngressIncidentRecord
-    ) -> None:
+    def write_public_ingress_incident_record(self, record: PublicIngressIncidentRecord) -> None:
         self.incidents = [
             incident for incident in self.incidents if incident.incident_id != record.incident_id
         ]
         self.incidents.append(record)
+
+    def list_public_ingress_notification_policy_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressNotificationPolicyRecord, ...]:
+        policies = [
+            policy
+            for policy in self.notification_policies
+            if (not product or policy.product in {"", product})
+            and (not context_name or policy.context in {"", context_name})
+            and (not instance_name or policy.instance in {"", instance_name})
+            and (not status or policy.status == status)
+        ]
+        policies.sort(key=lambda policy: (policy.updated_at, policy.policy_id), reverse=True)
+        if limit is not None:
+            policies = policies[:limit]
+        return tuple(policies)
+
+    def list_public_ingress_notification_attempt_records(
+        self,
+        *,
+        incident_id: str = "",
+        event: str = "",
+        destination_kind: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressNotificationAttemptRecord, ...]:
+        attempts = [
+            attempt
+            for attempt in self.notification_attempts
+            if (not incident_id or attempt.incident_id == incident_id)
+            and (not event or attempt.event == event)
+            and (not destination_kind or attempt.destination_kind == destination_kind)
+        ]
+        attempts.sort(key=lambda attempt: (attempt.attempted_at, attempt.attempt_id), reverse=True)
+        if limit is not None:
+            attempts = attempts[:limit]
+        return tuple(attempts)
+
+    def write_public_ingress_notification_attempt_record(
+        self, record: PublicIngressNotificationAttemptRecord
+    ) -> None:
+        self.notification_attempts = [
+            attempt
+            for attempt in self.notification_attempts
+            if attempt.attempt_id != record.attempt_id
+        ]
+        self.notification_attempts.append(record)
 
 
 def _profile(
@@ -134,6 +194,22 @@ def _identity() -> RuntimeIdentity:
     )
 
 
+def _notification_policy(
+    *destinations: PublicIngressNotificationDestination,
+) -> PublicIngressNotificationPolicyRecord:
+    return PublicIngressNotificationPolicyRecord(
+        policy_id="public-ingress-notifications-example-site",
+        product="example-site",
+        context="example-site",
+        instance="prod",
+        status="enabled",
+        destinations=destinations,
+        created_at="2026-05-29T12:00:00Z",
+        updated_at="2026-05-29T12:00:00Z",
+        source="test",
+    )
+
+
 def _record_notification(
     notifications: list[tuple[str, str]],
     record: PublicIngressObservationRecord,
@@ -146,6 +222,16 @@ def _record_notification(
 def _capture_command(commands: list[list[str]], command: list[str]) -> object:
     commands.append(command)
     return object()
+
+
+def _capture_github_call(
+    calls: list[tuple[str, dict[str, object]]], action: str, payload: dict[str, object]
+) -> dict[str, object]:
+    calls.append((action, payload))
+    return {
+        "url": "https://github.com/cbusillo/launchplane/issues/123",
+        "id": f"github-{action}",
+    }
 
 
 def _capture_request(requested_urls: list[str], url: str) -> HttpObservation:
@@ -317,6 +403,178 @@ class PublicIngressMonitorTests(unittest.TestCase):
         self.assertEqual(incident.opened_observation_id, store.records[0].record_id)
         self.assertEqual(incident.latest_observation_id, store.records[2].record_id)
         self.assertEqual(incident.resolved_observation_id, store.records[2].record_id)
+
+    def test_policy_driven_incident_notifications_record_attempts(self) -> None:
+        store = _Store((_profile(),))
+        store.notification_policies.append(
+            _notification_policy(
+                PublicIngressNotificationDestination(
+                    destination_id="github-main",
+                    kind="github_issue",
+                    github_repository="cbusillo/launchplane",
+                    github_label="public-ingress",
+                ),
+                PublicIngressNotificationDestination(
+                    destination_id="email-ops",
+                    kind="email",
+                    email_to=("ops@example.test",),
+                    email_from="launchplane@example.test",
+                    smtp_host="smtp.example.test",
+                    smtp_username_secret="smtp-username",
+                    smtp_password_secret="smtp-password",
+                ),
+                PublicIngressNotificationDestination(
+                    destination_id="discord-ops",
+                    kind="discord",
+                    discord_webhook_secret="discord-webhook",
+                ),
+            )
+        )
+        github_calls: list[tuple[str, dict[str, object]]] = []
+        email_subjects: list[str] = []
+        discord_posts: list[tuple[str, dict[str, object]]] = []
+        drivers = PublicIngressNotificationDriverSet(
+            github_client=lambda action, payload: _capture_github_call(
+                github_calls, action, payload
+            ),
+            email_sender=lambda _destination, message: email_subjects.append(
+                str(message["Subject"])
+            ),
+            discord_sender=lambda webhook_url, payload: discord_posts.append(
+                (webhook_url, payload)
+            ),
+            secret_resolver=lambda secret_name: {
+                "discord-webhook": "https://discord.com/api/webhooks/test/webhook",
+                "smtp-username": "launchplane",
+                "smtp-password": "secret",
+            }.get(secret_name, ""),
+        )
+
+        result = run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:25:00Z",
+            http_get=lambda _url, _timeout: HttpObservation(
+                status_code=503,
+                final_url="https://example.test",
+                redirect_count=0,
+            ),
+            notification_drivers=drivers,
+        )
+
+        self.assertEqual(result.open_incident_count, 1)
+        self.assertEqual(result.delivery_attempt_count, 3)
+        self.assertEqual(
+            {attempt.destination_kind for attempt in store.notification_attempts},
+            {"github_issue", "email", "discord"},
+        )
+        self.assertTrue(
+            all(attempt.delivery_status == "delivered" for attempt in store.notification_attempts)
+        )
+        self.assertEqual(github_calls[0][0], "create")
+        self.assertEqual(email_subjects, ["[Launchplane] Public ingress opened: example-site/prod"])
+        self.assertEqual(discord_posts[0][0], "https://discord.com/api/webhooks/test/webhook")
+
+    def test_policy_delivery_failures_are_recorded_per_destination(self) -> None:
+        store = _Store((_profile(),))
+        store.notification_policies.append(
+            _notification_policy(
+                PublicIngressNotificationDestination(
+                    destination_id="email-ops",
+                    kind="email",
+                    email_to=("ops@example.test",),
+                    email_from="launchplane@example.test",
+                    smtp_host="smtp.example.test",
+                    smtp_username_secret="smtp-username",
+                    smtp_password_secret="smtp-password",
+                ),
+                PublicIngressNotificationDestination(
+                    destination_id="discord-ops",
+                    kind="discord",
+                    discord_webhook_secret="discord-webhook",
+                ),
+            )
+        )
+        drivers = PublicIngressNotificationDriverSet(
+            email_sender=lambda _destination, _message: (_ for _ in ()).throw(
+                RuntimeError("smtp unavailable")
+            ),
+            discord_sender=lambda _webhook_url, _payload: None,
+            secret_resolver=lambda secret_name: {
+                "discord-webhook": "https://discord.com/api/webhooks/test/webhook",
+                "smtp-username": "launchplane",
+                "smtp-password": "secret",
+            }.get(secret_name, ""),
+        )
+
+        result = run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:25:00Z",
+            http_get=lambda _url, _timeout: HttpObservation(
+                status_code=503,
+                final_url="https://example.test",
+                redirect_count=0,
+            ),
+            notification_drivers=drivers,
+        )
+
+        self.assertEqual(result.delivery_attempt_count, 2)
+        statuses = {
+            attempt.destination_kind: attempt.delivery_status
+            for attempt in store.notification_attempts
+        }
+        self.assertEqual(statuses, {"email": "failed", "discord": "delivered"})
+        failed = next(
+            attempt
+            for attempt in store.notification_attempts
+            if attempt.delivery_status == "failed"
+        )
+        self.assertIn("smtp unavailable", failed.error_message)
+
+    def test_github_incident_delivery_closes_created_issue_on_recovery(self) -> None:
+        store = _Store((_profile(),))
+        store.notification_policies.append(
+            _notification_policy(
+                PublicIngressNotificationDestination(
+                    destination_id="github-main",
+                    kind="github_issue",
+                    github_repository="cbusillo/launchplane",
+                    github_label="public-ingress",
+                )
+            )
+        )
+        github_calls: list[tuple[str, dict[str, object]]] = []
+        drivers = PublicIngressNotificationDriverSet(
+            github_client=lambda action, payload: _capture_github_call(
+                github_calls, action, payload
+            )
+        )
+        run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:25:00Z",
+            http_get=lambda _url, _timeout: HttpObservation(
+                status_code=503,
+                final_url="https://example.test",
+                redirect_count=0,
+            ),
+            notification_drivers=drivers,
+        )
+        recovery = run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:30:00Z",
+            http_get=lambda url, _timeout: HttpObservation(
+                status_code=200,
+                final_url=url,
+                redirect_count=0,
+            ),
+            notification_drivers=drivers,
+        )
+
+        self.assertEqual(recovery.resolved_incident_count, 1)
+        self.assertEqual([call[0] for call in github_calls], ["create", "close"])
+        self.assertEqual(
+            github_calls[1][1]["issue_url"],
+            "https://github.com/cbusillo/launchplane/issues/123",
+        )
 
     def test_github_issue_notifier_comments_on_alert_issue(self) -> None:
         commands: list[list[str]] = []


### PR DESCRIPTION
## Summary
- add DB-backed public-ingress notification policy and delivery-attempt records
- wire incident transition delivery attempts into the public ingress monitor
- add GitHub issue, email, and Discord destination drivers with durable per-destination evidence
- document policy/delivery ownership and the initial driver set

## Validation
- `uv run python -m unittest`
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff check control_plane/contracts/public_ingress_monitoring.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/f8a0b2c3d4e5_add_public_ingress_notifications.py control_plane/workflows/public_ingress_monitor.py tests/test_public_ingress_monitor.py tests/test_filesystem_store.py`
- `uv run --extra dev ruff format --check control_plane/contracts/public_ingress_monitoring.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/f8a0b2c3d4e5_add_public_ingress_notifications.py control_plane/workflows/public_ingress_monitor.py tests/test_public_ingress_monitor.py tests/test_filesystem_store.py`
- `uv run alembic heads`

Refs #982
Refs #983
Refs #929
