### PR TITLE
Fix public ingress incident correctness

### DIFF
--- a/control_plane/contracts/product_environment_read_model.py
+++ b/control_plane/contracts/product_environment_read_model.py
@@ -136,6 +136,10 @@ class ProductEnvironmentReadModelStore(ProductReadModelStore, Protocol):
     ) -> tuple[PublicIngressIncidentRecord, ...]: ...
 
 
+class ProductEnvironmentReadModelCapabilityError(RuntimeError):
+    pass
+
+
 def _build_action_authz_by_route() -> dict[str, str]:
     return {
         action.route_path: action.authz_action
@@ -664,6 +668,18 @@ def _optional_records(
     method = getattr(record_store, method_name, None)
     if not callable(method):
         return ()
+    return tuple(method(**kwargs))
+
+
+def _required_records(
+    record_store: object, method_name: str, **kwargs: object
+) -> tuple[object, ...]:
+    method = getattr(record_store, method_name, None)
+    if not callable(method):
+        raise ProductEnvironmentReadModelCapabilityError(
+            "Product environment reads require DB-backed Launchplane storage; "
+            f"missing store method(s): {method_name}."
+        )
     return tuple(method(**kwargs))
 
 
@@ -1312,7 +1328,7 @@ def _public_ingress_summary(
     latest = next(iter(records), None)
     if latest is None or not isinstance(latest, PublicIngressObservationRecord):
         return ProductPublicIngressSummary()
-    incidents = _optional_records(
+    incidents = _required_records(
         record_store,
         "list_public_ingress_incident_records",
         product=profile.product,

--- a/control_plane/contracts/public_ingress_monitoring.py
+++ b/control_plane/contracts/public_ingress_monitoring.py
@@ -363,6 +363,14 @@ def build_public_ingress_incident_id(
     )
 
 
+def build_public_ingress_lane_incident_id(*, product: str, context: str, instance: str) -> str:
+    return "-".join(
+        _record_token(value)
+        for value in ("public-ingress-incident", product, context, instance)
+        if _record_token(value)
+    )
+
+
 def build_public_ingress_notification_attempt_id(
     *, incident_id: str, event: str, policy_id: str, destination_id: str, observation_id: str
 ) -> str:

--- a/control_plane/product_read_service.py
+++ b/control_plane/product_read_service.py
@@ -42,6 +42,7 @@ _PRODUCT_ENVIRONMENT_READ_MODEL_STORE_METHODS = (
     "list_preview_lifecycle_cleanup_records",
     "list_preview_pr_feedback_records",
     "list_public_ingress_observation_records",
+    "list_public_ingress_incident_records",
     "list_authz_policy_records",
 )
 

--- a/control_plane/workflows/public_ingress_monitor.py
+++ b/control_plane/workflows/public_ingress_monitor.py
@@ -34,7 +34,7 @@ from control_plane.contracts.public_ingress_monitoring import (
     PublicIngressObservationStatus,
     PublicIngressTargetKind,
     PublicIngressTargetObservation,
-    build_public_ingress_incident_id,
+    build_public_ingress_lane_incident_id,
     build_public_ingress_notification_attempt_id,
     build_public_ingress_observation_id,
 )
@@ -244,6 +244,8 @@ def run_public_ingress_monitor_once(
     records: list[PublicIngressObservationRecord] = []
     incidents: list[PublicIngressIncidentRecord] = []
     delivery_attempts: list[PublicIngressNotificationAttemptRecord] = []
+    open_incident_count = 0
+    resolved_incident_count = 0
     notification_count = 0
     for target in discover_public_ingress_monitor_targets(record_store):
         previous_record = _latest_observation(record_store=record_store, target=target)
@@ -260,13 +262,17 @@ def run_public_ingress_monitor_once(
                 notification_count += 1
         record_store.write_public_ingress_observation_record(record)
         records.append(record)
-        incident = reconcile_public_ingress_incident(
+        incident_records = reconcile_public_ingress_incident(
             record_store=record_store,
             record=record,
             previous_record=previous_record,
         )
-        if incident is not None:
-            incidents.append(incident)
+        incidents.extend(incident_records)
+        open_incident_count += sum(1 for incident in incident_records if incident.status == "open")
+        resolved_incident_count += sum(
+            1 for incident in incident_records if incident.status == "resolved"
+        )
+        for incident in incident_records:
             if notify and notification_drivers is not None:
                 delivery_attempts.extend(
                     deliver_public_ingress_incident_notifications(
@@ -284,8 +290,8 @@ def run_public_ingress_monitor_once(
         fail_count=sum(1 for record in records if record.status == "fail"),
         skipped_count=sum(1 for record in records if record.status == "skipped"),
         notification_count=notification_count,
-        open_incident_count=sum(1 for incident in incidents if incident.status == "open"),
-        resolved_incident_count=sum(1 for incident in incidents if incident.status == "resolved"),
+        open_incident_count=open_incident_count,
+        resolved_incident_count=resolved_incident_count,
         delivery_attempt_count=len(delivery_attempts),
         records=tuple(records),
         incidents=tuple(incidents),
@@ -362,9 +368,17 @@ def reconcile_public_ingress_incident(
     record_store: PublicIngressMonitorStore,
     record: PublicIngressObservationRecord,
     previous_record: PublicIngressObservationRecord | None,
-) -> PublicIngressIncidentRecord | None:
-    open_incident = _open_incident(record_store=record_store, record=record)
+) -> tuple[PublicIngressIncidentRecord, ...]:
+    open_incidents = _open_incidents(record_store=record_store, record=record)
     if record.status == "fail":
+        incident_id = build_public_ingress_lane_incident_id(
+            product=record.product,
+            context=record.context,
+            instance=record.instance,
+        )
+        open_incident = next(
+            (incident for incident in open_incidents if incident.incident_id == incident_id), None
+        )
         if open_incident is not None:
             incident = open_incident.model_copy(
                 update={
@@ -376,12 +390,7 @@ def reconcile_public_ingress_incident(
             )
         else:
             incident = PublicIngressIncidentRecord(
-                incident_id=build_public_ingress_incident_id(
-                    product=record.product,
-                    context=record.context,
-                    instance=record.instance,
-                    opened_at=record.observed_at,
-                ),
+                incident_id=incident_id,
                 product=record.product,
                 repository=record.repository,
                 driver_id=record.driver_id,
@@ -396,21 +405,24 @@ def reconcile_public_ingress_incident(
                 summary=record.summary,
             )
         record_store.write_public_ingress_incident_record(incident)
-        return incident
-    if record.status == "pass" and open_incident is not None:
-        incident = open_incident.model_copy(
-            update={
-                "status": "resolved",
-                "latest_observation_id": record.record_id,
-                "latest_observed_at": record.observed_at,
-                "resolved_at": record.observed_at,
-                "resolved_observation_id": record.record_id,
-                "summary": record.summary,
-            }
-        )
-        record_store.write_public_ingress_incident_record(incident)
-        return incident
-    return None
+        return (incident,)
+    if record.status == "pass" and open_incidents:
+        resolved_incidents: list[PublicIngressIncidentRecord] = []
+        for open_incident in open_incidents:
+            incident = open_incident.model_copy(
+                update={
+                    "status": "resolved",
+                    "latest_observation_id": record.record_id,
+                    "latest_observed_at": record.observed_at,
+                    "resolved_at": record.observed_at,
+                    "resolved_observation_id": record.record_id,
+                    "summary": record.summary,
+                }
+            )
+            record_store.write_public_ingress_incident_record(incident)
+            resolved_incidents.append(incident)
+        return tuple(resolved_incidents)
+    return ()
 
 
 def _incident_event(
@@ -668,17 +680,22 @@ def _latest_observation(
     return next(iter(records), None)
 
 
-def _open_incident(
+def _open_incidents(
     *, record_store: PublicIngressMonitorStore, record: PublicIngressObservationRecord
-) -> PublicIngressIncidentRecord | None:
+) -> tuple[PublicIngressIncidentRecord, ...]:
     incidents = record_store.list_public_ingress_incident_records(
         product=record.product,
         context_name=record.context,
         instance_name=record.instance,
         status="open",
-        limit=1,
     )
-    return next(iter(incidents), None)
+    return tuple(
+        incident
+        for incident in incidents
+        if incident.product == record.product
+        and incident.context == record.context
+        and incident.instance == record.instance
+    )
 
 
 def _should_notify(

--- a/tests/test_product_environment_read_model.py
+++ b/tests/test_product_environment_read_model.py
@@ -17,6 +17,7 @@ from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.product_environment_read_model import (
     ACTION_AUTHZ_BY_ROUTE,
+    ProductEnvironmentReadModelCapabilityError,
     build_product_activity_read_model,
     build_product_environment_config_status,
     build_product_environment_detail,
@@ -274,10 +275,42 @@ class _PublicIngressReadModelStore(_PreviewRecordStore):
             and (not instance_name or incident.instance == instance_name)
             and (not status or incident.status == status)
         ]
-        incidents.sort(key=lambda incident: (incident.opened_at, incident.incident_id), reverse=True)
+        incidents.sort(
+            key=lambda incident: (incident.opened_at, incident.incident_id), reverse=True
+        )
         if limit is not None:
             incidents = incidents[:limit]
         return tuple(incidents)
+
+
+class _PublicIngressObservationsOnlyStore(_PreviewRecordStore):
+    def __init__(
+        self,
+        profile: LaunchplaneProductProfileRecord,
+        observations: tuple[PublicIngressObservationRecord, ...],
+    ) -> None:
+        super().__init__(profile, ())
+        self._observations = observations
+
+    def list_public_ingress_observation_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[PublicIngressObservationRecord, ...]:
+        records = [
+            record
+            for record in self._observations
+            if (not product or record.product == product)
+            and (not context_name or record.context == context_name)
+            and (not instance_name or record.instance == instance_name)
+        ]
+        records.sort(key=lambda record: (record.observed_at, record.record_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
 
 
 class _ActivityRecordStore(_PreviewRecordStore):
@@ -994,6 +1027,48 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
         self.assertEqual(prod_summary.public_ingress.incident_status, "open")
         self.assertEqual(prod_summary.public_ingress.incident_id, incident.incident_id)
         self.assertTrue(detail.public_ingress.notification_sent)
+
+    def test_product_environment_detail_fails_without_public_ingress_incident_support(
+        self,
+    ) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(
+            _site_profile_payload(preview_enabled=False)
+        )
+        observation = PublicIngressObservationRecord(
+            record_id="public-ingress-example-site-prod-20260529t120000z",
+            product="example-site",
+            context="example-site-prod",
+            instance="prod",
+            observed_at="2026-05-29T12:00:00Z",
+            status="fail",
+            failure_code="http_error",
+            base_url="https://example-site.example",
+            health_url="https://example-site.example/healthz",
+            targets=(
+                PublicIngressTargetObservation(
+                    target="base_url",
+                    url="https://example-site.example",
+                    status="fail",
+                    failure_code="http_error",
+                    http_status=503,
+                    summary="HTTP 503",
+                ),
+            ),
+            notification_sent=True,
+            summary="Public ingress failed for example-site/prod: HTTP 503",
+        )
+        store = _PublicIngressObservationsOnlyStore(profile, (observation,))
+
+        with self.assertRaisesRegex(
+            ProductEnvironmentReadModelCapabilityError,
+            r"missing store method\(s\): list_public_ingress_incident_records",
+        ):
+            build_product_environment_detail(
+                record_store=store,
+                product="example-site",
+                environment="prod",
+                action_allowed=lambda *_: False,
+            )
 
     def test_product_environment_detail_exposes_runtime_identity_evidence(self) -> None:
         profile = LaunchplaneProductProfileRecord.model_validate(

--- a/tests/test_public_ingress_monitor.py
+++ b/tests/test_public_ingress_monitor.py
@@ -19,6 +19,7 @@ from control_plane.contracts.public_ingress_monitoring import (
 from control_plane.contracts.public_ingress_monitoring import PublicIngressNotificationDestination
 from control_plane.contracts.public_ingress_monitoring import PublicIngressNotificationPolicyRecord
 from control_plane.contracts.public_ingress_monitoring import PublicIngressTargetObservation
+from control_plane.contracts.public_ingress_monitoring import build_public_ingress_lane_incident_id
 from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.workflows.public_ingress_monitor import (
     HttpObservation,
@@ -403,6 +404,104 @@ class PublicIngressMonitorTests(unittest.TestCase):
         self.assertEqual(incident.opened_observation_id, store.records[0].record_id)
         self.assertEqual(incident.latest_observation_id, store.records[2].record_id)
         self.assertEqual(incident.resolved_observation_id, store.records[2].record_id)
+
+    def test_reuses_lane_scoped_public_ingress_incident_for_repeated_failures(self) -> None:
+        store = _Store((_profile(),))
+        incident_id = build_public_ingress_lane_incident_id(
+            product="example-site",
+            context="example-site",
+            instance="prod",
+        )
+        store.incidents.append(
+            PublicIngressIncidentRecord(
+                incident_id=incident_id,
+                product="example-site",
+                repository="cbusillo/example-site",
+                driver_id="generic-web",
+                context="example-site",
+                instance="prod",
+                status="open",
+                opened_at="2026-05-29T12:20:00Z",
+                opened_observation_id="public-ingress-example-site-prod-20260529t122000z",
+                latest_observation_id="public-ingress-example-site-prod-20260529t122000z",
+                latest_observed_at="2026-05-29T12:20:00Z",
+                failure_code="http_error",
+                summary="Public ingress failed.",
+            )
+        )
+
+        result = run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:25:00Z",
+            http_get=lambda url, _timeout: HttpObservation(
+                status_code=500,
+                final_url=url,
+                redirect_count=0,
+            ),
+        )
+
+        self.assertEqual(result.open_incident_count, 1)
+        self.assertEqual(len(store.incidents), 1)
+        self.assertEqual(store.incidents[0].incident_id, incident_id)
+        self.assertEqual(store.incidents[0].opened_at, "2026-05-29T12:20:00Z")
+        self.assertEqual(store.incidents[0].latest_observed_at, "2026-05-29T12:25:00Z")
+
+    def test_resolves_all_open_public_ingress_incidents_on_recovery(self) -> None:
+        store = _Store((_profile(),))
+        store.incidents.extend(
+            (
+                PublicIngressIncidentRecord(
+                    incident_id="public-ingress-incident-example-site-prod-1",
+                    product="example-site",
+                    repository="cbusillo/example-site",
+                    driver_id="generic-web",
+                    context="example-site",
+                    instance="prod",
+                    status="open",
+                    opened_at="2026-05-29T12:20:00Z",
+                    opened_observation_id="public-ingress-example-site-prod-20260529t122000z",
+                    latest_observation_id="public-ingress-example-site-prod-20260529t122000z",
+                    latest_observed_at="2026-05-29T12:20:00Z",
+                    failure_code="http_error",
+                    summary="Public ingress failed.",
+                ),
+                PublicIngressIncidentRecord(
+                    incident_id="public-ingress-incident-example-site-prod-2",
+                    product="example-site",
+                    repository="cbusillo/example-site",
+                    driver_id="generic-web",
+                    context="example-site",
+                    instance="prod",
+                    status="open",
+                    opened_at="2026-05-29T12:21:00Z",
+                    opened_observation_id="public-ingress-example-site-prod-20260529t122100z",
+                    latest_observation_id="public-ingress-example-site-prod-20260529t122100z",
+                    latest_observed_at="2026-05-29T12:21:00Z",
+                    failure_code="http_error",
+                    summary="Public ingress failed again.",
+                ),
+            )
+        )
+
+        result = run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:30:00Z",
+            http_get=lambda url, _timeout: HttpObservation(
+                status_code=200,
+                final_url=url,
+                redirect_count=0,
+            ),
+        )
+
+        self.assertEqual(result.resolved_incident_count, 2)
+        self.assertEqual(len(store.incidents), 2)
+        self.assertTrue(all(incident.status == "resolved" for incident in store.incidents))
+        self.assertTrue(
+            all(
+                incident.resolved_observation_id == store.records[-1].record_id
+                for incident in store.incidents
+            )
+        )
 
     def test_policy_driven_incident_notifications_record_attempts(self) -> None:
         store = _Store((_profile(),))


### PR DESCRIPTION
## Summary
- use a stable lane-scoped incident id so overlapping/repeated failures converge on one open incident
- resolve all open incidents for a lane on recovery to clean up stale duplicate-open rows
- require public-ingress incident listing support in the product read model instead of silently hiding active incidents

## Validation
- `uv run python -m unittest tests.test_public_ingress_monitor tests.test_product_environment_read_model tests.test_product_read_service`
- `uv run --extra dev ruff check control_plane/contracts/public_ingress_monitoring.py control_plane/contracts/product_environment_read_model.py control_plane/product_read_service.py control_plane/workflows/public_ingress_monitor.py tests/test_public_ingress_monitor.py tests/test_product_environment_read_model.py`
- `uv run --extra dev ruff format --check control_plane/contracts/public_ingress_monitoring.py control_plane/contracts/product_environment_read_model.py control_plane/product_read_service.py control_plane/workflows/public_ingress_monitor.py tests/test_public_ingress_monitor.py tests/test_product_environment_read_model.py`
- `uv run --extra dev mypy control_plane tests`

Refs #929
Refs #984
Refs #985
