### PR TITLE
Wire public ingress notification policy apply and delivery

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -174,6 +174,10 @@ from control_plane.contracts.promotion_record import (
     PromotionRecord,
     ReleaseStatus,
 )
+from control_plane.contracts.public_ingress_monitoring import (
+    PublicIngressIncidentRecord,
+    PublicIngressNotificationPolicyRecord,
+)
 from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyTarget
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
 from control_plane.runtime_key_safety import (
@@ -322,6 +326,7 @@ from control_plane.workflows.odoo_preview_runtime import (
 )
 from control_plane.workflows.product_onboarding import apply_product_onboarding_manifest
 from control_plane.workflows.public_ingress_monitor import (
+    PublicIngressNotificationDriverSet,
     build_github_issue_notifier,
     run_public_ingress_monitor_once,
 )
@@ -860,6 +865,24 @@ class PublicIngressMonitorRunOnceEnvelope(BaseModel):
         if self.product.strip() != "launchplane":
             raise ValueError("public ingress monitor run requires product 'launchplane'")
         self.product = "launchplane"
+        return self
+
+
+class PublicIngressNotificationPolicyApplyEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    mode: Literal["dry-run", "apply"] = "dry-run"
+    policy: PublicIngressNotificationPolicyRecord
+    reason: str = ""
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "PublicIngressNotificationPolicyApplyEnvelope":
+        self.reason = self.reason.strip()
+        if self.policy.product and self.policy.product != "launchplane":
+            raise ValueError(
+                "public ingress notification policy apply requires product 'launchplane'"
+            )
         return self
 
 
@@ -2967,6 +2990,13 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         "run-once",
     ]:
         return "public_ingress_monitor.run_once", {}
+    if len(segments) == 4 and segments == [
+        "v1",
+        "public-ingress",
+        "notification-policies",
+        "apply",
+    ]:
+        return "public_ingress_notification_policy.apply", {}
     if len(segments) == 4 and segments[:2] == ["v1", "products"] and segments[3] == "activity":
         return "product_environment.read", {"product": segments[2], "activity": "true"}
     if len(segments) == 3 and segments[:2] == ["v1", "products"]:
@@ -3064,6 +3094,7 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/work-graph/github/issues/reconcile",
         "/v1/work-graph/rank",
         "/v1/products/public-ingress-monitor/run-once",
+        "/v1/public-ingress/notification-policies/apply",
         "/v1/evidence/deployments",
         "/v1/evidence/backup-gates",
         "/v1/evidence/runner-host-hygiene/audits",
@@ -5083,6 +5114,7 @@ def _accepted_payload(
         "odoo_stable_target_replacement_operation_id",
         "runner_host_hygiene_audit_record_key",
         "generic_web_rollback_plan_id",
+        "public_ingress_notification_policy_id",
     }
     accepted_record_keys = record_keys | extra_record_keys
     records: dict[str, object] = {}
@@ -5601,6 +5633,64 @@ def _local_operator_product_config_dry_run_exists(
         return False
     return stored_record.request_fingerprint == _request_fingerprint(
         _local_operator_product_config_continuity_payload(payload=request_payload)
+    )
+
+
+def _public_ingress_notification_policy_summary(
+    policy: PublicIngressNotificationPolicyRecord,
+) -> dict[str, object]:
+    return {
+        "policy_id": policy.policy_id,
+        "product": policy.product,
+        "context": policy.context,
+        "instance": policy.instance,
+        "status": policy.status,
+        "destination_count": len(policy.destinations),
+        "destination_kinds": sorted({destination.kind for destination in policy.destinations}),
+        "created_at": policy.created_at,
+        "updated_at": policy.updated_at,
+        "source": policy.source,
+    }
+
+
+def _public_ingress_managed_secret_resolver(
+    *,
+    record_store: control_plane_secrets.SecretReadStore,
+) -> Callable[[str, PublicIngressIncidentRecord], str]:
+    def resolve(secret_id: str, incident: PublicIngressIncidentRecord) -> str:
+        normalized_secret_id = secret_id.strip()
+        if not normalized_secret_id:
+            return ""
+        try:
+            record = record_store.read_secret_record(normalized_secret_id)
+        except Exception:  # noqa: BLE001 - delivery records capture missing secrets per destination.
+            return ""
+        if record.status != control_plane_secrets.SECRET_STATUS_CONFIGURED:
+            return ""
+        if not control_plane_secrets._scope_matches_record(
+            record,
+            context_name=incident.context,
+            instance_name=incident.instance,
+        ):
+            return ""
+        try:
+            version = record_store.read_secret_version(record.current_version_id)
+            return control_plane_secrets._decrypt_secret_value(version.ciphertext)
+        except Exception:  # noqa: BLE001 - delivery records capture unreadable secrets per destination.
+            return ""
+
+    return resolve
+
+
+def _public_ingress_notification_drivers(
+    *,
+    record_store: object,
+) -> PublicIngressNotificationDriverSet:
+    secret_store = _secret_capable_store(record_store)
+    if secret_store is None:
+        return PublicIngressNotificationDriverSet()
+    return PublicIngressNotificationDriverSet(
+        incident_secret_resolver=_public_ingress_managed_secret_resolver(record_store=secret_store)
     )
 
 
@@ -10712,9 +10802,94 @@ def create_launchplane_service_app(
                     timeout_seconds=monitor_request.timeout_seconds,
                     notify=monitor_request.notify,
                     notifier=notifier,
+                    notification_drivers=(
+                        _public_ingress_notification_drivers(record_store=record_store)
+                        if monitor_request.notify
+                        else None
+                    ),
                 )
                 result = monitor_result.model_dump(mode="json")
                 driver_result = result
+            elif path == "/v1/public-ingress/notification-policies/apply":
+                policy_request = PublicIngressNotificationPolicyApplyEnvelope.model_validate(
+                    payload
+                )
+                if isinstance(identity, LocalOperatorIdentity) and not policy_request.reason:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=400,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "reason_required",
+                                "message": (
+                                    "Local operator public ingress notification policy apply"
+                                    " requires a reason."
+                                ),
+                            },
+                        },
+                    )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="public_ingress_notification_policy.apply",
+                    product=policy_request.policy.product or "launchplane",
+                    context=policy_request.policy.context or _LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot apply public ingress notification policy."
+                                ),
+                            },
+                        },
+                    )
+                if not isinstance(record_store, PostgresRecordStore):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "database_required",
+                                "message": (
+                                    "Public ingress notification policy apply requires"
+                                    " DB-backed Launchplane storage."
+                                ),
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                if policy_request.mode == "apply":
+                    record_store.write_public_ingress_notification_policy_record(
+                        policy_request.policy
+                    )
+                summary = _public_ingress_notification_policy_summary(policy_request.policy)
+                result = {
+                    "public_ingress_notification_policy_id": policy_request.policy.policy_id,
+                }
+                driver_result = {
+                    "mode": policy_request.mode,
+                    "changed": policy_request.mode == "apply",
+                    "policy": summary,
+                }
             elif path == "/v1/every-code/work-requests/claim":
                 if not authz_policy.allows(
                     identity=identity,

--- a/control_plane/service_auth.py
+++ b/control_plane/service_auth.py
@@ -78,6 +78,7 @@ LOCAL_OPERATOR_ALLOWED_ACTIONS = frozenset(
     {
         "merge_train.policy_targets",
         "public_ingress_monitor.run_once",
+        "public_ingress_notification_policy.apply",
         "product_config.plan",
         "product_config.apply",
         "work_graph.issue_inbox.reconcile",

--- a/control_plane/workflows/public_ingress_monitor.py
+++ b/control_plane/workflows/public_ingress_monitor.py
@@ -837,11 +837,13 @@ class PublicIngressNotificationDriverSet:
         | None = None,
         discord_sender: Callable[[str, dict[str, object]], object] | None = None,
         secret_resolver: Callable[[str], str] | None = None,
+        incident_secret_resolver: Callable[[str, PublicIngressIncidentRecord], str] | None = None,
     ) -> None:
         self.github_client = github_client or _gh_issue_client
         self.email_sender = email_sender or _send_email_message
         self.discord_sender = discord_sender or _post_discord_webhook
         self.secret_resolver = secret_resolver or (lambda _secret_name: "")
+        self.incident_secret_resolver = incident_secret_resolver
 
     def send(
         self,
@@ -869,7 +871,7 @@ class PublicIngressNotificationDriverSet:
                     incident=incident,
                     observation=observation,
                     email_sender=self.email_sender,
-                    secret_resolver=self.secret_resolver,
+                    secret_resolver=lambda secret_name: self._resolve_secret(secret_name, incident),
                 )
             if destination.kind == "discord":
                 return _deliver_discord_notification(
@@ -878,7 +880,7 @@ class PublicIngressNotificationDriverSet:
                     incident=incident,
                     observation=observation,
                     discord_sender=self.discord_sender,
-                    secret_resolver=self.secret_resolver,
+                    secret_resolver=lambda secret_name: self._resolve_secret(secret_name, incident),
                 )
         except Exception as error:  # noqa: BLE001 - delivery failures are recorded per destination.
             return PublicIngressNotificationDelivery(
@@ -891,6 +893,11 @@ class PublicIngressNotificationDriverSet:
             action="unsupported_destination",
             error_message=f"Unsupported public ingress notification destination: {destination.kind}",
         )
+
+    def _resolve_secret(self, secret_name: str, incident: PublicIngressIncidentRecord) -> str:
+        if self.incident_secret_resolver is not None:
+            return self.incident_secret_resolver(secret_name, incident)
+        return self.secret_resolver(secret_name)
 
 
 def _deliver_github_issue_notification(

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -100,6 +100,7 @@ Current implementation scope:
 - `POST /v1/authz-policies/github-humans/grants`
 - `POST /v1/product-profiles/context-cutover/apply`
 - `POST /v1/products/public-ingress-monitor/run-once`
+- `POST /v1/public-ingress/notification-policies/apply`
 - `POST /v1/previews/lifecycle-plan`
 - `POST /v1/drivers/verireel/preview-refresh`
 - `POST /v1/drivers/verireel/preview-destroy`

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -699,6 +699,16 @@ Product profiles are Launchplane-owned product/driver bindings. They are written
 through authenticated service ingress and stored in Launchplane records; product
 repos do not carry repo-local Launchplane lifecycle manifests.
 
+Public ingress notification policy writes use
+`POST /v1/public-ingress/notification-policies/apply`. The request carries
+`mode: "dry-run"` or `mode: "apply"` and a complete
+`PublicIngressNotificationPolicyRecord`. Apply requires
+`public_ingress_notification_policy.apply`, DB-backed Launchplane storage, and
+an idempotency key when a caller wants retry-safe service semantics. Local
+operator calls must include a non-empty reason. Policies store routing intent and
+managed secret record ids only; Discord webhook URLs, SMTP credentials, and
+operator destination values must not be encoded in text-file defaults or source.
+
 Product config writes use `POST /v1/product-config/apply`. The request carries
 `mode: "dry-run"` or `mode: "apply"`, product/context/instance, non-secret
 runtime values, and write-only managed secret values. Dry-run requires the

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -81,6 +81,11 @@ from control_plane.contracts.promotion_record import (
     HealthcheckEvidence,
     PromotionRecord,
 )
+from control_plane.contracts.public_ingress_monitoring import (
+    PublicIngressIncidentRecord,
+    PublicIngressNotificationDestination,
+    PublicIngressNotificationPolicyRecord,
+)
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeKeySafetyPolicyRecord,
@@ -967,6 +972,24 @@ def _generic_site_profile_payload(product: str = "example-site") -> dict[str, ob
 
 def _sqlite_database_url(database_path: Path) -> str:
     return f"sqlite+pysqlite:///{database_path}"
+
+
+def _public_ingress_incident(
+    *, context: str = "launchplane", instance: str = "prod"
+) -> PublicIngressIncidentRecord:
+    return PublicIngressIncidentRecord(
+        incident_id=f"public-ingress-incident-{context}-{instance}",
+        product="launchplane",
+        context=context,
+        instance=instance,
+        status="open",
+        opened_at="2026-05-29T12:00:00Z",
+        opened_observation_id="public-ingress-observation-opened",
+        latest_observation_id="public-ingress-observation-latest",
+        latest_observed_at="2026-05-29T12:00:00Z",
+        failure_code="http_error",
+        summary="Public ingress failed.",
+    )
 
 
 def create_launchplane_service_app(
@@ -1925,6 +1948,263 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 202)
         self.assertEqual(payload["status"], "accepted")
         run_monitor.assert_called_once()
+        self.assertIsNone(run_monitor.call_args.kwargs["notification_drivers"])
+
+    def test_public_ingress_monitor_run_once_service_wires_notification_drivers(
+        self,
+    ) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/public-ingress-monitor.yml@refs/heads/main"
+                        ],
+                        "event_names": ["schedule"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["public_ingress_monitor.run_once"],
+                    }
+                ]
+            }
+        )
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/public-ingress-monitor.yml@refs/heads/main",
+            event_name="schedule",
+        )
+
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                local_record_store_for_tests=store,
+                verifier=_StubVerifier(identity),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch("control_plane.service.run_public_ingress_monitor_once") as run_monitor:
+                run_monitor.return_value = PublicIngressMonitorResult(
+                    checked_at="2026-05-29T12:00:00Z",
+                    target_count=1,
+                    pass_count=1,
+                    records=(),
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/products/public-ingress-monitor/run-once",
+                    payload={"schema_version": 1, "product": "launchplane", "notify": True},
+                    headers={"Idempotency-Key": "public-ingress-monitor-notify-test"},
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["status"], "accepted")
+        run_monitor.assert_called_once()
+        self.assertIsNotNone(run_monitor.call_args.kwargs["notification_drivers"])
+
+    def test_public_ingress_notification_drivers_resolve_lane_scoped_secrets(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                with patch.dict(
+                    os.environ,
+                    {
+                        control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: (
+                            "test-master-key"
+                        )
+                    },
+                    clear=True,
+                ):
+                    secret_result = control_plane_secrets.write_secret_value(
+                        record_store=store,
+                        scope="context_instance",
+                        integration="public-ingress-notifications",
+                        name="discord webhook",
+                        plaintext_value="https://discord.com/api/webhooks/test/webhook",
+                        binding_key="DISCORD_WEBHOOK",
+                        context_name="example-site",
+                        instance_name="prod",
+                        actor="test",
+                        source_label="test",
+                    )
+                    resolver = control_plane_service._public_ingress_managed_secret_resolver(
+                        record_store=store
+                    )
+                    incident = _public_ingress_incident(context="example-site", instance="prod")
+                    other_incident = _public_ingress_incident(
+                        context="example-site", instance="preview"
+                    )
+                    resolved_value = resolver(str(secret_result["secret_id"]), incident)
+                    unresolved_value = resolver(str(secret_result["secret_id"]), other_incident)
+            finally:
+                store.close()
+
+        self.assertEqual(resolved_value, "https://discord.com/api/webhooks/test/webhook")
+        self.assertEqual(unresolved_value, "")
+
+    def test_public_ingress_notification_policy_apply_writes_db_policy(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["public_ingress_notification_policy.apply"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            policy_record = PublicIngressNotificationPolicyRecord(
+                policy_id="public-ingress-notification-launchplane",
+                product="launchplane",
+                context="launchplane",
+                status="enabled",
+                created_at="2026-05-29T12:00:00Z",
+                updated_at="2026-05-29T12:00:00Z",
+                source="test",
+                destinations=(
+                    PublicIngressNotificationDestination(
+                        destination_id="discord",
+                        kind="discord",
+                        discord_webhook_secret="secret-discord-webhook",
+                    ),
+                ),
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/public-ingress/notification-policies/apply",
+                payload={
+                    "schema_version": 1,
+                    "mode": "apply",
+                    "policy": policy_record.model_dump(mode="json"),
+                },
+                headers={"Idempotency-Key": "public-ingress-notification-policy-test"},
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                records = store.list_public_ingress_notification_policy_records(
+                    product="launchplane", context_name="launchplane", status="enabled"
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(
+            payload["records"]["public_ingress_notification_policy_id"],
+            policy_record.policy_id,
+        )
+        self.assertEqual(payload["result"]["mode"], "apply")
+        self.assertEqual(records, (policy_record,))
+
+    def test_public_ingress_notification_policy_dry_run_does_not_write(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["public_ingress_notification_policy.apply"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            policy_record = PublicIngressNotificationPolicyRecord(
+                policy_id="public-ingress-notification-launchplane-dry-run",
+                product="launchplane",
+                context="launchplane",
+                status="enabled",
+                created_at="2026-05-29T12:00:00Z",
+                updated_at="2026-05-29T12:00:00Z",
+                source="test",
+                destinations=(
+                    PublicIngressNotificationDestination(
+                        destination_id="discord",
+                        kind="discord",
+                        discord_webhook_secret="secret-discord-webhook",
+                    ),
+                ),
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/public-ingress/notification-policies/apply",
+                payload={
+                    "schema_version": 1,
+                    "mode": "dry-run",
+                    "policy": policy_record.model_dump(mode="json"),
+                },
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                records = store.list_public_ingress_notification_policy_records()
+            finally:
+                store.close()
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "dry-run")
+        self.assertEqual(records, ())
 
     def test_merge_train_run_once_service_returns_dry_run_from_policy(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -259,6 +259,7 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
             "every_code_work_request.rerun": "safe_write",
             "product_config.apply": "mutation",
             "product_config.apply.secret": "secret_backed",
+            "public_ingress_notification_policy.apply": "mutation",
             "generic_web_prod_promotion.execute": "prod",
             "preview_destroy.execute": "destructive",
             "secret_binding.apply": "secret_backed",


### PR DESCRIPTION
## Summary
- add DB-backed public ingress notification policy apply route with dry-run/apply, authz, idempotency, and DB-only writes
- wire scheduled public ingress monitor service route to pass notification drivers with managed-secret resolution
- document the service route and no text-file notification config boundary

Closes #990.

## Tests
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_public_ingress_monitor_run_once_service_writes_observation tests.test_service.LaunchplaneServiceTests.test_public_ingress_monitor_run_once_service_wires_notification_drivers tests.test_service.LaunchplaneServiceTests.test_public_ingress_notification_policy_apply_writes_db_policy tests.test_service.LaunchplaneServiceTests.test_public_ingress_notification_policy_dry_run_does_not_write tests.test_service_auth.LaunchplaneAuthzPolicyBoundaryTests.test_action_safety_classifies_privileged_action_families tests.test_public_ingress_monitor
- uv run python -m unittest tests.test_service tests.test_service_auth tests.test_public_ingress_monitor tests.test_postgres_store tests.test_filesystem_store
- uv run --extra dev mypy control_plane tests
- uv run ruff check control_plane/service.py control_plane/service_auth.py tests/test_service.py tests/test_service_auth.py
- uv run ruff format --check control_plane/service.py control_plane/service_auth.py tests/test_service.py tests/test_service_auth.py