### PR TITLE
Add policy-backed owner agent auth

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -26,6 +26,11 @@ on:
         required: false
         default: true
         type: boolean
+      omit_owner_agent_env:
+        description: Temporarily omit owner-agent env for one compatibility deploy.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   actions: read
@@ -79,6 +84,9 @@ jobs:
       LAUNCHPLANE_LOCAL_OPERATOR_TOKEN: ${{ secrets.LAUNCHPLANE_LOCAL_OPERATOR_TOKEN }}
       LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT: ${{ vars.LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT }}
       LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL: ${{ vars.LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL }}
+      LAUNCHPLANE_LOCAL_ADMIN_TOKEN: ${{ secrets.LAUNCHPLANE_LOCAL_ADMIN_TOKEN }}
+      LAUNCHPLANE_LOCAL_ADMIN_SUBJECT: ${{ vars.LAUNCHPLANE_LOCAL_ADMIN_SUBJECT }}
+      LAUNCHPLANE_LOCAL_ADMIN_TOKEN_LABEL: ${{ vars.LAUNCHPLANE_LOCAL_ADMIN_TOKEN_LABEL }}
       LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_LOGINS: ${{ vars.LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_LOGINS }}
       LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_PRODUCTS: ${{ vars.LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_PRODUCTS }}
       LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_CONTEXTS: ${{ vars.LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_CONTEXTS }}
@@ -266,8 +274,12 @@ jobs:
                 --arg local_operator_token "${LAUNCHPLANE_LOCAL_OPERATOR_TOKEN:-}" \
                 --arg local_operator_subject "${LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT:-}" \
                 --arg local_operator_token_label "${LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL:-}" \
+                --arg local_admin_token "${LAUNCHPLANE_LOCAL_ADMIN_TOKEN:-}" \
+                --arg local_admin_subject "${LAUNCHPLANE_LOCAL_ADMIN_SUBJECT:-}" \
+                --arg local_admin_token_label "${LAUNCHPLANE_LOCAL_ADMIN_TOKEN_LABEL:-}" \
                 --argjson omit_every_code_env '${{ inputs.omit_every_code_env || false }}' \
                 --argjson omit_terminal_agent_env '${{ inputs.omit_terminal_agent_env != false }}' \
+                --argjson omit_owner_agent_env '${{ inputs.omit_owner_agent_env || false }}' \
                 '(
                   {
                   LAUNCHPLANE_GITHUB_CLIENT_ID: $github_client_id,
@@ -282,10 +294,21 @@ jobs:
                       {
                         LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN: $terminal_agent_read_token,
                         LAUNCHPLANE_TERMINAL_AGENT_SUBJECT: $terminal_agent_subject,
-                        LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL: $terminal_agent_token_label,
+                        LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL: $terminal_agent_token_label
+                      }
+                    else
+                      {}
+                    end
+                  )
+                  + (
+                    if ($omit_owner_agent_env | not) then
+                      {
                         LAUNCHPLANE_LOCAL_OPERATOR_TOKEN: $local_operator_token,
                         LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT: $local_operator_subject,
-                        LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL: $local_operator_token_label
+                        LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL: $local_operator_token_label,
+                        LAUNCHPLANE_LOCAL_ADMIN_TOKEN: $local_admin_token,
+                        LAUNCHPLANE_LOCAL_ADMIN_SUBJECT: $local_admin_subject,
+                        LAUNCHPLANE_LOCAL_ADMIN_TOKEN_LABEL: $local_admin_token_label
                       }
                     else
                       {}

--- a/control_plane/authz_grant_service.py
+++ b/control_plane/authz_grant_service.py
@@ -17,6 +17,10 @@ from control_plane.service_auth import (
     GitHubHumanIdentity,
     LaunchplaneAuthzPolicy,
     LaunchplaneIdentity,
+    LocalAdminIdentity,
+    LocalAdminPolicyRule,
+    LocalOperatorIdentity,
+    LocalOperatorPolicyRule,
     TerminalAgentIdentity,
     TerminalAgentPolicyRule,
 )
@@ -200,9 +204,7 @@ class AuthzPolicyTerminalAgentGrant(BaseModel):
             raise ValueError("Authz terminal-agent policy grant requires a token label.")
         if not self.actions:
             raise ValueError("Authz terminal-agent policy grant requires at least one action.")
-        self.source_label = (
-            self.source_label.strip() or "service:authz-terminal-agent-policy-grant"
-        )
+        self.source_label = self.source_label.strip() or "service:authz-terminal-agent-policy-grant"
         return self
 
     def to_policy_rule(self) -> TerminalAgentPolicyRule:
@@ -228,7 +230,9 @@ class AuthzPolicyTerminalAgentGrantEnvelope(BaseModel):
     @model_validator(mode="after")
     def _validate_alignment(self) -> "AuthzPolicyTerminalAgentGrantEnvelope":
         if self.product.strip() != "launchplane":
-            raise ValueError("Authz terminal-agent policy grant writes require product 'launchplane'.")
+            raise ValueError(
+                "Authz terminal-agent policy grant writes require product 'launchplane'."
+            )
         self.product = "launchplane"
         self.reason = self.reason.strip()
         self.related_issue = self.related_issue.strip()
@@ -237,15 +241,145 @@ class AuthzPolicyTerminalAgentGrantEnvelope(BaseModel):
         return self
 
 
+class AuthzPolicyLocalOperatorGrant(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    subjects: tuple[str, ...] = ()
+    token_labels: tuple[str, ...] = ()
+    products: tuple[str, ...] = ()
+    contexts: tuple[str, ...] = ()
+    actions: tuple[str, ...]
+    source_label: str = "service:authz-local-operator-policy-grant"
+
+    @staticmethod
+    def _normalized_tuple(values: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(value.strip() for value in values if value.strip())
+
+    @model_validator(mode="after")
+    def _validate_grant(self) -> "AuthzPolicyLocalOperatorGrant":
+        self.subjects = self._normalized_tuple(self.subjects)
+        self.token_labels = self._normalized_tuple(self.token_labels)
+        self.products = self._normalized_tuple(self.products)
+        self.contexts = self._normalized_tuple(self.contexts)
+        self.actions = self._normalized_tuple(self.actions)
+        if not self.subjects:
+            raise ValueError("Authz local-operator policy grant requires a subject.")
+        if not self.token_labels:
+            raise ValueError("Authz local-operator policy grant requires a token label.")
+        if not self.actions:
+            raise ValueError("Authz local-operator policy grant requires at least one action.")
+        self.source_label = self.source_label.strip() or "service:authz-local-operator-policy-grant"
+        return self
+
+    def to_policy_rule(self) -> LocalOperatorPolicyRule:
+        return LocalOperatorPolicyRule(
+            subjects=self.subjects,
+            token_labels=self.token_labels,
+            products=self.products,
+            contexts=self.contexts,
+            actions=self.actions,
+        )
+
+
+class AuthzPolicyLocalOperatorGrantEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    mode: Literal["dry_run", "apply"] = "apply"
+    reason: str = ""
+    related_issue: str = ""
+    grant: AuthzPolicyLocalOperatorGrant
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "AuthzPolicyLocalOperatorGrantEnvelope":
+        if self.product.strip() != "launchplane":
+            raise ValueError(
+                "Authz local-operator policy grant writes require product 'launchplane'."
+            )
+        self.product = "launchplane"
+        self.reason = self.reason.strip()
+        self.related_issue = self.related_issue.strip()
+        if self.mode == "apply" and not self.reason:
+            raise ValueError("Authz local-operator policy grant apply requires reason.")
+        return self
+
+
+class AuthzPolicyLocalAdminGrant(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    subjects: tuple[str, ...] = ()
+    token_labels: tuple[str, ...] = ()
+    products: tuple[str, ...] = ()
+    contexts: tuple[str, ...] = ()
+    actions: tuple[str, ...]
+    source_label: str = "service:authz-local-admin-policy-grant"
+
+    @staticmethod
+    def _normalized_tuple(values: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(value.strip() for value in values if value.strip())
+
+    @model_validator(mode="after")
+    def _validate_grant(self) -> "AuthzPolicyLocalAdminGrant":
+        self.subjects = self._normalized_tuple(self.subjects)
+        self.token_labels = self._normalized_tuple(self.token_labels)
+        self.products = self._normalized_tuple(self.products)
+        self.contexts = self._normalized_tuple(self.contexts)
+        self.actions = self._normalized_tuple(self.actions)
+        if not self.subjects:
+            raise ValueError("Authz local-admin policy grant requires a subject.")
+        if not self.token_labels:
+            raise ValueError("Authz local-admin policy grant requires a token label.")
+        if not self.actions:
+            raise ValueError("Authz local-admin policy grant requires at least one action.")
+        self.source_label = self.source_label.strip() or "service:authz-local-admin-policy-grant"
+        return self
+
+    def to_policy_rule(self) -> LocalAdminPolicyRule:
+        return LocalAdminPolicyRule(
+            subjects=self.subjects,
+            token_labels=self.token_labels,
+            products=self.products,
+            contexts=self.contexts,
+            actions=self.actions,
+        )
+
+
+class AuthzPolicyLocalAdminGrantEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    mode: Literal["dry_run", "apply"] = "apply"
+    reason: str = ""
+    related_issue: str = ""
+    grant: AuthzPolicyLocalAdminGrant
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "AuthzPolicyLocalAdminGrantEnvelope":
+        if self.product.strip() != "launchplane":
+            raise ValueError("Authz local-admin policy grant writes require product 'launchplane'.")
+        self.product = "launchplane"
+        self.reason = self.reason.strip()
+        self.related_issue = self.related_issue.strip()
+        if self.mode == "apply" and not self.reason:
+            raise ValueError("Authz local-admin policy grant apply requires reason.")
+        return self
+
+
 AuthzPolicyGrant = (
     AuthzPolicyGitHubActionsGrant
     | AuthzPolicyGitHubHumanGrant
     | AuthzPolicyTerminalAgentGrant
+    | AuthzPolicyLocalOperatorGrant
+    | AuthzPolicyLocalAdminGrant
 )
 AuthzPolicyGrantEnvelope = (
     AuthzPolicyGitHubActionsGrantEnvelope
     | AuthzPolicyGitHubHumanGrantEnvelope
     | AuthzPolicyTerminalAgentGrantEnvelope
+    | AuthzPolicyLocalOperatorGrantEnvelope
+    | AuthzPolicyLocalAdminGrantEnvelope
 )
 
 
@@ -259,6 +393,8 @@ def summarize_authz_policy_record(record: LaunchplaneAuthzPolicyRecord) -> dict[
         "github_actions_rule_count": len(record.policy.github_actions),
         "github_humans_rule_count": len(record.policy.github_humans),
         "terminal_agents_rule_count": len(record.policy.terminal_agents),
+        "local_operators_rule_count": len(record.policy.local_operators),
+        "local_admins_rule_count": len(record.policy.local_admins),
     }
 
 
@@ -272,6 +408,18 @@ def authz_policy_operator_payload(identity: LaunchplaneIdentity) -> dict[str, ob
     if isinstance(identity, TerminalAgentIdentity):
         return {
             "type": "terminal_agent",
+            "subject": identity.subject,
+            "token_label": identity.token_label,
+        }
+    if isinstance(identity, LocalOperatorIdentity):
+        return {
+            "type": "local_operator",
+            "subject": identity.subject,
+            "token_label": identity.token_label,
+        }
+    if isinstance(identity, LocalAdminIdentity):
+        return {
+            "type": "local_admin",
             "subject": identity.subject,
             "token_label": identity.token_label,
         }
@@ -294,6 +442,10 @@ def authz_policy_grant_diff(
         changed = not any(rule == desired_rule for rule in current_policy.github_humans)
     elif isinstance(grant, AuthzPolicyTerminalAgentGrant):
         changed = not any(rule == desired_rule for rule in current_policy.terminal_agents)
+    elif isinstance(grant, AuthzPolicyLocalOperatorGrant):
+        changed = not any(rule == desired_rule for rule in current_policy.local_operators)
+    elif isinstance(grant, AuthzPolicyLocalAdminGrant):
+        changed = not any(rule == desired_rule for rule in current_policy.local_admins)
     else:
         changed = not any(rule == desired_rule for rule in current_policy.github_actions)
     return {
@@ -307,6 +459,12 @@ def authz_policy_grant_diff(
         "previous_terminal_agents_rule_count": len(current_policy.terminal_agents),
         "new_terminal_agents_rule_count": len(current_policy.terminal_agents)
         + int(changed and isinstance(grant, AuthzPolicyTerminalAgentGrant)),
+        "previous_local_operators_rule_count": len(current_policy.local_operators),
+        "new_local_operators_rule_count": len(current_policy.local_operators)
+        + int(changed and isinstance(grant, AuthzPolicyLocalOperatorGrant)),
+        "previous_local_admins_rule_count": len(current_policy.local_admins),
+        "new_local_admins_rule_count": len(current_policy.local_admins)
+        + int(changed and isinstance(grant, AuthzPolicyLocalAdminGrant)),
     }
 
 
@@ -320,10 +478,20 @@ def authz_policy_grant_audit_payload(
     trace_id: str,
     now_timestamp: TimestampProvider,
 ) -> dict[str, object]:
+    principal_type = "github_actions"
+    if isinstance(request.grant, AuthzPolicyGitHubHumanGrant):
+        principal_type = "github_human"
+    elif isinstance(request.grant, AuthzPolicyTerminalAgentGrant):
+        principal_type = "terminal_agent"
+    elif isinstance(request.grant, AuthzPolicyLocalOperatorGrant):
+        principal_type = "local_operator"
+    elif isinstance(request.grant, AuthzPolicyLocalAdminGrant):
+        principal_type = "local_admin"
     return {
         "mode": request.mode,
         "reason": request.reason,
         "related_issue": request.related_issue,
+        "principal_type": principal_type,
         "operator": authz_policy_operator_payload(identity),
         "requested_grant": request.grant.to_policy_rule().model_dump(mode="json"),
         "previous_policy_record_id": previous_record.record_id,
@@ -358,8 +526,9 @@ def authz_policy_grant_response_audit_payload(
                 "actions": requested_grant.get("actions") or (),
             }
         elif "subjects" in requested_grant or "token_labels" in requested_grant:
+            principal_type = str(response_audit.get("principal_type") or "terminal_agent")
             response_audit["requested_grant_summary"] = {
-                "principal_type": "terminal_agent",
+                "principal_type": principal_type,
                 "subject_count": len(requested_grant.get("subjects") or ()),
                 "token_label_count": len(requested_grant.get("token_labels") or ()),
                 "products": requested_grant.get("products") or (),
@@ -424,6 +593,46 @@ def plan_terminal_agent_authz_policy_grant(
     *,
     record_store: AuthzPolicyRecordStore,
     grant: AuthzPolicyTerminalAgentGrant,
+) -> tuple[LaunchplaneAuthzPolicy, LaunchplaneAuthzPolicyRecord, dict[str, object]]:
+    active_records = record_store.list_authz_policy_records(status="active", limit=1)
+    if not active_records:
+        raise ValueError("No active Launchplane authz policy record found.")
+    current_record = active_records[0]
+    current_policy = current_record.policy
+    return (
+        current_policy,
+        current_record,
+        authz_policy_grant_diff(
+            current_policy=current_policy,
+            grant=grant,
+        ),
+    )
+
+
+def plan_local_operator_authz_policy_grant(
+    *,
+    record_store: AuthzPolicyRecordStore,
+    grant: AuthzPolicyLocalOperatorGrant,
+) -> tuple[LaunchplaneAuthzPolicy, LaunchplaneAuthzPolicyRecord, dict[str, object]]:
+    active_records = record_store.list_authz_policy_records(status="active", limit=1)
+    if not active_records:
+        raise ValueError("No active Launchplane authz policy record found.")
+    current_record = active_records[0]
+    current_policy = current_record.policy
+    return (
+        current_policy,
+        current_record,
+        authz_policy_grant_diff(
+            current_policy=current_policy,
+            grant=grant,
+        ),
+    )
+
+
+def plan_local_admin_authz_policy_grant(
+    *,
+    record_store: AuthzPolicyRecordStore,
+    grant: AuthzPolicyLocalAdminGrant,
 ) -> tuple[LaunchplaneAuthzPolicy, LaunchplaneAuthzPolicyRecord, dict[str, object]]:
     active_records = record_store.list_authz_policy_records(status="active", limit=1)
     if not active_records:
@@ -614,6 +823,146 @@ def write_terminal_agent_authz_policy_grant(
 
     updated_policy = current_policy.model_copy(
         update={"terminal_agents": current_policy.terminal_agents + (desired_rule,)}
+    )
+    updated_at = now_timestamp()
+    policy_sha256 = authz_policy_sha256(updated_policy)
+    record = LaunchplaneAuthzPolicyRecord(
+        record_id=build_authz_policy_record_id(
+            updated_at=updated_at,
+            policy_sha256=policy_sha256,
+        ),
+        status="active",
+        source=request.grant.source_label,
+        updated_at=updated_at,
+        policy_sha256=policy_sha256,
+        policy=updated_policy,
+        audit=authz_policy_grant_audit_payload(
+            request=request,
+            identity=identity,
+            previous_record=current_record,
+            new_record=None,
+            changed=True,
+            trace_id=trace_id,
+            now_timestamp=now_timestamp,
+        ),
+    )
+    record.audit = authz_policy_grant_audit_payload(
+        request=request,
+        identity=identity,
+        previous_record=current_record,
+        new_record=record,
+        changed=True,
+        trace_id=trace_id,
+        now_timestamp=now_timestamp,
+    )
+    record_store.write_authz_policy_record(record)
+    return updated_policy, record, changed, diff, record.audit
+
+
+def write_local_operator_authz_policy_grant(
+    *,
+    record_store: AuthzPolicyRecordStore,
+    request: AuthzPolicyLocalOperatorGrantEnvelope,
+    identity: LaunchplaneIdentity,
+    trace_id: str,
+    now_timestamp: TimestampProvider,
+) -> tuple[
+    LaunchplaneAuthzPolicy,
+    LaunchplaneAuthzPolicyRecord,
+    bool,
+    dict[str, object],
+    dict[str, object],
+]:
+    current_policy, current_record, diff = plan_local_operator_authz_policy_grant(
+        record_store=record_store,
+        grant=request.grant,
+    )
+    changed = bool(diff["changed"])
+    desired_rule = request.grant.to_policy_rule()
+    if not changed:
+        audit = authz_policy_grant_audit_payload(
+            request=request,
+            identity=identity,
+            previous_record=current_record,
+            new_record=None,
+            changed=False,
+            trace_id=trace_id,
+            now_timestamp=now_timestamp,
+        )
+        return current_policy, current_record, False, diff, audit
+
+    updated_policy = current_policy.model_copy(
+        update={"local_operators": current_policy.local_operators + (desired_rule,)}
+    )
+    updated_at = now_timestamp()
+    policy_sha256 = authz_policy_sha256(updated_policy)
+    record = LaunchplaneAuthzPolicyRecord(
+        record_id=build_authz_policy_record_id(
+            updated_at=updated_at,
+            policy_sha256=policy_sha256,
+        ),
+        status="active",
+        source=request.grant.source_label,
+        updated_at=updated_at,
+        policy_sha256=policy_sha256,
+        policy=updated_policy,
+        audit=authz_policy_grant_audit_payload(
+            request=request,
+            identity=identity,
+            previous_record=current_record,
+            new_record=None,
+            changed=True,
+            trace_id=trace_id,
+            now_timestamp=now_timestamp,
+        ),
+    )
+    record.audit = authz_policy_grant_audit_payload(
+        request=request,
+        identity=identity,
+        previous_record=current_record,
+        new_record=record,
+        changed=True,
+        trace_id=trace_id,
+        now_timestamp=now_timestamp,
+    )
+    record_store.write_authz_policy_record(record)
+    return updated_policy, record, changed, diff, record.audit
+
+
+def write_local_admin_authz_policy_grant(
+    *,
+    record_store: AuthzPolicyRecordStore,
+    request: AuthzPolicyLocalAdminGrantEnvelope,
+    identity: LaunchplaneIdentity,
+    trace_id: str,
+    now_timestamp: TimestampProvider,
+) -> tuple[
+    LaunchplaneAuthzPolicy,
+    LaunchplaneAuthzPolicyRecord,
+    bool,
+    dict[str, object],
+    dict[str, object],
+]:
+    current_policy, current_record, diff = plan_local_admin_authz_policy_grant(
+        record_store=record_store,
+        grant=request.grant,
+    )
+    changed = bool(diff["changed"])
+    desired_rule = request.grant.to_policy_rule()
+    if not changed:
+        audit = authz_policy_grant_audit_payload(
+            request=request,
+            identity=identity,
+            previous_record=current_record,
+            new_record=None,
+            changed=False,
+            trace_id=trace_id,
+            now_timestamp=now_timestamp,
+        )
+        return current_policy, current_record, False, diff, audit
+
+    updated_policy = current_policy.model_copy(
+        update={"local_admins": current_policy.local_admins + (desired_rule,)}
     )
     updated_at = now_timestamp()
     policy_sha256 = authz_policy_sha256(updated_policy)

--- a/control_plane/contracts/authz_policy_record.py
+++ b/control_plane/contracts/authz_policy_record.py
@@ -16,6 +16,10 @@ def authz_policy_sha256(policy: LaunchplaneAuthzPolicy) -> str:
     payload = policy.model_dump(mode="json", exclude_none=True)
     if not policy.terminal_agents:
         payload.pop("terminal_agents", None)
+    if not policy.local_operators:
+        payload.pop("local_operators", None)
+    if not policy.local_admins:
+        payload.pop("local_admins", None)
     canonical_json = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canonical_json.encode("utf-8")).hexdigest()
 

--- a/control_plane/product_config_http.py
+++ b/control_plane/product_config_http.py
@@ -13,6 +13,7 @@ from control_plane.product_config import ProductConfigStore
 from control_plane.service_auth import (
     LaunchplaneAuthzPolicy,
     LaunchplaneIdentity,
+    LocalAdminIdentity,
     LocalOperatorIdentity,
 )
 
@@ -144,7 +145,7 @@ def validate_product_config_apply_request(
     start_response: StartResponse,
 ) -> tuple[ProductConfigApplyEnvelope | None, list[bytes] | None]:
     request = ProductConfigApplyEnvelope.model_validate(payload)
-    if isinstance(identity, LocalOperatorIdentity) and not request.reason:
+    if isinstance(identity, (LocalOperatorIdentity, LocalAdminIdentity)) and not request.reason:
         return None, json_response(
             start_response=start_response,
             status_code=400,

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -208,6 +208,7 @@ from control_plane.service_auth import (
     GitHubHumanIdentity,
     LaunchplaneAuthzPolicy,
     LaunchplaneIdentity,
+    LocalAdminIdentity,
     LocalOperatorIdentity,
     TerminalAgentIdentity,
     TokenVerifier,
@@ -774,6 +775,9 @@ _LAUNCHPLANE_SELF_DEPLOY_OAUTH_ENV_KEYS = frozenset(
         "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN",
         "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT",
         "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL",
+        "LAUNCHPLANE_LOCAL_ADMIN_TOKEN",
+        "LAUNCHPLANE_LOCAL_ADMIN_SUBJECT",
+        "LAUNCHPLANE_LOCAL_ADMIN_TOKEN_LABEL",
         "LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER",
         "LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER",
         "LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT",
@@ -2440,6 +2444,8 @@ _HUMAN_IDENTITY_MUTATION_ROUTES = frozenset(
         "/v1/authz-policies/github-actions/grants",
         "/v1/authz-policies/github-humans/grants",
         "/v1/authz-policies/terminal-agents/grants",
+        "/v1/authz-policies/local-operators/grants",
+        "/v1/authz-policies/local-admins/grants",
         "/v1/merge-train/policies/import",
     }
 )
@@ -3103,6 +3109,8 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/authz-policies/github-actions/grants",
         "/v1/authz-policies/github-humans/grants",
         "/v1/authz-policies/terminal-agents/grants",
+        "/v1/authz-policies/local-operators/grants",
+        "/v1/authz-policies/local-admins/grants",
         "/v1/merge-train/policies/import",
         "/v1/runtime-key-safety/policies/apply",
         "/v1/live-target-runtime/apply",
@@ -4993,6 +5001,8 @@ def _identity_actor(identity: LaunchplaneIdentity) -> str:
         return f"github:{identity.login}"
     if isinstance(identity, LocalOperatorIdentity):
         return f"local-operator:{identity.subject}"
+    if isinstance(identity, LocalAdminIdentity):
+        return f"local-admin:{identity.subject}"
     if isinstance(identity, TerminalAgentIdentity):
         return f"terminal-agent:{identity.subject}"
     return (
@@ -5005,6 +5015,8 @@ def _idempotency_scope(identity: LaunchplaneIdentity) -> str:
         return "|".join(("github-human", identity.login, str(identity.github_id)))
     if isinstance(identity, LocalOperatorIdentity):
         return "|".join(("local-operator", identity.subject, identity.token_label))
+    if isinstance(identity, LocalAdminIdentity):
+        return "|".join(("local-admin", identity.subject, identity.token_label))
     if isinstance(identity, TerminalAgentIdentity):
         return "|".join(("terminal-agent", identity.subject, identity.token_label))
     workflow_ref = identity.workflow_ref or identity.job_workflow_ref or ""
@@ -5767,6 +5779,8 @@ def _should_store_idempotency_record(
             "/v1/authz-policies/github-actions/grants",
             "/v1/authz-policies/github-humans/grants",
             "/v1/authz-policies/terminal-agents/grants",
+            "/v1/authz-policies/local-operators/grants",
+            "/v1/authz-policies/local-admins/grants",
         }
         and isinstance(driver_result, dict)
         and driver_result.get("mode") == "dry_run"
@@ -5869,6 +5883,18 @@ def _local_operator_token_label_from_env() -> str:
     return os.environ.get("LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL", "local-owner-write").strip()
 
 
+def _local_admin_token_from_env() -> str:
+    return os.environ.get("LAUNCHPLANE_LOCAL_ADMIN_TOKEN", "").strip()
+
+
+def _local_admin_subject_from_env() -> str:
+    return os.environ.get("LAUNCHPLANE_LOCAL_ADMIN_SUBJECT", "local-owner-admin").strip()
+
+
+def _local_admin_token_label_from_env() -> str:
+    return os.environ.get("LAUNCHPLANE_LOCAL_ADMIN_TOKEN_LABEL", "local-owner-admin").strip()
+
+
 def _local_operator_identity_from_bearer(
     environ: dict[str, object],
 ) -> LocalOperatorIdentity | None:
@@ -5884,6 +5910,23 @@ def _local_operator_identity_from_bearer(
     subject = _local_operator_subject_from_env() or "local-owner-agent"
     token_label = _local_operator_token_label_from_env() or "local-owner-write"
     return LocalOperatorIdentity(subject=subject, token_label=token_label)
+
+
+def _local_admin_identity_from_bearer(
+    environ: dict[str, object],
+) -> LocalAdminIdentity | None:
+    expected_token = _local_admin_token_from_env()
+    if not expected_token:
+        return None
+    try:
+        provided_token = _bearer_token(environ)
+    except PermissionError:
+        return None
+    if not secrets.compare_digest(provided_token, expected_token):
+        return None
+    subject = _local_admin_subject_from_env() or "local-owner-admin"
+    token_label = _local_admin_token_label_from_env() or "local-owner-admin"
+    return LocalAdminIdentity(subject=subject, token_label=token_label)
 
 
 def _terminal_agent_identity_from_bearer(
@@ -6505,6 +6548,9 @@ def _read_identity(
     )
     if human_identity is not None:
         return human_identity
+    local_admin_identity = _local_admin_identity_from_bearer(environ)
+    if local_admin_identity is not None:
+        return local_admin_identity
     local_operator_identity = _local_operator_identity_from_bearer(environ)
     if local_operator_identity is not None:
         return local_operator_identity
@@ -6560,6 +6606,12 @@ def _authz_diagnostic_payload(
             "subject": identity.subject,
             "token_label": identity.token_label,
         }
+    elif isinstance(identity, LocalAdminIdentity):
+        identity_payload = {
+            "type": "local_admin",
+            "subject": identity.subject,
+            "token_label": identity.token_label,
+        }
     else:
         identity_payload = {
             "type": "github_actions",
@@ -6597,6 +6649,61 @@ def _authz_diagnostic_payload(
             "context": context,
         }
     return payload
+
+
+def _authz_policy_grant_database_required_response(
+    *, trace_id: str, principal_label: str, start_response: _StartResponse
+) -> list[bytes]:
+    return _json_response(
+        start_response=start_response,
+        status_code=503,
+        payload={
+            "status": "rejected",
+            "trace_id": trace_id,
+            "error": {
+                "code": "database_required",
+                "message": (
+                    f"Authz {principal_label} policy grant writes require Launchplane database storage."
+                ),
+            },
+        },
+    )
+
+
+def _authz_policy_grant_denied_response(
+    *, trace_id: str, principal_label: str, start_response: _StartResponse
+) -> list[bytes]:
+    return _json_response(
+        start_response=start_response,
+        status_code=403,
+        payload={
+            "status": "rejected",
+            "trace_id": trace_id,
+            "error": {
+                "code": "authorization_denied",
+                "message": (
+                    f"Workflow cannot write Launchplane authz {principal_label} policy grants."
+                ),
+            },
+        },
+    )
+
+
+def _authz_policy_unavailable_response(
+    *, trace_id: str, start_response: _StartResponse
+) -> list[bytes]:
+    return _json_response(
+        start_response=start_response,
+        status_code=503,
+        payload={
+            "status": "rejected",
+            "trace_id": trace_id,
+            "error": {
+                "code": "authz_policy_unavailable",
+                "message": "Launchplane active authz policy is unavailable.",
+            },
+        },
+    )
 
 
 def _product_profile_context_cutover_allowed_contexts(
@@ -8221,10 +8328,20 @@ def create_launchplane_service_app(
                         on_renewed_session=record_renewed_session,
                     )
                 else:
-                    token = _bearer_token(environ)
-                    identity = verifier.verify(token)
-                    if not isinstance(identity, GitHubActionsIdentity):
-                        raise PermissionError("Mutation routes require GitHub Actions OIDC.")
+                    local_admin_identity = _local_admin_identity_from_bearer(environ)
+                    if local_admin_identity is not None:
+                        identity = local_admin_identity
+                    else:
+                        local_operator_identity = _local_operator_identity_from_bearer(environ)
+                        if local_operator_identity is not None:
+                            identity = local_operator_identity
+                        else:
+                            token = _bearer_token(environ)
+                            identity = verifier.verify(token)
+                            if not isinstance(identity, GitHubActionsIdentity):
+                                raise PermissionError(
+                                    "Mutation routes require GitHub Actions OIDC."
+                                )
             if (
                 isinstance(identity, TerminalAgentIdentity)
                 and method != "GET"
@@ -10814,7 +10931,10 @@ def create_launchplane_service_app(
                 policy_request = PublicIngressNotificationPolicyApplyEnvelope.model_validate(
                     payload
                 )
-                if isinstance(identity, LocalOperatorIdentity) and not policy_request.reason:
+                if (
+                    isinstance(identity, (LocalOperatorIdentity, LocalAdminIdentity))
+                    and not policy_request.reason
+                ):
                     return _json_response(
                         start_response=start_response,
                         status_code=400,
@@ -11172,7 +11292,7 @@ def create_launchplane_service_app(
                     return product_config_response
                 assert product_config_request is not None
                 if (
-                    isinstance(identity, LocalOperatorIdentity)
+                    isinstance(identity, (LocalOperatorIdentity, LocalAdminIdentity))
                     and product_config_request.mode == "apply"
                     and not _local_operator_product_config_dry_run_exists(
                         record_store=record_store,
@@ -11223,7 +11343,7 @@ def create_launchplane_service_app(
                     return product_config_result
                 driver_result = product_config_result.driver_result
                 if (
-                    isinstance(identity, LocalOperatorIdentity)
+                    isinstance(identity, (LocalOperatorIdentity, LocalAdminIdentity))
                     and product_config_request.mode == "dry-run"
                 ):
                     _write_local_operator_product_config_dry_run_record(
@@ -11587,6 +11707,198 @@ def create_launchplane_service_app(
                         authz_policy_record=authz_policy_record,
                         changed=changed,
                         mode=terminal_authz_grant_request.mode,
+                        diff=diff,
+                        audit=audit,
+                    )
+                )
+            elif path == "/v1/authz-policies/local-operators/grants":
+                local_operator_grant_request = control_plane_authz_grant_service.AuthzPolicyLocalOperatorGrantEnvelope.model_validate(
+                    payload
+                )
+                if not isinstance(record_store, PostgresRecordStore):
+                    return _authz_policy_grant_database_required_response(
+                        trace_id=request_trace_id,
+                        principal_label="local-operator",
+                        start_response=start_response,
+                    )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="launchplane_service_deploy.execute",
+                    product=local_operator_grant_request.product,
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _authz_policy_grant_denied_response(
+                        trace_id=request_trace_id,
+                        principal_label="local-operator",
+                        start_response=start_response,
+                    )
+                if local_operator_grant_request.mode == "apply":
+                    idempotent_response = _check_idempotent_request(
+                        record_store=record_store,
+                        scope=request_scope,
+                        route_path=path,
+                        idempotency_key=request_idempotency_key,
+                        request_fingerprint=request_fingerprint,
+                        start_response=start_response,
+                        trace_id=request_trace_id,
+                    )
+                    if idempotent_response is not None:
+                        return idempotent_response
+                try:
+                    (
+                        current_policy,
+                        current_record,
+                        diff,
+                    ) = control_plane_authz_grant_service.plan_local_operator_authz_policy_grant(
+                        record_store=record_store,
+                        grant=local_operator_grant_request.grant,
+                    )
+                    audit = control_plane_authz_grant_service.authz_policy_grant_audit_payload(
+                        request=local_operator_grant_request,
+                        identity=identity,
+                        previous_record=current_record,
+                        new_record=None,
+                        changed=bool(diff["changed"]),
+                        trace_id=request_trace_id,
+                        now_timestamp=_now_timestamp,
+                    )
+                    authz_policy_record = current_record
+                    changed = bool(diff["changed"])
+                    if local_operator_grant_request.mode == "apply":
+                        (
+                            updated_policy,
+                            authz_policy_record,
+                            changed,
+                            diff,
+                            audit,
+                        ) = control_plane_authz_grant_service.write_local_operator_authz_policy_grant(
+                            record_store=record_store,
+                            request=local_operator_grant_request,
+                            identity=identity,
+                            trace_id=request_trace_id,
+                            now_timestamp=_now_timestamp,
+                        )
+                    else:
+                        updated_policy = current_policy
+                        authz_policy_record = LaunchplaneAuthzPolicyRecord(
+                            record_id=current_record.record_id,
+                            status=current_record.status,
+                            source=current_record.source,
+                            updated_at=current_record.updated_at,
+                            policy_sha256=current_record.policy_sha256,
+                            policy=current_record.policy,
+                            audit=audit,
+                        )
+                except ValueError:
+                    return _authz_policy_unavailable_response(
+                        trace_id=request_trace_id,
+                        start_response=start_response,
+                    )
+                if local_operator_grant_request.mode == "apply":
+                    authz_policy = updated_policy
+                    resolved_authz_policy_sha256 = authz_policy_record.policy_sha256
+                    resolved_authz_policy_source = "db"
+                result, driver_result = (
+                    control_plane_authz_grant_service.build_authz_policy_grant_service_result(
+                        authz_policy_record=authz_policy_record,
+                        changed=changed,
+                        mode=local_operator_grant_request.mode,
+                        diff=diff,
+                        audit=audit,
+                    )
+                )
+            elif path == "/v1/authz-policies/local-admins/grants":
+                local_admin_grant_request = control_plane_authz_grant_service.AuthzPolicyLocalAdminGrantEnvelope.model_validate(
+                    payload
+                )
+                if not isinstance(record_store, PostgresRecordStore):
+                    return _authz_policy_grant_database_required_response(
+                        trace_id=request_trace_id,
+                        principal_label="local-admin",
+                        start_response=start_response,
+                    )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="launchplane_service_deploy.execute",
+                    product=local_admin_grant_request.product,
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _authz_policy_grant_denied_response(
+                        trace_id=request_trace_id,
+                        principal_label="local-admin",
+                        start_response=start_response,
+                    )
+                if local_admin_grant_request.mode == "apply":
+                    idempotent_response = _check_idempotent_request(
+                        record_store=record_store,
+                        scope=request_scope,
+                        route_path=path,
+                        idempotency_key=request_idempotency_key,
+                        request_fingerprint=request_fingerprint,
+                        start_response=start_response,
+                        trace_id=request_trace_id,
+                    )
+                    if idempotent_response is not None:
+                        return idempotent_response
+                try:
+                    (
+                        current_policy,
+                        current_record,
+                        diff,
+                    ) = control_plane_authz_grant_service.plan_local_admin_authz_policy_grant(
+                        record_store=record_store,
+                        grant=local_admin_grant_request.grant,
+                    )
+                    audit = control_plane_authz_grant_service.authz_policy_grant_audit_payload(
+                        request=local_admin_grant_request,
+                        identity=identity,
+                        previous_record=current_record,
+                        new_record=None,
+                        changed=bool(diff["changed"]),
+                        trace_id=request_trace_id,
+                        now_timestamp=_now_timestamp,
+                    )
+                    authz_policy_record = current_record
+                    changed = bool(diff["changed"])
+                    if local_admin_grant_request.mode == "apply":
+                        (
+                            updated_policy,
+                            authz_policy_record,
+                            changed,
+                            diff,
+                            audit,
+                        ) = control_plane_authz_grant_service.write_local_admin_authz_policy_grant(
+                            record_store=record_store,
+                            request=local_admin_grant_request,
+                            identity=identity,
+                            trace_id=request_trace_id,
+                            now_timestamp=_now_timestamp,
+                        )
+                    else:
+                        updated_policy = current_policy
+                        authz_policy_record = LaunchplaneAuthzPolicyRecord(
+                            record_id=current_record.record_id,
+                            status=current_record.status,
+                            source=current_record.source,
+                            updated_at=current_record.updated_at,
+                            policy_sha256=current_record.policy_sha256,
+                            policy=current_record.policy,
+                            audit=audit,
+                        )
+                except ValueError:
+                    return _authz_policy_unavailable_response(
+                        trace_id=request_trace_id,
+                        start_response=start_response,
+                    )
+                if local_admin_grant_request.mode == "apply":
+                    authz_policy = updated_policy
+                    resolved_authz_policy_sha256 = authz_policy_record.policy_sha256
+                    resolved_authz_policy_source = "db"
+                result, driver_result = (
+                    control_plane_authz_grant_service.build_authz_policy_grant_service_result(
+                        authz_policy_record=authz_policy_record,
+                        changed=changed,
+                        mode=local_admin_grant_request.mode,
                         diff=diff,
                         audit=audit,
                     )

--- a/control_plane/service_auth.py
+++ b/control_plane/service_auth.py
@@ -52,11 +52,21 @@ class LocalOperatorIdentity:
     token_label: str
 
 
+@dataclass(frozen=True)
+class LocalAdminIdentity:
+    subject: str
+    token_label: str
+
+
 LaunchplaneIdentity = (
-    GitHubActionsIdentity | GitHubHumanIdentity | TerminalAgentIdentity | LocalOperatorIdentity
+    GitHubActionsIdentity
+    | GitHubHumanIdentity
+    | TerminalAgentIdentity
+    | LocalOperatorIdentity
+    | LocalAdminIdentity
 )
 AgentConsumerSubjectType = Literal[
-    "github_actions", "github_human", "terminal_agent", "local_operator"
+    "github_actions", "github_human", "terminal_agent", "local_operator", "local_admin"
 ]
 AgentConsumerAccessProfile = Literal[
     "automation_worker",
@@ -74,16 +84,6 @@ AgentConsumerActionSafety = Literal[
     "policy_admin",
 ]
 AgentAuthzDecision = Literal["allowed", "denied"]
-LOCAL_OPERATOR_ALLOWED_ACTIONS = frozenset(
-    {
-        "merge_train.policy_targets",
-        "public_ingress_monitor.run_once",
-        "public_ingress_notification_policy.apply",
-        "product_config.plan",
-        "product_config.apply",
-        "work_graph.issue_inbox.reconcile",
-    }
-)
 
 
 class TokenVerifier(Protocol):
@@ -282,6 +282,66 @@ class TerminalAgentPolicyRule(BaseModel):
         return True
 
 
+class LocalOperatorPolicyRule(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    subjects: tuple[str, ...] = ()
+    token_labels: tuple[str, ...] = ()
+    products: tuple[str, ...] = ()
+    contexts: tuple[str, ...] = ()
+    actions: tuple[str, ...] = ()
+
+    @staticmethod
+    def _matches_any(value: str, allowed_values: tuple[str, ...]) -> bool:
+        normalized_value = value.strip()
+        return any(fnmatchcase(normalized_value, allowed_value) for allowed_value in allowed_values)
+
+    def allows(
+        self, *, identity: LocalOperatorIdentity, action: str, product: str, context: str
+    ) -> bool:
+        if self.subjects and not self._matches_any(identity.subject, self.subjects):
+            return False
+        if self.token_labels and not self._matches_any(identity.token_label, self.token_labels):
+            return False
+        if self.products and product not in self.products:
+            return False
+        if self.contexts and context not in self.contexts:
+            return False
+        if self.actions and action not in self.actions:
+            return False
+        return True
+
+
+class LocalAdminPolicyRule(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    subjects: tuple[str, ...] = ()
+    token_labels: tuple[str, ...] = ()
+    products: tuple[str, ...] = ()
+    contexts: tuple[str, ...] = ()
+    actions: tuple[str, ...] = ()
+
+    @staticmethod
+    def _matches_any(value: str, allowed_values: tuple[str, ...]) -> bool:
+        normalized_value = value.strip()
+        return any(fnmatchcase(normalized_value, allowed_value) for allowed_value in allowed_values)
+
+    def allows(
+        self, *, identity: LocalAdminIdentity, action: str, product: str, context: str
+    ) -> bool:
+        if self.subjects and not self._matches_any(identity.subject, self.subjects):
+            return False
+        if self.token_labels and not self._matches_any(identity.token_label, self.token_labels):
+            return False
+        if self.products and product not in self.products:
+            return False
+        if self.contexts and context not in self.contexts:
+            return False
+        if self.actions and action not in self.actions:
+            return False
+        return True
+
+
 class AgentConsumerSubject(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -340,11 +400,19 @@ def limited_remote_user_action_allowed(action: str) -> bool:
     return action_safety(action) in {"read", "safe_write"}
 
 
-def local_operator_action_allowed(*, identity: LocalOperatorIdentity, action: str) -> bool:
+def local_operator_identity_valid(*, identity: LocalOperatorIdentity, action: str) -> bool:
     return (
         bool(identity.subject.strip())
         and bool(identity.token_label.strip())
-        and action.strip() in LOCAL_OPERATOR_ALLOWED_ACTIONS
+        and bool(action.strip())
+    )
+
+
+def local_admin_identity_valid(*, identity: LocalAdminIdentity, action: str) -> bool:
+    return (
+        bool(identity.subject.strip())
+        and bool(identity.token_label.strip())
+        and bool(action.strip())
     )
 
 
@@ -393,6 +461,20 @@ def agent_consumer_subject(
             action_safety=safety,
             read_only_context=safety == "read",
             approval_capable=safety in {"mutation", "prod", "destructive", "secret_backed"},
+        )
+    if isinstance(identity, LocalAdminIdentity):
+        return AgentConsumerSubject(
+            subject_type="local_admin",
+            subject=identity.subject,
+            display_label=identity.token_label,
+            access_profile="owner_local_agent",
+            role="admin",
+            product=product,
+            context=context,
+            action=action,
+            action_safety=safety,
+            read_only_context=safety == "read",
+            approval_capable=True,
         )
     return AgentConsumerSubject(
         subject_type="github_actions",
@@ -445,6 +527,8 @@ class LaunchplaneAuthzPolicy(BaseModel):
     github_actions: tuple[GitHubActionsPolicyRule, ...] = ()
     github_humans: tuple[GitHubHumanPolicyRule, ...] = ()
     terminal_agents: tuple[TerminalAgentPolicyRule, ...] = ()
+    local_operators: tuple[LocalOperatorPolicyRule, ...] = ()
+    local_admins: tuple[LocalAdminPolicyRule, ...] = ()
 
     def allows(
         self, *, identity: LaunchplaneIdentity, action: str, product: str, context: str
@@ -462,7 +546,15 @@ class LaunchplaneAuthzPolicy(BaseModel):
                 for rule in self.terminal_agents
             )
         if isinstance(identity, LocalOperatorIdentity):
-            return local_operator_action_allowed(identity=identity, action=action)
+            return local_operator_identity_valid(identity=identity, action=action) and any(
+                rule.allows(identity=identity, action=action, product=product, context=context)
+                for rule in self.local_operators
+            )
+        if isinstance(identity, LocalAdminIdentity):
+            return local_admin_identity_valid(identity=identity, action=action) and any(
+                rule.allows(identity=identity, action=action, product=product, context=context)
+                for rule in self.local_admins
+            )
         return any(
             rule.allows(identity=identity, action=action, product=product, context=context)
             for rule in self.github_actions

--- a/control_plane/work_graph_http.py
+++ b/control_plane/work_graph_http.py
@@ -11,6 +11,7 @@ from control_plane.service_auth import (
     GitHubActionsIdentity,
     GitHubHumanIdentity,
     LaunchplaneAuthzPolicy,
+    LocalAdminIdentity,
     LocalOperatorIdentity,
     TerminalAgentIdentity,
 )
@@ -34,7 +35,11 @@ JsonResponse = Callable[..., list[bytes]]
 StartResponse = Callable[[str, list[tuple[str, str]]], None]
 UtcNow = Callable[[], str]
 ResolvedLaunchplaneIdentity: TypeAlias = (
-    GitHubActionsIdentity | GitHubHumanIdentity | TerminalAgentIdentity | LocalOperatorIdentity
+    GitHubActionsIdentity
+    | GitHubHumanIdentity
+    | TerminalAgentIdentity
+    | LocalOperatorIdentity
+    | LocalAdminIdentity
 )
 
 LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"

--- a/docs/agent-context-boundary.md
+++ b/docs/agent-context-boundary.md
@@ -37,11 +37,13 @@ Agent context callers are identified as compact agent consumers:
   on `GET` routes; policy still scopes products, contexts, and read actions.
 - `owner_local_agent`: trusted local operator using
   `LAUNCHPLANE_LOCAL_OPERATOR_TOKEN` from
-  `~/.config/launchplane/local-operator.env`. This identity is limited to
-  reason-bearing product-config dry-run/apply from a trusted shell; apply
-  requires a previously recorded matching dry-run, and all other mutation,
-  destructive, production, secret-backed non-product-config, and authz policy
-  actions remain out of scope.
+  `~/.config/launchplane/local-operator.env`. This identity is limited by exact
+  DB-backed `local_operators` authz policy rules and must include a reason for
+  write requests. Apply-shaped product-config mutations require a previously
+  recorded matching dry-run.
+- `owner_local_agent`: trusted local admin using `LAUNCHPLANE_LOCAL_ADMIN_TOKEN`.
+  This identity is limited by exact DB-backed `local_admins` authz policy rules
+  and is reserved for deliberate escalation, not routine owner-agent writes.
 - `limited_remote_user`: authenticated GitHub human with read-only role. This
   profile fails closed to read and safe-write action families even if a policy
   rule is accidentally broad.

--- a/docs/config-boundary.md
+++ b/docs/config-boundary.md
@@ -41,17 +41,18 @@ it can reach, trust, or decrypt DB-backed state.
 | Every Code webhook ingress secret | `LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET` | Bootstrap env or platform secret | Required before unauthenticated GitHub webhook ingress can trust the request body. Store it outside repository config. |
 | Every Code worker bearer token | `LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN` | Bootstrap env or platform secret | Shared by the Launchplane service and local worker to authorize worker read/claim/status routes. Store it outside repository config. |
 | Terminal-agent read bearer token | `LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN`, optional `LAUNCHPLANE_TERMINAL_AGENT_SUBJECT`, optional `LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL` | Bootstrap env or platform secret | Shared by the Launchplane service and a trusted local terminal agent for redacted `GET` context reads only. Store it outside repository config and keep it distinct from Every Code worker credentials. |
-| Local-operator write bearer token | `LAUNCHPLANE_LOCAL_OPERATOR_TOKEN`, optional `LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT`, optional `LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL` | Bootstrap env or platform secret | Shared by the Launchplane service and trusted local owner automation for narrow reason-bearing operator mutations such as product-config plan/apply and public-ingress notification-policy apply. Store it outside repository config and keep it distinct from read-only terminal-agent credentials. |
+| Local-operator write bearer token | `LAUNCHPLANE_LOCAL_OPERATOR_TOKEN`, optional `LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT`, optional `LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL` | Bootstrap env or platform secret | Shared by the Launchplane service and trusted local owner automation for routine reason-bearing operator mutations. Exact authority is DB-backed by `local_operators` authz policy rules. Store it outside repository config and keep it distinct from read-only terminal-agent credentials. |
+| Local-admin write bearer token | `LAUNCHPLANE_LOCAL_ADMIN_TOKEN`, optional `LAUNCHPLANE_LOCAL_ADMIN_SUBJECT`, optional `LAUNCHPLANE_LOCAL_ADMIN_TOKEN_LABEL` | Bootstrap env or platform secret | Shared by the Launchplane service and trusted local owner automation for rare privileged mutations. Exact authority is DB-backed by `local_admins` authz policy rules; the token alone does not grant blanket access. Store it outside repository config and load it only for deliberate escalation. |
 
 The Launchplane self-deploy workflow has a manual `omit_every_code_env`
 compatibility input for the one deploy that teaches an older running service to
 accept the Every Code env keys. Leave it unset for normal deploys so the service
 and worker keep the shared token/webhook secret in sync.
 
-The manual `omit_terminal_agent_env` compatibility input also omits local-operator
-write credentials because those keys were introduced in the same self-deploy env
-handoff path. Leave it unset for normal deploys after the service accepts both
-terminal-agent and local-operator keys.
+The manual `omit_terminal_agent_env` compatibility input omits terminal-agent
+read credentials. Owner-agent write credentials use the separate
+`omit_owner_agent_env` compatibility input. Leave both unset for normal deploys
+after the service accepts terminal-agent, local-operator, and local-admin keys.
 
 | Work graph GitHub Project read source | `LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER`, `LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER`, optional `LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT`, optional `LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT`, optional `LAUNCHPLANE_WORK_GRAPH_GH_BINARY` | Service target env | Opt-in read source for compact Project fields plus bounded dependency, subissue, and PR check signals. Deploy automation forwards these values only when the GitHub Project token secret is present. Requires a `gh` credential with the GitHub CLI `project` scope. Does not store copied issue bodies. |
 | Work graph and merge-train GitHub token | `GH_TOKEN` from deploy secret `LAUNCHPLANE_WORK_GRAPH_GH_TOKEN` | Platform secret projected into service target env | Authenticates the service's non-interactive `gh` reads and merge-train GitHub API calls. The token must have enough GitHub access for the configured Project, issue/PR signal reads, and the configured merge-train repository. |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -98,6 +98,9 @@ Current implementation scope:
 - `POST /v1/evidence/previews/destroyed`
 - `POST /v1/authz-policies/github-actions/grants`
 - `POST /v1/authz-policies/github-humans/grants`
+- `POST /v1/authz-policies/terminal-agents/grants`
+- `POST /v1/authz-policies/local-operators/grants`
+- `POST /v1/authz-policies/local-admins/grants`
 - `POST /v1/product-profiles/context-cutover/apply`
 - `POST /v1/products/public-ingress-monitor/run-once`
 - `POST /v1/public-ingress/notification-policies/apply`
@@ -503,10 +506,11 @@ Current derived-state behavior:
   this route when their session has the exact product/context/action grant.
   Trusted owner terminals can also use the dedicated
   `LAUNCHPLANE_LOCAL_OPERATOR_TOKEN` from
-  `~/.config/launchplane/local-operator.env`; local-operator requests must
-  include a non-empty `reason`, and local-operator apply is rejected until the
-  service has recorded a matching local-operator dry-run. Terminal-agent read
-  bearer credentials stay read-only and cannot apply product config. The service
+  `~/.config/launchplane/local-operator.env` when exact DB-backed
+  `local_operators` policy rules grant the product/context/action. Owner-agent
+  requests must include a non-empty `reason`, and owner-agent apply is rejected
+  until the service has recorded a matching dry-run. Terminal-agent read bearer
+  credentials stay read-only and cannot apply product config. The service
   response is redacted and the route rejects nested runtime or secret targets
   that differ from the authorized top-level context/instance. It fails closed
   when secret writes are requested without the Launchplane master encryption key

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -168,11 +168,14 @@ title: Secrets
   binding for the target runtime class.
 - Trusted local agents that need to call the deployed service instead of a
   browser session should source `~/.config/launchplane/local-operator.env` and
-  use `LAUNCHPLANE_LOCAL_OPERATOR_TOKEN`. Write requests sent with this token
-  must include a reason. Product-config apply also requires a previously
-  recorded matching dry-run. They must still send plaintext secret values only in
-  the request body over the Launchplane service API. Do not copy those request
-  bodies into logs, GitHub issues, PR bodies, or docs.
+  use `LAUNCHPLANE_LOCAL_OPERATOR_TOKEN` for routine owner-agent writes. Exact
+  authority is DB-backed by `local_operators` authz policy rules. Rare privileged
+  owner-agent writes can use `LAUNCHPLANE_LOCAL_ADMIN_TOKEN` only when matching
+  `local_admins` authz policy rules grant the action. Write requests sent with
+  either token must include a reason. Product-config apply also requires a
+  previously recorded matching dry-run. They must still send plaintext secret
+  values only in the request body over the Launchplane service API. Do not copy
+  those request bodies into logs, GitHub issues, PR bodies, or docs.
 - `uv run launchplane environments unset --scope <scope> --key KEY` removes
   stale keys from DB-backed runtime-environment records without reading or
   printing plaintext values.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -60,6 +60,8 @@ VeriReel product paths:
   - `POST /v1/authz-policies/github-actions/grants`
   - `POST /v1/authz-policies/github-humans/grants`
   - `POST /v1/authz-policies/terminal-agents/grants`
+  - `POST /v1/authz-policies/local-operators/grants`
+  - `POST /v1/authz-policies/local-admins/grants`
 - Every Code local automation work-request routes:
   - `POST /v1/every-code/github-webhook`
   - `GET /v1/every-code/summary`
@@ -132,13 +134,14 @@ and preview mutations as authenticated Launchplane routes. The authz policy
 grant routes accept GitHub Actions OIDC callers and authenticated admin human
 sessions, require the `launchplane_service_deploy.execute` action, and remain
 the service-owned write/reload boundary for DB-backed GitHub Actions and GitHub
-human policy rules. The terminal-agent grant route uses the same boundary for
-DB-backed terminal-agent read rules. Grant requests support `dry_run` and
-`apply` modes. Apply requests must include an audit reason, write a new active
-policy record only when the grant is not already present, and immediately
-refresh the in-process policy used by the current service worker. Responses
-return record metadata, rule counts, a compact diff, and redacted audit metadata
-rather than echoing workflow refs, human logins, or the full policy body.
+human policy rules. Terminal-agent, local-operator, and local-admin grant routes
+use the same boundary for DB-backed owner-agent rules. Grant requests support
+`dry_run` and `apply` modes. Apply requests must include an audit reason and
+write a new active policy record only when the grant is not already present, and
+immediately refresh the in-process policy used by the current service worker.
+Responses return record metadata, rule counts, a compact diff, and redacted audit
+metadata rather than echoing workflow refs, human logins, owner-agent subjects,
+or the full policy body.
 
 The service also serves the built operator UI shell at `/`, with `/ui` retained
 as a compatibility alias. Built assets live under `/ui/assets/...`, while
@@ -193,22 +196,25 @@ agent can access, such as `product_environment.read` for product environment and
 config-status diagnostics.
 
 Trusted owner terminals that need to make Launchplane-owned operator mutations
-without a browser session can use a separate local-operator bearer credential.
+without a browser session can use separate owner-agent bearer credentials.
 Configure `LAUNCHPLANE_LOCAL_OPERATOR_TOKEN` on the service and provide the same
 secret to trusted local agents through
 `~/.config/launchplane/local-operator.env`. Optional
 `LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT` and
 `LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL` values identify the actor in audit and
 idempotency records; the defaults are `local-owner-agent` and
-`local-owner-write`. Local-operator write requests must include a non-empty
-`reason`; product-config apply is also rejected until the service has recorded a
-matching local-operator dry-run for the same product config payload. These
+`local-owner-write`. Routine owner-operator authority is DB-backed by
+`local_operators` authz policy rules, scoped by subject, token label, product,
+context, and action.
+
+Rare owner-admin operations use `LAUNCHPLANE_LOCAL_ADMIN_TOKEN` with optional
+`LAUNCHPLANE_LOCAL_ADMIN_SUBJECT` and `LAUNCHPLANE_LOCAL_ADMIN_TOKEN_LABEL`.
+Those credentials are also DB-backed by exact `local_admins` authz policy rules;
+the token alone does not grant blanket access. Owner-agent write requests must
+include a non-empty `reason`; product-config apply is also rejected until the
+service has recorded a matching owner-agent dry-run for the same payload. These
 requests still use Launchplane records, redacted responses, runtime key-safety
-policy, and managed secret storage. The local-operator identity is scoped to a
-narrow allowlist, including product-config plan/apply and public-ingress
-notification-policy apply. It is not accepted for product-profile reads or authz
-policy administration, so the credential cannot enumerate product profiles or
-rewrite its own permission model.
+policy, and managed secret storage. Terminal-agent credentials remain read-only.
 
 `GET /v1/every-code/summary` returns a compact agent-safe projection of Every
 Code work requests. It requires `every_code_work_request.read` for

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -126,6 +126,77 @@ post_terminal_agent_grant() {
   return 1
 }
 
+post_local_owner_grant() {
+  local principal="$1"
+  local product_name="$2"
+  local context_name="$3"
+  local action_name="$4"
+  local source_label="$5"
+  local idempotency_suffix="$6"
+  local subject_env_key token_label_env_key default_subject default_token_label route_path
+  local request_payload response_file status_code
+
+  if [ "$principal" = "local-admin" ]; then
+    subject_env_key="LAUNCHPLANE_LOCAL_ADMIN_SUBJECT"
+    token_label_env_key="LAUNCHPLANE_LOCAL_ADMIN_TOKEN_LABEL"
+    default_subject="local-owner-admin"
+    default_token_label="local-owner-admin"
+    route_path="/v1/authz-policies/local-admins/grants"
+  elif [ "$principal" = "local-operator" ]; then
+    subject_env_key="LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT"
+    token_label_env_key="LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL"
+    default_subject="local-owner-agent"
+    default_token_label="local-owner-write"
+    route_path="/v1/authz-policies/local-operators/grants"
+  else
+    echo "Unsupported local owner grant principal ${principal}." >&2
+    return 1
+  fi
+
+  request_payload="$({
+    jq -n \
+      --arg product_name "$product_name" \
+      --arg context_name "$context_name" \
+      --arg action_name "$action_name" \
+      --arg source_label "$source_label" \
+      --arg subject "${!subject_env_key:-$default_subject}" \
+      --arg token_label "${!token_label_env_key:-$default_token_label}" \
+      --arg principal "$principal" \
+      '{
+        schema_version: 1,
+        product: "launchplane",
+        mode: "apply",
+        reason: ("Deploy workflow ensuring " + $principal + " authz grant " + $source_label),
+        related_issue: "cbusillo/launchplane#929",
+        grant: {
+          subjects: [$subject],
+          token_labels: [$token_label],
+          products: [$product_name],
+          contexts: [$context_name],
+          actions: [$action_name],
+          source_label: $source_label
+        }
+      }'
+  })"
+  response_file="$(mktemp)"
+  status_code="$(curl -sS \
+    -o "$response_file" \
+    -w '%{http_code}' \
+    -X POST \
+    -H "Authorization: Bearer ${oidc_token}" \
+    -H 'Content-Type: application/json' \
+    -H "Idempotency-Key: launchplane-${principal}-authz-grant:${idempotency_suffix}:${GITHUB_SHA}" \
+    --data "$request_payload" \
+    "${LAUNCHPLANE_SERVICE_URL}${route_path}")"
+  if [ "$status_code" = "200" ] || [ "$status_code" = "202" ]; then
+    cat "$response_file"
+    return 0
+  fi
+  cat "$response_file" >&2
+  echo "Launchplane ${principal} authz grant request failed with HTTP ${status_code}." >&2
+  return 1
+}
+
 post_product_config_human_grant() {
   local action_name="$1"
   local source_label="$2"
@@ -1121,6 +1192,48 @@ post_terminal_agent_grant \
   every_code_preview_gate.read \
   deploy:terminal-agent-agent-context-preview-grant \
   terminal-agent-agent-context-preview
+post_local_owner_grant \
+  local-operator \
+  launchplane \
+  launchplane \
+  merge_train.policy_targets \
+  deploy:local-operator-merge-train-policy-targets-grant \
+  local-operator-merge-train-policy-targets
+post_local_owner_grant \
+  local-operator \
+  launchplane \
+  launchplane \
+  work_graph.issue_inbox.reconcile \
+  deploy:local-operator-work-graph-issue-inbox-reconcile-grant \
+  local-operator-work-graph-issue-inbox-reconcile
+post_local_owner_grant \
+  local-operator \
+  launchplane \
+  launchplane \
+  public_ingress_monitor.run_once \
+  deploy:local-operator-public-ingress-monitor-run-once-grant \
+  local-operator-public-ingress-monitor-run-once
+post_local_owner_grant \
+  local-operator \
+  launchplane \
+  launchplane \
+  public_ingress_notification_policy.apply \
+  deploy:local-operator-public-ingress-notification-policy-grant \
+  local-operator-public-ingress-notification-policy
+post_local_owner_grant \
+  local-operator \
+  "*" \
+  "*" \
+  product_config.plan \
+  deploy:local-operator-product-config-plan-grant \
+  local-operator-product-config-plan
+post_local_owner_grant \
+  local-operator \
+  "*" \
+  "*" \
+  product_config.apply \
+  deploy:local-operator-product-config-apply-grant \
+  local-operator-product-config-apply
 post_product_config_human_grant \
   product_config.plan \
   deploy:product-config-human-plan-grant \

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -642,6 +642,8 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
                     "/v1/authz-policies/github-actions/grants",
                     "/v1/authz-policies/github-humans/grants",
                     "/v1/authz-policies/terminal-agents/grants",
+                    "/v1/authz-policies/local-operators/grants",
+                    "/v1/authz-policies/local-admins/grants",
                     "/v1/merge-train/policies/import",
                 }
             ),

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -459,6 +459,18 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn("deploy:terminal-agent-product-profile-read-grant", script_text)
         self.assertIn("terminal-agent-product-profile-read", script_text)
 
+    def test_deploy_authz_grants_include_local_operator_notification_apply(
+        self,
+    ) -> None:
+        script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(encoding="utf-8")
+
+        self.assertIn("/v1/authz-policies/local-operators/grants", script_text)
+        self.assertIn("public_ingress_notification_policy.apply", script_text)
+        self.assertIn(
+            "deploy:local-operator-public-ingress-notification-policy-grant",
+            script_text,
+        )
+
     def test_deploy_verireel_onboarding_manifest_enrolls_preview_lifecycle(
         self,
     ) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -116,6 +116,10 @@ from control_plane.service_auth import (
     GitHubActionsIdentity,
     GitHubHumanIdentity,
     LaunchplaneAuthzPolicy,
+    LocalAdminIdentity,
+    LocalAdminPolicyRule,
+    LocalOperatorIdentity,
+    LocalOperatorPolicyRule,
     TerminalAgentIdentity,
 )
 from control_plane.service_human_auth import (
@@ -588,6 +592,46 @@ def _merge_train_service_policy() -> LaunchplaneAuthzPolicy:
                 }
             ]
         }
+    )
+
+
+def _local_operator_policy(
+    *,
+    actions: tuple[str, ...],
+    products: tuple[str, ...] = ("*",),
+    contexts: tuple[str, ...] = ("*",),
+    subject: str = "local-owner-agent",
+    token_label: str = "local-owner-write",
+) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy(
+        local_operators=(
+            LocalOperatorPolicyRule(
+                subjects=(subject,),
+                token_labels=(token_label,),
+                products=products,
+                contexts=contexts,
+                actions=actions,
+            ),
+        )
+    )
+
+
+def _local_admin_policy(
+    *,
+    actions: tuple[str, ...],
+    products: tuple[str, ...] = ("launchplane",),
+    contexts: tuple[str, ...] = ("launchplane",),
+) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy(
+        local_admins=(
+            LocalAdminPolicyRule(
+                subjects=("local-owner-admin",),
+                token_labels=("local-owner-admin",),
+                products=products,
+                contexts=contexts,
+                actions=actions,
+            ),
+        )
     )
 
 
@@ -2205,6 +2249,76 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 202)
         self.assertEqual(payload["result"]["mode"], "dry-run")
         self.assertEqual(records, ())
+
+    def test_public_ingress_notification_policy_local_operator_requires_policy_and_reason(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_local_operator_policy(
+                    actions=("public_ingress_notification_policy.apply",),
+                    products=("launchplane",),
+                    contexts=("launchplane",),
+                ),
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            policy_record = PublicIngressNotificationPolicyRecord(
+                policy_id="public-ingress-notification-local-operator",
+                product="launchplane",
+                context="launchplane",
+                status="enabled",
+                created_at="2026-05-29T12:00:00Z",
+                updated_at="2026-05-29T12:00:00Z",
+                source="test",
+                destinations=(
+                    PublicIngressNotificationDestination(
+                        destination_id="discord",
+                        kind="discord",
+                        discord_webhook_secret="secret-discord-webhook",
+                    ),
+                ),
+            )
+
+            with patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token"},
+                clear=True,
+            ):
+                no_reason_status, no_reason_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/public-ingress/notification-policies/apply",
+                    payload={
+                        "schema_version": 1,
+                        "mode": "apply",
+                        "policy": policy_record.model_dump(mode="json"),
+                    },
+                    authorization="Bearer local-operator-token",
+                    headers={"Idempotency-Key": "public-ingress-local-operator-no-reason"},
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/public-ingress/notification-policies/apply",
+                    payload={
+                        "schema_version": 1,
+                        "mode": "apply",
+                        "reason": "Enable local operator ingress notifications.",
+                        "policy": policy_record.model_dump(mode="json"),
+                    },
+                    authorization="Bearer local-operator-token",
+                    headers={"Idempotency-Key": "public-ingress-local-operator-apply"},
+                )
+
+        self.assertEqual(no_reason_status, 400)
+        self.assertEqual(no_reason_payload["error"]["code"], "reason_required")
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "apply")
 
     def test_merge_train_run_once_service_returns_dry_run_from_policy(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(
@@ -5796,13 +5910,17 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 {
                     "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-token",
                     "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-read",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
                 },
             ):
                 app = create_launchplane_service_app(
                     state_dir=state_dir,
                     verifier=_StubVerifier(_merge_train_service_identity()),
-                    authz_policy=LaunchplaneAuthzPolicy(),
+                    authz_policy=_local_operator_policy(
+                        actions=("merge_train.policy_targets",),
+                        products=("launchplane",),
+                        contexts=("launchplane",),
+                    ),
                     control_plane_root_path=Path(temporary_directory_name),
                 )
                 status_code, payload = _invoke_app(
@@ -13425,7 +13543,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
             app = create_launchplane_service_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(_identity()),
-                authz_policy=LaunchplaneAuthzPolicy(),
+                authz_policy=_local_operator_policy(
+                    actions=("product_config.plan",),
+                    products=("sellyouroutboard",),
+                    contexts=("sellyouroutboard",),
+                ),
                 control_plane_root_path=root,
                 database_url=database_url,
             )
@@ -13486,7 +13608,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
             app = create_launchplane_service_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(_identity()),
-                authz_policy=LaunchplaneAuthzPolicy(),
+                authz_policy=_local_operator_policy(
+                    actions=("product_config.apply",),
+                    products=("sellyouroutboard",),
+                    contexts=("sellyouroutboard",),
+                ),
                 control_plane_root_path=root,
                 database_url=database_url,
             )
@@ -13515,7 +13641,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
             app = create_launchplane_service_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(_identity()),
-                authz_policy=LaunchplaneAuthzPolicy(),
+                authz_policy=_local_operator_policy(
+                    actions=("product_config.apply",),
+                    products=("sellyouroutboard",),
+                    contexts=("sellyouroutboard",),
+                ),
                 control_plane_root_path=root,
                 database_url=database_url,
             )
@@ -13549,7 +13679,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
             app = create_launchplane_service_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(_identity()),
-                authz_policy=LaunchplaneAuthzPolicy(),
+                authz_policy=_local_operator_policy(
+                    actions=("product_config.plan", "product_config.apply"),
+                    products=("sellyouroutboard",),
+                    contexts=("sellyouroutboard",),
+                ),
                 control_plane_root_path=root,
                 database_url=database_url,
             )
@@ -13627,7 +13761,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
             app = create_launchplane_service_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(_identity()),
-                authz_policy=LaunchplaneAuthzPolicy(),
+                authz_policy=_local_operator_policy(
+                    actions=("product_config.plan",),
+                    products=("sellyouroutboard",),
+                    contexts=("sellyouroutboard",),
+                    subject="configured-local-owner",
+                    token_label="configured-write-token",
+                ),
                 control_plane_root_path=root,
                 database_url=database_url,
             )
@@ -20011,6 +20151,192 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertIsNone(dry_run_idempotency_record)
         self.assertEqual(read_status_code, 403)
         self.assertEqual(read_payload["error"]["code"], "authorization_denied")
+
+    def test_local_operator_authz_policy_grant_endpoint_writes_db_record_and_updates_runtime(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_humans": [
+                        {
+                            "logins": ["alice"],
+                            "roles": ["admin"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["launchplane_service_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=_StubGitHubOAuthClient(_human_identity(role="admin")),
+            )
+            cookie = _signed_in_cookie(app)
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/authz-policies/local-operators/grants",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "mode": "apply",
+                    "reason": "Allow local owner operator ingress notification config.",
+                    "related_issue": "cbusillo/launchplane#929",
+                    "grant": {
+                        "subjects": ["local-owner-agent"],
+                        "token_labels": ["local-owner-write"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["public_ingress_notification_policy.apply"],
+                        "source_label": "test:local-operator-grant",
+                    },
+                },
+                authorization="",
+                headers={
+                    "Cookie": cookie,
+                    "Idempotency-Key": "authz-local-operator-grant:ingress",
+                },
+            )
+            repeat_status_code, repeat_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/authz-policies/local-operators/grants",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "mode": "apply",
+                    "reason": "Allow local owner operator ingress notification config.",
+                    "related_issue": "cbusillo/launchplane#929",
+                    "grant": {
+                        "subjects": ["local-owner-agent"],
+                        "token_labels": ["local-owner-write"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["public_ingress_notification_policy.apply"],
+                        "source_label": "test:local-operator-grant",
+                    },
+                },
+                authorization="",
+                headers={
+                    "Cookie": cookie,
+                    "Idempotency-Key": "authz-local-operator-grant:ingress-repeat",
+                },
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                active_policy = store.list_authz_policy_records(status="active", limit=1)[0]
+            finally:
+                store.close()
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["changed"], True)
+        self.assertEqual(payload["result"]["diff"]["new_local_operators_rule_count"], 1)
+        self.assertEqual(
+            payload["result"]["audit"]["requested_grant_summary"]["principal_type"],
+            "local_operator",
+        )
+        self.assertNotIn(
+            "local-owner-agent",
+            json.dumps(payload["result"]["audit"]["requested_grant_summary"], sort_keys=True),
+        )
+        self.assertEqual(repeat_status_code, 202)
+        self.assertEqual(repeat_payload["result"]["changed"], False)
+        self.assertTrue(
+            active_policy.policy.allows(
+                identity=LocalOperatorIdentity(
+                    subject="local-owner-agent", token_label="local-owner-write"
+                ),
+                action="public_ingress_notification_policy.apply",
+                product="launchplane",
+                context="launchplane",
+            )
+        )
+
+    def test_local_admin_authz_policy_grant_endpoint_writes_separate_rule(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_humans": [
+                        {
+                            "logins": ["alice"],
+                            "roles": ["admin"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["launchplane_service_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=_StubGitHubOAuthClient(_human_identity(role="admin")),
+            )
+            cookie = _signed_in_cookie(app)
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/authz-policies/local-admins/grants",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "mode": "apply",
+                    "reason": "Allow local owner admin authz grants.",
+                    "related_issue": "cbusillo/launchplane#929",
+                    "grant": {
+                        "subjects": ["local-owner-admin"],
+                        "token_labels": ["local-owner-admin"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["launchplane_service_deploy.execute"],
+                        "source_label": "test:local-admin-grant",
+                    },
+                },
+                authorization="",
+                headers={
+                    "Cookie": cookie,
+                    "Idempotency-Key": "authz-local-admin-grant:self-deploy",
+                },
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                active_policy = store.list_authz_policy_records(status="active", limit=1)[0]
+            finally:
+                store.close()
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["diff"]["new_local_admins_rule_count"], 1)
+        self.assertEqual(
+            payload["result"]["audit"]["requested_grant_summary"]["principal_type"],
+            "local_admin",
+        )
+        self.assertTrue(
+            active_policy.policy.allows(
+                identity=LocalAdminIdentity(
+                    subject="local-owner-admin", token_label="local-owner-admin"
+                ),
+                action="launchplane_service_deploy.execute",
+                product="launchplane",
+                context="launchplane",
+            )
+        )
 
     def test_authz_policy_grant_endpoint_apply_requires_reason(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -14,14 +14,16 @@ from control_plane.service_auth import (
     GitHubHumanPolicyRule,
     GitHubOidcVerifier,
     LaunchplaneAuthzPolicy,
+    LocalAdminIdentity,
+    LocalAdminPolicyRule,
     LocalOperatorIdentity,
+    LocalOperatorPolicyRule,
     TerminalAgentIdentity,
     TerminalAgentPolicyRule,
     action_safety,
     agent_authz_audit,
     agent_consumer_subject,
     limited_remote_user_action_allowed,
-    local_operator_action_allowed,
     parse_authz_policy_toml,
 )
 from control_plane.contracts.authz_policy_record import authz_policy_sha256
@@ -103,6 +105,18 @@ def _local_operator_identity(**overrides: object) -> LocalOperatorIdentity:
     }
     values.update(overrides)
     return LocalOperatorIdentity(
+        subject=str(values["subject"]),
+        token_label=str(values["token_label"]),
+    )
+
+
+def _local_admin_identity(**overrides: object) -> LocalAdminIdentity:
+    values: dict[str, object] = {
+        "subject": "local-owner-admin",
+        "token_label": "local-owner-admin",
+    }
+    values.update(overrides)
+    return LocalAdminIdentity(
         subject=str(values["subject"]),
         token_label=str(values["token_label"]),
     )
@@ -586,8 +600,22 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
             )
         )
 
-    def test_local_operator_policy_allows_only_product_config_actions(self) -> None:
-        policy = LaunchplaneAuthzPolicy()
+    def test_local_operator_policy_uses_db_backed_rules(self) -> None:
+        policy = LaunchplaneAuthzPolicy(
+            local_operators=(
+                LocalOperatorPolicyRule(
+                    subjects=("local-owner-agent",),
+                    token_labels=("local-owner-write",),
+                    products=("sellyouroutboard", "launchplane"),
+                    contexts=("sellyouroutboard", "launchplane"),
+                    actions=(
+                        "product_config.plan",
+                        "product_config.apply",
+                        "merge_train.policy_targets",
+                    ),
+                ),
+            )
+        )
         identity = _local_operator_identity()
 
         self.assertTrue(
@@ -647,26 +675,98 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
             )
         )
 
-    def test_local_operator_action_allows_configured_subject_and_label(self) -> None:
+    def test_local_operator_policy_fails_closed_without_rules(self) -> None:
+        policy = LaunchplaneAuthzPolicy()
+
+        self.assertFalse(
+            policy.allows(
+                identity=_local_operator_identity(),
+                action="product_config.apply",
+                product="sellyouroutboard",
+                context="sellyouroutboard",
+            )
+        )
+
+    def test_local_operator_rule_fails_closed_by_subject_label_and_scope(self) -> None:
+        rule = LocalOperatorPolicyRule(
+            subjects=("local-*-agent",),
+            token_labels=("local-owner-*",),
+            products=("launchplane",),
+            contexts=("launchplane",),
+            actions=("public_ingress_notification_policy.apply",),
+        )
+        identity = _local_operator_identity()
+
         self.assertTrue(
-            local_operator_action_allowed(
-                identity=_local_operator_identity(
-                    subject="configured-local-operator",
-                    token_label="configured-write-token",
+            rule.allows(
+                identity=identity,
+                action="public_ingress_notification_policy.apply",
+                product="launchplane",
+                context="launchplane",
+            )
+        )
+        denied_cases = (
+            (
+                "subject",
+                _local_operator_identity(subject="other-agent"),
+                "launchplane",
+                "launchplane",
+            ),
+            (
+                "token_label",
+                _local_operator_identity(token_label="read-token"),
+                "launchplane",
+                "launchplane",
+            ),
+            ("product", identity, "other-product", "launchplane"),
+            ("context", identity, "launchplane", "other-context"),
+        )
+        for name, case_identity, product, context in denied_cases:
+            with self.subTest(name=name):
+                self.assertFalse(
+                    rule.allows(
+                        identity=case_identity,
+                        action="public_ingress_notification_policy.apply",
+                        product=product,
+                        context=context,
+                    )
+                )
+
+    def test_local_admin_policy_uses_separate_rules(self) -> None:
+        policy = LaunchplaneAuthzPolicy(
+            local_admins=(
+                LocalAdminPolicyRule(
+                    subjects=("local-owner-admin",),
+                    token_labels=("local-owner-admin",),
+                    products=("launchplane",),
+                    contexts=("launchplane",),
+                    actions=("launchplane_service_deploy.execute",),
                 ),
-                action="product_config.apply",
+            )
+        )
+
+        self.assertTrue(
+            policy.allows(
+                identity=_local_admin_identity(),
+                action="launchplane_service_deploy.execute",
+                product="launchplane",
+                context="launchplane",
             )
         )
         self.assertFalse(
-            local_operator_action_allowed(
-                identity=_local_operator_identity(subject="  "),
-                action="product_config.apply",
+            policy.allows(
+                identity=_local_operator_identity(),
+                action="launchplane_service_deploy.execute",
+                product="launchplane",
+                context="launchplane",
             )
         )
         self.assertFalse(
-            local_operator_action_allowed(
-                identity=_local_operator_identity(token_label="  "),
-                action="product_config.apply",
+            policy.allows(
+                identity=_local_admin_identity(token_label="wrong"),
+                action="launchplane_service_deploy.execute",
+                product="launchplane",
+                context="launchplane",
             )
         )
 
@@ -774,15 +874,33 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
             products = ["sellyouroutboard"]
             contexts = ["sellyouroutboard-testing"]
             actions = ["product_environment.read"]
+
+            [[local_operators]]
+            subjects = ["local-owner-agent"]
+            token_labels = ["local-owner-write"]
+            products = ["launchplane"]
+            contexts = ["launchplane"]
+            actions = ["public_ingress_notification_policy.apply"]
+
+            [[local_admins]]
+            subjects = ["local-owner-admin"]
+            token_labels = ["local-owner-admin"]
+            products = ["launchplane"]
+            contexts = ["launchplane"]
+            actions = ["launchplane_service_deploy.execute"]
             """
         )
 
         self.assertEqual(len(policy.github_actions), 1)
         self.assertEqual(len(policy.github_humans), 1)
         self.assertEqual(len(policy.terminal_agents), 1)
+        self.assertEqual(len(policy.local_operators), 1)
+        self.assertEqual(len(policy.local_admins), 1)
         self.assertEqual(policy.github_actions[0].repository, "cbusillo/verireel")
         self.assertEqual(policy.github_humans[0].roles, ("admin",))
         self.assertEqual(policy.terminal_agents[0].subjects, ("local-owner-agent",))
+        self.assertEqual(policy.local_operators[0].token_labels, ("local-owner-write",))
+        self.assertEqual(policy.local_admins[0].subjects, ("local-owner-admin",))
 
 
 class HumanSessionBoundaryTests(unittest.TestCase):
@@ -868,7 +986,7 @@ class GitHubOidcVerifierHardeningTests(unittest.TestCase):
 
 
 class LaunchplaneAuthzPolicyCompatibilityTests(unittest.TestCase):
-    def test_policy_sha256_omits_empty_terminal_agents_for_existing_records(self) -> None:
+    def test_policy_sha256_omits_empty_owner_agents_for_existing_records(self) -> None:
         policy = LaunchplaneAuthzPolicy(
             github_actions=(
                 GitHubActionsPolicyRule(
@@ -881,6 +999,8 @@ class LaunchplaneAuthzPolicyCompatibilityTests(unittest.TestCase):
         )
         legacy_payload = policy.model_dump(mode="json", exclude_none=True)
         legacy_payload.pop("terminal_agents", None)
+        legacy_payload.pop("local_operators", None)
+        legacy_payload.pop("local_admins", None)
         legacy_sha256 = hashlib.sha256(
             json.dumps(legacy_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
         ).hexdigest()
@@ -913,6 +1033,47 @@ class LaunchplaneAuthzPolicyCompatibilityTests(unittest.TestCase):
         )
 
         self.assertNotEqual(authz_policy_sha256(terminal_policy), authz_policy_sha256(base_policy))
+
+    def test_policy_sha256_includes_local_owner_rules_when_present(self) -> None:
+        base_policy = LaunchplaneAuthzPolicy(
+            github_actions=(
+                GitHubActionsPolicyRule(
+                    repository="cbusillo/launchplane",
+                    products=("launchplane",),
+                    contexts=("launchplane",),
+                    actions=("launchplane_service_deploy.execute",),
+                ),
+            )
+        )
+        operator_policy = base_policy.model_copy(
+            update={
+                "local_operators": (
+                    LocalOperatorPolicyRule(
+                        subjects=("local-owner-agent",),
+                        token_labels=("local-owner-write",),
+                        products=("launchplane",),
+                        contexts=("launchplane",),
+                        actions=("public_ingress_notification_policy.apply",),
+                    ),
+                )
+            }
+        )
+        admin_policy = base_policy.model_copy(
+            update={
+                "local_admins": (
+                    LocalAdminPolicyRule(
+                        subjects=("local-owner-admin",),
+                        token_labels=("local-owner-admin",),
+                        products=("launchplane",),
+                        contexts=("launchplane",),
+                        actions=("launchplane_service_deploy.execute",),
+                    ),
+                )
+            }
+        )
+
+        self.assertNotEqual(authz_policy_sha256(operator_policy), authz_policy_sha256(base_policy))
+        self.assertNotEqual(authz_policy_sha256(admin_policy), authz_policy_sha256(base_policy))
 
     def test_actions_policy_matches_patterns_and_scopes(self) -> None:
         rule = GitHubActionsPolicyRule(


### PR DESCRIPTION
## Summary
- replace the hardcoded local-operator allowlist with DB-backed `local_operators` policy rules
- add a separate policy-backed `local_admins` identity tier without granting it by default
- split deploy env compatibility so terminal read creds and owner-agent write creds are controlled separately
- add owner-agent authz grant endpoints and deploy-time grants for routine local-operator actions
- update docs and tests for the deployed-API owner-agent model

## Verification
- `uv run --extra dev ruff check control_plane/authz_grant_service.py control_plane/contracts/authz_policy_record.py control_plane/product_config_http.py control_plane/service.py control_plane/service_auth.py control_plane/work_graph_http.py tests/test_driver_descriptors.py tests/test_product_onboarding.py tests/test_service.py tests/test_service_auth.py`
- `uv run --extra dev ruff format --check control_plane/authz_grant_service.py control_plane/contracts/authz_policy_record.py control_plane/product_config_http.py control_plane/service.py control_plane/service_auth.py control_plane/work_graph_http.py tests/test_driver_descriptors.py tests/test_product_onboarding.py tests/test_service.py tests/test_service_auth.py`
- `shellcheck scripts/deploy/ensure-authz-grants.sh`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest tests.test_authz_grant_service tests.test_service_auth tests.test_driver_descriptors tests.test_product_onboarding ...targeted LaunchplaneServiceTests owner-agent/authz/product-config/public-ingress cases`

## Notes
- `uv run --extra dev ruff format --check .` still reports pre-existing unrelated files that would reformat; all Python files touched by this PR pass format check.
- `shfmt -d scripts/deploy/ensure-authz-grants.sh` wants to reindent the entire existing script, so this PR keeps the script's current style and verifies it with `shellcheck`.
