### PR TITLE
Honor owner agent wildcard scopes

### DIFF
--- a/control_plane/service_auth.py
+++ b/control_plane/service_auth.py
@@ -303,9 +303,9 @@ class LocalOperatorPolicyRule(BaseModel):
             return False
         if self.token_labels and not self._matches_any(identity.token_label, self.token_labels):
             return False
-        if self.products and product not in self.products:
+        if self.products and not self._matches_any(product, self.products):
             return False
-        if self.contexts and context not in self.contexts:
+        if self.contexts and not self._matches_any(context, self.contexts):
             return False
         if self.actions and action not in self.actions:
             return False
@@ -333,9 +333,9 @@ class LocalAdminPolicyRule(BaseModel):
             return False
         if self.token_labels and not self._matches_any(identity.token_label, self.token_labels):
             return False
-        if self.products and product not in self.products:
+        if self.products and not self._matches_any(product, self.products):
             return False
-        if self.contexts and context not in self.contexts:
+        if self.contexts and not self._matches_any(context, self.contexts):
             return False
         if self.actions and action not in self.actions:
             return False

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -732,6 +732,24 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
                     )
                 )
 
+    def test_local_operator_rule_matches_product_and_context_patterns(self) -> None:
+        rule = LocalOperatorPolicyRule(
+            subjects=("local-owner-agent",),
+            token_labels=("local-owner-write",),
+            products=("*",),
+            contexts=("*",),
+            actions=("product_config.apply",),
+        )
+
+        self.assertTrue(
+            rule.allows(
+                identity=_local_operator_identity(),
+                action="product_config.apply",
+                product="sellyouroutboard",
+                context="sellyouroutboard-production",
+            )
+        )
+
     def test_local_admin_policy_uses_separate_rules(self) -> None:
         policy = LaunchplaneAuthzPolicy(
             local_admins=(
@@ -767,6 +785,32 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
                 action="launchplane_service_deploy.execute",
                 product="launchplane",
                 context="launchplane",
+            )
+        )
+
+    def test_local_admin_rule_matches_product_and_context_patterns(self) -> None:
+        rule = LocalAdminPolicyRule(
+            subjects=("local-owner-admin",),
+            token_labels=("local-owner-admin",),
+            products=("launch*",),
+            contexts=("*",),
+            actions=("launchplane_service_deploy.execute",),
+        )
+
+        self.assertTrue(
+            rule.allows(
+                identity=_local_admin_identity(),
+                action="launchplane_service_deploy.execute",
+                product="launchplane",
+                context="launchplane",
+            )
+        )
+        self.assertFalse(
+            rule.allows(
+                identity=_local_admin_identity(),
+                action="launchplane_service_deploy.execute",
+                product="sellyouroutboard",
+                context="sellyouroutboard-production",
             )
         )
 


### PR DESCRIPTION
## Summary
- let local operator/admin product and context policy scopes use the existing fnmatch pattern matcher
- add coverage for wildcard local-operator product config grants and patterned local-admin deploy grants

## Tests
- uv run --extra dev ruff check control_plane/service_auth.py tests/test_service_auth.py
- uv run --extra dev ruff format --check control_plane/service_auth.py tests/test_service_auth.py
- uv run --extra dev python -m unittest tests.test_service_auth
- uv run --extra dev mypy control_plane tests
- git diff --check