### PR TITLE
Keep deploy agent env switches separate

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -24,7 +24,7 @@ on:
       omit_terminal_agent_env:
         description: Temporarily omit terminal-agent env for one compatibility deploy.
         required: false
-        default: true
+        default: false
         type: boolean
       omit_owner_agent_env:
         description: Temporarily omit owner-agent env for one compatibility deploy.
@@ -278,7 +278,7 @@ jobs:
                 --arg local_admin_subject "${LAUNCHPLANE_LOCAL_ADMIN_SUBJECT:-}" \
                 --arg local_admin_token_label "${LAUNCHPLANE_LOCAL_ADMIN_TOKEN_LABEL:-}" \
                 --argjson omit_every_code_env '${{ inputs.omit_every_code_env || false }}' \
-                --argjson omit_terminal_agent_env '${{ inputs.omit_terminal_agent_env != false }}' \
+                --argjson omit_terminal_agent_env '${{ inputs.omit_terminal_agent_env || false }}' \
                 --argjson omit_owner_agent_env '${{ inputs.omit_owner_agent_env || false }}' \
                 '(
                   {

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -200,6 +200,37 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertNotIn("short_sha=", workflow_text)
         self.assertNotIn("IMAGE_REPOSITORY: ghcr.io/${{ github.repository }}", workflow_text)
 
+    def test_deploy_launchplane_keeps_terminal_agent_and_owner_agent_inputs_separate(
+        self,
+    ) -> None:
+        workflow_text = Path(".github/workflows/deploy-launchplane.yml").read_text(encoding="utf-8")
+
+        self.assertIn("omit_terminal_agent_env", workflow_text)
+        self.assertIn("omit_owner_agent_env", workflow_text)
+        self.assertIn(
+            "omit_terminal_agent_env:\n"
+            "        description: Temporarily omit terminal-agent env for one compatibility deploy.\n"
+            "        required: false\n"
+            "        default: false",
+            workflow_text,
+        )
+        self.assertIn(
+            "omit_owner_agent_env:\n"
+            "        description: Temporarily omit owner-agent env for one compatibility deploy.\n"
+            "        required: false\n"
+            "        default: false",
+            workflow_text,
+        )
+        self.assertIn("if ($omit_terminal_agent_env | not) then", workflow_text)
+        self.assertIn("if ($omit_owner_agent_env | not) then", workflow_text)
+        self.assertIn("LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN", workflow_text)
+        self.assertIn("LAUNCHPLANE_LOCAL_OPERATOR_TOKEN", workflow_text)
+        self.assertIn("LAUNCHPLANE_LOCAL_ADMIN_TOKEN", workflow_text)
+        self.assertNotIn(
+            "--argjson omit_terminal_agent_env '${{ inputs.omit_terminal_agent_env != false }}'",
+            workflow_text,
+        )
+
     def test_reusable_odoo_prod_promotion_fails_on_each_result_status(self) -> None:
         workflow_text = Path(".github/workflows/reusable-odoo-prod-promotion.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary
- include terminal-agent env on normal manual deploys by default
- keep terminal-agent and owner-agent compatibility switches independent
- add a workflow guard test for the deploy env switch shape

## Tests
- uv run --extra dev ruff check tests/test_product_onboarding.py
- uv run --extra dev ruff format --check tests/test_product_onboarding.py
- uv run --extra dev python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_deploy_launchplane_keeps_terminal_agent_and_owner_agent_inputs_separate
- git diff --check

## Live smoke
- public ingress monitor run-once delivered 3 Discord notification attempts through the DB-backed global policy and managed secret