### PR TITLE
Seed local admin deploy grant

### DIFF
--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -1234,6 +1234,13 @@ post_local_owner_grant \
   product_config.apply \
   deploy:local-operator-product-config-apply-grant \
   local-operator-product-config-apply
+post_local_owner_grant \
+  local-admin \
+  launchplane \
+  launchplane \
+  launchplane_service_deploy.execute \
+  deploy:local-admin-self-deploy-grant \
+  local-admin-self-deploy
 post_product_config_human_grant \
   product_config.plan \
   deploy:product-config-human-plan-grant \

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -231,6 +231,14 @@ class ProductOnboardingTests(unittest.TestCase):
             workflow_text,
         )
 
+    def test_deploy_authz_grants_seed_local_admin_self_deploy_authority(self) -> None:
+        script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(encoding="utf-8")
+
+        self.assertIn("local-admin \\", script_text)
+        self.assertIn("deploy:local-admin-self-deploy-grant", script_text)
+        self.assertIn("local-admin-self-deploy", script_text)
+        self.assertIn("launchplane_service_deploy.execute", script_text)
+
     def test_reusable_odoo_prod_promotion_fails_on_each_result_status(self) -> None:
         workflow_text = Path(".github/workflows/reusable-odoo-prod-promotion.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary
- seed the local-admin token with launchplane self-deploy/grant authority during deploy bootstrap
- keep the grant narrow to launchplane/launchplane and launchplane_service_deploy.execute
- add a product-onboarding guard test for the deploy grant seed

## Tests
- uv run --extra dev ruff check tests/test_product_onboarding.py
- uv run --extra dev ruff format --check tests/test_product_onboarding.py
- shellcheck scripts/deploy/ensure-authz-grants.sh
- uv run --extra dev python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_seed_local_admin_self_deploy_authority
- git diff --check