### PR TITLE
Make missing runtime identity advisory

### DIFF
--- a/control_plane/contracts/product_profile_record.py
+++ b/control_plane/contracts/product_profile_record.py
@@ -151,7 +151,7 @@ class ProductPublicIngressMonitoringPolicy(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     enabled: bool = True
-    require_runtime_identity: bool = True
+    require_runtime_identity: bool = False
     alert_issue_url: str = ""
 
     @model_validator(mode="after")

--- a/control_plane/workflows/public_ingress_monitor.py
+++ b/control_plane/workflows/public_ingress_monitor.py
@@ -609,7 +609,10 @@ def _check_url(
                 json_parse_failed=False,
             )
         )
-        if target.require_runtime_identity and runtime_status != "match":
+        hard_runtime_identity_failure = runtime_status in {"malformed", "mismatch"} or (
+            target.require_runtime_identity and runtime_status != "match"
+        )
+        if hard_runtime_identity_failure:
             return PublicIngressTargetObservation(
                 target=target_kind,
                 url=url,

--- a/docs/new-product-repo.md
+++ b/docs/new-product-repo.md
@@ -29,6 +29,8 @@ Every Launchplane-operated web product should expose a small runtime contract:
 - known runtime port
 - health endpoint path
 - non-secret build revision or image tag in the health response
+- Launchplane runtime identity echo from `LAUNCHPLANE_RUNTIME_IDENTITY_JSON`
+  before the lane is marked strict for runtime identity verification
 - documented required runtime environment keys
 - product-specific smoke check command when generic health is not enough
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -828,7 +828,11 @@ Dokploy targets. Product health endpoints may echo the JSON payload as
 or `LAUNCHPLANE_RUNTIME_IDENTITY_JSON`; Launchplane records whether the observed
 payload matches, mismatches, is missing, or cannot be parsed. Missing observed
 identity is evidence for adoption work, not a reason to hardcode product-specific
-health or logo probe URLs.
+health or logo probe URLs. Runtime identity mismatches and malformed identity
+evidence remain hard public-ingress failures because they indicate the public
+route may be serving a different artifact than Launchplane expects. Missing or
+unverifiable identity is advisory unless the lane explicitly requires runtime
+identity after adopting the health echo contract.
 
 Target replacement only reconciles the provider target and runtime envelope. If
 an intentionally empty CM testing lane needs its Odoo database and filestore

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -291,7 +291,8 @@ When creating a new website repo for Launchplane:
 - Add a health endpoint that returns enough non-secret version data for
   Launchplane to verify the deployed artifact. New products should expose the
   Launchplane runtime identity env payload from `LAUNCHPLANE_RUNTIME_IDENTITY_JSON`
-  or the equivalent discrete env keys.
+  or the equivalent discrete env keys, then mark lanes as requiring runtime
+  identity after the echo is verified.
 - Publish immutable container images or artifacts from GitHub Actions.
 - Apply an operator-owned Launchplane product onboarding manifest to seed the
   product profile, lane profiles, target records, runtime environment, disabled

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -991,7 +991,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertEqual(profile.lanes[0].health_url, "https://testing.example.invalid/api/health")
         self.assertTrue(profile.lanes[0].odoo_stable_bootstrap.enabled)
         self.assertTrue(profile.lanes[0].public_ingress_monitoring.enabled)
-        self.assertTrue(profile.lanes[0].public_ingress_monitoring.require_runtime_identity)
+        self.assertFalse(profile.lanes[0].public_ingress_monitoring.require_runtime_identity)
         self.assertEqual(
             profile.lanes[0].public_ingress_monitoring.alert_issue_url,
             "https://github.com/cbusillo/launchplane/issues/929",

--- a/tests/test_public_ingress_monitor.py
+++ b/tests/test_public_ingress_monitor.py
@@ -325,6 +325,134 @@ class PublicIngressMonitorTests(unittest.TestCase):
         health = store.records[0].targets[-1]
         self.assertEqual(health.runtime_identity_status, "match")
 
+    def test_missing_runtime_identity_is_advisory_until_lane_requires_it(self) -> None:
+        identity = _identity()
+        store = _Store((_profile(),))
+        store.lane_summaries[("example-site", "prod")] = LaunchplaneLaneSummary(
+            context="example-site",
+            instance="prod",
+            inventory=EnvironmentInventory(
+                context="example-site",
+                instance="prod",
+                source_git_ref="abc123",
+                deploy=DeploymentEvidence(
+                    target_name="example-site-prod",
+                    target_type="application",
+                    deploy_mode="git",
+                    status="pass",
+                ),
+                runtime_identity=identity,
+                updated_at="2026-05-29T12:10:00Z",
+                deployment_record_id="deploy-1",
+            ),
+        )
+
+        result = run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:10:00Z",
+            http_get=lambda url, _timeout: HttpObservation(
+                status_code=200,
+                final_url=url,
+                redirect_count=0,
+                payload={"status": "ok", "revision": "abc123"},
+            ),
+        )
+
+        self.assertEqual(result.pass_count, 1)
+        health = store.records[0].targets[-1]
+        self.assertEqual(health.runtime_identity_status, "missing")
+        self.assertEqual(health.status, "pass")
+        self.assertEqual(store.incidents, [])
+
+    def test_strict_lane_fails_when_runtime_identity_is_missing(self) -> None:
+        identity = _identity()
+        lane = ProductLaneProfile(
+            instance="prod",
+            context="example-site",
+            base_url="https://example.test",
+            public_ingress_monitoring=ProductPublicIngressMonitoringPolicy(
+                require_runtime_identity=True
+            ),
+        )
+        store = _Store((_profile(lane=lane),))
+        store.lane_summaries[("example-site", "prod")] = LaunchplaneLaneSummary(
+            context="example-site",
+            instance="prod",
+            inventory=EnvironmentInventory(
+                context="example-site",
+                instance="prod",
+                source_git_ref="abc123",
+                deploy=DeploymentEvidence(
+                    target_name="example-site-prod",
+                    target_type="application",
+                    deploy_mode="git",
+                    status="pass",
+                ),
+                runtime_identity=identity,
+                updated_at="2026-05-29T12:10:00Z",
+                deployment_record_id="deploy-1",
+            ),
+        )
+
+        result = run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:10:00Z",
+            http_get=lambda url, _timeout: HttpObservation(
+                status_code=200,
+                final_url=url,
+                redirect_count=0,
+                payload={"status": "ok", "revision": "abc123"},
+            ),
+        )
+
+        self.assertEqual(result.fail_count, 1)
+        health = store.records[0].targets[-1]
+        self.assertEqual(health.runtime_identity_status, "missing")
+        self.assertEqual(health.status, "fail")
+        self.assertEqual(store.incidents[0].status, "open")
+
+    def test_runtime_identity_mismatch_fails_even_when_advisory(self) -> None:
+        expected_identity = _identity()
+        observed_identity = expected_identity.model_copy(
+            update={"deployment_record_id": "deploy-other"}
+        )
+        store = _Store((_profile(),))
+        store.lane_summaries[("example-site", "prod")] = LaunchplaneLaneSummary(
+            context="example-site",
+            instance="prod",
+            inventory=EnvironmentInventory(
+                context="example-site",
+                instance="prod",
+                source_git_ref="abc123",
+                deploy=DeploymentEvidence(
+                    target_name="example-site-prod",
+                    target_type="application",
+                    deploy_mode="git",
+                    status="pass",
+                ),
+                runtime_identity=expected_identity,
+                updated_at="2026-05-29T12:10:00Z",
+                deployment_record_id="deploy-1",
+            ),
+        )
+
+        result = run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:10:00Z",
+            http_get=lambda url, _timeout: HttpObservation(
+                status_code=200,
+                final_url=url,
+                redirect_count=0,
+                payload={"runtime_identity": observed_identity.model_dump(mode="json")},
+            ),
+        )
+
+        self.assertEqual(result.fail_count, 1)
+        health = store.records[0].targets[-1]
+        self.assertEqual(health.runtime_identity_status, "mismatch")
+        self.assertEqual(health.status, "fail")
+        self.assertIn("deployment_record_id", health.runtime_identity_detail)
+
     def test_notifies_on_failure_and_recovery_transitions(self) -> None:
         store = _Store((_profile(),))
         notifications: list[tuple[str, str]] = []


### PR DESCRIPTION
## Summary
- make public-ingress runtime identity missing/unverifiable advisory by default
- keep malformed and mismatched runtime identity as hard public-ingress failures
- use require_runtime_identity as the strict/adopted lane marker
- document the staged adoption policy and update onboarding expectations

## Tests
- uv run --extra dev ruff check control_plane/contracts/product_profile_record.py control_plane/workflows/public_ingress_monitor.py tests/test_public_ingress_monitor.py tests/test_product_onboarding.py
- uv run --extra dev ruff format --check control_plane/contracts/product_profile_record.py control_plane/workflows/public_ingress_monitor.py tests/test_public_ingress_monitor.py tests/test_product_onboarding.py
- uv run --extra dev python -m unittest tests.test_public_ingress_monitor tests.test_product_onboarding.ProductOnboardingTests.test_apply_product_onboarding_manifest_writes_canonical_records
- uv run --extra dev mypy control_plane tests
- git diff --check