### PR TITLE
Use Launchplane health for Odoo runtime identity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM mirror.gcr.io/library/golang:1.26.3-bookworm AS github-cli-build
 ENV CGO_ENABLED=0 \
     GOTOOLCHAIN=local
 
-RUN go install github.com/cli/cli/v2/cmd/gh@v2.92.0
+RUN go install github.com/cli/cli/v2/cmd/gh@v2.93.0
 
 FROM mirror.gcr.io/library/python:3.13-slim
 

--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -168,7 +168,8 @@ x-odoo-env: &odoo-env
   ODOO_DEV_MODE: ${{ODOO_DEV_MODE:-}}
   ODOO_INSTALL_MODULES: ${{ODOO_INSTALL_MODULES:-}}
   ODOO_UPDATE_MODULES: ${{ODOO_UPDATE_MODULES:-AUTO}}
-  ODOO_ADDONS_PATH: ${{ODOO_ADDONS_PATH:-/opt/project/addons,/opt/extra_addons,/opt/enterprise,/odoo/addons}}
+  ODOO_ADDONS_PATH: ${{ODOO_ADDONS_PATH:-/opt/project/addons,/opt/extra_addons,/opt/launchplane/addons,/opt/enterprise,/odoo/addons}}
+  ODOO_SERVER_WIDE_MODULES: ${{ODOO_SERVER_WIDE_MODULES:-base,web,launchplane_runtime_health}}
   ODOO_DATA_WORKFLOW_LOCK_FILE: ${{ODOO_DATA_WORKFLOW_LOCK_FILE:-/volumes/data/.data_workflow_in_progress}}
   ODOO_DATA_WORKFLOW_LOCK_TIMEOUT_SECONDS: ${{ODOO_DATA_WORKFLOW_LOCK_TIMEOUT_SECONDS:-7200}}
   IMAGE_ODOO_ENTERPRISE_LOCATION: /volumes/enterprise_disabled

--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -38,6 +38,7 @@ from control_plane.workflows.generic_web_preview import (
 from control_plane.workflows.preview_resource_destroy import (
     destroy_dokploy_preview_resource,
 )
+from control_plane.workflows.odoo_verification import DEFAULT_ODOO_RUNTIME_HEALTH_PATH
 
 
 OdooPreviewDokployDryRunStatus = OdooPreviewRuntimePlanStatus
@@ -855,7 +856,7 @@ class OdooPreviewDokployApplyRequest(BaseModel):
     manifest: ArtifactIdentityManifest | None = None
     environment_values: dict[str, str] = Field(default_factory=dict)
     compose_file: str = ""
-    health_path: str = "/web/health"
+    health_path: str = DEFAULT_ODOO_RUNTIME_HEALTH_PATH
     timeout_seconds: int = Field(default=300, ge=1)
     wait_for_deploy: bool = True
     smoke_check: bool = True
@@ -874,7 +875,7 @@ class OdooPreviewDokployApplyRequest(BaseModel):
                 label="Odoo preview apply",
             )
         self.compose_file = self.compose_file.strip()
-        self.health_path = self.health_path.strip() or "/web/health"
+        self.health_path = self.health_path.strip() or DEFAULT_ODOO_RUNTIME_HEALTH_PATH
         if not self.health_path.startswith("/"):
             self.health_path = f"/{self.health_path}"
         self.environment_values = {

--- a/control_plane/workflows/odoo_verification.py
+++ b/control_plane/workflows/odoo_verification.py
@@ -59,11 +59,16 @@ class _ProbeFailure(click.ClickException):
         self.evidence = evidence
 
 
-def default_odoo_health_url(*, base_url: str, health_path: str = "/web/health") -> str:
+DEFAULT_ODOO_RUNTIME_HEALTH_PATH = "/launchplane/health"
+
+
+def default_odoo_health_url(
+    *, base_url: str, health_path: str = DEFAULT_ODOO_RUNTIME_HEALTH_PATH
+) -> str:
     normalized_base_url = base_url.strip().rstrip("/")
     if not normalized_base_url:
         return ""
-    normalized_health_path = health_path.strip() or "/web/health"
+    normalized_health_path = health_path.strip() or DEFAULT_ODOO_RUNTIME_HEALTH_PATH
     if not normalized_health_path.startswith("/"):
         normalized_health_path = f"/{normalized_health_path}"
     return f"{normalized_base_url}{normalized_health_path}"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -617,7 +617,7 @@ context only, and `context_instance` has both context and instance.
 - `POST /v1/drivers/odoo/prod-rollback` rolls a prod-named Odoo lane back to
   the DB-backed `testing` release tuple for the same context. The driver updates
   the Dokploy `DOCKER_IMAGE_REFERENCE`, deploys the compose target, runs the
-  Odoo post-deploy workflow, verifies `/web/health`, writes deployment,
+  Odoo post-deploy workflow, verifies `/launchplane/health`, writes deployment,
   inventory, release tuple, and rollback evidence, and annotates the current prod
   promotion record.
 - `POST /v1/drivers/odoo/prod-backup-gate` captures the DB and filestore backup
@@ -679,7 +679,8 @@ context only, and `context_instance` has both context and instance.
   writes rollback evidence with an `artifact:<artifact_id>` source marker.
 - A passing rollback writes deployment, inventory, prod release tuple,
   promotion rollback, and rollback-health evidence. Verify the target
-  `/web/health` endpoint and `inventory status` before taking another action.
+  `/launchplane/health` endpoint and `inventory status` before taking another
+  action.
 - A real destructive rollback drill requires a second known-good artifact
   manifest. Do not synthesize artifact ids or source SHAs to create one.
 - A re-promote drill should use the normal prod promotion path with a fresh

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -127,7 +127,7 @@ Dokploy environment ids, template compose ids, or Odoo database and volume names
 inside the tenant repo. The route discovers existing Odoo preview composes from
 provider inventory for refresh reuse and destroy planning, and it blocks destroy
 when the matching preview compose and hostname cannot be proven. After refresh,
-Launchplane owns `/web/health`, `/cm-website/health`, `/cell-mechanic`,
+Launchplane owns `/launchplane/health`, `/web/health`, `/cm-website/health`, `/cell-mechanic`,
 artifact/revision evidence, and module install/update evidence. Product
 workflows should treat the Odoo refresh route's `refresh_status="pass"` as the
 ready-to-comment signal instead of independently deciding readiness from raw

--- a/docs/records.md
+++ b/docs/records.md
@@ -321,9 +321,11 @@ authority by themselves.
 driver defaults. `resettable` lanes may explicitly allow `empty` rebuilds;
 `restorable` lanes may explicitly allow `upstream_restore` and must name an
 `upstream_source`; `authoritative` lanes require backup-before-destroy and
-restore-proof safeguards. Routine Odoo probe details such as `/web/health` and
-logo URL discovery belong in the Odoo driver, not in tenant-owned product config,
-unless a lane has a real exception that needs an explicit override.
+restore-proof safeguards. Routine Odoo probe details such as the Launchplane
+runtime identity endpoint `/launchplane/health`, local liveness endpoint
+`/web/health`, and logo URL discovery belong in the Odoo driver, not in
+tenant-owned product config, unless a lane has a real exception that needs an
+explicit override.
 
 This file layout describes today's local Launchplane implementation, not the
 final cross-product communication boundary. The stable long-term contract should

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -2317,6 +2317,14 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
         self.assertIn('- "${ODOO_LONGPOLL_HOST_PORT:-8072}:8072"', compose_file)
         self.assertIn("\n  database:", compose_file)
         self.assertIn("\n  script-runner:", compose_file)
+        self.assertIn(
+            "ODOO_ADDONS_PATH: ${ODOO_ADDONS_PATH:-/opt/project/addons,/opt/extra_addons,/opt/launchplane/addons,/opt/enterprise,/odoo/addons}",
+            compose_file,
+        )
+        self.assertIn(
+            "ODOO_SERVER_WIDE_MODULES: ${ODOO_SERVER_WIDE_MODULES:-base,web,launchplane_runtime_health}",
+            compose_file,
+        )
         self.assertIn("name: ${ODOO_PROJECT_NAME:-odoo}", compose_file)
         self.assertIn("dokploy-network:", compose_file)
         self.assertIn("traefik.enable=true", compose_file)

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -1321,7 +1321,7 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
     def test_smoke_check_retries_transient_http_404() -> None:
         responses: list[HTTPError | _SmokeResponse] = [
             HTTPError(
-                "https://pr-45.cm-preview.example.test/web/health",
+                "https://pr-45.cm-preview.example.test/launchplane/health",
                 404,
                 "Not Found",
                 hdrs=Message(),
@@ -1344,7 +1344,7 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         ):
             _wait_for_smoke_check(
                 preview_url="https://pr-45.cm-preview.example.test/",
-                health_path="/web/health",
+                health_path="/launchplane/health",
                 timeout_seconds=10,
             )
 

--- a/tests/test_odoo_verification.py
+++ b/tests/test_odoo_verification.py
@@ -23,7 +23,7 @@ class OdooVerificationTests(unittest.TestCase):
                     '<img src="/web/image/website/7/logo?unique=abc"></html>',
                     "text/html",
                 )
-            if url == "https://cm-testing.example.com/web/health":
+            if url == "https://cm-testing.example.com/launchplane/health":
                 return 200, '{"status":"ok"}', "application/json"
             if url == "https://cm-testing.example.com/web/image/website/7/logo?unique=abc":
                 return 200, "image-bytes", "image/png"
@@ -44,7 +44,7 @@ class OdooVerificationTests(unittest.TestCase):
         self.assertEqual(
             calls,
             [
-                "https://cm-testing.example.com/web/health",
+                "https://cm-testing.example.com/launchplane/health",
                 "https://cm-testing.example.com",
                 "https://cm-testing.example.com",
                 "https://cm-testing.example.com/web/image/website/7/logo?unique=abc",
@@ -317,7 +317,7 @@ class OdooVerificationTests(unittest.TestCase):
 
         def fake_http_text(url: str, *, timeout_seconds: int) -> tuple[int, str, str]:
             nonlocal attempts
-            self.assertEqual(url, "https://cm-testing.example.com/web/health")
+            self.assertEqual(url, "https://cm-testing.example.com/launchplane/health")
             self.assertEqual(timeout_seconds, 30)
             attempts += 1
             if attempts == 1:
@@ -348,7 +348,7 @@ class OdooVerificationTests(unittest.TestCase):
 
         def fake_http_text(url: str, *, timeout_seconds: int) -> tuple[int, str, str]:
             nonlocal attempts
-            self.assertEqual(url, "https://cm-testing.example.com/web/health")
+            self.assertEqual(url, "https://cm-testing.example.com/launchplane/health")
             self.assertEqual(timeout_seconds, 30)
             attempts += 1
             if attempts == 1:
@@ -379,7 +379,7 @@ class OdooVerificationTests(unittest.TestCase):
 
         def fake_http_text(url: str, *, timeout_seconds: int) -> tuple[int, str, str]:
             nonlocal attempts
-            self.assertEqual(url, "https://cm-testing.example.com/web/health")
+            self.assertEqual(url, "https://cm-testing.example.com/launchplane/health")
             self.assertEqual(timeout_seconds, 30)
             attempts += 1
             if attempts == 1:


### PR DESCRIPTION
## Summary
- switch Odoo runtime health default to /launchplane/health
- render Odoo compose defaults with the Launchplane addon path and server-wide module
- update Odoo preview/verification tests and docs for the runtime identity endpoint

## Validation
- uv run python -m unittest tests.test_odoo_verification tests.test_odoo_preview_runtime tests.test_dokploy
- uv run python -m unittest tests.test_odoo_stable_target_replacement tests.test_odoo_generic_web_post_deploy tests.test_odoo_prod_promotion tests.test_odoo_prod_rollback tests.test_public_ingress_monitor
- uv run --extra dev ruff check control_plane/dokploy.py control_plane/workflows/odoo_verification.py control_plane/workflows/odoo_preview_runtime.py tests/test_dokploy.py tests/test_odoo_verification.py tests/test_odoo_preview_runtime.py
- git diff --check

## Rollout note
Do not merge/deploy this before the odoo-docker runtime addon PR has merged and published a new usable image for Odoo tenant builds. Old Odoo images do not expose /launchplane/health.