### PR TITLE
Use tenant product for Odoo artifact publish

### DIFF
--- a/.github/workflows/reusable-odoo-artifact-publish.yml
+++ b/.github/workflows/reusable-odoo-artifact-publish.yml
@@ -12,6 +12,12 @@ name: Reusable Odoo Artifact Publish
         description: Odoo instance whose artifact should be published.
         required: true
         type: string
+      product:
+        description: >-
+          Launchplane product profile key. Defaults to odoo-tenant-${context}.
+        required: false
+        default: ""
+        type: string
       timeout-ms:
         description: Launchplane request timeout in milliseconds.
         required: false
@@ -90,6 +96,34 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.ODOO_GHCR_PUBLISH_TOKEN }}
 
+      - name: Resolve Launchplane product
+        id: product
+        env:
+          INPUT_PRODUCT: ${{ inputs.product }}
+          CONTEXT_NAME: ${{ inputs.context }}
+          INSTANCE_NAME: ${{ inputs.instance }}
+        run: |
+          set -euo pipefail
+          product="$INPUT_PRODUCT"
+          if [ -z "$product" ]; then
+            product="odoo-tenant-${CONTEXT_NAME}"
+          fi
+          publish_scope="${product}:${CONTEXT_NAME}:${INSTANCE_NAME}"
+          run_scope="run-${GITHUB_RUN_ID}-attempt-${GITHUB_RUN_ATTEMPT}"
+          echo "product=$product" >>"$GITHUB_OUTPUT"
+          {
+            printf '%s=%s:%s:%s\n' \
+              publish_inputs_idempotency_key \
+              odoo-artifact-publish-inputs \
+              "$publish_scope" \
+              "$run_scope"
+            printf '%s=%s:%s:%s\n' \
+              publish_idempotency_key \
+              odoo-artifact-publish \
+              "$publish_scope" \
+              "$run_scope"
+          } >>"$GITHUB_OUTPUT"
+
       - name: Resolve Launchplane publish inputs
         id: publish_inputs
         uses: cbusillo/launchplane/.github/actions/launchplane-request@main
@@ -98,15 +132,14 @@ jobs:
           audience: launchplane.shinycomputers.com
           route-path: /v1/drivers/odoo/artifact-publish-inputs
           payload: >-
-            {"schema_version":1,"product":"odoo","inputs":{"schema_version":1}}
+            {"schema_version":1,"inputs":{"schema_version":1}}
           payload-fields: |-
+            product=${{ steps.product.outputs.product }}
             inputs.context=${{ inputs.context }}
             inputs.instance=${{ inputs.instance }}
             inputs.source_git_ref=${{ github.sha }}
           idempotency-key: >-
-            odoo-artifact-publish-inputs:odoo:${{ inputs.context }}:${{
-              inputs.instance
-            }}:run-${{ github.run_id }}-attempt-${{ github.run_attempt }}
+            ${{ steps.product.outputs.publish_inputs_idempotency_key }}
           timeout-ms: ${{ inputs['timeout-ms'] }}
           fail-result-paths: result.input_status
           response-output-file: >-
@@ -179,15 +212,15 @@ jobs:
           audience: launchplane.shinycomputers.com
           route-path: /v1/drivers/odoo/artifact-publish
           payload: >-
-            {"schema_version":1,"product":"odoo","publish":{"schema_version":1}}
+            {"schema_version":1,"publish":{"schema_version":1}}
           payload-fields: |-
+            product=${{ steps.product.outputs.product }}
             publish.context=${{ inputs.context }}
             publish.instance=${{ inputs.instance }}
           payload-json-files: |-
             publish.manifest=${{ steps.publish.outputs.manifest_file }}
           idempotency-key: >-
-            odoo-artifact-publish:odoo:${{ inputs.context }}:${{ inputs.instance
-            }}:run-${{ github.run_id }}-attempt-${{ github.run_attempt }}
+            ${{ steps.product.outputs.publish_idempotency_key }}
           timeout-ms: ${{ inputs['timeout-ms'] }}
           fail-result-paths: result.status,result.publish_status
           output-paths: >-

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -184,7 +184,10 @@ own the manual dispatch confirmation and the source workspace, while
 `reusable-odoo-artifact-publish.yml` owns the Launchplane publish-input request,
 artifact-record request, idempotency keys, and response mapping. The tenant
 workflow should not duplicate `/v1/drivers/odoo/artifact-publish-inputs` or
-`/v1/drivers/odoo/artifact-publish` wiring once it uses that workflow.
+`/v1/drivers/odoo/artifact-publish` wiring once it uses that workflow. The
+reusable workflow defaults the Launchplane product key to
+`odoo-tenant-${context}` so publish metadata resolves through the tenant product
+profile that owns the image repository and stable lanes.
 
 Start with low-risk deletions and documentation, then replace active workflow
 behavior in small slices. Do not remove active backup, promotion, rollback,

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1193,15 +1193,14 @@ and returns the phase statuses and written record IDs. The lower-level inputs,
 backup-gate, and promotion routes remain available for diagnostics and explicit
 operator workflows, but product repos should not own the chain.
 
-The CM tenant preview workflow uses two product scopes deliberately. Artifact
-publish input and publish evidence requests use product `odoo` for context `cm`,
-because the publish handoff is an Odoo driver contract. Preview refresh and
-destroy requests use product `odoo-tenant-cm`, because preview lifecycle records
-and product profile configuration are tenant-product scoped. Deploy-maintained
-GitHub Actions grants must include both scopes for
-`cbusillo/odoo-tenant-cm/.github/workflows/odoo-preview.yml`; granting only the
-tenant product lets preview mutation through but blocks the earlier build input
-resolution step.
+The CM tenant preview workflow uses tenant-product scope for both artifact
+publish input/evidence and preview lifecycle requests. Artifact publish still
+uses Odoo driver routes, but source-ref build metadata resolves through the
+`odoo-tenant-cm` product profile so Launchplane can return the tenant image
+repository, tag, and lane-owned runtime payload. Deploy-maintained GitHub Actions
+grants for `cbusillo/odoo-tenant-cm/.github/workflows/odoo-preview.yml` should
+therefore include `odoo-tenant-cm` and context `cm` for publish input, publish
+evidence, refresh, and destroy actions.
 
 The CM preview workflow also needs `preview_pr_feedback.write` for product
 `odoo-tenant-cm` and context `cm` before it can retire tenant-side preview

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -1030,6 +1030,7 @@ post_odoo_stable_grant() {
   local source_label="$5"
   local idempotency_suffix="$6"
   local job_workflow_file="${7:-}"
+  local product_name="${8:-odoo}"
   local job_workflow_ref=""
   if [ -n "$job_workflow_file" ]; then
     job_workflow_ref="cbusillo/launchplane/.github/workflows/${job_workflow_file}@refs/heads/main"
@@ -1037,7 +1038,7 @@ post_odoo_stable_grant() {
   post_grant \
     "$repository" \
     "$workflow_file" \
-    odoo \
+    "$product_name" \
     "$context_name" \
     "$action_name" \
     "$source_label" \
@@ -1435,7 +1436,8 @@ post_odoo_stable_grant \
   odoo_artifact_publish_inputs.read \
   deploy:odoo-cm-artifact-publish-inputs-grant \
   odoo-cm-artifact-publish-inputs \
-  reusable-odoo-artifact-publish.yml
+  reusable-odoo-artifact-publish.yml \
+  odoo-tenant-cm
 post_odoo_stable_grant \
   cbusillo/odoo-tenant-cm \
   cm \
@@ -1443,7 +1445,8 @@ post_odoo_stable_grant \
   odoo_artifact_publish.write \
   deploy:odoo-cm-artifact-publish-grant \
   odoo-cm-artifact-publish \
-  reusable-odoo-artifact-publish.yml
+  reusable-odoo-artifact-publish.yml \
+  odoo-tenant-cm
 post_odoo_stable_grant \
   cbusillo/odoo-tenant-cm \
   cm \
@@ -1536,7 +1539,8 @@ post_odoo_stable_grant \
   odoo_artifact_publish_inputs.read \
   deploy:odoo-opw-artifact-publish-inputs-grant \
   odoo-opw-artifact-publish-inputs \
-  reusable-odoo-artifact-publish.yml
+  reusable-odoo-artifact-publish.yml \
+  odoo-tenant-opw
 post_odoo_stable_grant \
   cbusillo/odoo-tenant-opw \
   opw \
@@ -1544,7 +1548,8 @@ post_odoo_stable_grant \
   odoo_artifact_publish.write \
   deploy:odoo-opw-artifact-publish-grant \
   odoo-opw-artifact-publish \
-  reusable-odoo-artifact-publish.yml
+  reusable-odoo-artifact-publish.yml \
+  odoo-tenant-opw
 post_odoo_stable_grant \
   cbusillo/odoo-tenant-opw \
   opw \

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -179,10 +179,18 @@ class ProductOnboardingTests(unittest.TestCase):
         )
 
         self.assertIn("workflow_call", workflow_text)
+        self.assertIn("product:", workflow_text)
+        self.assertIn("product=\"odoo-tenant-${CONTEXT_NAME}\"", workflow_text)
         self.assertIn("/v1/drivers/odoo/artifact-publish-inputs", workflow_text)
         self.assertIn("/v1/drivers/odoo/artifact-publish", workflow_text)
-        self.assertIn("odoo-artifact-publish-inputs:odoo:", workflow_text)
-        self.assertIn("odoo-artifact-publish:odoo:", workflow_text)
+        self.assertIn("product=${{ steps.product.outputs.product }}", workflow_text)
+        self.assertIn("odoo-artifact-publish-inputs", workflow_text)
+        self.assertIn("odoo-artifact-publish", workflow_text)
+        self.assertIn(
+            "${{ steps.product.outputs.publish_inputs_idempotency_key }}",
+            workflow_text,
+        )
+        self.assertIn("${{ steps.product.outputs.publish_idempotency_key }}", workflow_text)
         self.assertIn("fail-result-paths: result.input_status", workflow_text)
         self.assertIn("fail-result-paths: result.status,result.publish_status", workflow_text)
         self.assertIn("token: ${{ secrets.ODOO_SOURCE_GITHUB_TOKEN }}", workflow_text)


### PR DESCRIPTION
## Summary
- Derive tenant product keys in the reusable Odoo artifact publish workflow
- Seed stable artifact publish grants for tenant product scope
- Update contract tests and docs for product-profile publish metadata

## Validation
- uv run python -m unittest tests.test_product_onboarding tests.test_odoo_artifact_publish_inputs
- uv run --extra dev ruff check tests/test_product_onboarding.py tests/test_odoo_artifact_publish_inputs.py
- bash -n scripts/deploy/ensure-authz-grants.sh
- shellcheck scripts/deploy/ensure-authz-grants.sh
- git diff --check