### PR TITLE
Add Odoo testing deploy driver

### DIFF
--- a/.github/workflows/reusable-odoo-testing-deploy.yml
+++ b/.github/workflows/reusable-odoo-testing-deploy.yml
@@ -1,0 +1,97 @@
+---
+name: Reusable Odoo Testing Deploy
+
+"on":
+  workflow_call:
+    inputs:
+      context:
+        description: Launchplane Odoo context.
+        required: true
+        type: string
+      product:
+        description: >-
+          Optional Launchplane product key. Defaults to odoo-tenant-${context}.
+        required: false
+        default: ""
+        type: string
+      artifact_id:
+        description: Stored Launchplane artifact ID to deploy to testing.
+        required: true
+        type: string
+      source_git_ref:
+        description: Source git ref attached to deployment evidence.
+        required: true
+        type: string
+      timeout-ms:
+        description: Launchplane request timeout in milliseconds.
+        required: false
+        default: "2700000"
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  testing-deploy:
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    steps:
+      - name: Resolve Launchplane product
+        id: product
+        env:
+          CONTEXT_NAME: ${{ inputs.context }}
+          PRODUCT_INPUT: ${{ inputs.product }}
+        run: |
+          product="$PRODUCT_INPUT"
+          if [ -z "$product" ]; then
+            product="odoo-tenant-${CONTEXT_NAME}"
+          fi
+          echo "product=$product" >> "$GITHUB_OUTPUT"
+
+      - name: Request Launchplane Odoo testing deploy
+        id: lp
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: https://launchplane.shinycomputers.com
+          audience: launchplane.shinycomputers.com
+          route-path: /v1/drivers/odoo/testing-deploy
+          payload: >-
+            {"schema_version":1,"deploy":{"schema_version":1,"instance":"testing"}}
+          payload-fields: |-
+            product=${{ steps.product.outputs.product }}
+            deploy.context=${{ inputs.context }}
+            deploy.artifact_id=${{ inputs.artifact_id }}
+            deploy.source_git_ref=${{ inputs.source_git_ref }}
+          idempotency-key: >-
+            odoo-testing-deploy:${{ steps.product.outputs.product }}:${{
+              inputs.context
+            }}:testing:${{ inputs.artifact_id }}:${{ github.run_id }}:${{
+              github.run_attempt
+            }}
+          timeout-ms: ${{ inputs['timeout-ms'] }}
+          fail-result-paths: >-
+            result.deployment_status,result.post_deploy_status,
+            result.destination_health_status
+          output-paths: >-
+            trace_id=trace_id,
+            deployment_record_id=result.deployment_record_id,
+            release_tuple_id=result.release_tuple_id,
+            deployment_status=result.deployment_status,
+            post_deploy_status=result.post_deploy_status,
+            destination_health_status=result.destination_health_status,
+            error_message=result.error_message
+
+      - name: Report result
+        env:
+          DEPLOYMENT_RECORD_ID: ${{ steps.lp.outputs.deployment_record_id }}
+          DESTINATION_HEALTH_STATUS: >-
+            ${{ steps.lp.outputs.destination_health_status }}
+          POST_DEPLOY_STATUS: ${{ steps.lp.outputs.post_deploy_status }}
+          RELEASE_TUPLE_ID: ${{ steps.lp.outputs.release_tuple_id }}
+        run: |
+          echo "deployment_record_id=$DEPLOYMENT_RECORD_ID"
+          echo "release_tuple_id=$RELEASE_TUPLE_ID"
+          echo "post_deploy_status=$POST_DEPLOY_STATUS"
+          echo "destination_health_status=$DESTINATION_HEALTH_STATUS"

--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -523,6 +523,7 @@ ODOO_DRIVER = DriverDescriptor(
             label="Stable promotion",
             description="Capture backup evidence, promote testing to prod, and roll back prod to stored artifacts.",
             actions=(
+                "testing_deploy",
                 "prod_promotion_inputs",
                 "prod_promotion_run",
                 "prod_backup_gate",
@@ -608,6 +609,16 @@ ODOO_DRIVER = DriverDescriptor(
             route_path="/v1/drivers/odoo/stable-bootstrap",
             authz_action="odoo_stable_bootstrap.execute",
             writes_records=("deployment", "inventory"),
+        ),
+        _action(
+            "testing_deploy",
+            "Deploy testing",
+            "Deploy a stored Odoo artifact to testing and mint the testing release tuple.",
+            safety="mutation",
+            scope="instance",
+            route_path="/v1/drivers/odoo/testing-deploy",
+            authz_action="odoo_testing_deploy.execute",
+            writes_records=("deployment", "inventory", "release_tuple"),
         ),
         _action(
             "preview_apply_inputs",

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -374,6 +374,11 @@ from control_plane.workflows.odoo_stable_bootstrap import (
     OdooStableBootstrapStore,
     execute_odoo_stable_bootstrap,
 )
+from control_plane.workflows.odoo_testing_deploy import (
+    OdooTestingDeployRequest,
+    OdooTestingDeployStore,
+    execute_odoo_testing_deploy,
+)
 from control_plane.workflows.odoo_prod_backup_gate import (
     OdooProdBackupGateRequest,
     execute_odoo_prod_backup_gate,
@@ -1813,6 +1818,18 @@ class OdooProdRollbackEnvelope(_ProductRouteEnvelope):
         return self
 
 
+class OdooTestingDeployEnvelope(_ProductRouteEnvelope):
+    schema_version: int = Field(default=1, ge=1)
+    deploy: OdooTestingDeployRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "OdooTestingDeployEnvelope":
+        _validate_driver_envelope_product(self.product, label="Odoo testing deploy")
+        if self.deploy.instance != "testing":
+            raise ValueError("Odoo testing deploy requires instance 'testing'.")
+        return self
+
+
 class OdooProdBackupGateEnvelope(_ProductRouteEnvelope):
     schema_version: int = Field(default=1, ge=1)
     backup_gate: OdooProdBackupGateRequest
@@ -1859,6 +1876,15 @@ _ODOO_PROD_BACKUP_GATE_ROUTE = _DriverRouteExecutionMetadata(
     denial_message=(
         "Workflow cannot execute the Odoo prod backup-gate driver"
         " for the requested product/context."
+    ),
+)
+
+
+_ODOO_TESTING_DEPLOY_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/odoo/testing-deploy",
+    envelope_model=OdooTestingDeployEnvelope,
+    denial_message=(
+        "Workflow cannot execute the Odoo testing deploy driver for the requested product/context."
     ),
 )
 
@@ -5150,6 +5176,8 @@ def _accepted_payload(
 
 
 def _accepted_payload_extra_record_keys(*, route_path: str) -> frozenset[str]:
+    if route_path == _ODOO_TESTING_DEPLOY_ROUTE.route_path:
+        return frozenset({"deployment_status", "post_deploy_status", "destination_health_status"})
     if route_path == _GENERIC_WEB_ROLLBACK_ROUTE.route_path:
         return frozenset({"rollback_status", "deploy_status", "post_deploy_status"})
     return frozenset()
@@ -12992,6 +13020,49 @@ def create_launchplane_service_app(
                     product_profile=resolved_driver_context.profile,
                 )
                 driver_result = result
+            elif path == _ODOO_TESTING_DEPLOY_ROUTE.route_path:
+                odoo_deploy_request = _ODOO_TESTING_DEPLOY_ROUTE.envelope_model.model_validate(
+                    payload
+                )
+                _, authorization_response = _resolve_and_authorize_descriptor_route(
+                    route_metadata=_ODOO_TESTING_DEPLOY_ROUTE,
+                    record_store=record_store,
+                    authz_policy=authz_policy,
+                    identity=identity,
+                    product=odoo_deploy_request.product,
+                    authorization_context=odoo_deploy_request.deploy.context,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                    descriptor_context=odoo_deploy_request.deploy.context,
+                    descriptor_instance=odoo_deploy_request.deploy.instance,
+                )
+                if authorization_response is not None:
+                    return authorization_response
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                driver_result = execute_odoo_testing_deploy(
+                    control_plane_root=resolved_root,
+                    state_dir=state_dir,
+                    database_url=database_url,
+                    record_store=cast(OdooTestingDeployStore, record_store),
+                    request=odoo_deploy_request.deploy,
+                )
+                result = {
+                    "deployment_record_id": driver_result.deployment_record_id,
+                    "release_tuple_id": driver_result.release_tuple_id,
+                    "deployment_status": driver_result.deployment_status,
+                    "post_deploy_status": driver_result.post_deploy_status,
+                    "destination_health_status": driver_result.destination_health_status,
+                }
             elif path == _ODOO_PROD_BACKUP_GATE_ROUTE.route_path:
                 odoo_backup_gate_request = (
                     _ODOO_PROD_BACKUP_GATE_ROUTE.envelope_model.model_validate(payload)

--- a/control_plane/workflows/odoo_testing_deploy.py
+++ b/control_plane/workflows/odoo_testing_deploy.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Literal, Protocol
+
+import click
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane import release_tuples as control_plane_release_tuples
+from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
+from control_plane.contracts.deployment_record import DeploymentRecord
+from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+
+
+class OdooTestingDeployStore(Protocol):
+    def read_artifact_manifest(self, artifact_id: str) -> ArtifactIdentityManifest: ...
+
+    def write_deployment_record(self, record: DeploymentRecord) -> Path | None: ...
+
+    def write_environment_inventory(self, record: EnvironmentInventory) -> Path | None: ...
+
+    def write_release_tuple_record(self, record: ReleaseTupleRecord) -> Path | None: ...
+
+
+class OdooTestingDeployRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    context: str
+    instance: str = "testing"
+    artifact_id: str
+    source_git_ref: str
+    wait: bool = True
+    timeout_seconds: int | None = Field(default=None, ge=1)
+    verify_health: bool = True
+    health_timeout_seconds: int | None = Field(default=None, ge=1)
+    no_cache: bool = False
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "OdooTestingDeployRequest":
+        self.context = self.context.strip().lower()
+        self.instance = self.instance.strip().lower()
+        self.artifact_id = self.artifact_id.strip()
+        self.source_git_ref = self.source_git_ref.strip()
+        if not self.context:
+            raise ValueError("Odoo testing deploy requires context.")
+        if self.instance != "testing":
+            raise ValueError("Odoo testing deploy requires instance 'testing'.")
+        if not self.artifact_id:
+            raise ValueError("Odoo testing deploy requires artifact_id.")
+        if not self.source_git_ref:
+            raise ValueError("Odoo testing deploy requires source_git_ref.")
+        if self.verify_health and not self.wait:
+            raise ValueError("Odoo testing deploy health verification requires wait=true.")
+        return self
+
+
+class OdooTestingDeployResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    context: str
+    instance: str
+    artifact_id: str
+    deployment_record_id: str = ""
+    release_tuple_id: str = ""
+    deployment_status: Literal["pending", "pass", "fail", "skipped"] = "skipped"
+    post_deploy_status: Literal["pending", "pass", "fail", "skipped"] = "skipped"
+    destination_health_status: Literal["pending", "pass", "fail", "skipped"] = "skipped"
+    error_message: str = ""
+
+
+def execute_odoo_testing_deploy(
+    *,
+    control_plane_root: Path,
+    state_dir: Path,
+    database_url: str | None,
+    record_store: OdooTestingDeployStore,
+    request: OdooTestingDeployRequest,
+) -> OdooTestingDeployResult:
+    del control_plane_root
+    from control_plane import cli as control_plane_cli
+
+    try:
+        ship_request = control_plane_cli._resolve_native_ship_request(
+            context_name=request.context,
+            instance_name=request.instance,
+            artifact_id=request.artifact_id,
+            source_git_ref=request.source_git_ref,
+            wait=request.wait,
+            timeout_override_seconds=request.timeout_seconds,
+            verify_health=request.verify_health,
+            health_timeout_override_seconds=request.health_timeout_seconds,
+            dry_run=False,
+            no_cache=request.no_cache,
+            allow_dirty=False,
+        )
+        resolved_artifact_id = control_plane_cli._require_artifact_id(
+            requested_artifact_id=ship_request.artifact_id
+        )
+        control_plane_cli._read_artifact_manifest(
+            record_store=record_store,
+            artifact_id=resolved_artifact_id,
+        )
+        normalized_request = ship_request.model_copy(update={"artifact_id": resolved_artifact_id})
+        _record_path, deployment_record = control_plane_cli._execute_ship(
+            state_dir=state_dir,
+            database_url=database_url,
+            env_file=None,
+            request=normalized_request,
+            mint_release_tuple=True,
+        )
+        if not isinstance(deployment_record, DeploymentRecord):
+            raise click.ClickException(
+                "Ship execution returned an unexpected non-record payload during Odoo testing deploy."
+            )
+    except (click.ClickException, json.JSONDecodeError, subprocess.CalledProcessError) as error:
+        return OdooTestingDeployResult(
+            context=request.context,
+            instance=request.instance,
+            artifact_id=request.artifact_id,
+            deployment_status="fail",
+            error_message=str(error),
+        )
+
+    release_tuple_id = ""
+    if deployment_record.wait_for_completion and deployment_record.deploy.status == "pass":
+        release_tuple_id = _release_tuple_id_for_deployment(deployment_record)
+    return OdooTestingDeployResult(
+        context=deployment_record.context,
+        instance=deployment_record.instance,
+        artifact_id=_deployment_artifact_id(deployment_record),
+        deployment_record_id=deployment_record.record_id,
+        release_tuple_id=release_tuple_id,
+        deployment_status=deployment_record.deploy.status,
+        post_deploy_status=deployment_record.post_deploy_update.status,
+        destination_health_status=deployment_record.destination_health.status,
+    )
+
+
+def _release_tuple_id_for_deployment(deployment_record: DeploymentRecord) -> str:
+    if not control_plane_release_tuples.should_mint_release_tuple_for_channel(
+        deployment_record.instance
+    ):
+        return ""
+    return (
+        f"{deployment_record.context}-{deployment_record.instance}-"
+        f"{_deployment_artifact_id(deployment_record)}"
+    )
+
+
+def _deployment_artifact_id(deployment_record: DeploymentRecord) -> str:
+    artifact_identity = deployment_record.artifact_identity
+    if artifact_identity is None:
+        return ""
+    return artifact_identity.artifact_id

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -189,6 +189,13 @@ reusable workflow defaults the Launchplane product key to
 `odoo-tenant-${context}` so publish metadata resolves through the tenant product
 profile that owns the image repository and stable lanes.
 
+Odoo testing deploys follow the same ownership shape. Tenant repos own the
+manual dispatch confirmation and pass an explicit stored `artifact_id` plus
+`source_git_ref` into `reusable-odoo-testing-deploy.yml`; the reusable workflow
+calls `/v1/drivers/odoo/testing-deploy` with product `odoo-tenant-${context}` by
+default. The Launchplane service owns the provider mutation, Odoo post-deploy
+extension, deployment and inventory records, and the testing release tuple.
+
 Start with low-risk deletions and documentation, then replace active workflow
 behavior in small slices. Do not remove active backup, promotion, rollback,
 runtime health, or cleanup safety gates until Launchplane owns the equivalent

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -103,6 +103,7 @@ VeriReel product paths:
   - `POST /v1/drivers/generic-web/preview-destroy`
   - `POST /v1/drivers/odoo/artifact-publish-inputs`
   - `POST /v1/drivers/odoo/artifact-publish`
+  - `POST /v1/drivers/odoo/testing-deploy`
   - `POST /v1/drivers/odoo/post-deploy`
   - `POST /v1/drivers/odoo/config-parameter-override`
   - `POST /v1/drivers/odoo/website-bootstrap-override`
@@ -990,6 +991,7 @@ These use the same authn/authz boundary as evidence ingress:
 
 - `POST /v1/drivers/odoo/post-deploy`
 - `POST /v1/drivers/odoo/artifact-publish`
+- `POST /v1/drivers/odoo/testing-deploy`
 - `POST /v1/drivers/odoo/prod-backup-gate`
 - `POST /v1/drivers/odoo/prod-promotion`
 - `POST /v1/drivers/odoo/prod-rollback`
@@ -1003,6 +1005,7 @@ current handlers include:
 - `POST /v1/drivers/odoo/post-deploy`
 - `POST /v1/drivers/odoo/artifact-publish-inputs`
 - `POST /v1/drivers/odoo/artifact-publish`
+- `POST /v1/drivers/odoo/testing-deploy`
 - `POST /v1/drivers/odoo/website-bootstrap-override`
 - `POST /v1/drivers/odoo/prod-backup-gate`
 - `POST /v1/drivers/odoo/prod-promotion`

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -1450,6 +1450,15 @@ post_odoo_stable_grant \
 post_odoo_stable_grant \
   cbusillo/odoo-tenant-cm \
   cm \
+  odoo-testing-deploy.yml \
+  odoo_testing_deploy.execute \
+  deploy:odoo-cm-testing-deploy-grant \
+  odoo-cm-testing-deploy \
+  reusable-odoo-testing-deploy.yml \
+  odoo-tenant-cm
+post_odoo_stable_grant \
+  cbusillo/odoo-tenant-cm \
+  cm \
   odoo-post-deploy.yml \
   odoo_post_deploy.execute \
   deploy:odoo-cm-post-deploy-grant \
@@ -1549,6 +1558,15 @@ post_odoo_stable_grant \
   deploy:odoo-opw-artifact-publish-grant \
   odoo-opw-artifact-publish \
   reusable-odoo-artifact-publish.yml \
+  odoo-tenant-opw
+post_odoo_stable_grant \
+  cbusillo/odoo-tenant-opw \
+  opw \
+  odoo-testing-deploy.yml \
+  odoo_testing_deploy.execute \
+  deploy:odoo-opw-testing-deploy-grant \
+  odoo-opw-testing-deploy \
+  reusable-odoo-testing-deploy.yml \
   odoo-tenant-opw
 post_odoo_stable_grant \
   cbusillo/odoo-tenant-opw \

--- a/tests/test_odoo_testing_deploy.py
+++ b/tests/test_odoo_testing_deploy.py
@@ -1,0 +1,135 @@
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import click
+from pydantic import ValidationError
+
+from control_plane.contracts.deployment_record import DeploymentRecord
+from control_plane.contracts.promotion_record import (
+    ArtifactIdentityReference,
+    DeploymentEvidence,
+    HealthcheckEvidence,
+    PostDeployUpdateEvidence,
+)
+from control_plane.contracts.ship_request import ShipRequest
+from control_plane.workflows.odoo_testing_deploy import (
+    OdooTestingDeployRequest,
+    execute_odoo_testing_deploy,
+)
+
+
+def _ship_request() -> ShipRequest:
+    return ShipRequest(
+        artifact_id="artifact-cm-new",
+        context="cm",
+        instance="testing",
+        source_git_ref="848bf1b69ff3adbe9b255c61c7b8f5ca04efbcbb",
+        target_name="cm-testing",
+        target_type="compose",
+        deploy_mode="dokploy-compose-api",
+        wait=True,
+        timeout_seconds=1800,
+        verify_health=True,
+        health_timeout_seconds=180,
+        destination_health=HealthcheckEvidence(
+            urls=("https://cm-testing.example/launchplane/health",),
+            timeout_seconds=180,
+            status="pending",
+        ),
+    )
+
+
+def _deployment_record() -> DeploymentRecord:
+    return DeploymentRecord(
+        record_id="deployment-cm-testing",
+        artifact_identity=ArtifactIdentityReference(artifact_id="artifact-cm-new"),
+        context="cm",
+        instance="testing",
+        source_git_ref="848bf1b69ff3adbe9b255c61c7b8f5ca04efbcbb",
+        wait_for_completion=True,
+        deploy=DeploymentEvidence(
+            target_name="cm-testing",
+            target_type="compose",
+            deploy_mode="dokploy-compose-api",
+            deployment_id="control-plane-dokploy",
+            status="pass",
+        ),
+        post_deploy_update=PostDeployUpdateEvidence(
+            attempted=True,
+            status="pass",
+            detail="Post-deploy passed.",
+        ),
+        destination_health=HealthcheckEvidence(
+            verified=True,
+            urls=("https://cm-testing.example/launchplane/health",),
+            timeout_seconds=180,
+            status="pass",
+        ),
+    )
+
+
+class OdooTestingDeployWorkflowTests(unittest.TestCase):
+    def test_request_rejects_non_testing_instance(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "requires instance 'testing'"):
+            OdooTestingDeployRequest(
+                context="cm",
+                instance="prod",
+                artifact_id="artifact-cm-new",
+                source_git_ref="848bf1b69ff3adbe9b255c61c7b8f5ca04efbcbb",
+            )
+
+    def test_deploy_executes_ship_and_reports_testing_release_tuple(self) -> None:
+        record_store = Mock()
+
+        with (
+            patch("control_plane.cli._resolve_native_ship_request", return_value=_ship_request()),
+            patch("control_plane.cli._read_artifact_manifest"),
+            patch("control_plane.cli._execute_ship", return_value=(None, _deployment_record())) as ship,
+        ):
+            result = execute_odoo_testing_deploy(
+                control_plane_root=Path("/control-plane"),
+                state_dir=Path("/state"),
+                database_url="postgresql://launchplane.example/db",
+                record_store=record_store,
+                request=OdooTestingDeployRequest(
+                    context="cm",
+                    artifact_id="artifact-cm-new",
+                    source_git_ref="848bf1b69ff3adbe9b255c61c7b8f5ca04efbcbb",
+                ),
+            )
+
+        self.assertEqual(result.deployment_status, "pass")
+        self.assertEqual(result.post_deploy_status, "pass")
+        self.assertEqual(result.destination_health_status, "pass")
+        self.assertEqual(result.deployment_record_id, "deployment-cm-testing")
+        self.assertEqual(result.release_tuple_id, "cm-testing-artifact-cm-new")
+        ship.assert_called_once()
+        self.assertTrue(ship.call_args.kwargs["mint_release_tuple"])
+
+    def test_failed_ship_returns_failed_result(self) -> None:
+        record_store = Mock()
+
+        with (
+            patch("control_plane.cli._resolve_native_ship_request", return_value=_ship_request()),
+            patch("control_plane.cli._read_artifact_manifest"),
+            patch("control_plane.cli._execute_ship", side_effect=click.ClickException("deploy failed")),
+        ):
+            result = execute_odoo_testing_deploy(
+                control_plane_root=Path("/control-plane"),
+                state_dir=Path("/state"),
+                database_url="postgresql://launchplane.example/db",
+                record_store=record_store,
+                request=OdooTestingDeployRequest(
+                    context="cm",
+                    artifact_id="artifact-cm-new",
+                    source_git_ref="848bf1b69ff3adbe9b255c61c7b8f5ca04efbcbb",
+                ),
+            )
+
+        self.assertEqual(result.deployment_status, "fail")
+        self.assertIn("deploy failed", result.error_message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -157,6 +157,7 @@ class ProductOnboardingTests(unittest.TestCase):
 
         expected_workflows = (
             "reusable-odoo-artifact-publish.yml",
+            "reusable-odoo-testing-deploy.yml",
             "reusable-odoo-post-deploy.yml",
             "reusable-odoo-prod-promotion.yml",
             "reusable-odoo-prod-rollback.yml",
@@ -169,6 +170,7 @@ class ProductOnboardingTests(unittest.TestCase):
                 script_text,
             )
             self.assertIn(f"deploy:odoo-{context_name}-artifact-publish-grant", script_text)
+            self.assertIn(f"deploy:odoo-{context_name}-testing-deploy-grant", script_text)
             self.assertIn(f"deploy:odoo-{context_name}-post-deploy-grant", script_text)
             self.assertIn(f"deploy:odoo-{context_name}-prod-promotion-run-grant", script_text)
             self.assertIn(f"deploy:odoo-{context_name}-prod-rollback-grant", script_text)
@@ -207,6 +209,24 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("publish.manifest=${{ steps.publish.outputs.manifest_file }}", workflow_text)
         self.assertNotIn("short_sha=", workflow_text)
         self.assertNotIn("IMAGE_REPOSITORY: ghcr.io/${{ github.repository }}", workflow_text)
+
+    def test_reusable_odoo_testing_deploy_uses_tenant_product_scope(self) -> None:
+        workflow_text = Path(".github/workflows/reusable-odoo-testing-deploy.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("/v1/drivers/odoo/testing-deploy", workflow_text)
+        self.assertIn("product=\"odoo-tenant-${CONTEXT_NAME}\"", workflow_text)
+        self.assertIn("product=${{ steps.product.outputs.product }}", workflow_text)
+        self.assertIn('"instance":"testing"', workflow_text)
+        self.assertIn("deploy.artifact_id=${{ inputs.artifact_id }}", workflow_text)
+        self.assertIn("deploy.source_git_ref=${{ inputs.source_git_ref }}", workflow_text)
+        for result_path in (
+            "result.deployment_status",
+            "result.post_deploy_status",
+            "result.destination_health_status",
+        ):
+            self.assertIn(result_path, workflow_text)
 
     def test_deploy_launchplane_keeps_terminal_agent_and_owner_agent_inputs_separate(
         self,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -164,6 +164,7 @@ from control_plane.workflows.odoo_prod_promotion_inputs import OdooProdPromotion
 from control_plane.workflows.odoo_prod_promotion import OdooProdPromotionResult
 from control_plane.workflows.odoo_prod_promotion_run import OdooProdPromotionRunResult
 from control_plane.workflows.odoo_prod_rollback import OdooProdRollbackResult
+from control_plane.workflows.odoo_testing_deploy import OdooTestingDeployResult
 from control_plane.workflows.odoo_stable_target_replacement import (
     OdooStableTargetReplacementPlan,
 )
@@ -21293,6 +21294,94 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(replay_status, 202, msg=json.dumps(replay_payload, indent=2))
             self.assertTrue(replay_payload["replayed"])
             self.assertEqual(replay_payload["records"], payload["records"])
+
+    def test_odoo_testing_deploy_driver_executes_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/tenant-cm",
+                            "workflow_refs": [
+                                "every/tenant-cm/.github/workflows/odoo-testing-deploy.yml@refs/heads/main"
+                            ],
+                            "job_workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/reusable-odoo-testing-deploy.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["odoo_testing_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="every/tenant-cm",
+                        workflow_ref=(
+                            "every/tenant-cm/.github/workflows/odoo-testing-deploy.yml@refs/heads/main"
+                        ),
+                        job_workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/reusable-odoo-testing-deploy.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_odoo_testing_deploy",
+                return_value=OdooTestingDeployResult(
+                    context="cm",
+                    instance="testing",
+                    artifact_id="artifact-cm-new",
+                    deployment_record_id="deployment-cm-testing",
+                    release_tuple_id="cm-testing-artifact-cm-new",
+                    deployment_status="pass",
+                    post_deploy_status="pass",
+                    destination_health_status="pass",
+                ),
+            ) as execute_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/testing-deploy",
+                    payload={
+                        "product": "odoo-tenant-cm",
+                        "deploy": {
+                            "context": "cm",
+                            "instance": "testing",
+                            "artifact_id": "artifact-cm-new",
+                            "source_git_ref": "848bf1b69ff3adbe9b255c61c7b8f5ca04efbcbb",
+                        },
+                    },
+                )
+
+            self.assertEqual(status_code, 202, msg=json.dumps(payload, indent=2))
+            self.assertEqual(payload["status"], "accepted")
+            self.assertEqual(
+                payload["records"],
+                {
+                    "deployment_record_id": "deployment-cm-testing",
+                    "release_tuple_id": "cm-testing-artifact-cm-new",
+                    "deployment_status": "pass",
+                    "post_deploy_status": "pass",
+                    "destination_health_status": "pass",
+                },
+            )
+            self.assertEqual(payload["result"]["release_tuple_id"], "cm-testing-artifact-cm-new")
+            execute_mock.assert_called_once()
 
     def test_generic_web_stable_verification_route_accepts_odoo_base_driver_profile(
         self,


### PR DESCRIPTION
## Summary
- add a service-backed Odoo testing deploy route that uses the native ship executor and mints the testing release tuple
- add reusable Odoo testing deploy workflow plus tenant-scoped authz grants
- document the tenant-product deploy shape and cover route/workflow contracts with tests

## Tests
- uv run python -m unittest tests.test_odoo_testing_deploy tests.test_service.LaunchplaneServiceTests.test_odoo_testing_deploy_driver_executes_for_authorized_workflow tests.test_product_onboarding.ProductOnboardingTests.test_reusable_odoo_testing_deploy_uses_tenant_product_scope tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_include_reusable_odoo_stable_workflows tests.test_driver_descriptors
- uv run --extra dev ruff check control_plane/workflows/odoo_testing_deploy.py control_plane/service.py control_plane/drivers/registry.py tests/test_odoo_testing_deploy.py tests/test_service.py tests/test_product_onboarding.py
- uv run --extra dev mypy control_plane/workflows/odoo_testing_deploy.py
- bash -n scripts/deploy/ensure-authz-grants.sh
- git diff --check