### PR TITLE
Use profile health URL for Odoo testing deploy

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -13054,7 +13054,9 @@ def create_launchplane_service_app(
                     state_dir=state_dir,
                     database_url=database_url,
                     record_store=cast(OdooTestingDeployStore, record_store),
-                    request=odoo_deploy_request.deploy,
+                    request=odoo_deploy_request.deploy.model_copy(
+                        update={"product": odoo_deploy_request.product}
+                    ),
                 )
                 result = {
                     "deployment_record_id": driver_result.deployment_record_id,

--- a/control_plane/workflows/odoo_testing_deploy.py
+++ b/control_plane/workflows/odoo_testing_deploy.py
@@ -12,10 +12,15 @@ from control_plane import release_tuples as control_plane_release_tuples
 from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.promotion_record import HealthcheckEvidence
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+from control_plane.contracts.ship_request import ShipRequest
 
 
 class OdooTestingDeployStore(Protocol):
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord: ...
+
     def read_artifact_manifest(self, artifact_id: str) -> ArtifactIdentityManifest: ...
 
     def write_deployment_record(self, record: DeploymentRecord) -> Path | None: ...
@@ -31,6 +36,7 @@ class OdooTestingDeployRequest(BaseModel):
     schema_version: int = Field(default=1, ge=1)
     context: str
     instance: str = "testing"
+    product: str = ""
     artifact_id: str
     source_git_ref: str
     wait: bool = True
@@ -43,6 +49,7 @@ class OdooTestingDeployRequest(BaseModel):
     def _validate_request(self) -> "OdooTestingDeployRequest":
         self.context = self.context.strip().lower()
         self.instance = self.instance.strip().lower()
+        self.product = self.product.strip()
         self.artifact_id = self.artifact_id.strip()
         self.source_git_ref = self.source_git_ref.strip()
         if not self.context:
@@ -72,6 +79,42 @@ class OdooTestingDeployResult(BaseModel):
     error_message: str = ""
 
 
+def _profile_health_url(
+    *,
+    record_store: OdooTestingDeployStore,
+    product: str,
+    context: str,
+    instance: str,
+) -> str:
+    profile = record_store.read_product_profile_record(product.strip())
+    for lane in profile.lanes:
+        if lane.context == context and lane.instance == instance:
+            return lane.health_url.strip()
+    return ""
+
+
+def _ship_request_with_profile_health_url(
+    *,
+    ship_request: ShipRequest,
+    health_url: str,
+) -> ShipRequest:
+    normalized_health_url = health_url.strip()
+    if not normalized_health_url:
+        return ship_request
+    destination_health = ship_request.destination_health
+    if destination_health.urls:
+        return ship_request
+    timeout_seconds = destination_health.timeout_seconds or ship_request.health_timeout_seconds
+    updated_health = HealthcheckEvidence(
+        urls=(normalized_health_url,),
+        timeout_seconds=timeout_seconds,
+        status="pending",
+    )
+    return ship_request.model_copy(
+        update={"verify_health": True, "destination_health": updated_health}
+    )
+
+
 def execute_odoo_testing_deploy(
     *,
     control_plane_root: Path,
@@ -84,6 +127,12 @@ def execute_odoo_testing_deploy(
     from control_plane import cli as control_plane_cli
 
     try:
+        health_url = _profile_health_url(
+            record_store=record_store,
+            product=request.product or f"odoo-tenant-{request.context}",
+            context=request.context,
+            instance=request.instance,
+        )
         ship_request = control_plane_cli._resolve_native_ship_request(
             context_name=request.context,
             instance_name=request.instance,
@@ -91,12 +140,17 @@ def execute_odoo_testing_deploy(
             source_git_ref=request.source_git_ref,
             wait=request.wait,
             timeout_override_seconds=request.timeout_seconds,
-            verify_health=request.verify_health,
+            verify_health=False if request.verify_health and health_url else request.verify_health,
             health_timeout_override_seconds=request.health_timeout_seconds,
             dry_run=False,
             no_cache=request.no_cache,
             allow_dirty=False,
         )
+        if request.verify_health:
+            ship_request = _ship_request_with_profile_health_url(
+                ship_request=ship_request,
+                health_url=health_url,
+            )
         resolved_artifact_id = control_plane_cli._require_artifact_id(
             requested_artifact_id=ship_request.artifact_id
         )

--- a/tests/test_odoo_testing_deploy.py
+++ b/tests/test_odoo_testing_deploy.py
@@ -12,6 +12,11 @@ from control_plane.contracts.promotion_record import (
     HealthcheckEvidence,
     PostDeployUpdateEvidence,
 )
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductImageProfile,
+    ProductLaneProfile,
+)
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.workflows.odoo_testing_deploy import (
     OdooTestingDeployRequest,
@@ -37,6 +42,32 @@ def _ship_request() -> ShipRequest:
             timeout_seconds=180,
             status="pending",
         ),
+    )
+
+
+def _ship_request_without_health_url() -> ShipRequest:
+    request = _ship_request()
+    return request.model_copy(update={"destination_health": HealthcheckEvidence(status="skipped")})
+
+
+def _profile() -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord(
+        product="odoo-tenant-cm",
+        display_name="CM Odoo",
+        repository="cbusillo/odoo-tenant-cm",
+        driver_id="odoo",
+        image=ProductImageProfile(repository="ghcr.io/cbusillo/odoo-tenant-cm"),
+        runtime_port=8069,
+        health_path="/launchplane/health",
+        lanes=(
+            ProductLaneProfile(
+                instance="testing",
+                context="cm",
+                health_url="https://cm-testing.example/launchplane/health",
+            ),
+        ),
+        updated_at="2026-05-30T20:30:00Z",
+        source="test",
     )
 
 
@@ -81,6 +112,7 @@ class OdooTestingDeployWorkflowTests(unittest.TestCase):
 
     def test_deploy_executes_ship_and_reports_testing_release_tuple(self) -> None:
         record_store = Mock()
+        record_store.read_product_profile_record.return_value = _profile()
 
         with (
             patch("control_plane.cli._resolve_native_ship_request", return_value=_ship_request()),
@@ -107,8 +139,42 @@ class OdooTestingDeployWorkflowTests(unittest.TestCase):
         ship.assert_called_once()
         self.assertTrue(ship.call_args.kwargs["mint_release_tuple"])
 
+    def test_deploy_uses_profile_health_url_when_target_has_no_health_url(self) -> None:
+        record_store = Mock()
+        record_store.read_product_profile_record.return_value = _profile()
+
+        with (
+            patch(
+                "control_plane.cli._resolve_native_ship_request",
+                return_value=_ship_request_without_health_url(),
+            ) as resolve_ship,
+            patch("control_plane.cli._read_artifact_manifest"),
+            patch("control_plane.cli._execute_ship", return_value=(None, _deployment_record())) as ship,
+        ):
+            execute_odoo_testing_deploy(
+                control_plane_root=Path("/control-plane"),
+                state_dir=Path("/state"),
+                database_url="postgresql://launchplane.example/db",
+                record_store=record_store,
+                request=OdooTestingDeployRequest(
+                    context="cm",
+                    product="odoo-tenant-cm",
+                    artifact_id="artifact-cm-new",
+                    source_git_ref="848bf1b69ff3adbe9b255c61c7b8f5ca04efbcbb",
+                ),
+            )
+
+        self.assertFalse(resolve_ship.call_args.kwargs["verify_health"])
+        normalized_request = ship.call_args.kwargs["request"]
+        self.assertTrue(normalized_request.verify_health)
+        self.assertEqual(
+            normalized_request.destination_health.urls,
+            ("https://cm-testing.example/launchplane/health",),
+        )
+
     def test_failed_ship_returns_failed_result(self) -> None:
         record_store = Mock()
+        record_store.read_product_profile_record.return_value = _profile()
 
         with (
             patch("control_plane.cli._resolve_native_ship_request", return_value=_ship_request()),


### PR DESCRIPTION
## Summary
- resolve the tenant product profile for Odoo testing deploys
- use the profile lane health URL when the tracked Dokploy target has no health URL/domain
- preserve health verification by injecting that URL into the ship request before execution

## Tests
- uv run python -m unittest tests.test_odoo_testing_deploy tests.test_service.LaunchplaneServiceTests.test_odoo_testing_deploy_driver_executes_for_authorized_workflow
- uv run --extra dev ruff check control_plane/workflows/odoo_testing_deploy.py control_plane/service.py tests/test_odoo_testing_deploy.py
- uv run --extra dev mypy control_plane/workflows/odoo_testing_deploy.py tests/test_odoo_testing_deploy.py
- git diff --check