### PR TITLE
Seed OPW stable health URLs

### DIFF
--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -630,6 +630,8 @@ apply_odoo_opw_onboarding() {
             {
               instance: "testing",
               context: "opw",
+              base_url: "https://opw-testing.shinycomputers.com",
+              health_url: "https://opw-testing.shinycomputers.com/web/health",
               odoo_prelaunch_rebuild: {
                 enabled: true,
                 approval_issue_url: "https://github.com/cbusillo/launchplane/issues/573",
@@ -650,6 +652,8 @@ apply_odoo_opw_onboarding() {
             {
               instance: "prod",
               context: "opw",
+              base_url: "https://opw-prod.shinycomputers.com",
+              health_url: "https://opw-prod.shinycomputers.com/web/health",
               odoo_prelaunch_rebuild: {
                 enabled: true,
                 approval_issue_url: "https://github.com/cbusillo/launchplane/issues/573",
@@ -690,6 +694,7 @@ apply_odoo_opw_onboarding() {
                   target_id: $testing_target_id,
                   target_type: "compose",
                   target_name: "opw-testing",
+                  domains: ["opw-testing.shinycomputers.com"],
                   healthcheck_path: "/web/health",
                   healthcheck_enabled: true,
                   deploy_timeout_seconds: 900
@@ -704,6 +709,7 @@ apply_odoo_opw_onboarding() {
                   target_id: $prod_target_id,
                   target_type: "compose",
                   target_name: "opw-prod",
+                  domains: ["opw-prod.shinycomputers.com"],
                   healthcheck_path: "/web/health",
                   healthcheck_enabled: true,
                   deploy_timeout_seconds: 900

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -174,6 +174,12 @@ class ProductOnboardingTests(unittest.TestCase):
             self.assertIn(f"deploy:odoo-{context_name}-post-deploy-grant", script_text)
             self.assertIn(f"deploy:odoo-{context_name}-prod-promotion-run-grant", script_text)
             self.assertIn(f"deploy:odoo-{context_name}-prod-rollback-grant", script_text)
+        self.assertIn('base_url: "https://opw-testing.shinycomputers.com"', script_text)
+        self.assertIn(
+            'health_url: "https://opw-testing.shinycomputers.com/web/health"',
+            script_text,
+        )
+        self.assertIn('domains: ["opw-testing.shinycomputers.com"]', script_text)
 
     def test_reusable_odoo_artifact_publish_standardizes_request_shape(self) -> None:
         workflow_text = Path(".github/workflows/reusable-odoo-artifact-publish.yml").read_text(


### PR DESCRIPTION
## Summary
- seed OPW stable lane base/health URLs in product onboarding
- seed OPW tracked Dokploy target domains so ship health resolution works directly
- add a contract assertion for the OPW testing health authority

## Tests
- bash -n scripts/deploy/ensure-authz-grants.sh
- shellcheck scripts/deploy/ensure-authz-grants.sh
- uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_include_reusable_odoo_stable_workflows
- uv run --extra dev ruff check tests/test_product_onboarding.py
- git diff --check