### PR TITLE
Fix Odoo testing deploy health and outputs

### DIFF
--- a/.github/workflows/reusable-odoo-testing-deploy.yml
+++ b/.github/workflows/reusable-odoo-testing-deploy.yml
@@ -27,6 +27,25 @@ name: Reusable Odoo Testing Deploy
         required: false
         default: "2700000"
         type: string
+    outputs:
+      deployment_record_id:
+        description: Launchplane deployment record ID.
+        value: ${{ jobs.testing-deploy.outputs.deployment_record_id }}
+      release_tuple_id:
+        description: Minted testing release tuple ID.
+        value: ${{ jobs.testing-deploy.outputs.release_tuple_id }}
+      deployment_status:
+        description: Launchplane deployment status.
+        value: ${{ jobs.testing-deploy.outputs.deployment_status }}
+      post_deploy_status:
+        description: Odoo post-deploy status.
+        value: ${{ jobs.testing-deploy.outputs.post_deploy_status }}
+      destination_health_status:
+        description: Destination health status.
+        value: ${{ jobs.testing-deploy.outputs.destination_health_status }}
+      error_message:
+        description: Launchplane driver error message, when present.
+        value: ${{ jobs.testing-deploy.outputs.error_message }}
 
 permissions:
   contents: read
@@ -34,6 +53,14 @@ permissions:
 
 jobs:
   testing-deploy:
+    outputs:
+      deployment_record_id: ${{ steps.lp.outputs.deployment_record_id }}
+      release_tuple_id: ${{ steps.lp.outputs.release_tuple_id }}
+      deployment_status: ${{ steps.lp.outputs.deployment_status }}
+      post_deploy_status: ${{ steps.lp.outputs.post_deploy_status }}
+      destination_health_status: >-
+        ${{ steps.lp.outputs.destination_health_status }}
+      error_message: ${{ steps.lp.outputs.error_message }}
     runs-on:
       - self-hosted
       - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}

--- a/control_plane/workflows/odoo_testing_deploy.py
+++ b/control_plane/workflows/odoo_testing_deploy.py
@@ -115,6 +115,55 @@ def _ship_request_with_profile_health_url(
     )
 
 
+def _resolve_ship_request_with_health_fallback(
+    *,
+    request: OdooTestingDeployRequest,
+    health_url: str,
+) -> ShipRequest:
+    from control_plane import cli as control_plane_cli
+
+    try:
+        return control_plane_cli._resolve_native_ship_request(
+            context_name=request.context,
+            instance_name=request.instance,
+            artifact_id=request.artifact_id,
+            source_git_ref=request.source_git_ref,
+            wait=request.wait,
+            timeout_override_seconds=request.timeout_seconds,
+            verify_health=request.verify_health,
+            health_timeout_override_seconds=request.health_timeout_seconds,
+            dry_run=False,
+            no_cache=request.no_cache,
+            allow_dirty=False,
+        )
+    except click.ClickException as error:
+        if not _should_retry_with_profile_health_url(error=error, health_url=health_url):
+            raise
+        fallback_request = control_plane_cli._resolve_native_ship_request(
+            context_name=request.context,
+            instance_name=request.instance,
+            artifact_id=request.artifact_id,
+            source_git_ref=request.source_git_ref,
+            wait=request.wait,
+            timeout_override_seconds=request.timeout_seconds,
+            verify_health=False,
+            health_timeout_override_seconds=request.health_timeout_seconds,
+            dry_run=False,
+            no_cache=request.no_cache,
+            allow_dirty=False,
+        )
+        return _ship_request_with_profile_health_url(
+            ship_request=fallback_request,
+            health_url=health_url,
+        )
+
+
+def _should_retry_with_profile_health_url(*, error: click.ClickException, health_url: str) -> bool:
+    if not health_url.strip():
+        return False
+    return "no target domain/URL was resolved" in str(error)
+
+
 def execute_odoo_testing_deploy(
     *,
     control_plane_root: Path,
@@ -133,24 +182,10 @@ def execute_odoo_testing_deploy(
             context=request.context,
             instance=request.instance,
         )
-        ship_request = control_plane_cli._resolve_native_ship_request(
-            context_name=request.context,
-            instance_name=request.instance,
-            artifact_id=request.artifact_id,
-            source_git_ref=request.source_git_ref,
-            wait=request.wait,
-            timeout_override_seconds=request.timeout_seconds,
-            verify_health=False if request.verify_health and health_url else request.verify_health,
-            health_timeout_override_seconds=request.health_timeout_seconds,
-            dry_run=False,
-            no_cache=request.no_cache,
-            allow_dirty=False,
+        ship_request = _resolve_ship_request_with_health_fallback(
+            request=request,
+            health_url=health_url,
         )
-        if request.verify_health:
-            ship_request = _ship_request_with_profile_health_url(
-                ship_request=ship_request,
-                health_url=health_url,
-            )
         resolved_artifact_id = control_plane_cli._require_artifact_id(
             requested_artifact_id=ship_request.artifact_id
         )

--- a/tests/test_odoo_testing_deploy.py
+++ b/tests/test_odoo_testing_deploy.py
@@ -142,11 +142,15 @@ class OdooTestingDeployWorkflowTests(unittest.TestCase):
     def test_deploy_uses_profile_health_url_when_target_has_no_health_url(self) -> None:
         record_store = Mock()
         record_store.read_product_profile_record.return_value = _profile()
+        no_health_error = click.ClickException(
+            "Healthcheck verification requested but no target domain/URL was resolved. "
+            "Define domains in the tracked Dokploy target record or disable with --no-verify-health."
+        )
 
         with (
             patch(
                 "control_plane.cli._resolve_native_ship_request",
-                return_value=_ship_request_without_health_url(),
+                side_effect=(no_health_error, _ship_request_without_health_url()),
             ) as resolve_ship,
             patch("control_plane.cli._read_artifact_manifest"),
             patch("control_plane.cli._execute_ship", return_value=(None, _deployment_record())) as ship,
@@ -164,7 +168,40 @@ class OdooTestingDeployWorkflowTests(unittest.TestCase):
                 ),
             )
 
-        self.assertFalse(resolve_ship.call_args.kwargs["verify_health"])
+        self.assertEqual(resolve_ship.call_count, 2)
+        self.assertTrue(resolve_ship.call_args_list[0].kwargs["verify_health"])
+        self.assertFalse(resolve_ship.call_args_list[1].kwargs["verify_health"])
+        normalized_request = ship.call_args.kwargs["request"]
+        self.assertTrue(normalized_request.verify_health)
+        self.assertEqual(
+            normalized_request.destination_health.urls,
+            ("https://cm-testing.example/launchplane/health",),
+        )
+
+    def test_deploy_preserves_target_health_url_when_resolved(self) -> None:
+        record_store = Mock()
+        record_store.read_product_profile_record.return_value = _profile()
+
+        with (
+            patch("control_plane.cli._resolve_native_ship_request", return_value=_ship_request()) as resolve_ship,
+            patch("control_plane.cli._read_artifact_manifest"),
+            patch("control_plane.cli._execute_ship", return_value=(None, _deployment_record())) as ship,
+        ):
+            execute_odoo_testing_deploy(
+                control_plane_root=Path("/control-plane"),
+                state_dir=Path("/state"),
+                database_url="postgresql://launchplane.example/db",
+                record_store=record_store,
+                request=OdooTestingDeployRequest(
+                    context="cm",
+                    product="odoo-tenant-cm",
+                    artifact_id="artifact-cm-new",
+                    source_git_ref="848bf1b69ff3adbe9b255c61c7b8f5ca04efbcbb",
+                ),
+            )
+
+        resolve_ship.assert_called_once()
+        self.assertTrue(resolve_ship.call_args.kwargs["verify_health"])
         normalized_request = ship.call_args.kwargs["request"]
         self.assertTrue(normalized_request.verify_health)
         self.assertEqual(

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -227,6 +227,9 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn('"instance":"testing"', workflow_text)
         self.assertIn("deploy.artifact_id=${{ inputs.artifact_id }}", workflow_text)
         self.assertIn("deploy.source_git_ref=${{ inputs.source_git_ref }}", workflow_text)
+        self.assertIn("outputs:", workflow_text)
+        self.assertIn("value: ${{ jobs.testing-deploy.outputs.deployment_record_id }}", workflow_text)
+        self.assertIn("deployment_record_id: ${{ steps.lp.outputs.deployment_record_id }}", workflow_text)
         for result_path in (
             "result.deployment_status",
             "result.post_deploy_status",


### PR DESCRIPTION
## Summary
- preserve normal target-derived Odoo testing health verification when target URLs resolve
- retry with profile-lane health URL only for the missing-target-health case
- expose reusable Odoo testing deploy workflow outputs to callers

## Tests
- uv run python -m unittest tests.test_odoo_testing_deploy tests.test_product_onboarding.ProductOnboardingTests.test_reusable_odoo_testing_deploy_uses_tenant_product_scope
- uv run --extra dev ruff check control_plane/workflows/odoo_testing_deploy.py tests/test_odoo_testing_deploy.py tests/test_product_onboarding.py
- uv run --extra dev mypy control_plane/workflows/odoo_testing_deploy.py tests/test_odoo_testing_deploy.py
- git diff --check