### PR TITLE
Use Launchplane health for Odoo lane verification

### DIFF
--- a/docs/records.md
+++ b/docs/records.md
@@ -321,11 +321,11 @@ authority by themselves.
 driver defaults. `resettable` lanes may explicitly allow `empty` rebuilds;
 `restorable` lanes may explicitly allow `upstream_restore` and must name an
 `upstream_source`; `authoritative` lanes require backup-before-destroy and
-restore-proof safeguards. Routine Odoo probe details such as the Launchplane
-runtime identity endpoint `/launchplane/health`, local liveness endpoint
-`/web/health`, and logo URL discovery belong in the Odoo driver, not in
-tenant-owned product config, unless a lane has a real exception that needs an
-explicit override.
+restore-proof safeguards. Routine Odoo probe details belong in the Odoo driver,
+not in tenant-owned product config, unless a lane has a real exception that
+needs an explicit override. Launchplane-managed Odoo lanes use the runtime
+identity endpoint `/launchplane/health` for lane verification; provider-local
+container liveness checks may continue to use Odoo's `/web/health` endpoint.
 
 This file layout describes today's local Launchplane implementation, not the
 final cross-product communication boundary. The stable long-term contract should

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -490,7 +490,7 @@ apply_odoo_cm_onboarding() {
           driver_id: "odoo",
           image_repository: "ghcr.io/cbusillo/odoo-tenant-cm",
           runtime_port: 8069,
-          health_path: "/web/health",
+          health_path: "/launchplane/health",
           lanes: [
             {
               instance: "testing",
@@ -625,13 +625,13 @@ apply_odoo_opw_onboarding() {
           driver_id: "odoo",
           image_repository: "ghcr.io/cbusillo/odoo-tenant-opw",
           runtime_port: 8069,
-          health_path: "/web/health",
+          health_path: "/launchplane/health",
           lanes: [
             {
               instance: "testing",
               context: "opw",
               base_url: "https://opw-testing.shinycomputers.com",
-              health_url: "https://opw-testing.shinycomputers.com/web/health",
+              health_url: "https://opw-testing.shinycomputers.com/launchplane/health",
               odoo_prelaunch_rebuild: {
                 enabled: true,
                 approval_issue_url: "https://github.com/cbusillo/launchplane/issues/573",
@@ -653,7 +653,7 @@ apply_odoo_opw_onboarding() {
               instance: "prod",
               context: "opw",
               base_url: "https://opw-prod.shinycomputers.com",
-              health_url: "https://opw-prod.shinycomputers.com/web/health",
+              health_url: "https://opw-prod.shinycomputers.com/launchplane/health",
               odoo_prelaunch_rebuild: {
                 enabled: true,
                 approval_issue_url: "https://github.com/cbusillo/launchplane/issues/573",

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -176,9 +176,10 @@ class ProductOnboardingTests(unittest.TestCase):
             self.assertIn(f"deploy:odoo-{context_name}-prod-rollback-grant", script_text)
         self.assertIn('base_url: "https://opw-testing.shinycomputers.com"', script_text)
         self.assertIn(
-            'health_url: "https://opw-testing.shinycomputers.com/web/health"',
+            'health_url: "https://opw-testing.shinycomputers.com/launchplane/health"',
             script_text,
         )
+        self.assertIn('health_path: "/launchplane/health"', script_text)
         self.assertIn('domains: ["opw-testing.shinycomputers.com"]', script_text)
 
     def test_reusable_odoo_artifact_publish_standardizes_request_shape(self) -> None:


### PR DESCRIPTION
## Summary
- switch seeded Odoo CM/OPW product profiles to /launchplane/health for lane verification
- keep Dokploy target healthcheck_path on /web/health for provider-local container liveness
- document the split between Launchplane lane verification and provider liveness

## Validation
- git diff --check
- bash -n scripts/deploy/ensure-authz-grants.sh
- shellcheck scripts/deploy/ensure-authz-grants.sh
- uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_include_reusable_odoo_stable_workflows tests.test_product_onboarding.ProductOnboardingTests.test_deploy_odoo_cm_onboarding_manifest_encodes_issue_backed_bootstrap_policy tests.test_product_onboarding.ProductOnboardingTests.test_deploy_odoo_opw_onboarding_manifest_encodes_upstream_restore_policy tests.test_product_onboarding.ProductOnboardingTests.test_apply_product_onboarding_manifest_writes_canonical_records
- uv run --extra dev ruff check --diff tests/test_product_onboarding.py
- uv run --extra dev ruff check tests/test_product_onboarding.py
- uv run --extra dev mypy tests/test_product_onboarding.py