### PR TITLE
Tighten Odoo testing deploy tuple contract

### DIFF
--- a/control_plane/workflows/odoo_testing_deploy.py
+++ b/control_plane/workflows/odoo_testing_deploy.py
@@ -60,8 +60,10 @@ class OdooTestingDeployRequest(BaseModel):
             raise ValueError("Odoo testing deploy requires artifact_id.")
         if not self.source_git_ref:
             raise ValueError("Odoo testing deploy requires source_git_ref.")
-        if self.verify_health and not self.wait:
-            raise ValueError("Odoo testing deploy health verification requires wait=true.")
+        if not self.wait:
+            raise ValueError(
+                "Odoo testing deploy requires wait=true so Launchplane can mint a release tuple."
+            )
         return self
 
 
@@ -118,7 +120,7 @@ def _ship_request_with_profile_health_url(
 def _resolve_ship_request_with_health_fallback(
     *,
     request: OdooTestingDeployRequest,
-    health_url: str,
+    record_store: OdooTestingDeployStore,
 ) -> ShipRequest:
     from control_plane import cli as control_plane_cli
 
@@ -137,6 +139,14 @@ def _resolve_ship_request_with_health_fallback(
             allow_dirty=False,
         )
     except click.ClickException as error:
+        if not _is_missing_target_health_url_error(error):
+            raise
+        health_url = _profile_health_url(
+            record_store=record_store,
+            product=request.product or f"odoo-tenant-{request.context}",
+            context=request.context,
+            instance=request.instance,
+        )
         if not _should_retry_with_profile_health_url(error=error, health_url=health_url):
             raise
         fallback_request = control_plane_cli._resolve_native_ship_request(
@@ -161,6 +171,10 @@ def _resolve_ship_request_with_health_fallback(
 def _should_retry_with_profile_health_url(*, error: click.ClickException, health_url: str) -> bool:
     if not health_url.strip():
         return False
+    return _is_missing_target_health_url_error(error)
+
+
+def _is_missing_target_health_url_error(error: click.ClickException) -> bool:
     return "no target domain/URL was resolved" in str(error)
 
 
@@ -176,15 +190,9 @@ def execute_odoo_testing_deploy(
     from control_plane import cli as control_plane_cli
 
     try:
-        health_url = _profile_health_url(
-            record_store=record_store,
-            product=request.product or f"odoo-tenant-{request.context}",
-            context=request.context,
-            instance=request.instance,
-        )
         ship_request = _resolve_ship_request_with_health_fallback(
             request=request,
-            health_url=health_url,
+            record_store=record_store,
         )
         resolved_artifact_id = control_plane_cli._require_artifact_id(
             requested_artifact_id=ship_request.artifact_id

--- a/tests/test_odoo_testing_deploy.py
+++ b/tests/test_odoo_testing_deploy.py
@@ -110,6 +110,16 @@ class OdooTestingDeployWorkflowTests(unittest.TestCase):
                 source_git_ref="848bf1b69ff3adbe9b255c61c7b8f5ca04efbcbb",
             )
 
+    def test_request_rejects_async_deploy_without_tuple_minting(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "requires wait=true"):
+            OdooTestingDeployRequest(
+                context="cm",
+                artifact_id="artifact-cm-new",
+                source_git_ref="848bf1b69ff3adbe9b255c61c7b8f5ca04efbcbb",
+                wait=False,
+                verify_health=False,
+            )
+
     def test_deploy_executes_ship_and_reports_testing_release_tuple(self) -> None:
         record_store = Mock()
         record_store.read_product_profile_record.return_value = _profile()
@@ -138,6 +148,34 @@ class OdooTestingDeployWorkflowTests(unittest.TestCase):
         self.assertEqual(result.release_tuple_id, "cm-testing-artifact-cm-new")
         ship.assert_called_once()
         self.assertTrue(ship.call_args.kwargs["mint_release_tuple"])
+        record_store.read_product_profile_record.assert_not_called()
+
+    def test_deploy_does_not_require_profile_when_target_health_url_resolves(self) -> None:
+        record_store = Mock()
+        record_store.read_product_profile_record.side_effect = FileNotFoundError(
+            "odoo-tenant-cm"
+        )
+
+        with (
+            patch("control_plane.cli._resolve_native_ship_request", return_value=_ship_request()),
+            patch("control_plane.cli._read_artifact_manifest"),
+            patch("control_plane.cli._execute_ship", return_value=(None, _deployment_record())),
+        ):
+            result = execute_odoo_testing_deploy(
+                control_plane_root=Path("/control-plane"),
+                state_dir=Path("/state"),
+                database_url="postgresql://launchplane.example/db",
+                record_store=record_store,
+                request=OdooTestingDeployRequest(
+                    context="cm",
+                    artifact_id="artifact-cm-new",
+                    source_git_ref="848bf1b69ff3adbe9b255c61c7b8f5ca04efbcbb",
+                ),
+            )
+
+        self.assertEqual(result.deployment_status, "pass")
+        self.assertEqual(result.release_tuple_id, "cm-testing-artifact-cm-new")
+        record_store.read_product_profile_record.assert_not_called()
 
     def test_deploy_uses_profile_health_url_when_target_has_no_health_url(self) -> None:
         record_store = Mock()
@@ -169,6 +207,7 @@ class OdooTestingDeployWorkflowTests(unittest.TestCase):
             )
 
         self.assertEqual(resolve_ship.call_count, 2)
+        record_store.read_product_profile_record.assert_called_once_with("odoo-tenant-cm")
         self.assertTrue(resolve_ship.call_args_list[0].kwargs["verify_health"])
         self.assertFalse(resolve_ship.call_args_list[1].kwargs["verify_health"])
         normalized_request = ship.call_args.kwargs["request"]


### PR DESCRIPTION
## Summary
- reject Odoo testing deploy requests with wait=false because the route must mint/report a testing release tuple
- defer product profile lookup until the native ship resolver actually needs the profile health URL fallback
- add regression coverage for target-health-only deploys and async request rejection

## Validation
- git diff --check
- uv run python -m unittest tests.test_odoo_testing_deploy
- uv run --extra dev ruff check --diff control_plane/workflows/odoo_testing_deploy.py tests/test_odoo_testing_deploy.py
- uv run --extra dev ruff check control_plane/workflows/odoo_testing_deploy.py tests/test_odoo_testing_deploy.py
- uv run --extra dev mypy control_plane/workflows/odoo_testing_deploy.py tests/test_odoo_testing_deploy.py