### PR TITLE
Prefer Odoo profile health for testing deploys

### DIFF
--- a/control_plane/workflows/odoo_testing_deploy.py
+++ b/control_plane/workflows/odoo_testing_deploy.py
@@ -95,6 +95,24 @@ def _profile_health_url(
     return ""
 
 
+def _optional_profile_health_url(
+    *,
+    record_store: OdooTestingDeployStore,
+    product: str,
+    context: str,
+    instance: str,
+) -> str:
+    try:
+        return _profile_health_url(
+            record_store=record_store,
+            product=product,
+            context=context,
+            instance=instance,
+        )
+    except FileNotFoundError:
+        return ""
+
+
 def _ship_request_with_profile_health_url(
     *,
     ship_request: ShipRequest,
@@ -104,8 +122,6 @@ def _ship_request_with_profile_health_url(
     if not normalized_health_url:
         return ship_request
     destination_health = ship_request.destination_health
-    if destination_health.urls:
-        return ship_request
     timeout_seconds = destination_health.timeout_seconds or ship_request.health_timeout_seconds
     updated_health = HealthcheckEvidence(
         urls=(normalized_health_url,),
@@ -124,8 +140,9 @@ def _resolve_ship_request_with_health_fallback(
 ) -> ShipRequest:
     from control_plane import cli as control_plane_cli
 
+    product = request.product or f"odoo-tenant-{request.context}"
     try:
-        return control_plane_cli._resolve_native_ship_request(
+        ship_request = control_plane_cli._resolve_native_ship_request(
             context_name=request.context,
             instance_name=request.instance,
             artifact_id=request.artifact_id,
@@ -138,12 +155,23 @@ def _resolve_ship_request_with_health_fallback(
             no_cache=request.no_cache,
             allow_dirty=False,
         )
+        if not request.verify_health:
+            return ship_request
+        return _ship_request_with_profile_health_url(
+            ship_request=ship_request,
+            health_url=_optional_profile_health_url(
+                record_store=record_store,
+                product=product,
+                context=request.context,
+                instance=request.instance,
+            ),
+        )
     except click.ClickException as error:
         if not _is_missing_target_health_url_error(error):
             raise
         health_url = _profile_health_url(
             record_store=record_store,
-            product=request.product or f"odoo-tenant-{request.context}",
+            product=product,
             context=request.context,
             instance=request.instance,
         )

--- a/tests/test_odoo_testing_deploy.py
+++ b/tests/test_odoo_testing_deploy.py
@@ -148,7 +148,7 @@ class OdooTestingDeployWorkflowTests(unittest.TestCase):
         self.assertEqual(result.release_tuple_id, "cm-testing-artifact-cm-new")
         ship.assert_called_once()
         self.assertTrue(ship.call_args.kwargs["mint_release_tuple"])
-        record_store.read_product_profile_record.assert_not_called()
+        record_store.read_product_profile_record.assert_called_once_with("odoo-tenant-cm")
 
     def test_deploy_does_not_require_profile_when_target_health_url_resolves(self) -> None:
         record_store = Mock()
@@ -175,7 +175,7 @@ class OdooTestingDeployWorkflowTests(unittest.TestCase):
 
         self.assertEqual(result.deployment_status, "pass")
         self.assertEqual(result.release_tuple_id, "cm-testing-artifact-cm-new")
-        record_store.read_product_profile_record.assert_not_called()
+        record_store.read_product_profile_record.assert_called_once_with("odoo-tenant-cm")
 
     def test_deploy_uses_profile_health_url_when_target_has_no_health_url(self) -> None:
         record_store = Mock()
@@ -217,12 +217,21 @@ class OdooTestingDeployWorkflowTests(unittest.TestCase):
             ("https://cm-testing.example/launchplane/health",),
         )
 
-    def test_deploy_preserves_target_health_url_when_resolved(self) -> None:
+    def test_deploy_prefers_profile_health_url_when_target_health_url_resolves(self) -> None:
         record_store = Mock()
         record_store.read_product_profile_record.return_value = _profile()
+        target_request = _ship_request().model_copy(
+            update={
+                "destination_health": HealthcheckEvidence(
+                    urls=("https://cm-testing.example/web/health",),
+                    timeout_seconds=180,
+                    status="pending",
+                )
+            }
+        )
 
         with (
-            patch("control_plane.cli._resolve_native_ship_request", return_value=_ship_request()) as resolve_ship,
+            patch("control_plane.cli._resolve_native_ship_request", return_value=target_request) as resolve_ship,
             patch("control_plane.cli._read_artifact_manifest"),
             patch("control_plane.cli._execute_ship", return_value=(None, _deployment_record())) as ship,
         ):
@@ -246,6 +255,47 @@ class OdooTestingDeployWorkflowTests(unittest.TestCase):
         self.assertEqual(
             normalized_request.destination_health.urls,
             ("https://cm-testing.example/launchplane/health",),
+        )
+
+    def test_deploy_preserves_target_health_url_when_profile_is_missing(self) -> None:
+        record_store = Mock()
+        record_store.read_product_profile_record.side_effect = FileNotFoundError(
+            "odoo-tenant-cm"
+        )
+        target_request = _ship_request().model_copy(
+            update={
+                "destination_health": HealthcheckEvidence(
+                    urls=("https://cm-testing.example/web/health",),
+                    timeout_seconds=180,
+                    status="pending",
+                )
+            }
+        )
+
+        with (
+            patch("control_plane.cli._resolve_native_ship_request", return_value=target_request) as resolve_ship,
+            patch("control_plane.cli._read_artifact_manifest"),
+            patch("control_plane.cli._execute_ship", return_value=(None, _deployment_record())) as ship,
+        ):
+            execute_odoo_testing_deploy(
+                control_plane_root=Path("/control-plane"),
+                state_dir=Path("/state"),
+                database_url="postgresql://launchplane.example/db",
+                record_store=record_store,
+                request=OdooTestingDeployRequest(
+                    context="cm",
+                    product="odoo-tenant-cm",
+                    artifact_id="artifact-cm-new",
+                    source_git_ref="848bf1b69ff3adbe9b255c61c7b8f5ca04efbcbb",
+                ),
+            )
+
+        resolve_ship.assert_called_once()
+        record_store.read_product_profile_record.assert_called_once_with("odoo-tenant-cm")
+        normalized_request = ship.call_args.kwargs["request"]
+        self.assertEqual(
+            normalized_request.destination_health.urls,
+            ("https://cm-testing.example/web/health",),
         )
 
     def test_failed_ship_returns_failed_result(self) -> None:


### PR DESCRIPTION
## Summary
- make Odoo testing deploy prefer product-profile lane health URLs when present
- keep target-derived health as the fallback when no product profile is available
- add regression coverage for profile override, profile-missing fallback, and missing-target fallback

## Validation
- git diff --check
- uv run python -m unittest tests.test_odoo_testing_deploy
- uv run --extra dev ruff check --diff control_plane/workflows/odoo_testing_deploy.py tests/test_odoo_testing_deploy.py
- uv run --extra dev ruff check control_plane/workflows/odoo_testing_deploy.py tests/test_odoo_testing_deploy.py
- uv run --extra dev mypy control_plane/workflows/odoo_testing_deploy.py tests/test_odoo_testing_deploy.py

## Runtime note
OPW testing deploy currently fails because the generic target healthcheck URL resolves to /web/health. This change makes the Odoo route use the product lane's /launchplane/health URL for verification once deployed.