### PR TITLE
Refresh OIDC token while polling Odoo target replacement

### DIFF
--- a/.github/workflows/odoo-target-replacement-apply.yml
+++ b/.github/workflows/odoo-target-replacement-apply.yml
@@ -157,13 +157,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          oidc_token="$({
+          launchplane_oidc_token() {
             token_url="${ACTIONS_ID_TOKEN_REQUEST_URL}"
             curl -fsSL \
               -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
               "${token_url}&audience=${LAUNCHPLANE_SERVICE_AUDIENCE}" \
             | jq -r '.value'
-          })"
+          }
           payload="$({
             jq -n \
               --arg product "$PRODUCT" \
@@ -226,6 +226,7 @@ jobs:
               "${GITHUB_RUN_ATTEMPT}"
           })"
           route="${LAUNCHPLANE_SERVICE_URL}/v1/drivers/odoo"
+          oidc_token="$(launchplane_oidc_token)"
           status_code="$({
             curl -sS \
               -o odoo-target-replacement-apply.json \
@@ -263,6 +264,7 @@ jobs:
           fi
           deadline=$((SECONDS + POLL_TIMEOUT_SECONDS))
           while true; do
+            oidc_token="$(launchplane_oidc_token)"
             status_code="$({
               curl -sS \
                 -o odoo-target-replacement-apply.json \


### PR DESCRIPTION
## Summary
- refresh the GitHub OIDC bearer token before the target replacement create request
- refresh the token on each poll request so long-running Odoo target replacement operations do not lose auth mid-flight

## Validation
- git diff --check
- extracted target replacement apply run script parses with bash -n
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_apply_driver_creates_operation_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_apply_driver_replays_existing_operation tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_apply_driver_blocks_second_active_lane_operation tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_apply_driver_rejects_unauthorized_workflow

Note: local actionlint still reports the existing workflow_dispatch input-count warning for this workflow.