### PR TITLE
Render Odoo raw compose ingress routers

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -3320,8 +3320,20 @@ def _sync_artifact_image_reference_for_target(
 
     runtime_source_evidence: dict[str, str] = {}
     if desired_image_reference and resolved_target.target_type == "compose":
+        target_domains: tuple[str, ...] = ()
+        source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
+            control_plane_root=control_plane_root,
+        )
+        target_definition = control_plane_dokploy.find_dokploy_target_definition(
+            source_of_truth,
+            context_name=context_name,
+            instance_name=instance_name,
+        )
+        if target_definition is not None:
+            target_domains = target_definition.domains
         compose_file = control_plane_dokploy.render_odoo_raw_compose_file(
-            image_reference=desired_image_reference
+            image_reference=desired_image_reference,
+            domain_hosts=target_domains,
         )
         runtime_source_evidence = control_plane_dokploy.sync_dokploy_compose_raw_source(
             host=host,

--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -112,6 +112,21 @@ def _render_odoo_web_traefik_labels(*, domain_hosts: tuple[str, ...], runtime_po
                 f"Odoo Traefik label rendering received an invalid domain host: {domain_host}"
             )
         seen_hosts.add(domain_host)
+        route_name = _traefik_route_name(domain_host=domain_host)
+        lines.extend(
+            [
+                f'      - "traefik.http.routers.{route_name}-web.rule=Host(`{domain_host}`)"',
+                f'      - "traefik.http.routers.{route_name}-web.entrypoints=web"',
+                f'      - "traefik.http.routers.{route_name}-web.service={route_name}-web"',
+                f'      - "traefik.http.routers.{route_name}-web.middlewares=redirect-to-https@file"',
+                f'      - "traefik.http.services.{route_name}-web.loadbalancer.server.port={runtime_port}"',
+                f'      - "traefik.http.routers.{route_name}-websecure.rule=Host(`{domain_host}`)"',
+                f'      - "traefik.http.routers.{route_name}-websecure.entrypoints=websecure"',
+                f'      - "traefik.http.routers.{route_name}-websecure.service={route_name}-websecure"',
+                f'      - "traefik.http.routers.{route_name}-websecure.tls=true"',
+                f'      - "traefik.http.services.{route_name}-websecure.loadbalancer.server.port={runtime_port}"',
+            ]
+        )
     return "\n".join(lines) + "\n"
 
 

--- a/control_plane/workflows/odoo_prod_rollback.py
+++ b/control_plane/workflows/odoo_prod_rollback.py
@@ -408,7 +408,8 @@ def _sync_artifact_image_reference_for_target(
     desired_image_reference = _artifact_image_reference_from_manifest(artifact_manifest)
     if target_definition.target_type == "compose":
         compose_file = control_plane_dokploy.render_odoo_raw_compose_file(
-            image_reference=desired_image_reference
+            image_reference=desired_image_reference,
+            domain_hosts=target_definition.domains,
         )
         control_plane_dokploy.sync_dokploy_compose_raw_source(
             host=host,

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -287,10 +287,10 @@ values, blocks before reading Dokploy credentials when required Odoo env keys ar
 missing, stamps per-preview `ODOO_PROJECT_NAME` and `ODOO_STACK_NAME` values so
 the raw compose does not inherit the template runtime identity, renders
 Launchplane-owned raw compose source without publishing shared host ports,
-keeps the raw compose limited to Dokploy network attachment labels so Dokploy's
-compose-domain records own the HTTP/HTTPS routers, reconciles the preview domain,
-and defaults preview domain certificate management to `none` so public TLS is
-owned by the external edge wildcard certificate rather than Dokploy ACME.
+renders explicit HTTP and HTTPS Traefik routers in the raw compose while also
+reconciling the preview domain record for Dokploy UI/provider state, and defaults
+preview domain certificate management to `none` so public TLS is owned by the
+external edge wildcard certificate rather than Dokploy ACME.
 Fresh-create dry-runs must carry the template compose id; apply creates new
 preview composes on that template compose's Dokploy server, deploys the compose,
 and returns redacted step evidence. Destroy looks up domains for the matching

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -811,15 +811,17 @@ the existing compose
 target, explicit Odoo volume env keys, and expected hostnames; the operation
 worker re-syncs the Launchplane-rendered compose source, reconciles each expected
 Dokploy compose domain route to the `web` service on the product runtime port,
-renders the matching Traefik router labels into the raw compose, injects the
-runtime identity breadcrumb, triggers Dokploy deploy, runs Odoo post-deploy,
-verifies health/canonical/logo, and writes deployment plus inventory records. By
-default it deploys the artifact already recorded in current inventory. Operators
-may supply both `artifact_id` and `source_git_ref` to deploy a newly published
-stored artifact before it has become inventory; the service refuses mismatches
-against the stored artifact manifest. Do not manually delete canonical stable
-targets as a replacement shortcut; add the missing Launchplane apply coverage
-first, then use the service-backed workflow.
+renders the matching HTTP and HTTPS Traefik router labels into the raw compose,
+injects the runtime identity breadcrumb, triggers Dokploy deploy, runs Odoo
+post-deploy, verifies health/canonical/logo, and writes deployment plus
+inventory records. The explicit raw-compose routers keep the runtime reachable
+even when Dokploy stores the compose domain record separately from the raw source
+update. By default it deploys the artifact already recorded in current
+inventory. Operators may supply both `artifact_id` and `source_git_ref` to deploy
+a newly published stored artifact before it has become inventory; the service
+refuses mismatches against the stored artifact manifest. Do not manually delete
+canonical stable targets as a replacement shortcut; add the missing Launchplane
+apply coverage first, then use the service-backed workflow.
 
 Runtime identity is a driver-owned breadcrumb, not tenant config. Launchplane
 injects `LAUNCHPLANE_RUNTIME_IDENTITY_JSON`, `LAUNCHPLANE_DEPLOYMENT_RECORD_ID`,

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -2329,8 +2329,38 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
         self.assertIn("dokploy-network:", compose_file)
         self.assertIn("traefik.enable=true", compose_file)
         self.assertIn("traefik.docker.network=dokploy-network", compose_file)
-        self.assertNotIn("traefik.http.routers", compose_file)
-        self.assertNotIn("traefik.http.services", compose_file)
+        self.assertIn(
+            'traefik.http.routers.launchplane-odoo-web-cm-testing-shinycomputers-com-c93dcbe8-web.rule=Host(`cm-testing.shinycomputers.com`)',
+            compose_file,
+        )
+        self.assertIn(
+            "traefik.http.routers.launchplane-odoo-web-cm-testing-shinycomputers-com-c93dcbe8-web.entrypoints=web",
+            compose_file,
+        )
+        self.assertIn(
+            "traefik.http.services.launchplane-odoo-web-cm-testing-shinycomputers-com-c93dcbe8-web.loadbalancer.server.port=8069",
+            compose_file,
+        )
+        self.assertIn(
+            "traefik.http.routers.launchplane-odoo-web-cm-testing-shinycomputers-com-c93dcbe8-web.middlewares=redirect-to-https@file",
+            compose_file,
+        )
+        self.assertIn(
+            'traefik.http.routers.launchplane-odoo-web-cm-testing-shinycomputers-com-c93dcbe8-websecure.rule=Host(`cm-testing.shinycomputers.com`)',
+            compose_file,
+        )
+        self.assertIn(
+            "traefik.http.routers.launchplane-odoo-web-cm-testing-shinycomputers-com-c93dcbe8-websecure.entrypoints=websecure",
+            compose_file,
+        )
+        self.assertIn(
+            "traefik.http.routers.launchplane-odoo-web-cm-testing-shinycomputers-com-c93dcbe8-websecure.tls=true",
+            compose_file,
+        )
+        self.assertIn(
+            "traefik.http.services.launchplane-odoo-web-cm-testing-shinycomputers-com-c93dcbe8-websecure.loadbalancer.server.port=8069",
+            compose_file,
+        )
 
     def test_render_odoo_raw_compose_file_omits_traefik_labels_without_domains(self) -> None:
         compose_file = control_plane_dokploy.render_odoo_raw_compose_file(
@@ -2338,7 +2368,28 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
         )
 
         self.assertNotIn("traefik.http.routers", compose_file)
+        self.assertNotIn("traefik.http.services", compose_file)
+        self.assertNotIn("traefik.enable=true", compose_file)
         self.assertIn("dokploy-network:", compose_file)
+
+    def test_render_odoo_raw_compose_file_normalizes_and_dedupes_domain_labels(self) -> None:
+        compose_file = control_plane_dokploy.render_odoo_raw_compose_file(
+            image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+            domain_hosts=(
+                " CM-Testing.shinycomputers.com ",
+                "cm-testing.shinycomputers.com",
+            ),
+            runtime_port=8069,
+        )
+
+        self.assertEqual(compose_file.count("Host(`cm-testing.shinycomputers.com`)"), 2)
+
+    def test_render_odoo_raw_compose_file_rejects_invalid_domain_label_host(self) -> None:
+        with self.assertRaisesRegex(click.ClickException, "invalid domain host"):
+            control_plane_dokploy.render_odoo_raw_compose_file(
+                image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                domain_hosts=("bad`host.example",),
+            )
 
     def test_render_odoo_raw_compose_file_can_avoid_host_port_publishing(self) -> None:
         compose_file = control_plane_dokploy.render_odoo_raw_compose_file(
@@ -2350,8 +2401,8 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
         self.assertNotIn("ODOO_WEB_HOST_PORT", compose_file)
         self.assertNotIn("ODOO_LONGPOLL_HOST_PORT", compose_file)
         self.assertIn("traefik.enable=true", compose_file)
-        self.assertNotIn("traefik.http.routers", compose_file)
-        self.assertNotIn("traefik.http.services", compose_file)
+        self.assertIn("traefik.http.routers", compose_file)
+        self.assertIn("traefik.http.services", compose_file)
 
     def test_sync_dokploy_compose_raw_source_updates_and_verifies_hash(self) -> None:
         compose_file = control_plane_dokploy.render_odoo_raw_compose_file(

--- a/tests/test_odoo_prod_rollback.py
+++ b/tests/test_odoo_prod_rollback.py
@@ -238,7 +238,7 @@ class OdooProdRollbackWorkflowTests(unittest.TestCase):
             ),
             patch(
                 "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.sync_dokploy_compose_raw_source"
-            ),
+            ) as raw_compose_sync,
             patch(
                 "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.update_dokploy_target_env"
             ),
@@ -273,6 +273,10 @@ class OdooProdRollbackWorkflowTests(unittest.TestCase):
         self.assertEqual(result.rollback_health_status, "pass")
         self.assertEqual(result.post_deploy_status, "pass")
         self.assertEqual(result.artifact_id, "artifact-opw-847c71c1db61785c")
+        self.assertIn(
+            "Host(`opw-prod.shinycomputers.com`)",
+            raw_compose_sync.call_args.kwargs["compose_file"],
+        )
         record_store.write_deployment_record.assert_called()
         record_store.write_environment_inventory.assert_called_once()
         record_store.write_release_tuple_record.assert_called_once()

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -506,6 +506,22 @@ class ArtifactImageOverrideTests(unittest.TestCase):
                     return_value={"source_type": "raw", "compose_sha256": "abc123"},
                 ) as raw_compose_sync,
                 patch(
+                    "control_plane.dokploy.read_control_plane_dokploy_source_of_truth",
+                    return_value=control_plane_dokploy.DokploySourceOfTruth(
+                        schema_version=1,
+                        targets=(
+                            control_plane_dokploy.DokployTargetDefinition(
+                                context="opw",
+                                instance="prod",
+                                target_type="compose",
+                                target_id="compose-123",
+                                target_name="opw-prod",
+                                domains=("opw-prod.shinycomputers.com",),
+                            ),
+                        )
+                    ),
+                ),
+                patch(
                     "control_plane.dokploy.update_dokploy_target_env",
                     side_effect=lambda **kwargs: captured_update.update(kwargs),
                 ),
@@ -519,6 +535,10 @@ class ArtifactImageOverrideTests(unittest.TestCase):
                 )
 
         raw_compose_sync.assert_called_once()
+        self.assertIn(
+            "Host(`opw-prod.shinycomputers.com`)",
+            raw_compose_sync.call_args.kwargs["compose_file"],
+        )
         self.assertEqual(captured_update["target_type"], "compose")
         self.assertEqual(captured_update["target_id"], "compose-123")
         self.assertIn(
@@ -628,6 +648,22 @@ class ArtifactImageOverrideTests(unittest.TestCase):
                 patch(
                     "control_plane.dokploy.sync_dokploy_compose_raw_source",
                     return_value={"source_type": "raw", "compose_sha256": "abc123"},
+                ),
+                patch(
+                    "control_plane.dokploy.read_control_plane_dokploy_source_of_truth",
+                    return_value=control_plane_dokploy.DokploySourceOfTruth(
+                        schema_version=1,
+                        targets=(
+                            control_plane_dokploy.DokployTargetDefinition(
+                                context="cm",
+                                instance="testing",
+                                target_type="compose",
+                                target_id="compose-123",
+                                target_name="cm-testing",
+                                domains=("cm-testing.shinycomputers.com",),
+                            ),
+                        )
+                    ),
                 ),
                 patch(
                     "control_plane.dokploy.update_dokploy_target_env",


### PR DESCRIPTION
## Summary
- render explicit HTTP and HTTPS Traefik routers for Odoo raw compose domain hosts
- preserve tracked domains in artifact image sync and Odoo prod rollback compose rewrites
- update Odoo operations/preview docs and tests for the raw-compose routing contract

## Validation
- uv run python -m unittest tests.test_dokploy tests.test_odoo_stable_target_replacement tests.test_odoo_prod_rollback tests.test_promote.ArtifactImageOverrideTests tests.test_odoo_preview_runtime
- uv run ruff check --diff control_plane/dokploy.py control_plane/cli.py control_plane/workflows/odoo_prod_rollback.py tests/test_dokploy.py tests/test_promote.py tests/test_odoo_prod_rollback.py docs/operations.md docs/driver-descriptors.md
- uv run ruff check control_plane/dokploy.py control_plane/cli.py control_plane/workflows/odoo_prod_rollback.py tests/test_dokploy.py tests/test_promote.py tests/test_odoo_prod_rollback.py docs/operations.md docs/driver-descriptors.md
- uv run --extra dev mypy control_plane/dokploy.py control_plane/cli.py control_plane/workflows/odoo_prod_rollback.py tests/test_dokploy.py tests/test_promote.py tests/test_odoo_prod_rollback.py
- git diff --check