### PR TITLE
Expose Odoo converted compose evidence

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -1227,6 +1227,32 @@ def ensure_compose_web_domain_route(
     return domain_id
 
 
+def fetch_dokploy_converted_compose_file(
+    *,
+    host: str,
+    token: str,
+    compose_id: str,
+) -> str:
+    normalized_compose_id = compose_id.strip()
+    if not normalized_compose_id:
+        raise click.ClickException("Converted compose fetch requires a compose id.")
+    payload = dokploy_request(
+        host=host,
+        token=token,
+        path="/api/compose.getConvertedCompose",
+        query={"composeId": normalized_compose_id},
+    )
+    if isinstance(payload, str):
+        return payload
+    payload_as_object = as_json_object(payload)
+    if payload_as_object is not None:
+        for key_name in ("composeFile", "compose", "content", "raw"):
+            value = payload_as_object.get(key_name)
+            if isinstance(value, str):
+                return value
+    raise click.ClickException("Dokploy converted compose response did not include compose text.")
+
+
 def _build_raw_compose_evidence(
     *, source_type: str, compose_file: str, changed: bool
 ) -> dict[str, str]:

--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -976,6 +976,20 @@ def execute_odoo_stable_target_replacement_apply(
                 ).items()
             }
         )
+        converted_compose_file = control_plane_dokploy.fetch_dokploy_converted_compose_file(
+            host=host,
+            token=token,
+            compose_id=target_id_record.target_id,
+        )
+        runtime_source.update(
+            {
+                f"converted_{key}": value
+                for key, value in _raw_compose_route_evidence(
+                    compose_file=converted_compose_file,
+                    domain_hosts=plan.expected_domain_hosts,
+                ).items()
+            }
+        )
         current_env_map = control_plane_dokploy.parse_dokploy_env_text(
             str(target_payload.get("env") or "")
         )
@@ -1056,6 +1070,22 @@ def execute_odoo_stable_target_replacement_apply(
             {
                 f"post_deploy_{key}": value
                 for key, value in _dokploy_compose_metadata_evidence(deployed_payload).items()
+            }
+        )
+        deployed_converted_compose_file = (
+            control_plane_dokploy.fetch_dokploy_converted_compose_file(
+                host=host,
+                token=token,
+                compose_id=target_id_record.target_id,
+            )
+        )
+        runtime_source.update(
+            {
+                f"post_deploy_converted_{key}": value
+                for key, value in _raw_compose_route_evidence(
+                    compose_file=deployed_converted_compose_file,
+                    domain_hosts=plan.expected_domain_hosts,
+                ).items()
             }
         )
     except click.ClickException as error:

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -681,6 +681,10 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                 "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.ensure_compose_web_domain_route"
             ) as ensure_domain,
             patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.fetch_dokploy_converted_compose_file",
+                return_value=rendered_compose_file,
+            ) as fetch_converted_compose,
+            patch(
                 "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.update_dokploy_target_env",
                 side_effect=_update_env,
             ) as update_env,
@@ -736,6 +740,7 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
             runtime_port=8069,
         )
         update_env.assert_called_once()
+        self.assertEqual(fetch_converted_compose.call_count, 2)
         trigger_deploy.assert_called_once()
         wait_deploy.assert_called_once()
         post_deploy.assert_called_once()
@@ -795,6 +800,15 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         self.assertEqual(
             final_deployment.runtime_source["post_deploy_latest_deployment_key"],
             "deploy-456",
+        )
+        self.assertEqual(
+            final_deployment.runtime_source["converted_traefik_router_label_count"], "8"
+        )
+        self.assertEqual(
+            final_deployment.runtime_source[
+                "post_deploy_converted_domain_cm-testing.shinycomputers.com_https_rule_present"
+            ],
+            "true",
         )
         self.assertEqual(result.runtime_source, final_deployment.runtime_source)
         assert final_deployment.runtime_identity is not None
@@ -865,6 +879,14 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
             ) as sync_source,
             patch(
                 "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.ensure_compose_web_domain_route"
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.fetch_dokploy_converted_compose_file",
+                return_value=control_plane_dokploy.render_odoo_raw_compose_file(
+                    image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:fresh",
+                    domain_hosts=("cm-testing.shinycomputers.com",),
+                    runtime_port=8069,
+                ),
             ),
             patch(
                 "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.update_dokploy_target_env",


### PR DESCRIPTION
## Summary
- Add a Dokploy helper for the converted compose output used by deploy-time domain rewriting
- Record converted-compose route evidence before and after Odoo target replacement deploys
- Extend target replacement tests for converted route evidence

## Validation
- uv run python -m unittest tests.test_dokploy tests.test_odoo_stable_target_replacement
- uv run ruff check --diff control_plane/dokploy.py control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_stable_target_replacement.py tests/test_dokploy.py
- uv run ruff check control_plane/dokploy.py control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_stable_target_replacement.py tests/test_dokploy.py
- uv run --extra dev mypy control_plane/dokploy.py control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_stable_target_replacement.py tests/test_dokploy.py
- git diff --check