### PR TITLE
Harden Odoo ingress diagnostics and identity health

### DIFF
--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -328,6 +328,136 @@ def _dokploy_compose_metadata_evidence(target_payload: JsonObject) -> dict[str, 
     return evidence
 
 
+def _container_name(container: JsonObject) -> str:
+    return _runtime_source_value(
+        container.get("name") or container.get("Name") or container.get("Names")
+    )
+
+
+def _container_id(container: JsonObject) -> str:
+    return _runtime_source_value(
+        container.get("containerId") or container.get("id") or container.get("Id")
+    )
+
+
+def _web_container_for_app(
+    *, containers_payload: JsonValue, app_name: str
+) -> JsonObject | None:
+    containers = _collect_json_objects(containers_payload)
+    if not app_name.strip():
+        return None
+    matching = [container for container in containers if app_name in _container_name(container)]
+    if not matching:
+        return None
+    web_suffixes = ("-web-1", "_web_1", "-web", "_web")
+    return next(
+        (
+            container
+            for container in matching
+            if any(_container_name(container).endswith(suffix) for suffix in web_suffixes)
+        ),
+        matching[0],
+    )
+
+
+def _container_config_labels(config_payload: JsonValue) -> dict[str, str]:
+    config = control_plane_dokploy.as_json_object(config_payload)
+    if config is None:
+        return {}
+    current: object = config
+    for key_name in ("Config", "Labels"):
+        if not isinstance(current, dict):
+            current = None
+            break
+        current = current.get(key_name)
+    if not isinstance(current, dict):
+        return {}
+    return {str(key): str(value) for key, value in current.items()}
+
+
+def _container_config_network_names(config_payload: JsonValue) -> tuple[str, ...]:
+    config = control_plane_dokploy.as_json_object(config_payload)
+    if config is None:
+        return ()
+    current: object = config
+    for key_name in ("NetworkSettings", "Networks"):
+        if not isinstance(current, dict):
+            current = None
+            break
+        current = current.get(key_name)
+    if not isinstance(current, dict):
+        return ()
+    return tuple(sorted(str(key) for key in current))
+
+
+def _dokploy_container_route_evidence(
+    *,
+    containers_payload: JsonValue,
+    config_payload: JsonValue | None,
+    app_name: str,
+    expected_domain_hosts: tuple[str, ...],
+) -> dict[str, str]:
+    containers = _collect_json_objects(containers_payload)
+    app_containers = [container for container in containers if app_name in _container_name(container)]
+    web_container = _web_container_for_app(
+        containers_payload=containers_payload,
+        app_name=app_name,
+    )
+    labels = _container_config_labels(config_payload) if config_payload is not None else {}
+    network_names = (
+        _container_config_network_names(config_payload) if config_payload is not None else ()
+    )
+    evidence: dict[str, str] = {
+        "container_app_name": app_name,
+        "container_match_count": str(len(app_containers)),
+        "container_web_found": "true" if web_container is not None else "false",
+        "container_web_id_present": "true" if web_container and _container_id(web_container) else "false",
+        "container_web_name": _container_name(web_container or {}),
+        "container_web_state": _runtime_source_value(
+            (web_container or {}).get("state") or (web_container or {}).get("State")
+        ),
+        "container_web_status": _runtime_source_value(
+            (web_container or {}).get("status") or (web_container or {}).get("Status")
+        ),
+        "container_config_present": "true" if config_payload is not None else "false",
+        "container_label_count": str(len(labels)),
+        "container_traefik_label_count": str(
+            len([key for key in labels if key.startswith("traefik.")])
+        ),
+        "container_traefik_enable": labels.get("traefik.enable", ""),
+        "container_traefik_network": labels.get("traefik.docker.network", ""),
+        "container_networks": ",".join(network_names),
+        "container_has_dokploy_network": "true"
+        if "dokploy-network" in network_names
+        else "false",
+    }
+    label_items = tuple(labels.items())
+    for raw_domain_host in expected_domain_hosts:
+        domain_host = raw_domain_host.strip().lower()
+        if not domain_host:
+            continue
+        route_name = control_plane_dokploy._traefik_route_name(domain_host=domain_host)
+        prefix = f"container_domain_{domain_host}"
+        evidence[f"{prefix}_http_rule_present"] = (
+            "true"
+            if labels.get(f"traefik.http.routers.{route_name}-web.rule")
+            == f"Host(`{domain_host}`)"
+            else "false"
+        )
+        evidence[f"{prefix}_https_rule_present"] = (
+            "true"
+            if labels.get(f"traefik.http.routers.{route_name}-websecure.rule")
+            == f"Host(`{domain_host}`)"
+            else "false"
+        )
+        evidence[f"{prefix}_any_host_rule_present"] = (
+            "true"
+            if any(f"Host(`{domain_host}`)" == value for _key, value in label_items)
+            else "false"
+        )
+    return evidence
+
+
 def _collect_json_objects(raw_items: JsonValue | None) -> list[JsonObject]:
     if not isinstance(raw_items, list):
         return []
@@ -1085,6 +1215,38 @@ def execute_odoo_stable_target_replacement_apply(
                 for key, value in _raw_compose_route_evidence(
                     compose_file=deployed_converted_compose_file,
                     domain_hosts=plan.expected_domain_hosts,
+                ).items()
+            }
+        )
+        containers_payload = dokploy_request(
+            host=host,
+            token=token,
+            path="/api/docker.getContainersByAppNameMatch",
+            query={
+                "appName": str(deployed_payload.get("appName") or ""),
+                "appType": "docker-compose",
+            },
+        )
+        web_container = _web_container_for_app(
+            containers_payload=containers_payload,
+            app_name=str(deployed_payload.get("appName") or ""),
+        )
+        config_payload: JsonValue | None = None
+        if web_container is not None and _container_id(web_container):
+            config_payload = dokploy_request(
+                host=host,
+                token=token,
+                path="/api/docker.getConfig",
+                query={"containerId": _container_id(web_container)},
+            )
+        runtime_source.update(
+            {
+                f"post_deploy_{key}": value
+                for key, value in _dokploy_container_route_evidence(
+                    containers_payload=containers_payload,
+                    config_payload=config_payload,
+                    app_name=str(deployed_payload.get("appName") or ""),
+                    expected_domain_hosts=plan.expected_domain_hosts,
                 ).items()
             }
         )

--- a/control_plane/workflows/runtime_identity_health.py
+++ b/control_plane/workflows/runtime_identity_health.py
@@ -97,7 +97,7 @@ def wait_for_runtime_identity_healthcheck_with_retry(
                 payload=healthcheck_pass.payload,
                 json_parse_failed=healthcheck_pass.json_parse_failed,
             )
-            if status in {"match", "mismatch"}:
+            if status == "match":
                 return healthcheck_pass
             last_detail = detail
         sleep(1)

--- a/scripts/deploy/capture-launchplane-deploy-diagnostics.py
+++ b/scripts/deploy/capture-launchplane-deploy-diagnostics.py
@@ -112,6 +112,30 @@ def _target_containers(*, containers_payload: Any, app_name: str) -> list[dict[s
     return target_containers
 
 
+def _container_id(container: Mapping[str, object]) -> str:
+    return str(container.get("containerId") or container.get("id") or container.get("Id") or "").strip()
+
+
+def _container_config_summary(config_payload: Any) -> dict[str, object]:
+    if not isinstance(config_payload, dict):
+        return {"config_present": False}
+    labels = ((config_payload.get("Config") or {}).get("Labels") or {})
+    networks = ((config_payload.get("NetworkSettings") or {}).get("Networks") or {})
+    label_map = labels if isinstance(labels, dict) else {}
+    network_map = networks if isinstance(networks, dict) else {}
+    return {
+        "config_present": True,
+        "label_count": len(label_map),
+        "traefik_label_count": len(
+            [key for key in label_map if str(key).startswith("traefik.")]
+        ),
+        "traefik_enable": label_map.get("traefik.enable"),
+        "traefik_docker_network": label_map.get("traefik.docker.network"),
+        "network_names": sorted(str(key) for key in network_map),
+        "has_dokploy_network": "dokploy-network" in network_map,
+    }
+
+
 def _print_json(payload: Mapping[str, object]) -> None:
     print(json.dumps(payload, indent=2, sort_keys=True))
 
@@ -179,6 +203,22 @@ def main() -> int:
     target_containers = _target_containers(containers_payload=containers_payload, app_name=app_name)
     _print_json({"diagnostic": "dokploy-containers", "containers": target_containers})
     for container in target_containers:
+        container_id = _container_id(container)
+        if container_id:
+            config_payload = _request_json(
+                host=host,
+                token=token,
+                path="/api/docker.getConfig",
+                query={"containerId": container_id},
+            )
+            _print_json(
+                {
+                    "diagnostic": "dokploy-container-config",
+                    "containerId": container_id,
+                    "name": container.get("name"),
+                    **_container_config_summary(config_payload),
+                }
+            )
         _print_container_logs(host=host, token=token, target_id=target_id, container=container)
     return 0
 

--- a/tests/test_deploy_diagnostics.py
+++ b/tests/test_deploy_diagnostics.py
@@ -66,6 +66,19 @@ class CaptureLaunchplaneDeployDiagnosticsTests(unittest.TestCase):
                     },
                     {"containerId": "other", "name": "postgres-1"},
                 ]
+            if path == "/api/docker.getConfig":
+                return {
+                    "Config": {
+                        "Labels": {
+                            "traefik.enable": "true",
+                            "traefik.docker.network": "dokploy-network",
+                            "com.docker.compose.project": "compose-launchplane-random",
+                        }
+                    },
+                    "NetworkSettings": {
+                        "Networks": {"dokploy-network": {}, "compose-launchplane-random_default": {}}
+                    },
+                }
             if path == "/api/compose.readLogs":
                 return "started\nLAUNCHPLANE_DATABASE_URL=postgresql://secret\n"
             raise AssertionError(f"Unexpected path: {path}")
@@ -96,6 +109,9 @@ class CaptureLaunchplaneDeployDiagnosticsTests(unittest.TestCase):
         self.assertIn('"diagnostic": "dokploy-target"', output.getvalue())
         self.assertIn('"docker_image_matches_expected": true', output.getvalue())
         self.assertIn('"containerId": "container-1"', output.getvalue())
+        self.assertIn('"diagnostic": "dokploy-container-config"', output.getvalue())
+        self.assertIn('"traefik_enable": "true"', output.getvalue())
+        self.assertIn('"has_dokploy_network": true', output.getvalue())
         self.assertIn("LAUNCHPLANE_DATABASE_URL=[redacted]", output.getvalue())
         self.assertNotIn("postgresql://secret", output.getvalue())
         self.assertEqual(requests[-1]["path"], "/api/compose.readLogs")

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -580,6 +580,9 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         deployment_records: list[JsonValue] = [
             {"deploymentId": "deploy-123", "status": "success"}
         ]
+        route_name = control_plane_dokploy._traefik_route_name(
+            domain_host="cm-testing.shinycomputers.com"
+        )
 
         def _fetch_target_payload(**_: object) -> JsonValue:
             return cast(JsonObject, {
@@ -604,6 +607,35 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         def _dokploy_request(path: str, query: object | None = None, **kwargs: object) -> JsonValue:
             if path == "/api/domain.byComposeId" and domain_records:
                 return domain_records
+            if path == "/api/docker.getContainersByAppNameMatch":
+                self.assertEqual(
+                    query,
+                    {"appName": "cm-testing", "appType": "docker-compose"},
+                )
+                return [
+                    {
+                        "containerId": "container-web",
+                        "name": "cm-testing-web-1",
+                        "state": "running",
+                        "status": "Up 1 minute",
+                    },
+                    {"containerId": "container-db", "name": "cm-testing-db-1"},
+                ]
+            if path == "/api/docker.getConfig":
+                self.assertEqual(query, {"containerId": "container-web"})
+                return {
+                    "Config": {
+                        "Labels": {
+                            "traefik.enable": "true",
+                            "traefik.docker.network": "dokploy-network",
+                            f"traefik.http.routers.{route_name}-web.rule": "Host(`cm-testing.shinycomputers.com`)",
+                            f"traefik.http.routers.{route_name}-websecure.rule": "Host(`cm-testing.shinycomputers.com`)",
+                        }
+                    },
+                    "NetworkSettings": {
+                        "Networks": {"cm-testing_default": {}, "dokploy-network": {}}
+                    },
+                }
             return _request(path=path, query=query, **kwargs)
 
         def _ensure_domain(**_: object) -> str:
@@ -808,6 +840,26 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
             final_deployment.runtime_source[
                 "post_deploy_converted_domain_cm-testing.shinycomputers.com_https_rule_present"
             ],
+            "true",
+        )
+        self.assertEqual(
+            final_deployment.runtime_source["post_deploy_container_web_found"], "true"
+        )
+        self.assertEqual(
+            final_deployment.runtime_source["post_deploy_container_traefik_enable"], "true"
+        )
+        self.assertEqual(
+            final_deployment.runtime_source["post_deploy_container_traefik_network"],
+            "dokploy-network",
+        )
+        self.assertEqual(
+            final_deployment.runtime_source[
+                "post_deploy_container_domain_cm-testing.shinycomputers.com_https_rule_present"
+            ],
+            "true",
+        )
+        self.assertEqual(
+            final_deployment.runtime_source["post_deploy_container_has_dokploy_network"],
             "true",
         )
         self.assertEqual(result.runtime_source, final_deployment.runtime_source)

--- a/tests/test_runtime_identity_health.py
+++ b/tests/test_runtime_identity_health.py
@@ -4,8 +4,10 @@ from control_plane.contracts.promotion_record import HealthcheckEvidence
 from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.workflows.runtime_identity_health import (
     HealthcheckPass,
+    RuntimeIdentityHealthcheckError,
     healthcheck_evidence_with_runtime_identity,
     wait_for_healthcheck_with_retry,
+    wait_for_runtime_identity_healthcheck_with_retry,
 )
 
 
@@ -118,10 +120,6 @@ class RuntimeIdentityHealthTests(unittest.TestCase):
         )
         sleeps: list[float] = []
 
-        from control_plane.workflows.runtime_identity_health import (
-            wait_for_runtime_identity_healthcheck_with_retry,
-        )
-
         result = wait_for_runtime_identity_healthcheck_with_retry(
             url="https://example.com/health",
             timeout_seconds=30,
@@ -133,6 +131,79 @@ class RuntimeIdentityHealthTests(unittest.TestCase):
 
         self.assertEqual(result.payload, {"runtime_identity": identity.model_dump(mode="json")})
         self.assertEqual(sleeps, [1, 1])
+
+    def test_wait_for_runtime_identity_healthcheck_retries_identity_mismatch(
+        self,
+    ) -> None:
+        expected_identity = RuntimeIdentity(
+            product="sellyouroutboard",
+            context="sellyouroutboard-prod",
+            instance="production",
+            deployment_record_id="deployment-new",
+            artifact_id="artifact-a",
+            source_git_ref="abc123",
+        )
+        stale_identity = expected_identity.model_copy(
+            update={"deployment_record_id": "deployment-old"}
+        )
+        attempts = iter(
+            (
+                HealthcheckPass(
+                    payload={"runtime_identity": stale_identity.model_dump(mode="json")}
+                ),
+                HealthcheckPass(
+                    payload={"runtime_identity": expected_identity.model_dump(mode="json")}
+                ),
+            )
+        )
+        sleeps: list[float] = []
+
+        result = wait_for_runtime_identity_healthcheck_with_retry(
+            url="https://example.com/health",
+            timeout_seconds=30,
+            expected_runtime_identity=expected_identity,
+            sleep=sleeps.append,
+            monotonic=lambda: 0,
+            wait_once=lambda **_kwargs: next(attempts),
+        )
+
+        self.assertEqual(
+            result.payload,
+            {"runtime_identity": expected_identity.model_dump(mode="json")},
+        )
+        self.assertEqual(sleeps, [1])
+
+    def test_wait_for_runtime_identity_healthcheck_timeout_keeps_last_mismatch(
+        self,
+    ) -> None:
+        expected_identity = RuntimeIdentity(
+            product="sellyouroutboard",
+            context="sellyouroutboard-prod",
+            instance="production",
+            deployment_record_id="deployment-new",
+            artifact_id="artifact-a",
+            source_git_ref="abc123",
+        )
+        stale_identity = expected_identity.model_copy(
+            update={"deployment_record_id": "deployment-old"}
+        )
+        observed_pass = HealthcheckPass(
+            payload={"runtime_identity": stale_identity.model_dump(mode="json")}
+        )
+        monotonic_values = iter((0.0, 0.0, 2.0))
+
+        with self.assertRaises(RuntimeIdentityHealthcheckError) as context:
+            wait_for_runtime_identity_healthcheck_with_retry(
+                url="https://example.com/health",
+                timeout_seconds=1,
+                expected_runtime_identity=expected_identity,
+                sleep=lambda _seconds: None,
+                monotonic=lambda: next(monotonic_values),
+                wait_once=lambda **_kwargs: observed_pass,
+            )
+
+        self.assertIn("mismatch", str(context.exception))
+        self.assertIs(context.exception.healthcheck_pass, observed_pass)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- retry runtime identity health checks through stale mismatches until the configured timeout
- record Odoo target replacement post-deploy container labels and network evidence from Dokploy inspect
- include container inspect label/network summaries in emergency deploy diagnostics

## Tests
- uv run python -m unittest tests.test_runtime_identity_health tests.test_odoo_stable_target_replacement tests.test_deploy_diagnostics
- uv run --extra dev ruff check --diff control_plane/workflows/odoo_stable_target_replacement.py control_plane/workflows/runtime_identity_health.py scripts/deploy/capture-launchplane-deploy-diagnostics.py tests/test_deploy_diagnostics.py tests/test_odoo_stable_target_replacement.py tests/test_runtime_identity_health.py
- uv run --extra dev ruff check control_plane/workflows/odoo_stable_target_replacement.py control_plane/workflows/runtime_identity_health.py scripts/deploy/capture-launchplane-deploy-diagnostics.py tests/test_deploy_diagnostics.py tests/test_odoo_stable_target_replacement.py tests/test_runtime_identity_health.py
- uv run --extra dev mypy control_plane/workflows/odoo_stable_target_replacement.py control_plane/workflows/runtime_identity_health.py scripts/deploy/capture-launchplane-deploy-diagnostics.py tests/test_deploy_diagnostics.py tests/test_odoo_stable_target_replacement.py tests/test_runtime_identity_health.py
- git diff --check