### PR TITLE
Pass Dokploy server id to Odoo container diagnostics

### DIFF
--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -303,6 +303,9 @@ def _dokploy_compose_metadata_evidence(target_payload: JsonObject) -> dict[str, 
         "compose_status": _runtime_source_value(target_payload.get("composeStatus")),
         "compose_type": _runtime_source_value(target_payload.get("composeType")),
         "compose_source_type": _runtime_source_value(target_payload.get("sourceType")),
+        "compose_server_id_present": "true"
+        if _runtime_source_value(target_payload.get("serverId"))
+        else "false",
         "compose_isolated_deployment": _runtime_source_value(
             target_payload.get("isolatedDeployment")
         ),
@@ -395,6 +398,7 @@ def _dokploy_container_route_evidence(
     containers_payload: JsonValue,
     config_payload: JsonValue | None,
     app_name: str,
+    server_id: str,
     expected_domain_hosts: tuple[str, ...],
 ) -> dict[str, str]:
     containers = _collect_json_objects(containers_payload)
@@ -409,6 +413,7 @@ def _dokploy_container_route_evidence(
     )
     evidence: dict[str, str] = {
         "container_app_name": app_name,
+        "container_server_id_present": "true" if server_id else "false",
         "container_match_count": str(len(app_containers)),
         "container_web_found": "true" if web_container is not None else "false",
         "container_web_id_present": "true" if web_container and _container_id(web_container) else "false",
@@ -1218,26 +1223,34 @@ def execute_odoo_stable_target_replacement_apply(
                 ).items()
             }
         )
+        deployed_app_name = str(deployed_payload.get("appName") or "")
+        deployed_server_id = str(deployed_payload.get("serverId") or "").strip()
+        container_query: dict[str, str] = {
+            "appName": deployed_app_name,
+            "appType": "docker-compose",
+        }
+        if deployed_server_id:
+            container_query["serverId"] = deployed_server_id
         containers_payload = dokploy_request(
             host=host,
             token=token,
             path="/api/docker.getContainersByAppNameMatch",
-            query={
-                "appName": str(deployed_payload.get("appName") or ""),
-                "appType": "docker-compose",
-            },
+            query=container_query,
         )
         web_container = _web_container_for_app(
             containers_payload=containers_payload,
-            app_name=str(deployed_payload.get("appName") or ""),
+            app_name=deployed_app_name,
         )
         config_payload: JsonValue | None = None
         if web_container is not None and _container_id(web_container):
+            config_query = {"containerId": _container_id(web_container)}
+            if deployed_server_id:
+                config_query["serverId"] = deployed_server_id
             config_payload = dokploy_request(
                 host=host,
                 token=token,
                 path="/api/docker.getConfig",
-                query={"containerId": _container_id(web_container)},
+                query=config_query,
             )
         runtime_source.update(
             {
@@ -1245,7 +1258,8 @@ def execute_odoo_stable_target_replacement_apply(
                 for key, value in _dokploy_container_route_evidence(
                     containers_payload=containers_payload,
                     config_payload=config_payload,
-                    app_name=str(deployed_payload.get("appName") or ""),
+                    app_name=deployed_app_name,
+                    server_id=deployed_server_id,
                     expected_domain_hosts=plan.expected_domain_hosts,
                 ).items()
             }

--- a/scripts/deploy/capture-launchplane-deploy-diagnostics.py
+++ b/scripts/deploy/capture-launchplane-deploy-diagnostics.py
@@ -199,17 +199,29 @@ def main() -> int:
     )
 
     app_name = str(target_payload.get("appName") or "")
-    containers_payload = _request_json(host=host, token=token, path="/api/docker.getContainers")
+    server_id = str(target_payload.get("serverId") or "").strip()
+    container_query = {"appName": app_name, "appType": "docker-compose"}
+    if server_id:
+        container_query["serverId"] = server_id
+    containers_payload = _request_json(
+        host=host,
+        token=token,
+        path="/api/docker.getContainersByAppNameMatch",
+        query=container_query,
+    )
     target_containers = _target_containers(containers_payload=containers_payload, app_name=app_name)
     _print_json({"diagnostic": "dokploy-containers", "containers": target_containers})
     for container in target_containers:
         container_id = _container_id(container)
         if container_id:
+            config_query = {"containerId": container_id}
+            if server_id:
+                config_query["serverId"] = server_id
             config_payload = _request_json(
                 host=host,
                 token=token,
                 path="/api/docker.getConfig",
-                query={"containerId": container_id},
+                query=config_query,
             )
             _print_json(
                 {

--- a/tests/test_deploy_diagnostics.py
+++ b/tests/test_deploy_diagnostics.py
@@ -33,6 +33,7 @@ class CaptureLaunchplaneDeployDiagnosticsTests(unittest.TestCase):
                 return {
                     "appName": "compose-launchplane-random",
                     "composeStatus": "done",
+                    "serverId": "server-1",
                     "env": (
                         "DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/launchplane@sha256:new\n"
                         "LAUNCHPLANE_DATABASE_URL=postgresql://secret\n"
@@ -54,7 +55,15 @@ class CaptureLaunchplaneDeployDiagnosticsTests(unittest.TestCase):
                         }
                     ],
                 }
-            if path == "/api/docker.getContainers":
+            if path == "/api/docker.getContainersByAppNameMatch":
+                self.assertEqual(
+                    kwargs["query"],
+                    {
+                        "appName": "compose-launchplane-random",
+                        "appType": "docker-compose",
+                        "serverId": "server-1",
+                    },
+                )
                 return [
                     {
                         "containerId": "container-1",
@@ -67,6 +76,10 @@ class CaptureLaunchplaneDeployDiagnosticsTests(unittest.TestCase):
                     {"containerId": "other", "name": "postgres-1"},
                 ]
             if path == "/api/docker.getConfig":
+                self.assertEqual(
+                    kwargs["query"],
+                    {"containerId": "container-1", "serverId": "server-1"},
+                )
                 return {
                     "Config": {
                         "Labels": {

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -591,6 +591,7 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                 "composeStatus": "done",
                 "composeType": "docker-compose",
                 "sourceType": "raw",
+                "serverId": "server-1",
                 "composePath": "docker-compose.yml",
                 "composeFile": persisted_compose_file,
                 "deployments": deployment_records,
@@ -610,7 +611,11 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
             if path == "/api/docker.getContainersByAppNameMatch":
                 self.assertEqual(
                     query,
-                    {"appName": "cm-testing", "appType": "docker-compose"},
+                    {
+                        "appName": "cm-testing",
+                        "appType": "docker-compose",
+                        "serverId": "server-1",
+                    },
                 )
                 return [
                     {
@@ -622,7 +627,10 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                     {"containerId": "container-db", "name": "cm-testing-db-1"},
                 ]
             if path == "/api/docker.getConfig":
-                self.assertEqual(query, {"containerId": "container-web"})
+                self.assertEqual(
+                    query,
+                    {"containerId": "container-web", "serverId": "server-1"},
+                )
                 return {
                     "Config": {
                         "Labels": {
@@ -844,6 +852,10 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         )
         self.assertEqual(
             final_deployment.runtime_source["post_deploy_container_web_found"], "true"
+        )
+        self.assertEqual(
+            final_deployment.runtime_source["post_deploy_container_server_id_present"],
+            "true",
         )
         self.assertEqual(
             final_deployment.runtime_source["post_deploy_container_traefik_enable"], "true"


### PR DESCRIPTION
## Summary
- pass compose serverId into Dokploy container list and inspect calls for remote-server targets
- record whether the deployed compose payload had a serverId available
- keep emergency deploy diagnostics aligned with remote-server container lookup

## Tests
- uv run python -m unittest tests.test_odoo_stable_target_replacement tests.test_deploy_diagnostics
- uv run --extra dev ruff check --diff control_plane/workflows/odoo_stable_target_replacement.py scripts/deploy/capture-launchplane-deploy-diagnostics.py tests/test_deploy_diagnostics.py tests/test_odoo_stable_target_replacement.py
- uv run --extra dev ruff check control_plane/workflows/odoo_stable_target_replacement.py scripts/deploy/capture-launchplane-deploy-diagnostics.py tests/test_deploy_diagnostics.py tests/test_odoo_stable_target_replacement.py
- uv run --extra dev mypy control_plane/workflows/odoo_stable_target_replacement.py scripts/deploy/capture-launchplane-deploy-diagnostics.py tests/test_deploy_diagnostics.py tests/test_odoo_stable_target_replacement.py
- git diff --check