### PR TITLE
Use requested source ref in Odoo runtime identity

### DIFF
--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -641,6 +641,7 @@ def _build_runtime_identity(
     plan: OdooStableTargetReplacementPlan,
     deployment_record_id: str,
     artifact_id: str,
+    source_git_ref: str,
     image_reference: str,
     deployed_at: str = "",
 ) -> RuntimeIdentity:
@@ -651,7 +652,7 @@ def _build_runtime_identity(
         environment_kind="stable",
         deployment_record_id=deployment_record_id,
         artifact_id=artifact_id,
-        source_git_ref=plan.expected_source_git_ref,
+        source_git_ref=source_git_ref,
         image_reference=image_reference,
         deployed_at=deployed_at,
     )
@@ -1014,6 +1015,7 @@ def execute_odoo_stable_target_replacement_apply(
         plan=plan,
         deployment_record_id=deployment_record_id,
         artifact_id=artifact_id,
+        source_git_ref=source_git_ref,
         image_reference=image_reference,
     )
 

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -999,6 +999,7 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         self.assertEqual(final_deployment.source_git_ref, "fresh-sha")
         assert final_deployment.runtime_identity is not None
         self.assertEqual(final_deployment.runtime_identity.artifact_id, "artifact-cm-fresh")
+        self.assertEqual(final_deployment.runtime_identity.source_git_ref, "fresh-sha")
         self.assertEqual(sync_source.call_args.kwargs["compose_name"], "cm-testing")
 
     def test_apply_refuses_explicit_artifact_source_mismatch(self) -> None:


### PR DESCRIPTION
## Summary
- set Odoo stable replacement runtime_identity.source_git_ref from the requested/deployed source ref, not the previous inventory ref
- add regression coverage for explicit artifact replacement identity evidence

## Tests
- uv run python -m unittest tests.test_odoo_stable_target_replacement
- uv run --extra dev ruff check --diff control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_stable_target_replacement.py
- uv run --extra dev ruff check control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_stable_target_replacement.py
- uv run --extra dev mypy control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_stable_target_replacement.py
- git diff --check