### PR TITLE
Add ingress route dry-run workflow

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -68,6 +68,7 @@
     "Security",
     "CodeQL",
     "Deploy Launchplane",
+    "Ingress Route Dry Run",
     "Live Target Runtime",
     "Merge Train Runner",
     "Odoo Config Parameter Override",

--- a/.github/workflows/ingress-route-dry-run.yml
+++ b/.github/workflows/ingress-route-dry-run.yml
@@ -1,0 +1,165 @@
+---
+name: Ingress Route Dry Run
+
+"on":
+  workflow_dispatch:
+    inputs:
+      product:
+        description: Launchplane product key authorized for the route plan.
+        required: true
+        type: string
+      context:
+        description: Launchplane context authorized for the route plan.
+        required: true
+        type: string
+      domain:
+        description: Public domain name to compare against the provider route.
+        required: true
+        type: string
+      forward_host:
+        description: Upstream host for the desired provider route.
+        required: true
+        type: string
+      forward_port:
+        description: Upstream port for the desired provider route.
+        required: true
+        type: number
+      certificate_id:
+        description: Existing provider certificate id.
+        required: true
+        type: number
+      expected_host_id:
+        description: Existing provider host id that must own the domain.
+        required: true
+        type: number
+      reason:
+        description: Operator reason recorded with the Launchplane request.
+        required: true
+        type: string
+      forward_scheme:
+        description: Upstream scheme.
+        required: true
+        default: http
+        type: choice
+        options:
+          - http
+          - https
+      route_options_json:
+        description: Optional JSON object for route toggles and provider options.
+        required: true
+        default: "{}"
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: launchplane-ingress-route-dry-run-${{ inputs.product }}-${{ inputs.context }}
+  cancel-in-progress: false
+
+jobs:
+  dry-run:
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    env:
+      LAUNCHPLANE_URL: >-
+        ${{ vars.LAUNCHPLANE_PUBLIC_URL ||
+        'https://launchplane.shinycomputers.com' }}
+    steps:
+      - name: Build ingress route dry run payload
+        id: payload
+        shell: bash
+        env:
+          PRODUCT: ${{ inputs.product }}
+          CONTEXT: ${{ inputs.context }}
+          DOMAIN: ${{ inputs.domain }}
+          REASON: ${{ inputs.reason }}
+          EXPECTED_HOST_ID: ${{ inputs.expected_host_id }}
+          FORWARD_SCHEME: ${{ inputs.forward_scheme }}
+          FORWARD_HOST: ${{ inputs.forward_host }}
+          FORWARD_PORT: ${{ inputs.forward_port }}
+          CERTIFICATE_ID: ${{ inputs.certificate_id }}
+          ROUTE_OPTIONS_JSON: ${{ inputs.route_options_json }}
+        run: |
+          set -euo pipefail
+          payload_file="$RUNNER_TEMP/ingress-route-dry-run-request.json"
+          jq -n \
+            --arg product "$PRODUCT" \
+            --arg context "$CONTEXT" \
+            --arg domain "$DOMAIN" \
+            --arg reason "$REASON" \
+            --arg forward_scheme "$FORWARD_SCHEME" \
+            --arg forward_host "$FORWARD_HOST" \
+            --arg route_options_json "$ROUTE_OPTIONS_JSON" \
+            --argjson expected_host_id "$EXPECTED_HOST_ID" \
+            --argjson forward_port "$FORWARD_PORT" \
+            --argjson certificate_id "$CERTIFICATE_ID" \
+            '($route_options_json | fromjson) as $options |
+            {
+              schema_version: 1,
+              product: $product,
+              context: $context,
+              ingress: {
+                schema_version: 1,
+                mode: "dry-run",
+                expected_host_id: $expected_host_id,
+                reason: $reason,
+                route: {
+                  domain_names: [$domain],
+                  forward_scheme: $forward_scheme,
+                  forward_host: $forward_host,
+                  forward_port: $forward_port,
+                  certificate_id: $certificate_id,
+                  enabled: ($options.enabled // true),
+                  ssl_forced: ($options.ssl_forced // true),
+                  http2_support: ($options.http2_support // true),
+                  npmplus_http3_support: ($options.npmplus_http3_support // true),
+                  npmplus_noindex: ($options.npmplus_noindex // true),
+                  access_list_id: ($options.access_list_id // 0)
+                }
+              }
+            }' >"$payload_file"
+          echo "payload_file=$payload_file" >>"$GITHUB_OUTPUT"
+
+      - name: Request ingress route dry run
+        id: launchplane
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          method: POST
+          route-path: /v1/drivers/ingress/route-apply
+          payload-file: ${{ steps.payload.outputs.payload_file }}
+          timeout-ms: "30000"
+          fail-result-paths: result.status
+          response-output-file: ingress-route-dry-run.json
+
+      - name: Summarize dry run
+        shell: bash
+        run: |
+          set -euo pipefail
+          result_file="ingress-route-dry-run.json"
+          jq . "$result_file"
+          {
+            echo '## Ingress route dry run'
+            echo
+            echo "- Product: ${{ inputs.product }}"
+            echo "- Context: ${{ inputs.context }}"
+            echo "- Domain: ${{ inputs.domain }}"
+            echo "- Status: $(jq -r '.result.status' "$result_file")"
+            echo "- Dry run: $(jq -r '.result.dry_run' "$result_file")"
+            echo
+            echo '### Operations'
+            jq -r '
+              .result.operations[]?
+              | "- \(.action) host=\(.host_id // "new") requires_apply=\(.requires_apply)"
+            ' "$result_file"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Upload dry run response
+        uses: actions/upload-artifact@v7
+        with:
+          name: ingress-route-dry-run
+          path: ingress-route-dry-run.json
+          if-no-files-found: error

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -178,6 +178,13 @@ an explicit `--idempotency-key`. The CLI accepts a bearer token from
 `LAUNCHPLANE_SERVICE_TOKEN` by default or a signed browser session via
 `--session-cookie`; it must not read NPMplus credentials locally.
 
+Operators can also use the `Ingress Route Dry Run` GitHub workflow for a
+service-mediated canary plan through GitHub OIDC. The workflow accepts the
+product, context, domain, upstream target, existing certificate id, expected
+provider host id, and route toggles as manual inputs, then calls the same route with
+`mode: dry-run`. Its authz grant is plan-only; an apply still requires the
+separate `ingress_route.apply` permission and an explicit mutation path.
+
 ## Product Repo Boundary
 
 Driver development should make product repos thinner, not larger. When a new

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -1241,6 +1241,16 @@ post_local_owner_grant \
   ingress_route.apply \
   deploy:local-operator-ingress-route-apply-grant \
   local-operator-ingress-route-apply
+# Keep the manual OIDC dry-run workflow canary-scoped until broader route
+# ownership and operator review flows are explicit.
+post_grant \
+  "$GITHUB_REPOSITORY" \
+  ingress-route-dry-run.yml \
+  launchplane \
+  reon-prod \
+  ingress_route.plan \
+  deploy:ingress-route-dry-run-plan-grant \
+  ingress-route-dry-run-plan
 post_local_owner_grant \
   local-operator \
   "*" \


### PR DESCRIPTION
## Summary
- add a manual GitHub OIDC workflow for service-mediated ingress route dry-runs
- seed a plan-only authz grant scoped to the current canary product/context
- document the operator dry-run path and mark the workflow as important metadata

## Validation
- actionlint .github/workflows/ingress-route-dry-run.yml
- shellcheck scripts/deploy/ensure-authz-grants.sh
- git diff --check
- jq empty .github/github.json
- dry-run jq payload smoke