### PR TITLE
Restore Odoo post-deploy sanitize wiring

### DIFF
--- a/.github/workflows/odoo-website-bootstrap-override.yml
+++ b/.github/workflows/odoo-website-bootstrap-override.yml
@@ -16,6 +16,7 @@ name: Odoo Website Bootstrap Override
         type: choice
         options:
           - cm
+          - opw
       instance:
         description: Stable Odoo instance to update.
         required: true
@@ -23,6 +24,7 @@ name: Odoo Website Bootstrap Override
         type: choice
         options:
           - testing
+          - prod
       website_bootstrap_payload:
         description: Website bootstrap JSON object rendered from the tenant bootstrap settings.
         required: true
@@ -57,9 +59,19 @@ jobs:
           : "${CONTEXT_NAME:?Missing context input}"
           : "${INSTANCE:?Missing instance input}"
           : "${WEBSITE_BOOTSTRAP_PAYLOAD:?Missing website bootstrap payload input}"
-          if [ "$CONTEXT_NAME" != "cm" ] || [ "$INSTANCE" != "testing" ]; then
-            echo 'This workflow currently writes only cm/testing Odoo website bootstrap overrides.' >&2
-            exit 1
+          target_key="$PRODUCT:$CONTEXT_NAME:$INSTANCE"
+          case "$target_key" in
+            odoo-tenant-cm:cm:testing|
+            odoo-tenant-opw:opw:testing|
+            odoo-tenant-opw:opw:prod)
+              ;;
+            *)
+              echo 'Unsupported Odoo website bootstrap override target.' >&2
+              exit 1
+              ;;
+          esac
+          if [ "$PRODUCT" = "odoo-tenant-opw" ] && [ "$INSTANCE" = "prod" ]; then
+            echo 'OPW prod bootstrap override allowed for canonical URL correction.' >&2
           fi
           if [ -z "${LAUNCHPLANE_SERVICE_URL:-}" ] || [ -z "${LAUNCHPLANE_SERVICE_AUDIENCE:-}" ]; then
             echo 'Missing Launchplane service URL or OIDC audience repository variable.' >&2

--- a/.github/workflows/odoo-website-bootstrap-override.yml
+++ b/.github/workflows/odoo-website-bootstrap-override.yml
@@ -60,16 +60,11 @@ jobs:
           : "${INSTANCE:?Missing instance input}"
           : "${WEBSITE_BOOTSTRAP_PAYLOAD:?Missing website bootstrap payload input}"
           target_key="$PRODUCT:$CONTEXT_NAME:$INSTANCE"
-          case "$target_key" in
-            odoo-tenant-cm:cm:testing|
-            odoo-tenant-opw:opw:testing|
-            odoo-tenant-opw:opw:prod)
-              ;;
-            *)
-              echo 'Unsupported Odoo website bootstrap override target.' >&2
-              exit 1
-              ;;
-          esac
+          allowed_targets=" odoo-tenant-cm:cm:testing odoo-tenant-opw:opw:testing odoo-tenant-opw:opw:prod "
+          if [[ "$allowed_targets" != *" $target_key "* ]]; then
+            echo 'Unsupported Odoo website bootstrap override target.' >&2
+            exit 1
+          fi
           if [ "$PRODUCT" = "odoo-tenant-opw" ] && [ "$INSTANCE" = "prod" ]; then
             echo 'OPW prod bootstrap override allowed for canonical URL correction.' >&2
           fi

--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -1445,6 +1445,7 @@ def run_compose_post_deploy_update(
     workflow_environment_overrides: Mapping[str, str] | None = None,
     required_workflow_environment_keys: tuple[str, ...] = (),
     protected_shopify_store_keys: tuple[str, ...] = (),
+    run_destructive_restore: bool = False,
 ) -> None:
     compose_id = target_definition.target_id.strip()
     compose_name = (
@@ -1544,6 +1545,7 @@ def run_compose_post_deploy_update(
         filestore_path=filestore_path,
         clear_stale_lock=_should_clear_stale_data_workflow_lock(existing_schedule),
         data_workflow_lock_path=data_workflow_lock_path,
+        workflow_mode="restore" if run_destructive_restore else "maintenance",
         workflow_environment_overrides=workflow_environment_overrides or {},
         required_workflow_environment_keys=required_workflow_environment_keys,
         protected_shopify_store_keys=protected_shopify_store_keys,
@@ -2075,7 +2077,7 @@ def _build_dokploy_data_workflow_script(
     filestore_path: str,
     clear_stale_lock: bool,
     data_workflow_lock_path: str,
-    workflow_mode: Literal["update", "bootstrap"] = "update",
+    workflow_mode: Literal["maintenance", "bootstrap", "restore"] = "maintenance",
     workflow_environment_overrides: Mapping[str, str] | None = None,
     required_workflow_environment_keys: tuple[str, ...] = (),
     protected_shopify_store_keys: tuple[str, ...] = (),
@@ -2095,8 +2097,18 @@ def _build_dokploy_data_workflow_script(
         "protected_shopify_store_keys",
         protected_shopify_store_keys,
     )
-    workflow_arguments = "--bootstrap" if workflow_mode == "bootstrap" else "--update-only"
-    workflow_label = "bootstrap" if workflow_mode == "bootstrap" else "post-deploy update"
+    workflow_arguments_by_mode = {
+        "maintenance": "--post-deploy-maintenance",
+        "bootstrap": "--bootstrap",
+        "restore": "",
+    }
+    workflow_label_by_mode = {
+        "maintenance": "post-deploy maintenance",
+        "bootstrap": "bootstrap",
+        "restore": "restore",
+    }
+    workflow_arguments = workflow_arguments_by_mode[workflow_mode]
+    workflow_label = workflow_label_by_mode[workflow_mode]
     return f"""#!/usr/bin/env bash
 set -euo pipefail
 

--- a/control_plane/workflows/odoo_post_deploy.py
+++ b/control_plane/workflows/odoo_post_deploy.py
@@ -148,6 +148,7 @@ def execute_odoo_post_deploy(
     record_store: object,
     request: OdooPostDeployRequest,
     env_file: Path | None = None,
+    run_destructive_restore: bool = False,
 ) -> OdooPostDeployResult:
     typed_record_store = _require_record_store(record_store)
     odoo_override_record = _read_odoo_instance_override_record(
@@ -212,6 +213,7 @@ def execute_odoo_post_deploy(
             workflow_environment_overrides=workflow_environment_overrides,
             required_workflow_environment_keys=required_workflow_environment_keys,
             protected_shopify_store_keys=protected_shopify_store_keys,
+            run_destructive_restore=run_destructive_restore,
         )
     except click.ClickException as error:
         if odoo_override_record is not None and override_phase_enabled:

--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -1287,6 +1287,7 @@ def execute_odoo_stable_target_replacement_apply(
         control_plane_root=control_plane_root,
         record_store=record_store,
         request=OdooPostDeployRequest(context=plan.context, instance=plan.instance, phase="deploy"),
+        run_destructive_restore=plan.data_source_mode == "upstream_restore",
     )
     post_deploy_evidence = PostDeployUpdateEvidence(
         attempted=True,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -613,7 +613,12 @@ context only, and `context_instance` has both context and instance.
 - `POST /v1/drivers/odoo/post-deploy` is the first Launchplane-owned Odoo
   driver route. It executes the remote compose post-deploy data-workflow runner
   for a stable Odoo target and applies DB-backed instance override records when
-  the requested phase matches `apply_on`.
+  the requested phase matches `apply_on`. Routine post-deploy runs use the
+  devkit post-deploy maintenance mode: update addons, apply typed Launchplane
+  settings and website bootstrap payloads, normalize the configured admin user,
+  and re-provision derived Odoo service-user API keys. Full database
+  sanitization such as disabling mail servers and cron remains tied to explicit
+  restore/bootstrap workflows, not ordinary prod image deploys.
 - `POST /v1/drivers/odoo/prod-rollback` rolls a prod-named Odoo lane back to
   the DB-backed `testing` release tuple for the same context. The driver updates
   the Dokploy `DOCKER_IMAGE_REFERENCE`, deploys the compose target, runs the
@@ -649,6 +654,11 @@ context only, and `context_instance` has both context and instance.
   record, giving the future Odoo driver a tested result-write path.
 - Compose post-deploy updates consume deploy-phase overrides from these records
   and pass them to the Odoo data-workflow runner as one typed payload env var.
+- Target replacement requests with `data_source_mode="upstream_restore"` use the
+  guarded post-deploy schedule in destructive restore mode after image deploy so
+  the devkit restore path performs restore sanitization, website bootstrap,
+  admin normalization, and service-user API-key replacement before readiness
+  verification.
 - Launchplane passes one typed payload to the Odoo settings apply path; legacy
   `ENV_OVERRIDE_*` values are migration input only, not the deploy-time
   settings contract.

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -2051,8 +2051,63 @@ domains = ["cm-testing.shinycomputers.com"]
         self.assertNotIn("DOKPLOY_TOKEN=should-not-sync", updated_env_payloads[0])
         self.assertEqual(len(schedule_payloads), 1)
         self.assertEqual(schedule_payloads[0]["command"], "control-plane post-deploy update")
+        self.assertIn("--post-deploy-maintenance", str(schedule_payloads[0]["script"]))
+        self.assertNotIn("--update-only", str(schedule_payloads[0]["script"]))
         self.assertIn("/api/compose.deploy", request_paths)
         self.assertIn("/api/schedule.runManually", request_paths)
+
+    def test_run_compose_post_deploy_update_can_run_destructive_restore_workflow(
+        self,
+    ) -> None:
+        target_definition = control_plane_dokploy.DokployTargetDefinition(
+            context="opw", instance="testing", target_id="compose-123", target_name="opw-testing"
+        )
+        schedule_payloads: list[dict[str, object]] = []
+
+        def capture_schedule_payload(**kwargs: object) -> dict[str, str]:
+            schedule_payloads.append(cast("dict[str, object]", kwargs["schedule_payload"]))
+            return {"scheduleId": "schedule-123"}
+
+        with (
+            patch(
+                "control_plane.dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "env": "ODOO_DB_NAME=opw_testing\nODOO_FILESTORE_PATH=/volumes/data/filestore\n",
+                    "appName": "opw-testing-app",
+                    "serverId": "server-123",
+                },
+            ),
+            patch("control_plane.dokploy.find_matching_dokploy_schedule", return_value=None),
+            patch(
+                "control_plane.dokploy.upsert_dokploy_schedule",
+                side_effect=capture_schedule_payload,
+            ),
+            patch(
+                "control_plane.dokploy.latest_deployment_for_schedule",
+                return_value={"deploymentId": "schedule-before"},
+            ),
+            patch(
+                "control_plane.dokploy.wait_for_dokploy_schedule_deployment",
+                side_effect=lambda **_kwargs: None,
+            ),
+            patch(
+                "control_plane.dokploy.dokploy_request",
+                side_effect=lambda **_kwargs: {"ok": True},
+            ),
+        ):
+            control_plane_dokploy.run_compose_post_deploy_update(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                target_definition=target_definition,
+                env_file=None,
+                run_destructive_restore=True,
+            )
+
+        self.assertEqual(len(schedule_payloads), 1)
+        script = str(schedule_payloads[0]["script"])
+        self.assertIn("workflow_arguments=()", script)
+        self.assertIn("Running Odoo restore", script)
+        self.assertNotIn("--post-deploy-maintenance", script)
 
     def test_run_compose_post_deploy_update_requires_database_name(self) -> None:
         target_definition = control_plane_dokploy.DokployTargetDefinition(

--- a/tests/test_odoo_post_deploy.py
+++ b/tests/test_odoo_post_deploy.py
@@ -89,6 +89,7 @@ class OdooPostDeployWorkflowTests(unittest.TestCase):
             )
             self.assertIn("ODOO_INSTANCE_OVERRIDES_PAYLOAD_B64", workflow_environment)
             self.assertNotIn("ENV_OVERRIDE_CONFIG_PARAM__WEB__BASE__URL", workflow_environment)
+            self.assertFalse(captured_runs[0]["run_destructive_restore"])
             updated_record = store.read_odoo_instance_override_record(
                 context_name="opw",
                 instance_name="testing",
@@ -128,6 +129,37 @@ class OdooPostDeployWorkflowTests(unittest.TestCase):
             self.assertFalse(result.override_record_found)
             self.assertEqual(len(captured_runs), 1)
             self.assertEqual(captured_runs[0]["workflow_environment_overrides"], {})
+
+    def test_execute_can_request_destructive_restore_for_prelaunch_rebuild(self) -> None:
+        captured_runs: list[dict[str, object]] = []
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+
+            with (
+                patch(
+                    "control_plane.workflows.odoo_post_deploy.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                    return_value=self._source_of_truth(),
+                ),
+                patch(
+                    "control_plane.workflows.odoo_post_deploy.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "token-123"),
+                ),
+                patch(
+                    "control_plane.workflows.odoo_post_deploy.control_plane_dokploy.run_compose_post_deploy_update",
+                    side_effect=lambda **kwargs: captured_runs.append(kwargs),
+                ),
+            ):
+                result = execute_odoo_post_deploy(
+                    control_plane_root=root,
+                    record_store=store,
+                    request=OdooPostDeployRequest(context="opw", instance="testing"),
+                    run_destructive_restore=True,
+                )
+
+            self.assertEqual(result.post_deploy_status, "pass")
+            self.assertEqual(len(captured_runs), 1)
+            self.assertTrue(captured_runs[0]["run_destructive_restore"])
 
 
 if __name__ == "__main__":

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -784,6 +784,7 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         trigger_deploy.assert_called_once()
         wait_deploy.assert_called_once()
         post_deploy.assert_called_once()
+        self.assertFalse(post_deploy.call_args.kwargs["run_destructive_restore"])
         verify_readiness.assert_called_once_with(
             base_url="https://cm-testing.shinycomputers.com",
             health_url="https://cm-testing.shinycomputers.com/web/health",
@@ -1001,6 +1002,133 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         self.assertEqual(final_deployment.runtime_identity.artifact_id, "artifact-cm-fresh")
         self.assertEqual(final_deployment.runtime_identity.source_git_ref, "fresh-sha")
         self.assertEqual(sync_source.call_args.kwargs["compose_name"], "cm-testing")
+
+    def test_apply_requests_destructive_restore_for_upstream_restore_mode(self) -> None:
+        profile = _opw_profile_with_prelaunch_policy(enabled=True)
+        manifest = _artifact_manifest(
+            artifact_id="artifact-opw-testing",
+            source_commit="opw-sha",
+            digest="sha256:opw",
+        ).model_copy(
+            update={"image": ArtifactImageReference(repository="ghcr.io/cbusillo/odoo-tenant-opw", digest="sha256:opw")}
+        )
+        store = _Store(
+            profile=profile,
+            target_record=_opw_target_record(),
+            target_id_record=_opw_target_id_record(),
+            inventory=EnvironmentInventory(
+                context="opw",
+                instance="prod",
+                artifact_identity=ArtifactIdentityReference(artifact_id="artifact-opw-testing"),
+                source_git_ref="opw-sha",
+                deploy=DeploymentEvidence(
+                    status="pass",
+                    target_type="compose",
+                    target_name="opw-prod",
+                    deploy_mode="dokploy-compose-api",
+                ),
+                updated_at="2026-05-10T00:00:00Z",
+                deployment_record_id="deployment-opw-prod",
+            ),
+            artifact_manifest=manifest,
+        )
+        persisted_env = ""
+
+        def _fetch_target_payload(**_: object) -> JsonValue:
+            return {
+                "name": "opw-prod",
+                "sourceType": "raw",
+                "composePath": "docker-compose.yml",
+                "composeFile": "services: {}",
+                "env": persisted_env
+                or "\n".join(
+                    (
+                        "ODOO_DATA_VOLUME=opw_prod_odoo_data",
+                        "ODOO_LOG_VOLUME=opw_prod_odoo_logs",
+                        "ODOO_DB_VOLUME=opw_prod_odoo_db",
+                    )
+                ),
+            }
+
+        def _update_env(*, env_text: str, **_: object) -> None:
+            nonlocal persisted_env
+            persisted_env = env_text
+
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.read_dokploy_config",
+                return_value=("host", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.fetch_dokploy_target_payload",
+                side_effect=_fetch_target_payload,
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.latest_deployment_for_target",
+                return_value={"deploymentId": "deploy-opw", "status": "success"},
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_runtime_environments.resolve_runtime_environment_values",
+                return_value={},
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.sync_dokploy_compose_raw_source"
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.ensure_compose_web_domain_route"
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.fetch_dokploy_converted_compose_file",
+                return_value=control_plane_dokploy.render_odoo_raw_compose_file(
+                    image_reference="ghcr.io/cbusillo/odoo-tenant-opw@sha256:opw",
+                    domain_hosts=("opw-prod.shinycomputers.com",),
+                    runtime_port=8069,
+                ),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.update_dokploy_target_env",
+                side_effect=_update_env,
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.trigger_deployment"
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.wait_for_target_deployment"
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.execute_odoo_post_deploy",
+                return_value=OdooPostDeployResult(
+                    context="opw",
+                    instance="prod",
+                    phase="deploy",
+                    post_deploy_status="pass",
+                ),
+            ) as post_deploy,
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.verify_odoo_stable_readiness",
+                return_value=OdooVerificationResult(
+                    health_status="pass",
+                    canonical_status="pass",
+                    logo_status="pass",
+                    evidence=OdooVerificationEvidence(),
+                ),
+            ),
+        ):
+            result = execute_odoo_stable_target_replacement_apply(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=OdooStableTargetReplacementApplyRequest(
+                    product="odoo-tenant-opw",
+                    instance="prod",
+                    allow_empty_data=True,
+                    data_source_mode="upstream_restore",
+                    confirmation="restore opw upstream",
+                ),
+                dokploy_request=cast(DokployRequest, _request),
+            )
+
+        self.assertEqual(result.deploy_status, "pass")
+        self.assertTrue(post_deploy.call_args.kwargs["run_destructive_restore"])
 
     def test_apply_refuses_explicit_artifact_source_mismatch(self) -> None:
         store = _Store(

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -227,6 +227,23 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("product=${{ steps.product.outputs.product }}", workflow_text)
         self.assertIn('"instance":"testing"', workflow_text)
         self.assertIn("deploy.artifact_id=${{ inputs.artifact_id }}", workflow_text)
+
+    def test_odoo_website_bootstrap_override_workflow_allows_opw_targets(self) -> None:
+        workflow_text = Path(".github/workflows/odoo-website-bootstrap-override.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("odoo-tenant-opw:opw:testing", workflow_text)
+        self.assertIn("odoo-tenant-opw:opw:prod", workflow_text)
+        self.assertIn("          - opw", workflow_text)
+        self.assertIn("          - prod", workflow_text)
+        self.assertNotIn("writes only cm/testing", workflow_text)
+
+    def test_reusable_odoo_testing_deploy_exposes_result_outputs(self) -> None:
+        workflow_text = Path(".github/workflows/reusable-odoo-testing-deploy.yml").read_text(
+            encoding="utf-8"
+        )
+
         self.assertIn("deploy.source_git_ref=${{ inputs.source_git_ref }}", workflow_text)
         self.assertIn("outputs:", workflow_text)
         self.assertIn("value: ${{ jobs.testing-deploy.outputs.deployment_record_id }}", workflow_text)


### PR DESCRIPTION
## Summary
- switch Odoo post-deploy schedules from update-only to devkit post-deploy maintenance
- wire upstream_restore target replacement to the destructive restore workflow
- allow OPW website-bootstrap override writes so tenant bootstrap intent can be persisted
- document the split between maintenance and full restore/bootstrap sanitization

## Tests
- uv run python -m unittest tests.test_dokploy tests.test_odoo_post_deploy tests.test_odoo_stable_target_replacement tests.test_product_onboarding
- uv run --extra dev ruff check control_plane/dokploy.py control_plane/workflows/odoo_post_deploy.py control_plane/workflows/odoo_stable_target_replacement.py tests/test_dokploy.py tests/test_odoo_post_deploy.py tests/test_odoo_stable_target_replacement.py tests/test_product_onboarding.py
- uv run --extra dev mypy control_plane/dokploy.py control_plane/workflows/odoo_post_deploy.py control_plane/workflows/odoo_stable_target_replacement.py tests/test_dokploy.py tests/test_odoo_post_deploy.py tests/test_odoo_stable_target_replacement.py tests/test_product_onboarding.py