### PR TITLE
Allow omitting NPMplus self-deploy env

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -31,6 +31,11 @@ on:
         required: false
         default: false
         type: boolean
+      omit_npmplus_env:
+        description: Temporarily omit NPMplus env for one compatibility deploy.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   actions: read
@@ -286,6 +291,7 @@ jobs:
                 --argjson omit_every_code_env '${{ inputs.omit_every_code_env || false }}' \
                 --argjson omit_terminal_agent_env '${{ inputs.omit_terminal_agent_env || false }}' \
                 --argjson omit_owner_agent_env '${{ inputs.omit_owner_agent_env || false }}' \
+                --argjson omit_npmplus_env '${{ inputs.omit_npmplus_env || false }}' \
                 '(
                   {
                   LAUNCHPLANE_GITHUB_CLIENT_ID: $github_client_id,
@@ -332,21 +338,21 @@ jobs:
                     end
                   )
                   + (
-                    if $npmplus_base_url != "" then
+                    if (($omit_npmplus_env | not) and $npmplus_base_url != "") then
                       {LAUNCHPLANE_NPMPLUS_BASE_URL: $npmplus_base_url}
                     else
                       {}
                     end
                   )
                   + (
-                    if $npmplus_identity != "" then
+                    if (($omit_npmplus_env | not) and $npmplus_identity != "") then
                       {LAUNCHPLANE_NPMPLUS_IDENTITY: $npmplus_identity}
                     else
                       {}
                     end
                   )
                   + (
-                    if $npmplus_secret != "" then
+                    if (($omit_npmplus_env | not) and $npmplus_secret != "") then
                       {LAUNCHPLANE_NPMPLUS_SECRET: $npmplus_secret}
                     else
                       {}


### PR DESCRIPTION
## Summary
- add an omit_npmplus_env compatibility input to Launchplane self-deploy
- skip NPMplus env fields when that one-shot input is enabled

## Tests
- docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml