### PR TITLE
Grant OPW website bootstrap override

### DIFF
--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -1346,6 +1346,14 @@ post_grant \
   odoo-cm-website-bootstrap-override
 post_grant \
   "$GITHUB_REPOSITORY" \
+  odoo-website-bootstrap-override.yml \
+  odoo-tenant-opw \
+  opw \
+  odoo_website_bootstrap_override.write \
+  deploy:odoo-opw-website-bootstrap-override-grant \
+  odoo-opw-website-bootstrap-override
+post_grant \
+  "$GITHUB_REPOSITORY" \
   odoo-stable-bootstrap.yml \
   odoo-tenant-cm \
   cm \

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -174,6 +174,10 @@ class ProductOnboardingTests(unittest.TestCase):
             self.assertIn(f"deploy:odoo-{context_name}-post-deploy-grant", script_text)
             self.assertIn(f"deploy:odoo-{context_name}-prod-promotion-run-grant", script_text)
             self.assertIn(f"deploy:odoo-{context_name}-prod-rollback-grant", script_text)
+        self.assertIn("deploy:odoo-cm-website-bootstrap-override-grant", script_text)
+        self.assertIn("deploy:odoo-opw-website-bootstrap-override-grant", script_text)
+        self.assertIn("odoo-cm-website-bootstrap-override", script_text)
+        self.assertIn("odoo-opw-website-bootstrap-override", script_text)
         self.assertIn('base_url: "https://opw-testing.shinycomputers.com"', script_text)
         self.assertIn(
             'health_url: "https://opw-testing.shinycomputers.com/launchplane/health"',


### PR DESCRIPTION
## Summary
- grant the Launchplane website bootstrap override workflow authority for OPW
- cover the OPW grant in product onboarding tests

## Tests
- bash -n scripts/deploy/ensure-authz-grants.sh
- uv run python -m unittest tests.test_product_onboarding