### PR TITLE
Grant OPW website bootstrap authz

### DIFF
--- a/.github/workflows/ingress-route-dry-run.yml
+++ b/.github/workflows/ingress-route-dry-run.yml
@@ -97,6 +97,9 @@ jobs:
             --argjson forward_port "$FORWARD_PORT" \
             --argjson certificate_id "$CERTIFICATE_ID" \
             '($route_options_json | fromjson) as $options |
+            if ($options | type) != "object" then
+              error("route_options_json must be a JSON object")
+            else
             {
               schema_version: 1,
               product: $product,
@@ -120,7 +123,8 @@ jobs:
                   access_list_id: ($options.access_list_id // 0)
                 }
               }
-            }' >"$payload_file"
+            }
+            end' >"$payload_file"
           echo "payload_file=$payload_file" >>"$GITHUB_OUTPUT"
 
       - name: Request ingress route dry run

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -243,6 +243,14 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("          - prod", workflow_text)
         self.assertNotIn("writes only cm/testing", workflow_text)
 
+    def test_ingress_route_dry_run_workflow_rejects_non_object_options(self) -> None:
+        workflow_text = Path(".github/workflows/ingress-route-dry-run.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn('($options | type) != "object"', workflow_text)
+        self.assertIn('error("route_options_json must be a JSON object")', workflow_text)
+
     def test_reusable_odoo_testing_deploy_exposes_result_outputs(self) -> None:
         workflow_text = Path(".github/workflows/reusable-odoo-testing-deploy.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary
- add the OPW website bootstrap override authz grant
- cover CM/OPW website bootstrap grants in product onboarding tests
- reject non-object ingress dry-run route options before building the request payload

## Validation
- actionlint .github/workflows/ingress-route-dry-run.yml
- uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_include_reusable_odoo_stable_workflows tests.test_product_onboarding.ProductOnboardingTests.test_odoo_website_bootstrap_override_workflow_allows_opw_targets tests.test_product_onboarding.ProductOnboardingTests.test_ingress_route_dry_run_workflow_rejects_non_object_options
- uv run --extra dev ruff check tests/test_product_onboarding.py
- git diff --check
- jq route_options_json non-object failure smoke