### PR TITLE
Add ingress canary apply workflow

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -68,6 +68,7 @@
     "Security",
     "CodeQL",
     "Deploy Launchplane",
+    "Ingress Route Canary Apply",
     "Ingress Route Dry Run",
     "Live Target Runtime",
     "Merge Train Runner",

--- a/.github/workflows/ingress-route-canary-apply.yml
+++ b/.github/workflows/ingress-route-canary-apply.yml
@@ -1,0 +1,152 @@
+---
+name: Ingress Route Canary Apply
+
+"on":
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: Operator reason recorded with the Launchplane request.
+        required: true
+        type: string
+      idempotency_key:
+        description: Unique idempotency key for this canary apply attempt.
+        required: true
+        type: string
+      confirmation:
+        description: Type apply ingress canary to confirm the mutation path.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: launchplane-ingress-route-canary-apply
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    env:
+      LAUNCHPLANE_URL: >-
+        ${{ vars.LAUNCHPLANE_PUBLIC_URL ||
+        'https://launchplane.shinycomputers.com' }}
+      CANARY_PRODUCT: launchplane
+      CANARY_CONTEXT: reon-prod
+      CANARY_DOMAIN: ${{ vars.LAUNCHPLANE_INGRESS_CANARY_DOMAIN }}
+      CANARY_EXPECTED_HOST_ID: ${{ vars.LAUNCHPLANE_INGRESS_CANARY_HOST_ID }}
+      CANARY_FORWARD_HOST: ${{ vars.LAUNCHPLANE_INGRESS_CANARY_FORWARD_HOST }}
+      CANARY_FORWARD_PORT: ${{ vars.LAUNCHPLANE_INGRESS_CANARY_FORWARD_PORT }}
+      CANARY_CERTIFICATE_ID: ${{ vars.LAUNCHPLANE_INGRESS_CANARY_CERTIFICATE_ID }}
+    steps:
+      - name: Validate canary apply confirmation
+        shell: bash
+        env:
+          CONFIRMATION: ${{ inputs.confirmation }}
+          IDEMPOTENCY_KEY: ${{ inputs.idempotency_key }}
+        run: |
+          set -euo pipefail
+          if [ "$CONFIRMATION" != "apply ingress canary" ]; then
+            echo "confirmation must be exactly: apply ingress canary" >&2
+            exit 1
+          fi
+          if [ -z "${IDEMPOTENCY_KEY// }" ]; then
+            echo "idempotency_key is required." >&2
+            exit 1
+          fi
+
+      - name: Build ingress route canary apply payload
+        id: payload
+        shell: bash
+        env:
+          REASON: ${{ inputs.reason }}
+        run: |
+          set -euo pipefail
+          : "${CANARY_PRODUCT:?Missing canary product}"
+          : "${CANARY_CONTEXT:?Missing canary context}"
+          : "${CANARY_DOMAIN:?Missing LAUNCHPLANE_INGRESS_CANARY_DOMAIN variable}"
+          : "${CANARY_EXPECTED_HOST_ID:?Missing LAUNCHPLANE_INGRESS_CANARY_HOST_ID variable}"
+          : "${CANARY_FORWARD_HOST:?Missing LAUNCHPLANE_INGRESS_CANARY_FORWARD_HOST variable}"
+          : "${CANARY_FORWARD_PORT:?Missing LAUNCHPLANE_INGRESS_CANARY_FORWARD_PORT variable}"
+          : "${CANARY_CERTIFICATE_ID:?Missing LAUNCHPLANE_INGRESS_CANARY_CERTIFICATE_ID variable}"
+
+          payload_file="$RUNNER_TEMP/ingress-route-canary-apply-request.json"
+          jq -n \
+            --arg product "$CANARY_PRODUCT" \
+            --arg context "$CANARY_CONTEXT" \
+            --arg domain "$CANARY_DOMAIN" \
+            --arg reason "$REASON" \
+            --arg forward_host "$CANARY_FORWARD_HOST" \
+            --argjson expected_host_id "$CANARY_EXPECTED_HOST_ID" \
+            --argjson forward_port "$CANARY_FORWARD_PORT" \
+            --argjson certificate_id "$CANARY_CERTIFICATE_ID" \
+            '{
+              schema_version: 1,
+              product: $product,
+              context: $context,
+              ingress: {
+                schema_version: 1,
+                mode: "apply",
+                expected_host_id: $expected_host_id,
+                reason: $reason,
+                route: {
+                  domain_names: [$domain],
+                  forward_scheme: "http",
+                  forward_host: $forward_host,
+                  forward_port: $forward_port,
+                  certificate_id: $certificate_id,
+                  enabled: true,
+                  ssl_forced: true,
+                  http2_support: true,
+                  npmplus_http3_support: true,
+                  npmplus_noindex: true,
+                  access_list_id: 0
+                }
+              }
+            }' >"$payload_file"
+          echo "payload_file=$payload_file" >>"$GITHUB_OUTPUT"
+
+      - name: Request ingress route canary apply
+        id: launchplane
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          method: POST
+          route-path: /v1/drivers/ingress/route-apply
+          payload-file: ${{ steps.payload.outputs.payload_file }}
+          idempotency-key: ${{ inputs.idempotency_key }}
+          timeout-ms: "30000"
+          fail-result-paths: result.status
+          response-output-file: ingress-route-canary-apply.json
+
+      - name: Summarize canary apply
+        shell: bash
+        run: |
+          set -euo pipefail
+          result_file="ingress-route-canary-apply.json"
+          jq . "$result_file"
+          {
+            echo '## Ingress route canary apply'
+            echo
+            echo "- Product: $CANARY_PRODUCT"
+            echo "- Context: $CANARY_CONTEXT"
+            echo "- Domain: $CANARY_DOMAIN"
+            echo "- Status: $(jq -r '.result.status' "$result_file")"
+            echo "- Dry run: $(jq -r '.result.dry_run' "$result_file")"
+            echo
+            echo '### Operations'
+            jq -r '
+              .result.operations[]?
+              | "- \(.action) host=\(.host_id // "new") requires_apply=\(.requires_apply)"
+            ' "$result_file"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Upload canary apply response
+        uses: actions/upload-artifact@v7
+        with:
+          name: ingress-route-canary-apply
+          path: ingress-route-canary-apply.json
+          if-no-files-found: error

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -185,6 +185,14 @@ provider host id, and route toggles as manual inputs, then calls the same route 
 `mode: dry-run`. Its authz grant is plan-only; an apply still requires the
 separate `ingress_route.apply` permission and an explicit mutation path.
 
+The `Ingress Route Canary Apply` workflow is the matching apply proof path. It
+uses the same canary-scoped product/context grant, reads the expected provider
+host id and canary route tuple from repository variables, and requires an explicit
+idempotency key plus the confirmation phrase `apply ingress canary`. It fixes the
+current canary route toggles instead of accepting arbitrary provider options.
+Keep this workflow canary-scoped until broader route ownership and approval UX are
+explicit.
+
 ## Product Repo Boundary
 
 Driver development should make product repos thinner, not larger. When a new

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -1251,6 +1251,14 @@ post_grant \
   ingress_route.plan \
   deploy:ingress-route-dry-run-plan-grant \
   ingress-route-dry-run-plan
+post_grant \
+  "$GITHUB_REPOSITORY" \
+  ingress-route-canary-apply.yml \
+  launchplane \
+  reon-prod \
+  ingress_route.apply \
+  deploy:ingress-route-canary-apply-grant \
+  ingress-route-canary-apply
 post_local_owner_grant \
   local-operator \
   "*" \

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -251,6 +251,28 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn('($options | type) != "object"', workflow_text)
         self.assertIn('error("route_options_json must be a JSON object")', workflow_text)
 
+    def test_ingress_route_canary_apply_workflow_requires_apply_guards(self) -> None:
+        workflow_text = Path(".github/workflows/ingress-route-canary-apply.yml").read_text(
+            encoding="utf-8"
+        )
+        script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(encoding="utf-8")
+
+        self.assertIn("mode: \"apply\"", workflow_text)
+        self.assertIn("idempotency-key: ${{ inputs.idempotency_key }}", workflow_text)
+        self.assertIn('CONFIRMATION: ${{ inputs.confirmation }}', workflow_text)
+        self.assertIn('apply ingress canary', workflow_text)
+        self.assertIn("CANARY_DOMAIN: ${{ vars.LAUNCHPLANE_INGRESS_CANARY_DOMAIN }}", workflow_text)
+        self.assertIn("CANARY_EXPECTED_HOST_ID: ${{ vars.LAUNCHPLANE_INGRESS_CANARY_HOST_ID }}", workflow_text)
+        inputs_section = workflow_text.split("permissions:", maxsplit=1)[0]
+        self.assertNotIn("      domain:", inputs_section)
+        self.assertNotIn("      expected_host_id:", inputs_section)
+        self.assertIn('forward_scheme: "http"', workflow_text)
+        self.assertIn("npmplus_noindex: true", workflow_text)
+        self.assertNotIn("route_options_json", workflow_text)
+        self.assertIn("ingress-route-canary-apply.yml", script_text)
+        self.assertIn("deploy:ingress-route-canary-apply-grant", script_text)
+        self.assertIn("ingress_route.apply", script_text)
+
     def test_reusable_odoo_testing_deploy_exposes_result_outputs(self) -> None:
         workflow_text = Path(".github/workflows/reusable-odoo-testing-deploy.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary
- add a canary-scoped ingress apply workflow guarded by confirmation and idempotency
- keep the canary route tuple in repository variables instead of workflow-dispatch route inputs
- seed an ingress_route.apply grant only for launchplane/reon-prod and document the proof path

## Validation
- post-hardening dry-run workflow run 26712059812: accepted/unchanged/no-op
- actionlint .github/workflows/ingress-route-canary-apply.yml .github/workflows/ingress-route-dry-run.yml
- shellcheck scripts/deploy/ensure-authz-grants.sh
- jq empty .github/github.json
- uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_ingress_route_canary_apply_workflow_requires_apply_guards tests.test_product_onboarding.ProductOnboardingTests.test_ingress_route_dry_run_workflow_rejects_non_object_options
- uv run --extra dev ruff check tests/test_product_onboarding.py
- git diff --check
- jq payload-shape smoke for canary apply