### PR TITLE
Fix ingress dry-run workflow options

### DIFF
--- a/.github/workflows/ingress-route-dry-run.yml
+++ b/.github/workflows/ingress-route-dry-run.yml
@@ -44,6 +44,10 @@ name: Ingress Route Dry Run
         options:
           - http
           - https
+          - path
+          - empty
+          - grpc
+          - grpcs
       route_options_json:
         description: Optional JSON object for route toggles and provider options.
         required: true
@@ -115,12 +119,12 @@ jobs:
                   forward_host: $forward_host,
                   forward_port: $forward_port,
                   certificate_id: $certificate_id,
-                  enabled: ($options.enabled // true),
-                  ssl_forced: ($options.ssl_forced // true),
-                  http2_support: ($options.http2_support // true),
-                  npmplus_http3_support: ($options.npmplus_http3_support // true),
-                  npmplus_noindex: ($options.npmplus_noindex // true),
-                  access_list_id: ($options.access_list_id // 0)
+                  enabled: (if $options | has("enabled") then $options.enabled else true end),
+                  ssl_forced: (if $options | has("ssl_forced") then $options.ssl_forced else true end),
+                  http2_support: (if $options | has("http2_support") then $options.http2_support else true end),
+                  npmplus_http3_support: (if $options | has("npmplus_http3_support") then $options.npmplus_http3_support else true end),
+                  npmplus_noindex: (if $options | has("npmplus_noindex") then $options.npmplus_noindex else true end),
+                  access_list_id: (if $options | has("access_list_id") then $options.access_list_id else 0 end)
                 }
               }
             }

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -257,6 +257,15 @@ class ProductOnboardingTests(unittest.TestCase):
 
         self.assertIn('($options | type) != "object"', workflow_text)
         self.assertIn('error("route_options_json must be a JSON object")', workflow_text)
+        self.assertIn(
+            'if $options | has("enabled") then $options.enabled else true end', workflow_text
+        )
+        self.assertIn(
+            'if $options | has("npmplus_noindex") then $options.npmplus_noindex else true end',
+            workflow_text,
+        )
+        for forward_scheme in ("http", "https", "path", "empty", "grpc", "grpcs"):
+            self.assertIn(f"          - {forward_scheme}", workflow_text)
 
     def test_ingress_route_canary_apply_workflow_requires_apply_guards(self) -> None:
         workflow_text = Path(".github/workflows/ingress-route-canary-apply.yml").read_text(


### PR DESCRIPTION
## Summary
- preserve explicit false route toggle values in the ingress dry-run workflow payload
- expose all NPMplus-supported forward schemes in workflow_dispatch choices
- add workflow text assertions for both behaviors

## Verification
- actionlint .github/workflows/ingress-route-dry-run.yml
- uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_ingress_route_dry_run_workflow_rejects_non_object_options
- uv run --extra dev ruff check tests/test_product_onboarding.py
- uv run --extra dev ruff format --check tests/test_product_onboarding.py
- git diff --check