### PR TITLE
Unify Odoo rollback through target replacement

### DIFF
--- a/control_plane/workflows/odoo_prod_rollback.py
+++ b/control_plane/workflows/odoo_prod_rollback.py
@@ -1,48 +1,31 @@
 from __future__ import annotations
 
-import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, Protocol, cast
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
 
 import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from control_plane import dokploy as control_plane_dokploy
-from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
-from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
-from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
-from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.promotion_record import (
     HealthcheckEvidence,
-    PostDeployUpdateEvidence,
     PromotionRecord,
     ReleaseStatus,
     RollbackExecutionEvidence,
 )
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
-from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyTarget
-from control_plane.contracts.ship_request import ShipRequest
-from control_plane.release_tuples import build_release_tuple_record_from_artifact_manifest
-from control_plane.runtime_key_safety import (
-    RuntimeKeySafetyPolicyReadStore,
-    evaluate_runtime_key_safety_from_store,
-    latest_active_runtime_key_safety_policy,
-    runtime_key_safety_environment_class,
+from control_plane.contracts.odoo_stable_target_replacement import (
+    OdooStableTargetReplacementApplyRequest,
 )
 from control_plane.workflows.inventory import build_environment_inventory
-from control_plane.workflows.odoo_post_deploy import OdooPostDeployRequest, execute_odoo_post_deploy
-from control_plane.workflows.ship import (
-    build_deployment_record,
-    generate_deployment_record_id,
-    utc_now_timestamp,
+from control_plane.workflows.odoo_stable_target_replacement import (
+    OdooStableTargetReplacementStore,
+    execute_odoo_stable_target_replacement_apply,
 )
-
-ARTIFACT_IMAGE_REFERENCE_ENV_KEY = "DOCKER_IMAGE_REFERENCE"
+from control_plane.workflows.ship import utc_now_timestamp
 
 
 @dataclass(frozen=True)
@@ -55,7 +38,7 @@ class _RollbackSource:
     detail: str
 
 
-class OdooProdRollbackStore(RuntimeKeySafetyPolicyReadStore, Protocol):
+class OdooProdRollbackStore(OdooStableTargetReplacementStore, Protocol):
     def read_release_tuple_record(
         self, *, context_name: str, channel_name: str
     ) -> ReleaseTupleRecord: ...
@@ -68,15 +51,9 @@ class OdooProdRollbackStore(RuntimeKeySafetyPolicyReadStore, Protocol):
 
     def read_promotion_record(self, promotion_record_id: str) -> PromotionRecord: ...
 
-    def read_dokploy_target_record(
-        self, *, context_name: str, instance_name: str
-    ) -> DokployTargetRecord: ...
-
-    def read_dokploy_target_id_record(
-        self, *, context_name: str, instance_name: str
-    ) -> DokployTargetIdRecord: ...
-
     def write_deployment_record(self, record: DeploymentRecord) -> None: ...
+
+    def read_deployment_record(self, record_id: str) -> DeploymentRecord: ...
 
     def write_environment_inventory(self, inventory: EnvironmentInventory) -> None: ...
 
@@ -91,9 +68,11 @@ def _require_record_store(record_store: object) -> OdooProdRollbackStore:
         "read_artifact_manifest",
         "read_environment_inventory",
         "read_promotion_record",
+        "read_product_profile_record",
         "read_dokploy_target_record",
         "read_dokploy_target_id_record",
         "write_deployment_record",
+        "read_deployment_record",
         "write_environment_inventory",
         "write_release_tuple_record",
         "write_promotion_record",
@@ -157,10 +136,6 @@ class OdooProdRollbackResult(BaseModel):
     rollback_health_status: Literal["pass", "fail", "skipped"] = "skipped"
     post_deploy_status: Literal["pass", "fail", "skipped"] = "skipped"
     error_message: str = ""
-
-
-def _artifact_image_reference_from_manifest(manifest: ArtifactIdentityManifest) -> str:
-    return f"{manifest.image.repository}@{manifest.image.digest}"
 
 
 def _read_source_release_tuple(
@@ -286,314 +261,11 @@ def _resolve_promotion_record(
     return promotion_record
 
 
-def _read_target_definition(
-    *,
-    record_store: OdooProdRollbackStore,
-    request: OdooProdRollbackRequest,
-) -> control_plane_dokploy.DokployTargetDefinition:
-    try:
-        target_record = record_store.read_dokploy_target_record(
-            context_name=request.context,
-            instance_name=request.instance,
-        )
-        target_id_record = record_store.read_dokploy_target_id_record(
-            context_name=request.context,
-            instance_name=request.instance,
-        )
-    except FileNotFoundError as exc:
-        raise click.ClickException(
-            f"Odoo prod rollback requires DB-backed Dokploy target records for {request.context}/{request.instance}."
-        ) from exc
-    return _build_dokploy_target_definition(
-        target_record=target_record,
-        target_id=target_id_record.target_id,
-    )
-
-
-def _build_dokploy_target_definition(
-    *,
-    target_record: DokployTargetRecord,
-    target_id: str,
-) -> control_plane_dokploy.DokployTargetDefinition:
-    payload = target_record.model_dump(
-        mode="json",
-        exclude={"schema_version", "updated_at", "source_label"},
-    )
-    payload["target_id"] = target_id
-    return control_plane_dokploy.DokployTargetDefinition.model_validate(payload)
-
-
-def _resolve_ship_request(
-    *,
-    request: OdooProdRollbackRequest,
-    rollback_source: _RollbackSource,
-    artifact_manifest: ArtifactIdentityManifest,
-    target_definition: control_plane_dokploy.DokployTargetDefinition,
-) -> ShipRequest:
-    health_timeout_seconds = control_plane_dokploy.resolve_ship_health_timeout_seconds(
-        health_timeout_override_seconds=request.health_timeout_seconds,
-        target_definition=target_definition,
-    )
-    health_urls = control_plane_dokploy.resolve_ship_healthcheck_urls(
-        target_definition=target_definition,
-        environment_values=target_definition.env,
-    )
-    should_verify_health = request.verify_health and request.wait
-    if should_verify_health and not health_urls:
-        raise click.ClickException(
-            "Odoo prod rollback health verification requested but no target health URL was resolved."
-        )
-    configured_ship_mode = control_plane_dokploy.resolve_dokploy_ship_mode(
-        request.context,
-        request.instance,
-        target_definition.env,
-    )
-    deploy_mode = (
-        f"dokploy-{target_definition.target_type}-api"
-        if configured_ship_mode == "auto"
-        else f"dokploy-{configured_ship_mode}-api"
-    )
-    return ShipRequest(
-        artifact_id=rollback_source.artifact_id,
-        context=request.context,
-        instance=request.instance,
-        source_git_ref=rollback_source.source_git_ref,
-        target_name=target_definition.target_name.strip()
-        or f"{request.context}-{request.instance}",
-        target_type=target_definition.target_type,
-        deploy_mode=deploy_mode,
-        wait=request.wait,
-        timeout_seconds=request.timeout_seconds,
-        verify_health=should_verify_health,
-        health_timeout_seconds=health_timeout_seconds,
-        dry_run=False,
-        no_cache=request.no_cache,
-        allow_dirty=False,
-        destination_health=HealthcheckEvidence(
-            urls=health_urls,
-            timeout_seconds=health_timeout_seconds,
-            status="pending" if should_verify_health else "skipped",
-        ),
-    )
-
-
-def _sync_artifact_image_reference_for_target(
-    *,
-    control_plane_root: Path,
-    record_store: RuntimeKeySafetyPolicyReadStore,
-    target_definition: control_plane_dokploy.DokployTargetDefinition,
-    artifact_manifest: ArtifactIdentityManifest,
-) -> None:
-    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
-    target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
-        host=host,
-        token=token,
-        target_type=target_definition.target_type,
-        target_id=target_definition.target_id,
-    )
-    env_map = control_plane_dokploy.parse_dokploy_env_text(str(target_payload.get("env") or ""))
-    runtime_environment_values = (
-        control_plane_runtime_environments.resolve_runtime_environment_values(
-            control_plane_root=control_plane_root,
-            context_name=target_definition.context,
-            instance_name=target_definition.instance,
-        )
-    )
-    _enforce_runtime_key_safety_for_target_env_sync(
-        record_store=record_store,
-        context_name=target_definition.context,
-        instance_name=target_definition.instance,
-        runtime_environment_values=runtime_environment_values,
-    )
-    desired_image_reference = _artifact_image_reference_from_manifest(artifact_manifest)
-    if target_definition.target_type == "compose":
-        compose_file = control_plane_dokploy.render_odoo_raw_compose_file(
-            image_reference=desired_image_reference,
-            domain_hosts=target_definition.domains,
-        )
-        control_plane_dokploy.sync_dokploy_compose_raw_source(
-            host=host,
-            token=token,
-            compose_id=target_definition.target_id,
-            compose_name=target_definition.target_name,
-            target_payload=target_payload,
-            compose_file=compose_file,
-        )
-
-    desired_env_map = dict(env_map)
-    desired_env_map.update(runtime_environment_values)
-    desired_env_map[ARTIFACT_IMAGE_REFERENCE_ENV_KEY] = desired_image_reference
-    if desired_env_map != env_map:
-        control_plane_dokploy.update_dokploy_target_env(
-            host=host,
-            token=token,
-            target_type=target_definition.target_type,
-            target_id=target_definition.target_id,
-            target_payload=target_payload,
-            env_text=control_plane_dokploy.serialize_dokploy_env_text(desired_env_map),
-        )
-        target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
-            host=host,
-            token=token,
-            target_type=target_definition.target_type,
-            target_id=target_definition.target_id,
-        )
-    refreshed_env_map = control_plane_dokploy.parse_dokploy_env_text(
-        str(target_payload.get("env") or "")
-    )
-    missing_or_mismatched_keys = sorted(
-        env_key
-        for env_key, env_value in desired_env_map.items()
-        if refreshed_env_map.get(env_key, "") != env_value
-    )
-    if missing_or_mismatched_keys:
-        raise click.ClickException(
-            "Dokploy target env did not persist Launchplane DB-backed runtime key(s): "
-            + ", ".join(missing_or_mismatched_keys)
-        )
-
-
-def _enforce_runtime_key_safety_for_target_env_sync(
-    *,
-    record_store: RuntimeKeySafetyPolicyReadStore,
-    context_name: str,
-    instance_name: str,
-    runtime_environment_values: dict[str, str],
-) -> None:
-    bindings = record_store.list_secret_bindings(
-        integration="runtime_environment",
-        context_name=context_name,
-        instance_name=instance_name,
-        limit=None,
-    )
-    binding_keys = tuple(
-        binding.binding_key
-        for binding in bindings
-        if binding.binding_key in runtime_environment_values
-    )
-    if not binding_keys:
-        return
-    try:
-        policy_record = latest_active_runtime_key_safety_policy(record_store)
-        evaluation = evaluate_runtime_key_safety_from_store(
-            record_store=record_store,
-            policy_record=policy_record,
-            target=RuntimeKeySafetyTarget(
-                context=context_name,
-                instance=instance_name,
-                environment_class=runtime_key_safety_environment_class(instance_name),
-            ),
-            required_binding_keys=binding_keys,
-        )
-    except ValueError as exc:
-        raise click.ClickException(
-            "Runtime key-safety policy is unavailable for Odoo prod rollback target env sync."
-        ) from exc
-    if evaluation.status == "pass":
-        return
-    finding_codes = sorted({finding.code for finding in evaluation.findings})
-    suffix = f": {', '.join(finding_codes)}" if finding_codes else ""
-    raise click.ClickException(
-        f"Runtime key-safety gate failed for Odoo prod rollback target env sync{suffix}."
-    )
-
-
-def _trigger_dokploy_deploy(
-    *,
-    control_plane_root: Path,
-    request: ShipRequest,
-    target_definition: control_plane_dokploy.DokployTargetDefinition,
-) -> None:
-    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
-    latest_before = None
-    if request.wait:
-        latest_before = control_plane_dokploy.latest_deployment_for_target(
-            host=host,
-            token=token,
-            target_type=target_definition.target_type,
-            target_id=target_definition.target_id,
-        )
-    control_plane_dokploy.trigger_deployment(
-        host=host,
-        token=token,
-        target_type=target_definition.target_type,
-        target_id=target_definition.target_id,
-        no_cache=request.no_cache,
-    )
-    if not request.wait:
-        return
-    deploy_timeout_seconds = control_plane_dokploy.resolve_ship_timeout_seconds(
-        timeout_override_seconds=request.timeout_seconds,
-        target_definition=target_definition,
-    )
-    control_plane_dokploy.wait_for_target_deployment(
-        host=host,
-        token=token,
-        target_type=target_definition.target_type,
-        target_id=target_definition.target_id,
-        before_key=control_plane_dokploy.deployment_key(latest_before),
-        timeout_seconds=deploy_timeout_seconds,
-    )
-
-
-def _wait_for_healthcheck(*, url: str, timeout_seconds: int) -> None:
-    deadline = time.monotonic() + timeout_seconds
-    last_error = ""
-    while time.monotonic() < deadline:
-        try:
-            request = Request(url, method="GET")
-            with urlopen(request, timeout=min(5, timeout_seconds)) as response:
-                if 200 <= response.status < 300:
-                    return
-                last_error = f"http {response.status}"
-        except HTTPError as error:
-            last_error = f"http {error.code}"
-        except URLError as error:
-            last_error = str(error.reason)
-        time.sleep(1)
-    raise click.ClickException(f"Healthcheck failed for {url}: {last_error or 'timeout'}")
-
-
-def _verify_healthchecks(*, request: ShipRequest) -> None:
-    if not request.wait or not request.verify_health:
-        return
-    if not request.destination_health.urls or request.destination_health.timeout_seconds is None:
-        raise click.ClickException(
-            "Odoo prod rollback health verification is missing URLs or timeout."
-        )
-    health_errors: list[str] = []
-    for health_url in request.destination_health.urls:
-        try:
-            _wait_for_healthcheck(
-                url=health_url,
-                timeout_seconds=request.destination_health.timeout_seconds,
-            )
-            return
-        except click.ClickException as error:
-            health_errors.append(str(error))
-    raise click.ClickException(
-        "Odoo prod rollback health verification failed for all resolved URLs:\n"
-        + "\n".join(health_errors)
-    )
-
-
-def _rollback_health_evidence(
-    *, request: ShipRequest, status: ReleaseStatus
-) -> HealthcheckEvidence:
-    return request.destination_health.model_copy(
-        update={
-            "verified": status in {"pass", "fail"} and bool(request.destination_health.urls),
-            "status": status,
-        }
-    )
-
-
 def _write_rollback_state(
     *,
     record_store: OdooProdRollbackStore,
     promotion_record: PromotionRecord,
     snapshot_name: str,
-    request: ShipRequest,
     status: ReleaseStatus,
     health_status: ReleaseStatus,
     started_at: str,
@@ -610,7 +282,10 @@ def _write_rollback_state(
                 started_at=started_at,
                 finished_at=finished_at,
             ),
-            "rollback_health": _rollback_health_evidence(request=request, status=health_status),
+            "rollback_health": HealthcheckEvidence(
+                verified=False,
+                status=health_status,
+            ),
         }
     )
     record_store.write_promotion_record(updated_record)
@@ -642,40 +317,11 @@ def execute_odoo_prod_rollback(
         source_tuple=source_tuple,
     )
     promotion_record = _resolve_promotion_record(record_store=typed_record_store, request=request)
-    target_definition = _read_target_definition(record_store=typed_record_store, request=request)
-    ship_request = _resolve_ship_request(
-        request=request,
-        rollback_source=rollback_source,
-        artifact_manifest=artifact_manifest,
-        target_definition=target_definition,
-    )
-    resolved_target = ResolvedTargetEvidence(
-        target_type=target_definition.target_type,
-        target_id=target_definition.target_id,
-        target_name=target_definition.target_name.strip() or ship_request.target_name,
-    )
-    deployment_record_id = generate_deployment_record_id(
-        context_name=request.context,
-        instance_name=request.instance,
-    )
     started_at = utc_now_timestamp()
-    typed_record_store.write_deployment_record(
-        build_deployment_record(
-            request=ship_request,
-            record_id=deployment_record_id,
-            deployment_id="control-plane-dokploy",
-            deployment_status="pending",
-            started_at=started_at,
-            finished_at="",
-            resolved_target=resolved_target,
-            post_deploy_update=PostDeployUpdateEvidence(attempted=True, status="pending"),
-        )
-    )
     _write_rollback_state(
         record_store=typed_record_store,
         promotion_record=promotion_record,
         snapshot_name=rollback_source.snapshot_name,
-        request=ship_request,
         status="pending",
         health_status="skipped",
         started_at=started_at,
@@ -683,61 +329,57 @@ def execute_odoo_prod_rollback(
         detail="Odoo prod rollback deployment is pending.",
     )
 
-    deploy_completed = False
-    post_deploy_status: Literal["pass", "fail", "skipped"] = "skipped"
-    health_status: Literal["pass", "fail", "skipped"] = "skipped"
+    replacement_result = None
+    health_status: Literal["pass", "fail", "skipped"] = (
+        "fail" if request.verify_health else "skipped"
+    )
     try:
-        _sync_artifact_image_reference_for_target(
+        replacement_result = execute_odoo_stable_target_replacement_apply(
             control_plane_root=control_plane_root,
             record_store=typed_record_store,
-            target_definition=target_definition,
-            artifact_manifest=artifact_manifest,
+            request=OdooStableTargetReplacementApplyRequest(
+                product=f"odoo-tenant-{request.context}",
+                instance=request.instance,
+                artifact_id=rollback_source.artifact_id,
+                source_git_ref=rollback_source.source_git_ref,
+                allow_empty_data=True,
+                data_source_mode="existing",
+                verify_health=request.verify_health,
+                verify_canonical=request.verify_health,
+                verify_logo=request.verify_health,
+                timeout_seconds=request.timeout_seconds,
+                health_timeout_seconds=request.health_timeout_seconds,
+                no_cache=request.no_cache,
+            ),
         )
-        _trigger_dokploy_deploy(
-            control_plane_root=control_plane_root,
-            request=ship_request,
-            target_definition=target_definition,
+        deployment_record = typed_record_store.read_deployment_record(
+            replacement_result.deployment_record_id
         )
-        deploy_completed = True
-        post_deploy_result = execute_odoo_post_deploy(
-            control_plane_root=control_plane_root,
-            record_store=typed_record_store,
-            request=OdooPostDeployRequest(context=request.context, instance=request.instance),
-        )
-        post_deploy_status = post_deploy_result.post_deploy_status
-        if post_deploy_result.post_deploy_status != "pass":
+        health_status = replacement_result.health_status
+        if replacement_result.deploy_status != "pass":
             raise click.ClickException(
-                post_deploy_result.error_message or "Odoo post-deploy failed."
+                replacement_result.error_message or "Odoo prod rollback deploy failed."
             )
-        _verify_healthchecks(request=ship_request)
-        health_status = "pass" if ship_request.verify_health else "skipped"
+        if replacement_result.post_deploy_status != "pass":
+            raise click.ClickException(
+                replacement_result.error_message or "Odoo prod rollback post-deploy failed."
+            )
+        if request.verify_health and replacement_result.health_status != "pass":
+            raise click.ClickException(
+                replacement_result.error_message or "Odoo prod rollback health verification failed."
+            )
     except (click.ClickException, OSError) as error:
         finished_at = utc_now_timestamp()
-        if deploy_completed and health_status == "skipped" and ship_request.verify_health:
-            health_status = "fail"
-        final_deployment = build_deployment_record(
-            request=ship_request,
-            record_id=deployment_record_id,
-            deployment_id="control-plane-dokploy",
-            deployment_status="pass" if deploy_completed else "fail",
-            started_at=started_at,
-            finished_at=finished_at,
-            resolved_target=resolved_target,
-            post_deploy_update=PostDeployUpdateEvidence(
-                attempted=post_deploy_status in {"pass", "fail"},
-                status=post_deploy_status if deploy_completed else "skipped",
-                detail=str(error),
-            ),
-            destination_health=_rollback_health_evidence(
-                request=ship_request, status=health_status
-            ),
-        )
-        typed_record_store.write_deployment_record(final_deployment)
+        deployment_record_id = ""
+        post_deploy_status: Literal["pass", "fail", "skipped"] = "skipped"
+        if replacement_result is not None:
+            deployment_record_id = replacement_result.deployment_record_id
+            health_status = replacement_result.health_status
+            post_deploy_status = replacement_result.post_deploy_status
         _write_rollback_state(
             record_store=typed_record_store,
             promotion_record=promotion_record,
             snapshot_name=rollback_source.snapshot_name,
-            request=ship_request,
             status="fail",
             health_status=health_status,
             started_at=started_at,
@@ -758,42 +400,18 @@ def execute_odoo_prod_rollback(
         )
 
     finished_at = utc_now_timestamp()
-    final_deployment = build_deployment_record(
-        request=ship_request,
-        record_id=deployment_record_id,
-        deployment_id="control-plane-dokploy",
-        deployment_status="pass",
-        started_at=started_at,
-        finished_at=finished_at,
-        resolved_target=resolved_target,
-        post_deploy_update=PostDeployUpdateEvidence(
-            attempted=True,
-            status=post_deploy_status,
-            detail="Odoo post-deploy completed after prod rollback.",
-        ),
-        destination_health=_rollback_health_evidence(request=ship_request, status=health_status),
+    typed_record_store.write_environment_inventory(
+        build_environment_inventory(
+            deployment_record=deployment_record,
+            updated_at=finished_at,
+            promotion_record_id=promotion_record.record_id,
+            promoted_from_instance=rollback_source.promoted_from_instance,
+        )
     )
-    typed_record_store.write_deployment_record(final_deployment)
-    inventory_record = build_environment_inventory(
-        deployment_record=final_deployment,
-        updated_at=finished_at,
-        promotion_record_id=promotion_record.record_id,
-        promoted_from_instance=rollback_source.promoted_from_instance,
-    )
-    typed_record_store.write_environment_inventory(inventory_record)
-    release_tuple = build_release_tuple_record_from_artifact_manifest(
-        context_name=request.context,
-        channel_name=request.instance,
-        artifact_manifest=artifact_manifest,
-        deployment_record_id=deployment_record_id,
-        minted_at=finished_at,
-    )
-    typed_record_store.write_release_tuple_record(release_tuple)
     _write_rollback_state(
         record_store=typed_record_store,
         promotion_record=promotion_record,
         snapshot_name=rollback_source.snapshot_name,
-        request=ship_request,
         status="pass",
         health_status=health_status,
         started_at=started_at,
@@ -806,9 +424,9 @@ def execute_odoo_prod_rollback(
         source_channel=rollback_source.result_source_channel,
         artifact_id=rollback_source.artifact_id,
         promotion_record_id=promotion_record.record_id,
-        deployment_record_id=deployment_record_id,
-        release_tuple_id=release_tuple.tuple_id,
+        deployment_record_id=replacement_result.deployment_record_id,
+        release_tuple_id=replacement_result.release_tuple_id,
         rollback_status="pass",
         rollback_health_status=health_status,
-        post_deploy_status=post_deploy_status,
+        post_deploy_status=replacement_result.post_deploy_status,
     )

--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -8,6 +8,7 @@ import click
 from pydantic import BaseModel, ConfigDict
 
 from control_plane import dokploy as control_plane_dokploy
+from control_plane import live_target_runtime as control_plane_live_target_runtime
 from control_plane import release_tuples as control_plane_release_tuples
 from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
@@ -37,6 +38,7 @@ from control_plane.workflows.odoo_verification import (
     default_odoo_health_url,
     verify_odoo_stable_readiness,
 )
+from control_plane.runtime_key_safety import RuntimeKeySafetyPolicyReadStore
 from control_plane.workflows.ship import (
     build_deployment_record,
     generate_deployment_record_id,
@@ -44,7 +46,7 @@ from control_plane.workflows.ship import (
 )
 
 
-class OdooStableTargetReplacementStore(Protocol):
+class OdooStableTargetReplacementStore(RuntimeKeySafetyPolicyReadStore, Protocol):
     def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord: ...
 
     def read_dokploy_target_record(
@@ -1065,6 +1067,23 @@ def execute_odoo_stable_target_replacement_apply(
                 context_name=plan.context,
                 instance_name=plan.instance,
             )
+        )
+        try:
+            runtime_key_safety = (
+                control_plane_live_target_runtime.evaluate_runtime_key_safety_for_live_target_sync(
+                    record_store=record_store,
+                    context_name=plan.context,
+                    instance_name=plan.instance,
+                )
+            )
+        except control_plane_live_target_runtime.LiveTargetRuntimeError as error:
+            raise click.ClickException(str(error)) from error
+        runtime_source.update(
+            {
+                f"runtime_key_safety_{key}": str(value)
+                for key, value in runtime_key_safety.items()
+                if key in {"required", "status", "policy_record_id", "policy_sha256"}
+            }
         )
         compose_file = control_plane_dokploy.render_odoo_raw_compose_file(
             image_reference=image_reference,

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -169,15 +169,15 @@ validation, persists the plan record, and applies ready plans through the normal
 generic-web deploy path using the previous immutable artifact identity. Generic
 rollback also forwards the generic deploy post-deploy extension hook, so a
 based driver can keep product-only post-deploy checks while reusing the common
-rollback deployment path once its other invariants are represented. Odoo profiles
-therefore run Odoo post-deploy through generic rollback apply, but the canonical
-Odoo rollback apply route remains product-specific until its release and
-promotion bookkeeping is generic-contract represented or explicitly wrapped. Product
+rollback deployment path once its other invariants are represented. Product
 drivers keep their own `prod_rollback` action only when they need additional
 product-specific gates, such as Odoo backup, release tuple, manifest, migration,
 or post-deploy checks. Odoo keeps `POST /v1/drivers/odoo/prod-rollback` as its
-product-specific apply route until those Odoo-only invariants are represented in
-the generic workflow contract.
+product-specific apply route, but that route delegates provider mutation to
+Odoo stable target replacement so runtime identity, post-deploy maintenance,
+canonical/logo verification, deployment records, inventory, and release tuples
+stay on the canonical stable executor while the rollback wrapper owns promotion
+rollback provenance.
 
 The `stable_verification` action routes to
 `POST /v1/drivers/generic-web/stable-verification`. Product workflows submit the

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -620,11 +620,13 @@ context only, and `context_instance` has both context and instance.
   sanitization such as disabling mail servers and cron remains tied to explicit
   restore/bootstrap workflows, not ordinary prod image deploys.
 - `POST /v1/drivers/odoo/prod-rollback` rolls a prod-named Odoo lane back to
-  the DB-backed `testing` release tuple for the same context. The driver updates
-  the Dokploy `DOCKER_IMAGE_REFERENCE`, deploys the compose target, runs the
-  Odoo post-deploy workflow, verifies `/launchplane/health`, writes deployment,
-  inventory, release tuple, and rollback evidence, and annotates the current prod
-  promotion record.
+  the DB-backed `testing` release tuple for the same context. The driver owns
+  rollback intent and promotion-record annotation, but the provider mutation runs
+  through the stable target replacement executor so deploy, runtime identity,
+  Odoo post-deploy maintenance, canonical/logo verification, deployment, and
+  release-tuple evidence stay on the canonical stable path. After the delegated
+  replacement passes, rollback refreshes prod inventory with rollback provenance
+  and annotates the current prod promotion record.
 - `POST /v1/drivers/odoo/prod-backup-gate` captures the DB and filestore backup
   evidence required before Odoo prod promotion. It resolves `ODOO_DB_NAME`,
   `ODOO_FILESTORE_PATH`, and `ODOO_BACKUP_ROOT` from DB-backed runtime
@@ -687,8 +689,9 @@ context only, and `context_instance` has both context and instance.
   an explicit DB-backed artifact id for the previous known-good prod artifact.
   The driver reads the artifact manifest directly from Launchplane records and
   writes rollback evidence with an `artifact:<artifact_id>` source marker.
-- A passing rollback writes deployment, inventory, prod release tuple,
-  promotion rollback, and rollback-health evidence. Verify the target
+- A passing rollback delegates deployment and prod release-tuple writes to stable
+  target replacement, then writes inventory rollback provenance, promotion
+  rollback, and rollback-health evidence. Verify the target
   `/launchplane/health` endpoint and `inventory status` before taking another
   action.
 - A real destructive rollback drill requires a second known-good artifact

--- a/docs/records.md
+++ b/docs/records.md
@@ -479,12 +479,13 @@ state/
   for a concurrent owner id to settle, then give that owner record its own
   bounded settle window before clearing abandoned empty or orphaned reservations
   so an interrupted writer cannot block the lane forever.
-- Odoo prod rollback writes a normal deployment record for the rollback deploy,
-  refreshes prod inventory, mints the prod release tuple from the selected
-  artifact manifest, and annotates the current prod promotion record's
-  `rollback` and `rollback_health` fields. The selected rollback source is the
-  DB-backed `testing` release tuple; operators must not supply unrecorded image
-  refs or source SHAs.
+- Odoo prod rollback delegates the rollback deploy to stable target replacement,
+  which writes the deployment record and prod release tuple. Rollback then
+  refreshes prod inventory with rollback provenance and annotates the current
+  prod promotion record's `rollback` and `rollback_health` fields. The selected
+  rollback source is the DB-backed `testing` release tuple unless the operator
+  supplies an explicit DB-backed artifact ID; operators must not supply
+  unrecorded image refs or source SHAs.
 - Generic-web rollback planning writes `GenericWebRollbackPlanRecord` entries
   under `generic_web_rollback_plans` in file-backed state and
   `launchplane_generic_web_rollback_plans` in DB-backed state. These records are

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1083,10 +1083,13 @@ manifest, and writes it to Launchplane records. Post-deploy reads DB-backed Odoo
 instance override records, renders the typed override payload, invokes the
 Dokploy data-workflow runner, and writes `last_apply` evidence back to
 Launchplane. Prod rollback reads DB-backed release tuples, artifact manifests,
-target records, and current inventory, deploys the selected artifact-backed
-image, verifies health, and writes durable rollback/deployment/inventory/release
-tuple evidence. Local Odoo runtime commands remain in `odoo-devkit`; these
-drivers are for remote control-plane execution only.
+and current promotion/inventory records, then delegates the provider mutation to
+stable target replacement. That shared executor deploys the selected
+artifact-backed image, injects runtime identity, runs post-deploy maintenance,
+verifies health/canonical/logo evidence, and writes deployment/release-tuple
+evidence. The rollback wrapper only adds rollback provenance to inventory and
+the current prod promotion record. Local Odoo runtime commands remain in
+`odoo-devkit`; these drivers are for remote control-plane execution only.
 
 Privileged product rollback actions should use a narrow delegated-worker runtime
 contract when they require network reach or host authority that does not belong

--- a/tests/test_odoo_prod_rollback.py
+++ b/tests/test_odoo_prod_rollback.py
@@ -1,6 +1,6 @@
 import unittest
 from pathlib import Path
-from typing import cast
+from typing import Literal, cast
 from unittest.mock import Mock, patch
 
 import click
@@ -14,24 +14,19 @@ from control_plane.contracts.artifact_identity import (
     ArtifactImageReference,
 )
 from control_plane.contracts.deployment_record import DeploymentRecord
-from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
-from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
     BackupGateEvidence,
     DeploymentEvidence,
     HealthcheckEvidence,
+    PostDeployUpdateEvidence,
     PromotionRecord,
 )
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
-from control_plane.contracts.runtime_key_safety_policy import (
-    RuntimeKeySafetyPolicyRecord,
-    RuntimeSecretClass,
-    RuntimeSecretSafetyRule,
+from control_plane.contracts.odoo_stable_target_replacement import (
+    OdooStableTargetReplacementApplyResult,
 )
-from control_plane.contracts.secret_record import SecretBinding
-from control_plane.workflows.odoo_post_deploy import OdooPostDeployResult
 from control_plane.workflows.odoo_prod_rollback import (
     OdooProdRollbackRequest,
     execute_odoo_prod_rollback,
@@ -132,27 +127,53 @@ def _inventory_record() -> EnvironmentInventory:
     )
 
 
-def _target_record() -> DokployTargetRecord:
-    return DokployTargetRecord(
+def _deployment_record() -> DeploymentRecord:
+    return DeploymentRecord(
+        record_id="deployment-opw-prod-rollback",
+        artifact_identity=ArtifactIdentityReference(artifact_id="artifact-opw-847c71c1db61785c"),
         context="opw",
         instance="prod",
-        target_type="compose",
-        target_name="opw-prod",
-        deploy_timeout_seconds=600,
-        healthcheck_path="/web/health",
-        healthcheck_timeout_seconds=180,
-        domains=("opw-prod.shinycomputers.com",),
-        env={"DOCKER_PULL_POLICY": "always"},
-        updated_at="2026-04-24T14:06:57Z",
+        source_git_ref="9e09b858e1f93aa4a1f4b887b528ba7e5a999ee6",
+        deploy=DeploymentEvidence(
+            target_name="opw-prod",
+            target_type="compose",
+            deploy_mode="dokploy-compose-api",
+            deployment_id="control-plane-dokploy",
+            status="pass",
+        ),
+        post_deploy_update=PostDeployUpdateEvidence(attempted=True, status="pass"),
+        destination_health=HealthcheckEvidence(
+            verified=True,
+            urls=("https://opw-prod.shinycomputers.com/web/health",),
+            timeout_seconds=180,
+            status="pass",
+        ),
     )
 
 
-def _target_id_record() -> DokployTargetIdRecord:
-    return DokployTargetIdRecord(
+def _replacement_result(
+    *,
+    deploy_status: Literal["pass", "fail"] = "pass",
+    post_deploy_status: Literal["pass", "fail", "skipped"] = "pass",
+    health_status: Literal["pass", "fail", "skipped"] = "pass",
+    release_tuple_id: str = "opw-prod-artifact-opw-847c71c1db61785c",
+    error_message: str = "",
+) -> OdooStableTargetReplacementApplyResult:
+    return OdooStableTargetReplacementApplyResult(
+        product="odoo-tenant-opw",
         context="opw",
         instance="prod",
-        target_id="opw-prod-compose-id",
-        updated_at="2026-04-24T14:06:57Z",
+        strategy="recreate-in-place",
+        deployment_record_id="deployment-opw-prod-rollback",
+        release_tuple_id=release_tuple_id,
+        deploy_status=deploy_status,
+        post_deploy_status=post_deploy_status,
+        health_status=health_status,
+        canonical_status="pass",
+        logo_status="pass",
+        artifact_id="artifact-opw-847c71c1db61785c",
+        image_reference="ghcr.io/cbusillo/odoo-tenant-opw@sha256:847c71c1db61785c0aa265949f45a74c5dd9535e62c89db26d5650684c340100",
+        error_message=error_message,
     )
 
 
@@ -172,97 +193,16 @@ class OdooProdRollbackWorkflowTests(unittest.TestCase):
         record_store.read_artifact_manifest.return_value = _artifact_manifest()
         record_store.read_environment_inventory.return_value = _inventory_record()
         record_store.read_promotion_record.return_value = _promotion_record()
-        record_store.read_dokploy_target_record.return_value = _target_record()
-        record_store.read_dokploy_target_id_record.return_value = _target_id_record()
-        record_store.list_secret_bindings.return_value = ()
-        record_store.list_runtime_key_safety_policy_records.return_value = ()
+        record_store.read_deployment_record.return_value = _deployment_record()
         return record_store
 
-    def _write_prod_secret_binding(
-        self,
-        record_store: Mock,
-        *,
-        secret_class: RuntimeSecretClass = "prod_only",
-    ) -> None:
-        binding_key = "ODOO_DB_PASSWORD"
-        record_store.list_secret_bindings.return_value = (
-            SecretBinding(
-                binding_id="secret-odoo-db-password-binding",
-                secret_id="secret-odoo-db-password",
-                integration="runtime_environment",
-                binding_key=binding_key,
-                context="opw",
-                instance="prod",
-                status="configured",
-                created_at="2026-05-05T22:45:00Z",
-                updated_at="2026-05-05T22:45:00Z",
-            ),
-        )
-        record_store.list_runtime_key_safety_policy_records.return_value = (
-            RuntimeKeySafetyPolicyRecord(
-                record_id="runtime-key-safety-policy-test",
-                status="active",
-                source="test",
-                updated_at="2026-05-05T22:45:00Z",
-                rules=(
-                    RuntimeSecretSafetyRule(
-                        binding_key=binding_key,
-                        secret_class=secret_class,
-                        allowed_contexts=("opw",),
-                        allowed_instances=("prod",),
-                    ),
-                ),
-            ),
-        )
-
-    def test_rollback_to_testing_tuple_records_successful_evidence(self) -> None:
+    def test_rollback_to_testing_tuple_delegates_to_target_replacement(self) -> None:
         record_store = self._record_store()
 
-        with (
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.read_dokploy_config",
-                return_value=("https://dokploy.example", "token"),
-            ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.fetch_dokploy_target_payload",
-                side_effect=[
-                    {"env": "DOCKER_IMAGE_REFERENCE=old\n"},
-                    {
-                        "env": "DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/odoo-tenant-opw@sha256:847c71c1db61785c0aa265949f45a74c5dd9535e62c89db26d5650684c340100"
-                    },
-                ],
-            ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_runtime_environments.resolve_runtime_environment_values",
-                return_value={},
-            ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.sync_dokploy_compose_raw_source"
-            ) as raw_compose_sync,
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.update_dokploy_target_env"
-            ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.latest_deployment_for_target",
-                return_value={"deploymentId": "before"},
-            ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.trigger_deployment"
-            ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.wait_for_target_deployment"
-            ),
-            patch("control_plane.workflows.odoo_prod_rollback._verify_healthchecks"),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.execute_odoo_post_deploy",
-                return_value=OdooPostDeployResult(
-                    context="opw",
-                    instance="prod",
-                    phase="deploy",
-                    post_deploy_status="pass",
-                ),
-            ),
-        ):
+        with patch(
+            "control_plane.workflows.odoo_prod_rollback.execute_odoo_stable_target_replacement_apply",
+            return_value=_replacement_result(),
+        ) as replacement_apply:
             result = execute_odoo_prod_rollback(
                 control_plane_root=Path("/control-plane"),
                 record_store=record_store,
@@ -272,70 +212,40 @@ class OdooProdRollbackWorkflowTests(unittest.TestCase):
         self.assertEqual(result.rollback_status, "pass")
         self.assertEqual(result.rollback_health_status, "pass")
         self.assertEqual(result.post_deploy_status, "pass")
-        self.assertEqual(result.artifact_id, "artifact-opw-847c71c1db61785c")
-        self.assertIn(
-            "Host(`opw-prod.shinycomputers.com`)",
-            raw_compose_sync.call_args.kwargs["compose_file"],
+        self.assertEqual(result.deployment_record_id, "deployment-opw-prod-rollback")
+        self.assertEqual(result.release_tuple_id, "opw-prod-artifact-opw-847c71c1db61785c")
+        replacement_apply.assert_called_once()
+        replacement_request = replacement_apply.call_args.kwargs["request"]
+        self.assertEqual(replacement_request.product, "odoo-tenant-opw")
+        self.assertEqual(replacement_request.instance, "prod")
+        self.assertEqual(replacement_request.artifact_id, "artifact-opw-847c71c1db61785c")
+        self.assertEqual(
+            replacement_request.source_git_ref,
+            "9e09b858e1f93aa4a1f4b887b528ba7e5a999ee6",
         )
-        record_store.write_deployment_record.assert_called()
+        self.assertTrue(replacement_request.verify_canonical)
+        self.assertTrue(replacement_request.verify_logo)
+        record_store.write_deployment_record.assert_not_called()
+        record_store.write_release_tuple_record.assert_not_called()
         record_store.write_environment_inventory.assert_called_once()
-        record_store.write_release_tuple_record.assert_called_once()
+        inventory = record_store.write_environment_inventory.call_args.args[0]
+        self.assertEqual(inventory.deployment_record_id, "deployment-opw-prod-rollback")
+        self.assertEqual(inventory.promotion_record_id, _promotion_record().record_id)
+        self.assertEqual(inventory.promoted_from_instance, "testing")
         final_promotion = record_store.write_promotion_record.call_args_list[-1].args[0]
         self.assertEqual(final_promotion.rollback.status, "pass")
         self.assertEqual(final_promotion.rollback_health.status, "pass")
-        written_deployment = record_store.write_deployment_record.call_args_list[-1].args[0]
-        self.assertIsInstance(written_deployment, DeploymentRecord)
-        self.assertEqual(written_deployment.deploy.status, "pass")
 
     def test_explicit_artifact_rolls_back_without_testing_tuple_match(self) -> None:
         record_store = self._record_store()
         record_store.read_artifact_manifest.return_value = _previous_prod_artifact_manifest()
 
-        with (
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.read_dokploy_config",
-                return_value=("https://dokploy.example", "token"),
+        with patch(
+            "control_plane.workflows.odoo_prod_rollback.execute_odoo_stable_target_replacement_apply",
+            return_value=_replacement_result(
+                release_tuple_id="opw-prod-artifact-opw-previous-prod"
             ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.fetch_dokploy_target_payload",
-                side_effect=[
-                    {"env": "DOCKER_IMAGE_REFERENCE=old\n"},
-                    {
-                        "env": "DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/odoo-tenant-opw@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                    },
-                ],
-            ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_runtime_environments.resolve_runtime_environment_values",
-                return_value={},
-            ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.sync_dokploy_compose_raw_source"
-            ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.update_dokploy_target_env"
-            ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.latest_deployment_for_target",
-                return_value={"deploymentId": "before"},
-            ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.trigger_deployment"
-            ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.wait_for_target_deployment"
-            ),
-            patch("control_plane.workflows.odoo_prod_rollback._verify_healthchecks"),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.execute_odoo_post_deploy",
-                return_value=OdooPostDeployResult(
-                    context="opw",
-                    instance="prod",
-                    phase="deploy",
-                    post_deploy_status="pass",
-                ),
-            ),
-        ):
+        ) as replacement_apply:
             result = execute_odoo_prod_rollback(
                 control_plane_root=Path("/control-plane"),
                 record_store=record_store,
@@ -349,17 +259,15 @@ class OdooProdRollbackWorkflowTests(unittest.TestCase):
         self.assertEqual(result.source_channel, "artifact")
         self.assertEqual(result.artifact_id, "artifact-opw-previous-prod")
         record_store.read_release_tuple_record.assert_not_called()
+        replacement_request = replacement_apply.call_args.kwargs["request"]
+        self.assertEqual(replacement_request.artifact_id, "artifact-opw-previous-prod")
+        self.assertEqual(replacement_request.source_git_ref, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
         final_promotion = record_store.write_promotion_record.call_args_list[-1].args[0]
         self.assertEqual(
             final_promotion.rollback.snapshot_name, "artifact:artifact-opw-previous-prod"
         )
         inventory = record_store.write_environment_inventory.call_args.args[0]
         self.assertEqual(inventory.promoted_from_instance, "explicit-artifact")
-        written_deployment = record_store.write_deployment_record.call_args_list[-1].args[0]
-        self.assertEqual(
-            written_deployment.artifact_identity.artifact_id,
-            "artifact-opw-previous-prod",
-        )
 
     def test_missing_explicit_artifact_fails_before_deploy(self) -> None:
         record_store = self._record_store()
@@ -376,41 +284,19 @@ class OdooProdRollbackWorkflowTests(unittest.TestCase):
             )
 
         record_store.read_release_tuple_record.assert_not_called()
-        record_store.write_deployment_record.assert_not_called()
+        record_store.write_promotion_record.assert_not_called()
 
     def test_failed_deploy_records_failed_rollback(self) -> None:
         record_store = self._record_store()
 
-        with (
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.read_dokploy_config",
-                return_value=("https://dokploy.example", "token"),
-            ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.fetch_dokploy_target_payload",
-                side_effect=[
-                    {"env": ""},
-                    {
-                        "env": "DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/odoo-tenant-opw@sha256:847c71c1db61785c0aa265949f45a74c5dd9535e62c89db26d5650684c340100"
-                    },
-                ],
-            ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_runtime_environments.resolve_runtime_environment_values",
-                return_value={},
-            ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.sync_dokploy_compose_raw_source"
-            ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.update_dokploy_target_env"
-            ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.latest_deployment_for_target"
-            ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.trigger_deployment",
-                side_effect=click.ClickException("deploy failed"),
+        with patch(
+            "control_plane.workflows.odoo_prod_rollback.execute_odoo_stable_target_replacement_apply",
+            return_value=_replacement_result(
+                deploy_status="fail",
+                post_deploy_status="skipped",
+                health_status="skipped",
+                release_tuple_id="",
+                error_message="deploy failed",
             ),
         ):
             result = execute_odoo_prod_rollback(
@@ -420,48 +306,8 @@ class OdooProdRollbackWorkflowTests(unittest.TestCase):
             )
 
         self.assertEqual(result.rollback_status, "fail")
+        self.assertEqual(result.deployment_record_id, "deployment-opw-prod-rollback")
         self.assertIn("deploy failed", result.error_message)
-        final_promotion = record_store.write_promotion_record.call_args_list[-1].args[0]
-        self.assertEqual(final_promotion.rollback.status, "fail")
-
-    def test_runtime_key_safety_blocks_managed_secret_target_env_sync(self) -> None:
-        record_store = self._record_store()
-        self._write_prod_secret_binding(record_store, secret_class="testing")
-
-        with (
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.read_dokploy_config",
-                return_value=("https://dokploy.example", "token"),
-            ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.fetch_dokploy_target_payload",
-                return_value={"env": ""},
-            ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_runtime_environments.resolve_runtime_environment_values",
-                return_value={"ODOO_DB_PASSWORD": "managed-secret-value"},
-            ),
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.sync_dokploy_compose_raw_source"
-            ) as sync_compose_mock,
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.update_dokploy_target_env"
-            ) as update_env_mock,
-            patch(
-                "control_plane.workflows.odoo_prod_rollback.control_plane_dokploy.trigger_deployment"
-            ) as trigger_deployment_mock,
-        ):
-            result = execute_odoo_prod_rollback(
-                control_plane_root=Path("/control-plane"),
-                record_store=record_store,
-                request=OdooProdRollbackRequest(context="opw"),
-            )
-
-        self.assertEqual(result.rollback_status, "fail")
-        self.assertIn("Runtime key-safety gate failed", result.error_message)
-        sync_compose_mock.assert_not_called()
-        update_env_mock.assert_not_called()
-        trigger_deployment_mock.assert_not_called()
         final_promotion = record_store.write_promotion_record.call_args_list[-1].args[0]
         self.assertEqual(final_promotion.rollback.status, "fail")
 

--- a/tests/test_odoo_stable_authority.py
+++ b/tests/test_odoo_stable_authority.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+from unittest import TestCase
+
+
+class OdooStableAuthorityTests(TestCase):
+    def test_reusable_testing_deploy_uses_target_replacement_apply(self) -> None:
+        workflow = Path(".github/workflows/reusable-odoo-testing-deploy.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("route-path: /v1/drivers/odoo/target-replacement-apply", workflow)
+        self.assertIn("poll_url=result.poll_url", workflow)
+        self.assertIn('${LAUNCHPLANE_URL}${POLL_URL}', workflow)
+        self.assertNotIn("route-path: /v1/drivers/odoo/testing-deploy", workflow)
+        self.assertNotIn("odoo_testing_deploy.execute", workflow)
+
+    def test_odoo_stable_workflows_do_not_use_retired_testing_deploy_route(self) -> None:
+        retired_tokens = (
+            "/v1/drivers/odoo/testing-deploy",
+            "odoo_testing_deploy.execute",
+            "control_plane.workflows.odoo_testing_deploy",
+        )
+        scanned_paths = tuple(
+            path
+            for root in (Path("control_plane"), Path(".github/workflows"), Path("scripts/deploy"))
+            for path in root.rglob("*")
+            if path.is_file() and path.suffix in {".py", ".sh", ".yml", ".yaml"}
+        )
+
+        offenders: list[str] = []
+        for path in scanned_paths:
+            text = path.read_text(encoding="utf-8")
+            for token in retired_tokens:
+                if token in text:
+                    offenders.append(f"{path.as_posix()}: {token}")
+
+        self.assertEqual(offenders, [])
+
+    def test_prod_rollback_has_no_direct_provider_mutation(self) -> None:
+        rollback_source = Path("control_plane/workflows/odoo_prod_rollback.py").read_text(
+            encoding="utf-8"
+        )
+        required_tokens = (
+            "execute_odoo_stable_target_replacement_apply",
+            "OdooStableTargetReplacementApplyRequest",
+        )
+        forbidden_tokens = (
+            "control_plane_dokploy.trigger_deployment",
+            "control_plane_dokploy.sync_dokploy_compose_raw_source",
+            "control_plane_dokploy.update_dokploy_target_env",
+            "execute_odoo_post_deploy",
+            "render_odoo_raw_compose_file",
+            "wait_for_target_deployment",
+        )
+
+        for token in required_tokens:
+            self.assertIn(token, rollback_source)
+        for token in forbidden_tokens:
+            self.assertNotIn(token, rollback_source)
+
+    def test_documents_name_target_replacement_as_canonical_rollback_deployer(self) -> None:
+        operations_doc = Path("docs/operations.md").read_text(encoding="utf-8")
+        records_doc = Path("docs/records.md").read_text(encoding="utf-8")
+        service_boundary_doc = Path("docs/service-boundary.md").read_text(encoding="utf-8")
+
+        self.assertIn("through the stable target replacement executor", operations_doc)
+        self.assertIn("delegates the rollback deploy to stable target replacement", records_doc)
+        self.assertIn("delegates the provider mutation to\nstable target replacement", service_boundary_doc)

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -27,6 +27,11 @@ from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
     DeploymentEvidence,
 )
+from control_plane.contracts.runtime_key_safety_policy import (
+    RuntimeKeySafetyPolicyRecord,
+    RuntimeSecretSafetyRule,
+)
+from control_plane.contracts.secret_record import SecretBinding
 from control_plane.contracts.odoo_stable_target_replacement import (
     OdooStableTargetReplacementApplyRequest,
     OdooStableTargetReplacementRequest,
@@ -66,6 +71,8 @@ class _Store:
         self.deployment_records: list[DeploymentRecord] = []
         self.environment_inventories: list[EnvironmentInventory] = []
         self.release_tuples: list[object] = []
+        self.secret_bindings: tuple[SecretBinding, ...] = ()
+        self.runtime_key_safety_policy_records: tuple[RuntimeKeySafetyPolicyRecord, ...] = ()
 
     def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
         if product != self.profile.product:
@@ -106,6 +113,36 @@ class _Store:
 
     def write_release_tuple_record(self, record: object) -> None:
         self.release_tuples.append(record)
+
+    def list_secret_bindings(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[SecretBinding, ...]:
+        records = tuple(
+            binding
+            for binding in self.secret_bindings
+            if (not integration or binding.integration == integration)
+            and (not context_name or binding.context == context_name)
+            and (not instance_name or binding.instance == instance_name)
+        )
+        return records[:limit] if limit is not None else records
+
+    def list_runtime_key_safety_policy_records(
+        self,
+        *,
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[RuntimeKeySafetyPolicyRecord, ...]:
+        records = tuple(
+            record
+            for record in self.runtime_key_safety_policy_records
+            if not status or record.status == status
+        )
+        return records[:limit] if limit is not None else records
 
 
 def _profile(driver_id: str = "odoo") -> LaunchplaneProductProfileRecord:
@@ -1136,6 +1173,210 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
 
         self.assertEqual(result.deploy_status, "pass")
         self.assertTrue(post_deploy.call_args.kwargs["run_destructive_restore"])
+
+    def test_apply_blocks_managed_runtime_secret_without_safety_policy(self) -> None:
+        store = _Store(
+            target_record=_target_record(),
+            target_id_record=_target_id_record(),
+            inventory=_inventory(),
+        )
+        store.secret_bindings = (
+            SecretBinding(
+                binding_id="secret-odoo-db-password-binding",
+                secret_id="secret-odoo-db-password",
+                integration="runtime_environment",
+                binding_key="ODOO_DB_PASSWORD",
+                context="cm",
+                instance="testing",
+                status="configured",
+                created_at="2026-05-05T22:45:00Z",
+                updated_at="2026-05-05T22:45:00Z",
+            ),
+        )
+
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.read_dokploy_config",
+                return_value=("host", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "name": "cm-testing",
+                    "sourceType": "raw",
+                    "composePath": "docker-compose.yml",
+                    "composeFile": "services: {}",
+                    "env": "\n".join(
+                        (
+                            "ODOO_DATA_VOLUME=cm_testing_odoo_data",
+                            "ODOO_LOG_VOLUME=cm_testing_odoo_logs",
+                            "ODOO_DB_VOLUME=cm_testing_odoo_db",
+                        )
+                    ),
+                },
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.latest_deployment_for_target",
+                return_value={"deploymentId": "deploy-123", "status": "success"},
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_runtime_environments.resolve_runtime_environment_values",
+                return_value={"ODOO_DB_PASSWORD": "managed-secret-value"},
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.sync_dokploy_compose_raw_source"
+            ) as sync_source,
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.update_dokploy_target_env"
+            ) as update_env,
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.trigger_deployment"
+            ) as trigger_deploy,
+        ):
+            result = execute_odoo_stable_target_replacement_apply(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=OdooStableTargetReplacementApplyRequest(
+                    product="odoo-tenant-cm", instance="testing"
+                ),
+                dokploy_request=cast(DokployRequest, _request),
+            )
+
+        self.assertEqual(result.deploy_status, "fail")
+        self.assertIn("Runtime key-safety policy is unavailable", result.error_message)
+        sync_source.assert_not_called()
+        update_env.assert_not_called()
+        trigger_deploy.assert_not_called()
+
+    def test_apply_records_runtime_key_safety_pass_evidence(self) -> None:
+        store = _Store(
+            target_record=_target_record(),
+            target_id_record=_target_id_record(),
+            inventory=_inventory(),
+        )
+        store.secret_bindings = (
+            SecretBinding(
+                binding_id="secret-odoo-db-password-binding",
+                secret_id="secret-odoo-db-password",
+                integration="runtime_environment",
+                binding_key="ODOO_DB_PASSWORD",
+                context="cm",
+                instance="testing",
+                status="configured",
+                created_at="2026-05-05T22:45:00Z",
+                updated_at="2026-05-05T22:45:00Z",
+            ),
+        )
+        store.runtime_key_safety_policy_records = (
+            RuntimeKeySafetyPolicyRecord(
+                record_id="runtime-key-safety-policy-test",
+                status="active",
+                source="test",
+                updated_at="2026-05-05T22:45:00Z",
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key="ODOO_DB_PASSWORD",
+                        secret_class="testing",
+                        allowed_contexts=("cm",),
+                        allowed_instances=("testing",),
+                    ),
+                ),
+            ),
+        )
+        persisted_env = ""
+
+        def _fetch_target_payload(**_: object) -> JsonValue:
+            return {
+                "name": "cm-testing",
+                "sourceType": "raw",
+                "composePath": "docker-compose.yml",
+                "composeFile": "services: {}",
+                "env": persisted_env
+                or "\n".join(
+                    (
+                        "ODOO_DATA_VOLUME=cm_testing_odoo_data",
+                        "ODOO_LOG_VOLUME=cm_testing_odoo_logs",
+                        "ODOO_DB_VOLUME=cm_testing_odoo_db",
+                    )
+                ),
+            }
+
+        def _update_env(*, env_text: str, **_: object) -> None:
+            nonlocal persisted_env
+            persisted_env = env_text
+
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.read_dokploy_config",
+                return_value=("host", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.fetch_dokploy_target_payload",
+                side_effect=_fetch_target_payload,
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.latest_deployment_for_target",
+                return_value={"deploymentId": "deploy-123", "status": "success"},
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_runtime_environments.resolve_runtime_environment_values",
+                return_value={"ODOO_DB_PASSWORD": "managed-secret-value"},
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.sync_dokploy_compose_raw_source"
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.ensure_compose_web_domain_route"
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.fetch_dokploy_converted_compose_file",
+                return_value=control_plane_dokploy.render_odoo_raw_compose_file(
+                    image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:artifact",
+                    domain_hosts=("cm-testing.shinycomputers.com",),
+                    runtime_port=8069,
+                ),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.update_dokploy_target_env",
+                side_effect=_update_env,
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.trigger_deployment"
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.wait_for_target_deployment"
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.execute_odoo_post_deploy",
+                return_value=OdooPostDeployResult(
+                    context="cm",
+                    instance="testing",
+                    phase="deploy",
+                    post_deploy_status="pass",
+                ),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.verify_odoo_stable_readiness",
+                return_value=_verification_result(),
+            ),
+        ):
+            result = execute_odoo_stable_target_replacement_apply(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=OdooStableTargetReplacementApplyRequest(
+                    product="odoo-tenant-cm", instance="testing"
+                ),
+                dokploy_request=cast(DokployRequest, _request),
+            )
+
+        self.assertEqual(result.deploy_status, "pass")
+        final_deployment = store.deployment_records[-1]
+        self.assertEqual(final_deployment.runtime_source["runtime_key_safety_required"], "True")
+        self.assertEqual(final_deployment.runtime_source["runtime_key_safety_status"], "pass")
+        self.assertEqual(
+            final_deployment.runtime_source["runtime_key_safety_policy_record_id"],
+            "runtime-key-safety-policy-test",
+        )
 
     def test_apply_refuses_explicit_artifact_source_mismatch(self) -> None:
         store = _Store(


### PR DESCRIPTION
## Summary
- move Odoo prod rollback provider mutation onto stable target replacement apply
- add runtime key-safety gating to the canonical Odoo stable target replacement executor
- add guard tests so testing deploy and rollback cannot drift back to retired/split stable deploy paths
- update docs to describe rollback as a wrapper around canonical target replacement

## Verification
- uv run python -m unittest tests.test_odoo_stable_target_replacement tests.test_odoo_prod_rollback tests.test_odoo_stable_authority
- uv run python -m unittest tests.test_odoo_prod_rollback tests.test_odoo_stable_authority tests.test_odoo_stable_target_replacement tests.test_odoo_prod_promotion tests.test_odoo_prod_promotion_run tests.test_driver_descriptors tests.test_docs_contracts
- uv run --extra dev ruff check --diff control_plane/workflows/odoo_prod_rollback.py control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_prod_rollback.py tests/test_odoo_stable_target_replacement.py tests/test_odoo_stable_authority.py
- uv run --extra dev ruff check control_plane/workflows/odoo_prod_rollback.py control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_prod_rollback.py tests/test_odoo_stable_target_replacement.py tests/test_odoo_stable_authority.py
- uv run --extra dev mypy control_plane/workflows/odoo_prod_rollback.py control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_prod_rollback.py tests/test_odoo_stable_target_replacement.py tests/test_odoo_stable_authority.py
- uv run python -m unittest
