### PR TITLE
Add ingress audit read API

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -756,7 +756,11 @@ class _OdooStableTargetReplacementOperationStore(Protocol):
         limit: int | None = None,
     ) -> tuple[OdooStableTargetReplacementOperationRecord, ...]: ...
 
+
+class _IngressRouteAuditRecordStore(Protocol):
     def write_ingress_route_audit_record(self, record: IngressRouteAuditRecord) -> object: ...
+
+    def read_ingress_route_audit_record(self, record_id: str) -> IngressRouteAuditRecord: ...
 
     def list_ingress_route_audit_records(
         self,
@@ -3021,6 +3025,10 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "operations.read", {"context": segments[2]}
     if len(segments) == 3 and segments == ["v1", "service", "runtime"]:
         return "launchplane_service.read", {}
+    if len(segments) == 4 and segments == ["v1", "ingress", "route-audits", "records"]:
+        return "ingress_route.plan", {"ingress_route_audit_list": "true"}
+    if len(segments) == 5 and segments[:4] == ["v1", "ingress", "route-audits", "records"]:
+        return "ingress_route.plan", {"ingress_route_audit_record_id": segments[4]}
     if path == _MERGE_TRAIN_ADMISSION_ROUTE:
         return "merge_train.admission", {}
     if path == _MERGE_TRAIN_CONTROLLER_STATUS_ROUTE:
@@ -5267,6 +5275,74 @@ def _odoo_stable_target_replacement_operation_store(
     raise click.ClickException(
         "Odoo stable target replacement operations require Launchplane operation-record storage."
     )
+
+
+def _ingress_route_audit_record_store(record_store: object) -> _IngressRouteAuditRecordStore:
+    required_methods = (
+        "write_ingress_route_audit_record",
+        "read_ingress_route_audit_record",
+        "list_ingress_route_audit_records",
+    )
+    if all(hasattr(record_store, method_name) for method_name in required_methods):
+        return cast(_IngressRouteAuditRecordStore, record_store)
+    raise click.ClickException(
+        "Ingress route audit reads require Launchplane ingress-audit record storage."
+    )
+
+
+def _query_string_value(query: dict[str, list[str]], key: str) -> str:
+    return str((query.get(key) or [""])[0] or "").strip()
+
+
+def _query_int_value(
+    query: dict[str, list[str]],
+    key: str,
+    *,
+    default: int | None = None,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int | None:
+    raw_value = _query_string_value(query, key)
+    if not raw_value:
+        value = default
+    else:
+        value = int(raw_value)
+    if value is None:
+        return None
+    if minimum is not None and value < minimum:
+        raise ValueError(f"Query parameter {key} must be at least {minimum}")
+    if maximum is not None and value > maximum:
+        raise ValueError(f"Query parameter {key} must be at most {maximum}")
+    return value
+
+
+def _filter_ingress_route_audit_records(
+    records: tuple[IngressRouteAuditRecord, ...],
+    *,
+    status: str = "",
+    mode: str = "",
+    provider_host_id: int | None = None,
+    trace_id: str = "",
+    idempotency_key: str = "",
+) -> tuple[IngressRouteAuditRecord, ...]:
+    filtered_records = records
+    if status:
+        filtered_records = tuple(record for record in filtered_records if record.status == status)
+    if mode:
+        filtered_records = tuple(record for record in filtered_records if record.mode == mode)
+    if provider_host_id is not None:
+        filtered_records = tuple(
+            record for record in filtered_records if record.provider_host_id == provider_host_id
+        )
+    if trace_id:
+        filtered_records = tuple(
+            record for record in filtered_records if record.trace_id == trace_id
+        )
+    if idempotency_key:
+        filtered_records = tuple(
+            record for record in filtered_records if record.idempotency_key == idempotency_key
+        )
+    return filtered_records
 
 
 def _find_odoo_stable_bootstrap_operation_by_idempotency_key(
@@ -8691,6 +8767,131 @@ def create_launchplane_service_app(
                             "trace_id": request_trace_id,
                             "drivers": [
                                 descriptor.model_dump(mode="json") for descriptor in descriptors
+                            ],
+                        },
+                    )
+                if action == "ingress_route.plan":
+                    audit_store = _ingress_route_audit_record_store(record_store)
+                    if "ingress_route_audit_record_id" in params:
+                        product = _query_string_value(query, "product")
+                        context_name = _query_string_value(query, "context")
+                        if not product or not context_name:
+                            return _json_response(
+                                start_response=start_response,
+                                status_code=400,
+                                payload={
+                                    "status": "rejected",
+                                    "trace_id": request_trace_id,
+                                    "error": {
+                                        "code": "invalid_query",
+                                        "message": "Ingress route audit record reads require product and context query parameters.",
+                                    },
+                                },
+                            )
+                        if not authz_policy.allows(
+                            identity=identity,
+                            action=action,
+                            product=product,
+                            context=context_name,
+                        ):
+                            return _json_response(
+                                start_response=start_response,
+                                status_code=403,
+                                payload={
+                                    "status": "rejected",
+                                    "trace_id": request_trace_id,
+                                    "error": {
+                                        "code": "authorization_denied",
+                                        "message": "Workflow cannot read ingress route audit records for the requested product/context.",
+                                    },
+                                },
+                            )
+                        try:
+                            audit_record = audit_store.read_ingress_route_audit_record(
+                                params["ingress_route_audit_record_id"]
+                            )
+                        except FileNotFoundError:
+                            return _not_found_response(
+                                start_response=start_response,
+                                trace_id=request_trace_id,
+                                path=path,
+                            )
+                        if audit_record.product != product or audit_record.context != context_name:
+                            return _not_found_response(
+                                start_response=start_response,
+                                trace_id=request_trace_id,
+                                path=path,
+                            )
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=200,
+                            payload={
+                                "status": "ok",
+                                "trace_id": request_trace_id,
+                                "record": audit_record.model_dump(mode="json"),
+                            },
+                        )
+                    product = _query_string_value(query, "product")
+                    context_name = _query_string_value(query, "context")
+                    if not product or not context_name:
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=400,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "invalid_query",
+                                    "message": "Ingress route audit list requires product and context query parameters.",
+                                },
+                            },
+                        )
+                    if not authz_policy.allows(
+                        identity=identity,
+                        action=action,
+                        product=product,
+                        context=context_name,
+                    ):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=403,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "authorization_denied",
+                                    "message": "Workflow cannot read ingress route audit records for the requested product/context.",
+                                },
+                            },
+                        )
+                    limit = _query_int_value(query, "limit", default=25, minimum=1, maximum=100)
+                    provider_host_id = _query_int_value(query, "provider_host_id", minimum=1)
+                    listed_records = audit_store.list_ingress_route_audit_records(
+                        product=product,
+                        context_name=context_name,
+                        limit=None,
+                    )
+                    listed_records = _filter_ingress_route_audit_records(
+                        listed_records,
+                        status=_query_string_value(query, "status"),
+                        mode=_query_string_value(query, "mode"),
+                        provider_host_id=provider_host_id,
+                        trace_id=_query_string_value(query, "trace_id"),
+                        idempotency_key=_query_string_value(query, "idempotency_key"),
+                    )
+                    limited_records = listed_records[:limit]
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=200,
+                        payload={
+                            "status": "ok",
+                            "trace_id": request_trace_id,
+                            "product": product,
+                            "context": context_name,
+                            "limit": limit,
+                            "count": len(limited_records),
+                            "records": [
+                                record.model_dump(mode="json") for record in limited_records
                             ],
                         },
                     )

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -101,8 +101,8 @@ class FilesystemRecordStore:
         return True
 
     def _read_model(
-        self, model_type: type[BaseModel], record_type: str, record_id: str
-    ) -> BaseModel:
+        self, model_type: type[RecordModel], record_type: str, record_id: str
+    ) -> RecordModel:
         record_path = self._record_path(record_type, record_id)
         payload = json.loads(record_path.read_text(encoding="utf-8"))
         return model_type.model_validate(payload)
@@ -565,6 +565,13 @@ class FilesystemRecordStore:
 
     def write_ingress_route_audit_record(self, record: IngressRouteAuditRecord) -> Path:
         return self._write_model("launchplane_ingress_route_audits", record.record_id, record)
+
+    def read_ingress_route_audit_record(self, record_id: str) -> IngressRouteAuditRecord:
+        return self._read_model(
+            IngressRouteAuditRecord,
+            "launchplane_ingress_route_audits",
+            record_id,
+        )
 
     def list_ingress_route_audit_records(
         self,

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -2836,6 +2836,13 @@ class PostgresRecordStore(HumanSessionStore):
             )
         )
 
+    def read_ingress_route_audit_record(self, record_id: str) -> IngressRouteAuditRecord:
+        return self._read_model(
+            model_type=IngressRouteAuditRecord,
+            orm_model=LaunchplaneIngressRouteAuditRow,
+            filters=(LaunchplaneIngressRouteAuditRow.record_id == record_id,),
+        )
+
     def list_ingress_route_audit_records(
         self,
         *,

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -197,6 +197,15 @@ mode, status, requested domains, expected/provider host ids, operations, reason,
 and idempotency key. Keep this workflow canary-scoped until broader route
 ownership and approval UX are explicit.
 
+Operators with `ingress_route.plan` for the target product/context can inspect
+those audit records through the service. List records with
+`GET /v1/ingress/route-audits/records?product=launchplane&context=example-prod`
+and optional `status`, `mode`, `provider_host_id`, `trace_id`,
+`idempotency_key`, and `limit` filters. Read one record with
+`GET /v1/ingress/route-audits/records/{record_id}?product=launchplane&context=example-prod`.
+Both list and single-record endpoints require `product` and `context` so audit
+browsing stays scoped.
+
 ## Product Repo Boundary
 
 Driver development should make product repos thinner, not larger. When a new

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -639,6 +639,7 @@ class FilesystemRecordStoreTests(unittest.TestCase):
                 product="launchplane", context_name="reon-prod"
             )
             limited_records = store.list_ingress_route_audit_records(product="launchplane", limit=1)
+            loaded_record = store.read_ingress_route_audit_record(newer_record.record_id)
             self.assertTrue(written_path.exists())
 
         self.assertEqual(
@@ -646,6 +647,7 @@ class FilesystemRecordStoreTests(unittest.TestCase):
             [newer_record.record_id, older_record.record_id],
         )
         self.assertEqual([record.record_id for record in limited_records], [newer_record.record_id])
+        self.assertEqual(loaded_record.record_id, newer_record.record_id)
 
     def test_postgres_store_round_trips_ingress_route_audit_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -681,9 +683,11 @@ class FilesystemRecordStoreTests(unittest.TestCase):
             listed_records = store.list_ingress_route_audit_records(
                 product="launchplane", context_name="reon-prod"
             )
+            loaded_record = store.read_ingress_route_audit_record(record.record_id)
 
         self.assertEqual([stored.record_id for stored in listed_records], [record.record_id])
         self.assertEqual(listed_records[0].provider_host_id, 78)
+        self.assertEqual(loaded_record.record_id, record.record_id)
 
     def test_write_and_list_public_ingress_incident_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2061,6 +2061,244 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(records[0].status, "planned")
         self.assertEqual(records[0].trace_id, payload["trace_id"])
 
+    def test_ingress_route_audit_record_api_lists_and_reads_records(self) -> None:
+        client = _FakeNpmplusIngressClient()
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "every/verireel",
+                        "workflow_refs": [
+                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                        ],
+                        "event_names": ["pull_request"],
+                        "products": ["launchplane"],
+                        "contexts": ["reon-prod"],
+                        "actions": ["ingress_route.plan"],
+                    }
+                ]
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                local_record_store_for_tests=FilesystemRecordStore(root / "state"),
+                npmplus_ingress_client_factory=lambda: client,
+            )
+            _, apply_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/ingress/route-apply",
+                payload=_npmplus_ingress_route_payload(),
+                headers={"Idempotency-Key": "npmplus-ingress-dry-run"},
+            )
+            audit_record_id = apply_payload["records"]["ingress_route_audit_record_id"]
+
+            list_status_code, list_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/ingress/route-audits/records",
+                query_string="product=launchplane&context=reon-prod&mode=dry-run&status=planned&limit=10",
+            )
+            read_status_code, read_payload = _invoke_app(
+                app,
+                method="GET",
+                path=f"/v1/ingress/route-audits/records/{audit_record_id}",
+                query_string="product=launchplane&context=reon-prod",
+            )
+
+        self.assertEqual(list_status_code, 200)
+        self.assertEqual(list_payload["status"], "ok")
+        self.assertEqual(list_payload["count"], 1)
+        self.assertEqual(list_payload["records"][0]["record_id"], audit_record_id)
+        self.assertEqual(read_status_code, 200)
+        self.assertEqual(read_payload["record"]["record_id"], audit_record_id)
+        self.assertEqual(read_payload["record"]["trace_id"], apply_payload["trace_id"])
+
+    def test_ingress_route_audit_record_api_requires_scope_for_single_record_read(
+        self,
+    ) -> None:
+        client = _FakeNpmplusIngressClient()
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "every/verireel",
+                        "workflow_refs": [
+                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                        ],
+                        "event_names": ["pull_request"],
+                        "products": ["launchplane"],
+                        "contexts": ["reon-prod"],
+                        "actions": ["ingress_route.plan"],
+                    }
+                ]
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                local_record_store_for_tests=FilesystemRecordStore(root / "state"),
+                npmplus_ingress_client_factory=lambda: client,
+            )
+            _, apply_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/ingress/route-apply",
+                payload=_npmplus_ingress_route_payload(),
+                headers={"Idempotency-Key": "npmplus-ingress-dry-run"},
+            )
+            audit_record_id = apply_payload["records"]["ingress_route_audit_record_id"]
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path=f"/v1/ingress/route-audits/records/{audit_record_id}",
+            )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_query")
+
+    def test_ingress_route_audit_record_api_hides_record_outside_requested_scope(
+        self,
+    ) -> None:
+        client = _FakeNpmplusIngressClient()
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "every/verireel",
+                        "workflow_refs": [
+                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                        ],
+                        "event_names": ["pull_request"],
+                        "products": ["launchplane"],
+                        "contexts": ["reon-prod", "cm-prod"],
+                        "actions": ["ingress_route.plan"],
+                    }
+                ]
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                local_record_store_for_tests=FilesystemRecordStore(root / "state"),
+                npmplus_ingress_client_factory=lambda: client,
+            )
+            _, apply_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/ingress/route-apply",
+                payload=_npmplus_ingress_route_payload(),
+                headers={"Idempotency-Key": "npmplus-ingress-dry-run"},
+            )
+            audit_record_id = apply_payload["records"]["ingress_route_audit_record_id"]
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path=f"/v1/ingress/route-audits/records/{audit_record_id}",
+                query_string="product=launchplane&context=cm-prod",
+            )
+
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
+
+    def test_ingress_route_audit_record_api_requires_scoped_list_query(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "every/verireel",
+                        "workflow_refs": [
+                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                        ],
+                        "event_names": ["pull_request"],
+                        "products": ["launchplane"],
+                        "contexts": ["reon-prod"],
+                        "actions": ["ingress_route.plan"],
+                    }
+                ]
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                local_record_store_for_tests=FilesystemRecordStore(root / "state"),
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/ingress/route-audits/records",
+                query_string="product=launchplane",
+            )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_query")
+
+    def test_ingress_route_audit_record_api_rejects_unauthorized_context(self) -> None:
+        client = _FakeNpmplusIngressClient()
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "every/verireel",
+                        "workflow_refs": [
+                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                        ],
+                        "event_names": ["pull_request"],
+                        "products": ["launchplane"],
+                        "contexts": ["reon-prod"],
+                        "actions": ["ingress_route.plan"],
+                    }
+                ]
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                local_record_store_for_tests=FilesystemRecordStore(root / "state"),
+                npmplus_ingress_client_factory=lambda: client,
+            )
+            _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/ingress/route-apply",
+                payload=_npmplus_ingress_route_payload(),
+                headers={"Idempotency-Key": "npmplus-ingress-dry-run"},
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/ingress/route-audits/records",
+                query_string="product=launchplane&context=cm-prod",
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
     def test_npmplus_ingress_dry_run_idempotency_key_does_not_replay(self) -> None:
         client = _FakeNpmplusIngressClient()
         policy = LaunchplaneAuthzPolicy.model_validate(


### PR DESCRIPTION
## Summary
- add service-mediated list/read endpoints for ingress route audit records
- require product/context scope for both list and single-record reads
- authorize reads with ingress_route.plan and hide records outside requested scope
- add filesystem/Postgres read helpers plus focused service/storage tests

## Verification
- uv run python -m unittest tests.test_filesystem_store.FilesystemRecordStoreTests.test_write_and_list_ingress_route_audit_records tests.test_filesystem_store.FilesystemRecordStoreTests.test_postgres_store_round_trips_ingress_route_audit_records tests.test_service.LaunchplaneServiceTests.test_ingress_route_audit_record_api_lists_and_reads_records tests.test_service.LaunchplaneServiceTests.test_ingress_route_audit_record_api_requires_scope_for_single_record_read tests.test_service.LaunchplaneServiceTests.test_ingress_route_audit_record_api_hides_record_outside_requested_scope tests.test_service.LaunchplaneServiceTests.test_ingress_route_audit_record_api_requires_scoped_list_query tests.test_service.LaunchplaneServiceTests.test_ingress_route_audit_record_api_rejects_unauthorized_context
- uv run --extra dev ruff check control_plane/service.py control_plane/storage/filesystem.py control_plane/storage/postgres.py tests/test_filesystem_store.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/service.py control_plane/storage/filesystem.py control_plane/storage/postgres.py tests/test_filesystem_store.py tests/test_service.py
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest tests.test_filesystem_store tests.test_service
- git diff --check
- agent review: one stricter single-record scoping finding patched