### PR TITLE
Suppress Odoo bootstrap payload during restore

### DIFF
--- a/control_plane/odoo_instance_overrides.py
+++ b/control_plane/odoo_instance_overrides.py
@@ -1,6 +1,7 @@
 import base64
 import json
 from dataclasses import dataclass
+from typing import Literal
 
 import click
 
@@ -17,6 +18,7 @@ SHOPIFY_ALLOW_PRODUCTION_SETTING = "allow_production"
 SHOPIFY_PRODUCTION_INDICATORS_SETTING = "production_indicators"
 SHOPIFY_REQUIRED_SETTINGS = ("shop_url_key", "api_token", "webhook_key", "api_version")
 DEFAULT_SHOPIFY_PRODUCTION_INDICATORS = ("production", "live", "prod-")
+PostDeployWorkflowIntent = Literal["deploy", "restore", "bootstrap"]
 
 
 @dataclass(frozen=True)
@@ -180,6 +182,7 @@ def _payload_override_value(
 def render_post_deploy_payload(
     record: OdooInstanceOverrideRecord,
     *,
+    workflow_intent: PostDeployWorkflowIntent = "deploy",
     protected_shopify_store_keys: tuple[str, ...] = (),
 ) -> dict[str, object]:
     payload: dict[str, object] = {
@@ -225,7 +228,7 @@ def render_post_deploy_payload(
         )
     payload["config_parameters"] = config_parameters
     payload["addon_settings"] = addon_settings
-    if record.website_bootstrap is not None:
+    if record.website_bootstrap is not None and workflow_intent != "restore":
         payload["website_bootstrap"] = record.website_bootstrap.model_dump(mode="json")
     return payload
 
@@ -263,10 +266,12 @@ def addon_setting_secret_env_key(*, addon_name: str, setting_name: str) -> str:
 def build_post_deploy_environment(
     record: OdooInstanceOverrideRecord,
     *,
+    workflow_intent: PostDeployWorkflowIntent = "deploy",
     protected_shopify_store_keys: tuple[str, ...] = (),
 ) -> PostDeployOverrideEnvironment:
     payload = render_post_deploy_payload(
         record,
+        workflow_intent=workflow_intent,
         protected_shopify_store_keys=protected_shopify_store_keys,
     )
     inline_environment: dict[str, str] = {
@@ -302,9 +307,11 @@ def build_post_deploy_environment(
 def render_post_deploy_environment(
     record: OdooInstanceOverrideRecord,
     *,
+    workflow_intent: PostDeployWorkflowIntent = "deploy",
     protected_shopify_store_keys: tuple[str, ...] = (),
 ) -> dict[str, str]:
     return build_post_deploy_environment(
         record,
+        workflow_intent=workflow_intent,
         protected_shopify_store_keys=protected_shopify_store_keys,
     ).inline_environment

--- a/control_plane/workflows/odoo_post_deploy.py
+++ b/control_plane/workflows/odoo_post_deploy.py
@@ -181,6 +181,7 @@ def execute_odoo_post_deploy(
             post_deploy_environment = (
                 control_plane_odoo_instance_overrides.build_post_deploy_environment(
                     odoo_override_record,
+                    workflow_intent="restore" if run_destructive_restore else "deploy",
                     protected_shopify_store_keys=protected_shopify_store_keys,
                 )
             )

--- a/tests/test_odoo_instance_override_rendering.py
+++ b/tests/test_odoo_instance_override_rendering.py
@@ -152,6 +152,58 @@ class OdooInstanceOverrideRenderingTests(unittest.TestCase):
         self.assertEqual(routes[0]["url"], "/home")
         self.assertEqual(decoded_payload, payload)
 
+    def test_restore_intent_suppresses_website_bootstrap(self) -> None:
+        record = OdooInstanceOverrideRecord(
+            context="example",
+            instance="testing",
+            config_parameters=(
+                OdooConfigParameterOverride(
+                    key="web.base.url",
+                    value=OdooOverrideValue(
+                        source="literal",
+                        value="https://example-testing.example.com",
+                    ),
+                ),
+            ),
+            website_bootstrap=OdooWebsiteBootstrapPayload(
+                tenant="example",
+                name="Example Site",
+                canonical_url="https://example-testing.example.com",
+                routes=(
+                    OdooWebsiteBootstrapRoute(
+                        name="Home",
+                        url="/home",
+                        homepage=True,
+                    ),
+                ),
+            ),
+            updated_at="2026-05-16T00:00:00Z",
+        )
+
+        payload = render_post_deploy_payload(record, workflow_intent="restore")
+        environment = build_post_deploy_environment(record, workflow_intent="restore")
+        decoded_payload = json.loads(
+            base64.b64decode(
+                environment.inline_environment[ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY]
+            ).decode("utf-8")
+        )
+
+        self.assertNotIn("website_bootstrap", payload)
+        self.assertNotIn("website_bootstrap", decoded_payload)
+        self.assertEqual(
+            payload["config_parameters"],
+            [
+                {
+                    "key": "web.base.url",
+                    "value": {
+                        "source": "literal",
+                        "value": "https://example-testing.example.com",
+                    },
+                }
+            ],
+        )
+        self.assertEqual(decoded_payload, payload)
+
     def test_build_post_deploy_environment_requires_container_env_for_secret_backed_values(
         self,
     ) -> None:

--- a/tests/test_odoo_post_deploy.py
+++ b/tests/test_odoo_post_deploy.py
@@ -11,6 +11,8 @@ from control_plane.contracts.odoo_instance_override_record import (
     OdooConfigParameterOverride,
     OdooInstanceOverrideRecord,
     OdooOverrideValue,
+    OdooWebsiteBootstrapPayload,
+    OdooWebsiteBootstrapRoute,
 )
 from control_plane.dokploy import DokploySourceOfTruth, DokployTargetDefinition
 from control_plane.storage.filesystem import FilesystemRecordStore
@@ -180,6 +182,18 @@ class OdooPostDeployWorkflowTests(unittest.TestCase):
                             value=OdooOverrideValue(
                                 source="literal",
                                 value="https://opw-testing.example.com",
+                            ),
+                        ),
+                    ),
+                    website_bootstrap=OdooWebsiteBootstrapPayload(
+                        tenant="opw",
+                        name="OPW Testing",
+                        canonical_url="https://opw-testing.example.com",
+                        routes=(
+                            OdooWebsiteBootstrapRoute(
+                                name="Shop",
+                                url="/shop",
+                                homepage=True,
                             ),
                         ),
                     ),


### PR DESCRIPTION
## Summary
- add explicit Odoo post-deploy workflow intent for override payload rendering
- suppress website bootstrap payloads during destructive restore while preserving config/addon sanitization
- add render-level and workflow-level tests with a real website_bootstrap fixture

Refs #1042

## Verification
- uv run python -m unittest tests.test_odoo_post_deploy tests.test_odoo_instance_override_rendering tests.test_odoo_stable_target_replacement tests.test_odoo_stable_authority tests.test_odoo_instance_overrides tests.test_odoo_stable_bootstrap
- uv run --extra dev ruff check --diff control_plane/odoo_instance_overrides.py control_plane/workflows/odoo_post_deploy.py tests/test_odoo_post_deploy.py tests/test_odoo_instance_override_rendering.py
- uv run --extra dev ruff check control_plane/odoo_instance_overrides.py control_plane/workflows/odoo_post_deploy.py tests/test_odoo_post_deploy.py tests/test_odoo_instance_override_rendering.py
- uv run --extra dev mypy control_plane/odoo_instance_overrides.py control_plane/workflows/odoo_post_deploy.py tests/test_odoo_post_deploy.py tests/test_odoo_instance_override_rendering.py
- uv run python -m unittest
