### PR TITLE
Fix NPMplus compatibility env removal

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -376,13 +376,27 @@ jobs:
                   )
                 ) | with_entries(select(.value != ""))'
             })"
+            service_env_removals_json="$({
+              jq -n \
+                --argjson omit_npmplus_env '${{ inputs.omit_npmplus_env || false }}' \
+                'if $omit_npmplus_env then
+                  [
+                    "LAUNCHPLANE_NPMPLUS_BASE_URL",
+                    "LAUNCHPLANE_NPMPLUS_IDENTITY",
+                    "LAUNCHPLANE_NPMPLUS_SECRET"
+                  ]
+                else
+                  []
+                end'
+            })"
             request_payload="$({
               jq -n \
                 --arg target_type "$LAUNCHPLANE_DOKPLOY_TARGET_TYPE" \
                 --arg target_id "$LAUNCHPLANE_DOKPLOY_TARGET_ID" \
                 --arg image_reference "${{ steps.image.outputs.image_reference }}" \
                 --argjson service_env "$service_env_json" \
-                '{schema_version: 1, product: "launchplane", deploy: ({target_type: $target_type, target_id: $target_id, image_reference: $image_reference} + (if ($service_env | length) > 0 then {oauth_env: $service_env} else {} end))}'
+                --argjson service_env_removals "$service_env_removals_json" \
+                '{schema_version: 1, product: "launchplane", deploy: ({target_type: $target_type, target_id: $target_id, image_reference: $image_reference} + (if ($service_env | length) > 0 then {oauth_env: $service_env} else {} end) + (if ($service_env_removals | length) > 0 then {oauth_env_removals: $service_env_removals} else {} end))}'
             })"
             idempotency_key="launchplane-self-deploy:${{ steps.image.outputs.image_reference }}:${{ github.run_id }}:${{ github.run_attempt }}:db-authz"
 

--- a/.github/workflows/ingress-route-dry-run.yml
+++ b/.github/workflows/ingress-route-dry-run.yml
@@ -103,6 +103,31 @@ jobs:
             '($route_options_json | fromjson) as $options |
             if ($options | type) != "object" then
               error("route_options_json must be a JSON object")
+            elif ([
+              $options
+              | keys[]
+              | select(. as $key | [
+                "enabled",
+                "ssl_forced",
+                "hsts_enabled",
+                "hsts_subdomains",
+                "trust_forwarded_proto",
+                "http2_support",
+                "npmplus_http3_support",
+                "access_list_id",
+                "npmplus_noindex",
+                "npmplus_crowdsec_appsec",
+                "npmplus_proxy_request_buffering",
+                "npmplus_proxy_response_buffering",
+                "npmplus_upstream_compression",
+                "npmplus_fancyindex",
+                "npmplus_x_frame_options",
+                "npmplus_auth_request",
+                "advanced_config",
+                "locations"
+              ] | index($key) | not)
+            ] | length) > 0 then
+              error("route_options_json contains unsupported route option key(s)")
             else
             {
               schema_version: 1,
@@ -119,13 +144,13 @@ jobs:
                   forward_host: $forward_host,
                   forward_port: $forward_port,
                   certificate_id: $certificate_id,
-                  enabled: (if $options | has("enabled") then $options.enabled else true end),
-                  ssl_forced: (if $options | has("ssl_forced") then $options.ssl_forced else true end),
-                  http2_support: (if $options | has("http2_support") then $options.http2_support else true end),
-                  npmplus_http3_support: (if $options | has("npmplus_http3_support") then $options.npmplus_http3_support else true end),
-                  npmplus_noindex: (if $options | has("npmplus_noindex") then $options.npmplus_noindex else true end),
-                  access_list_id: (if $options | has("access_list_id") then $options.access_list_id else 0 end)
-                }
+                  enabled: true,
+                  ssl_forced: true,
+                  http2_support: true,
+                  npmplus_http3_support: true,
+                  npmplus_noindex: false,
+                  access_list_id: 0
+                } + $options
               }
             }
             end' >"$payload_file"

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2530,6 +2530,7 @@ class LaunchplaneSelfDeployRequest(BaseModel):
     image_reference: str
     policy_b64: str = ""
     oauth_env: dict[str, str] = Field(default_factory=dict)
+    oauth_env_removals: tuple[str, ...] = ()
     no_cache: bool = False
 
     @model_validator(mode="after")
@@ -2571,6 +2572,20 @@ class LaunchplaneSelfDeployRequest(BaseModel):
             if normalized_value:
                 normalized_oauth_env[normalized_key] = normalized_value
         self.oauth_env = normalized_oauth_env
+        normalized_oauth_env_removals: list[str] = []
+        for env_key in self.oauth_env_removals:
+            normalized_key = env_key.strip()
+            if normalized_key not in _LAUNCHPLANE_SELF_DEPLOY_OAUTH_ENV_KEYS:
+                raise ValueError(
+                    f"Launchplane self deploy does not accept oauth_env_removals key {normalized_key!r}."
+                )
+            if normalized_key in normalized_oauth_env:
+                raise ValueError(
+                    f"Launchplane self deploy cannot update and remove oauth env key {normalized_key!r}."
+                )
+            if normalized_key not in normalized_oauth_env_removals:
+                normalized_oauth_env_removals.append(normalized_key)
+        self.oauth_env_removals = tuple(normalized_oauth_env_removals)
         return self
 
 
@@ -5215,6 +5230,8 @@ def _accepted_payload(
 
 
 def _accepted_payload_extra_record_keys(*, route_path: str) -> frozenset[str]:
+    if route_path == "/v1/drivers/launchplane/self-deploy":
+        return frozenset({"oauth_env_keys_removed"})
     if route_path == _ODOO_TARGET_REPLACEMENT_APPLY_ROUTE.route_path:
         return frozenset({"deployment_record_id", "release_tuple_id"})
     if route_path == _GENERIC_WEB_ROLLBACK_ROUTE.route_path:
@@ -7220,10 +7237,14 @@ def _request_launchplane_self_deploy(
     previous_env_map = control_plane_dokploy.parse_dokploy_env_text(raw_env_text)
     updates = {_LAUNCHPLANE_IMAGE_REFERENCE_ENV_KEY: request.image_reference}
     updates.update(request.oauth_env)
-    removals: tuple[str, ...] = ()
+    removals: tuple[str, ...] = request.oauth_env_removals
     if request.policy_b64:
         updates["LAUNCHPLANE_POLICY_B64"] = request.policy_b64
-        removals = ("LAUNCHPLANE_POLICY_TOML", "LAUNCHPLANE_POLICY_FILE")
+        removals = (
+            *removals,
+            "LAUNCHPLANE_POLICY_TOML",
+            "LAUNCHPLANE_POLICY_FILE",
+        )
     updated_env_text = control_plane_dokploy.render_dokploy_env_text_with_overrides(
         raw_env_text,
         updates=updates,
@@ -7262,6 +7283,9 @@ def _request_launchplane_self_deploy(
             env_key
             for env_key in request.oauth_env
             if previous_env_map.get(env_key, "") != request.oauth_env[env_key]
+        ),
+        "oauth_env_keys_removed": sorted(
+            env_key for env_key in request.oauth_env_removals if env_key in previous_env_map
         ),
     }
 

--- a/docs/config-boundary.md
+++ b/docs/config-boundary.md
@@ -54,6 +54,12 @@ read credentials. Owner-agent write credentials use the separate
 `omit_owner_agent_env` compatibility input. Leave both unset for normal deploys
 after the service accepts terminal-agent, local-operator, and local-admin keys.
 
+The manual `omit_npmplus_env` compatibility input removes NPMplus service env
+keys from the deployed Launchplane target instead of only skipping new writes.
+Leave it unset for normal deploys so the ingress driver can build its provider
+client from the service target env until those provider credentials move behind
+managed runtime records.
+
 | Work graph GitHub Project read source | `LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER`, `LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER`, optional `LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT`, optional `LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT`, optional `LAUNCHPLANE_WORK_GRAPH_GH_BINARY` | Service target env | Opt-in read source for compact Project fields plus bounded dependency, subissue, and PR check signals. Deploy automation forwards these values only when the GitHub Project token secret is present. Requires a `gh` credential with the GitHub CLI `project` scope. Does not store copied issue bodies. |
 | Work graph and merge-train GitHub token | `GH_TOKEN` from deploy secret `LAUNCHPLANE_WORK_GRAPH_GH_TOKEN` | Platform secret projected into service target env | Authenticates the service's non-interactive `gh` reads and merge-train GitHub API calls. The token must have enough GitHub access for the configured Project, issue/PR signal reads, and the configured merge-train repository. |
 

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -258,12 +258,29 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn('($options | type) != "object"', workflow_text)
         self.assertIn('error("route_options_json must be a JSON object")', workflow_text)
         self.assertIn(
-            'if $options | has("enabled") then $options.enabled else true end', workflow_text
-        )
-        self.assertIn(
-            'if $options | has("npmplus_noindex") then $options.npmplus_noindex else true end',
+            'error("route_options_json contains unsupported route option key(s)")',
             workflow_text,
         )
+        self.assertIn(
+            "npmplus_noindex: false",
+            workflow_text,
+        )
+        self.assertIn("} + $options", workflow_text)
+        for route_option in (
+            "hsts_enabled",
+            "hsts_subdomains",
+            "trust_forwarded_proto",
+            "npmplus_crowdsec_appsec",
+            "npmplus_proxy_request_buffering",
+            "npmplus_proxy_response_buffering",
+            "npmplus_upstream_compression",
+            "npmplus_fancyindex",
+            "npmplus_x_frame_options",
+            "npmplus_auth_request",
+            "advanced_config",
+            "locations",
+        ):
+            self.assertIn(f'"{route_option}"', workflow_text)
         for forward_scheme in ("http", "https", "path", "empty", "grpc", "grpcs"):
             self.assertIn(f"          - {forward_scheme}", workflow_text)
 
@@ -338,6 +355,20 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("if ($omit_terminal_agent_env | not) then", workflow_text)
         self.assertIn("if ($omit_owner_agent_env | not) then", workflow_text)
         self.assertIn("LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN", workflow_text)
+
+    def test_deploy_launchplane_omit_npmplus_env_removes_existing_keys(self) -> None:
+        workflow_text = Path(".github/workflows/deploy-launchplane.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("service_env_removals_json=", workflow_text)
+        self.assertIn("oauth_env_removals: $service_env_removals", workflow_text)
+        for env_key in (
+            "LAUNCHPLANE_NPMPLUS_BASE_URL",
+            "LAUNCHPLANE_NPMPLUS_IDENTITY",
+            "LAUNCHPLANE_NPMPLUS_SECRET",
+        ):
+            self.assertIn(f'"{env_key}"', workflow_text)
         self.assertIn("LAUNCHPLANE_LOCAL_OPERATOR_TOKEN", workflow_text)
         self.assertIn("LAUNCHPLANE_LOCAL_ADMIN_TOKEN", workflow_text)
         self.assertNotIn(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -20034,6 +20034,148 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 400)
         self.assertEqual(payload["error"]["code"], "invalid_request")
 
+    def test_self_deploy_endpoint_removes_requested_oauth_env_keys(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["launchplane_service_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+
+            with (
+                patch(
+                    "control_plane.service.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "token-123"),
+                ),
+                patch(
+                    "control_plane.service.control_plane_dokploy.fetch_dokploy_target_payload",
+                    return_value={
+                        "env": "DOCKER_IMAGE_REFERENCE=old\n"
+                        "LAUNCHPLANE_NPMPLUS_BASE_URL=https://npmplus.example\n"
+                        "LAUNCHPLANE_NPMPLUS_IDENTITY=automation@example.com\n"
+                        "LAUNCHPLANE_NPMPLUS_SECRET=npmplus-secret\n"
+                    },
+                ),
+                patch(
+                    "control_plane.service.control_plane_dokploy.update_dokploy_target_env"
+                ) as update_env_mock,
+                patch("control_plane.service.control_plane_dokploy.trigger_deployment"),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/launchplane/self-deploy",
+                    payload={
+                        "product": "launchplane",
+                        "deploy": {
+                            "target_type": "compose",
+                            "target_id": "compose-123",
+                            "image_reference": "ghcr.io/cbusillo/launchplane@sha256:new",
+                            "oauth_env_removals": [
+                                "LAUNCHPLANE_NPMPLUS_BASE_URL",
+                                "LAUNCHPLANE_NPMPLUS_IDENTITY",
+                                "LAUNCHPLANE_NPMPLUS_SECRET",
+                            ],
+                        },
+                    },
+                    headers={"Idempotency-Key": "launchplane-self-deploy:remove-oauth-env"},
+                )
+
+        self.assertEqual(status_code, 202)
+        removed_keys = str(payload["records"]["oauth_env_keys_removed"])
+        self.assertIn("LAUNCHPLANE_NPMPLUS_BASE_URL", removed_keys)
+        self.assertIn("LAUNCHPLANE_NPMPLUS_IDENTITY", removed_keys)
+        self.assertIn("LAUNCHPLANE_NPMPLUS_SECRET", removed_keys)
+        update_env_mock.assert_called_once()
+        updated_env_text = update_env_mock.call_args.kwargs["env_text"]
+        self.assertIn(
+            "DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/launchplane@sha256:new",
+            updated_env_text,
+        )
+        self.assertNotIn("LAUNCHPLANE_NPMPLUS_BASE_URL=", updated_env_text)
+        self.assertNotIn("LAUNCHPLANE_NPMPLUS_IDENTITY=", updated_env_text)
+        self.assertNotIn("LAUNCHPLANE_NPMPLUS_SECRET=", updated_env_text)
+
+    def test_self_deploy_endpoint_rejects_remove_and_update_same_oauth_env_key(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["launchplane_service_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/launchplane/self-deploy",
+                payload={
+                    "product": "launchplane",
+                    "deploy": {
+                        "target_type": "compose",
+                        "target_id": "compose-123",
+                        "image_reference": "ghcr.io/cbusillo/launchplane@sha256:new",
+                        "oauth_env": {
+                            "LAUNCHPLANE_NPMPLUS_BASE_URL": "https://npmplus.example"
+                        },
+                        "oauth_env_removals": ["LAUNCHPLANE_NPMPLUS_BASE_URL"],
+                    },
+                },
+                headers={"Idempotency-Key": "launchplane-self-deploy:bad-removal"},
+            )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+
     def test_authz_policy_grant_endpoint_writes_db_record_and_updates_runtime(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add explicit self-deploy oauth_env_removals so compatibility deploys can clear stale NPMplus env vars
- have deploy-launchplane send NPMplus env removals when omit_npmplus_env is selected
- fix ingress route dry-run defaults and route option passthrough, including rejecting unsupported option keys
- document omit_npmplus_env as removal semantics

Refs #1043

## Verification
- uv run python -m unittest tests.test_product_onboarding tests.test_service.LaunchplaneServiceTests.test_self_deploy_endpoint_updates_target_env_and_triggers_dokploy tests.test_service.LaunchplaneServiceTests.test_self_deploy_endpoint_rejects_unknown_oauth_env_keys tests.test_service.LaunchplaneServiceTests.test_self_deploy_endpoint_removes_requested_oauth_env_keys tests.test_service.LaunchplaneServiceTests.test_self_deploy_endpoint_rejects_remove_and_update_same_oauth_env_key tests.test_docs_contracts tests.test_driver_descriptors tests.test_ingress_cli tests.test_npmplus
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_service.py tests/test_product_onboarding.py
- uv run --extra dev ruff check control_plane/service.py tests/test_service.py tests/test_product_onboarding.py
- uv run --extra dev mypy control_plane/service.py tests/test_service.py tests/test_product_onboarding.py
- actionlint .github/workflows/deploy-launchplane.yml .github/workflows/ingress-route-dry-run.yml
- jq smoke checks for ingress-route-dry-run route_options_json merge/reject behavior
- uv run python -m unittest
