### PR TITLE
Type Odoo post-deploy payload evidence

### DIFF
--- a/control_plane/contracts/odoo_post_deploy_payload.py
+++ b/control_plane/contracts/odoo_post_deploy_payload.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.odoo_instance_override_record import (
+    OdooOverrideValueSource,
+    OdooWebsiteBootstrapPayload,
+)
+from control_plane.contracts.runtime_environment_record import ScalarValue
+
+OdooPostDeployWorkflowIntent = Literal["deploy", "restore", "bootstrap"]
+
+
+class OdooPostDeployRenderedValue(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: OdooOverrideValueSource
+    value: ScalarValue | None = None
+    secret_binding_id: str = ""
+    environment_variable: str = ""
+
+    @model_validator(mode="after")
+    def _validate_source(self) -> "OdooPostDeployRenderedValue":
+        self.secret_binding_id = self.secret_binding_id.strip()
+        self.environment_variable = self.environment_variable.strip()
+        if self.source == "literal":
+            if self.value is None:
+                raise ValueError("literal Odoo post-deploy payload values require value")
+            if self.secret_binding_id:
+                raise ValueError(
+                    "literal Odoo post-deploy payload values must not include secret_binding_id"
+                )
+            if self.environment_variable:
+                raise ValueError(
+                    "literal Odoo post-deploy payload values must not include environment_variable"
+                )
+            return self
+        if self.source == "secret_binding":
+            if self.value is not None:
+                raise ValueError(
+                    "secret-backed Odoo post-deploy payload values must not include plaintext value"
+                )
+            if not self.secret_binding_id:
+                raise ValueError(
+                    "secret-backed Odoo post-deploy payload values require secret_binding_id"
+                )
+            if not self.environment_variable:
+                raise ValueError(
+                    "secret-backed Odoo post-deploy payload values require environment_variable"
+                )
+            return self
+        raise ValueError(f"unsupported Odoo post-deploy payload value source: {self.source}")
+
+    def to_wire_dict(self) -> dict[str, object]:
+        if self.source == "literal":
+            return {"source": self.source, "value": self.value}
+        return {
+            "source": self.source,
+            "secret_binding_id": self.secret_binding_id,
+            "environment_variable": self.environment_variable,
+        }
+
+
+class OdooPostDeployConfigParameter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    value: OdooPostDeployRenderedValue
+
+    @model_validator(mode="after")
+    def _validate_key(self) -> "OdooPostDeployConfigParameter":
+        self.key = self.key.strip().lower()
+        if not self.key:
+            raise ValueError("Odoo post-deploy config parameter requires key")
+        return self
+
+    def to_wire_dict(self) -> dict[str, object]:
+        return {"key": self.key, "value": self.value.to_wire_dict()}
+
+
+class OdooPostDeployAddonSetting(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    addon: str
+    setting: str
+    value: OdooPostDeployRenderedValue
+
+    @model_validator(mode="after")
+    def _validate_key(self) -> "OdooPostDeployAddonSetting":
+        self.addon = self.addon.strip().lower()
+        self.setting = self.setting.strip().lower()
+        if not self.addon:
+            raise ValueError("Odoo post-deploy addon setting requires addon")
+        if not self.setting:
+            raise ValueError("Odoo post-deploy addon setting requires setting")
+        return self
+
+    def to_wire_dict(self) -> dict[str, object]:
+        return {
+            "addon": self.addon,
+            "setting": self.setting,
+            "value": self.value.to_wire_dict(),
+        }
+
+
+class OdooPostDeployPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    context: str
+    instance: str
+    workflow_intent: OdooPostDeployWorkflowIntent = "deploy"
+    config_parameters: tuple[OdooPostDeployConfigParameter, ...] = ()
+    addon_settings: tuple[OdooPostDeployAddonSetting, ...] = ()
+    website_bootstrap: OdooWebsiteBootstrapPayload | None = None
+
+    @model_validator(mode="after")
+    def _validate_payload(self) -> "OdooPostDeployPayload":
+        self.context = self.context.strip().lower()
+        self.instance = self.instance.strip().lower()
+        if not self.context:
+            raise ValueError("Odoo post-deploy payload requires context")
+        if not self.instance:
+            raise ValueError("Odoo post-deploy payload requires instance")
+        if self.workflow_intent == "restore" and self.website_bootstrap is not None:
+            raise ValueError(
+                "restore Odoo post-deploy payloads must not include website_bootstrap"
+            )
+        return self
+
+    @property
+    def required_container_environment_keys(self) -> tuple[str, ...]:
+        keys: list[str] = []
+        for config_parameter in self.config_parameters:
+            if config_parameter.value.source == "secret_binding":
+                keys.append(config_parameter.value.environment_variable)
+        for addon_setting in self.addon_settings:
+            if addon_setting.value.source == "secret_binding":
+                keys.append(addon_setting.value.environment_variable)
+        return tuple(sorted(set(keys)))
+
+    @property
+    def override_count(self) -> int:
+        website_count = 1 if self.website_bootstrap is not None else 0
+        return len(self.config_parameters) + len(self.addon_settings) + website_count
+
+    @property
+    def website_bootstrap_included(self) -> bool:
+        return self.website_bootstrap is not None
+
+    def to_wire_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "schema_version": self.schema_version,
+            "context": self.context,
+            "instance": self.instance,
+            "config_parameters": [
+                override.to_wire_dict() for override in self.config_parameters
+            ],
+            "addon_settings": [override.to_wire_dict() for override in self.addon_settings],
+        }
+        if self.website_bootstrap is not None:
+            payload["website_bootstrap"] = self.website_bootstrap.model_dump(mode="json")
+        return payload
+
+    def to_wire_json_bytes(self) -> bytes:
+        return json.dumps(
+            self.to_wire_dict(), separators=(",", ":"), sort_keys=True
+        ).encode("utf-8")
+
+    @property
+    def wire_sha256(self) -> str:
+        return hashlib.sha256(self.to_wire_json_bytes()).hexdigest()
+
+    def redacted_evidence(self) -> dict[str, str]:
+        return {
+            "workflow_intent": self.workflow_intent,
+            "payload_schema_version": str(self.schema_version),
+            "payload_sha256": self.wire_sha256,
+            "config_parameter_count": str(len(self.config_parameters)),
+            "addon_setting_count": str(len(self.addon_settings)),
+            "website_bootstrap_included": str(self.website_bootstrap_included).lower(),
+            "required_container_environment_keys": ",".join(
+                self.required_container_environment_keys
+            ),
+        }

--- a/control_plane/contracts/promotion_record.py
+++ b/control_plane/contracts/promotion_record.py
@@ -64,6 +64,7 @@ class PostDeployUpdateEvidence(BaseModel):
     attempted: bool = False
     status: ReleaseStatus = "skipped"
     detail: str = ""
+    evidence: dict[str, str] = Field(default_factory=dict)
 
     @model_validator(mode="after")
     def _validate_attempted_update(self) -> "PostDeployUpdateEvidence":

--- a/control_plane/odoo_instance_overrides.py
+++ b/control_plane/odoo_instance_overrides.py
@@ -1,12 +1,16 @@
 import base64
-import json
 from dataclasses import dataclass
-from typing import Literal
 
 import click
 
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.odoo_instance_override_record import OdooOverrideValue
+from control_plane.contracts.odoo_post_deploy_payload import OdooPostDeployAddonSetting
+from control_plane.contracts.odoo_post_deploy_payload import OdooPostDeployConfigParameter
+from control_plane.contracts.odoo_post_deploy_payload import OdooPostDeployPayload
+from control_plane.contracts.odoo_post_deploy_payload import OdooPostDeployRenderedValue
+from control_plane.contracts.odoo_post_deploy_payload import OdooPostDeployWorkflowIntent
+from control_plane.contracts.runtime_environment_record import ScalarValue
 
 ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY = "ODOO_INSTANCE_OVERRIDES_PAYLOAD_B64"
 ODOO_OVERRIDE_SECRET_ENV_PREFIX = "ODOO_OVERRIDE_SECRET__"
@@ -18,13 +22,14 @@ SHOPIFY_ALLOW_PRODUCTION_SETTING = "allow_production"
 SHOPIFY_PRODUCTION_INDICATORS_SETTING = "production_indicators"
 SHOPIFY_REQUIRED_SETTINGS = ("shop_url_key", "api_token", "webhook_key", "api_version")
 DEFAULT_SHOPIFY_PRODUCTION_INDICATORS = ("production", "live", "prod-")
-PostDeployWorkflowIntent = Literal["deploy", "restore", "bootstrap"]
+PostDeployWorkflowIntent = OdooPostDeployWorkflowIntent
 
 
 @dataclass(frozen=True)
 class PostDeployOverrideEnvironment:
     inline_environment: dict[str, str]
     required_container_environment_keys: tuple[str, ...]
+    payload: OdooPostDeployPayload
 
 
 def _normalize_boolean_literal(*, value: object, setting_name: str) -> bool:
@@ -56,18 +61,15 @@ def _shopify_override_value_text(*, override_value: OdooOverrideValue, setting_n
     return _normalize_text_literal(value=override_value.value)
 
 
-def _render_literal_payload_override(*, value: object) -> dict[str, object]:
-    return {
-        "source": "literal",
-        "value": value,
-    }
+def _render_literal_payload_override(*, value: ScalarValue) -> OdooPostDeployRenderedValue:
+    return OdooPostDeployRenderedValue(source="literal", value=value)
 
 
 def _resolve_shopify_payload_settings(
     *,
     record: OdooInstanceOverrideRecord,
     protected_shopify_store_keys: tuple[str, ...] = (),
-) -> list[dict[str, object]]:
+) -> list[OdooPostDeployAddonSetting]:
     shopify_overrides = [
         override for override in record.addon_settings if override.addon == SHOPIFY_ADDON_NAME
     ]
@@ -82,11 +84,11 @@ def _resolve_shopify_payload_settings(
     ]
     if len(configured_required_settings) != len(SHOPIFY_REQUIRED_SETTINGS):
         return [
-            {
-                "addon": SHOPIFY_ADDON_NAME,
-                "setting": SHOPIFY_ACTION_SETTING,
-                "value": _render_literal_payload_override(value=SHOPIFY_ACTION_CLEAR),
-            }
+            OdooPostDeployAddonSetting(
+                addon=SHOPIFY_ADDON_NAME,
+                setting=SHOPIFY_ACTION_SETTING,
+                value=_render_literal_payload_override(value=SHOPIFY_ACTION_CLEAR),
+            )
         ]
 
     shop_url_key = _shopify_override_value_text(
@@ -133,12 +135,12 @@ def _resolve_shopify_payload_settings(
             f"key={shop_url_key!r} indicator={matched_indicator!r}"
         )
 
-    payload_settings: list[dict[str, object]] = [
-        {
-            "addon": SHOPIFY_ADDON_NAME,
-            "setting": SHOPIFY_ACTION_SETTING,
-            "value": _render_literal_payload_override(value=SHOPIFY_ACTION_APPLY),
-        }
+    payload_settings: list[OdooPostDeployAddonSetting] = [
+        OdooPostDeployAddonSetting(
+            addon=SHOPIFY_ADDON_NAME,
+            setting=SHOPIFY_ACTION_SETTING,
+            value=_render_literal_payload_override(value=SHOPIFY_ACTION_APPLY),
+        )
     ]
     for override in shopify_overrides:
         if override.setting in {
@@ -150,33 +152,31 @@ def _resolve_shopify_payload_settings(
             addon_name=override.addon, setting_name=override.setting
         )
         payload_settings.append(
-            {
-                "addon": override.addon,
-                "setting": override.setting,
-                "value": _payload_override_value(
+            OdooPostDeployAddonSetting(
+                addon=override.addon,
+                setting=override.setting,
+                value=_payload_override_value(
                     value=override.value, environment_key=environment_key
                 ),
-            }
+            )
         )
     return payload_settings
 
 
 def _payload_override_value(
     *, value: OdooOverrideValue, environment_key: str | None = None
-) -> dict[str, object]:
-    payload: dict[str, object] = {
-        "source": value.source,
-    }
+) -> OdooPostDeployRenderedValue:
     if value.source == "literal":
-        payload["value"] = value.value
-        return payload
-    payload["secret_binding_id"] = value.secret_binding_id
+        return OdooPostDeployRenderedValue(source=value.source, value=value.value)
     if not environment_key:
         raise click.ClickException(
             "Secret-backed Odoo overrides require a runtime environment key."
         )
-    payload["environment_variable"] = environment_key
-    return payload
+    return OdooPostDeployRenderedValue(
+        source=value.source,
+        secret_binding_id=value.secret_binding_id,
+        environment_variable=environment_key,
+    )
 
 
 def render_post_deploy_payload(
@@ -184,26 +184,19 @@ def render_post_deploy_payload(
     *,
     workflow_intent: PostDeployWorkflowIntent = "deploy",
     protected_shopify_store_keys: tuple[str, ...] = (),
-) -> dict[str, object]:
-    payload: dict[str, object] = {
-        "schema_version": 1,
-        "context": record.context,
-        "instance": record.instance,
-        "config_parameters": [],
-        "addon_settings": [],
-    }
-    config_parameters: list[dict[str, object]] = []
+) -> OdooPostDeployPayload:
+    config_parameters: list[OdooPostDeployConfigParameter] = []
     for config_parameter_override in record.config_parameters:
         environment_key = config_parameter_secret_env_key(config_parameter_override.key)
         config_parameters.append(
-            {
-                "key": config_parameter_override.key,
-                "value": _payload_override_value(
+            OdooPostDeployConfigParameter(
+                key=config_parameter_override.key,
+                value=_payload_override_value(
                     value=config_parameter_override.value, environment_key=environment_key
                 ),
-            }
+            )
         )
-    addon_settings: list[dict[str, object]] = []
+    addon_settings: list[OdooPostDeployAddonSetting] = []
     addon_settings.extend(
         _resolve_shopify_payload_settings(
             record=record,
@@ -218,24 +211,28 @@ def render_post_deploy_payload(
             setting_name=addon_setting_override.setting,
         )
         addon_settings.append(
-            {
-                "addon": addon_setting_override.addon,
-                "setting": addon_setting_override.setting,
-                "value": _payload_override_value(
+            OdooPostDeployAddonSetting(
+                addon=addon_setting_override.addon,
+                setting=addon_setting_override.setting,
+                value=_payload_override_value(
                     value=addon_setting_override.value, environment_key=environment_key
                 ),
-            }
+            )
         )
-    payload["config_parameters"] = config_parameters
-    payload["addon_settings"] = addon_settings
-    if record.website_bootstrap is not None and workflow_intent != "restore":
-        payload["website_bootstrap"] = record.website_bootstrap.model_dump(mode="json")
-    return payload
+    website_bootstrap = record.website_bootstrap if workflow_intent != "restore" else None
+    return OdooPostDeployPayload(
+        schema_version=1,
+        context=record.context,
+        instance=record.instance,
+        workflow_intent=workflow_intent,
+        config_parameters=tuple(config_parameters),
+        addon_settings=tuple(addon_settings),
+        website_bootstrap=website_bootstrap,
+    )
 
 
-def _encode_post_deploy_payload(payload: dict[str, object]) -> str:
-    encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
-    return base64.b64encode(encoded).decode("ascii")
+def _encode_post_deploy_payload(payload: OdooPostDeployPayload) -> str:
+    return base64.b64encode(payload.to_wire_json_bytes()).decode("ascii")
 
 
 def _secret_env_suffix(raw_value: str) -> str:
@@ -277,30 +274,10 @@ def build_post_deploy_environment(
     inline_environment: dict[str, str] = {
         ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY: _encode_post_deploy_payload(payload),
     }
-    required_container_environment_keys: list[str] = []
-    config_parameter_payloads = payload.get("config_parameters")
-    if not isinstance(config_parameter_payloads, list):
-        raise click.ClickException("Odoo override payload is missing config_parameters.")
-    for override in config_parameter_payloads:
-        value_payload = override.get("value") if isinstance(override, dict) else None
-        if not isinstance(value_payload, dict) or value_payload.get("source") != "secret_binding":
-            continue
-        environment_key = str(value_payload.get("environment_variable") or "").strip()
-        if environment_key:
-            required_container_environment_keys.append(environment_key)
-    addon_setting_payloads = payload.get("addon_settings")
-    if not isinstance(addon_setting_payloads, list):
-        raise click.ClickException("Odoo override payload is missing addon_settings.")
-    for override in addon_setting_payloads:
-        value_payload = override.get("value") if isinstance(override, dict) else None
-        if not isinstance(value_payload, dict) or value_payload.get("source") != "secret_binding":
-            continue
-        environment_key = str(value_payload.get("environment_variable") or "").strip()
-        if environment_key:
-            required_container_environment_keys.append(environment_key)
     return PostDeployOverrideEnvironment(
         inline_environment=inline_environment,
-        required_container_environment_keys=tuple(sorted(set(required_container_environment_keys))),
+        required_container_environment_keys=payload.required_container_environment_keys,
+        payload=payload,
     )
 
 

--- a/control_plane/workflows/odoo_generic_web_post_deploy.py
+++ b/control_plane/workflows/odoo_generic_web_post_deploy.py
@@ -36,6 +36,16 @@ def post_deploy_evidence_from_odoo_result(
             result.error_message
             or "Odoo post-deploy completed through the generic-web extension hook."
         ),
+        evidence={
+            "driver_id": "odoo",
+            "context": result.context,
+            "instance": result.instance,
+            "phase": result.phase,
+            "override_status": result.override_status,
+            "override_record_found": str(result.override_record_found).lower(),
+            "override_payload_rendered": str(result.override_payload_rendered).lower(),
+            **result.override_evidence,
+        },
     )
 
 

--- a/control_plane/workflows/odoo_post_deploy.py
+++ b/control_plane/workflows/odoo_post_deploy.py
@@ -14,6 +14,8 @@ from control_plane.contracts.odoo_instance_override_record import (
     OdooOverrideApplyResult,
     OdooOverrideApplyStatus,
 )
+from control_plane.contracts.odoo_post_deploy_payload import OdooPostDeployPayload
+from control_plane.contracts.odoo_post_deploy_payload import OdooPostDeployWorkflowIntent
 from control_plane.workflows.ship import utc_now_timestamp
 
 
@@ -54,7 +56,13 @@ class OdooPostDeployResult(BaseModel):
     override_status: OdooOverrideApplyStatus = "skipped"
     override_record_found: bool = False
     override_payload_rendered: bool = False
+    override_payload_sha256: str = ""
+    override_payload_schema_version: int | None = None
+    override_count: int = 0
+    website_bootstrap_included: bool = False
+    workflow_intent: OdooPostDeployWorkflowIntent = "deploy"
     required_container_environment_keys: tuple[str, ...] = ()
+    override_evidence: dict[str, str] = Field(default_factory=dict)
     applied_at: str = ""
     error_message: str = ""
 
@@ -167,6 +175,10 @@ def execute_odoo_post_deploy(
     )
     workflow_environment_overrides: dict[str, str] = {}
     required_workflow_environment_keys: tuple[str, ...] = ()
+    workflow_intent: OdooPostDeployWorkflowIntent = (
+        "restore" if run_destructive_restore else "deploy"
+    )
+    override_payload: OdooPostDeployPayload | None = None
 
     target_definition = _resolve_compose_target_definition(
         control_plane_root=control_plane_root,
@@ -181,10 +193,11 @@ def execute_odoo_post_deploy(
             post_deploy_environment = (
                 control_plane_odoo_instance_overrides.build_post_deploy_environment(
                     odoo_override_record,
-                    workflow_intent="restore" if run_destructive_restore else "deploy",
+                    workflow_intent=workflow_intent,
                     protected_shopify_store_keys=protected_shopify_store_keys,
                 )
             )
+            override_payload = post_deploy_environment.payload
             workflow_environment_overrides = post_deploy_environment.inline_environment
             required_workflow_environment_keys = (
                 post_deploy_environment.required_container_environment_keys
@@ -203,6 +216,7 @@ def execute_odoo_post_deploy(
                 post_deploy_status="fail",
                 override_status="fail" if override_should_apply else "skipped",
                 override_record_found=True,
+                workflow_intent=workflow_intent,
                 required_container_environment_keys=required_workflow_environment_keys,
                 error_message=str(error),
             )
@@ -239,7 +253,19 @@ def execute_odoo_post_deploy(
             override_payload_rendered=bool(
                 workflow_environment_overrides or required_workflow_environment_keys
             ),
+            override_payload_sha256=override_payload.wire_sha256 if override_payload else "",
+            override_payload_schema_version=(
+                override_payload.schema_version if override_payload else None
+            ),
+            override_count=override_payload.override_count if override_payload else 0,
+            website_bootstrap_included=(
+                override_payload.website_bootstrap_included if override_payload else False
+            ),
+            workflow_intent=workflow_intent,
             required_container_environment_keys=required_workflow_environment_keys,
+            override_evidence=(
+                override_payload.redacted_evidence() if override_payload else {}
+            ),
             error_message=str(error),
         )
 
@@ -276,6 +302,14 @@ def execute_odoo_post_deploy(
         override_payload_rendered=bool(
             workflow_environment_overrides or required_workflow_environment_keys
         ),
+        override_payload_sha256=override_payload.wire_sha256 if override_payload else "",
+        override_payload_schema_version=(override_payload.schema_version if override_payload else None),
+        override_count=override_payload.override_count if override_payload else 0,
+        website_bootstrap_included=(
+            override_payload.website_bootstrap_included if override_payload else False
+        ),
+        workflow_intent=workflow_intent,
         required_container_environment_keys=required_workflow_environment_keys,
+        override_evidence=override_payload.redacted_evidence() if override_payload else {},
         applied_at=applied_at,
     )

--- a/docs/records.md
+++ b/docs/records.md
@@ -590,9 +590,12 @@ state/
 - This record is the target authority for the Odoo driver. Runtime-environment
   `ENV_OVERRIDE_*` keys remain a migration input to retire, not the final
   override model.
-- The compose post-deploy bridge renders one typed Odoo override payload for
-  the data-workflow runner; it does not make legacy `ENV_OVERRIDE_*` names the
-  deploy-time contract.
+- The compose post-deploy bridge renders one typed, workflow-intent-aware Odoo
+  post-deploy payload for the data-workflow runner, then serializes it to the
+  compatible v1 JSON/base64 wire shape. Launchplane evidence records the
+  redacted payload digest, counts, required container keys, and whether
+  website bootstrap was included; it does not make legacy `ENV_OVERRIDE_*`
+  names the deploy-time contract.
 - Secret-backed values still avoid Dokploy schedule plaintext. The payload
   points at the already-present neutral `ODOO_OVERRIDE_SECRET__*` container
   environment key for each managed secret binding, and the driver asserts those

--- a/tests/test_odoo_generic_web_post_deploy.py
+++ b/tests/test_odoo_generic_web_post_deploy.py
@@ -44,6 +44,16 @@ class OdooGenericWebPostDeployTests(unittest.TestCase):
                     phase="deploy",
                     post_deploy_status="pass",
                     override_status="pass",
+                    override_record_found=True,
+                    override_payload_rendered=True,
+                    override_payload_sha256="a" * 64,
+                    override_payload_schema_version=1,
+                    override_count=2,
+                    override_evidence={
+                        "payload_sha256": "a" * 64,
+                        "workflow_intent": "deploy",
+                        "config_parameter_count": "1",
+                    },
                 ),
             ) as post_deploy:
                 evidence = execute_odoo_generic_web_post_deploy(
@@ -55,6 +65,12 @@ class OdooGenericWebPostDeployTests(unittest.TestCase):
         self.assertTrue(evidence.attempted)
         self.assertEqual(evidence.status, "pass")
         self.assertIn("generic-web extension hook", evidence.detail)
+        self.assertEqual(evidence.evidence["driver_id"], "odoo")
+        self.assertEqual(evidence.evidence["override_status"], "pass")
+        self.assertEqual(evidence.evidence["override_record_found"], "true")
+        self.assertEqual(evidence.evidence["override_payload_rendered"], "true")
+        self.assertEqual(evidence.evidence["payload_sha256"], "a" * 64)
+        self.assertEqual(evidence.evidence["workflow_intent"], "deploy")
         post_deploy.assert_called_once()
         request = post_deploy.call_args.kwargs["request"]
         self.assertEqual(request.context, "cm")

--- a/tests/test_odoo_instance_override_rendering.py
+++ b/tests/test_odoo_instance_override_rendering.py
@@ -52,7 +52,7 @@ class OdooInstanceOverrideRenderingTests(unittest.TestCase):
         payload = render_post_deploy_payload(record)
 
         self.assertEqual(
-            payload,
+            payload.to_wire_dict(),
             {
                 "schema_version": 1,
                 "context": "opw",
@@ -97,7 +97,7 @@ class OdooInstanceOverrideRenderingTests(unittest.TestCase):
         encoded_payload = environment.inline_environment[ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY]
         decoded_payload = json.loads(base64.b64decode(encoded_payload).decode("utf-8"))
 
-        self.assertEqual(decoded_payload, render_post_deploy_payload(record))
+        self.assertEqual(decoded_payload, render_post_deploy_payload(record).to_wire_dict())
         self.assertEqual(
             set(environment.inline_environment), {ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY}
         )
@@ -141,16 +141,17 @@ class OdooInstanceOverrideRenderingTests(unittest.TestCase):
             ).decode("utf-8")
         )
 
-        self.assertEqual(payload["config_parameters"], [])
-        self.assertEqual(payload["addon_settings"], [])
-        website_bootstrap = cast("dict[str, object]", payload["website_bootstrap"])
+        wire_payload = payload.to_wire_dict()
+        self.assertEqual(wire_payload["config_parameters"], [])
+        self.assertEqual(wire_payload["addon_settings"], [])
+        website_bootstrap = cast("dict[str, object]", wire_payload["website_bootstrap"])
         routes = cast("list[dict[str, object]]", website_bootstrap["routes"])
         self.assertEqual(website_bootstrap["name"], "Example Site")
         self.assertEqual(
             website_bootstrap["canonical_url"], "https://example-testing.example.com"
         )
         self.assertEqual(routes[0]["url"], "/home")
-        self.assertEqual(decoded_payload, payload)
+        self.assertEqual(decoded_payload, wire_payload)
 
     def test_restore_intent_suppresses_website_bootstrap(self) -> None:
         record = OdooInstanceOverrideRecord(
@@ -181,6 +182,7 @@ class OdooInstanceOverrideRenderingTests(unittest.TestCase):
         )
 
         payload = render_post_deploy_payload(record, workflow_intent="restore")
+        wire_payload = payload.to_wire_dict()
         environment = build_post_deploy_environment(record, workflow_intent="restore")
         decoded_payload = json.loads(
             base64.b64decode(
@@ -188,10 +190,10 @@ class OdooInstanceOverrideRenderingTests(unittest.TestCase):
             ).decode("utf-8")
         )
 
-        self.assertNotIn("website_bootstrap", payload)
+        self.assertNotIn("website_bootstrap", wire_payload)
         self.assertNotIn("website_bootstrap", decoded_payload)
         self.assertEqual(
-            payload["config_parameters"],
+            wire_payload["config_parameters"],
             [
                 {
                     "key": "web.base.url",
@@ -202,7 +204,7 @@ class OdooInstanceOverrideRenderingTests(unittest.TestCase):
                 }
             ],
         )
-        self.assertEqual(decoded_payload, payload)
+        self.assertEqual(decoded_payload, wire_payload)
 
     def test_build_post_deploy_environment_requires_container_env_for_secret_backed_values(
         self,
@@ -290,7 +292,7 @@ class OdooInstanceOverrideRenderingTests(unittest.TestCase):
 
         payload = render_post_deploy_payload(record)
         self.assertEqual(
-            payload["addon_settings"],
+            payload.to_wire_dict()["addon_settings"],
             [
                 {
                     "addon": "shopify",
@@ -352,7 +354,7 @@ class OdooInstanceOverrideRenderingTests(unittest.TestCase):
         environment = build_post_deploy_environment(record)
 
         self.assertEqual(
-            payload["addon_settings"],
+            payload.to_wire_dict()["addon_settings"],
             [
                 {
                     "addon": "shopify",

--- a/tests/test_odoo_instance_overrides.py
+++ b/tests/test_odoo_instance_overrides.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 
 import click
 from control_plane.odoo_instance_overrides import ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY
+from control_plane.odoo_instance_overrides import build_post_deploy_environment
+from control_plane.odoo_instance_overrides import render_post_deploy_payload
 from click.testing import CliRunner
 from pydantic import ValidationError
 
@@ -69,6 +71,100 @@ class OdooInstanceOverrideTests(unittest.TestCase):
     def test_apply_result_requires_completed_timestamp(self) -> None:
         with self.assertRaisesRegex(ValidationError, "requires applied_at"):
             OdooOverrideApplyResult(attempted=True, status="pass")
+
+    def test_render_post_deploy_payload_returns_typed_v1_wire_payload(self) -> None:
+        record = OdooInstanceOverrideRecord(
+            context="OPW",
+            instance="Testing",
+            apply_on=("deploy",),
+            config_parameters=(
+                OdooConfigParameterOverride(
+                    key="WEB.BASE.URL",
+                    value=OdooOverrideValue(
+                        source="literal", value="https://opw-testing.example.com"
+                    ),
+                ),
+            ),
+            addon_settings=(
+                OdooAddonSettingOverride(
+                    addon="openai",
+                    setting="api-key",
+                    value=OdooOverrideValue(
+                        source="secret_binding",
+                        secret_binding_id="secret-opw-openai",
+                    ),
+                ),
+            ),
+            updated_at="2026-04-21T18:30:00Z",
+        )
+
+        payload = render_post_deploy_payload(record)
+
+        self.assertEqual(payload.context, "opw")
+        self.assertEqual(payload.instance, "testing")
+        self.assertEqual(
+            payload.required_container_environment_keys,
+            ("ODOO_OVERRIDE_SECRET__ADDON__OPENAI__API_KEY",),
+        )
+        self.assertEqual(payload.override_count, 2)
+        self.assertEqual(
+            payload.to_wire_dict(),
+            {
+                "schema_version": 1,
+                "context": "opw",
+                "instance": "testing",
+                "config_parameters": [
+                    {
+                        "key": "web.base.url",
+                        "value": {
+                            "source": "literal",
+                            "value": "https://opw-testing.example.com",
+                        },
+                    }
+                ],
+                "addon_settings": [
+                    {
+                        "addon": "openai",
+                        "setting": "api-key",
+                        "value": {
+                            "source": "secret_binding",
+                            "secret_binding_id": "secret-opw-openai",
+                            "environment_variable": "ODOO_OVERRIDE_SECRET__ADDON__OPENAI__API_KEY",
+                        },
+                    }
+                ],
+            },
+        )
+
+    def test_build_post_deploy_environment_reuses_typed_payload_required_keys(self) -> None:
+        record = OdooInstanceOverrideRecord(
+            context="opw",
+            instance="testing",
+            addon_settings=(
+                OdooAddonSettingOverride(
+                    addon="openai",
+                    setting="api_key",
+                    value=OdooOverrideValue(
+                        source="secret_binding",
+                        secret_binding_id="secret-opw-openai",
+                    ),
+                ),
+            ),
+            updated_at="2026-04-21T18:30:00Z",
+        )
+
+        environment = build_post_deploy_environment(record)
+
+        self.assertEqual(
+            environment.required_container_environment_keys,
+            environment.payload.required_container_environment_keys,
+        )
+        decoded_payload = json.loads(
+            base64.b64decode(
+                environment.inline_environment[ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY]
+            ).decode("utf-8")
+        )
+        self.assertEqual(decoded_payload, environment.payload.to_wire_dict())
 
     def test_cli_put_config_param_does_not_echo_plaintext_value(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_odoo_post_deploy.py
+++ b/tests/test_odoo_post_deploy.py
@@ -88,6 +88,17 @@ class OdooPostDeployWorkflowTests(unittest.TestCase):
             self.assertEqual(result.post_deploy_status, "pass")
             self.assertEqual(result.override_status, "pass")
             self.assertTrue(result.override_payload_rendered)
+            self.assertEqual(result.workflow_intent, "deploy")
+            self.assertEqual(result.override_payload_schema_version, 1)
+            self.assertEqual(result.override_count, 1)
+            self.assertFalse(result.website_bootstrap_included)
+            self.assertRegex(result.override_payload_sha256, r"^[0-9a-f]{64}$")
+            self.assertEqual(
+                result.override_evidence["payload_sha256"],
+                result.override_payload_sha256,
+            )
+            self.assertEqual(result.override_evidence["workflow_intent"], "deploy")
+            self.assertEqual(result.override_evidence["config_parameter_count"], "1")
             self.assertEqual(len(captured_runs), 1)
             workflow_environment = cast(
                 "dict[str, str]", captured_runs[0]["workflow_environment_overrides"]
@@ -226,6 +237,12 @@ class OdooPostDeployWorkflowTests(unittest.TestCase):
             self.assertEqual(result.post_deploy_status, "pass")
             self.assertEqual(result.override_status, "pass")
             self.assertTrue(result.override_payload_rendered)
+            self.assertEqual(result.workflow_intent, "restore")
+            self.assertEqual(result.override_count, 1)
+            self.assertFalse(result.website_bootstrap_included)
+            self.assertEqual(
+                result.override_evidence["website_bootstrap_included"], "false"
+            )
             self.assertEqual(len(captured_runs), 1)
             workflow_environment = cast(
                 "dict[str, str]", captured_runs[0]["workflow_environment_overrides"]
@@ -297,6 +314,14 @@ class OdooPostDeployWorkflowTests(unittest.TestCase):
 
             self.assertEqual(result.post_deploy_status, "pass")
             self.assertEqual(result.override_status, "pass")
+            self.assertEqual(
+                result.required_container_environment_keys,
+                ("ODOO_OVERRIDE_SECRET__ADDON__OPENAI__API_KEY",),
+            )
+            self.assertEqual(
+                result.override_evidence["required_container_environment_keys"],
+                "ODOO_OVERRIDE_SECRET__ADDON__OPENAI__API_KEY",
+            )
             workflow_environment = cast(
                 "dict[str, str]", captured_runs[0]["workflow_environment_overrides"]
             )


### PR DESCRIPTION
## Summary
- add a typed `OdooPostDeployPayload` contract that preserves the existing v1 JSON/base64 wire shape
- derive required container env keys, override counts, website-bootstrap inclusion, and payload digest from the typed payload instead of re-parsing raw dicts
- carry redacted Odoo override evidence through `OdooPostDeployResult` and `PostDeployUpdateEvidence`
- update records docs and tests around typed payload rendering/evidence

Closes #1044.

## Verification
- `uv run python -m unittest tests.test_odoo_instance_overrides tests.test_odoo_post_deploy tests.test_odoo_generic_web_post_deploy`
- `uv run python -m unittest tests.test_odoo_stable_target_replacement tests.test_generic_web_deploy tests.test_filesystem_store`
- `uv run python -m unittest tests.test_odoo_instance_override_rendering`
- `uv run --extra dev ruff check --diff control_plane/contracts/odoo_post_deploy_payload.py control_plane/odoo_instance_overrides.py control_plane/workflows/odoo_post_deploy.py control_plane/workflows/odoo_generic_web_post_deploy.py control_plane/contracts/promotion_record.py tests/test_odoo_instance_overrides.py tests/test_odoo_post_deploy.py tests/test_odoo_generic_web_post_deploy.py tests/test_odoo_instance_override_rendering.py`
- `uv run --extra dev ruff check control_plane/contracts/odoo_post_deploy_payload.py control_plane/odoo_instance_overrides.py control_plane/workflows/odoo_post_deploy.py control_plane/workflows/odoo_generic_web_post_deploy.py control_plane/contracts/promotion_record.py tests/test_odoo_instance_overrides.py tests/test_odoo_post_deploy.py tests/test_odoo_generic_web_post_deploy.py tests/test_odoo_instance_override_rendering.py`
- `uv run --extra dev mypy control_plane/contracts/odoo_post_deploy_payload.py control_plane/odoo_instance_overrides.py control_plane/workflows/odoo_post_deploy.py control_plane/workflows/odoo_generic_web_post_deploy.py control_plane/contracts/promotion_record.py tests/test_odoo_instance_overrides.py tests/test_odoo_post_deploy.py tests/test_odoo_generic_web_post_deploy.py tests/test_odoo_instance_override_rendering.py`
- `uv run python -m unittest` (1828 tests)