### PR TITLE
Add provider-neutral deploy target evidence

### DIFF
--- a/control_plane/contracts/deploy_target.py
+++ b/control_plane/contracts/deploy_target.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+DeployTargetCategory = Literal[
+    "application",
+    "compose",
+    "container",
+    "service",
+    "static",
+    "unknown",
+]
+
+
+class DeployedTargetReference(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    provider_id: str
+    target_category: DeployTargetCategory = "unknown"
+    target_id: str
+    display_name: str
+    provider_target_type: str = ""
+    provider_evidence: dict[str, str] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_target(self) -> "DeployedTargetReference":
+        self.provider_id = self.provider_id.strip().lower()
+        self.target_id = self.target_id.strip()
+        self.display_name = self.display_name.strip()
+        self.provider_target_type = self.provider_target_type.strip().lower()
+        if not self.provider_id:
+            raise ValueError("deployed target reference requires provider_id")
+        if not self.target_id:
+            raise ValueError("deployed target reference requires target_id")
+        if not self.display_name:
+            raise ValueError("deployed target reference requires display_name")
+        normalized_evidence: dict[str, str] = {}
+        for raw_key, raw_value in self.provider_evidence.items():
+            key = raw_key.strip()
+            if not key:
+                raise ValueError("deployed target provider evidence keys must be non-empty")
+            normalized_evidence[key] = raw_value.strip()
+        self.provider_evidence = normalized_evidence
+        return self

--- a/control_plane/contracts/deployment_record.py
+++ b/control_plane/contracts/deployment_record.py
@@ -2,6 +2,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane.contracts.deploy_target import DeployedTargetReference
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
     BootstrapEvidence,
@@ -29,6 +30,15 @@ class ResolvedTargetEvidence(BaseModel):
             raise ValueError("resolved target evidence requires target_name")
         return self
 
+    def to_deployed_target_reference(self) -> DeployedTargetReference:
+        return DeployedTargetReference(
+            provider_id="dokploy",
+            target_category=self.target_type,
+            target_id=self.target_id,
+            display_name=self.target_name,
+            provider_target_type=self.target_type,
+        )
+
 
 class DeploymentRecord(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -44,6 +54,7 @@ class DeploymentRecord(BaseModel):
     no_cache: bool = False
     delegated_executor: DelegatedExecutor = "control-plane.dokploy"
     resolved_target: ResolvedTargetEvidence | None = None
+    deployed_target: DeployedTargetReference | None = None
     runtime_source: dict[str, str] = Field(default_factory=dict)
     runtime_identity: RuntimeIdentity | None = None
     deploy: DeploymentEvidence
@@ -59,4 +70,6 @@ class DeploymentRecord(BaseModel):
             raise ValueError("deployment record requires instance")
         if not self.source_git_ref.strip():
             raise ValueError("deployment record requires source_git_ref")
+        if self.deployed_target is None and self.resolved_target is not None:
+            self.deployed_target = self.resolved_target.to_deployed_target_reference()
         return self

--- a/control_plane/contracts/lane_summary.py
+++ b/control_plane/contracts/lane_summary.py
@@ -1,8 +1,9 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.data_provenance import DataProvenance
+from control_plane.contracts.deploy_target import DeployedTargetReference
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
@@ -25,6 +26,7 @@ class LaunchplaneLaneSummary(BaseModel):
     latest_deployment: DeploymentRecord | None = None
     latest_promotion: PromotionRecord | None = None
     latest_backup_gate: BackupGateRecord | None = None
+    deployed_target: DeployedTargetReference | None = None
     dokploy_target_id: DokployTargetIdRecord | None = None
     dokploy_target: DokployTargetRecord | None = None
     runtime_environment_records: tuple[RuntimeEnvironmentRecord, ...] = ()
@@ -35,3 +37,9 @@ class LaunchplaneLaneSummary(BaseModel):
         freshness_status="missing",
         detail="Launchplane has not recorded lane evidence for this context and instance.",
     )
+
+    @model_validator(mode="after")
+    def _populate_provider_neutral_target(self) -> "LaunchplaneLaneSummary":
+        if self.deployed_target is None and self.latest_deployment is not None:
+            self.deployed_target = self.latest_deployment.deployed_target
+        return self

--- a/control_plane/contracts/promotion_record.py
+++ b/control_plane/contracts/promotion_record.py
@@ -2,6 +2,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane.contracts.deploy_target import DeployTargetCategory
 from control_plane.contracts.runtime_identity import RuntimeIdentity, RuntimeIdentityStatus
 
 ReleaseStatus = Literal["pending", "pass", "fail", "skipped"]
@@ -52,10 +53,25 @@ class DeploymentEvidence(BaseModel):
     target_name: str
     target_type: Literal["compose", "application"]
     deploy_mode: str
+    provider_id: str = "dokploy"
+    target_category: DeployTargetCategory | None = None
+    provider_deploy_mode: str = ""
     deployment_id: str = ""
     status: ReleaseStatus = "pending"
     started_at: str = ""
     finished_at: str = ""
+
+    @model_validator(mode="after")
+    def _validate_provider_evidence(self) -> "DeploymentEvidence":
+        self.provider_id = self.provider_id.strip().lower()
+        self.provider_deploy_mode = self.provider_deploy_mode.strip()
+        if not self.provider_id:
+            raise ValueError("deployment evidence requires provider_id")
+        if self.target_category is None:
+            self.target_category = self.target_type
+        if not self.provider_deploy_mode:
+            self.provider_deploy_mode = self.deploy_mode
+        return self
 
 
 class PostDeployUpdateEvidence(BaseModel):

--- a/control_plane/contracts/ship_request.py
+++ b/control_plane/contracts/ship_request.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane.contracts.deploy_target import DeployTargetCategory
 from control_plane.contracts.dokploy_target_record import DokployTargetType
 from control_plane.contracts.promotion_record import HealthcheckEvidence
 
@@ -14,7 +15,10 @@ class ShipRequest(BaseModel):
     source_git_ref: str
     target_name: str
     target_type: DokployTargetType
+    provider_id: str = "dokploy"
+    target_category: DeployTargetCategory | None = None
     deploy_mode: str
+    provider_deploy_mode: str = ""
     wait: bool = True
     timeout_seconds: int | None = Field(default=None, ge=1)
     verify_health: bool = True
@@ -34,4 +38,12 @@ class ShipRequest(BaseModel):
             raise ValueError("ship request requires instance")
         if not self.source_git_ref.strip():
             raise ValueError("ship request requires source_git_ref")
+        self.provider_id = self.provider_id.strip().lower()
+        self.provider_deploy_mode = self.provider_deploy_mode.strip()
+        if not self.provider_id:
+            raise ValueError("ship request requires provider_id")
+        if self.target_category is None:
+            self.target_category = self.target_type
+        if not self.provider_deploy_mode:
+            self.provider_deploy_mode = self.deploy_mode
         return self

--- a/docs/records.md
+++ b/docs/records.md
@@ -54,8 +54,9 @@ typed repository methods, not through service/UI code that reaches into JSONB
 payloads. The first GUI-facing repository projections are:
 
 - `LaunchplaneLaneSummary`: lane inventory, release tuple, latest deployment,
-  latest promotion, latest backup gate, target metadata, runtime environment
-  records, Odoo override metadata, and secret binding status.
+  latest promotion, latest backup gate, provider-neutral deployed target
+  metadata, runtime environment records, Odoo override metadata, and secret
+  binding status.
 - `LaunchplanePreviewSummary`: preview identity plus recent/latest generation
   state.
 
@@ -122,6 +123,11 @@ an ORM column/table or remains only in the evidence payload.
 - Dokploy target: modeled fields are `context`, `instance`, and `updated_at`.
   Provider-specific names, domains, policies, schedule, and app details stay
   payload-only until a provider-neutral target model needs them.
+- Deployment records carry provider-neutral deployed target evidence in the
+  payload (`provider_id`, `target_category`, `target_id`, and `display_name`).
+  Existing Dokploy-shaped `resolved_target` and deploy-mode fields remain
+  readable compatibility evidence and are translated into the neutral target
+  reference when no explicit provider-neutral target is present.
 - Runtime environment: modeled fields are `scope`, `context`, `instance`, and
   `updated_at`. Individual key/value settings stay payload-only until GUI
   filtering or editing requires a setting table.

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -12,6 +12,7 @@ from control_plane.contracts.artifact_identity import (
     ArtifactImageReference,
 )
 from control_plane.contracts.backup_gate_record import BackupGateRecord
+from control_plane.contracts.deploy_target import DeployedTargetReference
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
@@ -1258,6 +1259,59 @@ class FilesystemRecordStoreTests(unittest.TestCase):
             resolved_target = loaded_record.resolved_target
             assert resolved_target is not None
             self.assertEqual(resolved_target.target_id, "compose-123")
+            deployed_target = loaded_record.deployed_target
+            assert deployed_target is not None
+            self.assertEqual(deployed_target.provider_id, "dokploy")
+            self.assertEqual(deployed_target.target_category, "compose")
+            self.assertEqual(deployed_target.target_id, "compose-123")
+            self.assertEqual(deployed_target.display_name, "opw-prod")
+
+    def test_deployment_record_accepts_provider_neutral_target_without_dokploy_target(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            record = DeploymentRecord(
+                record_id="deployment-20260410T182231Z-syo-prod",
+                artifact_identity=_artifact_identity("artifact-20260410-f45db648"),
+                context="syo",
+                instance="prod",
+                source_git_ref="abc123",
+                deployed_target=DeployedTargetReference(
+                    provider_id="fake-cloud",
+                    target_category="service",
+                    target_id="svc-123",
+                    display_name="syo-prod-service",
+                    provider_target_type="managed-service",
+                    provider_evidence={"region": "us-east-1"},
+                ),
+                deploy=DeploymentEvidence(
+                    target_name="syo-prod-service",
+                    target_type="application",
+                    deploy_mode="fake-cloud-service-api",
+                    provider_id="fake-cloud",
+                    target_category="service",
+                    provider_deploy_mode="service-api",
+                    deployment_id="deploy-123",
+                    status="pass",
+                    started_at="2026-04-10T18:22:31Z",
+                    finished_at="2026-04-10T18:24:00Z",
+                ),
+            )
+
+            store.write_deployment_record(record)
+            loaded_record = store.read_deployment_record(record.record_id)
+
+        self.assertIsNone(loaded_record.resolved_target)
+        deployed_target = loaded_record.deployed_target
+        assert deployed_target is not None
+        self.assertEqual(deployed_target.provider_id, "fake-cloud")
+        self.assertEqual(deployed_target.target_category, "service")
+        self.assertEqual(deployed_target.provider_target_type, "managed-service")
+        self.assertEqual(deployed_target.provider_evidence, {"region": "us-east-1"})
+        self.assertEqual(loaded_record.deploy.provider_id, "fake-cloud")
+        self.assertEqual(loaded_record.deploy.target_category, "service")
 
     def test_list_deployment_records_filters_and_sorts_latest_first(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -25,6 +25,7 @@ from control_plane.contracts.agent_write_intent import (
 )
 from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRecord
 from control_plane.contracts.backup_gate_record import BackupGateRecord
+from control_plane.contracts.deploy_target import DeployedTargetReference
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
@@ -1312,6 +1313,59 @@ class PostgresRecordStoreTests(unittest.TestCase):
         resolved_target = loaded_record.resolved_target
         assert resolved_target is not None
         self.assertEqual(resolved_target.target_id, "compose-123")
+        deployed_target = loaded_record.deployed_target
+        assert deployed_target is not None
+        self.assertEqual(deployed_target.provider_id, "dokploy")
+        self.assertEqual(deployed_target.target_category, "compose")
+
+    def test_write_and_read_provider_neutral_deployment_target(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            record = DeploymentRecord(
+                record_id="deployment-20260420T153000Z-syo-prod",
+                artifact_identity=ArtifactIdentityReference(
+                    artifact_id="artifact-20260420-a1b2c3d4"
+                ),
+                context="syo",
+                instance="prod",
+                source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
+                deployed_target=DeployedTargetReference(
+                    provider_id="fake-cloud",
+                    target_category="service",
+                    target_id="svc-123",
+                    display_name="syo-prod-service",
+                    provider_target_type="managed-service",
+                ),
+                deploy=DeploymentEvidence(
+                    target_name="syo-prod-service",
+                    target_type="application",
+                    deploy_mode="fake-cloud-service-api",
+                    provider_id="fake-cloud",
+                    target_category="service",
+                    deployment_id="deploy-123",
+                    status="pass",
+                    started_at="2026-04-20T15:30:00Z",
+                    finished_at="2026-04-20T15:32:00Z",
+                ),
+            )
+
+            store.write_deployment_record(record)
+            loaded_record = store.read_deployment_record(record.record_id)
+            store.close()
+
+        self.assertIsNone(loaded_record.resolved_target)
+        deployed_target = loaded_record.deployed_target
+        assert deployed_target is not None
+        self.assertEqual(deployed_target.provider_id, "fake-cloud")
+        self.assertEqual(deployed_target.target_category, "service")
+        self.assertEqual(deployed_target.target_id, "svc-123")
+        self.assertEqual(loaded_record.deploy.provider_id, "fake-cloud")
+        self.assertEqual(loaded_record.deploy.target_category, "service")
 
     def test_write_and_list_generic_web_rollback_plan_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -2434,6 +2488,11 @@ env_var = "GH_TOKEN"
         dokploy_target = summary.dokploy_target
         assert dokploy_target is not None
         self.assertEqual(dokploy_target.target_name, "opw-testing")
+        deployed_target = summary.deployed_target
+        assert deployed_target is not None
+        self.assertEqual(deployed_target.provider_id, "dokploy")
+        self.assertEqual(deployed_target.target_category, "compose")
+        self.assertEqual(deployed_target.target_id, "compose-123")
         self.assertEqual(
             [
                 (record.scope, record.context, record.instance)


### PR DESCRIPTION
## Summary
- add provider-neutral deployed target evidence with provider id, target category, id, display name, and adapter evidence
- keep existing Dokploy-shaped resolved target fields readable and translate them into neutral target references
- add provider metadata to ship/deploy evidence while preserving existing defaults
- expose neutral deployed target metadata on lane summaries
- document the compatibility boundary and add fake-provider storage coverage

Closes #1045.

## Verification
- `uv run python -m unittest tests.test_filesystem_store tests.test_postgres_store`
- `uv run python -m unittest tests.test_generic_web_deploy tests.test_generic_web_promotion tests.test_promote tests.test_evidence_ingestion tests.test_public_ingress_monitor tests.test_product_environment_read_model`
- `uv run --extra dev ruff check --diff control_plane/contracts/deploy_target.py control_plane/contracts/deployment_record.py control_plane/contracts/promotion_record.py control_plane/contracts/ship_request.py control_plane/contracts/lane_summary.py tests/test_filesystem_store.py tests/test_postgres_store.py`
- `uv run --extra dev ruff check control_plane/contracts/deploy_target.py control_plane/contracts/deployment_record.py control_plane/contracts/promotion_record.py control_plane/contracts/ship_request.py control_plane/contracts/lane_summary.py tests/test_filesystem_store.py tests/test_postgres_store.py`
- `uv run --extra dev mypy control_plane/contracts/deploy_target.py control_plane/contracts/deployment_record.py control_plane/contracts/promotion_record.py control_plane/contracts/ship_request.py control_plane/contracts/lane_summary.py tests/test_filesystem_store.py tests/test_postgres_store.py`
- `uv run python -m unittest` (1830 tests)