### PR TITLE
Model ingress identity access bindings

### DIFF
--- a/control_plane/workflows/npmplus_ingress.py
+++ b/control_plane/workflows/npmplus_ingress.py
@@ -15,6 +15,8 @@ from control_plane.npmplus import (
 type NpmplusIngressMode = Literal["dry-run", "apply"]
 type NpmplusIngressOperationAction = Literal["create", "update", "enable", "disable", "no-op"]
 type NpmplusIngressStatus = Literal["planned", "applied", "unchanged"]
+type IngressIdentityAccessMode = Literal["none", "forward-auth"]
+type IngressIdentityAccessProvider = Literal["none", "anubis", "tinyauth", "authelia", "authentik"]
 
 
 class NpmplusIngressClient(Protocol):
@@ -29,6 +31,49 @@ class NpmplusIngressClient(Protocol):
     def disable_proxy_host(self, host_id: int) -> NpmplusProxyHost: ...
 
     def enable_proxy_host(self, host_id: int) -> NpmplusProxyHost: ...
+
+
+class IngressIdentityAccessBinding(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = 1
+    mode: IngressIdentityAccessMode = "none"
+    provider: IngressIdentityAccessProvider = "none"
+    send_basic_auth: bool = False
+
+    @model_validator(mode="after")
+    def _validate_binding(self) -> "IngressIdentityAccessBinding":
+        if self.schema_version != 1:
+            raise ValueError("Unsupported ingress identity/access schema version")
+        if self.mode == "none":
+            if self.provider != "none" or self.send_basic_auth:
+                raise ValueError("Disabled ingress identity/access binding must use provider=none")
+        elif self.provider == "none":
+            raise ValueError("Forward-auth ingress identity/access binding requires a provider")
+        return self
+
+    def to_npmplus_auth_request(self) -> NpmplusAuthRequest:
+        if self.mode == "none":
+            return "none"
+        if self.provider == "authentik" and self.send_basic_auth:
+            return "authentik-send-basic-auth"
+        if self.provider in {"anubis", "tinyauth", "authelia", "authentik"}:
+            return self.provider
+        raise ValueError("Unsupported ingress identity/access provider")
+
+
+def identity_access_from_npmplus_auth_request(
+    auth_request: NpmplusAuthRequest,
+) -> IngressIdentityAccessBinding:
+    if auth_request == "none":
+        return IngressIdentityAccessBinding()
+    if auth_request == "authentik":
+        return IngressIdentityAccessBinding(mode="forward-auth", provider="authentik")
+    if auth_request == "authentik-send-basic-auth":
+        return IngressIdentityAccessBinding(
+            mode="forward-auth", provider="authentik", send_basic_auth=True
+        )
+    return IngressIdentityAccessBinding(mode="forward-auth", provider=auth_request)
 
 
 class NpmplusIngressRouteDesiredState(BaseModel):
@@ -54,12 +99,28 @@ class NpmplusIngressRouteDesiredState(BaseModel):
     npmplus_fancyindex: bool = False
     npmplus_x_frame_options: Literal["DENY", "SAMEORIGIN", "upstream", "none"] = "SAMEORIGIN"
     npmplus_auth_request: NpmplusAuthRequest = "none"
+    identity_access: IngressIdentityAccessBinding | None = None
     advanced_config: str = ""
     enabled: bool = True
     locations: tuple[NpmplusLocationPayload, ...] = ()
 
+    @model_validator(mode="after")
+    def _validate_identity_access(self) -> "NpmplusIngressRouteDesiredState":
+        if self.identity_access is None:
+            return self
+        mapped_auth_request = self.identity_access.to_npmplus_auth_request()
+        if "npmplus_auth_request" in self.model_fields_set and self.npmplus_auth_request not in {
+            "none",
+            mapped_auth_request,
+        }:
+            raise ValueError("ingress identity_access conflicts with npmplus_auth_request")
+        self.npmplus_auth_request = mapped_auth_request
+        return self
+
     def to_proxy_host_payload(self) -> NpmplusProxyHostPayload:
-        return NpmplusProxyHostPayload.model_validate(self.model_dump(mode="json"))
+        return NpmplusProxyHostPayload.model_validate(
+            self.model_dump(mode="json", exclude={"identity_access"})
+        )
 
 
 class NpmplusIngressApplyRequest(BaseModel):

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -178,6 +178,17 @@ an explicit `--idempotency-key`. The CLI accepts a bearer token from
 `LAUNCHPLANE_SERVICE_TOKEN` by default or a signed browser session via
 `--session-cookie`; it must not read NPMplus credentials locally.
 
+Ingress identity/access should be modeled separately from the edge data plane.
+Routes may carry a provider-neutral `identity_access` binding with
+`mode: "none"` or `mode: "forward-auth"`. The binding maps the existing NPMplus
+`anubis`, `tinyauth`, `authelia`, and `authentik` auth-request modes into a
+provider-neutral provider name. `send_basic_auth: true` is specific to
+Authentik and maps to NPMplus `authentik-send-basic-auth`, which forwards basic
+auth material through the Authentik integration for routes that intentionally
+need that mode. Keep Authentik instance placement, provider ids, app slugs, and
+private route evidence in private infra docs. Launchplane should consume only
+sanitized desired state and managed-secret references.
+
 Operators can also use the `Ingress Route Dry Run` GitHub workflow for a
 service-mediated canary plan through GitHub OIDC. The workflow accepts the
 product, context, domain, upstream target, existing certificate id, expected

--- a/tests/test_npmplus_ingress_workflow.py
+++ b/tests/test_npmplus_ingress_workflow.py
@@ -4,9 +4,11 @@ import click
 
 from control_plane.npmplus import NpmplusProxyHost, NpmplusProxyHostPayload
 from control_plane.workflows.npmplus_ingress import (
+    IngressIdentityAccessBinding,
     NpmplusIngressApplyRequest,
     NpmplusIngressRouteDesiredState,
     apply_npmplus_ingress_route,
+    identity_access_from_npmplus_auth_request,
 )
 
 
@@ -182,6 +184,71 @@ class NpmplusIngressWorkflowTests(unittest.TestCase):
         self.assertEqual(result.status, "unchanged")
         self.assertEqual(tuple(operation.action for operation in result.operations), ("no-op",))
         self.assertEqual(client.calls, ["list"])
+
+    def test_identity_access_binding_maps_authentik_forward_auth(self) -> None:
+        route = _desired_route(
+            identity_access={
+                "mode": "forward-auth",
+                "provider": "authentik",
+            }
+        )
+
+        payload = route.to_proxy_host_payload()
+
+        self.assertEqual(payload.npmplus_auth_request, "authentik")
+        self.assertEqual(
+            route.identity_access.provider if route.identity_access else "", "authentik"
+        )
+
+    def test_identity_access_binding_maps_authentik_basic_auth_forwarding(self) -> None:
+        route = _desired_route(
+            identity_access={
+                "mode": "forward-auth",
+                "provider": "authentik",
+                "send_basic_auth": True,
+            }
+        )
+
+        self.assertEqual(
+            route.to_proxy_host_payload().npmplus_auth_request,
+            "authentik-send-basic-auth",
+        )
+
+    def test_identity_access_binding_rejects_provider_without_forward_auth(self) -> None:
+        with self.assertRaises(ValueError):
+            IngressIdentityAccessBinding.model_validate({"mode": "none", "provider": "authentik"})
+
+    def test_identity_access_binding_rejects_npmplus_conflict(self) -> None:
+        with self.assertRaises(ValueError):
+            _desired_route(
+                npmplus_auth_request="authelia",
+                identity_access={"mode": "forward-auth", "provider": "authentik"},
+            )
+
+    def test_identity_access_binding_treats_legacy_none_as_unset(self) -> None:
+        route = _desired_route(
+            npmplus_auth_request="none",
+            identity_access={"mode": "forward-auth", "provider": "authentik"},
+        )
+
+        self.assertEqual(route.to_proxy_host_payload().npmplus_auth_request, "authentik")
+
+    def test_identity_access_can_be_derived_from_npmplus_authentik(self) -> None:
+        binding = identity_access_from_npmplus_auth_request("authentik-send-basic-auth")
+
+        self.assertEqual(binding.mode, "forward-auth")
+        self.assertEqual(binding.provider, "authentik")
+        self.assertTrue(binding.send_basic_auth)
+
+    def test_identity_access_round_trips_existing_npmplus_auth_request_modes(self) -> None:
+        for auth_request in ("anubis", "tinyauth", "authelia", "authentik"):
+            with self.subTest(auth_request=auth_request):
+                binding = identity_access_from_npmplus_auth_request(auth_request)
+
+                self.assertEqual(binding.mode, "forward-auth")
+                self.assertEqual(binding.provider, auth_request)
+                self.assertFalse(binding.send_basic_auth)
+                self.assertEqual(binding.to_npmplus_auth_request(), auth_request)
 
     def test_rejects_ambiguous_domain_matches(self) -> None:
         client = _FakeNpmplusClient((_proxy_host(id=78), _proxy_host(id=79)))


### PR DESCRIPTION
## Summary

- add a provider-neutral ingress `identity_access` binding shape
- map NPMplus forward-auth modes (`anubis`, `tinyauth`, `authelia`, `authentik`) through the typed binding
- keep Authentik `send_basic_auth` explicit and mapped to `authentik-send-basic-auth`
- reject conflicting `identity_access` and raw `npmplus_auth_request` inputs
- document that private Authentik placement/provider ids stay in private infra docs

## Verification

- `uv run python -m unittest tests.test_npmplus_ingress_workflow`
- `uv run --extra dev ruff check control_plane/workflows/npmplus_ingress.py tests/test_npmplus_ingress_workflow.py`
- `uv run --extra dev ruff format --check control_plane/workflows/npmplus_ingress.py tests/test_npmplus_ingress_workflow.py`
- `uv run --extra dev mypy control_plane/workflows/npmplus_ingress.py tests/test_npmplus_ingress_workflow.py`
- `git diff --check`

Refs #1051
