### PR TITLE
Extract generic web deploy provider seam

### DIFF
--- a/control_plane/contracts/deployment_record.py
+++ b/control_plane/contracts/deployment_record.py
@@ -12,7 +12,7 @@ from control_plane.contracts.promotion_record import (
 )
 from control_plane.contracts.runtime_identity import RuntimeIdentity
 
-DelegatedExecutor = Literal["control-plane.dokploy"]
+DelegatedExecutor = str
 
 
 class ResolvedTargetEvidence(BaseModel):
@@ -70,6 +70,9 @@ class DeploymentRecord(BaseModel):
             raise ValueError("deployment record requires instance")
         if not self.source_git_ref.strip():
             raise ValueError("deployment record requires source_git_ref")
+        self.delegated_executor = self.delegated_executor.strip()
+        if not self.delegated_executor:
+            raise ValueError("deployment record requires delegated_executor")
         if self.deployed_target is None and self.resolved_target is not None:
             self.deployed_target = self.resolved_target.to_deployed_target_reference()
         return self

--- a/control_plane/workflows/generic_web_deploy.py
+++ b/control_plane/workflows/generic_web_deploy.py
@@ -6,9 +6,7 @@ from typing import Callable, Literal, Protocol
 import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from control_plane import dokploy as control_plane_dokploy
-from control_plane import runtime_environments as control_plane_runtime_environments
-from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
+from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetType
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.product_profile_record import (
@@ -19,7 +17,9 @@ from control_plane.contracts.promotion_record import HealthcheckEvidence, PostDe
 from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.drivers.registry import read_driver_descriptor
-from control_plane.workflows.dokploy_deploy import execute_dokploy_artifact_deploy
+from control_plane.workflows.generic_web_deploy_provider import GenericWebDeployProvider
+from control_plane.workflows.generic_web_deploy_provider import GenericWebResolvedDeployTarget
+from control_plane.workflows.generic_web_deploy_provider import default_generic_web_deploy_provider
 from control_plane.workflows.inventory import build_environment_inventory
 from control_plane.workflows.ship import (
     build_deployment_record,
@@ -143,12 +143,6 @@ def product_profile_uses_generic_web_base(profile: LaunchplaneProductProfileReco
         return False
 
 
-def _resolve_deploy_mode(*, configured_ship_mode: str, target_type: DokployTargetType) -> str:
-    if configured_ship_mode == "auto":
-        return f"dokploy-{target_type}-api"
-    return f"dokploy-{configured_ship_mode}-api"
-
-
 def _fallback_target_name(
     *, profile: LaunchplaneProductProfileRecord, lane: ProductLaneProfile
 ) -> str:
@@ -202,7 +196,12 @@ def _fallback_ship_request(
     request: GenericWebDeployRequest,
     profile: LaunchplaneProductProfileRecord,
     lane: ProductLaneProfile,
+    deploy_provider: GenericWebDeployProvider,
 ) -> ShipRequest:
+    provider_id = deploy_provider.provider_id.strip().lower()
+    if not provider_id:
+        raise click.ClickException("Generic web deploy provider requires provider_id.")
+    deploy_mode = f"{provider_id}-application-api"
     return ShipRequest(
         artifact_id=normalize_generic_web_artifact_id(
             profile=profile,
@@ -213,7 +212,10 @@ def _fallback_ship_request(
         source_git_ref=request.source_git_ref,
         target_name=_fallback_target_name(profile=profile, lane=lane),
         target_type="application",
-        deploy_mode="dokploy-application-api",
+        deploy_mode=deploy_mode,
+        provider_id=provider_id,
+        target_category="application",
+        provider_deploy_mode=deploy_mode,
         wait=True,
         timeout_seconds=request.timeout_seconds,
         verify_health=False,
@@ -222,69 +224,28 @@ def _fallback_ship_request(
     )
 
 
-def _resolve_ship_request(
+def _resolve_deploy_target(
     *,
     control_plane_root: Path,
     request: GenericWebDeployRequest,
     profile: LaunchplaneProductProfileRecord,
     lane: ProductLaneProfile,
-) -> tuple[ShipRequest, ResolvedTargetEvidence, int]:
-    source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
+    deploy_provider: GenericWebDeployProvider,
+) -> GenericWebResolvedDeployTarget:
+    return deploy_provider.resolve_deploy_target(
         control_plane_root=control_plane_root,
-    )
-    target_definition = control_plane_dokploy.find_dokploy_target_definition(
-        source_of_truth,
-        context_name=lane.context,
-        instance_name=lane.instance,
-    )
-    if target_definition is None:
-        raise click.ClickException(
-            f"No Dokploy target definition found for {lane.context}/{lane.instance}."
-        )
-
-    environment_values = control_plane_runtime_environments.resolve_runtime_environment_values(
-        control_plane_root=control_plane_root,
-        context_name=lane.context,
-        instance_name=lane.instance,
-    )
-    deploy_mode = _resolve_deploy_mode(
-        configured_ship_mode=control_plane_dokploy.resolve_dokploy_ship_mode(
-            lane.context,
-            lane.instance,
-            environment_values,
-        ),
-        target_type=target_definition.target_type,
-    )
-    target_name = target_definition.target_name.strip() or _fallback_target_name(
-        profile=profile, lane=lane
-    )
-    ship_request = ShipRequest(
-        artifact_id=normalize_generic_web_artifact_id(
+        request_artifact_id=request.artifact_id,
+        request_source_git_ref=request.source_git_ref,
+        request_timeout_seconds=request.timeout_seconds,
+        request_no_cache=request.no_cache,
+        profile=profile,
+        lane=lane,
+        normalized_artifact_id=normalize_generic_web_artifact_id(
             profile=profile,
             artifact_id=request.artifact_id,
         ),
-        context=lane.context,
-        instance=lane.instance,
-        source_git_ref=request.source_git_ref,
-        target_name=target_name,
-        target_type=target_definition.target_type,
-        deploy_mode=deploy_mode,
-        wait=True,
-        timeout_seconds=request.timeout_seconds,
-        verify_health=False,
-        no_cache=request.no_cache,
-        destination_health=HealthcheckEvidence(status="skipped"),
+        fallback_target_name=_fallback_target_name(profile=profile, lane=lane),
     )
-    resolved_target = ResolvedTargetEvidence(
-        target_type=target_definition.target_type,
-        target_id=target_definition.target_id,
-        target_name=target_name,
-    )
-    deploy_timeout_seconds = control_plane_dokploy.resolve_ship_timeout_seconds(
-        timeout_override_seconds=request.timeout_seconds,
-        target_definition=target_definition,
-    )
-    return ship_request, resolved_target, deploy_timeout_seconds
 
 
 def execute_generic_web_deploy(
@@ -295,7 +256,9 @@ def execute_generic_web_deploy(
     profile: LaunchplaneProductProfileRecord | None = None,
     lane: ProductLaneProfile | None = None,
     post_deploy_executor: GenericWebPostDeployExecutor | None = None,
+    deploy_provider: GenericWebDeployProvider | None = None,
 ) -> GenericWebDeployResult:
+    resolved_deploy_provider = deploy_provider or default_generic_web_deploy_provider()
     resolved_profile = profile
     resolved_lane = lane
     if resolved_profile is None or resolved_lane is None:
@@ -313,15 +276,19 @@ def execute_generic_web_deploy(
         request=request,
         profile=resolved_profile,
         lane=resolved_lane,
+        deploy_provider=resolved_deploy_provider,
     )
 
     try:
-        ship_request, resolved_target, deploy_timeout_seconds = _resolve_ship_request(
+        resolved_deploy_target = _resolve_deploy_target(
             control_plane_root=control_plane_root,
             request=request,
             profile=resolved_profile,
             lane=resolved_lane,
+            deploy_provider=resolved_deploy_provider,
         )
+        ship_request = resolved_deploy_target.ship_request
+        resolved_target = resolved_deploy_target.resolved_target
     except click.ClickException as exc:
         finished_at = utc_now_timestamp()
         record_store.write_deployment_record(
@@ -332,6 +299,7 @@ def execute_generic_web_deploy(
                 deployment_status="fail",
                 started_at=started_at,
                 finished_at=finished_at,
+                delegated_executor=resolved_deploy_provider.delegated_executor,
             )
         )
         return GenericWebDeployResult(
@@ -348,15 +316,9 @@ def execute_generic_web_deploy(
     deploy_completed = False
     post_deploy_update = PostDeployUpdateEvidence()
     try:
-        host, token = control_plane_dokploy.read_dokploy_config(
-            control_plane_root=control_plane_root
-        )
-        execute_dokploy_artifact_deploy(
-            host=host,
-            token=token,
-            ship_request=ship_request,
-            resolved_target=resolved_target,
-            deploy_timeout_seconds=deploy_timeout_seconds,
+        resolved_deploy_provider.execute_artifact_deploy(
+            control_plane_root=control_plane_root,
+            resolved_deploy_target=resolved_deploy_target,
             runtime_identity=_build_runtime_identity(
                 profile=resolved_profile,
                 lane=resolved_lane,
@@ -414,6 +376,8 @@ def execute_generic_web_deploy(
             started_at=started_at,
             finished_at=finished_at,
             resolved_target=resolved_target,
+            deployed_target=resolved_deploy_target.deployed_target,
+            delegated_executor=resolved_deploy_provider.delegated_executor,
             post_deploy_update=post_deploy_update,
             runtime_identity=runtime_identity,
         )
@@ -449,6 +413,8 @@ def execute_generic_web_deploy(
         started_at=started_at,
         finished_at=finished_at,
         resolved_target=resolved_target,
+        deployed_target=resolved_deploy_target.deployed_target,
+        delegated_executor=resolved_deploy_provider.delegated_executor,
         post_deploy_update=post_deploy_update,
         runtime_identity=_build_runtime_identity(
             profile=resolved_profile,

--- a/control_plane/workflows/generic_web_deploy_provider.py
+++ b/control_plane/workflows/generic_web_deploy_provider.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+import click
+from pydantic import BaseModel, ConfigDict, Field
+
+from control_plane import dokploy as control_plane_dokploy
+from control_plane import runtime_environments as control_plane_runtime_environments
+from control_plane.contracts.deploy_target import DeployedTargetReference
+from control_plane.contracts.deployment_record import ResolvedTargetEvidence
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductLaneProfile,
+)
+from control_plane.contracts.promotion_record import HealthcheckEvidence
+from control_plane.contracts.runtime_identity import RuntimeIdentity
+from control_plane.contracts.ship_request import ShipRequest
+from control_plane.workflows.dokploy_deploy import execute_dokploy_artifact_deploy
+
+
+class GenericWebResolvedDeployTarget(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ship_request: ShipRequest
+    resolved_target: ResolvedTargetEvidence
+    deployed_target: DeployedTargetReference | None = None
+    deploy_timeout_seconds: int = Field(ge=1)
+
+
+class GenericWebDeployProvider(Protocol):
+    provider_id: str
+    delegated_executor: str
+
+    def resolve_deploy_target(
+        self,
+        *,
+        control_plane_root: Path,
+        request_artifact_id: str,
+        request_source_git_ref: str,
+        request_timeout_seconds: int | None,
+        request_no_cache: bool,
+        profile: LaunchplaneProductProfileRecord,
+        lane: ProductLaneProfile,
+        normalized_artifact_id: str,
+        fallback_target_name: str,
+    ) -> GenericWebResolvedDeployTarget: ...
+
+    def execute_artifact_deploy(
+        self,
+        *,
+        control_plane_root: Path,
+        resolved_deploy_target: GenericWebResolvedDeployTarget,
+        runtime_identity: RuntimeIdentity,
+    ) -> None: ...
+
+
+class DokployGenericWebDeployProvider:
+    provider_id = "dokploy"
+    delegated_executor = "control-plane.dokploy"
+
+    def resolve_deploy_target(
+        self,
+        *,
+        control_plane_root: Path,
+        request_artifact_id: str,
+        request_source_git_ref: str,
+        request_timeout_seconds: int | None,
+        request_no_cache: bool,
+        profile: LaunchplaneProductProfileRecord,
+        lane: ProductLaneProfile,
+        normalized_artifact_id: str,
+        fallback_target_name: str,
+    ) -> GenericWebResolvedDeployTarget:
+        del request_artifact_id, profile
+        source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
+            control_plane_root=control_plane_root,
+        )
+        target_definition = control_plane_dokploy.find_dokploy_target_definition(
+            source_of_truth,
+            context_name=lane.context,
+            instance_name=lane.instance,
+        )
+        if target_definition is None:
+            raise click.ClickException(
+                f"No Dokploy target definition found for {lane.context}/{lane.instance}."
+            )
+
+        environment_values = (
+            control_plane_runtime_environments.resolve_runtime_environment_values(
+                control_plane_root=control_plane_root,
+                context_name=lane.context,
+                instance_name=lane.instance,
+            )
+        )
+        configured_ship_mode = control_plane_dokploy.resolve_dokploy_ship_mode(
+            lane.context,
+            lane.instance,
+            environment_values,
+        )
+        deploy_mode = _resolve_dokploy_deploy_mode(
+            configured_ship_mode=configured_ship_mode,
+            target_type=target_definition.target_type,
+        )
+        target_name = target_definition.target_name.strip() or fallback_target_name
+        ship_request = ShipRequest(
+            artifact_id=normalized_artifact_id,
+            context=lane.context,
+            instance=lane.instance,
+            source_git_ref=request_source_git_ref,
+            target_name=target_name,
+            target_type=target_definition.target_type,
+            deploy_mode=deploy_mode,
+            provider_id=self.provider_id,
+            target_category=target_definition.target_type,
+            provider_deploy_mode=deploy_mode,
+            wait=True,
+            timeout_seconds=request_timeout_seconds,
+            verify_health=False,
+            no_cache=request_no_cache,
+            destination_health=HealthcheckEvidence(status="skipped"),
+        )
+        resolved_target = ResolvedTargetEvidence(
+            target_type=target_definition.target_type,
+            target_id=target_definition.target_id,
+            target_name=target_name,
+        )
+        deployed_target = DeployedTargetReference(
+            provider_id=self.provider_id,
+            target_category=target_definition.target_type,
+            target_id=target_definition.target_id,
+            display_name=target_name,
+            provider_target_type=target_definition.target_type,
+        )
+        deploy_timeout_seconds = control_plane_dokploy.resolve_ship_timeout_seconds(
+            timeout_override_seconds=request_timeout_seconds,
+            target_definition=target_definition,
+        )
+        return GenericWebResolvedDeployTarget(
+            ship_request=ship_request,
+            resolved_target=resolved_target,
+            deployed_target=deployed_target,
+            deploy_timeout_seconds=deploy_timeout_seconds,
+        )
+
+    def execute_artifact_deploy(
+        self,
+        *,
+        control_plane_root: Path,
+        resolved_deploy_target: GenericWebResolvedDeployTarget,
+        runtime_identity: RuntimeIdentity,
+    ) -> None:
+        host, token = control_plane_dokploy.read_dokploy_config(
+            control_plane_root=control_plane_root
+        )
+        execute_dokploy_artifact_deploy(
+            host=host,
+            token=token,
+            ship_request=resolved_deploy_target.ship_request,
+            resolved_target=resolved_deploy_target.resolved_target,
+            deploy_timeout_seconds=resolved_deploy_target.deploy_timeout_seconds,
+            runtime_identity=runtime_identity,
+        )
+
+
+def _resolve_dokploy_deploy_mode(*, configured_ship_mode: str, target_type: str) -> str:
+    if configured_ship_mode == "auto":
+        return f"dokploy-{target_type}-api"
+    return f"dokploy-{configured_ship_mode}-api"
+
+
+def default_generic_web_deploy_provider() -> GenericWebDeployProvider:
+    return DokployGenericWebDeployProvider()

--- a/control_plane/workflows/ship.py
+++ b/control_plane/workflows/ship.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime
 
+from control_plane.contracts.deploy_target import DeployedTargetReference
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.deployment_record import DelegatedExecutor
 from control_plane.contracts.deployment_record import ResolvedTargetEvidence
@@ -91,6 +92,7 @@ def build_deployment_record(
     started_at: str,
     finished_at: str,
     resolved_target: ResolvedTargetEvidence | None = None,
+    deployed_target: DeployedTargetReference | None = None,
     delegated_executor: DelegatedExecutor = "control-plane.dokploy",
     runtime_source: dict[str, str] | None = None,
     runtime_identity: RuntimeIdentity | None = None,
@@ -113,12 +115,16 @@ def build_deployment_record(
         no_cache=request.no_cache,
         delegated_executor=delegated_executor,
         resolved_target=resolved_target,
+        deployed_target=deployed_target,
         runtime_source=runtime_source or {},
         runtime_identity=runtime_identity,
         deploy=DeploymentEvidence(
             target_name=request.target_name,
             target_type=request.target_type,
             deploy_mode=request.deploy_mode,
+            provider_id=request.provider_id,
+            target_category=request.target_category,
+            provider_deploy_mode=request.provider_deploy_mode,
             deployment_id=deployment_id,
             status=deployment_status,
             started_at=started_at,

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -70,6 +70,13 @@ release, backup, promotion, migration, and post-deploy invariants are either
 represented in generic contracts or still explicitly wrapped by the product
 driver.
 
+Generic-web deploy resolves and executes runtime targets through a deploy
+provider adapter. The default adapter is Dokploy, but generic-web orchestration
+must depend on the adapter protocol rather than importing provider clients
+directly. Deployment records must carry the adapter's provider identity,
+provider target reference, and delegated executor so operator evidence stays
+accurate when a future deploy provider is introduced.
+
 ## Capability Design
 
 Use capability names to describe operator-visible behavior, not implementation

--- a/tests/test_generic_web_deploy.py
+++ b/tests/test_generic_web_deploy.py
@@ -1,10 +1,11 @@
-import unittest
 from pathlib import Path
+import unittest
 from unittest.mock import patch
 
 import click
 
-from control_plane.contracts.deployment_record import DeploymentRecord
+from control_plane.contracts.deploy_target import DeployedTargetReference
+from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.promotion_record import PostDeployUpdateEvidence
 from control_plane.contracts.product_profile_record import (
@@ -13,6 +14,8 @@ from control_plane.contracts.product_profile_record import (
     ProductLaneProfile,
     ProductPreviewProfile,
 )
+from control_plane.contracts.runtime_identity import RuntimeIdentity
+from control_plane.contracts.ship_request import ShipRequest
 from control_plane.dokploy import DokploySourceOfTruth, DokployTargetDefinition
 from control_plane.workflows.generic_web_deploy import (
     GenericWebDeployRequest,
@@ -22,6 +25,23 @@ from control_plane.workflows.generic_web_deploy import (
     normalize_generic_web_artifact_id,
     resolve_generic_web_profile_lane,
 )
+from control_plane.workflows.generic_web_deploy_provider import DokployGenericWebDeployProvider
+from control_plane.workflows.generic_web_deploy_provider import GenericWebResolvedDeployTarget
+
+
+def _source_of_truth() -> DokploySourceOfTruth:
+    return DokploySourceOfTruth(
+        schema_version=1,
+        targets=(
+            DokployTargetDefinition(
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_type="application",
+                target_id="target-123",
+                target_name="sellyouroutboard-testing-app",
+            ),
+        ),
+    )
 
 
 class _GenericWebDeployStore:
@@ -78,19 +98,74 @@ def _request(instance: str = "testing") -> GenericWebDeployRequest:
     )
 
 
-def _source_of_truth() -> DokploySourceOfTruth:
-    return DokploySourceOfTruth(
-        schema_version=1,
-        targets=(
-            DokployTargetDefinition(
-                context="sellyouroutboard-testing",
-                instance="testing",
+class _FakeGenericWebDeployProvider:
+    provider_id = "fake-cloud"
+    delegated_executor = "control-plane.fake-cloud"
+
+    def __init__(self, *, deploy_error: click.ClickException | None = None) -> None:
+        self.deploy_error = deploy_error
+        self.resolved_targets: list[GenericWebResolvedDeployTarget] = []
+        self.runtime_identities: list[RuntimeIdentity] = []
+
+    def resolve_deploy_target(
+        self,
+        *,
+        control_plane_root: Path,
+        request_artifact_id: str,
+        request_source_git_ref: str,
+        request_timeout_seconds: int | None,
+        request_no_cache: bool,
+        profile: LaunchplaneProductProfileRecord,
+        lane: ProductLaneProfile,
+        normalized_artifact_id: str,
+        fallback_target_name: str,
+    ) -> GenericWebResolvedDeployTarget:
+        del control_plane_root, request_artifact_id, profile, fallback_target_name
+        resolved = GenericWebResolvedDeployTarget(
+            ship_request=ShipRequest(
+                artifact_id=normalized_artifact_id,
+                context=lane.context,
+                instance=lane.instance,
+                source_git_ref=request_source_git_ref,
+                target_name="sellyouroutboard-testing-app",
+                target_type="application",
+                deploy_mode="fake-cloud-service-api",
+                provider_id=self.provider_id,
+                target_category="service",
+                provider_deploy_mode="service-api",
+                wait=True,
+                timeout_seconds=request_timeout_seconds,
+                verify_health=False,
+                no_cache=request_no_cache,
+            ),
+            resolved_target=ResolvedTargetEvidence(
                 target_type="application",
                 target_id="target-123",
                 target_name="sellyouroutboard-testing-app",
             ),
-        ),
-    )
+            deployed_target=DeployedTargetReference(
+                provider_id=self.provider_id,
+                target_category="service",
+                target_id="target-123",
+                display_name="sellyouroutboard-testing-app",
+                provider_target_type="managed-service",
+            ),
+            deploy_timeout_seconds=request_timeout_seconds or 600,
+        )
+        self.resolved_targets.append(resolved)
+        return resolved
+
+    def execute_artifact_deploy(
+        self,
+        *,
+        control_plane_root: Path,
+        resolved_deploy_target: GenericWebResolvedDeployTarget,
+        runtime_identity: RuntimeIdentity,
+    ) -> None:
+        del control_plane_root, resolved_deploy_target
+        self.runtime_identities.append(runtime_identity)
+        if self.deploy_error is not None:
+            raise self.deploy_error
 
 
 class GenericWebDeployTests(unittest.TestCase):
@@ -114,29 +189,14 @@ class GenericWebDeployTests(unittest.TestCase):
 
     def test_execute_generic_web_deploy_writes_pass_record_for_profile_lane(self) -> None:
         store = _GenericWebDeployStore(_profile())
+        deploy_provider = _FakeGenericWebDeployProvider()
 
-        with (
-            patch(
-                "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
-                return_value=_source_of_truth(),
-            ),
-            patch(
-                "control_plane.workflows.generic_web_deploy.control_plane_runtime_environments.resolve_runtime_environment_values",
-                return_value={},
-            ),
-            patch(
-                "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_dokploy_config",
-                return_value=("https://dokploy.example", "token"),
-            ),
-            patch(
-                "control_plane.workflows.generic_web_deploy.execute_dokploy_artifact_deploy"
-            ) as deploy,
-        ):
-            result = execute_generic_web_deploy(
-                control_plane_root=Path("."),
-                record_store=store,
-                request=_request(),
-            )
+        result = execute_generic_web_deploy(
+            control_plane_root=Path("."),
+            record_store=store,
+            request=_request(),
+            deploy_provider=deploy_provider,
+        )
 
         self.assertEqual(result.deploy_status, "pass")
         self.assertEqual(result.context, "sellyouroutboard-testing")
@@ -174,9 +234,20 @@ class GenericWebDeployTests(unittest.TestCase):
         resolved_target = store.deployments[0].resolved_target
         assert resolved_target is not None
         self.assertEqual(resolved_target.target_name, "sellyouroutboard-testing-app")
-        deploy.assert_called_once()
         self.assertEqual(
-            deploy.call_args.kwargs["runtime_identity"].deployment_record_id,
+            store.deployments[0].delegated_executor,
+            "control-plane.fake-cloud",
+        )
+        self.assertEqual(store.deployments[0].deploy.provider_id, "fake-cloud")
+        self.assertEqual(store.deployments[0].deploy.target_category, "service")
+        deployed_target = store.deployments[0].deployed_target
+        assert deployed_target is not None
+        self.assertEqual(deployed_target.provider_id, "fake-cloud")
+        self.assertEqual(deployed_target.target_category, "service")
+        self.assertEqual(deployed_target.provider_target_type, "managed-service")
+        self.assertEqual(len(deploy_provider.runtime_identities), 1)
+        self.assertEqual(
+            deploy_provider.runtime_identities[0].deployment_record_id,
             store.deployments[0].record_id,
         )
 
@@ -198,27 +269,13 @@ class GenericWebDeployTests(unittest.TestCase):
                 detail="Product post-deploy extension completed.",
             )
 
-        with (
-            patch(
-                "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
-                return_value=_source_of_truth(),
-            ),
-            patch(
-                "control_plane.workflows.generic_web_deploy.control_plane_runtime_environments.resolve_runtime_environment_values",
-                return_value={},
-            ),
-            patch(
-                "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_dokploy_config",
-                return_value=("https://dokploy.example", "token"),
-            ),
-            patch("control_plane.workflows.generic_web_deploy.execute_dokploy_artifact_deploy"),
-        ):
-            result = execute_generic_web_deploy(
-                control_plane_root=Path("."),
-                record_store=store,
-                request=_request(),
-                post_deploy_executor=post_deploy,
-            )
+        result = execute_generic_web_deploy(
+            control_plane_root=Path("."),
+            record_store=store,
+            request=_request(),
+            post_deploy_executor=post_deploy,
+            deploy_provider=_FakeGenericWebDeployProvider(),
+        )
 
         self.assertEqual(result.deploy_status, "pass")
         self.assertEqual(result.post_deploy_status, "pass")
@@ -241,27 +298,13 @@ class GenericWebDeployTests(unittest.TestCase):
         ) -> PostDeployUpdateEvidence:
             raise click.ClickException("post deploy failed")
 
-        with (
-            patch(
-                "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
-                return_value=_source_of_truth(),
-            ),
-            patch(
-                "control_plane.workflows.generic_web_deploy.control_plane_runtime_environments.resolve_runtime_environment_values",
-                return_value={},
-            ),
-            patch(
-                "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_dokploy_config",
-                return_value=("https://dokploy.example", "token"),
-            ),
-            patch("control_plane.workflows.generic_web_deploy.execute_dokploy_artifact_deploy"),
-        ):
-            result = execute_generic_web_deploy(
-                control_plane_root=Path("."),
-                record_store=store,
-                request=_request(),
-                post_deploy_executor=post_deploy,
-            )
+        result = execute_generic_web_deploy(
+            control_plane_root=Path("."),
+            record_store=store,
+            request=_request(),
+            post_deploy_executor=post_deploy,
+            deploy_provider=_FakeGenericWebDeployProvider(),
+        )
 
         self.assertEqual(result.deploy_status, "pass")
         self.assertEqual(result.post_deploy_status, "fail")
@@ -288,27 +331,13 @@ class GenericWebDeployTests(unittest.TestCase):
         ) -> PostDeployUpdateEvidence:
             raise RuntimeError("unexpected post deploy failure")
 
-        with (
-            patch(
-                "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
-                return_value=_source_of_truth(),
-            ),
-            patch(
-                "control_plane.workflows.generic_web_deploy.control_plane_runtime_environments.resolve_runtime_environment_values",
-                return_value={},
-            ),
-            patch(
-                "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_dokploy_config",
-                return_value=("https://dokploy.example", "token"),
-            ),
-            patch("control_plane.workflows.generic_web_deploy.execute_dokploy_artifact_deploy"),
-        ):
-            result = execute_generic_web_deploy(
-                control_plane_root=Path("."),
-                record_store=store,
-                request=_request(),
-                post_deploy_executor=post_deploy,
-            )
+        result = execute_generic_web_deploy(
+            control_plane_root=Path("."),
+            record_store=store,
+            request=_request(),
+            post_deploy_executor=post_deploy,
+            deploy_provider=_FakeGenericWebDeployProvider(),
+        )
 
         self.assertEqual(result.deploy_status, "pass")
         self.assertEqual(result.post_deploy_status, "fail")
@@ -339,27 +368,13 @@ class GenericWebDeployTests(unittest.TestCase):
                 detail="returned failure",
             )
 
-        with (
-            patch(
-                "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
-                return_value=_source_of_truth(),
-            ),
-            patch(
-                "control_plane.workflows.generic_web_deploy.control_plane_runtime_environments.resolve_runtime_environment_values",
-                return_value={},
-            ),
-            patch(
-                "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_dokploy_config",
-                return_value=("https://dokploy.example", "token"),
-            ),
-            patch("control_plane.workflows.generic_web_deploy.execute_dokploy_artifact_deploy"),
-        ):
-            result = execute_generic_web_deploy(
-                control_plane_root=Path("."),
-                record_store=store,
-                request=_request(),
-                post_deploy_executor=post_deploy,
-            )
+        result = execute_generic_web_deploy(
+            control_plane_root=Path("."),
+            record_store=store,
+            request=_request(),
+            post_deploy_executor=post_deploy,
+            deploy_provider=_FakeGenericWebDeployProvider(),
+        )
 
         self.assertEqual(result.deploy_status, "pass")
         self.assertEqual(result.post_deploy_status, "fail")
@@ -374,35 +389,20 @@ class GenericWebDeployTests(unittest.TestCase):
     def test_execute_generic_web_deploy_uses_qualified_bare_tag(self) -> None:
         store = _GenericWebDeployStore(_profile())
 
-        with (
-            patch(
-                "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
-                return_value=_source_of_truth(),
+        deploy_provider = _FakeGenericWebDeployProvider()
+        execute_generic_web_deploy(
+            control_plane_root=Path("."),
+            record_store=store,
+            request=GenericWebDeployRequest(
+                product="sellyouroutboard",
+                instance="testing",
+                artifact_id="sha-2da6435e10cade0870ed5cbdf40c8048594f8b1c",
+                source_git_ref="2da6435e10cade0870ed5cbdf40c8048594f8b1c",
             ),
-            patch(
-                "control_plane.workflows.generic_web_deploy.control_plane_runtime_environments.resolve_runtime_environment_values",
-                return_value={},
-            ),
-            patch(
-                "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_dokploy_config",
-                return_value=("https://dokploy.example", "token"),
-            ),
-            patch(
-                "control_plane.workflows.generic_web_deploy.execute_dokploy_artifact_deploy"
-            ) as deploy,
-        ):
-            execute_generic_web_deploy(
-                control_plane_root=Path("."),
-                record_store=store,
-                request=GenericWebDeployRequest(
-                    product="sellyouroutboard",
-                    instance="testing",
-                    artifact_id="sha-2da6435e10cade0870ed5cbdf40c8048594f8b1c",
-                    source_git_ref="2da6435e10cade0870ed5cbdf40c8048594f8b1c",
-                ),
-            )
+            deploy_provider=deploy_provider,
+        )
 
-        deploy_request = deploy.call_args.kwargs["ship_request"]
+        deploy_request = deploy_provider.resolved_targets[0].ship_request
         expected_artifact_id = (
             "ghcr.io/cbusillo/sellyouroutboard:sha-2da6435e10cade0870ed5cbdf40c8048594f8b1c"
         )
@@ -414,35 +414,103 @@ class GenericWebDeployTests(unittest.TestCase):
     def test_execute_generic_web_deploy_records_failure_when_provider_fails(self) -> None:
         store = _GenericWebDeployStore(_profile())
 
-        with (
-            patch(
-                "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
-                return_value=_source_of_truth(),
+        result = execute_generic_web_deploy(
+            control_plane_root=Path("."),
+            record_store=store,
+            request=_request(),
+            deploy_provider=_FakeGenericWebDeployProvider(
+                deploy_error=click.ClickException("provider failed")
             ),
-            patch(
-                "control_plane.workflows.generic_web_deploy.control_plane_runtime_environments.resolve_runtime_environment_values",
-                return_value={},
-            ),
-            patch(
-                "control_plane.workflows.generic_web_deploy.control_plane_dokploy.read_dokploy_config",
-                return_value=("https://dokploy.example", "token"),
-            ),
-            patch(
-                "control_plane.workflows.generic_web_deploy.execute_dokploy_artifact_deploy",
-                side_effect=click.ClickException("provider failed"),
-            ),
-        ):
-            result = execute_generic_web_deploy(
-                control_plane_root=Path("."),
-                record_store=store,
-                request=_request(),
-            )
+        )
 
         self.assertEqual(result.deploy_status, "fail")
         self.assertEqual(result.error_message, "provider failed")
         self.assertEqual(len(store.deployments), 1)
         self.assertEqual(store.deployments[0].deploy.status, "fail")
         self.assertEqual(store.inventories, [])
+
+    def test_execute_generic_web_deploy_records_provider_resolution_failures_against_provider(
+        self,
+    ) -> None:
+        class FailingResolveProvider(_FakeGenericWebDeployProvider):
+            def resolve_deploy_target(
+                self,
+                *,
+                control_plane_root: Path,
+                request_artifact_id: str,
+                request_source_git_ref: str,
+                request_timeout_seconds: int | None,
+                request_no_cache: bool,
+                profile: LaunchplaneProductProfileRecord,
+                lane: ProductLaneProfile,
+                normalized_artifact_id: str,
+                fallback_target_name: str,
+            ) -> GenericWebResolvedDeployTarget:
+                del (
+                    control_plane_root,
+                    request_artifact_id,
+                    request_source_git_ref,
+                    request_timeout_seconds,
+                    request_no_cache,
+                    profile,
+                    lane,
+                    normalized_artifact_id,
+                    fallback_target_name,
+                )
+                raise click.ClickException("target missing")
+
+        store = _GenericWebDeployStore(_profile())
+
+        result = execute_generic_web_deploy(
+            control_plane_root=Path("."),
+            record_store=store,
+            request=_request(),
+            deploy_provider=FailingResolveProvider(),
+        )
+
+        self.assertEqual(result.deploy_status, "fail")
+        self.assertEqual(result.error_message, "target missing")
+        self.assertEqual(len(store.deployments), 1)
+        self.assertEqual(store.deployments[0].delegated_executor, "control-plane.fake-cloud")
+        self.assertEqual(store.deployments[0].deploy.provider_id, "fake-cloud")
+        self.assertEqual(
+            store.deployments[0].deploy.provider_deploy_mode,
+            "fake-cloud-application-api",
+        )
+        self.assertEqual(store.inventories, [])
+
+    def test_dokploy_provider_resolves_target_without_generic_web_dokploy_imports(
+        self,
+    ) -> None:
+        provider = DokployGenericWebDeployProvider()
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_deploy_provider.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                return_value=_source_of_truth(),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_deploy_provider.control_plane_runtime_environments.resolve_runtime_environment_values",
+                return_value={},
+            ),
+        ):
+            resolved = provider.resolve_deploy_target(
+                control_plane_root=Path("."),
+                request_artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+                request_source_git_ref="abc123",
+                request_timeout_seconds=45,
+                request_no_cache=True,
+                profile=_profile(),
+                lane=_profile().lanes[0],
+                normalized_artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+                fallback_target_name="fallback-target",
+            )
+
+        self.assertEqual(resolved.ship_request.provider_id, "dokploy")
+        self.assertEqual(resolved.ship_request.deploy_mode, "dokploy-application-api")
+        self.assertEqual(resolved.ship_request.target_category, "application")
+        self.assertEqual(resolved.resolved_target.target_id, "target-123")
+        self.assertEqual(resolved.deploy_timeout_seconds, 45)
 
     def test_resolve_generic_web_profile_lane_rejects_missing_lane(self) -> None:
         store = _GenericWebDeployStore(_profile())


### PR DESCRIPTION
## Summary
- add a generic-web deploy provider protocol and Dokploy adapter so generic-web orchestration no longer imports Dokploy directly
- carry provider identity, delegated executor, and deployed target evidence through deployment records
- cover the seam with a fake provider and keep Dokploy resolution tested at the adapter boundary
- document the generic-web deploy provider adapter expectation

## Scope
This is the deploy-provider slice of #1046. Ingress provider extraction remains follow-up work under the same planning issue.

## Tests
- `uv run --extra dev ruff check --diff control_plane/contracts/deployment_record.py control_plane/workflows/generic_web_deploy.py control_plane/workflows/generic_web_deploy_provider.py control_plane/workflows/ship.py tests/test_generic_web_deploy.py`
- `uv run --extra dev ruff check control_plane/contracts/deployment_record.py control_plane/workflows/generic_web_deploy.py control_plane/workflows/generic_web_deploy_provider.py control_plane/workflows/ship.py tests/test_generic_web_deploy.py`
- `uv run --extra dev mypy control_plane/contracts/deployment_record.py control_plane/workflows/generic_web_deploy.py control_plane/workflows/generic_web_deploy_provider.py control_plane/workflows/ship.py tests/test_generic_web_deploy.py`
- `uv run python -m unittest tests.test_generic_web_deploy`
- `uv run python -m unittest tests.test_generic_web_deploy tests.test_generic_web_promotion tests.test_service tests.test_odoo_generic_web_post_deploy tests.test_odoo_prod_promotion tests.test_odoo_prod_rollback`
- `uv run python -m unittest`