### PR TITLE
Extract ingress provider seam

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -270,8 +270,8 @@ from control_plane.workflows.npmplus_ingress import (
     NpmplusIngressApplyRequest,
     NpmplusIngressClient,
     NpmplusIngressApplyResult,
-    apply_npmplus_ingress_route,
 )
+from control_plane.workflows.ingress_provider import IngressProvider, NpmplusIngressProvider
 from control_plane.merge_train import MergeTrainDryRunResult
 from control_plane.merge_train import MergeTrainDryRunSnapshot
 from control_plane.merge_train import build_merge_train_dry_run_result
@@ -704,6 +704,10 @@ class _TestLaunchplaneServiceRecordStore(Protocol):
     def backend_name(self) -> str: ...
 
     def close(self) -> None: ...
+
+
+class _IngressProviderFactory(Protocol):
+    def __call__(self) -> IngressProvider: ...
 
 
 class _NpmplusIngressClientFactory(Protocol):
@@ -5236,6 +5240,8 @@ def _accepted_payload_extra_record_keys(*, route_path: str) -> frozenset[str]:
         return frozenset({"deployment_record_id", "release_tuple_id"})
     if route_path == _GENERIC_WEB_ROLLBACK_ROUTE.route_path:
         return frozenset({"rollback_status", "deploy_status", "post_deploy_status"})
+    if route_path == _NPMPLUS_INGRESS_APPLY_ROUTE.route_path:
+        return frozenset({"ingress_provider"})
     return frozenset()
 
 
@@ -5970,6 +5976,7 @@ def _write_ingress_route_audit_record(
     trace_id: str,
     product: str,
     context: str,
+    provider: str,
     request: NpmplusIngressApplyRequest,
     result: NpmplusIngressApplyResult,
     idempotency_key: str,
@@ -5987,6 +5994,7 @@ def _write_ingress_route_audit_record(
         ),
         product=product,
         context=context,
+        provider=provider,
         mode=request.mode,
         status=result.status,
         dry_run=result.dry_run,
@@ -6012,6 +6020,7 @@ def _write_ingress_route_pending_audit_record(
     trace_id: str,
     product: str,
     context: str,
+    provider: str,
     request: NpmplusIngressApplyRequest,
     idempotency_key: str,
 ) -> IngressRouteAuditRecord:
@@ -6027,6 +6036,7 @@ def _write_ingress_route_pending_audit_record(
         ),
         product=product,
         context=context,
+        provider=provider,
         mode=request.mode,
         status="pending",
         dry_run=request.mode == "dry-run",
@@ -6176,6 +6186,10 @@ def _build_npmplus_ingress_client_from_env() -> NpmplusIngressClient:
             secret=os.environ.get(_NPMPLUS_SECRET_ENV_KEY, ""),
         )
     )
+
+
+def _build_ingress_provider_from_env() -> IngressProvider:
+    return NpmplusIngressProvider(client=_build_npmplus_ingress_client_from_env())
 
 
 def _local_admin_identity_from_bearer(
@@ -8241,6 +8255,7 @@ def create_launchplane_service_app(
     work_graph_planning_facts_provider: WorkGraphPlanningFactsProvider | None = None,
     work_graph_issue_inbox_provider: WorkGraphIssueInboxProvider | None = None,
     work_graph_issue_inbox_reconcile_provider: WorkGraphIssueInboxReconcileProvider | None = None,
+    ingress_provider_factory: _IngressProviderFactory | None = None,
     npmplus_ingress_client_factory: _NpmplusIngressClientFactory | None = None,
 ) -> _WsgiApp:
     resolved_root = control_plane_root_path or control_plane_root()
@@ -8277,9 +8292,15 @@ def create_launchplane_service_app(
         )
     )
     write_routes = _build_write_routes()
-    resolved_npmplus_ingress_client_factory = (
-        npmplus_ingress_client_factory or _build_npmplus_ingress_client_from_env
-    )
+    resolved_ingress_provider_factory = ingress_provider_factory
+    if resolved_ingress_provider_factory is None:
+        if npmplus_ingress_client_factory is not None:
+            def npmplus_ingress_provider_from_client_factory() -> IngressProvider:
+                return NpmplusIngressProvider(client=npmplus_ingress_client_factory())
+
+            resolved_ingress_provider_factory = npmplus_ingress_provider_from_client_factory
+        else:
+            resolved_ingress_provider_factory = _build_ingress_provider_from_env
 
     def app(
         environ: dict[str, object],
@@ -11320,6 +11341,7 @@ def create_launchplane_service_app(
                             },
                         },
                     )
+                ingress_provider = resolved_ingress_provider_factory()
                 if ingress_request.ingress.mode == "apply":
                     idempotent_response = _check_idempotent_request(
                         record_store=record_store,
@@ -11337,11 +11359,11 @@ def create_launchplane_service_app(
                         trace_id=request_trace_id,
                         product=ingress_request.product,
                         context=ingress_request.context,
+                        provider=ingress_provider.provider_id,
                         request=ingress_request.ingress,
                         idempotency_key=request_idempotency_key,
                     )
-                ingress_result = apply_npmplus_ingress_route(
-                    client=resolved_npmplus_ingress_client_factory(),
+                ingress_result = ingress_provider.apply_route(
                     request=ingress_request.ingress,
                 )
                 ingress_audit_record = _write_ingress_route_audit_record(
@@ -11349,12 +11371,13 @@ def create_launchplane_service_app(
                     trace_id=request_trace_id,
                     product=ingress_request.product,
                     context=ingress_request.context,
+                    provider=ingress_provider.provider_id,
                     request=ingress_request.ingress,
                     result=ingress_result,
                     idempotency_key=request_idempotency_key,
                 )
                 result = {
-                    "ingress_provider": "npmplus",
+                    "ingress_provider": ingress_provider.provider_id,
                     "ingress_status": ingress_result.status,
                     "ingress_dry_run": ingress_result.dry_run,
                 }

--- a/control_plane/workflows/ingress_provider.py
+++ b/control_plane/workflows/ingress_provider.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from control_plane.workflows.npmplus_ingress import (
+    NpmplusIngressApplyRequest,
+    NpmplusIngressApplyResult,
+    NpmplusIngressClient,
+    apply_npmplus_ingress_route,
+)
+
+
+class IngressProvider(Protocol):
+    provider_id: str
+    delegated_executor: str
+
+    def apply_route(
+        self,
+        *,
+        request: NpmplusIngressApplyRequest,
+    ) -> NpmplusIngressApplyResult: ...
+
+
+class NpmplusIngressProvider:
+    provider_id = "npmplus"
+    delegated_executor = "control-plane.npmplus"
+
+    def __init__(self, *, client: NpmplusIngressClient) -> None:
+        self._client = client
+
+    def apply_route(
+        self,
+        *,
+        request: NpmplusIngressApplyRequest,
+    ) -> NpmplusIngressApplyResult:
+        return apply_npmplus_ingress_route(client=self._client, request=request)

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -161,10 +161,13 @@ The service-backed ingress route is `POST /v1/drivers/ingress/route-apply`.
 Callers send a product/context envelope plus a typed route request. `mode` is
 `dry-run` by default for CLI callers; `apply` must be explicit. The route uses
 `ingress_route.plan` for dry-run authorization and `ingress_route.apply` for
-provider mutation authorization. The service constructs the NPMplus client from
-environment keys named `LAUNCHPLANE_NPMPLUS_BASE_URL`,
+provider mutation authorization. The service resolves an ingress provider
+adapter for route execution; the default provider is NPMplus. The default
+provider constructs its client from environment keys named `LAUNCHPLANE_NPMPLUS_BASE_URL`,
 `LAUNCHPLANE_NPMPLUS_IDENTITY`, and `LAUNCHPLANE_NPMPLUS_SECRET`; do not commit
 real values or local operator overrides.
+Ingress audit records must persist the adapter's provider identity explicitly;
+do not rely on a provider-specific model default for operator evidence.
 
 The matching CLI entrypoint is service-mediated:
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -184,6 +184,11 @@ from control_plane.workflows.generic_web_preview import (
 from control_plane.workflows.odoo_preview_runtime import OdooPreviewDokployApplyResult
 from control_plane.workflows.public_ingress_monitor import PublicIngressMonitorResult
 from control_plane.npmplus import NpmplusProxyHost, NpmplusProxyHostPayload
+from control_plane.workflows.ingress_provider import NpmplusIngressProvider
+from control_plane.workflows.npmplus_ingress import (
+    NpmplusIngressApplyRequest,
+    NpmplusIngressApplyResult,
+)
 
 StartResponse = Callable[[str, list[tuple[str, str]]], None]
 WsgiApp = Callable[[dict[str, object], StartResponse], Iterable[bytes]]
@@ -262,6 +267,23 @@ class _FakeNpmplusIngressClient:
                 self.proxy_hosts[index] = updated
                 return updated
         raise AssertionError(f"Unknown proxy host: {host_id}")
+
+
+class _FakeIngressProvider:
+    provider_id = "fake-ingress"
+    delegated_executor = "control-plane.fake-ingress"
+
+    def __init__(self, result: NpmplusIngressApplyResult) -> None:
+        self.result = result
+        self.requests: list[NpmplusIngressApplyRequest] = []
+
+    def apply_route(
+        self,
+        *,
+        request: NpmplusIngressApplyRequest,
+    ) -> NpmplusIngressApplyResult:
+        self.requests.append(request)
+        return self.result
 
 
 class _FakeGitHubResponse:
@@ -2392,6 +2414,64 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(records[0].mode, "apply")
         self.assertEqual(records[0].idempotency_key, "npmplus-ingress-apply")
         self.assertEqual(records[0].provider_host_id, 100)
+
+    def test_ingress_route_apply_uses_provider_adapter(self) -> None:
+        client = _FakeNpmplusIngressClient()
+        provider = _FakeIngressProvider(
+            NpmplusIngressProvider(client=client).apply_route(
+                request=NpmplusIngressApplyRequest.model_validate(
+                    _npmplus_ingress_route_payload()["ingress"]
+                )
+            )
+        )
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "every/verireel",
+                        "workflow_refs": [
+                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                        ],
+                        "event_names": ["pull_request"],
+                        "products": ["launchplane"],
+                        "contexts": ["reon-prod"],
+                        "actions": ["ingress_route.plan"],
+                    }
+                ]
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                local_record_store_for_tests=FilesystemRecordStore(root / "state"),
+                ingress_provider_factory=lambda: provider,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/ingress/route-apply",
+                payload=_npmplus_ingress_route_payload(),
+                headers={"Idempotency-Key": "ingress-provider-plan"},
+            )
+            records = FilesystemRecordStore(root / "state").list_ingress_route_audit_records(
+                product="launchplane", context_name="reon-prod"
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["records"]["ingress_provider"], "fake-ingress")
+        self.assertEqual(payload["result"]["status"], "planned")
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].provider, "fake-ingress")
+        self.assertEqual(len(provider.requests), 1)
+        self.assertEqual(
+            provider.requests[0].route.domain_names,
+            ("ingress-canary.example.test",),
+        )
 
     def test_npmplus_ingress_route_apply_fails_before_mutation_when_audit_unavailable(
         self,


### PR DESCRIPTION
## Summary
- add an ingress provider protocol with NPMplus as the default adapter
- route service ingress apply execution through the provider adapter instead of directly calling the NPMplus workflow
- persist the active provider identity in pending/final ingress audit records and expose it in accepted response records
- document the ingress provider adapter boundary

## Scope
This completes the provider-adapter seam work tracked by #1046 at the service execution boundary. A future route-contract cleanup can make the public desired-state model less NPMplus-shaped.

Fixes #1046

## Tests
- `uv run --extra dev ruff check --diff control_plane/service.py control_plane/workflows/ingress_provider.py docs/driver-development.md tests/test_service.py`
- `uv run --extra dev ruff check control_plane/service.py control_plane/workflows/ingress_provider.py tests/test_service.py`
- `uv run --extra dev mypy control_plane/service.py control_plane/workflows/ingress_provider.py tests/test_service.py`
- `uv run python -m unittest tests.test_npmplus_ingress_workflow tests.test_ingress_cli tests.test_driver_descriptors tests.test_service`
- `uv run python -m unittest`